### PR TITLE
Add cost minimizer to tune `moving_avg` parameters

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgBuilder.java
@@ -36,6 +36,7 @@ public class MovAvgBuilder extends PipelineAggregatorBuilder<MovAvgBuilder> {
     private MovAvgModelBuilder modelBuilder;
     private Integer window;
     private Integer predict;
+    private Boolean minimize;
 
     public MovAvgBuilder(String name) {
         super(name, MovAvgPipelineAggregator.TYPE.name());
@@ -94,6 +95,18 @@ public class MovAvgBuilder extends PipelineAggregatorBuilder<MovAvgBuilder> {
         return this;
     }
 
+    /**
+     * Determines if the model should be fit to the data using a cost
+     * minimizing algorithm.
+     *
+     * @param minimize If the model should be fit to the underlying data
+     * @return Returns the builder to continue chaining
+     */
+    public MovAvgBuilder minimize(boolean minimize) {
+        this.minimize = minimize;
+        return this;
+    }
+
 
     @Override
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
@@ -111,6 +124,9 @@ public class MovAvgBuilder extends PipelineAggregatorBuilder<MovAvgBuilder> {
         }
         if (predict != null) {
             builder.field(MovAvgParser.PREDICT.getPreferredName(), predict);
+        }
+        if (minimize != null) {
+            builder.field(MovAvgParser.MINIMIZE.getPreferredName(), minimize);
         }
         return builder;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/SimulatedAnealingMinimizer.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/SimulatedAnealingMinimizer.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline.movavg;
+
+import com.google.common.collect.EvictingQueue;
+import org.elasticsearch.search.aggregations.pipeline.movavg.models.MovAvgModel;
+
+/**
+ * A cost minimizer which will fit a MovAvgModel to the data.
+ *
+ * This optimizer uses naive simulated annealing.  Random solutions in the problem space
+ * are generated, compared against the last period of data, and the least absolute deviation
+ * is recorded as a cost.
+ *
+ * If the new cost is better than the old cost, the new coefficients are chosen.  If the new
+ * solution is worse, there is a temperature-dependent probability it will be randomly selected
+ * anyway.  This allows the algo to sample the problem space widely.  As iterations progress,
+ * the temperature decreases and the algorithm rejects poor solutions more regularly,
+ * theoretically honing in on a global minimum.
+ */
+public class SimulatedAnealingMinimizer {
+
+    /**
+     * Runs the simulated annealing algorithm and produces a model with new coefficients that, theoretically
+     * fit the data better and generalizes to future forecasts without overfitting.
+     *
+     * @param model         The MovAvgModel to be optimized for
+     * @param train         A training set provided to the model, which predictions will be
+     *                      generated from
+     * @param test          A test set of data to compare the predictions against and derive
+     *                      a cost for the model
+     * @return              A new, minimized model that (theoretically) better fits the data
+     */
+    public static MovAvgModel minimize(MovAvgModel model, EvictingQueue<Double> train, double[] test) {
+
+        double temp = 1;
+        double minTemp = 0.0001;
+        int iterations = 100;
+        double alpha = 0.9;
+
+        MovAvgModel bestModel = model;
+        MovAvgModel oldModel = model;
+
+        double oldCost = cost(model, train, test);
+        double bestCost = oldCost;
+
+        while (temp > minTemp) {
+            for (int i = 0; i < iterations; i++) {
+                MovAvgModel newModel = oldModel.neighboringModel();
+                double newCost = cost(newModel, train, test);
+
+                double ap = acceptanceProbability(oldCost, newCost, temp);
+                if (ap > Math.random()) {
+                    oldModel = newModel;
+                    oldCost = newCost;
+
+                    if (newCost < bestCost) {
+                        bestCost = newCost;
+                        bestModel = newModel;
+                    }
+                }
+            }
+
+            temp *= alpha;
+        }
+
+        return bestModel;
+    }
+
+    /**
+     * If the new cost is better than old, return 1.0.  Otherwise, return a double that increases
+     * as the two costs are closer to each other.
+     *
+     * @param oldCost   Old model cost
+     * @param newCost   New model cost
+     * @param temp      Current annealing temperature
+     * @return          The probability of accepting the new cost over the old
+     */
+    private static double acceptanceProbability(double oldCost, double newCost, double temp) {
+        return newCost < oldCost ? 1.0 : Math.exp(-(newCost - oldCost) / temp);
+    }
+
+    /**
+     * Calculates the "cost" of a model.  E.g. when run on the training data, how closely do the  predictions
+     * match the test data
+     *
+     * Uses Least Absolute Differences to calculate error.  Note that this is not scale free, but seems
+     * to work fairly well in practice
+     *
+     * @param model     The MovAvgModel we are fitting
+     * @param train     A training set of data given to the model, which will then generate predictions from
+     * @param test      A test set of data to compare against the predictions
+     * @return          A cost, or error, of the model
+     */
+    private static double cost(MovAvgModel model, EvictingQueue<Double> train, double[] test) {
+        double error = 0;
+        double[] predictions = model.predict(train, test.length);
+
+        assert(predictions.length == test.length);
+
+        for (int i = 0; i < predictions.length; i++) {
+            error += Math.abs(test[i] - predictions[i]) ;
+        }
+
+        return error;
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/EwmaModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/EwmaModel.java
@@ -41,14 +41,31 @@ public class EwmaModel extends MovAvgModel {
     protected static final ParseField NAME_FIELD = new ParseField("ewma");
 
     /**
-     * Controls smoothing of data. Alpha = 1 retains no memory of past values
+     * Controls smoothing of data.  Also known as "level" value.
+     * Alpha = 1 retains no memory of past values
      * (e.g. random walk), while alpha = 0 retains infinite memory of past values (e.g.
-     * mean of the series).  Useful values are somewhere in between
+     * mean of the series).
      */
-    private double alpha;
+    private final double alpha;
 
     public EwmaModel(double alpha) {
         this.alpha = alpha;
+    }
+
+    @Override
+    public boolean canBeMinimized() {
+        return true;
+    }
+
+    @Override
+    public MovAvgModel neighboringModel() {
+        double alpha = Math.random();
+        return new EwmaModel(alpha);
+    }
+
+    @Override
+    public MovAvgModel clone() {
+        return new EwmaModel(this.alpha);
     }
 
     @Override
@@ -105,8 +122,7 @@ public class EwmaModel extends MovAvgModel {
         @Override
         public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException {
 
-            double alpha = parseDoubleParam(settings, "alpha", 0.5);
-
+            double alpha = parseDoubleParam(settings, "alpha", 0.3);
             return new EwmaModel(alpha);
         }
 
@@ -114,7 +130,7 @@ public class EwmaModel extends MovAvgModel {
 
     public static class EWMAModelBuilder implements MovAvgModelBuilder {
 
-        private double alpha = 0.5;
+        private Double alpha;
 
         /**
          * Alpha controls the smoothing of the data.  Alpha = 1 retains no memory of past values
@@ -134,7 +150,10 @@ public class EwmaModel extends MovAvgModel {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(MovAvgParser.MODEL.getPreferredName(), NAME_FIELD.getPreferredName());
             builder.startObject(MovAvgParser.SETTINGS.getPreferredName());
+            if (alpha != null) {
                 builder.field("alpha", alpha);
+            }
+
             builder.endObject();
             return builder;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltLinearModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltLinearModel.java
@@ -39,20 +39,48 @@ public class HoltLinearModel extends MovAvgModel {
     protected static final ParseField NAME_FIELD = new ParseField("holt");
 
     /**
-     * Controls smoothing of data. Alpha = 1 retains no memory of past values
+     * Controls smoothing of data.  Also known as "level" value.
+     * Alpha = 1 retains no memory of past values
      * (e.g. random walk), while alpha = 0 retains infinite memory of past values (e.g.
-     * mean of the series).  Useful values are somewhere in between
+     * mean of the series).
      */
-    private double alpha;
+    private final double alpha;
 
     /**
-     * Equivalent to <code>alpha</code>, but controls the smoothing of the trend instead of the data
+     * Controls smoothing of trend.
+     * Beta = 1 retains no memory of past values
+     * (e.g. random walk), while alpha = 0 retains infinite memory of past values (e.g.
+     * mean of the series).
      */
-    private double beta;
+    private final double beta;
 
     public HoltLinearModel(double alpha, double beta) {
         this.alpha = alpha;
         this.beta = beta;
+    }
+
+    @Override
+    public boolean canBeMinimized() {
+        return true;
+    }
+
+    @Override
+    public MovAvgModel neighboringModel() {
+        double newValue = Math.random();
+        switch ((int) (Math.random() * 2)) {
+            case 0:
+                return new HoltLinearModel(newValue, this.beta);
+            case 1:
+                return new HoltLinearModel(this.alpha, newValue);
+            default:
+                assert (false): "Random value fell outside of range [0-1]";
+                return new HoltLinearModel(newValue, this.beta);    // This should never technically happen...
+        }
+    }
+
+    @Override
+    public MovAvgModel clone() {
+        return new HoltLinearModel(this.alpha, this.beta);
     }
 
     /**
@@ -154,16 +182,17 @@ public class HoltLinearModel extends MovAvgModel {
         @Override
         public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException {
 
-            double alpha = parseDoubleParam(settings, "alpha", 0.5);
-            double beta = parseDoubleParam(settings, "beta", 0.5);
+            double alpha = parseDoubleParam(settings, "alpha", 0.3);
+            double beta = parseDoubleParam(settings, "beta", 0.1);
             return new HoltLinearModel(alpha, beta);
         }
     }
 
     public static class HoltLinearModelBuilder implements MovAvgModelBuilder {
 
-        private double alpha = 0.5;
-        private double beta = 0.5;
+
+        private Double alpha;
+        private Double beta;
 
         /**
          * Alpha controls the smoothing of the data.  Alpha = 1 retains no memory of past values
@@ -195,8 +224,15 @@ public class HoltLinearModel extends MovAvgModel {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(MovAvgParser.MODEL.getPreferredName(), NAME_FIELD.getPreferredName());
             builder.startObject(MovAvgParser.SETTINGS.getPreferredName());
+
+            if (alpha != null) {
                 builder.field("alpha", alpha);
+            }
+
+            if (beta != null) {
                 builder.field("beta", beta);
+            }
+
             builder.endObject();
             return builder;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltWintersModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/HoltWintersModel.java
@@ -41,6 +41,47 @@ public class HoltWintersModel extends MovAvgModel {
 
     protected static final ParseField NAME_FIELD = new ParseField("holt_winters");
 
+    /**
+     * Controls smoothing of data.  Also known as "level" value.
+     * Alpha = 1 retains no memory of past values
+     * (e.g. random walk), while alpha = 0 retains infinite memory of past values (e.g.
+     * mean of the series).
+     */
+    private final double alpha;
+
+    /**
+     * Controls smoothing of trend.
+     * Beta = 1 retains no memory of past values
+     * (e.g. random walk), while alpha = 0 retains infinite memory of past values (e.g.
+     * mean of the series).
+     */
+    private final double beta;
+
+    /**
+     * Controls smoothing of seasonality.
+     * Gamma = 1 retains no memory of past values
+     * (e.g. random walk), while alpha = 0 retains infinite memory of past values (e.g.
+     * mean of the series).
+     */
+    private final double gamma;
+
+    /**
+     * Periodicity of the data
+     */
+    private final int period;
+
+    /**
+     * Whether this is a multiplicative or additive HW
+     */
+    private final SeasonalityType seasonalityType;
+
+    /**
+     * Padding is used to add a very small amount to values, so that zeroes do not interfere
+     * with multiplicative seasonality math (e.g. division by zero)
+     */
+    private final boolean pad;
+    private final double padding;
+
     public enum SeasonalityType {
         ADDITIVE((byte) 0, "add"), MULTIPLICATIVE((byte) 1, "mult");
 
@@ -116,27 +157,6 @@ public class HoltWintersModel extends MovAvgModel {
     }
 
 
-    /**
-     * Controls smoothing of data. Alpha = 1 retains no memory of past values
-     * (e.g. random walk), while alpha = 0 retains infinite memory of past values (e.g.
-     * mean of the series).  Useful values are somewhere in between
-     */
-    private double alpha;
-
-    /**
-     * Equivalent to <code>alpha</code>, but controls the smoothing of the trend instead of the data
-     */
-    private double beta;
-
-    private double gamma;
-
-    private int period;
-
-    private SeasonalityType seasonalityType;
-
-    private boolean pad;
-    private double padding;
-
     public HoltWintersModel(double alpha, double beta, double gamma, int period, SeasonalityType seasonalityType, boolean pad) {
         this.alpha = alpha;
         this.beta = beta;
@@ -150,11 +170,41 @@ public class HoltWintersModel extends MovAvgModel {
         this.padding = seasonalityType.equals(SeasonalityType.MULTIPLICATIVE) && pad ? 0.0000000001 : 0;
     }
 
+    @Override
+    public boolean minimizeByDefault() {
+        return true;
+    }
 
     @Override
-    public boolean hasValue(int windowLength) {
+    public boolean canBeMinimized() {
+        return true;
+    }
+
+    @Override
+    public MovAvgModel neighboringModel() {
+        double newValue = Math.random();
+        switch ((int) (Math.random() * 3)) {
+            case 0:
+                return new HoltWintersModel(newValue, beta, gamma, period, seasonalityType, pad);
+            case 1:
+                return new HoltWintersModel(alpha, newValue, gamma, period, seasonalityType, pad);
+            case 2:
+                return new HoltWintersModel(alpha, beta, newValue, period, seasonalityType, pad);
+            default:
+                assert (false): "Random value fell outside of range [0-2]";
+                return new HoltWintersModel(newValue, beta, gamma, period, seasonalityType, pad); // This should never technically happen...
+        }
+    }
+
+    @Override
+    public MovAvgModel clone() {
+        return new HoltWintersModel(alpha, beta, gamma, period, seasonalityType, pad);
+    }
+
+    @Override
+    public boolean hasValue(int valuesAvailable) {
         // We need at least (period * 2) data-points (e.g. two "seasons")
-        return windowLength >= period * 2;
+        return valuesAvailable >= period * 2;
     }
 
     /**
@@ -198,7 +248,7 @@ public class HoltWintersModel extends MovAvgModel {
 
         // Smoothed value
         double s = 0;
-        double last_s = 0;
+        double last_s;
 
         // Trend value
         double b = 0;
@@ -218,12 +268,11 @@ public class HoltWintersModel extends MovAvgModel {
         // Calculate the slopes between first and second season for each period
         for (int i = 0; i < period; i++) {
             s += vs[i];
-            b += (vs[i] - vs[i + period]) / 2;
+            b += (vs[i + period] - vs[i]) / period;
         }
         s /= (double) period;
         b /= (double) period;
         last_s = s;
-        last_b = b;
 
         // Calculate first seasonal
         if (Double.compare(s, 0.0) == 0 || Double.compare(s, -0.0) == 0) {
@@ -247,7 +296,7 @@ public class HoltWintersModel extends MovAvgModel {
             if (seasonalityType.equals(SeasonalityType.MULTIPLICATIVE)) {
                 seasonal[i] = gamma * (vs[i] / (last_s + last_b )) + (1 - gamma) * seasonal[i - period];
             } else {
-                seasonal[i] = gamma * (vs[i] - (last_s + last_b )) + (1 - gamma) * seasonal[i - period];
+                seasonal[i] = gamma * (vs[i] - (last_s - last_b )) + (1 - gamma) * seasonal[i - period];
             }
 
             last_s = s;
@@ -255,18 +304,15 @@ public class HoltWintersModel extends MovAvgModel {
         }
 
         double[] forecastValues = new double[numForecasts];
-        int seasonCounter = (values.size() - 1) - period;
-
-        for (int i = 0; i < numForecasts; i++) {
+        for (int i = 1; i <= numForecasts; i++) {
+            int idx = values.size() - period + ((i - 1) % period);
 
             // TODO perhaps pad out seasonal to a power of 2 and use a mask instead of modulo?
             if (seasonalityType.equals(SeasonalityType.MULTIPLICATIVE)) {
-                forecastValues[i] = s + (i * b) * seasonal[seasonCounter % values.size()];
+                forecastValues[i-1] = (s + (i * b)) * seasonal[idx];
             } else {
-                forecastValues[i] = s + (i * b) + seasonal[seasonCounter % values.size()];
+                forecastValues[i-1] = s + (i * b) + seasonal[idx];
             }
-
-            seasonCounter += 1;
         }
 
         return forecastValues;
@@ -312,9 +358,9 @@ public class HoltWintersModel extends MovAvgModel {
         @Override
         public MovAvgModel parse(@Nullable Map<String, Object> settings, String pipelineName, int windowSize, ParseFieldMatcher parseFieldMatcher) throws ParseException {
 
-            double alpha = parseDoubleParam(settings, "alpha", 0.5);
-            double beta = parseDoubleParam(settings, "beta", 0.5);
-            double gamma = parseDoubleParam(settings, "gamma", 0.5);
+            double alpha = parseDoubleParam(settings, "alpha", 0.3);
+            double beta = parseDoubleParam(settings, "beta", 0.1);
+            double gamma = parseDoubleParam(settings, "gamma", 0.3);
             int period = parseIntegerParam(settings, "period", 1);
 
             if (windowSize < 2 * period) {
@@ -345,12 +391,12 @@ public class HoltWintersModel extends MovAvgModel {
 
     public static class HoltWintersModelBuilder implements MovAvgModelBuilder {
 
-        private double alpha = 0.5;
-        private double beta = 0.5;
-        private double gamma = 0.5;
-        private int period = 1;
-        private SeasonalityType seasonalityType = SeasonalityType.ADDITIVE;
-        private boolean pad = true;
+        private Double alpha;
+        private Double beta;
+        private Double gamma;
+        private Integer period;
+        private SeasonalityType seasonalityType;
+        private Boolean pad;
 
         /**
          * Alpha controls the smoothing of the data.  Alpha = 1 retains no memory of past values
@@ -402,12 +448,31 @@ public class HoltWintersModel extends MovAvgModel {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(MovAvgParser.MODEL.getPreferredName(), NAME_FIELD.getPreferredName());
             builder.startObject(MovAvgParser.SETTINGS.getPreferredName());
-            builder.field("alpha", alpha);
-            builder.field("beta", beta);
-            builder.field("gamma", gamma);
-            builder.field("period", period);
-            builder.field("type", seasonalityType.getName());
-            builder.field("pad", pad);
+
+            if (alpha != null) {
+                builder.field("alpha", alpha);
+            }
+
+            if (beta != null) {
+                builder.field("beta", beta);
+            }
+
+            if (gamma != null) {
+                builder.field("gamma", gamma);
+            }
+
+            if (period != null) {
+                builder.field("period", period);
+            }
+
+            if (pad != null) {
+                builder.field("pad", pad);
+            }
+
+            if (seasonalityType != null) {
+                builder.field("seasonalityType", seasonalityType);
+            }
+
             builder.endObject();
             return builder;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/LinearModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/LinearModel.java
@@ -42,6 +42,22 @@ public class LinearModel extends MovAvgModel {
 
     protected static final ParseField NAME_FIELD = new ParseField("linear");
 
+
+    @Override
+    public boolean canBeMinimized() {
+        return false;
+    }
+
+    @Override
+    public MovAvgModel neighboringModel() {
+        return new LinearModel();
+    }
+
+    @Override
+    public MovAvgModel clone() {
+        return new LinearModel();
+    }
+
     @Override
     protected  <T extends Number> double[] doPredict(Collection<T> values, int numPredictions) {
         double[] predictions = new double[numPredictions];

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/MovAvgModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/MovAvgModel.java
@@ -33,16 +33,41 @@ import java.util.Map;
 public abstract class MovAvgModel {
 
     /**
+     * Should this model be fit to the data via a cost minimizing algorithm by default?
+     *
+     * @return
+     */
+    public boolean minimizeByDefault() {
+        return false;
+    }
+
+    /**
+     * Returns if the model can be cost minimized.  Not all models have parameters
+     * which can be tuned / optimized.
+     *
+     * @return
+     */
+    public abstract boolean canBeMinimized();
+
+    /**
+     * Generates a "neighboring" model, where one of the tunable parameters has been
+     * randomly mutated within the allowed range.  Used for minimization
+     *
+     * @return
+     */
+    public abstract MovAvgModel neighboringModel();
+
+    /**
      * Checks to see this model can produce a new value, without actually running the algo.
      * This can be used for models that have certain preconditions that need to be met in order
      * to short-circuit execution
      *
-     * @param windowLength  Length of current window
-     * @return              Returns `true` if calling next() will produce a value, `false` otherwise
+     * @param valuesAvailable Number of values in the current window of values
+     * @return                Returns `true` if calling next() will produce a value, `false` otherwise
      */
-    public boolean hasValue(int windowLength) {
+    public boolean hasValue(int valuesAvailable) {
         // Default implementation can always provide a next() value
-        return windowLength > 0;
+        return valuesAvailable > 0;
     }
 
     /**
@@ -85,6 +110,8 @@ public abstract class MovAvgModel {
 
     /**
      * Returns an empty set of predictions, filled with NaNs
+     * @param numPredictions Number of empty predictions to generate
+     * @return
      */
     protected double[] emptyPredictions(int numPredictions) {
         double[] predictions = new double[numPredictions];
@@ -99,6 +126,13 @@ public abstract class MovAvgModel {
      * @throws IOException
      */
     public abstract void writeTo(StreamOutput out) throws IOException;
+
+    /**
+     * Clone the model, returning an exact copy
+     *
+     * @return
+     */
+    public abstract MovAvgModel clone();
 
     /**
      * Abstract class which also provides some concrete parsing functionality.

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/SimpleModel.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/models/SimpleModel.java
@@ -40,6 +40,22 @@ public class SimpleModel extends MovAvgModel {
 
     protected static final ParseField NAME_FIELD = new ParseField("simple");
 
+
+    @Override
+    public boolean canBeMinimized() {
+        return false;
+    }
+
+    @Override
+    public MovAvgModel neighboringModel() {
+        return new SimpleModel();
+    }
+
+    @Override
+    public MovAvgModel clone() {
+        return new SimpleModel();
+    }
+
     @Override
     protected <T extends Number> double[] doPredict(Collection<T> values, int numPredictions) {
         double[] predictions = new double[numPredictions];

--- a/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
@@ -44,6 +44,8 @@ A `moving_avg` aggregation looks like this in isolation:
 |`model` |The moving average weighting model that we wish to use |Optional |`simple`
 |`gap_policy` |Determines what should happen when a gap in the data is encountered. |Optional |`insert_zero`
 |`window` |The size of window to "slide" across the histogram. |Optional |`5`
+|`minimize` |If the model should be algorithmically minimized.  See <<movavg-minimizer, Minimization>> for more
+ details |Optional |`false` for most models
 |`settings` |Model-specific settings, contents which differ depending on the model specified. |Optional |
 |===
 
@@ -100,6 +102,7 @@ the values from a `simple` moving average tend to "lag" behind the real data.
     "the_movavg":{
         "moving_avg":{
             "buckets_path": "the_sum",
+            "window" : 30,
             "model" : "simple"
         }
     }
@@ -135,6 +138,7 @@ the "lag" behind the data's mean, since older points have less influence.
     "the_movavg":{
         "moving_avg":{
             "buckets_path": "the_sum",
+            "window" : 30,
             "model" : "linear"
         }
 }
@@ -165,7 +169,9 @@ setting.  Small values make the weight decay slowly, which provides greater smoo
 portion of the window.  Larger valuers make the weight decay quickly, which reduces the impact of older values on the
 moving average.  This tends to make the moving average track the data more closely but with less smoothing.
 
-The default value of `alpha` is `0.5`, and the setting accepts any float from 0-1 inclusive.
+The default value of `alpha` is `0.3`, and the setting accepts any float from 0-1 inclusive.
+
+The EWMA model can be <<movavg-minimizer, Minimized>>
 
 [source,js]
 --------------------------------------------------
@@ -173,6 +179,7 @@ The default value of `alpha` is `0.5`, and the setting accepts any float from 0-
     "the_movavg":{
         "moving_avg":{
             "buckets_path": "the_sum",
+            "window" : 30,
             "model" : "ewma",
             "settings" : {
                 "alpha" : 0.5
@@ -204,7 +211,9 @@ smoothed data).  The trend value is also exponentially weighted.
 
 Values are produced by multiplying the level and trend components.
 
-The default value of `alpha` and `beta` is `0.5`, and the settings accept any float from 0-1 inclusive.
+The default value of `alpha` is `0.3` and `beta` is `0.1`. The settings accept any float from 0-1 inclusive.
+
+The Holt-Linear model can be <<movavg-minimizer, Minimized>>
 
 [source,js]
 --------------------------------------------------
@@ -212,6 +221,7 @@ The default value of `alpha` and `beta` is `0.5`, and the settings accept any fl
     "the_movavg":{
         "moving_avg":{
             "buckets_path": "the_sum",
+            "window" : 30,
             "model" : "holt",
             "settings" : {
                 "alpha" : 0.5,
@@ -270,8 +280,10 @@ Additive seasonality is the default; it can also be specified by setting `"type"
 when the seasonal affect is additive to your data. E.g. you could simply subtract the seasonal effect to "de-seasonalize"
 your data into a flat trend.
 
-The default value of `alpha`, `beta` and `gamma` is `0.5`, and the settings accept any float from 0-1 inclusive.
+The default values of `alpha` and `gamma` are `0.3` while `beta` is `0.1`.  The settings accept any float from 0-1 inclusive.
 The default value of `period` is `1`.
+
+The additive Holt-Winters model can be <<movavg-minimizer, Minimized>>
 
 [source,js]
 --------------------------------------------------
@@ -279,6 +291,7 @@ The default value of `period` is `1`.
     "the_movavg":{
         "moving_avg":{
             "buckets_path": "the_sum",
+            "window" : 30,
             "model" : "holt_winters",
             "settings" : {
                 "type" : "add",
@@ -301,8 +314,10 @@ image::images/pipeline_movavg/triple.png[]
 Multiplicative is specified by setting `"type": "mult"`.  This variety is preferred when the seasonal affect is
 multiplied against your data. E.g. if the seasonal affect is x5 the data, rather than simply adding to it.
 
-The default value of `alpha`, `beta` and `gamma` is `0.5`, and the settings accept any float from 0-1 inclusive.
+The default values of `alpha` and `gamma` are `0.3` while `beta` is `0.1`.  The settings accept any float from 0-1 inclusive.
 The default value of `period` is `1`.
+
+The multiplicative Holt-Winters model can be <<movavg-minimizer, Minimized>>
 
 [WARNING]
 ======
@@ -319,6 +334,7 @@ you can disable this behavior with `pad: false`
     "the_movavg":{
         "moving_avg":{
             "buckets_path": "the_sum",
+            "window" : 30,
             "model" : "holt_winters",
             "settings" : {
                 "type" : "mult",
@@ -347,6 +363,7 @@ as your buckets:
     "the_movavg":{
         "moving_avg":{
             "buckets_path": "the_sum",
+            "window" : 30,
             "model" : "simple",
             "predict" 10
         }
@@ -381,3 +398,53 @@ fluctuations into the model:
 [[holt_winters_prediction_global]]
 .Holt-Winters moving average with window of size 120, predict = 25, alpha = 0.8, beta = 0.2, gamma = 0.7, period = 30
 image::images/pipeline_movavg/triple_prediction.png[]
+
+[[movavg-minimizer]]
+==== Minimization
+
+Some of the models (EWMA, Holt-Linear, Holt-Winters) require one or more parameters to be configured.  Parameter choice
+can be tricky and sometimes non-intuitive.  Furthermore, small deviations in these parameters can sometimes have a drastic
+effect on the output moving average.
+
+For that reason, the three "tunable" models can be algorithmically *minimized*.  Minimization is a process where parameters
+are tweaked until the predictions generated by the model closely match the output data.  Minimization is not fullproof
+and can be susceptible to overfitting, but it often gives better results than hand-tuning.
+
+Minimization is disabled by default for `ewma` and `holt_linear`, while it is enabled by default for `holt_winters`.
+Minimization is most useful with Holt-Winters, since it helps improve the accuracy of the predictions.  EWMA and
+Holt-Linear are not great predictors, and mostly used for smoothing data, so minimization is less useful on those
+models.
+
+Minimization is enabled/disabled via the `minimize` parameter:
+
+[source,js]
+--------------------------------------------------
+{
+    "the_movavg":{
+        "moving_avg":{
+            "buckets_path": "the_sum",
+            "model" : "holt_winters",
+            "window" : 30,
+            "minimize" : true,  <1>
+            "settings" : {
+                "period" : 7
+            }
+        }
+}
+--------------------------------------------------
+<1> Minimization is enabled with the `minimize` parameter
+
+When enabled, minimization will find the optimal values for `alpha`, `beta` and `gamma`.  The user should still provide
+appropriate values for `window`, `period` and `type`.
+
+[WARNING]
+======
+Minimization works by running a stochastic process called *simulated annealing*.  This process will usually generate
+a good solution, but is not guaranteed to find the global optimum.  It also requires some amount of additional
+computational power, since the model needs to be re-run multiple times as the values are tweaked.  The run-time of
+minimization is linear to the size of the window being processed: excessively large windows may cause latency.
+
+Finally, minimization fits the model to the last `n` values, where `n = window`.  This generally produces
+better forecasts into the future, since the parameters are tuned around the end of the series.  It can, however, generate
+poorer fitting moving averages at the beginning of the series.
+======


### PR DESCRIPTION
Introduces an optimizer that will fit a model to the underlying data by automatically tuning the model's parameters.

Not all models can be optimized, and only Holt-Winters is optimized by default.  I think only HW is useful for prediction (since the other models just predict constant "lines"), and the main utility of fitting the model to the data is to generate accurate predictions.  The other moving average are more useful for their smoothing capabilities than their predictive capabilities (again, in my opinion :) )

To make the optimizer semi-generic, models have moved from explicit local variables (`alpha`, `beta`, etc) to an array of doubles.   Each model knows what is supposed to be in each position.  The optimizer doesn't actually care what the values represents, and can generically work with the array.  This seemed like the least painful way to accomplish it ... open to suggestions!

Still a WIP:
- Needs tests, and current tests were temporarily disabled because of changes
- Lots of edge cases that can currently explode, e.g not enough data to train on
- The architecture is a bit wonky.  E.g. we rely on the model to extract settings (because only it knows what kind of settings are available for that model), but the settings manipulation is all done "outside" the model by the Aggregator and Optimizer
- Need to run it through a profiler

Putting this up so I can ping a few people for eyeballs on certain design decisions, does not need a review yet! :)
