### PR TITLE
Store filter cache statistics at the shard level instead of index.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/cache/IndexCache.java
+++ b/core/src/main/java/org/elasticsearch/index/cache/IndexCache.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.cache;
 
-import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -38,23 +37,17 @@ import java.io.IOException;
 public class IndexCache extends AbstractIndexComponent implements Closeable {
 
     private final QueryCache queryCache;
-    private final QueryCachingPolicy queryCachingPolicy;
     private final BitsetFilterCache bitsetFilterCache;
 
     @Inject
-    public IndexCache(Index index, @IndexSettings Settings indexSettings, QueryCache queryCache, QueryCachingPolicy queryCachingPolicy, BitsetFilterCache bitsetFilterCache) {
+    public IndexCache(Index index, @IndexSettings Settings indexSettings, QueryCache queryCache, BitsetFilterCache bitsetFilterCache) {
         super(index, indexSettings);
         this.queryCache = queryCache;
-        this.queryCachingPolicy = queryCachingPolicy;
         this.bitsetFilterCache = bitsetFilterCache;
     }
 
     public QueryCache query() {
         return queryCache;
-    }
-
-    public QueryCachingPolicy queryPolicy() {
-        return queryCachingPolicy;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/cache/query/QueryCacheModule.java
+++ b/core/src/main/java/org/elasticsearch/index/cache/query/QueryCacheModule.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.cache.query;
 
-import org.apache.lucene.search.QueryCachingPolicy;
-import org.apache.lucene.search.UsageTrackingQueryCachingPolicy;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Scopes;
 import org.elasticsearch.common.settings.Settings;
@@ -48,13 +46,5 @@ public class QueryCacheModule extends AbstractModule {
         bind(QueryCache.class)
                 .to(settings.getAsClass(QueryCacheSettings.QUERY_CACHE_TYPE, IndexQueryCache.class, "org.elasticsearch.index.cache.query.", "QueryCache"))
                 .in(Scopes.SINGLETON);
-        // the query cache is a node-level thing, however we want the most popular queries
-        // to be computed on a per-index basis, that is why we don't use the SINGLETON
-        // scope below
-        if (settings.getAsBoolean(QueryCacheSettings.QUERY_CACHE_EVERYTHING, false)) {
-            bind(QueryCachingPolicy.class).toInstance(QueryCachingPolicy.ALWAYS_CACHE);
-        } else {
-            bind(QueryCachingPolicy.class).toInstance(new UsageTrackingQueryCachingPolicy());
-        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
@@ -373,8 +374,9 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         contextProcessing(context);
         try {
             final IndexCache indexCache = context.indexShard().indexService().cache();
+            final QueryCachingPolicy cachingPolicy = context.indexShard().engine().config().getQueryCachingPolicy();
             context.searcher().dfSource(new CachedDfSource(context.searcher().getIndexReader(), request.dfs(), context.similarityService().similarity(),
-                    indexCache.query(), indexCache.queryPolicy()));
+                    indexCache.query(), cachingPolicy));
         } catch (Throwable e) {
             processFailure(context, e);
             cleanContext(context);
@@ -447,8 +449,9 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         contextProcessing(context);
         try {
             final IndexCache indexCache = context.indexShard().indexService().cache();
+            final QueryCachingPolicy cachingPolicy = context.indexShard().engine().config().getQueryCachingPolicy();
             context.searcher().dfSource(new CachedDfSource(context.searcher().getIndexReader(), request.dfs(), context.similarityService().similarity(),
-                    indexCache.query(), indexCache.queryPolicy()));
+                    indexCache.query(), cachingPolicy));
         } catch (Throwable e) {
             freeContext(context.id());
             cleanContext(context);


### PR DESCRIPTION
Today we keep track of how often filters are used at the index level in order
to decide whether they should be cached or not. This is an issue if you have
several shards of the same index on the same node as it will multiply statistics
by the number of shards that you have for this index on the node, which defeats
the purpose of waiting for a filter to be reused before caching it.
