### PR TITLE
Treat path object as a simple value instead of Iterable in XContentBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -651,36 +651,34 @@ public final class XContentBuilder implements BytesStream, Releasable {
         value(value);
         return this;
     }
-    
-    public XContentBuilder field(String name, Path value) throws IOException {
-        //treat as single value, even though Path implements Iterable
-        field(name);
-        value(value);
-        return this;
-    }
 
-    public XContentBuilder field(String name, Iterable value) throws IOException {
-        startArray(name);
-        for (Object o : value) {
-            value(o);
+    public XContentBuilder field(String name, Iterable<?> value) throws IOException {
+        if (value instanceof Path) {
+            //treat Paths as single value
+            field(name);
+            value(value);            
+        } else {
+            startArray(name);
+            for (Object o : value) {
+                value(o);
+            }
+            endArray();
         }
-        endArray();
         return this;
     }
 
-    public XContentBuilder field(XContentBuilderString name, Path value) throws IOException {
-        //treat as single value, even though Path implements Iterable
-        field(name);
-        value(value);
-        return this;
-    }
-
-    public XContentBuilder field(XContentBuilderString name, Iterable value) throws IOException {
-        startArray(name);
-        for (Object o : value) {
-            value(o);
+    public XContentBuilder field(XContentBuilderString name, Iterable<?> value) throws IOException {
+        if (value instanceof Path) {
+            //treat Paths as single value
+            field(name);
+            value(value);            
+        } else {
+            startArray(name);
+            for (Object o : value) {
+                value(o);
+            }
+            endArray();
         }
-        endArray();
         return this;
     }
 
@@ -1156,21 +1154,20 @@ public final class XContentBuilder implements BytesStream, Releasable {
         return this;
     }
 
-    public XContentBuilder value(Path value) throws IOException {
-        //treat as single value
-        writeValue(value);
-        return this;
-    }
-
-    public XContentBuilder value(Iterable value) throws IOException {
+    public XContentBuilder value(Iterable<?> value) throws IOException {
         if (value == null) {
             return nullValue();
         }
-        startArray();
-        for (Object o : value) {
-            value(o);
+        if (value instanceof Path) {
+            //treat as single value
+            writeValue(value);
+        } else {
+            startArray();
+            for (Object o : value) {
+                value(o);
+            }
+            endArray();
         }
-        endArray();
         return this;
     }
 
@@ -1253,7 +1250,7 @@ public final class XContentBuilder implements BytesStream, Releasable {
             generator.writeNull();
             return;
         }
-        Class type = value.getClass();
+        Class<?> type = value.getClass();
         if (type == String.class) {
             generator.writeString((String) value);
         } else if (type == Integer.class) {
@@ -1282,7 +1279,7 @@ public final class XContentBuilder implements BytesStream, Releasable {
             generator.writeString(value.toString());            
         } else if (value instanceof Iterable) {
             generator.writeStartArray();
-            for (Object v : (Iterable) value) {
+            for (Object v : (Iterable<?>) value) {
                 writeValue(v);
             }
             generator.writeEndArray();

--- a/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -20,14 +20,17 @@
 package org.elasticsearch.common.xcontent.builder;
 
 import com.google.common.collect.Lists;
+
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.FastCharArrayWriter;
+import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 
 import static org.elasticsearch.common.xcontent.XContentBuilder.FieldCaseConversion.CAMELCASE;
@@ -260,4 +263,36 @@ public class XContentBuilderTests extends ElasticsearchTestCase {
 
         assertThat(i, equalTo(terms.size()));
     }
+
+    @Test
+    public void testHandlingOfPath() throws IOException {
+        Path path = PathUtils.get("path");
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);        
+        builder.startObject().field("file", path).endObject();
+
+        assertThat(builder.string(), equalTo("{\"file\":\"path\"}"));
+    }
+
+    @Test
+    public void testHandlingOfPath_XContentBuilderStringName() throws IOException {
+        Path path = PathUtils.get("path");        
+        XContentBuilderString name = new XContentBuilderString("file");
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        builder.startObject().field(name, path).endObject();
+
+        assertThat(builder.string(), equalTo("{\"file\":\"path\"}"));
+    }
+
+    @Test
+    public void testHandlingOfCollectionOfPaths() throws IOException {
+        Path path = PathUtils.get("path");
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+
+        builder.startObject().field("file", Arrays.asList(path)).endObject();
+
+        assertThat(builder.string(), equalTo("{\"file\":[\"path\"]}"));
+    }
+    
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 
-import static org.apache.commons.lang3.StringEscapeUtils.escapeJson;
 import static org.elasticsearch.common.xcontent.XContentBuilder.FieldCaseConversion.CAMELCASE;
 import static org.elasticsearch.common.xcontent.XContentBuilder.FieldCaseConversion.UNDERSCORE;
 import static org.hamcrest.Matchers.equalTo;
@@ -284,10 +283,13 @@ public class XContentBuilderTests extends ElasticsearchTestCase {
     }     
 
     private void checkPathSerialization(Path path) throws IOException {
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);        
-        builder.startObject().field("file", path).endObject();
-
-        assertThat(builder.string(), equalTo("{\"file\":\""+escapeJson(path.toString())+"\"}"));
+        XContentBuilder pathBuilder = XContentFactory.contentBuilder(XContentType.JSON);        
+        pathBuilder.startObject().field("file", path).endObject();
+        
+        XContentBuilder stringBuilder = XContentFactory.contentBuilder(XContentType.JSON);        
+        stringBuilder.startObject().field("file", path.toString()).endObject();
+        
+        assertThat(pathBuilder.string(), equalTo(stringBuilder.string()));
     }
 
     @Test
@@ -295,20 +297,26 @@ public class XContentBuilderTests extends ElasticsearchTestCase {
         Path path = PathUtils.get("path");        
         XContentBuilderString name = new XContentBuilderString("file");
 
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
-        builder.startObject().field(name, path).endObject();
+        XContentBuilder pathBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        pathBuilder.startObject().field(name, path).endObject();
 
-        assertThat(builder.string(), equalTo("{\"file\":\""+escapeJson(path.toString())+"\"}"));
+        XContentBuilder stringBuilder = XContentFactory.contentBuilder(XContentType.JSON);        
+        stringBuilder.startObject().field(name, path.toString()).endObject();
+        
+        assertThat(pathBuilder.string(), equalTo(stringBuilder.string()));
     }
 
     @Test
     public void testHandlingOfCollectionOfPaths() throws IOException {
         Path path = PathUtils.get("path");
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        
+        XContentBuilder pathBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        pathBuilder.startObject().field("file", Arrays.asList(path)).endObject();
 
-        builder.startObject().field("file", Arrays.asList(path)).endObject();
-
-        assertThat(builder.string(), equalTo("{\"file\":[\""+escapeJson(path.toString())+"\"]}"));
+        XContentBuilder stringBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        stringBuilder.startObject().field("file", Arrays.asList(path.toString())).endObject();
+        
+        assertThat(pathBuilder.string(), equalTo(stringBuilder.string()));
     }
     
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 
+import static org.apache.commons.lang3.StringEscapeUtils.escapeJson;
 import static org.elasticsearch.common.xcontent.XContentBuilder.FieldCaseConversion.CAMELCASE;
 import static org.elasticsearch.common.xcontent.XContentBuilder.FieldCaseConversion.UNDERSCORE;
 import static org.hamcrest.Matchers.equalTo;
@@ -271,8 +272,18 @@ public class XContentBuilderTests extends ElasticsearchTestCase {
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);        
         builder.startObject().field("file", path).endObject();
 
-        assertThat(builder.string(), equalTo("{\"file\":\"path\"}"));
-    }
+        assertThat(builder.string(), equalTo("{\"file\":\""+escapeJson(path.toString())+"\"}"));
+    }   
+
+    @Test
+    public void testHandlingOfPath_relative() throws IOException {
+        Path path = PathUtils.get("..", "..", "path");
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);        
+        builder.startObject().field("file", path).endObject();
+
+        assertThat(builder.string(), equalTo("{\"file\":\""+escapeJson(path.toString())+"\"}"));
+    }        
 
     @Test
     public void testHandlingOfPath_XContentBuilderStringName() throws IOException {
@@ -282,7 +293,7 @@ public class XContentBuilderTests extends ElasticsearchTestCase {
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         builder.startObject().field(name, path).endObject();
 
-        assertThat(builder.string(), equalTo("{\"file\":\"path\"}"));
+        assertThat(builder.string(), equalTo("{\"file\":\""+escapeJson(path.toString())+"\"}"));
     }
 
     @Test
@@ -292,7 +303,7 @@ public class XContentBuilderTests extends ElasticsearchTestCase {
 
         builder.startObject().field("file", Arrays.asList(path)).endObject();
 
-        assertThat(builder.string(), equalTo("{\"file\":[\"path\"]}"));
+        assertThat(builder.string(), equalTo("{\"file\":[\""+escapeJson(path.toString())+"\"]}"));
     }
     
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -268,22 +268,27 @@ public class XContentBuilderTests extends ElasticsearchTestCase {
     @Test
     public void testHandlingOfPath() throws IOException {
         Path path = PathUtils.get("path");
-
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);        
-        builder.startObject().field("file", path).endObject();
-
-        assertThat(builder.string(), equalTo("{\"file\":\""+escapeJson(path.toString())+"\"}"));
-    }   
+        checkPathSerialization(path);
+    }
 
     @Test
     public void testHandlingOfPath_relative() throws IOException {
         Path path = PathUtils.get("..", "..", "path");
+        checkPathSerialization(path);
+    }
 
+    @Test
+    public void testHandlingOfPath_absolute() throws IOException {
+        Path path = createTempDir().toAbsolutePath();
+        checkPathSerialization(path);
+    }     
+
+    private void checkPathSerialization(Path path) throws IOException {
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);        
         builder.startObject().field("file", path).endObject();
 
         assertThat(builder.string(), equalTo("{\"file\":\""+escapeJson(path.toString())+"\"}"));
-    }        
+    }
 
     @Test
     public void testHandlingOfPath_XContentBuilderStringName() throws IOException {


### PR DESCRIPTION
Treat path object as a simple value objects instead of Iterable in XContentBuilder, using toString() to create String representation.

This addresses #11771
