### PR TITLE
Using putIfAbsent to prevent race condition

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/deletionpolicy/SnapshotDeletionPolicy.java
+++ b/core/src/main/java/org/elasticsearch/index/deletionpolicy/SnapshotDeletionPolicy.java
@@ -144,11 +144,9 @@ public class SnapshotDeletionPolicy extends AbstractESDeletionPolicy {
      * Helper method to snapshot a give commit.
      */
     private SnapshotIndexCommit snapshot(SnapshotIndexCommit commit) throws IOException {
-        SnapshotHolder snapshotHolder = snapshots.get(commit.getGeneration());
-        if (snapshotHolder == null) {
-            snapshotHolder = new SnapshotHolder(0);
-            snapshots.put(commit.getGeneration(), snapshotHolder);
-        }
+		SnapshotHolder snapshotHolder = new SnapshotHolder(0);
+        snapshotHolder = snapshots.putIfAbsent(commit.getGeneration(), snapshotHolder);
+        
         snapshotHolder.counter++;
         return new OneTimeReleaseSnapshotIndexCommit(this, commit);
     }


### PR DESCRIPTION
It was possible to override a existing SnapshotHolder with a new one. If
a thread t1 calls the same function  after another thread t2 checks the
current value. Now t1 sets a new SnapshotHolder before the t2 could sets
a new SnapshotHolder. With putIfAbsent the sementic of the original code
segment will be executed atomically.
