### PR TITLE
Properly support named queries for both nested and parent child inner hits

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryParser.java
@@ -151,7 +151,8 @@ public class HasChildQueryParser implements QueryParser {
         }
 
         if (innerHits != null) {
-            InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), innerQuery, null, parseContext.mapperService(), childDocMapper);
+            ParsedQuery parsedQuery = new ParsedQuery(innerQuery, parseContext.copyNamedQueries());
+            InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), parsedQuery, null, parseContext.mapperService(), childDocMapper);
             String name = innerHits.v1() != null ? innerHits.v1() : childType;
             parseContext.addInnerHits(name, parentChildInnerHits);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryParser.java
@@ -154,7 +154,8 @@ public class HasParentQueryParser implements QueryParser {
         }
 
         if (innerHits != null) {
-            InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), innerQuery, null, parseContext.mapperService(), parentDocMapper);
+            ParsedQuery parsedQuery = new ParsedQuery(innerQuery, parseContext.copyNamedQueries());
+            InnerHitsContext.ParentChildInnerHits parentChildInnerHits = new InnerHitsContext.ParentChildInnerHits(innerHits.v2(), parsedQuery, null, parseContext.mapperService(), parentDocMapper);
             String name = innerHits.v1() != null ? innerHits.v1() : parentType;
             parseContext.addInnerHits(name, parentChildInnerHits);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
@@ -217,7 +217,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
             if (filter == null) {
                 return null;
             }
-            return new ParsedQuery(filter, context.copyNamedFilters());
+            return new ParsedQuery(filter, context.copyNamedQueries());
         } finally {
             context.reset(null);
         }
@@ -300,7 +300,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
             if (query == null) {
                 query = Queries.newMatchNoDocsQuery();
             }
