### PR TITLE
Release: Build two RPMS, signed and unsigned

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -819,7 +819,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>rpm-maven-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>2.1.3</version>
                 <configuration>
                     <distribution>Elasticsearch</distribution>
                     <group>Application/Internet</group>
@@ -834,11 +834,6 @@
                     <defaultDirmode>755</defaultDirmode>
                     <defaultUsername>root</defaultUsername>
                     <defaultGroupname>root</defaultGroupname>
-                    <keyname>${gpg.key}</keyname>
-                    <keypath>${gpg.keyring}</keypath>
-                    <keyPassphrase>
-                        <passphrase>${gpg.passphrase}</passphrase>
-                    </keyPassphrase>
                     <mappings>
                         <!-- Add bin directory -->
                         <mapping>
@@ -1100,6 +1095,30 @@
                 </property>
             </activation>
             <!-- not including license-maven-plugin is sufficent to expose default license -->
+        </profile>
+        <profile>
+            <id>sign-rpm</id>
+            <activation>
+                <property>
+                    <name>rpm.sign</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                        <configuration>
+                            <keyname>${gpg.key}</keyname>
+                            <keypath>${gpg.keyring}</keypath>
+                            <keyPassphrase>
+                                <passphrase>${gpg.passphrase}</passphrase>
+                            </keyPassphrase>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
In order to support older RPM based distributions like CentOS5,
we should have one RPM available, which is not signed.

This commit creates an unsigned RPM first, then moves it over to
target/releases during the build, then builds a signed RPM.

The unsigned one is uploaded via S3, where as the signed one is
used for the repositories.

In addition, you can now build an RPM without having to specify
any gpg credentials due to offloading this into a maven profile
that is only activated when specifying `rpm.sign` property.

Closes #11587
