### PR TITLE
Aggregations: Adds a new GapPolicy - NONE

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
@@ -53,7 +53,7 @@ public class BucketHelpers {
      * "ignore": empty buckets will simply be ignored
      */
     public static enum GapPolicy {
-        INSERT_ZEROS((byte) 0, "insert_zeros"), SKIP((byte) 1, "skip");
+        NONE((byte) 0, "none"), SKIP((byte) 1, "skip"), INSERT_ZEROS((byte) 2, "insert_zeros");
 
         /**
          * Parse a string GapPolicy into the byte enum
@@ -182,6 +182,7 @@ public class BucketHelpers {
                     case INSERT_ZEROS:
                         return 0.0;
                     case SKIP:
+                    case NONE:
                     default:
                         return Double.NaN;
                     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregator.java
@@ -113,26 +113,36 @@ public class BucketScriptPipelineAggregator extends PipelineAggregator {
             if (script.getParams() != null) {
                 vars.putAll(script.getParams());
             }
+            boolean skipBucket = false;
             for (Map.Entry<String, String> entry : bucketsPathsMap.entrySet()) {
                 String varName = entry.getKey();
                 String bucketsPath = entry.getValue();
                 Double value = resolveBucketValue(originalAgg, bucket, bucketsPath, gapPolicy);
+                if (GapPolicy.SKIP == gapPolicy && (value == null || Double.isNaN(value))) {
+                    skipBucket = true;
+                    break;
+                }
                 vars.put(varName, value);
             }
-            ExecutableScript executableScript = reduceContext.scriptService().executable(compiledScript, vars);
-            Object returned = executableScript.run();
-            if (returned == null) {
+            if (skipBucket) {
                 newBuckets.add(bucket);
             } else {
-                if (!(returned instanceof Number)) {
-                    throw new AggregationExecutionException("series_arithmetic script for reducer [" + name() + "] must return a Number");
+                ExecutableScript executableScript = reduceContext.scriptService().executable(compiledScript, vars);
+                Object returned = executableScript.run();
+                if (returned == null) {
+                    newBuckets.add(bucket);
+                } else {
+                    if (!(returned instanceof Number)) {
+                        throw new AggregationExecutionException("series_arithmetic script for reducer [" + name()
+                                + "] must return a Number");
+                    }
+                    List<InternalAggregation> aggs = new ArrayList<>(Lists.transform(bucket.getAggregations().asList(), FUNCTION));
+                    aggs.add(new InternalSimpleValue(name(), ((Number) returned).doubleValue(), formatter,
+                            new ArrayList<PipelineAggregator>(), metaData()));
+                    InternalMultiBucketAggregation.InternalBucket newBucket = originalAgg.createBucket(new InternalAggregations(aggs),
+                            (InternalMultiBucketAggregation.InternalBucket) bucket);
+                    newBuckets.add(newBucket);
                 }
-                List<InternalAggregation> aggs = new ArrayList<>(Lists.transform(bucket.getAggregations().asList(), FUNCTION));
-                aggs.add(new InternalSimpleValue(name(), ((Number) returned).doubleValue(), formatter, new ArrayList<PipelineAggregator>(),
-                        metaData()));
-                InternalMultiBucketAggregation.InternalBucket newBucket = originalAgg.createBucket(new InternalAggregations(aggs),
-                        (InternalMultiBucketAggregation.InternalBucket) bucket);
-                newBuckets.add(newBucket);
             }
         }
         return originalAgg.create(newBuckets);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Order;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
-import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValue;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
@@ -34,12 +33,11 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders.avgBucket;
-
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders.avgBucket;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -222,6 +220,61 @@ public class AvgBucketTests extends ElasticsearchIntegrationTest {
                                                 .extendedBounds((long) minRandomValue, (long) maxRandomValue)
                                                 .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
                                 .subAggregation(avgBucket("avg_bucket").setBucketsPaths("histo>sum"))).execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Terms terms = response.getAggregations().get("terms");
+        assertThat(terms, notNullValue());
+        assertThat(terms.getName(), equalTo("terms"));
+        List<Terms.Bucket> termsBuckets = terms.getBuckets();
+        assertThat(termsBuckets.size(), equalTo(interval));
+
+        for (int i = 0; i < interval; ++i) {
+            Terms.Bucket termsBucket = termsBuckets.get(i);
+            assertThat(termsBucket, notNullValue());
+            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+
+            Histogram histo = termsBucket.getAggregations().get("histo");
+            assertThat(histo, notNullValue());
+            assertThat(histo.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = histo.getBuckets();
+
+            double bucketSum = 0;
+            int count = 0;
+            for (int j = 0; j < numValueBuckets; ++j) {
+                Histogram.Bucket bucket = buckets.get(j);
+                assertThat(bucket, notNullValue());
+                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                if (bucket.getDocCount() != 0) {
+                    Sum sum = bucket.getAggregations().get("sum");
+                    assertThat(sum, notNullValue());
+                    count++;
+                    bucketSum += sum.value();
+                }
+            }
+
+            double avgValue = count == 0 ? Double.NaN : (bucketSum / count);
+            InternalSimpleValue avgBucketValue = termsBucket.getAggregations().get("avg_bucket");
+            assertThat(avgBucketValue, notNullValue());
+            assertThat(avgBucketValue.getName(), equalTo("avg_bucket"));
+            assertThat(avgBucketValue.value(), equalTo(avgValue));
+        }
+    }
+
+    @Test
+    public void testMetric_asSubAggNoneGapPolicy() throws Exception {
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        terms("terms")
+                                .field("tag")
+                                .order(Order.term(true))
+                                .subAggregation(
+                                        histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval)
+                                                .extendedBounds((long) minRandomValue, (long) maxRandomValue)
+                                                .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
+                                .subAggregation(avgBucket("avg_bucket").gapPolicy(GapPolicy.NONE).setBucketsPaths("histo>sum"))).execute()
+                .actionGet();
 
         assertSearchResponse(response);
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/MaxBucketTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/MaxBucketTests.java
@@ -286,6 +286,66 @@ public class MaxBucketTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void testMetric_asSubAggWithNoneGapPolicy() throws Exception {
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        terms("terms")
+                                .field("tag")
+                                .order(Order.term(true))
+                                .subAggregation(
+                                        histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval)
+                                                .extendedBounds((long) minRandomValue, (long) maxRandomValue)
+                                                .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
+                                .subAggregation(maxBucket("max_bucket").gapPolicy(GapPolicy.NONE).setBucketsPaths("histo>sum"))).execute()
+                .actionGet();
+
+        assertSearchResponse(response);
+
+        Terms terms = response.getAggregations().get("terms");
+        assertThat(terms, notNullValue());
+        assertThat(terms.getName(), equalTo("terms"));
+        List<Terms.Bucket> termsBuckets = terms.getBuckets();
+        assertThat(termsBuckets.size(), equalTo(interval));
+
+        for (int i = 0; i < interval; ++i) {
+            Terms.Bucket termsBucket = termsBuckets.get(i);
+            assertThat(termsBucket, notNullValue());
+            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+
+            Histogram histo = termsBucket.getAggregations().get("histo");
+            assertThat(histo, notNullValue());
+            assertThat(histo.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = histo.getBuckets();
+
+            List<String> maxKeys = new ArrayList<>();
+            double maxValue = Double.NEGATIVE_INFINITY;
+            for (int j = 0; j < numValueBuckets; ++j) {
+                Histogram.Bucket bucket = buckets.get(j);
+                assertThat(bucket, notNullValue());
+                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                if (bucket.getDocCount() != 0) {
+                    Sum sum = bucket.getAggregations().get("sum");
+                    assertThat(sum, notNullValue());
+                    if (sum.value() > maxValue) {
+                        maxValue = sum.value();
+                        maxKeys = new ArrayList<>();
+                        maxKeys.add(bucket.getKeyAsString());
+                    } else if (sum.value() == maxValue) {
+                        maxKeys.add(bucket.getKeyAsString());
+                    }
+                }
+            }
+
+            InternalBucketMetricValue maxBucketValue = termsBucket.getAggregations().get("max_bucket");
+            assertThat(maxBucketValue, notNullValue());
+            assertThat(maxBucketValue.getName(), equalTo("max_bucket"));
+            assertThat(maxBucketValue.value(), equalTo(maxValue));
+            assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[maxKeys.size()])));
+        }
+    }
+
+    @Test
     public void testMetric_asSubAggOfSingleBucketAgg() throws Exception {
         SearchResponse response = client()
                 .prepareSearch("idx")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/MinBucketTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/MinBucketTests.java
@@ -34,11 +34,11 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders.minBucket;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders.minBucket;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -236,6 +236,66 @@ public class MinBucketTests extends ElasticsearchIntegrationTest {
                                                 .extendedBounds((long) minRandomValue, (long) maxRandomValue)
                                                 .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
                                 .subAggregation(minBucket("min_bucket").setBucketsPaths("histo>sum"))).execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Terms terms = response.getAggregations().get("terms");
+        assertThat(terms, notNullValue());
+        assertThat(terms.getName(), equalTo("terms"));
+        List<Terms.Bucket> termsBuckets = terms.getBuckets();
+        assertThat(termsBuckets.size(), equalTo(interval));
+
+        for (int i = 0; i < interval; ++i) {
+            Terms.Bucket termsBucket = termsBuckets.get(i);
+            assertThat(termsBucket, notNullValue());
+            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+
+            Histogram histo = termsBucket.getAggregations().get("histo");
+            assertThat(histo, notNullValue());
+            assertThat(histo.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = histo.getBuckets();
+
+            List<String> minKeys = new ArrayList<>();
+            double minValue = Double.POSITIVE_INFINITY;
+            for (int j = 0; j < numValueBuckets; ++j) {
+                Histogram.Bucket bucket = buckets.get(j);
+                assertThat(bucket, notNullValue());
+                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                if (bucket.getDocCount() != 0) {
+                    Sum sum = bucket.getAggregations().get("sum");
+                    assertThat(sum, notNullValue());
+                    if (sum.value() < minValue) {
+                        minValue = sum.value();
+                        minKeys = new ArrayList<>();
+                        minKeys.add(bucket.getKeyAsString());
+                    } else if (sum.value() == minValue) {
+                        minKeys.add(bucket.getKeyAsString());
+                    }
+                }
+            }
+
+            InternalBucketMetricValue minBucketValue = termsBucket.getAggregations().get("min_bucket");
+            assertThat(minBucketValue, notNullValue());
+            assertThat(minBucketValue.getName(), equalTo("min_bucket"));
+            assertThat(minBucketValue.value(), equalTo(minValue));
+            assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[minKeys.size()])));
+        }
+    }
+
+    @Test
+    public void testMetric_asSubAggWithNoneGapPolicy() throws Exception {
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        terms("terms")
+                                .field("tag")
+                                .order(Order.term(true))
+                                .subAggregation(
+                                        histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval)
+                                                .extendedBounds((long) minRandomValue, (long) maxRandomValue)
+                                                .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
+                                .subAggregation(minBucket("min_bucket").gapPolicy(GapPolicy.NONE).setBucketsPaths("histo>sum"))).execute()
+                .actionGet();
 
         assertSearchResponse(response);
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/SumBucketTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/SumBucketTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Order;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
-import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValue;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
@@ -34,12 +33,11 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders.sumBucket;
-
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders.sumBucket;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
@@ -213,6 +211,58 @@ public class SumBucketTests extends ElasticsearchIntegrationTest {
                                                 .extendedBounds((long) minRandomValue, (long) maxRandomValue)
                                                 .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
                                 .subAggregation(sumBucket("sum_bucket").setBucketsPaths("histo>sum"))).execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Terms terms = response.getAggregations().get("terms");
+        assertThat(terms, notNullValue());
+        assertThat(terms.getName(), equalTo("terms"));
+        List<Terms.Bucket> termsBuckets = terms.getBuckets();
+        assertThat(termsBuckets.size(), equalTo(interval));
+
+        for (int i = 0; i < interval; ++i) {
+            Terms.Bucket termsBucket = termsBuckets.get(i);
+            assertThat(termsBucket, notNullValue());
+            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+
+            Histogram histo = termsBucket.getAggregations().get("histo");
+            assertThat(histo, notNullValue());
+            assertThat(histo.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = histo.getBuckets();
+
+            double bucketSum = 0;
+            for (int j = 0; j < numValueBuckets; ++j) {
+                Histogram.Bucket bucket = buckets.get(j);
+                assertThat(bucket, notNullValue());
+                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                if (bucket.getDocCount() != 0) {
+                    Sum sum = bucket.getAggregations().get("sum");
+                    assertThat(sum, notNullValue());
+                    bucketSum += sum.value();
+                }
+            }
+
+            InternalSimpleValue sumBucketValue = termsBucket.getAggregations().get("sum_bucket");
+            assertThat(sumBucketValue, notNullValue());
+            assertThat(sumBucketValue.getName(), equalTo("sum_bucket"));
+            assertThat(sumBucketValue.value(), equalTo(bucketSum));
+        }
+    }
+
+    @Test
+    public void testMetric_asSubAggWithNonGapPolicy() throws Exception {
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .addAggregation(
+                        terms("terms")
+                                .field("tag")
+                                .order(Order.term(true))
+                                .subAggregation(
+                                        histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval)
+                                                .extendedBounds((long) minRandomValue, (long) maxRandomValue)
+                                                .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
+                                .subAggregation(sumBucket("sum_bucket").gapPolicy(GapPolicy.NONE).setBucketsPaths("histo>sum"))).execute()
+                .actionGet();
 
         assertSearchResponse(response);
 

--- a/docs/reference/aggregations/pipeline.asciidoc
+++ b/docs/reference/aggregations/pipeline.asciidoc
@@ -145,11 +145,16 @@ the current bucket and the next bucket. In the derivative pipeline aggregation h
 should be when a gap in the data is found. There are currently two options for controlling the gap policy:
 
 _skip_::
-                This option will not produce a derivative value for any buckets where the value in the current or previous bucket is
+                This option will not produce a value for any buckets where the value in the current or previous bucket is
                 missing
 
 _insert_zeros_::
-                This option will assume the missing value is `0` and calculate the derivative with the value `0`.
+                This option will assume the missing value is `0` and calculate the value of the pipeline aggregation with the value `0`.
+
+_none_::        This option will insert the missing value as `NaN`. In practice, this policy has exactly the same result as the _`skip`_ 
+                gap policy except where scripts are used. In the scriptable pipeline aggregations the script will recieve a `Double.NaN` value for 
+                any `bucket_paths` where the value is missing and these `NaN` values will need to be dealt with in the script if this gap policy 
+                is used.
 
 
 


### PR DESCRIPTION
This is to allow the skip gap policy to always skip execution if values are missing. The none gap policy will set the value of the missing metric to NaN. In practice the skip and non gap policies work the same in all pipeline aggregators except the `bucket_script` agg, where `skip` will not execute the script for buckets where any of the input metrics are missing, and `none` will pass Double.NaN into the skip as the value of these missing metrics
