### PR TITLE
Cut over to writeable for TransportAddress

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/transport/DummyTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/DummyTransportAddress.java
@@ -31,7 +31,7 @@ public class DummyTransportAddress implements TransportAddress {
 
     public static final DummyTransportAddress INSTANCE = new DummyTransportAddress();
 
-    DummyTransportAddress() {
+    private DummyTransportAddress() {
     }
 
     @Override
@@ -45,7 +45,8 @@ public class DummyTransportAddress implements TransportAddress {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
+    public DummyTransportAddress readFrom(StreamInput in) throws IOException {
+        return INSTANCE;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
@@ -42,10 +42,31 @@ public class InetSocketTransportAddress implements TransportAddress {
         return resolveAddress;
     }
 
-    private InetSocketAddress address;
+    public static final InetSocketTransportAddress PROTO = new InetSocketTransportAddress();
 
-    InetSocketTransportAddress() {
+    private final InetSocketAddress address;
 
+    public InetSocketTransportAddress(StreamInput in) throws IOException {
+        if (in.readByte() == 0) {
+            int len = in.readByte();
+            byte[] a = new byte[len]; // 4 bytes (IPv4) or 16 bytes (IPv6)
+            in.readFully(a);
+            InetAddress inetAddress;
+            if (len == 16) {
+                int scope_id = in.readInt();
+                inetAddress = Inet6Address.getByAddress(null, a, scope_id);
+            } else {
+                inetAddress = InetAddress.getByAddress(a);
+            }
+            int port = in.readInt();
+            this.address = new InetSocketAddress(inetAddress, port);
+        } else {
+            this.address = new InetSocketAddress(in.readString(), in.readInt());
+        }
+    }
+
+    private InetSocketTransportAddress() {
+        address = null;
     }
 
     public InetSocketTransportAddress(String hostname, int port) {
@@ -76,23 +97,8 @@ public class InetSocketTransportAddress implements TransportAddress {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        if (in.readByte() == 0) {
-            int len = in.readByte();
-            byte[] a = new byte[len]; // 4 bytes (IPv4) or 16 bytes (IPv6)
-            in.readFully(a);
-            InetAddress inetAddress;
-            if (len == 16) {
-                int scope_id = in.readInt();
-                inetAddress = Inet6Address.getByAddress(null, a, scope_id);
-            } else {
-                inetAddress = InetAddress.getByAddress(a);
-            }
-            int port = in.readInt();
-            this.address = new InetSocketAddress(inetAddress, port);
-        } else {
-            this.address = new InetSocketAddress(in.readString(), in.readInt());
-        }
+    public TransportAddress readFrom(StreamInput in) throws IOException {
+        return new InetSocketTransportAddress(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/transport/LocalTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/LocalTransportAddress.java
@@ -21,6 +21,8 @@ package org.elasticsearch.common.transport;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.transport.local.LocalTransport;
 
 import java.io.IOException;
 
@@ -29,9 +31,12 @@ import java.io.IOException;
  */
 public class LocalTransportAddress implements TransportAddress {
 
+    public static final LocalTransportAddress PROTO = new LocalTransportAddress("_na");
+
     private String id;
 
-    LocalTransportAddress() {
+    public LocalTransportAddress(StreamInput in) throws IOException {
+        id = in.readString();
     }
 
     public LocalTransportAddress(String id) {
@@ -53,8 +58,8 @@ public class LocalTransportAddress implements TransportAddress {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        id = in.readString();
+    public LocalTransportAddress readFrom(StreamInput in) throws IOException {
+        return new LocalTransportAddress(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
@@ -20,12 +20,13 @@
 package org.elasticsearch.common.transport;
 
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 
 
 /**
  *
  */
-public interface TransportAddress extends Streamable {
+public interface TransportAddress extends Writeable<TransportAddress> {
 
     short uniqueAddressTypeId();
 


### PR DESCRIPTION
This will allow us to move away from reflection hacks to serialize
transport exceptions.
