### PR TITLE
core-types.asciidoc, fielddata.asciidoc: replace "faceting" with "aggregating"

### DIFF
--- a/docs/reference/index-modules/fielddata.asciidoc
+++ b/docs/reference/index-modules/fielddata.asciidoc
@@ -1,7 +1,7 @@
 [[index-modules-fielddata]]
 == Field data
 
-The field data cache is used mainly when sorting on or faceting on a
+The field data cache is used mainly when sorting on or aggregating on a
 field. It loads all the field values to memory in order to provide fast
 document based access to those values. The field data cache can be
 expensive to build for a field, so its recommended to have enough memory

--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -498,7 +498,7 @@ default and can't be disabled).
 ==== Fielddata filters
 
 It is possible to control which field values are loaded into memory,
-which is particularly useful for faceting on string fields, using
+which is particularly useful for aggregating on string fields, using
 fielddata filters, which are explained in detail in the
 <<index-modules-fielddata,Fielddata>> section.
 


### PR DESCRIPTION
Replaced "faceting" with "aggregating" because facets were deprecated. It seems to me that this change makes reading more clear, pointing to appropriate Elasticsearch module (instead of using the term 'faceting' that refers to the deprecated module - this can confuse reader).