-            return new ParsedQuery(query, parseContext.copyNamedFilters());
+            return new ParsedQuery(query, parseContext.copyNamedQueries());
         } finally {
             parseContext.reset(null);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -151,7 +151,8 @@ public class NestedQueryParser implements QueryParser {
             }
 
             if (innerHits != null) {
-                InnerHitsContext.NestedInnerHits nestedInnerHits = new InnerHitsContext.NestedInnerHits(innerHits.v2(), innerQuery, null, getParentObjectMapper(), nestedObjectMapper);
+                ParsedQuery parsedQuery = new ParsedQuery(innerQuery, parseContext.copyNamedQueries());
+                InnerHitsContext.NestedInnerHits nestedInnerHits = new InnerHitsContext.NestedInnerHits(innerHits.v2(), parsedQuery, null, getParentObjectMapper(), nestedObjectMapper);
                 String name = innerHits.v1() != null ? innerHits.v1() : path;
                 parseContext.addInnerHits(name, nestedInnerHits);
             }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -185,11 +185,11 @@ public class QueryParseContext {
         namedQueries.put(name, query);
     }
 
-    public ImmutableMap<String, Query> copyNamedFilters() {
+    public ImmutableMap<String, Query> copyNamedQueries() {
         return ImmutableMap.copyOf(namedQueries);
     }
 
-    public void combineNamedFilters(QueryParseContext context) {
+    public void combineNamedQueries(QueryParseContext context) {
         namedQueries.putAll(context.namedQueries);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -62,7 +62,7 @@ public class WrapperQueryParser implements QueryParser {
             context.reset(qSourceParser);
             Query result = context.parseInnerQuery();
             parser.nextToken();
-            parseContext.combineNamedFilters(context);
+            parseContext.combineNamedQueries(context);
             return result;
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
@@ -881,7 +881,6 @@ public class TopHitsTests extends ElasticsearchIntegrationTest {
         long version = searchHit.version();
         assertThat(version, equalTo(1l));
 
-        // Can't use named queries for the same reason explain doesn't work:
         assertThat(searchHit.matchedQueries(), arrayContaining("test"));
 
         SearchHitField field = searchHit.field("comments.user");

--- a/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsTests.java
@@ -20,13 +20,13 @@
 package org.elasticsearch.search.innerhits;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.SearchHit;
@@ -42,21 +42,9 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
-import static org.elasticsearch.index.query.QueryBuilders.hasChildQuery;
-import static org.elasticsearch.index.query.QueryBuilders.hasParentQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
-import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHit;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.hamcrest.Matchers.*;
 
 /**
  */
@@ -1002,6 +990,141 @@ public class InnerHitsTests extends ElasticsearchIntegrationTest {
         innerInnerHits = innerHits.getAt(0).getInnerHits().get("kings");
         assertThat(innerInnerHits.totalHits(), equalTo(1l));
         assertThat(innerInnerHits.getAt(0).getId(), equalTo("king"));
+    }
+
+    @Test
+    public void matchesQueries_nestedInnerHits() throws Exception {
+        XContentBuilder builder = jsonBuilder().startObject()
+                .startObject("type1")
+                .startObject("properties")
+                .startObject("nested1")
+                .field("type", "nested")
+                .endObject()
+                .startObject("field1")
+                .field("type", "long")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        assertAcked(prepareCreate("test").addMapping("type1", builder));
+        ensureGreen();
+
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        int numDocs = randomIntBetween(2, 35);
+        requests.add(client().prepareIndex("test", "type1", "0").setSource(jsonBuilder().startObject()
+                .field("field1", 0)
+                .startArray("nested1")
+                .startObject()
+                .field("n_field1", "n_value1_1")
+                .field("n_field2", "n_value2_1")
+                .endObject()
+                .startObject()
+                .field("n_field1", "n_value1_2")
+                .field("n_field2", "n_value2_2")
+                .endObject()
+                .endArray()
+                .endObject()));
+        requests.add(client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
+                .field("field1", 1)
+                .startArray("nested1")
+                .startObject()
+                .field("n_field1", "n_value1_8")
+                .field("n_field2", "n_value2_5")
+                .endObject()
+                .startObject()
+                .field("n_field1", "n_value1_3")
+                .field("n_field2", "n_value2_1")
+                .endObject()
+                .endArray()
+                .endObject()));
+
+        for (int i = 2; i < numDocs; i++) {
+            requests.add(client().prepareIndex("test", "type1", String.valueOf(i)).setSource(jsonBuilder().startObject()
+                    .field("field1", i)
+                    .startArray("nested1")
+                    .startObject()
+                    .field("n_field1", "n_value1_8")
+                    .field("n_field2", "n_value2_5")
+                    .endObject()
+                    .startObject()
+                    .field("n_field1", "n_value1_2")
+                    .field("n_field2", "n_value2_2")
+                    .endObject()
+                    .endArray()
+                    .endObject()));
+        }
+
+        indexRandom(true, requests);
+        waitForRelocation(ClusterHealthStatus.GREEN);
+
+        SearchResponse searchResponse = client().prepareSearch("test")
+                .setQuery(nestedQuery("nested1", boolQuery()
+                                .should(termQuery("nested1.n_field1", "n_value1_1").queryName("test1"))
+                                .should(termQuery("nested1.n_field1", "n_value1_3").queryName("test2"))
+                                .should(termQuery("nested1.n_field2", "n_value2_2").queryName("test3"))
+                ).innerHit(new QueryInnerHitBuilder()))
+                .setSize(numDocs)
+                .addSort("field1", SortOrder.ASC)
+                .get();
+        assertNoFailures(searchResponse);
+        assertAllSuccessful(searchResponse);
+        assertThat(searchResponse.getHits().totalHits(), equalTo((long) numDocs));
+        assertThat(searchResponse.getHits().getAt(0).id(), equalTo("0"));
+        assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getAt(0).getMatchedQueries().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getAt(0).getMatchedQueries()[0], equalTo("test1"));
+        assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getAt(1).getMatchedQueries().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getAt(1).getMatchedQueries()[0], equalTo("test3"));
+
+
+        assertThat(searchResponse.getHits().getAt(1).id(), equalTo("1"));
+        assertThat(searchResponse.getHits().getAt(1).getInnerHits().get("nested1").getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getAt(1).getInnerHits().get("nested1").getAt(0).getMatchedQueries().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(1).getInnerHits().get("nested1").getAt(0).getMatchedQueries()[0], equalTo("test2"));
+
+        for (int i = 2; i < numDocs; i++) {
+            assertThat(searchResponse.getHits().getAt(i).id(), equalTo(String.valueOf(i)));
+            assertThat(searchResponse.getHits().getAt(i).getInnerHits().get("nested1").getTotalHits(), equalTo(1l));
+            assertThat(searchResponse.getHits().getAt(i).getInnerHits().get("nested1").getAt(0).getMatchedQueries().length, equalTo(1));
+            assertThat(searchResponse.getHits().getAt(i).getInnerHits().get("nested1").getAt(0).getMatchedQueries()[0], equalTo("test3"));
+        }
+    }
+
+    @Test
+    public void matchesQueries_parentChildInnerHits() throws Exception {
+        assertAcked(prepareCreate("index").addMapping("child", "_parent", "type=parent"));
+        List<IndexRequestBuilder> requests = new ArrayList<>();
+        requests.add(client().prepareIndex("index", "parent", "1").setSource("{}"));
+        requests.add(client().prepareIndex("index", "child", "1").setParent("1").setSource("field", "value1"));
+        requests.add(client().prepareIndex("index", "child", "2").setParent("1").setSource("field", "value2"));
+        requests.add(client().prepareIndex("index", "parent", "2").setSource("{}"));
+        requests.add(client().prepareIndex("index", "child", "3").setParent("2").setSource("field", "value1"));
+        indexRandom(true, requests);
+
+        SearchResponse response = client().prepareSearch("index")
+                .setQuery(hasChildQuery("child", matchQuery("field", "value1").queryName("_name1")).innerHit(new QueryInnerHitBuilder()))
+                .addSort("_uid", SortOrder.ASC)
+                .get();
+        assertHitCount(response, 2);
+        assertThat(response.getHits().getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
+
+        assertThat(response.getHits().getAt(1).id(), equalTo("2"));
+        assertThat(response.getHits().getAt(1).getInnerHits().get("child").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
+        assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
+
+        response = client().prepareSearch("index")
+                .setQuery(hasChildQuery("child", matchQuery("field", "value2").queryName("_name2")).innerHit(new QueryInnerHitBuilder()))
+                .addSort("_id", SortOrder.ASC)
+                .get();
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).id(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name2"));
     }
 
 }


### PR DESCRIPTION
Before inner_hits existed named queries had support to also verify if inner queries of nested query matched with returned documents. This logic was broken and became obsolete from the moment inner hits got released. #10694 fixed named queries for nested docs in the top_hits agg, but it didn't fix the named query support for nested inner hits. This commit fixes that and on top of this also adds support for parent/child inner hits.

Left over of issue #10661
