### PR TITLE
Fail engine without marking it as corrupt when recovering on SharedFS

### DIFF
--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -195,6 +195,21 @@ public final class ExceptionsHelper {
     }
 
     /**
+     * Returns <code>true</code> iff the given throwable is an IOException
+     * for running out of disk, otherwise <code>false</code>
+     */
+    public static boolean isOutOfDisk(Throwable t) {
+        if (t != null && t instanceof IOException && t.getMessage() != null) {
+            if (t.getMessage().equalsIgnoreCase("There is not enough space on the disk") // Windows
+                || t.getMessage().equalsIgnoreCase("Not enough space") // POSIX
+                || t.getMessage().equalsIgnoreCase("No space left on device")) { // GNU compiler
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns <code>true</code> iff the given throwable is and OutOfMemoryException, otherwise <code>false</code>
      */
     public static boolean isOOM(Throwable t) {

--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -195,21 +195,6 @@ public final class ExceptionsHelper {
     }
 
     /**
-     * Returns <code>true</code> iff the given throwable is an IOException
-     * for running out of disk, otherwise <code>false</code>
-     */
-    public static boolean isOutOfDisk(Throwable t) {
-        if (t != null && t instanceof IOException && t.getMessage() != null) {
-            if (t.getMessage().equalsIgnoreCase("There is not enough space on the disk") // Windows
-                || t.getMessage().equalsIgnoreCase("Not enough space") // POSIX
-                || t.getMessage().equalsIgnoreCase("No space left on device")) { // GNU compiler
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * Returns <code>true</code> iff the given throwable is and OutOfMemoryException, otherwise <code>false</code>
      */
     public static boolean isOOM(Throwable t) {

--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -510,7 +510,10 @@ public abstract class Engine implements Closeable {
      */
     public abstract SnapshotIndexCommit snapshotIndex(boolean flushFirst) throws EngineException;
 
-    /** fail engine due to some error. the engine will also be closed. */
+    /**
+     * fail engine due to some error. the engine will also be closed.
+     * The engine is marked corrupted iff failure is caused by index corruption
+     */
     public void failEngine(String reason, Throwable failure) {
         assert failure != null;
         if (failEngineLock.tryLock()) {
@@ -519,17 +522,6 @@ public abstract class Engine implements Closeable {
                 try {
                     // we just go and close this engine - no way to recover
                     closeNoLock("engine failed on: [" + reason + "]");
-                    // we first mark the store as corrupted before we notify any listeners
-                    // this must happen first otherwise we might try to reallocate so quickly
-                    // on the same node that we don't see the corrupted marker file when
-                    // the shard is initializing
-                    if (Lucene.isCorruptionException(failure)) {
-                        try {
-                            store.markStoreCorrupted(ExceptionsHelper.unwrapCorruption(failure));
-                        } catch (IOException e) {
-                            logger.warn("Couldn't marks store corrupted", e);
-                        }
-                    }
                 } finally {
                     if (failedEngine != null) {
                         logger.debug("tried to fail engine but engine is already failed. ignoring. [{}]", reason, failure);
@@ -538,6 +530,17 @@ public abstract class Engine implements Closeable {
                     logger.warn("failed engine [{}]", failure, reason);
                     // we must set a failure exception, generate one if not supplied
                     failedEngine = failure;
+                    // we first mark the store as corrupted before we notify any listeners
+                    // this must happen first otherwise we might try to reallocate so quickly
+                    // on the same node that we don't see the corrupted marker file when
+                    // the shard is initializing
+                    if (Lucene.isCorruptionException(failure)) {
+                        try {
+                            store.markStoreCorrupted(new IOException("failed engine (reason: [" + reason + "])", ExceptionsHelper.unwrapCorruption(failure)));
+                        } catch (IOException e) {
+                            logger.warn("Couldn't mark store corrupted", e);
+                        }
+                    }
                     failedEngineListener.onFailedEngine(shardId, reason, failure);
                 }
             } catch (Throwable t) {
@@ -557,7 +560,10 @@ public abstract class Engine implements Closeable {
             failEngine("corrupt file detected source: [" + source + "]", t);
             return true;
         } else if (ExceptionsHelper.isOOM(t)) {
-            failEngine("out of memory", t);
+            failEngine("out of memory detected source: [" + source + "]", t);
+            return true;
+        } else if (ExceptionsHelper.isOutOfDisk(t)) {
+            failEngine("out of disk space detected source: [" + source + "]", t);
             return true;
         }
         return false;

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -741,6 +741,10 @@ public class IndexShard extends AbstractIndexShardComponent {
         }
     }
 
+    /**
+     * Fails the shard and marks the engine as corrupted if
+     * <code>e</code> is caused by index corruption
+     */
     public void failShard(String reason, Throwable e) {
         // fail the engine. This will cause this shard to also be removed from the node's index service.
         engine().failEngine(reason, e);
@@ -1271,18 +1275,11 @@ public class IndexShard extends AbstractIndexShardComponent {
         // called by the current engine
         @Override
         public void onFailedEngine(ShardId shardId, String reason, @Nullable Throwable failure) {
-            try {
-                // mark as corrupted, so opening the store will fail
-                store.markStoreCorrupted(new IOException("failed engine (reason: [" + reason + "])", failure));
-            } catch (IOException e) {
-                logger.warn("failed to mark shard store as corrupted", e);
-            } finally {
-                for (Engine.FailedEngineListener listener : delegates) {
-                    try {
-                        listener.onFailedEngine(shardId, reason, failure);
-                    } catch (Exception e) {
-                        logger.warn("exception while notifying engine failure", e);
-                    }
+            for (Engine.FailedEngineListener listener : delegates) {
+                try {
+                    listener.onFailedEngine(shardId, reason, failure);
+                } catch (Exception e) {
+                    logger.warn("exception while notifying engine failure", e);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -742,10 +742,10 @@ public class IndexShard extends AbstractIndexShardComponent {
     }
 
     /**
-     * Fails the shard and marks the engine as corrupted if
+     * Fails the shard and marks the shard store as corrupted if
      * <code>e</code> is caused by index corruption
      */
-    public void failShard(String reason, Throwable e) {
+    public void failShard(String reason, @Nullable Throwable e) {
         // fail the engine. This will cause this shard to also be removed from the node's index service.
         engine().failEngine(reason, e);
     }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
@@ -68,8 +68,8 @@ public class SharedFSRecoverySourceHandler extends RecoverySourceHandler {
                 // that case, fail the shard to reallocate a new IndexShard and
                 // create a new IndexWriter
                 logger.info("recovery failed for primary shadow shard, failing shard");
-                // close the IndexWriter but don't mark store as corrupted
-                shard.failShard("primary relocation failed on shared filesystem", t);
+                // pass the failure as null, as we want to ensure the store is not marked as corrupted
+                shard.failShard("primary relocation failed on shared filesystem caused by: [" + t.getMessage() + "]", null);
             } else {
                 logger.info("recovery failed on shared filesystem", t);
             }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/SharedFSRecoverySourceHandler.java
@@ -68,6 +68,7 @@ public class SharedFSRecoverySourceHandler extends RecoverySourceHandler {
                 // that case, fail the shard to reallocate a new IndexShard and
                 // create a new IndexWriter
                 logger.info("recovery failed for primary shadow shard, failing shard");
+                // close the IndexWriter but don't mark store as corrupted
                 shard.failShard("primary relocation failed on shared filesystem", t);
             } else {
                 logger.info("recovery failed on shared filesystem", t);

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasTests.java
@@ -647,7 +647,6 @@ public class IndexWithShadowReplicasTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/11788")
     public void testIndexOnSharedFSRecoversToAnyNode() throws Exception {
         Settings nodeSettings = nodeSettings();
         Settings fooSettings = Settings.builder().put(nodeSettings).put("node.affinity", "foo").build();

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.shard;
 
+import org.apache.lucene.index.CorruptIndexException;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
@@ -214,7 +215,7 @@ public class IndexShardTests extends ElasticsearchSingleNodeTest {
         IndexService test = indicesService.indexService("test");
         IndexShard shard = test.shard(0);
         // fail shard
-        shard.failShard("test shard fail", new IOException("corrupted"));
+        shard.failShard("test shard fail", new CorruptIndexException("", ""));
         // check state file still exists
         ShardStateMetaData shardStateMetaData = load(logger, env.availableShardPaths(shard.shardId));
         assertEquals(shardStateMetaData, getShardStateMetadata(shard));


### PR DESCRIPTION
Currently when an engine is failed, it is marked as corrupted regardless of
the failure type. This change marks the engine as corrupted only when the failure
is caused by an actual index corruption. When an engine is failed for other
reasons, the engine is only closed without removing the shard state.

closes #11788
