### PR TITLE
Aggregations: Makes ValueFormat and ValueFormatter never null

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketStreamContext.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketStreamContext.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -31,7 +30,6 @@ import java.util.Map;
 
 public class BucketStreamContext implements Streamable {
 
-    @Nullable
     private ValueFormatter formatter;
     private boolean keyed;
     private Map<String, Object> attributes;
@@ -39,7 +37,7 @@ public class BucketStreamContext implements Streamable {
     public BucketStreamContext() {
     }
 
-    public void formatter(@Nullable ValueFormatter formatter) {
+    public void formatter(ValueFormatter formatter) {
         this.formatter = formatter;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregator.java
@@ -47,7 +47,7 @@ import java.util.Map;
 public class HistogramAggregator extends BucketsAggregator {
 
     private final ValuesSource.Numeric valuesSource;
-    private final @Nullable ValueFormatter formatter;
+    private final ValueFormatter formatter;
     private final Rounding rounding;
     private final InternalOrder order;
     private final boolean keyed;
@@ -58,11 +58,10 @@ public class HistogramAggregator extends BucketsAggregator {
 
     private final LongHash bucketOrds;
 
-    public HistogramAggregator(String name, AggregatorFactories factories, Rounding rounding, InternalOrder order,
-                               boolean keyed, long minDocCount, @Nullable ExtendedBounds extendedBounds,
-                               @Nullable ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
-                               InternalHistogram.Factory<?> histogramFactory, AggregationContext aggregationContext,
-                               Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
+    public HistogramAggregator(String name, AggregatorFactories factories, Rounding rounding, InternalOrder order, boolean keyed,
+            long minDocCount, @Nullable ExtendedBounds extendedBounds, @Nullable ValuesSource.Numeric valuesSource,
+            ValueFormatter formatter, InternalHistogram.Factory<?> histogramFactory, AggregationContext aggregationContext,
+            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
 
         super(name, factories, aggregationContext, parent, pipelineAggregators, metaData);
         this.rounding = rounding;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.InternalAggregation.Type;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -35,11 +34,11 @@ public class InternalDateHistogram {
 
     static class Bucket extends InternalHistogram.Bucket {
 
-        Bucket(boolean keyed, @Nullable ValueFormatter formatter, InternalHistogram.Factory<Bucket> factory) {
+        Bucket(boolean keyed, ValueFormatter formatter, InternalHistogram.Factory<Bucket> factory) {
             super(keyed, formatter, factory);
         }
 
-        Bucket(long key, long docCount, InternalAggregations aggregations, boolean keyed, @Nullable ValueFormatter formatter,
+        Bucket(long key, long docCount, InternalAggregations aggregations, boolean keyed, ValueFormatter formatter,
                 InternalHistogram.Factory<Bucket> factory) {
             super(key, docCount, keyed, formatter, factory, aggregations);
         }
@@ -77,7 +76,7 @@ public class InternalDateHistogram {
 
         @Override
         public InternalDateHistogram.Bucket createBucket(Object key, long docCount, InternalAggregations aggregations, boolean keyed,
-                @Nullable ValueFormatter formatter) {
+                ValueFormatter formatter) {
             if (key instanceof Number) {
                 return new Bucket(((Number) key).longValue(), docCount, aggregations, keyed, formatter, this);
             } else if (key instanceof DateTime) {
@@ -88,7 +87,7 @@ public class InternalDateHistogram {
         }
 
         @Override
-        protected InternalDateHistogram.Bucket createEmptyBucket(boolean keyed, @Nullable ValueFormatter formatter) {
+        protected InternalDateHistogram.Bucket createEmptyBucket(boolean keyed, ValueFormatter formatter) {
             return new Bucket(keyed, formatter, this);
         }
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Lists;
 
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.PriorityQueue;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.rounding.Rounding;
@@ -98,16 +97,16 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
         long docCount;
         InternalAggregations aggregations;
         private transient final boolean keyed;
-        protected transient final @Nullable ValueFormatter formatter;
+        protected transient final ValueFormatter formatter;
         private Factory<?> factory;
 
-        public Bucket(boolean keyed, @Nullable ValueFormatter formatter, Factory<?> factory) {
+        public Bucket(boolean keyed, ValueFormatter formatter, Factory<?> factory) {
             this.formatter = formatter;
             this.keyed = keyed;
             this.factory = factory;
         }
 
-        public Bucket(long key, long docCount, boolean keyed, @Nullable ValueFormatter formatter, Factory factory,
+        public Bucket(long key, long docCount, boolean keyed, ValueFormatter formatter, Factory factory,
                 InternalAggregations aggregations) {
             this(keyed, formatter, factory);
             this.key = key;
@@ -152,7 +151,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            if (formatter != null && formatter != ValueFormatter.RAW) {
+            if (formatter != ValueFormatter.RAW) {
                 Text keyTxt = new StringText(formatter.format(key));
                 if (keyed) {
                     builder.startObject(keyTxt.string());
@@ -243,7 +242,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
         }
 
         public InternalHistogram<B> create(String name, List<B> buckets, InternalOrder order, long minDocCount,
-                EmptyBucketInfo emptyBucketInfo, @Nullable ValueFormatter formatter, boolean keyed,
+                EmptyBucketInfo emptyBucketInfo, ValueFormatter formatter, boolean keyed,
                 List<PipelineAggregator> pipelineAggregators,
                 Map<String, Object> metaData) {
             return new InternalHistogram<>(name, buckets, order, minDocCount, emptyBucketInfo, formatter, keyed, this, pipelineAggregators,
@@ -259,8 +258,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
             return (B) new Bucket(prototype.key, prototype.docCount, prototype.getKeyed(), prototype.formatter, this, aggregations);
         }
 
-        public B createBucket(Object key, long docCount, InternalAggregations aggregations, boolean keyed,
-                @Nullable ValueFormatter formatter) {
+        public B createBucket(Object key, long docCount, InternalAggregations aggregations, boolean keyed, ValueFormatter formatter) {
             if (key instanceof Number) {
                 return (B) new Bucket(((Number) key).longValue(), docCount, keyed, formatter, this, aggregations);
             } else {
@@ -268,7 +266,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
             }
         }
 
-        protected B createEmptyBucket(boolean keyed, @Nullable ValueFormatter formatter) {
+        protected B createEmptyBucket(boolean keyed, ValueFormatter formatter) {
             return (B) new Bucket(keyed, formatter, this);
         }
 
@@ -276,7 +274,7 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
 
     protected List<B> buckets;
     private InternalOrder order;
-    private @Nullable ValueFormatter formatter;
+    private ValueFormatter formatter;
     private boolean keyed;
     private long minDocCount;
     private EmptyBucketInfo emptyBucketInfo;
@@ -284,9 +282,8 @@ public class InternalHistogram<B extends InternalHistogram.Bucket> extends Inter
 
     InternalHistogram() {} // for serialization
 
-    InternalHistogram(String name, List<B> buckets, InternalOrder order, long minDocCount,
- EmptyBucketInfo emptyBucketInfo,
-            @Nullable ValueFormatter formatter, boolean keyed, Factory<B> factory, List<PipelineAggregator> pipelineAggregators,
+    InternalHistogram(String name, List<B> buckets, InternalOrder order, long minDocCount, EmptyBucketInfo emptyBucketInfo,
+            ValueFormatter formatter, boolean keyed, Factory<B> factory, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.buckets = buckets;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.bucket.range;
 
 import com.google.common.collect.Lists;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -91,12 +90,13 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         InternalAggregations aggregations;
         private String key;
 
-        public Bucket(boolean keyed, @Nullable ValueFormatter formatter) {
+        public Bucket(boolean keyed, ValueFormatter formatter) {
             this.keyed = keyed;
             this.formatter = formatter;
         }
 
-        public Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed, @Nullable ValueFormatter formatter) {
+        public Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed,
+                ValueFormatter formatter) {
             this(keyed, formatter);
             this.key = key != null ? key : generateKey(from, to, formatter);
             this.from = from;
@@ -137,8 +137,6 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         public String getFromAsString() {
             if (Double.isInfinite(from)) {
                 return null;
-            } else if (formatter == null) {
-                return ValueFormatter.RAW.format(from);
             } else {
                 return formatter.format(from);
             }
@@ -148,8 +146,6 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         public String getToAsString() {
             if (Double.isInfinite(to)) {
                 return null;
-            } else if (formatter == null) {
-                return ValueFormatter.RAW.format(to);
             } else {
                 return formatter.format(to);
             }
@@ -206,11 +202,11 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             return builder;
         }
 
-        protected String generateKey(double from, double to, @Nullable ValueFormatter formatter) {
+        protected String generateKey(double from, double to, ValueFormatter formatter) {
             StringBuilder sb = new StringBuilder();
-            sb.append(Double.isInfinite(from) ? "*" : formatter != null ? formatter.format(from) : ValueFormatter.RAW.format(from));
+            sb.append(Double.isInfinite(from) ? "*" : formatter.format(from));
             sb.append("-");
-            sb.append(Double.isInfinite(to) ? "*" : formatter != null ? formatter.format(to) : ValueFormatter.RAW.format(to));
+            sb.append(Double.isInfinite(to) ? "*" : formatter.format(to));
             return sb.toString();
         }
 
@@ -231,13 +227,13 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             return TYPE.name();
         }
 
-        public R create(String name, List<B> ranges, @Nullable ValueFormatter formatter, boolean keyed, List<PipelineAggregator> pipelineAggregators,
+        public R create(String name, List<B> ranges, ValueFormatter formatter, boolean keyed, List<PipelineAggregator> pipelineAggregators,
                 Map<String, Object> metaData) {
             return (R) new InternalRange<>(name, ranges, formatter, keyed, pipelineAggregators, metaData);
         }
 
         public B createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed,
-                @Nullable ValueFormatter formatter) {
+                ValueFormatter formatter) {
             return (B) new Bucket(key, from, to, docCount, aggregations, keyed, formatter);
         }
 
@@ -254,13 +250,13 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
     private List<B> ranges;
     private Map<String, B> rangeMap;
-    @Nullable
     protected ValueFormatter formatter;
     protected boolean keyed;
 
     public InternalRange() {} // for serialization
 
-    public InternalRange(String name, List<B> ranges, @Nullable ValueFormatter formatter, boolean keyed, List<PipelineAggregator> pipelineAggregators,
+    public InternalRange(String name, List<B> ranges, ValueFormatter formatter, boolean keyed,
+            List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.ranges = ranges;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -22,15 +22,13 @@ import com.google.common.collect.Lists;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.InPlaceMergeSorter;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.AggregatorBase;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
@@ -90,28 +88,21 @@ public class RangeAggregator extends BucketsAggregator {
     }
 
     final ValuesSource.Numeric valuesSource;
-    final @Nullable ValueFormatter formatter;
+    final ValueFormatter formatter;
     final Range[] ranges;
     final boolean keyed;
     final InternalRange.Factory rangeFactory;
 
     final double[] maxTo;
 
-    public RangeAggregator(String name,
-                           AggregatorFactories factories,
-                           ValuesSource.Numeric valuesSource,
-                           @Nullable ValueFormat format,
-                           InternalRange.Factory rangeFactory,
-                           List<Range> ranges,
-                           boolean keyed,
-                           AggregationContext aggregationContext,
-                           Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                           Map<String, Object> metaData) throws IOException {
+    public RangeAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, ValueFormat format,
+            InternalRange.Factory rangeFactory, List<Range> ranges, boolean keyed, AggregationContext aggregationContext,
+            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
 
         super(name, factories, aggregationContext, parent, pipelineAggregators, metaData);
         assert valuesSource != null;
         this.valuesSource = valuesSource;
-        this.formatter = format != null ? format.formatter() : null;
+        this.formatter = format.formatter();
         this.keyed = keyed;
         this.rangeFactory = rangeFactory;
         this.ranges = ranges.toArray(new Range[ranges.size()]);
@@ -261,14 +252,9 @@ public class RangeAggregator extends BucketsAggregator {
         private final InternalRange.Factory factory;
         private final ValueFormatter formatter;
 
-        public Unmapped(String name,
-                        List<RangeAggregator.Range> ranges,
-                        boolean keyed,
-                        ValueFormat format,
-                        AggregationContext context,
-                        Aggregator parent,
-                        InternalRange.Factory factory, List<PipelineAggregator> pipelineAggregators,
-                        Map<String, Object> metaData) throws IOException {
+        public Unmapped(String name, List<RangeAggregator.Range> ranges, boolean keyed, ValueFormat format, AggregationContext context,
+                Aggregator parent, InternalRange.Factory factory, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData)
+                throws IOException {
 
             super(name, context, parent, pipelineAggregators, metaData);
             this.ranges = ranges;
@@ -277,7 +263,7 @@ public class RangeAggregator extends BucketsAggregator {
                 range.process(parser, context.searchContext());
             }
             this.keyed = keyed;
-            this.formatter = format != null ? format.formatter() : null;
+            this.formatter = format.formatter();
             this.factory = factory;
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRange.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range.date;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -77,7 +76,7 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
 
     public static class Bucket extends InternalRange.Bucket {
 
-        public Bucket(boolean keyed, @Nullable ValueFormatter formatter) {
+        public Bucket(boolean keyed, ValueFormatter formatter) {
             super(keyed, formatter);
         }
 
@@ -146,7 +145,7 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
 
     InternalDateRange() {} // for serialization
 
-    InternalDateRange(String name, List<InternalDateRange.Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed,
+    InternalDateRange(String name, List<InternalDateRange.Bucket> ranges, ValueFormatter formatter, boolean keyed,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, ranges, formatter, keyed, pipelineAggregators, metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -188,7 +188,8 @@ public class GeoDistanceParser implements Aggregator.Parser {
         @Override
         protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
                 Map<String, Object> metaData) throws IOException {
-            return new Unmapped(name, ranges, keyed, null, aggregationContext, parent, rangeFactory, pipelineAggregators, metaData);
+            return new Unmapped(name, ranges, keyed, config.format(), aggregationContext, parent, rangeFactory, pipelineAggregators,
+                    metaData);
         }
 
         @Override
@@ -197,7 +198,8 @@ public class GeoDistanceParser implements Aggregator.Parser {
                 Map<String, Object> metaData)
                 throws IOException {
             DistanceSource distanceSource = new DistanceSource(valuesSource, distanceType, origin, unit);
-            return new RangeAggregator(name, factories, distanceSource, null, rangeFactory, ranges, keyed, aggregationContext, parent,
+            return new RangeAggregator(name, factories, distanceSource, config.format(), rangeFactory, ranges, keyed, aggregationContext,
+                    parent,
                     pipelineAggregators, metaData);
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistance.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistance.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range.geodistance;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -75,15 +74,16 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
 
     static class Bucket extends InternalRange.Bucket {
 
-        Bucket(boolean keyed, @Nullable ValueFormatter formatter) {
+        Bucket(boolean keyed, ValueFormatter formatter) {
             super(keyed, formatter);
         }
 
-        Bucket(String key, double from, double to, long docCount, List<InternalAggregation> aggregations, boolean keyed, @Nullable ValueFormatter formatter) {
+        Bucket(String key, double from, double to, long docCount, List<InternalAggregation> aggregations, boolean keyed,
+                ValueFormatter formatter) {
             this(key, from, to, docCount, new InternalAggregations(aggregations), keyed, formatter);
         }
 
-        Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed, @Nullable ValueFormatter formatter) {
+        Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed, ValueFormatter formatter) {
             super(key, from, to, docCount, aggregations, keyed, formatter);
         }
 
@@ -109,7 +109,7 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
         }
 
         @Override
-        public InternalGeoDistance create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed,
+        public InternalGeoDistance create(String name, List<Bucket> ranges, ValueFormatter formatter, boolean keyed,
                 List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
             return new InternalGeoDistance(name, ranges, formatter, keyed, pipelineAggregators, metaData);
         }
@@ -121,7 +121,8 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
         }
 
         @Override
-        public Bucket createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed, @Nullable ValueFormatter formatter) {
+        public Bucket createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed,
+                ValueFormatter formatter) {
             return new Bucket(key, from, to, docCount, aggregations, keyed, formatter);
         }
 
@@ -134,7 +135,8 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
 
     InternalGeoDistance() {} // for serialization
 
-    public InternalGeoDistance(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed, List<PipelineAggregator> pipelineAggregators,
+    public InternalGeoDistance(String name, List<Bucket> ranges, ValueFormatter formatter, boolean keyed,
+            List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, ranges, formatter, keyed, pipelineAggregators, metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/InternalIPv4Range.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/InternalIPv4Range.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range.ipv4;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -118,7 +117,7 @@ public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket, I
         }
 
         @Override
-        public InternalIPv4Range create(String name, List<Bucket> ranges, @Nullable ValueFormatter formatter, boolean keyed,
+        public InternalIPv4Range create(String name, List<Bucket> ranges, ValueFormatter formatter, boolean keyed,
                 List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
             return new InternalIPv4Range(name, ranges, keyed, pipelineAggregators, metaData);
         }
@@ -129,7 +128,8 @@ public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket, I
         }
 
         @Override
-        public Bucket createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed, @Nullable ValueFormatter formatter) {
+        public Bucket createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed,
+                ValueFormatter formatter) {
             return new Bucket(key, from, to, docCount, aggregations, keyed);
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.significant;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -85,13 +84,14 @@ public class SignificantLongTerms extends InternalSignificantTerms<SignificantLo
         long term;
         private transient final ValueFormatter formatter;
 
-        public Bucket(long subsetSize, long supersetSize, @Nullable ValueFormatter formatter) {
+        public Bucket(long subsetSize, long supersetSize, ValueFormatter formatter) {
             super(subsetSize, supersetSize);
             this.formatter = formatter;
             // for serialization
         }
 
-        public Bucket(long subsetDf, long subsetSize, long supersetDf, long supersetSize, long term, InternalAggregations aggregations, @Nullable ValueFormatter formatter) {
+        public Bucket(long subsetDf, long subsetSize, long supersetDf, long supersetSize, long term, InternalAggregations aggregations,
+                ValueFormatter formatter) {
             super(subsetDf, subsetSize, supersetDf, supersetSize, aggregations);
             this.formatter = formatter;
             this.term = term;
@@ -166,7 +166,7 @@ public class SignificantLongTerms extends InternalSignificantTerms<SignificantLo
     SignificantLongTerms() {
     } // for serialization
 
-    public SignificantLongTerms(long subsetSize, long supersetSize, String name, @Nullable ValueFormatter formatter, int requiredSize,
+    public SignificantLongTerms(long subsetSize, long supersetSize, String name, ValueFormatter formatter, int requiredSize,
             long minDocCount, SignificanceHeuristic significanceHeuristic, List<? extends InternalSignificantTerms.Bucket> buckets,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.bucket.significant;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -45,9 +44,9 @@ import java.util.Map;
  */
 public class SignificantLongTermsAggregator extends LongTermsAggregator {
 
-    public SignificantLongTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, @Nullable ValueFormat format,
-              BucketCountThresholds bucketCountThresholds, AggregationContext aggregationContext,
-              Aggregator parent, SignificantTermsAggregatorFactory termsAggFactory, IncludeExclude.LongFilter includeExclude,
+    public SignificantLongTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource,
+            ValueFormat format, BucketCountThresholds bucketCountThresholds, AggregationContext aggregationContext, Aggregator parent,
+            SignificantTermsAggregatorFactory termsAggFactory, IncludeExclude.LongFilter includeExclude,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
 
         super(name, factories, valuesSource, format, null, bucketCountThresholds, aggregationContext, parent,

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -81,12 +80,12 @@ public class DoubleTerms extends InternalTerms<DoubleTerms, DoubleTerms.Bucket> 
 
         double term;
 
-        public Bucket(@Nullable ValueFormatter formatter, boolean showDocCountError) {
+        public Bucket(ValueFormatter formatter, boolean showDocCountError) {
             super(formatter, showDocCountError);
         }
 
         public Bucket(double term, long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError,
-                @Nullable ValueFormatter formatter) {
+                ValueFormatter formatter) {
             super(docCount, aggregations, showDocCountError, docCountError, formatter);
             this.term = term;
         }
@@ -141,7 +140,7 @@ public class DoubleTerms extends InternalTerms<DoubleTerms, DoubleTerms.Bucket> 
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(CommonFields.KEY, term);
-            if (formatter != null && formatter != ValueFormatter.RAW) {
+            if (formatter != ValueFormatter.RAW) {
                 builder.field(CommonFields.KEY_AS_STRING, formatter.format(term));
             }
             builder.field(CommonFields.DOC_COUNT, getDocCount());
@@ -154,13 +153,12 @@ public class DoubleTerms extends InternalTerms<DoubleTerms, DoubleTerms.Bucket> 
         }
     }
 
-    private @Nullable
-    ValueFormatter formatter;
+    private ValueFormatter formatter;
 
     DoubleTerms() {
     } // for serialization
 
-    public DoubleTerms(String name, Terms.Order order, @Nullable ValueFormatter formatter, int requiredSize, int shardSize,
+    public DoubleTerms(String name, Terms.Order order, ValueFormatter formatter, int requiredSize, int shardSize,
             long minDocCount, List<? extends InternalTerms.Bucket> buckets, boolean showTermDocCountError, long docCountError,
             long otherDocCount, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, order, requiredSize, shardSize, minDocCount, buckets, showTermDocCountError, docCountError, otherDocCount, pipelineAggregators,

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -42,10 +41,10 @@ import java.util.Map;
  */
 public class DoubleTermsAggregator extends LongTermsAggregator {
 
-    public DoubleTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, @Nullable ValueFormat format,
-            Terms.Order order, BucketCountThresholds bucketCountThresholds,
-            AggregationContext aggregationContext, Aggregator parent, SubAggCollectionMode collectionMode, boolean showTermDocCountError,
-            IncludeExclude.LongFilter longFilter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
+    public DoubleTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, ValueFormat format,
+            Terms.Order order, BucketCountThresholds bucketCountThresholds, AggregationContext aggregationContext, Aggregator parent,
+            SubAggCollectionMode collectionMode, boolean showTermDocCountError, IncludeExclude.LongFilter longFilter,
+            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, factories, valuesSource, format, order, bucketCountThresholds, aggregationContext, parent, collectionMode,
                 showTermDocCountError, longFilter, pipelineAggregators, metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -58,13 +57,14 @@ public abstract class InternalTerms<A extends InternalTerms, B extends InternalT
         protected boolean showDocCountError;
         transient final ValueFormatter formatter;
 
-        protected Bucket(@Nullable ValueFormatter formatter, boolean showDocCountError) {
+        protected Bucket(ValueFormatter formatter, boolean showDocCountError) {
             // for serialization
             this.showDocCountError = showDocCountError;
             this.formatter = formatter;
         }
 
-        protected Bucket(long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError, @Nullable ValueFormatter formatter) {
+        protected Bucket(long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError,
+                ValueFormatter formatter) {
             this(formatter, showDocCountError);
             this.docCount = docCount;
             this.aggregations = aggregations;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -80,11 +79,12 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
 
         long term;
 
-        public Bucket(@Nullable ValueFormatter formatter, boolean showDocCountError) {
+        public Bucket(ValueFormatter formatter, boolean showDocCountError) {
             super(formatter, showDocCountError);
         }
 
-        public Bucket(long term, long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError, @Nullable ValueFormatter formatter) {
+        public Bucket(long term, long docCount, InternalAggregations aggregations, boolean showDocCountError, long docCountError,
+                ValueFormatter formatter) {
             super(docCount, aggregations, showDocCountError, docCountError, formatter);
             this.term = term;
         }
@@ -139,7 +139,7 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(CommonFields.KEY, term);
-            if (formatter != null && formatter != ValueFormatter.RAW) {
+            if (formatter != ValueFormatter.RAW) {
                 builder.field(CommonFields.KEY_AS_STRING, formatter.format(term));
             }
             builder.field(CommonFields.DOC_COUNT, getDocCount());
@@ -152,11 +152,11 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
         }
     }
 
-    @Nullable ValueFormatter formatter;
+    ValueFormatter formatter;
 
     LongTerms() {} // for serialization
 
-    public LongTerms(String name, Terms.Order order, @Nullable ValueFormatter formatter, int requiredSize, int shardSize, long minDocCount,
+    public LongTerms(String name, Terms.Order order, ValueFormatter formatter, int requiredSize, int shardSize, long minDocCount,
             List<? extends InternalTerms.Bucket> buckets, boolean showTermDocCountError, long docCountError, long otherDocCount,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, order, requiredSize, shardSize, minDocCount, buckets, showTermDocCountError, docCountError, otherDocCount, pipelineAggregators,

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -20,14 +20,13 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.terms.support.BucketPriorityQueue;
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude.LongFilter;
@@ -49,19 +48,19 @@ import java.util.Map;
 public class LongTermsAggregator extends TermsAggregator {
 
     protected final ValuesSource.Numeric valuesSource;
-    protected final @Nullable ValueFormatter formatter;
+    protected final ValueFormatter formatter;
     protected final LongHash bucketOrds;
     private boolean showTermDocCountError;
     private LongFilter longFilter;
 
-    public LongTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, @Nullable ValueFormat format,
+    public LongTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, ValueFormat format,
             Terms.Order order, BucketCountThresholds bucketCountThresholds, AggregationContext aggregationContext, Aggregator parent,
             SubAggCollectionMode subAggCollectMode, boolean showTermDocCountError, IncludeExclude.LongFilter longFilter,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, factories, aggregationContext, parent, bucketCountThresholds, order, subAggCollectMode, pipelineAggregators, metaData);
         this.valuesSource = valuesSource;
         this.showTermDocCountError = showTermDocCountError;
-        this.formatter = format != null ? format.formatter() : null;
+        this.formatter = format.formatter();
         this.longFilter = longFilter;
         bucketOrds = new LongHash(1, aggregationContext.bigArrays());
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -41,11 +41,7 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
 
         @Override
         public String getValueAsString() {
-            if (valueFormatter == null) {
-                return ValueFormatter.RAW.format(value());
-            } else {
-                return valueFormatter.format(value());
-            }
+            return valueFormatter.format(value());
         }
 
         @Override
@@ -72,11 +68,7 @@ public abstract class InternalNumericMetricsAggregation extends InternalMetricsA
         public abstract double value(String name);
 
         public String valueAsString(String name) {
-            if (valueFormatter == null) {
-                return ValueFormatter.RAW.format(value(name));
-            } else {
-                return valueFormatter.format(value(name));
-            }
+            return valueFormatter.format(value(name));
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics.avg;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -52,7 +51,7 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
     DoubleArray sums;
     ValueFormatter formatter;
 
-    public AvgAggregator(String name, ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
+    public AvgAggregator(String name, ValuesSource.Numeric valuesSource, ValueFormatter formatter,
  AggregationContext context,
             Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, context, parent, pipelineAggregators, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/InternalAvg.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.avg;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -58,7 +57,7 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalAvg() {} // for serialization
 
-    public InternalAvg(String name, double sum, long count, @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
+    public InternalAvg(String name, double sum, long count, ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.sum = sum;
@@ -109,7 +108,7 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field(CommonFields.VALUE, count != 0 ? getValue() : null);
-        if (count != 0 && valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+        if (count != 0 && !(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(getValue()));
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityAggregator.java
@@ -29,7 +29,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
@@ -67,7 +66,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
     private Collector collector;
     private ValueFormatter formatter;
 
-    public CardinalityAggregator(String name, ValuesSource valuesSource, boolean rehash, int precision, @Nullable ValueFormatter formatter,
+    public CardinalityAggregator(String name, ValuesSource valuesSource, boolean rehash, int precision, ValueFormatter formatter,
             AggregationContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, context, parent, pipelineAggregators, metaData);
         this.valuesSource = valuesSource;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinality.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.metrics.cardinality;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
@@ -54,7 +53,7 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
 
     private HyperLogLogPlusPlus counts;
 
-    InternalCardinality(String name, HyperLogLogPlusPlus counts, @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
+    InternalCardinality(String name, HyperLogLogPlusPlus counts, ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.counts = counts;
@@ -130,7 +129,7 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         final long cardinality = getValue();
         builder.field(CommonFields.VALUE, cardinality);
-        if (valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+        if (!(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(cardinality));
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/InternalMax.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.max;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -57,7 +56,8 @@ public class InternalMax extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalMax() {} // for serialization
 
-    public InternalMax(String name, double max, @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+    public InternalMax(String name, double max, ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.valueFormatter = formatter;
         this.max = max;
@@ -103,7 +103,7 @@ public class InternalMax extends InternalNumericMetricsAggregation.SingleValue i
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         boolean hasValue = !Double.isInfinite(max);
         builder.field(CommonFields.VALUE, hasValue ? max : null);
-        if (hasValue && valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+        if (hasValue && !(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(max));
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics.max;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -52,7 +51,7 @@ public class MaxAggregator extends NumericMetricsAggregator.SingleValue {
 
     DoubleArray maxes;
 
-    public MaxAggregator(String name, ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
+    public MaxAggregator(String name, ValuesSource.Numeric valuesSource, ValueFormatter formatter,
  AggregationContext context,
             Aggregator parent, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) throws IOException {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/InternalMin.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.min;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -58,7 +57,8 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalMin() {} // for serialization
 
-    public InternalMin(String name, double min, @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+    public InternalMin(String name, double min, ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.min = min;
         this.valueFormatter = formatter;
@@ -104,7 +104,7 @@ public class InternalMin extends InternalNumericMetricsAggregation.SingleValue i
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         boolean hasValue = !Double.isInfinite(min);
         builder.field(CommonFields.VALUE, hasValue ? min : null);
-        if (hasValue && valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+        if (hasValue && !(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(min));
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics.min;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -52,7 +51,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
 
     DoubleArray mins;
 
-    public MinAggregator(String name, ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
+    public MinAggregator(String name, ValuesSource.Numeric valuesSource, ValueFormatter formatter,
             AggregationContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) throws IOException {
         super(name, context, parent, pipelineAggregators, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractInternalPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractInternalPercentiles.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -42,7 +41,7 @@ abstract class AbstractInternalPercentiles extends InternalNumericMetricsAggrega
 
     AbstractInternalPercentiles() {} // for serialization
 
-    public AbstractInternalPercentiles(String name, double[] keys, TDigestState state, boolean keyed, @Nullable ValueFormatter formatter,
+    public AbstractInternalPercentiles(String name, double[] keys, TDigestState state, boolean keyed, ValueFormatter formatter,
             List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
@@ -56,7 +55,7 @@ abstract class AbstractInternalPercentiles extends InternalNumericMetricsAggrega
     public double value(String name) {
         return value(Double.parseDouble(name));
     }
-    
+
     public abstract double value(double key);
 
     @Override
@@ -105,7 +104,7 @@ abstract class AbstractInternalPercentiles extends InternalNumericMetricsAggrega
                 String key = String.valueOf(keys[i]);
                 double value = value(keys[i]);
                 builder.field(key, value);
-                if (valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+                if (!(valueFormatter instanceof ValueFormatter.Raw)) {
                     builder.field(key + "_as_string", valueFormatter.format(value));
                 }
             }
@@ -117,7 +116,7 @@ abstract class AbstractInternalPercentiles extends InternalNumericMetricsAggrega
                 builder.startObject();
                 builder.field(CommonFields.KEY, keys[i]);
                 builder.field(CommonFields.VALUE, value);
-                if (valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+                if (!(valueFormatter instanceof ValueFormatter.Raw)) {
                     builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(value));
                 }
                 builder.endObject();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesAggregator.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.util.BigArrays;
@@ -54,7 +53,7 @@ public abstract class AbstractPercentilesAggregator extends NumericMetricsAggreg
     protected final boolean keyed;
 
     public AbstractPercentilesAggregator(String name, ValuesSource.Numeric valuesSource, AggregationContext context, Aggregator parent,
-            double[] keys, double compression, boolean keyed, @Nullable ValueFormatter formatter,
+            double[] keys, double compression, boolean keyed, ValueFormatter formatter,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, context, parent, pipelineAggregators, metaData);
         this.valuesSource = valuesSource;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentileRanks.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentileRanks.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import com.google.common.collect.UnmodifiableIterator;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
@@ -51,10 +50,10 @@ public class InternalPercentileRanks extends AbstractInternalPercentiles impleme
     public static void registerStreams() {
         AggregationStreams.registerStream(STREAM, TYPE.stream());
     }
-    
+
     InternalPercentileRanks() {} // for serialization
 
-    public InternalPercentileRanks(String name, double[] cdfValues, TDigestState state, boolean keyed, @Nullable ValueFormatter formatter,
+    public InternalPercentileRanks(String name, double[] cdfValues, TDigestState state, boolean keyed, ValueFormatter formatter,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, cdfValues, state, keyed, formatter, pipelineAggregators, metaData);
     }
@@ -89,7 +88,7 @@ public class InternalPercentileRanks extends AbstractInternalPercentiles impleme
     public Type type() {
         return TYPE;
     }
-    
+
     static double percentileRank(TDigestState state, double value) {
         double percentileRank = state.cdf(value);
         if (percentileRank < 0) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentiles.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import com.google.common.collect.UnmodifiableIterator;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
@@ -55,7 +54,7 @@ public class InternalPercentiles extends AbstractInternalPercentiles implements 
     InternalPercentiles() {
     } // for serialization
 
-    public InternalPercentiles(String name, double[] percents, TDigestState state, boolean keyed, @Nullable ValueFormatter formatter,
+    public InternalPercentiles(String name, double[] percents, TDigestState state, boolean keyed, ValueFormatter formatter,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, percents, state, keyed, formatter, pipelineAggregators, metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksAggregator.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
@@ -40,7 +39,7 @@ import java.util.Map;
 public class PercentileRanksAggregator extends AbstractPercentilesAggregator {
 
     public PercentileRanksAggregator(String name, Numeric valuesSource, AggregationContext context, Aggregator parent, double[] percents,
-            double compression, boolean keyed, @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
+            double compression, boolean keyed, ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData)
             throws IOException {
         super(name, valuesSource, context, parent, percents, compression, keyed, formatter, pipelineAggregators, metaData);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.TDigestState;
@@ -41,7 +40,7 @@ public class PercentilesAggregator extends AbstractPercentilesAggregator {
 
     public PercentilesAggregator(String name, Numeric valuesSource, AggregationContext context,
             Aggregator parent, double[] percents,
-            double compression, boolean keyed, @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
+            double compression, boolean keyed, ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) throws IOException {
         super(name, valuesSource, context, parent, percents, compression, keyed, formatter, pipelineAggregators, metaData);
     }
@@ -55,7 +54,7 @@ public class PercentilesAggregator extends AbstractPercentilesAggregator {
             return new InternalPercentiles(name, keys, state, keyed, formatter, pipelineAggregators(), metaData());
         }
     }
-    
+
     @Override
     public double metric(String name, long bucketOrd) {
         TDigestState state = getState(bucketOrd);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.stats;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -70,7 +69,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
 
     protected InternalStats() {} // for serialization
 
-    public InternalStats(String name, long count, double sum, double min, double max, @Nullable ValueFormatter formatter,
+    public InternalStats(String name, long count, double sum, double min, double max, ValueFormatter formatter,
             List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
@@ -211,7 +210,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
         builder.field(Fields.MAX, count != 0 ? max : null);
         builder.field(Fields.AVG, count != 0 ? getAvg() : null);
         builder.field(Fields.SUM, count != 0 ? sum : null);
-        if (count != 0 && valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+        if (count != 0 && !(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(Fields.MIN_AS_STRING, valueFormatter.format(min));
             builder.field(Fields.MAX_AS_STRING, valueFormatter.format(max));
             builder.field(Fields.AVG_AS_STRING, valueFormatter.format(getAvg()));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics.stats;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -55,7 +54,7 @@ public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
     DoubleArray maxes;
 
 
-    public StatsAggegator(String name, ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
+    public StatsAggegator(String name, ValuesSource.Numeric valuesSource, ValueFormatter formatter,
  AggregationContext context,
             Aggregator parent, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) throws IOException {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics.stats.extended;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -56,7 +55,7 @@ public class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue
     DoubleArray maxes;
     DoubleArray sumOfSqrs;
 
-    public ExtendedStatsAggregator(String name, ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
+    public ExtendedStatsAggregator(String name, ValuesSource.Numeric valuesSource, ValueFormatter formatter,
             AggregationContext context, Aggregator parent, double sigma, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData)
             throws IOException {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/InternalExtendedStats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/InternalExtendedStats.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics.stats.extended;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -68,9 +67,8 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
 
     InternalExtendedStats() {} // for serialization
 
-    public InternalExtendedStats(String name, long count, double sum, double min, double max, double sumOfSqrs,
- double sigma,
-            @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+    public InternalExtendedStats(String name, long count, double sum, double min, double max, double sumOfSqrs, double sigma,
+            ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, count, sum, min, max, formatter, pipelineAggregators, metaData);
         this.sumOfSqrs = sumOfSqrs;
         this.sigma = sigma;
@@ -200,7 +198,7 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
                 .field(Fields.LOWER, count != 0 ? getStdDeviationBound(Bounds.LOWER) : null)
                 .endObject();
 
-        if (count != 0 && valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+        if (count != 0 && !(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(Fields.SUM_OF_SQRS_AS_STRING, valueFormatter.format(sumOfSqrs));
             builder.field(Fields.VARIANCE_AS_STRING, valueFormatter.format(getVariance()));
             builder.field(Fields.STD_DEVIATION_AS_STRING, getStdDeviationAsString());

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.sum;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -57,7 +56,7 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
 
     InternalSum() {} // for serialization
 
-    InternalSum(String name, double sum, @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
+    InternalSum(String name, double sum, ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.sum = sum;
@@ -103,7 +102,7 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field(CommonFields.VALUE, sum);
-        if (valueFormatter != null && !(valueFormatter instanceof ValueFormatter.Raw)) {
+        if (!(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(sum));
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics.sum;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
@@ -50,10 +49,8 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
 
     DoubleArray sums;
 
-    public SumAggregator(String name, ValuesSource.Numeric valuesSource, @Nullable ValueFormatter formatter,
- AggregationContext context,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metaData) throws IOException {
+    public SumAggregator(String name, ValuesSource.Numeric valuesSource, ValueFormatter formatter, AggregationContext context,
+            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, context, parent, pipelineAggregators, metaData);
         this.valuesSource = valuesSource;
         this.formatter = formatter;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics.valuecount;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongArray;
@@ -54,7 +53,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
     // a count per bucket
     LongArray counts;
 
-    public ValueCountAggregator(String name, ValuesSource valuesSource, @Nullable ValueFormatter formatter,
+    public ValueCountAggregator(String name, ValuesSource valuesSource, ValueFormatter formatter,
             AggregationContext aggregationContext, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData)
             throws IOException {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValue.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValue.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
-import org.elasticsearch.common.inject.internal.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -56,7 +55,8 @@ public class InternalSimpleValue extends InternalNumericMetricsAggregation.Singl
     protected InternalSimpleValue() {
     } // for serialization
 
-    public InternalSimpleValue(String name, double value, @Nullable ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+    public InternalSimpleValue(String name, double value, ValueFormatter formatter, List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.valueFormatter = formatter;
         this.value = value;
@@ -97,7 +97,7 @@ public class InternalSimpleValue extends InternalNumericMetricsAggregation.Singl
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         boolean hasValue = !(Double.isInfinite(value) || Double.isNaN(value));
         builder.field(CommonFields.VALUE, hasValue ? value : null);
-        if (hasValue && valueFormatter != null) {
+        if (hasValue && !(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(value));
         }
         return builder;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/BucketMetricsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/BucketMetricsParser.java
@@ -19,14 +19,13 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.search.SearchParseException;
+import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.search.aggregations.support.format.ValueFormat;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.internal.SearchContext;
@@ -53,7 +52,7 @@ public abstract class BucketMetricsParser implements PipelineAggregator.Parser {
         String[] bucketsPaths = null;
         String format = null;
         GapPolicy gapPolicy = GapPolicy.SKIP;
-    
+
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -87,22 +86,24 @@ public abstract class BucketMetricsParser implements PipelineAggregator.Parser {
                         parser.getTokenLocation());
             }
         }
-    
+
         if (bucketsPaths == null) {
             throw new SearchParseException(context, "Missing required field [" + BUCKETS_PATH.getPreferredName()
                     + "] for derivative aggregation [" + pipelineAggregatorName + "]", parser.getTokenLocation());
         }
-    
+
         ValueFormatter formatter = null;
         if (format != null) {
             formatter = ValueFormat.Patternable.Number.format(format).formatter();
+        } else {
+            formatter = ValueFormatter.RAW;
         }
-    
+
         return buildFactory(pipelineAggregatorName, bucketsPaths, gapPolicy, formatter);
     }
 
     protected abstract PipelineAggregatorFactory buildFactory(String pipelineAggregatorName, String[] bucketsPaths, GapPolicy gapPolicy,
-            @Nullable ValueFormatter formatter);
+            ValueFormatter formatter);
 
     protected boolean doParse(String pipelineAggregatorName, String currentFieldName, Token token, XContentParser parser, SearchContext context) {
         return false;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/BucketMetricsPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/BucketMetricsPipelineAggregator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -54,13 +53,14 @@ public abstract class BucketMetricsPipelineAggregator extends SiblingPipelineAgg
         super();
     }
 
-    protected BucketMetricsPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter,
+    protected BucketMetricsPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter,
             Map<String, Object> metaData) {
         super(name, bucketsPaths, metaData);
         this.gapPolicy = gapPolicy;
         this.formatter = formatter;
     }
 
+    @Override
     public final InternalAggregation doReduce(Aggregations aggregations, ReduceContext context) {
         preCollection();
         List<String> bucketsPath = AggregationPath.parse(bucketsPaths()[0]).getPathElementsAsStringList();
@@ -91,7 +91,7 @@ public abstract class BucketMetricsPipelineAggregator extends SiblingPipelineAgg
     /**
      * Called after a collection run is finished to build the aggregation for
      * the collected state.
-     * 
+     *
      * @param pipelineAggregators
      *            the pipeline aggregators to add to the resulting aggregation
      * @param metadata
@@ -103,7 +103,7 @@ public abstract class BucketMetricsPipelineAggregator extends SiblingPipelineAgg
     /**
      * Called for each bucket with a value so the state can be modified based on
      * the key and metric value for this bucket
-     * 
+     *
      * @param bucketKey
      *            the key for this bucket as a String
      * @param bucketValue

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/InternalBucketMetricValue.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/InternalBucketMetricValue.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -59,7 +58,7 @@ public class InternalBucketMetricValue extends InternalNumericMetricsAggregation
         super();
     }
 
-    public InternalBucketMetricValue(String name, String[] keys, double value, @Nullable ValueFormatter formatter,
+    public InternalBucketMetricValue(String name, String[] keys, double value, ValueFormatter formatter,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.keys = keys;
@@ -117,7 +116,7 @@ public class InternalBucketMetricValue extends InternalNumericMetricsAggregation
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         boolean hasValue = !Double.isInfinite(value);
         builder.field(CommonFields.VALUE, hasValue ? value : null);
-        if (hasValue && valueFormatter != null) {
+        if (hasValue && !(valueFormatter instanceof ValueFormatter.Raw)) {
             builder.field(CommonFields.VALUE_AS_STRING, valueFormatter.format(value));
         }
         builder.startArray("keys");

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/avg/AvgBucketParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/avg/AvgBucketParser.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.avg;
 
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorFactory;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorFactory;
 import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.BucketMetricsParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
@@ -32,7 +31,8 @@ public class AvgBucketParser extends BucketMetricsParser {
     }
 
     @Override
-    protected PipelineAggregatorFactory buildFactory(String pipelineAggregatorName, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter) {
+    protected PipelineAggregatorFactory buildFactory(String pipelineAggregatorName, String[] bucketsPaths, GapPolicy gapPolicy,
+            ValueFormatter formatter) {
         return new AvgBucketPipelineAggregator.Factory(pipelineAggregatorName, bucketsPaths, gapPolicy, formatter);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/avg/AvgBucketPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/avg/AvgBucketPipelineAggregator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.avg;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -59,7 +58,7 @@ public class AvgBucketPipelineAggregator extends BucketMetricsPipelineAggregator
     private AvgBucketPipelineAggregator() {
     }
 
-    protected AvgBucketPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter,
+    protected AvgBucketPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter,
             Map<String, Object> metaData) {
         super(name, bucketsPaths, gapPolicy, formatter, metaData);
     }
@@ -92,7 +91,7 @@ public class AvgBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         private final ValueFormatter formatter;
         private final GapPolicy gapPolicy;
 
-        public Factory(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter) {
+        public Factory(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter) {
             super(name, TYPE.name(), bucketsPaths);
             this.gapPolicy = gapPolicy;
             this.formatter = formatter;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/max/MaxBucketPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/max/MaxBucketPipelineAggregator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.max;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -61,7 +60,7 @@ public class MaxBucketPipelineAggregator extends BucketMetricsPipelineAggregator
     private MaxBucketPipelineAggregator() {
     }
 
-    protected MaxBucketPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter,
+    protected MaxBucketPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter,
             Map<String, Object> metaData) {
         super(name, bucketsPaths, gapPolicy, formatter, metaData);
     }
@@ -99,7 +98,7 @@ public class MaxBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         private final ValueFormatter formatter;
         private final GapPolicy gapPolicy;
 
-        public Factory(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter) {
+        public Factory(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter) {
             super(name, TYPE.name(), bucketsPaths);
             this.gapPolicy = gapPolicy;
             this.formatter = formatter;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/min/MinBucketPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/min/MinBucketPipelineAggregator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.min;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -61,7 +60,7 @@ public class MinBucketPipelineAggregator extends BucketMetricsPipelineAggregator
     private MinBucketPipelineAggregator() {
     }
 
-    protected MinBucketPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter,
+    protected MinBucketPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter,
             Map<String, Object> metaData) {
         super(name, bucketsPaths, gapPolicy, formatter, metaData);
     }
@@ -88,6 +87,7 @@ public class MinBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         }
     }
 
+    @Override
     protected InternalAggregation buildAggregation(java.util.List<PipelineAggregator> pipelineAggregators,
             java.util.Map<String, Object> metadata) {
         String[] keys = minBucketKeys.toArray(new String[minBucketKeys.size()]);
@@ -99,7 +99,7 @@ public class MinBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         private final ValueFormatter formatter;
         private final GapPolicy gapPolicy;
 
-        public Factory(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter) {
+        public Factory(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter) {
             super(name, TYPE.name(), bucketsPaths);
             this.gapPolicy = gapPolicy;
             this.formatter = formatter;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/sum/SumBucketParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/sum/SumBucketParser.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.sum;
 
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorFactory;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorFactory;
 import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.BucketMetricsParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
@@ -32,7 +31,8 @@ public class SumBucketParser extends BucketMetricsParser {
     }
 
     @Override
-    protected PipelineAggregatorFactory buildFactory(String pipelineAggregatorName, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter) {
+    protected PipelineAggregatorFactory buildFactory(String pipelineAggregatorName, String[] bucketsPaths, GapPolicy gapPolicy,
+            ValueFormatter formatter) {
         return new SumBucketPipelineAggregator.Factory(pipelineAggregatorName, bucketsPaths, gapPolicy, formatter);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/sum/SumBucketPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/sum/SumBucketPipelineAggregator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.sum;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -58,7 +57,7 @@ public class SumBucketPipelineAggregator extends BucketMetricsPipelineAggregator
     private SumBucketPipelineAggregator() {
     }
 
-    protected SumBucketPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter,
+    protected SumBucketPipelineAggregator(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter,
             Map<String, Object> metaData) {
         super(name, bucketsPaths, gapPolicy, formatter, metaData);
     }
@@ -88,7 +87,7 @@ public class SumBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         private final ValueFormatter formatter;
         private final GapPolicy gapPolicy;
 
-        public Factory(String name, String[] bucketsPaths, GapPolicy gapPolicy, @Nullable ValueFormatter formatter) {
+        public Factory(String name, String[] bucketsPaths, GapPolicy gapPolicy, ValueFormatter formatter) {
             super(name, TYPE.name(), bucketsPaths);
             this.gapPolicy = gapPolicy;
             this.formatter = formatter;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptParser.java
@@ -121,6 +121,8 @@ public class BucketScriptParser implements PipelineAggregator.Parser {
         ValueFormatter formatter = null;
         if (format != null) {
             formatter = ValueFormat.Patternable.Number.format(format).formatter();
+        } else {
+            formatter = ValueFormatter.RAW;
         }
 
         return new BucketScriptPipelineAggregator.Factory(reducerName, bucketsPathsMap, script, formatter, gapPolicy);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregator.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.pipeline.bucketscript;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.script.CompiledScript;
@@ -87,7 +86,7 @@ public class BucketScriptPipelineAggregator extends PipelineAggregator {
     public BucketScriptPipelineAggregator() {
     }
 
-    public BucketScriptPipelineAggregator(String name, Map<String, String> bucketsPathsMap, Script script, @Nullable ValueFormatter formatter,
+    public BucketScriptPipelineAggregator(String name, Map<String, String> bucketsPathsMap, Script script, ValueFormatter formatter,
             GapPolicy gapPolicy, Map<String, Object> metadata) {
         super(name, bucketsPathsMap.values().toArray(new String[bucketsPathsMap.size()]), metadata);
         this.bucketsPathsMap = bucketsPathsMap;
@@ -162,7 +161,7 @@ public class BucketScriptPipelineAggregator extends PipelineAggregator {
         private GapPolicy gapPolicy;
         private Map<String, String> bucketsPathsMap;
 
-        public Factory(String name, Map<String, String> bucketsPathsMap, Script script, @Nullable ValueFormatter formatter, GapPolicy gapPolicy) {
+        public Factory(String name, Map<String, String> bucketsPathsMap, Script script, ValueFormatter formatter, GapPolicy gapPolicy) {
             super(name, TYPE.name(), bucketsPathsMap.values().toArray(new String[bucketsPathsMap.size()]));
             this.bucketsPathsMap = bucketsPathsMap;
             this.script = script;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/cumulativesum/CumulativeSumParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/cumulativesum/CumulativeSumParser.java
@@ -88,6 +88,8 @@ public class CumulativeSumParser implements PipelineAggregator.Parser {
         ValueFormatter formatter = null;
         if (format != null) {
             formatter = ValueFormat.Patternable.Number.format(format).formatter();
+        } else {
+            formatter = ValueFormatter.RAW;
         }
 
         return new CumulativeSumPipelineAggregator.Factory(pipelineAggregatorName, bucketsPaths, formatter);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/cumulativesum/CumulativeSumPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/cumulativesum/CumulativeSumPipelineAggregator.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.pipeline.cumulativesum;
 
 import com.google.common.collect.Lists;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -68,7 +67,7 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
     public CumulativeSumPipelineAggregator() {
     }
 
-    public CumulativeSumPipelineAggregator(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter,
+    public CumulativeSumPipelineAggregator(String name, String[] bucketsPaths, ValueFormatter formatter,
             Map<String, Object> metadata) {
         super(name, bucketsPaths, metadata);
         this.formatter = formatter;
@@ -114,7 +113,7 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
 
         private final ValueFormatter formatter;
 
-        public Factory(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter) {
+        public Factory(String name, String[] bucketsPaths, ValueFormatter formatter) {
             super(name, TYPE.name(), bucketsPaths);
             this.formatter = formatter;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativeParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramParser;
+import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.search.aggregations.support.format.ValueFormat;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.internal.SearchContext;
@@ -98,6 +98,8 @@ public class DerivativeParser implements PipelineAggregator.Parser {
         ValueFormatter formatter = null;
         if (format != null) {
             formatter = ValueFormat.Patternable.Number.format(format).formatter();
+        } else {
+            formatter = ValueFormatter.RAW;
         }
 
         Long xAxisUnits = null;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativePipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativePipelineAggregator.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.pipeline.derivative;
 
 import com.google.common.collect.Lists;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
@@ -71,7 +70,7 @@ public class DerivativePipelineAggregator extends PipelineAggregator {
     public DerivativePipelineAggregator() {
     }
 
-    public DerivativePipelineAggregator(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter, GapPolicy gapPolicy, Long xAxisUnits,
+    public DerivativePipelineAggregator(String name, String[] bucketsPaths, ValueFormatter formatter, GapPolicy gapPolicy, Long xAxisUnits,
             Map<String, Object> metadata) {
         super(name, bucketsPaths, metadata);
         this.formatter = formatter;
@@ -158,7 +157,7 @@ public class DerivativePipelineAggregator extends PipelineAggregator {
         private GapPolicy gapPolicy;
         private Long xAxisUnits;
 
-        public Factory(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter, GapPolicy gapPolicy, Long xAxisUnits) {
+        public Factory(String name, String[] bucketsPaths, ValueFormatter formatter, GapPolicy gapPolicy, Long xAxisUnits) {
             super(name, TYPE.name(), bucketsPaths);
             this.formatter = formatter;
             this.gapPolicy = gapPolicy;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivative.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivative.java
@@ -101,7 +101,7 @@ public class InternalDerivative extends InternalSimpleValue implements Derivativ
         if (normalizationFactor > 0) {
             boolean hasValue = !(Double.isInfinite(normalizedValue()) || Double.isNaN(normalizedValue()));
             builder.field("normalized_value", hasValue ? normalizedValue() : null);
-            if (hasValue && valueFormatter != null) {
+            if (hasValue && !(valueFormatter instanceof ValueFormatter.Raw)) {
                 builder.field("normalized_value_as_string", valueFormatter.format(normalizedValue()));
             }
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgParser.java
@@ -138,6 +138,8 @@ public class MovAvgParser implements PipelineAggregator.Parser {
         ValueFormatter formatter = null;
         if (format != null) {
             formatter = ValueFormat.Patternable.Number.format(format).formatter();
+        } else {
+            formatter = ValueFormatter.RAW;
         }
 
         MovAvgModel.AbstractModelParser modelParser = movAvgModelParserMapper.get(model);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/movavg/MovAvgPipelineAggregator.java
@@ -23,7 +23,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.Lists;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -47,7 +46,9 @@ import org.elasticsearch.search.aggregations.support.format.ValueFormatterStream
 import org.joda.time.DateTime;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.search.aggregations.pipeline.BucketHelpers.resolveBucketValue;
 
@@ -84,7 +85,7 @@ public class MovAvgPipelineAggregator extends PipelineAggregator {
     public MovAvgPipelineAggregator() {
     }
 
-    public MovAvgPipelineAggregator(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter, GapPolicy gapPolicy,
+    public MovAvgPipelineAggregator(String name, String[] bucketsPaths, ValueFormatter formatter, GapPolicy gapPolicy,
                          int window, int predict, MovAvgModel model, Map<String, Object> metadata) {
         super(name, bucketsPaths, metadata);
         this.formatter = formatter;
@@ -221,7 +222,7 @@ public class MovAvgPipelineAggregator extends PipelineAggregator {
         private MovAvgModel model;
         private int predict;
 
-        public Factory(String name, String[] bucketsPaths, @Nullable ValueFormatter formatter, GapPolicy gapPolicy,
+        public Factory(String name, String[] bucketsPaths, ValueFormatter formatter, GapPolicy gapPolicy,
                        int window, int predict, MovAvgModel model) {
             super(name, TYPE.name(), bucketsPaths);
             this.formatter = formatter;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
@@ -29,8 +29,9 @@ import org.elasticsearch.search.aggregations.support.format.ValueFormat;
  */
 public enum ValueType {
 
-    @Deprecated ANY("any", ValuesSource.class, IndexFieldData.class, null),
-    STRING("string", ValuesSource.Bytes.class, IndexFieldData.class, null),
+    @Deprecated
+    ANY("any", ValuesSource.class, IndexFieldData.class, ValueFormat.RAW), STRING("string", ValuesSource.Bytes.class, IndexFieldData.class,
+            ValueFormat.RAW),
     LONG("byte|short|integer|long", ValuesSource.Numeric.class, IndexNumericFieldData.class, ValueFormat.RAW) {
         @Override
         public boolean isNumeric() {
@@ -72,7 +73,7 @@ public enum ValueType {
             return true;
         }
     },
-    GEOPOINT("geo_point", ValuesSource.GeoPoint.class, IndexGeoPointFieldData.class, null) {
+    GEOPOINT("geo_point", ValuesSource.GeoPoint.class, IndexGeoPointFieldData.class, ValueFormat.RAW) {
         @Override
         public boolean isGeoPoint() {
             return true;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -34,7 +34,7 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
     ValueType scriptValueType;
     boolean unmapped = false;
     String formatPattern;
-    ValueFormat format;
+    ValueFormat format = ValueFormat.RAW;
     Object missing;
 
     public ValuesSourceConfig(Class<VS> valueSourceType) {
@@ -81,10 +81,10 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
     }
 
     public ValueFormatter formatter() {
-        return format != null ? format.formatter() : null;
+        return format.formatter();
     }
 
     public ValueParser parser() {
-        return format != null ? format.parser() : null;
+        return format.parser();
     }
 }


### PR DESCRIPTION
This allows a lot of null checks to be removed where we were always falling back to the ValueFormat.RAW anyway. Now the format is set to ValueFormat.RAW when no alternative is suitable.

Closes #10594
