### PR TITLE
really ban exitVM with security policy

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -57,7 +57,16 @@ final class Security {
         Policy.setPolicy(new ESPolicy(createPermissions(environment)));
 
         // enable security manager
-        System.setSecurityManager(new SecurityManager());
+        System.setSecurityManager(new SecurityManager() {
+            // we disable this completely, because its granted otherwise:
+            // 'Note: The "exitVM.*" permission is automatically granted to
+            // all code loaded from the application class path, thus enabling
+            // applications to terminate themselves.'
+            @Override
+            public void checkExit(int status) {
+                throw new SecurityException("exit(" + status + ") not allowed by system policy");
+            }
+        });
 
         // do some basic tests
         selfTest();


### PR DESCRIPTION
Today this is implicitly allowed. In tests actually we stop it, because Uwe already fixed this issue in TestSecurityManager. But nothing stops it when you are actually running ES.

See the notes in RuntimePermission[1]:

```
 Note: The "exitVM.*" permission is automatically granted to all code loaded from 
 the application class path, thus enabling applications to terminate themselves.
```
1. http://docs.oracle.com/javase/7/docs/api/java/lang/RuntimePermission.html
