### PR TITLE
Add checksum to snapshot metadata files

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeFilters;
 import org.elasticsearch.cluster.routing.HashFunction;
 import org.elasticsearch.cluster.routing.Murmur3HashFunction;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -40,10 +41,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
@@ -64,7 +62,7 @@ import static org.elasticsearch.common.settings.Settings.*;
 /**
  *
  */
-public class IndexMetaData implements Diffable<IndexMetaData> {
+public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuilder<IndexMetaData>, ToXContent  {
 
     public static final IndexMetaData PROTO = IndexMetaData.builder("")
             .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
@@ -513,6 +511,17 @@ public class IndexMetaData implements Diffable<IndexMetaData> {
     @Override
     public Diff<IndexMetaData> readDiffFrom(StreamInput in) throws IOException {
         return new IndexMetaDataDiff(in);
+    }
+
+    @Override
+    public IndexMetaData fromXContent(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        return Builder.fromXContent(parser);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        Builder.toXContent(this, builder, params);
+        return builder;
     }
 
     private static class IndexMetaDataDiff implements Diff<IndexMetaData> {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.cluster.service.InternalClusterService;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.HppcMaps;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -60,7 +61,7 @@ import java.util.*;
 
 import static org.elasticsearch.common.settings.Settings.*;
 
-public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData> {
+public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, FromXContentBuilder<MetaData>, ToXContent {
 
     public static final MetaData PROTO = builder().build();
 
@@ -633,6 +634,17 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData> {
     @Override
     public Diff<MetaData> readDiffFrom(StreamInput in) throws IOException {
         return new MetaDataDiff(in);
+    }
+
+    @Override
+    public MetaData fromXContent(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
+        return Builder.fromXContent(parser);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        Builder.toXContent(this, builder, params);
+        return builder;
     }
 
     private static class MetaDataDiff implements Diff<MetaData> {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RestoreSource.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RestoreSource.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.routing;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -37,11 +38,14 @@ public class RestoreSource implements Streamable, ToXContent {
 
     private String index;
 
+    private Version version;
+
     RestoreSource() {
     }
 
-    public RestoreSource(SnapshotId snapshotId, String index) {
+    public RestoreSource(SnapshotId snapshotId, Version version, String index) {
         this.snapshotId = snapshotId;
+        this.version = version;
         this.index = index;
     }
 
@@ -51,6 +55,10 @@ public class RestoreSource implements Streamable, ToXContent {
 
     public String index() {
         return index;
+    }
+
+    public Version version() {
+        return version;
     }
 
     public static RestoreSource readRestoreSource(StreamInput in) throws IOException {
@@ -66,12 +74,14 @@ public class RestoreSource implements Streamable, ToXContent {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         snapshotId = SnapshotId.readSnapshotId(in);
+        version = Version.readVersion(in);
         index = in.readString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         snapshotId.writeTo(out);
+        Version.writeVersion(version, out);
         out.writeString(index);
     }
 
@@ -80,6 +90,7 @@ public class RestoreSource implements Streamable, ToXContent {
         return builder.startObject()
                 .field("repository", snapshotId.getRepository())
                 .field("snapshot", snapshotId.getSnapshot())
+                .field("version", version.toString())
                 .field("index", index)
                 .endObject();
     }

--- a/core/src/main/java/org/elasticsearch/common/lucene/store/ByteArrayIndexInput.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/store/ByteArrayIndexInput.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.lucene.store;
+
+import org.apache.lucene.store.IndexInput;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+/**
+ * Wraps array of bytes into IndexInput
+ */
+public class ByteArrayIndexInput extends IndexInput {
+    private final byte[] bytes;
+
+    private int pos;
+
+    private int offset;
+
+    private int length;
+
+    public ByteArrayIndexInput(String resourceDesc, byte[] bytes) {
+        this(resourceDesc, bytes, 0, bytes.length);
+    }
+
+    public ByteArrayIndexInput(String resourceDesc, byte[] bytes, int offset, int length) {
+        super(resourceDesc);
+        this.bytes = bytes;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public long getFilePointer() {
+        return pos;
+    }
+
+    @Override
+    public void seek(long l) throws IOException {
+        if (l < 0) {
+            throw new IllegalArgumentException("Seeking to negative position: " + pos);
+        } else if (l > length) {
+            throw new EOFException("seek past EOF");
+        }
+        pos = (int)l;
+    }
+
+    @Override
+    public long length() {
+        return length;
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+        if (offset >= 0L && length >= 0L && offset + length <= this.length) {
+            return new ByteArrayIndexInput(sliceDescription, bytes, this.offset + (int)offset, (int)length);
+        } else {
+            throw new IllegalArgumentException("slice() " + sliceDescription + " out of bounds: offset=" + offset + ",length=" + length + ",fileLength=" + this.length + ": " + this);
+        }
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        if (pos >= offset + length) {
+            throw new EOFException("seek past EOF");
+        }
+        return bytes[offset + pos++];
+    }
+
+    @Override
+    public void readBytes(final byte[] b, final int offset, int len) throws IOException {
+        if (pos + len > this.offset + length) {
+            throw new EOFException("seek past EOF");
+        }
+        System.arraycopy(bytes, this.offset + pos, b, offset, len);
+        pos += len;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/lucene/store/IndexOutputOutputStream.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/store/IndexOutputOutputStream.java
@@ -17,34 +17,41 @@
  * under the License.
  */
 
-package org.elasticsearch.snapshots;
+package org.elasticsearch.common.lucene.store;
 
-import org.elasticsearch.cluster.metadata.SnapshotId;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.rest.RestStatus;
+import org.apache.lucene.store.IndexOutput;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 /**
- * Thrown if requested snapshot doesn't exist
+ * {@link OutputStream} that writes into underlying IndexOutput
  */
-public class SnapshotMissingException extends SnapshotException {
+public class IndexOutputOutputStream extends OutputStream {
 
-    public SnapshotMissingException(SnapshotId snapshot, Throwable cause) {
-        super(snapshot, "is missing", cause);
-    }
+    private final IndexOutput out;
 
-    public SnapshotMissingException(SnapshotId snapshot) {
-        super(snapshot, "is missing");
-    }
-
-    public SnapshotMissingException(StreamInput in) throws IOException {
-        super(in);
+    public IndexOutputOutputStream(IndexOutput out) {
+        this.out = out;
     }
 
     @Override
-    public RestStatus status() {
-        return RestStatus.NOT_FOUND;
+    public void write(int b) throws IOException {
+        out.writeByte((byte) b);
     }
 
+    @Override
+    public void write(byte[] b) throws IOException {
+        out.writeBytes(b, b.length);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.writeBytes(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/FromXContentBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/FromXContentBuilder.java
@@ -17,40 +17,22 @@
  * under the License.
  */
 
-package org.elasticsearch.common.lucene.store;
+package org.elasticsearch.common.xcontent;
 
-import org.apache.lucene.store.IndexOutput;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.io.stream.StreamableReader;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 /**
+ * Indicates that the class supports XContent deserialization.
+ *
+ * This interface is similar to what {@link StreamableReader} does, only it works with XContent serialization
+ * instead of binary serialization.
  */
-public class OutputStreamIndexOutput extends OutputStream {
-
-    private final IndexOutput out;
-
-    public OutputStreamIndexOutput(IndexOutput out) {
-        this.out = out;
-    }
-
-    @Override
-    public void write(int b) throws IOException {
-        out.writeByte((byte) b);
-    }
-
-    @Override
-    public void write(byte[] b) throws IOException {
-        out.writeBytes(b, b.length);
-    }
-
-    @Override
-    public void write(byte[] b, int off, int len) throws IOException {
-        out.writeBytes(b, off, len);
-    }
-
-    @Override
-    public void close() throws IOException {
-        out.close();
-    }
+public interface FromXContentBuilder<T> {
+    /**
+     * Parses an object with the type T from parser
+     */
+    T fromXContent(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException;
 }

--- a/core/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
@@ -35,6 +35,7 @@ import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -114,7 +115,7 @@ public abstract class MetaDataStateFormat<T> {
                 CodecUtil.writeHeader(out, STATE_FILE_CODEC, STATE_FILE_VERSION);
                 out.writeInt(format.index());
                 out.writeLong(version);
-                try (XContentBuilder builder = newXContentBuilder(format, new org.elasticsearch.common.lucene.store.OutputStreamIndexOutput(out) {
+                try (XContentBuilder builder = newXContentBuilder(format, new IndexOutputOutputStream(out) {
                     @Override
                     public void close() throws IOException {
                         // this is important since some of the XContentBuilders write bytes on close.

--- a/core/src/main/java/org/elasticsearch/index/shard/StoreRecoveryService.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/StoreRecoveryService.java
@@ -317,7 +317,7 @@ public class StoreRecoveryService extends AbstractIndexShardComponent implements
             if (!shardId.getIndex().equals(restoreSource.index())) {
                 snapshotShardId = new ShardId(restoreSource.index(), shardId.id());
             }
-            indexShardRepository.restore(restoreSource.snapshotId(), shardId, snapshotShardId, recoveryState);
+            indexShardRepository.restore(restoreSource.snapshotId(), restoreSource.version(), shardId, snapshotShardId, recoveryState);
             indexShard.skipTranslogRecovery(true);
             indexShard.finalizeRecovery();
             indexShard.postRecovery("restore done");

--- a/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardRepository.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardRepository.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.snapshots;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.index.deletionpolicy.SnapshotIndexCommit;
 import org.elasticsearch.index.shard.ShardId;
@@ -35,7 +36,7 @@ public interface IndexShardRepository {
     /**
      * Creates a snapshot of the shard based on the index commit point.
      * <p/>
-     * The index commit point can be obtained by using {@link org.elasticsearch.index.engine.Engine#snapshotIndex()} method.
+     * The index commit point can be obtained by using {@link org.elasticsearch.index.engine.Engine#snapshotIndex} method.
      * IndexShardRepository implementations shouldn't release the snapshot index commit point. It is done by the method caller.
      * <p/>
      * As snapshot process progresses, implementation of this method should update {@link IndexShardSnapshotStatus} object and check
@@ -55,19 +56,21 @@ public interface IndexShardRepository {
      *
      * @param snapshotId      snapshot id
      * @param shardId         shard id (in the current index)
+     * @param version   version of elasticsearch that created this snapshot
      * @param snapshotShardId shard id (in the snapshot)
      * @param recoveryState   recovery state
      */
-    void restore(SnapshotId snapshotId, ShardId shardId, ShardId snapshotShardId, RecoveryState recoveryState);
+    void restore(SnapshotId snapshotId, Version version, ShardId shardId, ShardId snapshotShardId, RecoveryState recoveryState);
 
     /**
      * Retrieve shard snapshot status for the stored snapshot
      *
      * @param snapshotId snapshot id
+     * @param version   version of elasticsearch that created this snapshot
      * @param shardId    shard id
      * @return snapshot status
      */
-    IndexShardSnapshotStatus snapshotStatus(SnapshotId snapshotId, ShardId shardId);
+    IndexShardSnapshotStatus snapshotStatus(SnapshotId snapshotId, Version version, ShardId shardId);
 
     /**
      * Verifies repository settings on data node

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreFormat.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.repositories.blobstore;
+
+import com.google.common.collect.Maps;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.*;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Base class that handles serialization of various data structures during snapshot/restore operations.
+ */
+public abstract class BlobStoreFormat<T extends ToXContent> {
+
+    protected final String blobNameFormat;
+
+    protected final FromXContentBuilder<T> reader;
+
+    protected final ParseFieldMatcher parseFieldMatcher;
+
+    // Serialization parameters to specify correct context for metadata serialization
+    protected static final ToXContent.Params SNAPSHOT_ONLY_FORMAT_PARAMS;
+
+    static {
+        Map<String, String> snapshotOnlyParams = Maps.newHashMap();
+        // when metadata is serialized certain elements of the metadata shouldn't be included into snapshot
+        // exclusion of these elements is done by setting MetaData.CONTEXT_MODE_PARAM to MetaData.CONTEXT_MODE_SNAPSHOT
+        snapshotOnlyParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_SNAPSHOT);
+        SNAPSHOT_ONLY_FORMAT_PARAMS = new ToXContent.MapParams(snapshotOnlyParams);
+    }
+
+    /**
+     * @param blobNameFormat format of the blobname in {@link String#format(Locale, String, Object...)} format
+     * @param reader the prototype object that can deserialize objects with type T
+     * @param parseFieldMatcher parse field matcher
+     */
+    protected BlobStoreFormat(String blobNameFormat, FromXContentBuilder<T> reader, ParseFieldMatcher parseFieldMatcher) {
+        this.reader = reader;
+        this.blobNameFormat = blobNameFormat;
+        this.parseFieldMatcher = parseFieldMatcher;
+    }
+
+    /**
+     * Reads and parses the blob with given blob name.
+     *
+     * @param blobContainer blob container
+     * @param blobName blob name
+     * @return parsed blob object
+     * @throws IOException
+     */
+    public abstract T readBlob(BlobContainer blobContainer, String blobName) throws IOException;
+
+    /**
+     * Reads and parses the blob with given name, applying name translation using the {link #blobName} method
+     *
+     * @param blobContainer blob container
+     * @param name          name to be translated into
+     * @return parsed blob object
+     * @throws IOException
+     */
+    public T read(BlobContainer blobContainer, String name) throws IOException {
+        String blobName = blobName(name);
+        return readBlob(blobContainer, blobName);
+    }
+
+
+    /**
+     * Deletes obj in the blob container
+     */
+    public void delete(BlobContainer blobContainer, String name) throws IOException {
+        blobContainer.deleteBlob(blobName(name));
+    }
+
+    /**
+     * Checks obj in the blob container
+     */
+    public boolean exists(BlobContainer blobContainer, String name) throws IOException {
+        return blobContainer.blobExists(blobName(name));
+    }
+
+    protected String blobName(String name) {
+        return String.format(Locale.ROOT, blobNameFormat, name);
+    }
+
+    protected T read(BytesReference bytes) throws IOException {
+        try (XContentParser parser = XContentHelper.createParser(bytes)) {
+            T obj = reader.fromXContent(parser, parseFieldMatcher);
+            return obj;
+
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -19,18 +19,15 @@
 
 package org.elasticsearch.repositories.blobstore;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
-
 import org.apache.lucene.store.RateLimiter;
-import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.SnapshotId;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobMetaData;
@@ -39,7 +36,6 @@ import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.compress.NotXContentException;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
@@ -47,7 +43,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -61,12 +56,7 @@ import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositorySettings;
 import org.elasticsearch.repositories.RepositoryVerificationException;
-import org.elasticsearch.snapshots.InvalidSnapshotNameException;
-import org.elasticsearch.snapshots.Snapshot;
-import org.elasticsearch.snapshots.SnapshotCreationException;
-import org.elasticsearch.snapshots.SnapshotException;
-import org.elasticsearch.snapshots.SnapshotMissingException;
-import org.elasticsearch.snapshots.SnapshotShardFailure;
+import org.elasticsearch.snapshots.*;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -93,13 +83,13 @@ import static com.google.common.collect.Lists.newArrayList;
  *   STORE_ROOT
  *   |- index             - list of all snapshot name as JSON array
  *   |- snapshot-20131010 - JSON serialized Snapshot for snapshot "20131010"
- *   |- metadata-20131010 - JSON serialized MetaData for snapshot "20131010" (includes only global metadata)
+ *   |- meta-20131010.dat - JSON serialized MetaData for snapshot "20131010" (includes only global metadata)
  *   |- snapshot-20131011 - JSON serialized Snapshot for snapshot "20131011"
- *   |- metadata-20131011 - JSON serialized MetaData for snapshot "20131011"
+ *   |- meta-20131011.dat - JSON serialized MetaData for snapshot "20131011"
  *   .....
  *   |- indices/ - data for all indices
  *      |- foo/ - data for index "foo"
- *      |  |- snapshot-20131010 - JSON Serialized IndexMetaData for index "foo"
+ *      |  |- meta-20131010.dat - JSON Serialized IndexMetaData for index "foo"
  *      |  |- 0/ - data for shard "0" of index "foo"
  *      |  |  |- __1 \
  *      |  |  |- __2 |
@@ -107,8 +97,9 @@ import static com.google.common.collect.Lists.newArrayList;
  *      |  |  |- __4 |
  *      |  |  |- __5 /
  *      |  |  .....
- *      |  |  |- snapshot-20131010 - JSON serialized BlobStoreIndexShardSnapshot for snapshot "20131010"
- *      |  |  |- snapshot-20131011 - JSON serialized BlobStoreIndexShardSnapshot for snapshot "20131011"
+ *      |  |  |- snap-20131010.dat - JSON serialized BlobStoreIndexShardSnapshot for snapshot "20131010"
+ *      |  |  |- snap-20131011.dat - JSON serialized BlobStoreIndexShardSnapshot for snapshot "20131011"
+ *      |  |  |- list-123 - JSON serialized BlobStoreIndexShardSnapshot for snapshot "20131011"
  *      |  |
  *      |  |- 1/ - data for shard "1" of index "foo"
  *      |  |  |- __1
@@ -128,23 +119,34 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
 
     protected final String repositoryName;
 
-    private static final String SNAPSHOT_PREFIX = "snapshot-";
+    private static final String LEGACY_SNAPSHOT_PREFIX = "snapshot-";
 
-    private static final String TEMP_SNAPSHOT_FILE_PREFIX = "pending-";
+    private static final String SNAPSHOT_PREFIX = "snap-";
+
+    private static final String SNAPSHOT_SUFFIX = ".dat";
+
+    private static final String COMMON_SNAPSHOT_PREFIX = "snap";
+
+    private static final String SNAPSHOT_CODEC = "snapshot";
 
     private static final String SNAPSHOTS_FILE = "index";
 
     private static final String TESTS_FILE = "tests-";
 
-    private static final String METADATA_PREFIX = "meta-";
+    private static final String METADATA_NAME_FORMAT = "meta-%s.dat";
 
-    private static final String LEGACY_METADATA_PREFIX = "metadata-";
+    private static final String LEGACY_METADATA_NAME_FORMAT = "metadata-%s";
 
-    private static final String METADATA_SUFFIX = ".dat";
+    private static final String METADATA_CODEC = "metadata";
+
+    private static final String INDEX_METADATA_CODEC = "index-metadata";
+
+    private static final String SNAPSHOT_NAME_FORMAT = SNAPSHOT_PREFIX + "%s" + SNAPSHOT_SUFFIX;
+
+    private static final String LEGACY_SNAPSHOT_NAME_FORMAT = LEGACY_SNAPSHOT_PREFIX + "%s";
+
 
     private final BlobStoreIndexShardRepository indexShardRepository;
-
-    private final ToXContent.Params snapshotOnlyFormatParams;
 
     private final RateLimiter snapshotRateLimiter;
 
@@ -154,6 +156,17 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
 
     private final CounterMetric restoreRateLimitingTimeInNanos = new CounterMetric();
 
+    private ChecksumBlobStoreFormat<MetaData> globalMetaDataFormat;
+
+    private LegacyBlobStoreFormat<MetaData> globalMetaDataLegacyFormat;
+
+    private ChecksumBlobStoreFormat<IndexMetaData> indexMetaDataFormat;
+
+    private LegacyBlobStoreFormat<IndexMetaData> indexMetaDataLegacyFormat;
+
+    private ChecksumBlobStoreFormat<Snapshot> snapshotFormat;
+
+    private LegacyBlobStoreFormat<Snapshot> snapshotLegacyFormat;
 
     /**
      * Constructs new BlobStoreRepository
@@ -166,9 +179,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
         super(repositorySettings.globalSettings());
         this.repositoryName = repositoryName;
         this.indexShardRepository = (BlobStoreIndexShardRepository) indexShardRepository;
-        Map<String, String> snpashotOnlyParams = Maps.newHashMap();
-        snpashotOnlyParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_SNAPSHOT);
-        snapshotOnlyFormatParams = new ToXContent.MapParams(snpashotOnlyParams);
         snapshotRateLimiter = getRateLimiter(repositorySettings, "max_snapshot_bytes_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB));
         restoreRateLimiter = getRateLimiter(repositorySettings, "max_restore_bytes_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB));
     }
@@ -180,6 +190,16 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
     protected void doStart() {
         this.snapshotsBlobContainer = blobStore().blobContainer(basePath());
         indexShardRepository.initialize(blobStore(), basePath(), chunkSize(), snapshotRateLimiter, restoreRateLimiter, this, isCompress());
+
+        ParseFieldMatcher parseFieldMatcher = new ParseFieldMatcher(settings);
+        globalMetaDataFormat = new ChecksumBlobStoreFormat<>(METADATA_CODEC, METADATA_NAME_FORMAT, MetaData.PROTO, parseFieldMatcher, isCompress());
+        globalMetaDataLegacyFormat = new LegacyBlobStoreFormat<>(LEGACY_METADATA_NAME_FORMAT, MetaData.PROTO, parseFieldMatcher);
+
+        indexMetaDataFormat = new ChecksumBlobStoreFormat<>(INDEX_METADATA_CODEC, METADATA_NAME_FORMAT, IndexMetaData.PROTO, parseFieldMatcher, isCompress());
+        indexMetaDataLegacyFormat = new LegacyBlobStoreFormat<>(LEGACY_SNAPSHOT_NAME_FORMAT, IndexMetaData.PROTO, parseFieldMatcher);
+
+        snapshotFormat = new ChecksumBlobStoreFormat<>(SNAPSHOT_CODEC, SNAPSHOT_NAME_FORMAT, Snapshot.PROTO, parseFieldMatcher, isCompress());
+        snapshotLegacyFormat = new LegacyBlobStoreFormat<>(LEGACY_SNAPSHOT_NAME_FORMAT, Snapshot.PROTO, parseFieldMatcher);
     }
 
     /**
@@ -241,26 +261,17 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
     @Override
     public void initializeSnapshot(SnapshotId snapshotId, List<String> indices, MetaData metaData) {
         try {
-            String snapshotBlobName = snapshotBlobName(snapshotId);
-            if (snapshotsBlobContainer.blobExists(snapshotBlobName)) {
+            if (snapshotFormat.exists(snapshotsBlobContainer, snapshotId.getSnapshot()) ||
+                    snapshotLegacyFormat.exists(snapshotsBlobContainer, snapshotId.getSnapshot())) {
                 throw new InvalidSnapshotNameException(snapshotId, "snapshot with such name already exists");
             }
             // Write Global MetaData
-            // TODO: Check if metadata needs to be written
-            try (StreamOutput output = compressIfNeeded(snapshotsBlobContainer.createOutput(metaDataBlobName(snapshotId, false)))) {
-                writeGlobalMetaData(metaData, output);
-            }
+            globalMetaDataFormat.write(metaData, snapshotsBlobContainer, snapshotId.getSnapshot());
             for (String index : indices) {
                 final IndexMetaData indexMetaData = metaData.index(index);
                 final BlobPath indexPath = basePath().add("indices").add(index);
                 final BlobContainer indexMetaDataBlobContainer = blobStore().blobContainer(indexPath);
-                try (StreamOutput output = compressIfNeeded(indexMetaDataBlobContainer.createOutput(snapshotBlobName(snapshotId)))) {
-                    XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON, output);
-                    builder.startObject();
-                    IndexMetaData.Builder.toXContent(indexMetaData, builder, ToXContent.EMPTY_PARAMS);
-                    builder.endObject();
-                    builder.close();
-                }
+                indexMetaDataFormat.write(indexMetaData, indexMetaDataBlobContainer, snapshotId.getSnapshot());
             }
         } catch (IOException ex) {
             throw new SnapshotCreationException(snapshotId, ex);
@@ -279,7 +290,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
             indices = snapshot.indices();
         } catch (SnapshotMissingException ex) {
             throw ex;
-        } catch (SnapshotException | ElasticsearchParseException ex) {
+        } catch (IllegalStateException | SnapshotException | ElasticsearchParseException ex) {
             logger.warn("cannot read snapshot file [{}]", ex, snapshotId);
         }
         MetaData metaData = null;
@@ -287,25 +298,22 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
             if (snapshot != null) {
                 metaData = readSnapshotMetaData(snapshotId, snapshot.version(), indices, true);
             } else {
-                try {
-                    metaData = readSnapshotMetaData(snapshotId, false, indices, true);
-                } catch (IOException ex) {
-                    metaData = readSnapshotMetaData(snapshotId, true, indices, true);
-                }
+                metaData = readSnapshotMetaData(snapshotId, null, indices, true);
             }
         } catch (IOException | SnapshotException ex) {
             logger.warn("cannot read metadata for snapshot [{}]", ex, snapshotId);
         }
         try {
-            String blobName = snapshotBlobName(snapshotId);
             // Delete snapshot file first so we wouldn't end up with partially deleted snapshot that looks OK
-            snapshotsBlobContainer.deleteBlob(blobName);
             if (snapshot != null) {
-                snapshotsBlobContainer.deleteBlob(metaDataBlobName(snapshotId, legacyMetaData(snapshot.version())));
+                snapshotFormat(snapshot.version()).delete(snapshotsBlobContainer, snapshotId.getSnapshot());
+                globalMetaDataFormat(snapshot.version()).delete(snapshotsBlobContainer, snapshotId.getSnapshot());
             } else {
-                // We don't know which version was the snapshot created with - try deleting both current and legacy metadata
-                snapshotsBlobContainer.deleteBlob(metaDataBlobName(snapshotId, true));
-                snapshotsBlobContainer.deleteBlob(metaDataBlobName(snapshotId, false));
+                // We don't know which version was the snapshot created with - try deleting both current and legacy formats
+                snapshotFormat.delete(snapshotsBlobContainer, snapshotId.getSnapshot());
+                snapshotLegacyFormat.delete(snapshotsBlobContainer, snapshotId.getSnapshot());
+                globalMetaDataLegacyFormat.delete(snapshotsBlobContainer, snapshotId.getSnapshot());
+                globalMetaDataFormat.delete(snapshotsBlobContainer, snapshotId.getSnapshot());
             }
             // Delete snapshot from the snapshot list
             List<SnapshotId> snapshotIds = snapshots();
@@ -324,7 +332,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
                 BlobPath indexPath = basePath().add("indices").add(index);
                 BlobContainer indexMetaDataBlobContainer = blobStore().blobContainer(indexPath);
                 try {
-                    indexMetaDataBlobContainer.deleteBlob(blobName);
+                    indexMetaDataFormat(snapshot.version()).delete(indexMetaDataBlobContainer, snapshotId.getSnapshot());
                 } catch (IOException ex) {
                     logger.warn("[{}] failed to delete metadata for index [{}]", ex, snapshotId, index);
                 }
@@ -334,7 +342,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
                         for (int i = 0; i < indexMetaData.getNumberOfShards(); i++) {
                             ShardId shardId = new ShardId(index, i);
                             try {
-                                indexShardRepository.delete(snapshotId, shardId);
+                                indexShardRepository.delete(snapshotId, snapshot.version(), shardId);
                             } catch (SnapshotException ex) {
                                 logger.warn("[{}] failed to delete shard data for shard [{}]", ex, snapshotId, shardId);
                             }
@@ -347,40 +355,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
         }
     }
 
-    private StreamOutput compressIfNeeded(OutputStream output) throws IOException {
-        return toStreamOutput(output, isCompress());
-    }
-
-    public static StreamOutput toStreamOutput(OutputStream output, boolean compress) throws IOException {
-        StreamOutput out = null;
-        boolean success = false;
-        try {
-            out = new OutputStreamStreamOutput(output);
-            if (compress) {
-                out = CompressorFactory.defaultCompressor().streamOutput(out);
-            }
-            success = true;
-            return out;
-        } finally {
-            if (!success) {
-                IOUtils.closeWhileHandlingException(out, output);
-            }
-        }
-    }
-
     /**
      * {@inheritDoc}
      */
     @Override
     public Snapshot finalizeSnapshot(SnapshotId snapshotId, List<String> indices, long startTime, String failure, int totalShards, List<SnapshotShardFailure> shardFailures) {
         try {
-            String tempBlobName = tempSnapshotBlobName(snapshotId);
-            String blobName = snapshotBlobName(snapshotId);
             Snapshot blobStoreSnapshot = new Snapshot(snapshotId.getSnapshot(), indices, startTime, failure, System.currentTimeMillis(), totalShards, shardFailures);
-            try (StreamOutput output = compressIfNeeded(snapshotsBlobContainer.createOutput(tempBlobName))) {
-                writeSnapshot(blobStoreSnapshot, output);
-            }
-            snapshotsBlobContainer.move(tempBlobName, blobName);
+            snapshotFormat.write(blobStoreSnapshot, snapshotsBlobContainer, snapshotId.getSnapshot());
             List<SnapshotId> snapshotIds = snapshots();
             if (!snapshotIds.contains(snapshotId)) {
                 snapshotIds = ImmutableList.<SnapshotId>builder().addAll(snapshotIds).add(snapshotId).build();
@@ -401,14 +383,25 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
             List<SnapshotId> snapshots = newArrayList();
             Map<String, BlobMetaData> blobs;
             try {
-                blobs = snapshotsBlobContainer.listBlobsByPrefix(SNAPSHOT_PREFIX);
+                blobs = snapshotsBlobContainer.listBlobsByPrefix(COMMON_SNAPSHOT_PREFIX);
             } catch (UnsupportedOperationException ex) {
                 // Fall back in case listBlobsByPrefix isn't supported by the blob store
                 return readSnapshotList();
             }
             int prefixLength = SNAPSHOT_PREFIX.length();
+            int suffixLength = SNAPSHOT_SUFFIX.length();
+            int legacyPrefixLength = LEGACY_SNAPSHOT_PREFIX.length();
             for (BlobMetaData md : blobs.values()) {
-                String name = md.name().substring(prefixLength);
+                String blobName = md.name();
+                final String name;
+                if (blobName.startsWith(SNAPSHOT_PREFIX) && blobName.length() > legacyPrefixLength) {
+                    name = blobName.substring(prefixLength, blobName.length() - suffixLength);
+                } else if (blobName.startsWith(LEGACY_SNAPSHOT_PREFIX) && blobName.length() > suffixLength + prefixLength) {
+                    name = blobName.substring(legacyPrefixLength);
+                } else {
+                    // not sure what it was - ignore
+                    continue;
+                }
                 snapshots.add(new SnapshotId(repositoryName, name));
             }
             return ImmutableList.copyOf(snapshots);
@@ -431,24 +424,37 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
     @Override
     public Snapshot readSnapshot(SnapshotId snapshotId) {
         try {
-            try (InputStream blob = snapshotsBlobContainer.openInput(snapshotBlobName(snapshotId))) {
-                return readSnapshot(ByteStreams.toByteArray(blob));
-            }
+            return snapshotFormat.read(snapshotsBlobContainer, snapshotId.getSnapshot());
         } catch (FileNotFoundException | NoSuchFileException ex) {
-            throw new SnapshotMissingException(snapshotId, ex);
+            // File is missing - let's try legacy format instead
+            try {
+                return snapshotLegacyFormat.read(snapshotsBlobContainer, snapshotId.getSnapshot());
+            } catch (FileNotFoundException | NoSuchFileException ex1) {
+                throw new SnapshotMissingException(snapshotId, ex);
+            } catch (IOException | NotXContentException ex1) {
+                throw new SnapshotException(snapshotId, "failed to get snapshots", ex1);
+            }
         } catch (IOException | NotXContentException ex) {
             throw new SnapshotException(snapshotId, "failed to get snapshots", ex);
         }
     }
 
     private MetaData readSnapshotMetaData(SnapshotId snapshotId, Version snapshotVersion, List<String> indices, boolean ignoreIndexErrors) throws IOException {
-        return readSnapshotMetaData(snapshotId, legacyMetaData(snapshotVersion), indices, ignoreIndexErrors);
-    }
-
-    private MetaData readSnapshotMetaData(SnapshotId snapshotId, boolean legacy, List<String> indices, boolean ignoreIndexErrors) throws IOException {
         MetaData metaData;
-        try (InputStream blob = snapshotsBlobContainer.openInput(metaDataBlobName(snapshotId, legacy))) {
-            metaData = readMetaData(ByteStreams.toByteArray(blob));
+        if (snapshotVersion == null) {
+            // When we delete corrupted snapshots we might not know which version we are dealing with
+            // We can try detecting the version based on the metadata file format
+            assert ignoreIndexErrors;
+            if (globalMetaDataFormat.exists(snapshotsBlobContainer, snapshotId.getSnapshot())) {
+                snapshotVersion = Version.CURRENT;
+            } else if (globalMetaDataLegacyFormat.exists(snapshotsBlobContainer, snapshotId.getSnapshot())) {
+                snapshotVersion = Version.V_1_0_0;
+            } else {
+                throw new SnapshotMissingException(snapshotId);
+            }
+        }
+        try {
+            metaData = globalMetaDataFormat(snapshotVersion).read(snapshotsBlobContainer, snapshotId.getSnapshot());
         } catch (FileNotFoundException | NoSuchFileException ex) {
             throw new SnapshotMissingException(snapshotId, ex);
         } catch (IOException ex) {
@@ -458,28 +464,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
         for (String index : indices) {
             BlobPath indexPath = basePath().add("indices").add(index);
             BlobContainer indexMetaDataBlobContainer = blobStore().blobContainer(indexPath);
-            try (InputStream blob = indexMetaDataBlobContainer.openInput(snapshotBlobName(snapshotId))) {
-                byte[] data = ByteStreams.toByteArray(blob);
-                try (XContentParser parser = XContentHelper.createParser(new BytesArray(data))) {
-                    XContentParser.Token token;
-                    if ((token = parser.nextToken()) == XContentParser.Token.START_OBJECT) {
-                        IndexMetaData indexMetaData = IndexMetaData.Builder.fromXContent(parser);
-                        if ((token = parser.nextToken()) == XContentParser.Token.END_OBJECT) {
-                            metaDataBuilder.put(indexMetaData, false);
-                            continue;
-                        }
-                    }
-                    if (!ignoreIndexErrors) {
-                        throw new ElasticsearchParseException("unexpected token [{}]", token);
-                    } else {
-                        logger.warn("[{}] [{}] unexpected token while reading snapshot metadata [{}]", snapshotId, index, token);
-                    }
-                }
-            } catch (IOException ex) {
-                if (!ignoreIndexErrors) {
-                    throw new SnapshotException(snapshotId, "failed to read metadata", ex);
-                } else {
+            try {
+                metaDataBuilder.put(indexMetaDataFormat(snapshotVersion).read(indexMetaDataBlobContainer, snapshotId.getSnapshot()), false);
+            } catch (ElasticsearchParseException | IOException ex) {
+                if (ignoreIndexErrors) {
                     logger.warn("[{}] [{}] failed to read metadata for index", snapshotId, index, ex);
+                } else {
+                    throw ex;
                 }
             }
         }
@@ -505,85 +496,24 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
     }
 
     /**
-     * Parses JSON containing snapshot description
-     *
-     * @param data snapshot description in JSON format
-     * @return parsed snapshot description
-     * @throws IOException parse exceptions
+     * Returns appropriate global metadata format based on the provided version of the snapshot
      */
-    public Snapshot readSnapshot(byte[] data) throws IOException {
-        try (XContentParser parser = XContentHelper.createParser(new BytesArray(data))) {
-            XContentParser.Token token;
-            if ((token = parser.nextToken()) == XContentParser.Token.START_OBJECT) {
-                if ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME) {
-                    parser.nextToken();
-                    Snapshot snapshot = Snapshot.fromXContent(parser);
-                    if ((token = parser.nextToken()) == XContentParser.Token.END_OBJECT) {
-                        return snapshot;
-                    }
-                }
-            }
-            throw new ElasticsearchParseException("unexpected token  [{}]", token);
-        } catch (JsonParseException ex) {
-            throw new ElasticsearchParseException("failed to read snapshot", ex);
-        }
-    }
-
-    /**
-     * Parses JSON containing cluster metadata
-     *
-     * @param data cluster metadata in JSON format
-     * @return parsed metadata
-     * @throws IOException parse exceptions
-     */
-    private MetaData readMetaData(byte[] data) throws IOException {
-        try (XContentParser parser = XContentHelper.createParser(new BytesArray(data))) {
-            XContentParser.Token token;
-            if ((token = parser.nextToken()) == XContentParser.Token.START_OBJECT) {
-                if ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME) {
-                    parser.nextToken();
-                    MetaData metaData = MetaData.Builder.fromXContent(parser);
-                    if ((token = parser.nextToken()) == XContentParser.Token.END_OBJECT) {
-                        return metaData;
-                    }
-                }
-            }
-            throw new ElasticsearchParseException("unexpected token [{}]", token);
-        }
-    }
-
-    /**
-     * Returns name of snapshot blob
-     *
-     * @param snapshotId snapshot id
-     * @return name of snapshot blob
-     */
-    private String snapshotBlobName(SnapshotId snapshotId) {
-        return SNAPSHOT_PREFIX + snapshotId.getSnapshot();
-    }
-
-    /**
-     * Returns temporary name of snapshot blob
-     *
-     * @param snapshotId snapshot id
-     * @return name of snapshot blob
-     */
-    private String tempSnapshotBlobName(SnapshotId snapshotId) {
-        return TEMP_SNAPSHOT_FILE_PREFIX + snapshotId.getSnapshot();
-    }
-
-    /**
-     * Returns name of metadata blob
-     *
-     * @param snapshotId snapshot id
-     * @param legacy true if legacy (pre-2.0.0) format should be used
-     * @return name of metadata blob
-     */
-    private String metaDataBlobName(SnapshotId snapshotId, boolean legacy) {
-        if (legacy) {
-            return LEGACY_METADATA_PREFIX + snapshotId.getSnapshot();
+    private BlobStoreFormat<MetaData> globalMetaDataFormat(Version version) {
+        if(legacyMetaData(version)) {
+            return globalMetaDataLegacyFormat;
         } else {
-            return METADATA_PREFIX + snapshotId.getSnapshot() + METADATA_SUFFIX;
+            return globalMetaDataFormat;
+        }
+    }
+
+    /**
+     * Returns appropriate snapshot format based on the provided version of the snapshot
+     */
+    private BlobStoreFormat<Snapshot> snapshotFormat(Version version) {
+        if(legacyMetaData(version)) {
+            return snapshotLegacyFormat;
+        } else {
+            return snapshotFormat;
         }
     }
 
@@ -592,38 +522,19 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
      * @param version
      * @return true if legacy version should be used false otherwise
      */
-    private boolean legacyMetaData(Version version) {
+    public static boolean legacyMetaData(Version version) {
         return version.before(Version.V_2_0_0_beta1);
     }
 
     /**
-     * Serializes Snapshot into JSON
-     *
-     * @param snapshot - snapshot description
-     * @return BytesStreamOutput representing JSON serialized Snapshot
-     * @throws IOException
+     * Returns appropriate index metadata format based on the provided version of the snapshot
      */
-    private void writeSnapshot(Snapshot snapshot, StreamOutput outputStream) throws IOException {
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON, outputStream);
-        builder.startObject();
-        snapshot.toXContent(builder, snapshotOnlyFormatParams);
-        builder.endObject();
-        builder.flush();
-    }
-
-    /**
-     * Serializes global MetaData into JSON
-     *
-     * @param metaData - metaData
-     * @return BytesStreamOutput representing JSON serialized global MetaData
-     * @throws IOException
-     */
-    private void writeGlobalMetaData(MetaData metaData, StreamOutput outputStream) throws IOException {
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON, outputStream);
-        builder.startObject();
-        MetaData.Builder.toXContent(metaData, builder, snapshotOnlyFormatParams);
-        builder.endObject();
-        builder.flush();
+    private BlobStoreFormat<IndexMetaData> indexMetaDataFormat(Version version) {
+        if(legacyMetaData(version)) {
+            return indexMetaDataLegacyFormat;
+        } else {
+            return indexMetaDataFormat;
+        }
     }
 
     /**
@@ -635,18 +546,22 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
      * @throws IOException I/O errors
      */
     protected void writeSnapshotList(List<SnapshotId> snapshots) throws IOException {
-        BytesStreamOutput bStream = new BytesStreamOutput();
-        StreamOutput stream = compressIfNeeded(bStream);
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON, stream);
-        builder.startObject();
-        builder.startArray("snapshots");
-        for (SnapshotId snapshot : snapshots) {
-            builder.value(snapshot.getSnapshot());
+        final BytesReference bRef;
+        try(BytesStreamOutput bStream = new BytesStreamOutput()) {
+            try(StreamOutput stream = new OutputStreamStreamOutput(bStream)) {
+                XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON, stream);
+                builder.startObject();
+                builder.startArray("snapshots");
+                for (SnapshotId snapshot : snapshots) {
+                    builder.value(snapshot.getSnapshot());
+                }
+                builder.endArray();
+                builder.endObject();
+                builder.close();
+            }
+            bRef = bStream.bytes();
         }
-        builder.endArray();
-        builder.endObject();
-        builder.close();
-        BytesReference bRef = bStream.bytes();
+        snapshotsBlobContainer.deleteBlob(SNAPSHOTS_FILE);
         try (OutputStream output = snapshotsBlobContainer.createOutput(SNAPSHOTS_FILE)) {
             bRef.writeTo(output);
         }

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.repositories.blobstore;
+
+import com.google.common.io.ByteStreams;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.IndexFormatTooNewException;
+import org.apache.lucene.index.IndexFormatTooOldException;
+import org.apache.lucene.store.OutputStreamIndexOutput;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
+import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
+import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.gateway.CorruptStateException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Locale;
+
+/**
+ * Snapshot metadata file format used in v2.0 and above
+ */
+public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreFormat<T> {
+
+    private static final String TEMP_FILE_PREFIX = "pending-";
+
+    private static final XContentType DEFAULT_X_CONTENT_TYPE = XContentType.SMILE;
+
+    // The format version
+    public static final int VERSION = 1;
+
+    private static final int BUFFER_SIZE = 4096;
+
+    protected final XContentType xContentType;
+
+    protected final boolean compress;
+
+    private final String codec;
+
+    /**
+     * @param codec          codec name
+     * @param blobNameFormat format of the blobname in {@link String#format} format
+     * @param reader         prototype object that can deserialize T from XContent
+     * @param compress       true if the content should be compressed
+     * @param xContentType   content type that should be used for write operations
+     */
+    public ChecksumBlobStoreFormat(String codec, String blobNameFormat, FromXContentBuilder<T> reader, ParseFieldMatcher parseFieldMatcher, boolean compress, XContentType xContentType) {
+        super(blobNameFormat, reader, parseFieldMatcher);
+        this.xContentType = xContentType;
+        this.compress = compress;
+        this.codec = codec;
+    }
+
+    /**
+     * @param codec          codec name
+     * @param blobNameFormat format of the blobname in {@link String#format} format
+     * @param reader         prototype object that can deserialize T from XContent
+     * @param compress       true if the content should be compressed
+     */
+    public ChecksumBlobStoreFormat(String codec, String blobNameFormat, FromXContentBuilder<T> reader, ParseFieldMatcher parseFieldMatcher, boolean compress) {
+        this(codec, blobNameFormat, reader, parseFieldMatcher, compress, DEFAULT_X_CONTENT_TYPE);
+    }
+
+    /**
+     * Reads blob with specified name without resolving the blobName using using {@link #blobName} method.
+     *
+     * @param blobContainer blob container
+     * @param blobName blob name
+     * @return
+     * @throws IOException
+     */
+    public T readBlob(BlobContainer blobContainer, String blobName) throws IOException {
+        try (InputStream inputStream = blobContainer.openInput(blobName)) {
+            byte[] bytes = ByteStreams.toByteArray(inputStream);
+            final String resourceDesc = "ChecksumBlobStoreFormat.readBlob(blob=\"" + blobName + "\")";
+            try (ByteArrayIndexInput indexInput = new ByteArrayIndexInput(resourceDesc, bytes)) {
+                CodecUtil.checksumEntireFile(indexInput);
+                CodecUtil.checkHeader(indexInput, codec, VERSION, VERSION);
+                long filePointer = indexInput.getFilePointer();
+                long contentSize = indexInput.length() - CodecUtil.footerLength() - filePointer;
+                BytesReference bytesReference = new BytesArray(bytes, (int) filePointer, (int) contentSize);
+                return read(bytesReference);
+            } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+                // we trick this into a dedicated exception with the original stacktrace
+                throw new CorruptStateException(ex);
+            }
+        }
+    }
+
+    /**
+     * Writes blob in atomic manner with resolving the blob name using {@link #blobName} and {@link #tempBlobName} methods.
+     * <p/>
+     * The blob will be compressed and checksum will be written if required.
+     *
+     * Atomic move might be very inefficient on some repositories. It also cannot override existing files.
+     *
+     * @param obj           object to be serialized
+     * @param blobContainer blob container
+     * @param name          blob name
+     * @throws IOException
+     */
+    public void writeAtomic(T obj, BlobContainer blobContainer, String name) throws IOException {
+        String blobName = blobName(name);
+        String tempBlobName = tempBlobName(name);
+        writeBlob(obj, blobContainer, tempBlobName);
+        try {
+            blobContainer.move(tempBlobName, blobName);
+        } catch (IOException ex) {
+            // Move failed - try cleaning up
+            blobContainer.deleteBlob(tempBlobName);
+            throw ex;
+        }
+    }
+
+    /**
+     * Writes blob with resolving the blob name using {@link #blobName} method.
+     * <p/>
+     * The blob will be compressed and checksum will be written if required.
+     *
+     * @param obj           object to be serialized
+     * @param blobContainer blob container
+     * @param name          blob name
+     * @throws IOException
+     */
+    public void write(T obj, BlobContainer blobContainer, String name) throws IOException {
+        String blobName = blobName(name);
+        writeBlob(obj, blobContainer, blobName);
+    }
+
+    /**
+     * Writes blob in atomic manner without resolving the blobName using using {@link #blobName} method.
+     * <p/>
+     * The blob will be compressed and checksum will be written if required.
+     *
+     * @param obj           object to be serialized
+     * @param blobContainer blob container
+     * @param blobName          blob name
+     * @throws IOException
+     */
+    protected void writeBlob(T obj, BlobContainer blobContainer, String blobName) throws IOException {
+        BytesReference bytes = write(obj);
+        try (OutputStream outputStream = blobContainer.createOutput(blobName)) {
+            final String resourceDesc = "ChecksumBlobStoreFormat.writeBlob(blob=\"" + blobName + "\")";
+            try (OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput(resourceDesc, outputStream, BUFFER_SIZE)) {
+                CodecUtil.writeHeader(indexOutput, codec, VERSION);
+                try (OutputStream indexOutputOutputStream = new IndexOutputOutputStream(indexOutput) {
+                    @Override
+                    public void close() throws IOException {
+                        // this is important since some of the XContentBuilders write bytes on close.
+                        // in order to write the footer we need to prevent closing the actual index input.
+                    } }) {
+                    bytes.writeTo(indexOutputOutputStream);
+                }
+                CodecUtil.writeFooter(indexOutput);
+            }
+        }
+    }
+
+    /**
+     * Returns true if the blob is a leftover temporary blob.
+     *
+     * The temporary blobs might be left after failed atomic write operation.
+     */
+    public boolean isTempBlobName(String blobName) {
+        return blobName.startsWith(ChecksumBlobStoreFormat.TEMP_FILE_PREFIX);
+    }
+
+    protected BytesReference write(T obj) throws IOException {
+        try (BytesStreamOutput bytesStreamOutput = new BytesStreamOutput()) {
+            if (compress) {
+                try (StreamOutput compressedStreamOutput = CompressorFactory.defaultCompressor().streamOutput(bytesStreamOutput)) {
+                    write(obj, compressedStreamOutput);
+                }
+            } else {
+                write(obj, bytesStreamOutput);
+            }
+            return bytesStreamOutput.bytes();
+        }
+    }
+
+    protected void write(T obj, StreamOutput streamOutput) throws IOException {
+        try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, streamOutput)) {
+            builder.startObject();
+            obj.toXContent(builder, SNAPSHOT_ONLY_FORMAT_PARAMS);
+            builder.endObject();
+        }
+    }
+
+
+    protected String tempBlobName(String name) {
+        return TEMP_FILE_PREFIX + String.format(Locale.ROOT, blobNameFormat, name);
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/LegacyBlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/LegacyBlobStoreFormat.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.repositories.blobstore;
+
+import com.google.common.io.ByteStreams;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.FromXContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Snapshot metadata file format used before v2.0
+ */
+public class LegacyBlobStoreFormat<T extends ToXContent> extends BlobStoreFormat<T> {
+
+    /**
+     * @param blobNameFormat format of the blobname in {@link String#format} format
+     * @param reader the prototype object that can deserialize objects with type T
+     */
+    public LegacyBlobStoreFormat(String blobNameFormat, FromXContentBuilder<T> reader, ParseFieldMatcher parseFieldMatcher) {
+        super(blobNameFormat, reader, parseFieldMatcher);
+    }
+
+    /**
+     * Reads and parses the blob with given name.
+     *
+     * If required the checksum of the blob will be verified.
+     *
+     * @param blobContainer blob container
+     * @param blobName blob name
+     * @return parsed blob object
+     * @throws IOException
+     */
+    public T readBlob(BlobContainer blobContainer, String blobName) throws IOException {
+        try (InputStream inputStream = blobContainer.openInput(blobName)) {
+            return read(new BytesArray(ByteStreams.toByteArray(inputStream)));
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -84,7 +84,7 @@ import static org.elasticsearch.cluster.metadata.MetaDataIndexStateService.INDEX
  * {@link StoreRecoveryService#recover(IndexShard, boolean, StoreRecoveryService.RecoveryListener)}
  * method, which detects that shard should be restored from snapshot rather than recovered from gateway by looking
  * at the {@link org.elasticsearch.cluster.routing.ShardRouting#restoreSource()} property. If this property is not null
- * {@code recover} method uses {@link StoreRecoveryService#restore(org.elasticsearch.indices.recovery.RecoveryState)}
+ * {@code recover} method uses {@link StoreRecoveryService#restore}
  * method to start shard restore process.
  * <p/>
  * At the end of the successful restore process {@code IndexShardSnapshotAndRestoreService} calls {@link #indexShardRestoreCompleted(SnapshotId, ShardId)},
@@ -203,7 +203,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                         for (Map.Entry<String, String> indexEntry : renamedIndices.entrySet()) {
                             String index = indexEntry.getValue();
                             boolean partial = checkPartial(index);
-                            RestoreSource restoreSource = new RestoreSource(snapshotId, index);
+                            RestoreSource restoreSource = new RestoreSource(snapshotId, snapshot.version(), index);
                             String renamedIndex = indexEntry.getKey();
                             IndexMetaData snapshotIndexMetaData = metaData.index(index);
                             snapshotIndexMetaData = updateIndexSettings(snapshotIndexMetaData, request.indexSettings, request.ignoreIndexSettings);

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -471,7 +471,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
                         shardSnapshotStatus.failure(shardFailure.reason());
                         shardStatusBuilder.put(shardId, shardSnapshotStatus);
                     } else {
-                        IndexShardSnapshotStatus shardSnapshotStatus = indexShardRepository.snapshotStatus(snapshotId, shardId);
+                        IndexShardSnapshotStatus shardSnapshotStatus = indexShardRepository.snapshotStatus(snapshotId, snapshot.version(), shardId);
                         shardStatusBuilder.put(shardId, shardSnapshotStatus);
                     }
                 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -126,7 +126,7 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
                 .build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
                 .metaData(metaData)
-                .routingTable(RoutingTable.builder().addAsNewRestore(metaData.index("test"), new RestoreSource(new SnapshotId("rep1", "snp1"), "test"), new IntHashSet())).build();
+                .routingTable(RoutingTable.builder().addAsNewRestore(metaData.index("test"), new RestoreSource(new SnapshotId("rep1", "snp1"), Version.CURRENT, "test"), new IntHashSet())).build();
         for (ShardRouting shard : clusterState.routingNodes().shardsWithState(UNASSIGNED)) {
             assertThat(shard.unassignedInfo().getReason(), equalTo(UnassignedInfo.Reason.NEW_INDEX_RESTORED));
         }
@@ -139,7 +139,7 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
                 .build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
                 .metaData(metaData)
-                .routingTable(RoutingTable.builder().addAsRestore(metaData.index("test"), new RestoreSource(new SnapshotId("rep1", "snp1"), "test"))).build();
+                .routingTable(RoutingTable.builder().addAsRestore(metaData.index("test"), new RestoreSource(new SnapshotId("rep1", "snp1"), Version.CURRENT, "test"))).build();
         for (ShardRouting shard : clusterState.routingNodes().shardsWithState(UNASSIGNED)) {
             assertThat(shard.unassignedInfo().getReason(), equalTo(UnassignedInfo.Reason.EXISTING_INDEX_RESTORED));
         }

--- a/core/src/test/java/org/elasticsearch/common/lucene/store/ByteArrayIndexInputTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/store/ByteArrayIndexInputTests.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.lucene.store;
+
+import com.google.common.base.Charsets;
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class ByteArrayIndexInputTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testRandomReads() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(Charsets.UTF_8);
+            ByteArrayIndexInput indexInput = new ByteArrayIndexInput("test", input);
+            assertEquals(input.length, indexInput.length());
+            assertEquals(0, indexInput.getFilePointer());
+            byte[] output = randomReadAndSlice(indexInput, input.length);
+            assertArrayEquals(input, output);
+        }
+    }
+
+    @Test
+    public void testRandomOverflow() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(Charsets.UTF_8);
+            ByteArrayIndexInput indexInput = new ByteArrayIndexInput("test", input);
+            int firstReadLen = randomIntBetween(0, input.length - 1);
+            randomReadAndSlice(indexInput, firstReadLen);
+            int bytesLeft = input.length - firstReadLen;
+            try {
+                // read using int size
+                int secondReadLen = bytesLeft + randomIntBetween(1, 100);
+                indexInput.readBytes(new byte[secondReadLen], 0, secondReadLen);
+                fail();
+            } catch (IOException ex) {
+                assertThat(ex.getMessage(), containsString("EOF"));
+            }
+        }
+    }
+
+    @Test
+    public void testSeekOverflow() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(Charsets.UTF_8);
+            ByteArrayIndexInput indexInput = new ByteArrayIndexInput("test", input);
+            int firstReadLen = randomIntBetween(0, input.length - 1);
+            randomReadAndSlice(indexInput, firstReadLen);
+            try {
+                switch (randomIntBetween(0, 2)) {
+                    case 0:
+                        indexInput.seek(Integer.MAX_VALUE + 4L);
+                        break;
+                    case 1:
+                        indexInput.seek(-randomIntBetween(1, 10));
+                        break;
+                    case 2:
+                        int seek = input.length + randomIntBetween(1, 100);
+                        indexInput.seek(seek);
+                        break;
+                    default:
+                        fail();
+                }
+                fail();
+            } catch (IOException ex) {
+                assertThat(ex.getMessage(), containsString("EOF"));
+            } catch (IllegalArgumentException ex) {
+                assertThat(ex.getMessage(), containsString("negative position"));
+            }
+        }
+    }
+
+    private byte[] randomReadAndSlice(IndexInput indexInput, int length) throws IOException {
+        int readPos = (int) indexInput.getFilePointer();
+        byte[] output = new byte[length];
+        while (readPos < length) {
+            switch (randomIntBetween(0, 3)) {
+                case 0:
+                    // Read by one byte at a time
+                    output[readPos++] = indexInput.readByte();
+                    break;
+                case 1:
+                    // Read several bytes into target
+                    int len = randomIntBetween(1, length - readPos);
+                    indexInput.readBytes(output, readPos, len);
+                    readPos += len;
+                    break;
+                case 2:
+                    // Read several bytes into 0-offset target
+                    len = randomIntBetween(1, length - readPos);
+                    byte[] temp = new byte[len];
+                    indexInput.readBytes(temp, 0, len);
+                    System.arraycopy(temp, 0, output, readPos, len);
+                    readPos += len;
+                    break;
+                case 3:
+                    // Read using slice
+                    len = randomIntBetween(1, length - readPos);
+                    IndexInput slice = indexInput.slice("slice (" + readPos + ", " + len + ") of " + indexInput.toString(), readPos, len);
+                    temp = randomReadAndSlice(slice, len);
+                    // assert that position in the original input didn't change
+                    assertEquals(readPos, indexInput.getFilePointer());
+                    System.arraycopy(temp, 0, output, readPos, len);
+                    readPos += len;
+                    indexInput.seek(readPos);
+                    assertEquals(readPos, indexInput.getFilePointer());
+                    break;
+                default:
+                    fail();
+            }
+            assertEquals((long) readPos, indexInput.getFilePointer());
+        }
+        return output;
+    }
+}
+

--- a/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatTests.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.ElasticsearchCorruptionException;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseFieldMatcher;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobMetaData;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.blobstore.fs.FsBlobStore;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.index.translog.BufferedChecksumStreamOutput;
+import org.elasticsearch.repositories.blobstore.ChecksumBlobStoreFormat;
+import org.elasticsearch.repositories.blobstore.LegacyBlobStoreFormat;
+import org.junit.Test;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.concurrent.*;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class BlobStoreFormatTests extends AbstractSnapshotTests {
+
+    private static final ParseFieldMatcher parseFieldMatcher = new ParseFieldMatcher(Settings.EMPTY);
+
+    public static final String BLOB_CODEC = "blob";
+
+    private static class BlobObj implements ToXContent, FromXContentBuilder<BlobObj> {
+        public static final BlobObj PROTO = new BlobObj("");
+
+        private final String text;
+
+        public BlobObj(String text) {
+            this.text = text;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        @Override
+        public BlobObj fromXContent(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException {
+            String text = null;
+            XContentParser.Token token = parser.currentToken();
+            if (token == null) {
+                token = parser.nextToken();
+            }
+            if (token == XContentParser.Token.START_OBJECT) {
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token != XContentParser.Token.FIELD_NAME) {
+                        throw new ElasticsearchParseException("unexpected token [{}]", token);
+                    }
+                    String currentFieldName = parser.currentName();
+                    token = parser.nextToken();
+                    if (token.isValue()) {
+                        if ("text" .equals(currentFieldName)) {
+                            text = parser.text();
+                        } else {
+                            throw new ElasticsearchParseException("unexpected field [{}]", currentFieldName);
+                        }
+                    } else {
+                        throw new ElasticsearchParseException("unexpected token [{}]", token);
+                    }
+                }
+            }
+            if (text == null) {
+                throw new ElasticsearchParseException("missing mandatory parameter text");
+            }
+            return new BlobObj(text);
+        }
+
+        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.field("text", getText());
+            return builder;
+        }
+    }
+
+    /**
+     * Extends legacy format with writing functionality. It's used to simulate legacy file formats in tests.
+     */
+    private static final class LegacyEmulationBlobStoreFormat<T extends ToXContent> extends LegacyBlobStoreFormat<T> {
+
+        protected final XContentType xContentType;
+
+        protected final boolean compress;
+
+        public LegacyEmulationBlobStoreFormat(String blobNameFormat, FromXContentBuilder<T> reader, ParseFieldMatcher parseFieldMatcher, boolean compress, XContentType xContentType) {
+            super(blobNameFormat, reader, parseFieldMatcher);
+            this.xContentType = xContentType;
+            this.compress = compress;
+        }
+
+        public void write(T obj, BlobContainer blobContainer, String blobName) throws IOException {
+            BytesReference bytes = write(obj);
+            try (OutputStream outputStream = blobContainer.createOutput(blobName)) {
+                bytes.writeTo(outputStream);
+            }
+        }
+
+        private BytesReference write(T obj) throws IOException {
+            try (BytesStreamOutput bytesStreamOutput = new BytesStreamOutput()) {
+                if (compress) {
+                    try (StreamOutput compressedStreamOutput = CompressorFactory.defaultCompressor().streamOutput(bytesStreamOutput)) {
+                        write(obj, compressedStreamOutput);
+                    }
+                } else {
+                    write(obj, bytesStreamOutput);
+                }
+                return bytesStreamOutput.bytes();
+            }
+        }
+
+        private void write(T obj, StreamOutput streamOutput) throws IOException {
+            XContentBuilder builder = XContentFactory.contentBuilder(xContentType, streamOutput);
+            builder.startObject();
+            obj.toXContent(builder, SNAPSHOT_ONLY_FORMAT_PARAMS);
+            builder.endObject();
+            builder.close();
+        }
+    }
+
+    @Test
+    public void testBlobStoreOperations() throws IOException {
+        BlobStore blobStore = createTestBlobStore();
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        ChecksumBlobStoreFormat<BlobObj> checksumJSON = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj.PROTO, parseFieldMatcher, false, XContentType.JSON);
+        ChecksumBlobStoreFormat<BlobObj> checksumSMILE = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj.PROTO, parseFieldMatcher, false, XContentType.SMILE);
+        ChecksumBlobStoreFormat<BlobObj> checksumSMILECompressed = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj.PROTO, parseFieldMatcher, true, XContentType.SMILE);
+        LegacyEmulationBlobStoreFormat<BlobObj> legacyJSON = new LegacyEmulationBlobStoreFormat<>("%s", BlobObj.PROTO, parseFieldMatcher, false, XContentType.JSON);
+        LegacyEmulationBlobStoreFormat<BlobObj> legacySMILE = new LegacyEmulationBlobStoreFormat<>("%s", BlobObj.PROTO, parseFieldMatcher, false, XContentType.SMILE);
+        LegacyEmulationBlobStoreFormat<BlobObj> legacySMILECompressed = new LegacyEmulationBlobStoreFormat<>("%s", BlobObj.PROTO, parseFieldMatcher, true, XContentType.SMILE);
+
+        // Write blobs in different formats
+        checksumJSON.write(new BlobObj("checksum json"), blobContainer, "check-json");
+        checksumSMILE.write(new BlobObj("checksum smile"), blobContainer, "check-smile");
+        checksumSMILECompressed.write(new BlobObj("checksum smile compressed"), blobContainer, "check-smile-comp");
+        legacyJSON.write(new BlobObj("legacy json"), blobContainer, "legacy-json");
+        legacySMILE.write(new BlobObj("legacy smile"), blobContainer, "legacy-smile");
+        legacySMILECompressed.write(new BlobObj("legacy smile compressed"), blobContainer, "legacy-smile-comp");
+
+        // Assert that all checksum blobs can be read by all formats
+        assertEquals(checksumJSON.read(blobContainer, "check-json").getText(), "checksum json");
+        assertEquals(checksumSMILE.read(blobContainer, "check-json").getText(), "checksum json");
+        assertEquals(checksumJSON.read(blobContainer, "check-smile").getText(), "checksum smile");
+        assertEquals(checksumSMILE.read(blobContainer, "check-smile").getText(), "checksum smile");
+        assertEquals(checksumJSON.read(blobContainer, "check-smile-comp").getText(), "checksum smile compressed");
+        assertEquals(checksumSMILE.read(blobContainer, "check-smile-comp").getText(), "checksum smile compressed");
+
+        // Assert that all legacy blobs can be read be all formats
+        assertEquals(legacyJSON.read(blobContainer, "legacy-json").getText(), "legacy json");
+        assertEquals(legacySMILE.read(blobContainer, "legacy-json").getText(), "legacy json");
+        assertEquals(legacyJSON.read(blobContainer, "legacy-smile").getText(), "legacy smile");
+        assertEquals(legacySMILE.read(blobContainer, "legacy-smile").getText(), "legacy smile");
+        assertEquals(legacyJSON.read(blobContainer, "legacy-smile-comp").getText(), "legacy smile compressed");
+        assertEquals(legacySMILE.read(blobContainer, "legacy-smile-comp").getText(), "legacy smile compressed");
+    }
+
+
+    @Test
+    public void testCompressionIsApplied() throws IOException {
+        BlobStore blobStore = createTestBlobStore();
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        StringBuilder veryRedundantText = new StringBuilder();
+        for (int i = 0; i < randomIntBetween(100, 300); i++) {
+            veryRedundantText.append("Blah ");
+        }
+        ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj.PROTO, parseFieldMatcher, false, randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+        ChecksumBlobStoreFormat<BlobObj> checksumFormatComp = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj.PROTO, parseFieldMatcher, true, randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+        BlobObj blobObj = new BlobObj(veryRedundantText.toString());
+        checksumFormatComp.write(blobObj, blobContainer, "blob-comp");
+        checksumFormat.write(blobObj, blobContainer, "blob-not-comp");
+        Map<String, BlobMetaData> blobs = blobContainer.listBlobsByPrefix("blob-");
+        assertEquals(blobs.size(), 2);
+        assertThat(blobs.get("blob-not-comp").length(), greaterThan(blobs.get("blob-comp").length()));
+    }
+
+    @Test
+    public void testBlobCorruption() throws IOException {
+        BlobStore blobStore = createTestBlobStore();
+        BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        String testString = randomAsciiOfLength(randomInt(10000));
+        BlobObj blobObj = new BlobObj(testString);
+        ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj.PROTO, parseFieldMatcher, randomBoolean(), randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+        checksumFormat.write(blobObj, blobContainer, "test-path");
+        assertEquals(checksumFormat.read(blobContainer, "test-path").getText(), testString);
+        randomCorruption(blobContainer, "test-path");
+        try {
+            checksumFormat.read(blobContainer, "test-path");
+            fail("Should have failed due to corruption");
+        } catch (ElasticsearchCorruptionException ex) {
+            assertThat(ex.getMessage(), containsString("test-path"));
+        } catch (EOFException ex) {
+            // This can happen if corrupt the byte length
+        }
+    }
+
+    public void testAtomicWrite() throws Exception {
+        final BlobStore blobStore = createTestBlobStore();
+        final BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
+        String testString = randomAsciiOfLength(randomInt(10000));
+        final CountDownLatch block = new CountDownLatch(1);
+        final CountDownLatch unblock = new CountDownLatch(1);
+        final BlobObj blobObj = new BlobObj(testString) {
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+                super.toXContent(builder, params);
+                // Block before finishing writing
+                try {
+                    block.countDown();
+                    unblock.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+                return builder;
+            }
+        };
+        final ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj.PROTO, parseFieldMatcher, randomBoolean(), randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+        ExecutorService threadPool = Executors.newFixedThreadPool(1);
+        try {
+            Future<Void> future = threadPool.submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    checksumFormat.writeAtomic(blobObj, blobContainer, "test-blob");
+                    return null;
+                }
+            });
+            block.await(5, TimeUnit.SECONDS);
+            assertFalse(blobContainer.blobExists("test-blob"));
+            unblock.countDown();
+            future.get();
+            assertTrue(blobContainer.blobExists("test-blob"));
+        } finally {
+            threadPool.shutdown();
+        }
+    }
+
+    protected BlobStore createTestBlobStore() throws IOException {
+        Settings settings = Settings.builder().build();
+        return new FsBlobStore(settings, randomRepoPath());
+    }
+
+    protected void randomCorruption(BlobContainer blobContainer, String blobName) throws IOException {
+        byte[] buffer = new byte[(int) blobContainer.listBlobsByPrefix(blobName).get(blobName).length()];
+        long originalChecksum = checksum(buffer);
+        try (InputStream inputStream = blobContainer.openInput(blobName)) {
+            Streams.readFully(inputStream, buffer);
+        }
+        do {
+            int location = randomIntBetween(0, buffer.length - 1);
+            buffer[location] = (byte) (buffer[location] ^ 42);
+        } while (originalChecksum == checksum(buffer));
+        try (OutputStream outputStream = blobContainer.createOutput(blobName)) {
+            Streams.copy(buffer, outputStream);
+        }
+    }
+
+    private long checksum(byte[] buffer) throws IOException {
+        try (BytesStreamOutput streamOutput = new BytesStreamOutput()) {
+            try (BufferedChecksumStreamOutput checksumOutput = new BufferedChecksumStreamOutput(streamOutput)) {
+                checksumOutput.write(buffer);
+                return checksumOutput.getChecksum();
+            }
+        }
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreTests.java
@@ -906,7 +906,7 @@ public class SharedClusterSnapshotRestoreTests extends AbstractSnapshotTests {
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
         logger.info("--> truncate snapshot file to make it unreadable");
-        Path snapshotPath = repo.resolve("snapshot-test-snap-1");
+        Path snapshotPath = repo.resolve("snap-test-snap-1.dat");
         try(SeekableByteChannel outChan = Files.newByteChannel(snapshotPath, StandardOpenOption.WRITE)) {
             outChan.truncate(randomInt(10));
         }


### PR DESCRIPTION
This commit adds checksum to snapshot files that store global and index based metadata as well as shard information.

Closes #11589
