### PR TITLE
Don't convert possibly corrupted bytes to UTF-8

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
@@ -233,8 +233,9 @@ public abstract class TranslogReader implements Closeable, Comparable<TranslogRe
                         BytesRef ref = new BytesRef(len);
                         ref.length = len;
                         headerStream.read(ref.bytes, ref.offset, ref.length);
-                        if (ref.utf8ToString().equals(translogUUID) == false) {
-                            throw new TranslogCorruptedException("expected shard UUID [" + translogUUID + "] but got: [" + ref.utf8ToString() + "] this translog file belongs to a different translog");
+                        BytesRef uuidBytes = new BytesRef(translogUUID);
+                        if (uuidBytes.bytesEquals(ref) == false) {
+                            throw new TranslogCorruptedException("expected shard UUID [" + uuidBytes + "] but got: [" + ref + "] this translog file belongs to a different translog");
                         }
                         return new ImmutableTranslogReader(channelReference.getGeneration(), channelReference, ref.length + CodecUtil.headerLength(TranslogWriter.TRANSLOG_CODEC) + RamUsageEstimator.NUM_BYTES_INT, checkpoint.offset, checkpoint.numOps);
                     default:


### PR DESCRIPTION
If the translog UUID is corrupted we should not convert it
to UTF-8 since it might be invalid. Instead we should compare
the UTF-8 byte representation directly.

this failed on jenkins last weekend here http://build-us-00.elastic.co/job/es_core_master_debian/5924/
the seed fails without this fix:

```
mvn test -Pdev -Dtests.seed=EDA6944EE3C55BD1 -Dtests.class=org.elasticsearch.index.store.CorruptedTranslogTests -Dtests.method="testCorruptTranslogFiles" -Des.logger.level=DEBUG -Des.node.mode=network -Dtests.assertion.disabled=false -Dtests.security.manager=true -Dtests.nightly=false -Dtests.heap.size=512m -Dtests.locale=sr_RS -Dtests.timezone=WET
```
