### PR TITLE
Add missing format tick in 1.6 documents

### DIFF
--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -103,7 +103,7 @@ The `function_score` query provides several types of score functions:
 
 * <<function-script-score,`script_score`>>
 * <<function-weight,`weight`>>
-* <<function-random,`random_score>>
+* <<function-random,`random_score`>>
 * <<function-field-value-factor,`field_value_factor`>>
 * <<function-decay,decay functions>>: `gauss`, `linear`, `exp`
 


### PR DESCRIPTION
Formatting tick missing in `function-score-query` documents.
