### PR TITLE
[build] Update maven-invoker-plugin to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1278,7 +1278,7 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>1.10</version>
+                    <version>2.0.0</version>
                 </plugin>
                 <plugin>
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->


### PR DESCRIPTION
Release Notes - Apache Maven Invoker Plugin - Version 2.0.0

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317525&version=12332831

Important Note:

This Release is intended for the bug fix MINVOKER-187 and in this relationship
is was necessary to upgrade the JDK minimum to JDK 1.6. This was the reason for
the version upgrade to 2.0.0.

Bug:
- [MINVOKER-187] - Cloned IT project must be writable

Improvement:
- [MINVOKER-192] - Using fluido skin
