### PR TITLE
Add `min` score mode to `nested` query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NestedQueryParser.java
@@ -87,6 +87,8 @@ public class NestedQueryParser implements QueryParser {
                     String sScoreMode = parser.text();
                     if ("avg".equals(sScoreMode)) {
                         scoreMode = ScoreMode.Avg;
+                    } else if ("min".equals(sScoreMode)) {
+                        scoreMode = ScoreMode.Min;
                     } else if ("max".equals(sScoreMode)) {
                         scoreMode = ScoreMode.Max;
                     } else if ("total".equals(sScoreMode) || "sum".equals(sScoreMode)) {

--- a/docs/reference/query-dsl/nested-query.asciidoc
+++ b/docs/reference/query-dsl/nested-query.asciidoc
@@ -52,8 +52,8 @@ fields referenced inside the query must use the complete path (fully
 qualified).
 
 The `score_mode` allows to set how inner children matching affects
-scoring of parent. It defaults to `avg`, but can be `sum`, `max` and
-`none`.
+scoring of parent. It defaults to `avg`, but can be `sum`, `min`,
+`max` and `none`.
 
 Multi level nesting is automatically supported, and detected, resulting
 in an inner nested query to automatically match the relevant nesting


### PR DESCRIPTION
This score mode was added with the Lucene 5.2 release, but the `nested` query parser hasn't been changed to use it.
