### PR TITLE
 Save repository to it's own sources.list file

### DIFF
--- a/docs/reference/setup/repositories.asciidoc
+++ b/docs/reference/setup/repositories.asciidoc
@@ -25,11 +25,11 @@ Download and install the Public Signing Key:
 wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
 --------------------------------------------------
 
-Add the repository definition to your `/etc/apt/sources.list` file:
+Save the repository definition to  `/etc/apt/sources.list.d/elasticsearch-{branch}.list`:
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-echo "deb http://packages.elastic.co/elasticsearch/{branch}/debian stable main" | sudo tee -a /etc/apt/sources.list
+echo "deb http://packages.elastic.co/elasticsearch/{branch}/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-{branch}.list
 --------------------------------------------------
 
 [WARNING]

--- a/docs/reference/setup/repositories.asciidoc
+++ b/docs/reference/setup/repositories.asciidoc
@@ -51,6 +51,15 @@ Run apt-get update and the repository is ready for use. You can install it with:
 sudo apt-get update && sudo apt-get install elasticsearch
 --------------------------------------------------
 
+[WARNING]
+==================================================
+If two entries exist for the same Elasticsearch repository, you will see an error like this during `apt-get update`: 
+
+`Duplicate sources.list entry http://packages.elastic.co/elasticsearch/1.6/debian/ ...`
+
+Examine `/etc/apt/sources.list.d/elasticsearch-{branch}.list` for the duplicate entry or locate the duplicate entry amongst the files in `/etc/apt/sources.list.d/` and the `/etc/apt/sources.list` file.
+==================================================
+
 Configure Elasticsearch to automatically start during bootup. If your
 distribution is using SysV init, then you will need to run:
 


### PR DESCRIPTION
Best to put repo definitions in a separate file from that of the core OS's sources.list.

Plus if someone has to type this command manually and skips the `-a` flag they won't clobber their sources.list. 

Also makes it easy to swap/replace sources.list without having to worry about packages that were added there. 
