### PR TITLE
Build: If SHA files have changed, explain how to update them in the license check exception

### DIFF
--- a/dev-tools/src/main/resources/license-check/check_license_and_sha.pl
+++ b/dev-tools/src/main/resources/license-check/check_license_and_sha.pl
@@ -28,18 +28,22 @@ sub check_shas_and_licenses {
     my %licenses = get_files_with('LICENSE');
     my %notices  = get_files_with('NOTICE');
 
-    my $error = 0;
+    my $error     = 0;
+    my $sha_error = 0;
+
     for my $jar ( sort keys %new ) {
         my $old_sha = delete $old{$jar};
         unless ($old_sha) {
             say STDERR "$jar: SHA is missing";
             $error++;
+            $sha_error++;
             next;
         }
 
         unless ( $old_sha eq $new{$jar} ) {
             say STDERR "$jar: SHA has changed";
             $error++;
+            $sha_error++;
             next;
         }
 
@@ -67,6 +71,7 @@ sub check_shas_and_licenses {
         unless ($license_found) {
             say STDERR "$jar: LICENSE is missing";
             $error++;
+            $sha_error++;
         }
         unless ($notice_found) {
             say STDERR "$jar: NOTICE is missing";
@@ -89,6 +94,16 @@ sub check_shas_and_licenses {
     if (@unused_notices) {
         say STDERR "Extra NOTICE file present: " . join ", ",
             sort @unused_notices;
+    }
+
+    if ($sha_error) {
+        say STDERR <<"SHAS"
+
+You can update the SHA files by running:
+
+    $0 --update core
+
+SHAS
     }
 
     exit $error;


### PR DESCRIPTION
If SHA files have changed or been added or removed (ie the dependencies have changed), the 
license check utility now throws an exception explaining what command to run in order to update
the list of SHA files.
