### PR TITLE
Allow shards to be allocated if leftover shard from different index exists.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -138,7 +138,7 @@ public final class ShardPath {
                         logger.warn("{} failed to archive shard from an index with a different UUID into {}", ex, shardId, target);
                         throw ex;
                     }
-                    logger.warn("{} archived shard from an index with a different UUID into {}, Remove the leftover shard if it's not needed anymore", shardId, target);
+                    logger.warn("{} archived shard from an index with a different UUID into {}, Delete the leftover shard manually if it's not needed anymore", shardId, target);
                 }
             }
         }


### PR DESCRIPTION
If an index name is reused but a leftover shard still exists on any node
we fail repeatedly to allocate the shard since we now check the index UUID
before reusing data. This commit allows to recover even if there is such a
leftover shard by trying to archive the shard into a seperate directory.

Closes #10677
