### PR TITLE
Logging: Allow to hardcode logging factory

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/logging/ESLoggerFactory.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/ESLoggerFactory.java
@@ -32,38 +32,21 @@ public abstract class ESLoggerFactory {
     private static volatile ESLoggerFactory defaultFactory = new JdkESLoggerFactory();
 
     static {
-        ESLoggerFactory configuredEsLoggerFactory = getConfiguredEsLoggerFactory();
-        if (configuredEsLoggerFactory == null) {
-            try {
-                Class<?> loggerClazz = Class.forName("org.apache.log4j.Logger");
-                // below will throw a NoSuchMethod failure with using slf4j log4j bridge
-                loggerClazz.getMethod("setLevel", Class.forName("org.apache.log4j.Level"));
-                defaultFactory = new Log4jESLoggerFactory();
-            } catch (Throwable e) {
-                // no log4j
-                try {
-                    Class.forName("org.slf4j.Logger");
-                    defaultFactory = new Slf4jESLoggerFactory();
-                } catch (Throwable e1) {
-                    // no slf4j
-                }
-            }
-        } else {
-            defaultFactory = configuredEsLoggerFactory;
-        }
+        defaultFactory = getConfiguredEsLoggerFactory();
     }
 
     static ESLoggerFactory getConfiguredEsLoggerFactory() {
-        String loggingType = System.getProperty(LOGGER_IMPL_PROPERTY_NAME);
-        if ("log4j".equals(loggingType)) {
-            return new Log4jESLoggerFactory();
-        } else if ("slf4j".equals(loggingType)) {
-            return new Slf4jESLoggerFactory();
-        } else if ("jdk".equals(loggingType)) {
-            return new JdkESLoggerFactory();
+        String loggingType = System.getProperty(LOGGER_IMPL_PROPERTY_NAME, "log4j");
+        switch (loggingType) {
+            case "slf4j":
+                return new Slf4jESLoggerFactory();
+            case "jdk":
+                return new JdkESLoggerFactory();
+            case "log4j":
+                return new Log4jESLoggerFactory();
+            default:
+                throw new IllegalArgumentException("Unknown logger impl configured: " + LOGGER_IMPL_PROPERTY_NAME + "[" + loggingType + "]");
         }
-
-        return null;
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/common/logging/ESLoggerFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/common/logging/ESLoggerFactoryTests.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.elasticsearch.common.logging.jdk.JdkESLoggerFactory;
+import org.elasticsearch.common.logging.log4j.Log4jESLoggerFactory;
+import org.elasticsearch.common.logging.slf4j.Slf4jESLoggerFactory;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+import static org.hamcrest.Matchers.*;
+
+public class ESLoggerFactoryTests extends ElasticsearchTestCase {
+
+    public void testThatLoggerFactoryCanBeConfigured() {
+        System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "slf4j");
+        assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), instanceOf(Slf4jESLoggerFactory.class));
+
+        System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "log4j");
+        assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), instanceOf(Log4jESLoggerFactory.class));
+
+        System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "jdk");
+        assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), instanceOf(JdkESLoggerFactory.class));
+
+        System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "unknown");
+        assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), is(nullValue()));
+
+        System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "");
+        assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), is(nullValue()));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/common/logging/ESLoggerFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/common/logging/ESLoggerFactoryTests.java
@@ -37,12 +37,24 @@ public class ESLoggerFactoryTests extends ElasticsearchTestCase {
 
         System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "jdk");
         assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), instanceOf(JdkESLoggerFactory.class));
+    }
 
-        System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "unknown");
-        assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), is(nullValue()));
+    public void testThatUnknownLoggingFactoryThrowsException() {
+        try {
+            System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "unknown");
+            assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), is(nullValue()));
+            fail("Expected to fail but didnt with unknown logging type");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("unknown"));
+        }
 
-        System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "");
-        assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), is(nullValue()));
+        try {
+            System.setProperty(ESLoggerFactory.LOGGER_IMPL_PROPERTY_NAME, "");
+            assertThat(ESLoggerFactory.getConfiguredEsLoggerFactory(), is(nullValue()));
+            fail("Expected to fail but didnt with unset logging type");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("[]"));
+        }
     }
 
 }

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -390,3 +390,16 @@ deprecation: DEBUG, deprecation_log_file
 This will create a daily rolling deprecation log file in your log directory.
 Check this file regularly, especially when you intend to upgrade to a new
 major version.
+
+[float]
+[[changing-logging-technology]]
+==== Using a different logging framework.
+
+Earlier Elasticsearch releases tried to load classes to find out which logging
+implementation to use. This caused problems, when a logging technology had a
+bridging implementation to another logging framework. In order to solve this,
+the logging framework now needs to be configured via a system property named
+`es.logger.impl` manually. By default, `log4j` is used and loaded, but you
+can change this to `slf4j` or `jdk` if you want to. Note: If you do not have
+log4j available, elasticsearch will not start up, if you do not change the
+property up front.


### PR DESCRIPTION
Due to the mechanism to automatically select an existing logging
factory on startup this might clash with packages that bridge to
existing logging mechanisms.

In order to be more explicit this commit allows to set the
es.logger.impl property to explicitely configure a JDK, log4j or slf4j
logging factory.

Closes #11423
