### PR TITLE
Fix wrong reused file bytes in Recovery API reports

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -942,7 +942,7 @@ public class RecoveryState implements ToXContent, Streamable {
             // stream size first, as it matters more and the files section can be long
             builder.startObject(Fields.SIZE);
             builder.byteSizeField(Fields.TOTAL_IN_BYTES, Fields.TOTAL, totalBytes());
-            builder.byteSizeField(Fields.REUSED_IN_BYTES, Fields.REUSED, totalBytes());
+            builder.byteSizeField(Fields.REUSED_IN_BYTES, Fields.REUSED, reusedBytes());
             builder.byteSizeField(Fields.RECOVERED_IN_BYTES, Fields.RECOVERED, recoveredBytes());
             builder.field(Fields.PERCENT, String.format(Locale.ROOT, "%1.1f%%", recoveredBytesPercent()));
             builder.endObject();

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.restore/10_basic.yaml
@@ -1,0 +1,57 @@
+---
+setup:
+
+  - do:
+      snapshot.create_repository:
+        repository: test_repo1
+        body:
+          type: fs
+          settings:
+            location: "test_repo1"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 1
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+---
+"Create a snapshot and then restore it":
+
+  - do:
+      snapshot.create:
+        repository: test_repo1
+        snapshot: test_snapshot
+        wait_for_completion: true
+
+  - match: { snapshot.snapshot: test_snapshot }
+  - match: { snapshot.state : SUCCESS }
+  - match: { snapshot.shards.successful: 1 }
+  - match: { snapshot.shards.failed : 0 }
+
+  - do:
+      indices.close:
+        index : test_index
+
+  - do:
+      snapshot.restore:
+        repository: test_repo1
+        snapshot: test_snapshot
+        wait_for_completion: true
+
+  - do:
+      indices.recovery:
+        index: test_index
+
+  - match: { test_index.shards.0.type: SNAPSHOT }
+  - match: { test_index.shards.0.stage: DONE }
+  - match: { test_index.shards.0.index.files.recovered: 1}
+  - gt: { test_index.shards.0.index.size.recovered_in_bytes: 0}
+  - match: { test_index.shards.0.index.files.reused: 0}
+  - match: { test_index.shards.0.index.size.reused_in_bytes: 0}


### PR DESCRIPTION
Calling the correct method, reusedBytes() when creating json output.
This fixes #11876.
