### PR TITLE
Move short name access out of field type

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -193,13 +193,6 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
                         it.remove();
                     }
                 }
-                for (Iterator<FieldMapper> it = remainingFieldMappers.iterator(); it.hasNext(); ) {
-                    final FieldMapper fieldMapper = it.next();
-                    if (Regex.simpleMatch(field, fieldMapper.fieldType().names().shortName())) {
-                        addFieldMapper(fieldMapper.fieldType().names().shortName(), fieldMapper, fieldMappings, request.includeDefaults());
-                        it.remove();
-                    }
-                }
 
             } else {
                 // not a pattern

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -23,28 +23,27 @@ import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 
 import java.io.IOException;
 
-/**
- *
- */
-public interface FieldMapper extends Mapper {
+public abstract class FieldMapper extends Mapper {
 
-    String DOC_VALUES_FORMAT = "doc_values_format";
+    public FieldMapper(String simpleName) {
+        super(simpleName);
+    }
 
-    MappedFieldType fieldType();
+    public abstract MappedFieldType fieldType();
 
     /** Returns a reference to the MappedFieldType for this mapper. */
-    MappedFieldTypeReference fieldTypeReference();
+    public abstract MappedFieldTypeReference fieldTypeReference();
 
     /**
      * Updates the reference to this field's MappedFieldType.
      * Implementations should assert equality of the underlying field type
      */
-    void setFieldTypeReference(MappedFieldTypeReference ref);
+    public abstract void setFieldTypeReference(MappedFieldTypeReference ref);
 
     /**
      * List of fields where this field should be copied to
      */
-    AbstractFieldMapper.CopyTo copyTo();
+    public abstract AbstractFieldMapper.CopyTo copyTo();
 
     /**
      * Fields might not be available before indexing, for example _all, token_count,...
@@ -52,13 +51,13 @@ public interface FieldMapper extends Mapper {
      *
      * @return If the field is available before indexing or not.
      * */
-    boolean isGenerated();
+    public abstract boolean isGenerated();
 
     /**
      * Parse using the provided {@link ParseContext} and return a mapping
      * update if dynamic mappings modified the mappings, or {@code null} if
      * mappings were not modified.
      */
-    Mapper parse(ParseContext context) throws IOException;
+    public abstract Mapper parse(ParseContext context) throws IOException;
 
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -54,8 +54,6 @@ public abstract class MappedFieldType extends FieldType {
 
     public static class Names {
 
-        private final String shortName;
-
         private final String indexName;
 
         private final String originalIndexName;
@@ -63,21 +61,13 @@ public abstract class MappedFieldType extends FieldType {
         private final String fullName;
 
         public Names(String name) {
-            this(name, name, name, name);
+            this(name, name, name);
         }
 
-        public Names(String shortName, String indexName, String originalIndexName, String fullName) {
-            this.shortName = shortName;
+        public Names(String indexName, String originalIndexName, String fullName) {
             this.indexName = indexName;
             this.originalIndexName = originalIndexName;
             this.fullName = fullName;
-        }
-
-        /**
-         * The logical name of the field.
-         */
-        public String shortName() {
-            return shortName;
         }
 
         /**
@@ -111,15 +101,13 @@ public abstract class MappedFieldType extends FieldType {
             if (!fullName.equals(names.fullName)) return false;
             if (!indexName.equals(names.indexName)) return false;
             if (!originalIndexName.equals(names.originalIndexName)) return false;
-            if (!shortName.equals(names.shortName)) return false;
 
             return true;
         }
 
         @Override
         public int hashCode() {
-            int result = shortName.hashCode();
-            result = 31 * result + indexName.hashCode();
+            int result = indexName.hashCode();
             result = 31 * result + originalIndexName.hashCode();
             result = 31 * result + fullName.hashCode();
             return result;

--- a/core/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -30,11 +30,9 @@ import org.elasticsearch.index.similarity.SimilarityLookupService;
 
 import java.util.Map;
 
-public interface Mapper extends ToXContent, Iterable<Mapper> {
+public abstract class Mapper implements ToXContent, Iterable<Mapper> {
 
-    Mapper[] EMPTY_ARRAY = new Mapper[0];
-
-    class BuilderContext {
+    public static class BuilderContext {
         private final Settings indexSettings;
         private final ContentPath contentPath;
 
@@ -61,7 +59,7 @@ public interface Mapper extends ToXContent, Iterable<Mapper> {
         }
     }
 
-    abstract class Builder<T extends Builder, Y extends Mapper> {
+    public static abstract class Builder<T extends Builder, Y extends Mapper> {
 
         public String name;
 
@@ -78,7 +76,7 @@ public interface Mapper extends ToXContent, Iterable<Mapper> {
         public abstract Y build(BuilderContext context);
     }
 
-    interface TypeParser {
+    public interface TypeParser {
 
         class ParserContext {
 
@@ -126,7 +124,20 @@ public interface Mapper extends ToXContent, Iterable<Mapper> {
         Mapper.Builder<?,?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException;
     }
 
-    String name();
+    private final String simpleName;
 
-    void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException;
+    public Mapper(String simpleName) {
+        this.simpleName = simpleName;
+    }
+
+    /** Returns the simple name, which identifies this mapper against other mappers at the same level in the mappers hierarchy
+     * TODO: make this protected once Mapper, FieldMapper and AbstractFieldMapper are merged together */
+    public final String simpleName() {
+        return simpleName;
+    }
+
+    /** Returns the canonical name which uniquely identifies the mapper against other mappers in a type. */
+    public abstract String name();
+
+    public abstract void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException;
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -102,7 +102,7 @@ public final class Mapping implements ToXContent {
         return (T) rootMappersMap.get(clazz);
     }
 
-    /** @see DocumentMapper#merge(Mapping, boolean) */
+    /** @see DocumentMapper#merge(Mapping, boolean, boolean) */
     public void merge(Mapping mergeWith, MergeResult mergeResult) {
         assert metadataMappers.length == mergeWith.metadataMappers.length;
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -38,8 +38,8 @@ public abstract class MetadataFieldMapper extends AbstractFieldMapper {
         }
     }
 
-    protected MetadataFieldMapper(MappedFieldType fieldType, Boolean docValues, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, docValues, fieldDataSettings, indexSettings, MultiFields.empty(), null);
+    protected MetadataFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues, @Nullable Settings fieldDataSettings, Settings indexSettings) {
+        super(simpleName, fieldType, docValues, fieldDataSettings, indexSettings, MultiFields.empty(), null);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BinaryFieldMapper.java
@@ -84,7 +84,7 @@ public class BinaryFieldMapper extends AbstractFieldMapper {
         public BinaryFieldMapper build(BuilderContext context) {
             setupFieldType(context);
             ((BinaryFieldType)fieldType).setTryUncompressing(context.indexCreatedVersion().before(Version.V_2_0_0));
-            return new BinaryFieldMapper(fieldType, docValues,
+            return new BinaryFieldMapper(name, fieldType, docValues,
                     fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
         }
     }
@@ -184,9 +184,9 @@ public class BinaryFieldMapper extends AbstractFieldMapper {
         }
     }
 
-    protected BinaryFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected BinaryFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                                 @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -90,7 +90,7 @@ public class BooleanFieldMapper extends AbstractFieldMapper {
         @Override
         public BooleanFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            return new BooleanFieldMapper(fieldType, docValues,
+            return new BooleanFieldMapper(name, fieldType, docValues,
                     fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
         }
     }
@@ -194,9 +194,9 @@ public class BooleanFieldMapper extends AbstractFieldMapper {
         }
     }
 
-    protected BooleanFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected BooleanFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                                  @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/ByteFieldMapper.java
@@ -81,7 +81,7 @@ public class ByteFieldMapper extends NumberFieldMapper {
         @Override
         public ByteFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            ByteFieldMapper fieldMapper = new ByteFieldMapper(fieldType, docValues, ignoreMalformed(context),
+            ByteFieldMapper fieldMapper = new ByteFieldMapper(name, fieldType, docValues, ignoreMalformed(context),
                     coerce(context), fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -193,10 +193,10 @@ public class ByteFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected ByteFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected ByteFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                               Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                               @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -151,7 +151,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
             CompletionFieldType completionFieldType = (CompletionFieldType)fieldType;
             completionFieldType.setProvider(new AnalyzingCompletionLookupProvider(preserveSeparators, false, preservePositionIncrements, payloads));
             completionFieldType.setContextMapping(contextMapping);
-            return new CompletionFieldMapper(fieldType, maxInputLength, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            return new CompletionFieldMapper(name, fieldType, maxInputLength, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
         }
 
     }
@@ -311,8 +311,8 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
 
     private int maxInputLength;
 
-    public CompletionFieldMapper(MappedFieldType fieldType, int maxInputLength, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, false, null, indexSettings, multiFields, copyTo);
+    public CompletionFieldMapper(String simpleName, MappedFieldType fieldType, int maxInputLength, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, false, null, indexSettings, multiFields, copyTo);
         this.maxInputLength = maxInputLength;
     }
 
@@ -505,7 +505,7 @@ public class CompletionFieldMapper extends AbstractFieldMapper {
     
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(fieldType().names().shortName())
+        builder.startObject(simpleName())
                 .field(Fields.TYPE, CONTENT_TYPE);
         
         builder.field(Fields.ANALYZER, fieldType().indexAnalyzer().name());

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -117,7 +117,7 @@ public class DateFieldMapper extends NumberFieldMapper {
         public DateFieldMapper build(BuilderContext context) {
             setupFieldType(context);
             fieldType.setNullValue(nullValue);
-            DateFieldMapper fieldMapper = new DateFieldMapper(fieldType,
+            DateFieldMapper fieldMapper = new DateFieldMapper(name, fieldType,
                     docValues, ignoreMalformed(context), coerce(context),
                     fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
@@ -414,9 +414,9 @@ public class DateFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected DateFieldMapper(MappedFieldType fieldType, Boolean docValues, Explicit<Boolean> ignoreMalformed,Explicit<Boolean> coerce,
+    protected DateFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues, Explicit<Boolean> ignoreMalformed,Explicit<Boolean> coerce,
                               @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DoubleFieldMapper.java
@@ -88,7 +88,7 @@ public class DoubleFieldMapper extends NumberFieldMapper {
         @Override
         public DoubleFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            DoubleFieldMapper fieldMapper = new DoubleFieldMapper(fieldType, docValues, ignoreMalformed(context), coerce(context),
+            DoubleFieldMapper fieldMapper = new DoubleFieldMapper(name, fieldType, docValues, ignoreMalformed(context), coerce(context),
                     fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -201,9 +201,9 @@ public class DoubleFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected DoubleFieldMapper(MappedFieldType fieldType, Boolean docValues, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+    protected DoubleFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                 @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/FloatFieldMapper.java
@@ -89,7 +89,7 @@ public class FloatFieldMapper extends NumberFieldMapper {
         @Override
         public FloatFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            FloatFieldMapper fieldMapper = new FloatFieldMapper(fieldType, docValues, ignoreMalformed(context), coerce(context),
+            FloatFieldMapper fieldMapper = new FloatFieldMapper(name, fieldType, docValues, ignoreMalformed(context), coerce(context),
                     fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -202,10 +202,10 @@ public class FloatFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected FloatFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected FloatFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                                Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                @Nullable Settings fieldDataSettings, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/IntegerFieldMapper.java
@@ -89,7 +89,7 @@ public class IntegerFieldMapper extends NumberFieldMapper {
         @Override
         public IntegerFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            IntegerFieldMapper fieldMapper = new IntegerFieldMapper(fieldType, docValues,
+            IntegerFieldMapper fieldMapper = new IntegerFieldMapper(name, fieldType, docValues,
                     ignoreMalformed(context), coerce(context), fieldDataSettings,
                     context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
@@ -202,11 +202,11 @@ public class IntegerFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected IntegerFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected IntegerFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                                  Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                  @Nullable Settings fieldDataSettings,
                                  Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/LongFieldMapper.java
@@ -89,7 +89,7 @@ public class LongFieldMapper extends NumberFieldMapper {
         @Override
         public LongFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            LongFieldMapper fieldMapper = new LongFieldMapper(fieldType, docValues,
+            LongFieldMapper fieldMapper = new LongFieldMapper(name, fieldType, docValues,
                     ignoreMalformed(context), coerce(context), fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -201,11 +201,11 @@ public class LongFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected LongFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected LongFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                               Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                               @Nullable Settings fieldDataSettings,
                               Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/Murmur3FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/Murmur3FieldMapper.java
@@ -61,7 +61,7 @@ public class Murmur3FieldMapper extends LongFieldMapper {
         @Override
         public Murmur3FieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            Murmur3FieldMapper fieldMapper = new Murmur3FieldMapper(fieldType, docValues,
+            Murmur3FieldMapper fieldMapper = new Murmur3FieldMapper(name, fieldType, docValues,
                     ignoreMalformed(context), coerce(context),
                     fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
@@ -119,11 +119,11 @@ public class Murmur3FieldMapper extends LongFieldMapper {
         }
     }
 
-    protected Murmur3FieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected Murmur3FieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
             Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
             @Nullable Settings fieldDataSettings,
             Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce,
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce,
                 fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/NumberFieldMapper.java
@@ -185,11 +185,11 @@ public abstract class NumberFieldMapper extends AbstractFieldMapper implements A
      */
     protected final boolean useSortedNumericDocValues;
 
-    protected NumberFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected NumberFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                                 Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, @Nullable Settings fieldDataSettings, Settings indexSettings,
                                 MultiFields multiFields, CopyTo copyTo) {
         // LUCENE 4 UPGRADE: Since we can't do anything before the super call, we have to push the boost check down to subclasses
-        super(fieldType, docValues, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, fieldDataSettings, indexSettings, multiFields, copyTo);
         this.ignoreMalformed = ignoreMalformed;
         this.coerce = coerce;
         this.useSortedNumericDocValues = Version.indexCreated(indexSettings).onOrAfter(Version.V_1_4_0_Beta1);

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/ShortFieldMapper.java
@@ -85,7 +85,7 @@ public class ShortFieldMapper extends NumberFieldMapper {
         @Override
         public ShortFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            ShortFieldMapper fieldMapper = new ShortFieldMapper(fieldType, docValues,
+            ShortFieldMapper fieldMapper = new ShortFieldMapper(name, fieldType, docValues,
                     ignoreMalformed(context), coerce(context), fieldDataSettings,
                     context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
@@ -199,11 +199,11 @@ public class ShortFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected ShortFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected ShortFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                                Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                                @Nullable Settings fieldDataSettings,
                                Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce,
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce,
              fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -130,7 +130,7 @@ public class StringFieldMapper extends AbstractFieldMapper implements AllFieldMa
             defaultFieldType.freeze();
             setupFieldType(context);
             StringFieldMapper fieldMapper = new StringFieldMapper(
-                    fieldType, defaultFieldType, docValues, positionOffsetGap, ignoreAbove,
+                    name, fieldType, defaultFieldType, docValues, positionOffsetGap, ignoreAbove,
                     fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -223,10 +223,10 @@ public class StringFieldMapper extends AbstractFieldMapper implements AllFieldMa
     private int ignoreAbove;
     private final MappedFieldType defaultFieldType;
 
-    protected StringFieldMapper(MappedFieldType fieldType, MappedFieldType defaultFieldType, Boolean docValues,
+    protected StringFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Boolean docValues,
                                 int positionOffsetGap, int ignoreAbove, @Nullable Settings fieldDataSettings,
                                 Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, fieldDataSettings, indexSettings, multiFields, copyTo);
         if (fieldType.tokenized() && fieldType.indexOptions() != NONE && fieldType().hasDocValues()) {
             throw new MapperParsingException("Field [" + fieldType.names().fullName() + "] cannot be analyzed and have doc values");
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TokenCountFieldMapper.java
@@ -78,7 +78,7 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
         @Override
         public TokenCountFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            TokenCountFieldMapper fieldMapper = new TokenCountFieldMapper(fieldType, docValues,
+            TokenCountFieldMapper fieldMapper = new TokenCountFieldMapper(name, fieldType, docValues,
                     ignoreMalformed(context), coerce(context), fieldDataSettings, context.indexSettings(),
                     analyzer, multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
@@ -127,10 +127,10 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
 
     private NamedAnalyzer analyzer;
 
-    protected TokenCountFieldMapper(MappedFieldType fieldType, Boolean docValues, Explicit<Boolean> ignoreMalformed,
+    protected TokenCountFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues, Explicit<Boolean> ignoreMalformed,
                                     Explicit<Boolean> coerce, Settings fieldDataSettings, Settings indexSettings,
                                     NamedAnalyzer analyzer, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce, fieldDataSettings, indexSettings, multiFields, copyTo);
         this.analyzer = analyzer;
     }
 
@@ -146,7 +146,7 @@ public class TokenCountFieldMapper extends IntegerFieldMapper {
             if (valueAndBoost.value() == null) {
                 count = fieldType().nullValue();
             } else {
-                count = countPositions(analyzer.analyzer().tokenStream(fieldType().names().shortName(), valueAndBoost.value()));
+                count = countPositions(analyzer.analyzer().tokenStream(simpleName(), valueAndBoost.value()));
             }
             addIntegerFields(context, fields, count, valueAndBoost.boost());
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -48,7 +48,6 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeFl
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeIntegerValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeMapValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeStringValue;
-import static org.elasticsearch.index.mapper.FieldMapper.DOC_VALUES_FORMAT;
 
 /**
  *
@@ -273,7 +272,7 @@ public class TypeParsers {
             } else if (propName.equals("postings_format") && parserContext.indexVersionCreated().before(Version.V_2_0_0)) {
                 // ignore for old indexes
                 iterator.remove();
-            } else if (propName.equals(DOC_VALUES_FORMAT) && parserContext.indexVersionCreated().before(Version.V_2_0_0)) {
+            } else if (propName.equals("doc_values_format") && parserContext.indexVersionCreated().before(Version.V_2_0_0)) {
                 // ignore for old indexes
                 iterator.remove();
             } else if (propName.equals("similarity")) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -207,7 +207,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper implements ArrayVal
             fieldType.setHasDocValues(false);
             setupFieldType(context);
 
-            return new GeoPointFieldMapper(fieldType, docValues, fieldDataSettings, context.indexSettings(), origPathType,
+            return new GeoPointFieldMapper(name, fieldType, docValues, fieldDataSettings, context.indexSettings(), origPathType,
                      latMapper, lonMapper, geohashMapper, multiFieldsBuilder.build(this, context));
         }
     }
@@ -586,9 +586,9 @@ public class GeoPointFieldMapper extends AbstractFieldMapper implements ArrayVal
 
     private final StringFieldMapper geohashMapper;
 
-    public GeoPointFieldMapper(MappedFieldType fieldType, Boolean docValues, @Nullable Settings fieldDataSettings, Settings indexSettings,
+    public GeoPointFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues, @Nullable Settings fieldDataSettings, Settings indexSettings,
             ContentPath.Type pathType, DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper, StringFieldMapper geohashMapper,MultiFields multiFields) {
-        super(fieldType, docValues, fieldDataSettings, indexSettings, multiFields, null);
+        super(simpleName, fieldType, docValues, fieldDataSettings, indexSettings, multiFields, null);
         this.pathType = pathType;
         this.latMapper = latMapper;
         this.lonMapper = lonMapper;
@@ -629,7 +629,7 @@ public class GeoPointFieldMapper extends AbstractFieldMapper implements ArrayVal
     public Mapper parse(ParseContext context) throws IOException {
         ContentPath.Type origPathType = context.path().pathType();
         context.path().pathType(pathType);
-        context.path().add(fieldType().names().shortName());
+        context.path().add(simpleName());
 
         GeoPoint sparse = context.parseExternalValue(GeoPoint.class);
         

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapper.java
@@ -131,7 +131,7 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper {
             }
             setupFieldType(context);
 
-            return new GeoShapeFieldMapper(fieldType, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+            return new GeoShapeFieldMapper(name, fieldType, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
         }
     }
 
@@ -358,8 +358,8 @@ public class GeoShapeFieldMapper extends AbstractFieldMapper {
 
     }
 
-    public GeoShapeFieldMapper(MappedFieldType fieldType, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, false, null, indexSettings, multiFields, copyTo);
+    public GeoShapeFieldMapper(String simpleName, MappedFieldType fieldType, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, false, null, indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -59,7 +59,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
  */
 public class AllFieldMapper extends MetadataFieldMapper {
 
-    public interface IncludeInAll extends Mapper {
+    public interface IncludeInAll {
 
         void includeInAll(Boolean includeInAll);
 
@@ -202,7 +202,7 @@ public class AllFieldMapper extends MetadataFieldMapper {
 
     protected AllFieldMapper(MappedFieldType fieldType, EnabledAttributeMapper enabled,
                              @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, false, fieldDataSettings, indexSettings);
+        super(NAME, fieldType, false, fieldDataSettings, indexSettings);
         this.enabledState = enabled;
 
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -207,7 +207,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
     }
 
     public FieldNamesFieldMapper(MappedFieldType fieldType, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, false, fieldDataSettings, indexSettings);
+        super(NAME, fieldType, false, fieldDataSettings, indexSettings);
         this.defaultFieldType = Defaults.FIELD_TYPE;
         this.pre13Index = Version.indexCreated(indexSettings).before(Version.V_1_3_0);
         if (this.pre13Index) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -108,7 +108,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
 
         @Override
         public IdFieldMapper build(BuilderContext context) {
-            fieldType.setNames(new MappedFieldType.Names(name, indexName, indexName, name));
+            fieldType.setNames(new MappedFieldType.Names(indexName, indexName, name));
             return new IdFieldMapper(fieldType, docValues, path, fieldDataSettings, context.indexSettings());
         }
     }
@@ -235,7 +235,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
 
     protected IdFieldMapper(MappedFieldType fieldType, Boolean docValues, String path,
                             @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, docValues, fieldDataSettings, indexSettings);
+        super(NAME, fieldType, docValues, fieldDataSettings, indexSettings);
         this.path = path;
     }
     

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -90,7 +90,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
 
         @Override
         public IndexFieldMapper build(BuilderContext context) {
-            fieldType.setNames(new MappedFieldType.Names(name, indexName, indexName, name));
+            fieldType.setNames(new MappedFieldType.Names(indexName, indexName, name));
             return new IndexFieldMapper(fieldType, enabledState, fieldDataSettings, context.indexSettings());
         }
     }
@@ -154,7 +154,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
 
     public IndexFieldMapper(MappedFieldType fieldType, EnabledAttributeMapper enabledState,
                             @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, false, fieldDataSettings, indexSettings);
+        super(NAME, fieldType, false, fieldDataSettings, indexSettings);
         this.enabledState = enabledState;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -230,7 +230,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
     private final String type;
 
     protected ParentFieldMapper(MappedFieldType fieldType, String type, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, Version.indexCreated(indexSettings).onOrAfter(Version.V_2_0_0), fieldDataSettings, indexSettings);
+        super(NAME, fieldType, Version.indexCreated(indexSettings).onOrAfter(Version.V_2_0_0), fieldDataSettings, indexSettings);
         this.type = type;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/RoutingFieldMapper.java
@@ -157,7 +157,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
     }
 
     protected RoutingFieldMapper(MappedFieldType fieldType, boolean required, String path, Settings indexSettings) {
-        super(fieldType, false, null, indexSettings);
+        super(NAME, fieldType, false, null, indexSettings);
         this.required = required;
         this.path = path;
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SizeFieldMapper.java
@@ -52,7 +52,6 @@ public class SizeFieldMapper extends MetadataFieldMapper {
     public static final String CONTENT_TYPE = "_size";
 
     public static class Defaults extends IntegerFieldMapper.Defaults {
-        public static final String NAME = CONTENT_TYPE;
         public static final EnabledAttributeMapper ENABLED_STATE = EnabledAttributeMapper.UNSET_DISABLED;
 
         public static final MappedFieldType SIZE_FIELD_TYPE = IntegerFieldMapper.Defaults.FIELD_TYPE.clone();
@@ -72,7 +71,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
         protected EnabledAttributeMapper enabledState = EnabledAttributeMapper.UNSET_DISABLED;
 
         public Builder(MappedFieldType existing) {
-            super(Defaults.NAME, existing == null ? Defaults.SIZE_FIELD_TYPE : existing);
+            super(NAME, existing == null ? Defaults.SIZE_FIELD_TYPE : existing);
             builder = this;
         }
 
@@ -115,14 +114,14 @@ public class SizeFieldMapper extends MetadataFieldMapper {
     }
 
     public SizeFieldMapper(EnabledAttributeMapper enabled, MappedFieldType fieldType, Settings indexSettings) {
-        super(fieldType, false, null, indexSettings);
+        super(NAME, fieldType, false, null, indexSettings);
         this.enabledState = enabled;
 
     }
 
     @Override
     protected String contentType() {
-        return Defaults.NAME;
+        return NAME;
     }
 
     public boolean enabled() {

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -256,7 +256,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     protected SourceFieldMapper(boolean enabled, String format, Boolean compress, long compressThreshold,
                                 String[] includes, String[] excludes, Settings indexSettings) {
-        super(Defaults.FIELD_TYPE.clone(), false, null, indexSettings); // Only stored.
+        super(NAME, Defaults.FIELD_TYPE.clone(), false, null, indexSettings); // Only stored.
         this.enabled = enabled;
         this.compress = compress;
         this.compressThreshold = compressThreshold;

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TTLFieldMapper.java
@@ -167,7 +167,7 @@ public class TTLFieldMapper extends MetadataFieldMapper {
 
     protected TTLFieldMapper(MappedFieldType fieldType, EnabledAttributeMapper enabled, long defaultTTL,
                              @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, false, fieldDataSettings, indexSettings);
+        super(NAME, fieldType, false, fieldDataSettings, indexSettings);
         this.enabledState = enabled;
         this.defaultTTL = defaultTTL;
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TimestampFieldMapper.java
@@ -249,7 +249,7 @@ public class TimestampFieldMapper extends MetadataFieldMapper {
 
     protected TimestampFieldMapper(MappedFieldType fieldType, Boolean docValues, EnabledAttributeMapper enabledState, String path,
                                    String defaultTimestamp, Boolean ignoreMissing, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, docValues, fieldDataSettings, indexSettings);
+        super(NAME, fieldType, docValues, fieldDataSettings, indexSettings);
         this.enabledState = enabledState;
         this.path = path;
         this.defaultTimestamp = defaultTimestamp;

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -87,7 +87,7 @@ public class TypeFieldMapper extends MetadataFieldMapper {
 
         @Override
         public TypeFieldMapper build(BuilderContext context) {
-            fieldType.setNames(new MappedFieldType.Names(name, indexName, indexName, name));
+            fieldType.setNames(new MappedFieldType.Names(indexName, indexName, name));
             return new TypeFieldMapper(fieldType, context.indexSettings());
         }
     }
@@ -150,7 +150,7 @@ public class TypeFieldMapper extends MetadataFieldMapper {
     }
 
     public TypeFieldMapper(MappedFieldType fieldType, Settings indexSettings) {
-        super(fieldType, false, null, indexSettings);
+        super(NAME, fieldType, false, null, indexSettings);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/UidFieldMapper.java
@@ -88,7 +88,7 @@ public class UidFieldMapper extends MetadataFieldMapper {
 
         @Override
         public UidFieldMapper build(BuilderContext context) {
-            fieldType.setNames(new MappedFieldType.Names(name, indexName, indexName, name));
+            fieldType.setNames(new MappedFieldType.Names(indexName, indexName, name));
             return new UidFieldMapper(fieldType, docValues, fieldDataSettings, context.indexSettings());
         }
     }
@@ -139,7 +139,7 @@ public class UidFieldMapper extends MetadataFieldMapper {
     }
 
     protected UidFieldMapper(MappedFieldType fieldType, Boolean docValues, @Nullable Settings fieldDataSettings, Settings indexSettings) {
-        super(fieldType, docValuesEnabled(docValues, indexSettings), fieldDataSettings, indexSettings);
+        super(NAME, fieldType, docValuesEnabled(docValues, indexSettings), fieldDataSettings, indexSettings);
     }
     
     static Boolean docValuesEnabled(Boolean docValues, Settings indexSettings) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/VersionFieldMapper.java
@@ -78,7 +78,7 @@ public class VersionFieldMapper extends MetadataFieldMapper {
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = Strings.toUnderscoreCase(entry.getKey());
-                if (fieldName.equals(DOC_VALUES_FORMAT) && parserContext.indexVersionCreated().before(Version.V_2_0_0)) {
+                if (fieldName.equals("doc_values_format") && parserContext.indexVersionCreated().before(Version.V_2_0_0)) {
                     // ignore in 1.x, reject in 2.x
                     iterator.remove();
                 }
@@ -116,7 +116,7 @@ public class VersionFieldMapper extends MetadataFieldMapper {
     }
 
     public VersionFieldMapper(Settings indexSettings) {
-        super(Defaults.FIELD_TYPE, true, null, indexSettings);
+        super(NAME, Defaults.FIELD_TYPE, true, null, indexSettings);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -119,7 +119,7 @@ public class IpFieldMapper extends NumberFieldMapper {
         @Override
         public IpFieldMapper build(BuilderContext context) {
             setupFieldType(context);
-            IpFieldMapper fieldMapper = new IpFieldMapper(fieldType, docValues, ignoreMalformed(context), coerce(context),
+            IpFieldMapper fieldMapper = new IpFieldMapper(name, fieldType, docValues, ignoreMalformed(context), coerce(context),
                     fieldDataSettings, context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
             fieldMapper.includeInAll(includeInAll);
             return fieldMapper;
@@ -235,11 +235,11 @@ public class IpFieldMapper extends NumberFieldMapper {
         }
     }
 
-    protected IpFieldMapper(MappedFieldType fieldType, Boolean docValues,
+    protected IpFieldMapper(String simpleName, MappedFieldType fieldType, Boolean docValues,
                             Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
                             @Nullable Settings fieldDataSettings,
                             Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, docValues, ignoreMalformed, coerce,
+        super(simpleName, fieldType, docValues, ignoreMalformed, coerce,
               fieldDataSettings, indexSettings, multiFields, copyTo);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/object/ObjectMapper.java
@@ -66,7 +66,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
 /**
  *
  */
-public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Cloneable {
+public class ObjectMapper extends Mapper implements AllFieldMapper.IncludeInAll, Cloneable {
 
     public static final String CONTENT_TYPE = "object";
     public static final String NESTED_CONTENT_TYPE = "nested";
@@ -175,7 +175,7 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
             Map<String, Mapper> mappers = new HashMap<>();
             for (Mapper.Builder builder : mappersBuilders) {
                 Mapper mapper = builder.build(context);
-                mappers.put(mapper.name(), mapper);
+                mappers.put(mapper.simpleName(), mapper);
             }
             context.path().pathType(origPathType);
             context.path().remove();
@@ -331,8 +331,6 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
         }
     }
 
-    private final String name;
-
     private final String fullPath;
 
     private final boolean enabled;
@@ -353,7 +351,7 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
     private volatile CopyOnWriteHashMap<String, Mapper> mappers;
 
     ObjectMapper(String name, String fullPath, boolean enabled, Nested nested, Dynamic dynamic, ContentPath.Type pathType, Map<String, Mapper> mappers) {
-        this.name = name;
+        super(name);
         this.fullPath = fullPath;
         this.enabled = enabled;
         this.nested = nested;
@@ -393,7 +391,7 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
 
     @Override
     public String name() {
-        return this.name;
+        return this.fullPath;
     }
 
     public boolean isEnabled() {
@@ -463,7 +461,7 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
         if (mapper instanceof AllFieldMapper.IncludeInAll) {
             ((AllFieldMapper.IncludeInAll) mapper).includeInAllIfNotSet(includeInAll);
         }
-        mappers = mappers.copyAndPut(mapper.name(), mapper);
+        mappers = mappers.copyAndPut(mapper.simpleName(), mapper);
     }
 
     @Override
@@ -516,7 +514,7 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
         List<FieldMapper> newFieldMappers = new ArrayList<>();
         for (Mapper mapper : mergeWithObject) {
             Mapper mergeWithMapper = mapper;
-            Mapper mergeIntoMapper = mappers.get(mergeWithMapper.name());
+            Mapper mergeIntoMapper = mappers.get(mergeWithMapper.simpleName());
             if (mergeIntoMapper == null) {
                 // no mapping, simply add it if not simulating
                 if (!mergeResult.simulate()) {
@@ -551,7 +549,7 @@ public class ObjectMapper implements Mapper, AllFieldMapper.IncludeInAll, Clonea
     }
 
     public void toXContent(XContentBuilder builder, Params params, ToXContent custom) throws IOException {
-        builder.startObject(name);
+        builder.startObject(simpleName());
         if (nested.isNested()) {
             builder.field("type", NESTED_CONTENT_TYPE);
             if (nested.isIncludeInParent()) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -179,11 +179,11 @@ public class FieldTypeLookupTests extends ElasticsearchTestCase {
     static class FakeFieldMapper extends AbstractFieldMapper {
         static Settings dummySettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
         public FakeFieldMapper(String fullName, String indexName) {
-            super(makeFieldType(fullName, indexName), null, null, dummySettings, null, null);
+            super(fullName, makeFieldType(fullName, indexName), null, null, dummySettings, null, null);
         }
         static MappedFieldType makeFieldType(String fullName, String indexName) {
             FakeFieldType fieldType = new FakeFieldType();
-            fieldType.setNames(new MappedFieldType.Names(fullName, indexName, indexName, fullName));
+            fieldType.setNames(new MappedFieldType.Names(indexName, indexName, fullName));
             return fieldType;
         }
         static class FakeFieldType extends MappedFieldType {

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -108,7 +108,7 @@ public class ExternalMapper extends AbstractFieldMapper {
             context.path().pathType(origPathType);
             setupFieldType(context);
 
-            return new ExternalMapper(fieldType, generatedValue, mapperName, binMapper, boolMapper, pointMapper, shapeMapper, stringMapper,
+            return new ExternalMapper(name, fieldType, generatedValue, mapperName, binMapper, boolMapper, pointMapper, shapeMapper, stringMapper,
                     context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
         }
     }
@@ -170,11 +170,11 @@ public class ExternalMapper extends AbstractFieldMapper {
     private final GeoShapeFieldMapper shapeMapper;
     private final FieldMapper stringMapper;
 
-    public ExternalMapper(MappedFieldType fieldType,
+    public ExternalMapper(String simpleName, MappedFieldType fieldType,
                           String generatedValue, String mapperName,
                           BinaryFieldMapper binMapper, BooleanFieldMapper boolMapper, GeoPointFieldMapper pointMapper,
                           GeoShapeFieldMapper shapeMapper, FieldMapper stringMapper, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
-        super(fieldType, false, null, indexSettings,
+        super(simpleName, fieldType, false, null, indexSettings,
                 multiFields, copyTo);
         this.generatedValue = generatedValue;
         this.mapperName = mapperName;
@@ -238,7 +238,7 @@ public class ExternalMapper extends AbstractFieldMapper {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(fieldType().names().shortName());
+        builder.startObject(simpleName());
         builder.field("type", mapperName);
         multiFields.toXContent(builder, params);
         builder.endObject();

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMetadataMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMetadataMapper.java
@@ -53,7 +53,7 @@ public class ExternalMetadataMapper extends MetadataFieldMapper {
     }
 
     protected ExternalMetadataMapper(Settings indexSettings) {
-        super(FIELD_TYPE, true, null, indexSettings);
+        super(FIELD_NAME, FIELD_TYPE, true, null, indexSettings);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionPostingsFormatTest.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionPostingsFormatTest.java
@@ -249,7 +249,7 @@ public class CompletionPostingsFormatTest extends ElasticsearchTestCase {
         AnalyzingCompletionLookupProvider currentProvider = new AnalyzingCompletionLookupProvider(preserveSeparators, false, preservePositionIncrements, usePayloads);
         CompletionFieldMapper.CompletionFieldType fieldType = FIELD_TYPE.clone();
         fieldType.setProvider(currentProvider);
-        final CompletionFieldMapper mapper = new CompletionFieldMapper(fieldType, Integer.MAX_VALUE, indexSettings, AbstractFieldMapper.MultiFields.empty(), null);
+        final CompletionFieldMapper mapper = new CompletionFieldMapper("foo", fieldType, Integer.MAX_VALUE, indexSettings, AbstractFieldMapper.MultiFields.empty(), null);
         Lookup buildAnalyzingLookup = buildAnalyzingLookup(mapper, titles, titles, weights);
         Field field = buildAnalyzingLookup.getClass().getDeclaredField("maxAnalyzedPathsForOneInput");
         field.setAccessible(true);


### PR DESCRIPTION
Eventually, the field type should not need any names, because there
will be only one name which leads to finding it (the full name, which is
also the index name). However, the short or "simple" name (using java
terminology for class names) is needed just in a couple places, for
serialization.

This change moves the simple name out of MappedFieldType.Names, into
Mapper, and makes Mapper and FieldMapper abstract classes.
