### PR TITLE
Aggregations: Adds other bucket to filters aggregation

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregator.java
@@ -60,14 +60,25 @@ public class FiltersAggregator extends BucketsAggregator {
     private final String[] keys;
     private final Weight[] filters;
     private final boolean keyed;
+    private final boolean showOtherBucket;
+    private final String otherBucketKey;
+    private final int totalNumKeys;
 
-    public FiltersAggregator(String name, AggregatorFactories factories, List<KeyedFilter> filters, boolean keyed, AggregationContext aggregationContext,
+    public FiltersAggregator(String name, AggregatorFactories factories, List<KeyedFilter> filters, boolean keyed, String otherBucketKey,
+            AggregationContext aggregationContext,
             Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData)
             throws IOException {
         super(name, factories, aggregationContext, parent, pipelineAggregators, metaData);
         this.keyed = keyed;
         this.keys = new String[filters.size()];
         this.filters = new Weight[filters.size()];
+        this.showOtherBucket = otherBucketKey != null;
+        this.otherBucketKey = otherBucketKey;
+        if (showOtherBucket) {
+            this.totalNumKeys = filters.size() + 1;
+        } else {
+            this.totalNumKeys = filters.size();
+        }
         for (int i = 0; i < filters.size(); ++i) {
             KeyedFilter keyedFilter = filters.get(i);
             this.keys[i] = keyedFilter.key;
@@ -86,10 +97,15 @@ public class FiltersAggregator extends BucketsAggregator {
         return new LeafBucketCollectorBase(sub, null) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
+                boolean matched = false;
                 for (int i = 0; i < bits.length; i++) {
                     if (bits[i].get(doc)) {
                         collectBucket(sub, doc, bucketOrd(bucket, i));
+                        matched = true;
                     }
+                }
+                if (showOtherBucket && !matched) {
+                    collectBucket(sub, doc, bucketOrd(bucket, bits.length));
                 }
             }
         };
@@ -101,6 +117,13 @@ public class FiltersAggregator extends BucketsAggregator {
         for (int i = 0; i < keys.length; i++) {
             long bucketOrd = bucketOrd(owningBucketOrdinal, i);
             InternalFilters.Bucket bucket = new InternalFilters.Bucket(keys[i], bucketDocCount(bucketOrd), bucketAggregations(bucketOrd), keyed);
+            buckets.add(bucket);
+        }
+        // other bucket
+        if (showOtherBucket) {
+            long bucketOrd = bucketOrd(owningBucketOrdinal, keys.length);
+            InternalFilters.Bucket bucket = new InternalFilters.Bucket(otherBucketKey, bucketDocCount(bucketOrd),
+                    bucketAggregations(bucketOrd), keyed);
             buckets.add(bucket);
         }
         return new InternalFilters(name, buckets, keyed, pipelineAggregators(), metaData());
@@ -118,24 +141,26 @@ public class FiltersAggregator extends BucketsAggregator {
     }
 
     final long bucketOrd(long owningBucketOrdinal, int filterOrd) {
-        return owningBucketOrdinal * filters.length + filterOrd;
+        return owningBucketOrdinal * totalNumKeys + filterOrd;
     }
 
     public static class Factory extends AggregatorFactory {
 
         private final List<KeyedFilter> filters;
         private boolean keyed;
+        private String otherBucketKey;
 
-        public Factory(String name, List<KeyedFilter> filters, boolean keyed) {
+        public Factory(String name, List<KeyedFilter> filters, boolean keyed, String otherBucketKey) {
             super(name, InternalFilters.TYPE.name());
             this.filters = filters;
             this.keyed = keyed;
+            this.otherBucketKey = otherBucketKey;
         }
 
         @Override
         public Aggregator createInternal(AggregationContext context, Aggregator parent, boolean collectsFromSingleBucket,
                 List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
-            return new FiltersAggregator(name, factories, filters, keyed, context, parent, pipelineAggregators, metaData);
+            return new FiltersAggregator(name, factories, filters, keyed, otherBucketKey, context, parent, pipelineAggregators, metaData);
         }
     }
 

--- a/docs/reference/aggregations/bucket/filters-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/filters-aggregation.asciidoc
@@ -126,3 +126,81 @@ request.  The response for this example would be:
   }
 ...
 --------------------------------------------------
+
+==== `Other` Bucket
+
+The `other_bucket` parameter can be set to add a bucket to the response which will contain all documents that do 
+not match any of the given filters. The value of this parameter can be as follows:
+
+`false`::         Does not compute the `other` bucket
+`true`::          Returns the `other` bucket bucket either in a bucket (named `_other_` by default) if named filters are being used, 
+                  or as the last bucket if anonymous filters are being used
+
+The `other_bucket_key` parameter can be used to set the key for the `other` bucket to a value other than the default `_other_`. Seting 
+this parameter will implicitly set the `other_bucket` parameter to `true`.
+
+The following snippet shows a response where the `other` bucket is requested to be named `other_messages`.
+
+[source,js]
+--------------------------------------------------
+{
+  "aggs" : {
+    "messages" : {
+      "filters" : {
+        "other_bucket": "other_messages",
+        "filters" : {
+          "errors" :   { "term" : { "body" : "error"   }},
+          "warnings" : { "term" : { "body" : "warning" }}
+        }
+      },
+      "aggs" : {
+        "monthly" : {
+          "histogram" : {
+            "field" : "timestamp",
+            "interval" : "1M"
+          }
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+The response would be something like the following:
+
+[source,js]
+--------------------------------------------------
+...
+  "aggs" : {
+    "messages" : {
+      "buckets" : {
+        "errors" : {
+          "doc_count" : 34,
+            "monthly" : {
+              "buckets" : [
+                ... // the histogram monthly breakdown
+              ]
+            }
+          },
+          "warnings" : {
+            "doc_count" : 439,
+            "monthly" : {
+              "buckets" : [
+                 ... // the histogram monthly breakdown
+              ]
+            }
+          },
+          "other_messages" : {
+            "doc_count" : 237,
+            "monthly" : {
+              "buckets" : [
+                 ... // the histogram monthly breakdown
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+...
+--------------------------------------------------


### PR DESCRIPTION
The filters aggregation now has an option to add an 'other' bucket which will, when turned on, contain all documents which do not match any of the defined filters. There is also an option to change the name of the 'other' bucket from the default of '_other_'

Closes #11289
