### PR TITLE
Don't join master nodes or accept join requests of old and too new nodes

### DIFF
--- a/core/src/test/java/org/elasticsearch/discovery/zen/ElectMasterServiceTest.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ElectMasterServiceTest.java
@@ -32,7 +32,7 @@ import java.util.*;
 public class ElectMasterServiceTest extends ElasticsearchTestCase {
 
     ElectMasterService electMasterService() {
-        return new ElectMasterService(Settings.EMPTY);
+        return new ElectMasterService(Settings.EMPTY, Version.CURRENT);
     }
 
     List<DiscoveryNode> generateRandomNodes() {

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
@@ -57,7 +57,7 @@ public class UnicastZenPingTests extends ElasticsearchTestCase {
         ThreadPool threadPool = new ThreadPool(getClass().getName());
         ClusterName clusterName = new ClusterName("test");
         NetworkService networkService = new NetworkService(settings);
-        ElectMasterService electMasterService = new ElectMasterService(settings);
+        ElectMasterService electMasterService = new ElectMasterService(settings, Version.CURRENT);
 
         NettyTransport transportA = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT);
         final TransportService transportServiceA = new TransportService(transportA, threadPool).start();


### PR DESCRIPTION
If the version of a node is lower than the minimum supported version or higher than the maximum hypothetical supported version, a node shouldn't be allowed to join and nodes should join that elected master node

Closes #11924
