### PR TITLE
Aggregations: Makes SKIP Gap Policy work correctly for Bucket Script aggregation

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptTests.java
@@ -46,6 +46,7 @@ import static org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorB
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 @ElasticsearchIntegrationTest.SuiteScopeTest
 public class BucketScriptTests extends ElasticsearchIntegrationTest {
@@ -119,9 +120,7 @@ public class BucketScriptTests extends ElasticsearchIntegrationTest {
             Histogram.Bucket bucket = buckets.get(i);
             if (bucket.getDocCount() == 0) {
                 SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertTrue(Double.isNaN(seriesArithmeticValue));
+                assertThat(seriesArithmetic, nullValue());
             } else {
                 Sum field2Sum = bucket.getAggregations().get("field2Sum");
                 assertThat(field2Sum, notNullValue());
@@ -167,9 +166,7 @@ public class BucketScriptTests extends ElasticsearchIntegrationTest {
             Histogram.Bucket bucket = buckets.get(i);
             if (bucket.getDocCount() == 0) {
                 SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertTrue(Double.isNaN(seriesArithmeticValue));
+                assertThat(seriesArithmetic, nullValue());
             } else {
                 Sum field2Sum = bucket.getAggregations().get("field2Sum");
                 assertThat(field2Sum, notNullValue());
@@ -213,9 +210,7 @@ public class BucketScriptTests extends ElasticsearchIntegrationTest {
             Histogram.Bucket bucket = buckets.get(i);
             if (bucket.getDocCount() == 0) {
                 SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertTrue(Double.isNaN(seriesArithmeticValue));
+                assertThat(seriesArithmetic, nullValue());
             } else {
                 Sum field2Sum = bucket.getAggregations().get("field2Sum");
                 assertThat(field2Sum, notNullValue());
@@ -259,9 +254,7 @@ public class BucketScriptTests extends ElasticsearchIntegrationTest {
             Histogram.Bucket bucket = buckets.get(i);
             if (bucket.getDocCount() == 0) {
                 SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertTrue(Double.isNaN(seriesArithmeticValue));
+                assertThat(seriesArithmetic, nullValue());
             } else {
                 Sum field2Sum = bucket.getAggregations().get("field2Sum");
                 assertThat(field2Sum, notNullValue());
@@ -309,9 +302,7 @@ public class BucketScriptTests extends ElasticsearchIntegrationTest {
             Histogram.Bucket bucket = buckets.get(i);
             if (bucket.getDocCount() == 0) {
                 SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertTrue(Double.isNaN(seriesArithmeticValue));
+                assertThat(seriesArithmetic, nullValue());
             } else {
                 Sum field2Sum = bucket.getAggregations().get("field2Sum");
                 assertThat(field2Sum, notNullValue());
@@ -392,7 +383,7 @@ public class BucketScriptTests extends ElasticsearchIntegrationTest {
                                 .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
                                 .subAggregation(
                                         bucketScript("seriesArithmetic").setBucketsPaths("field2Sum", "field3Sum", "field4Sum").script(
-                                                new Script("my_script", ScriptType.INDEXED, null, null)).gapPolicy(GapPolicy.INSERT_ZEROS))).execute().actionGet();
+                                                new Script("my_script", ScriptType.INDEXED, null, null)))).execute().actionGet();
 
         assertSearchResponse(response);
 
@@ -405,9 +396,7 @@ public class BucketScriptTests extends ElasticsearchIntegrationTest {
             Histogram.Bucket bucket = buckets.get(i);
             if (bucket.getDocCount() == 0) {
                 SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(0.0));
+                assertThat(seriesArithmetic, nullValue());
             } else {
                 Sum field2Sum = bucket.getAggregations().get("field2Sum");
                 assertThat(field2Sum, notNullValue());
@@ -476,9 +465,7 @@ public class BucketScriptTests extends ElasticsearchIntegrationTest {
             Histogram.Bucket bucket = buckets.get(i);
             if (bucket.getDocCount() == 0) {
                 SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertTrue(Double.isNaN(seriesArithmeticValue));
+                assertThat(seriesArithmetic, nullValue());
             } else {
                 Sum field2Sum = bucket.getAggregations().get("field2Sum");
                 assertThat(field2Sum, notNullValue());


### PR DESCRIPTION
This change means that when the skip gap policy is used, the bucket script aggregation will skip executing the script on a bucket if any of the required bucket_paths are missing for the bucket. No aggregation will be added to the bucket, and the aggregation will move to the next bucket.
