### PR TITLE
Introduced ESMessageFormat

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.support.LoggerMessageFormat;
+import org.elasticsearch.common.ESMessageFormat;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.HasRestHeaders;
@@ -56,7 +56,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * @param args the arguments for the message
      */
     public ElasticsearchException(String msg, Object... args) {
-        super(LoggerMessageFormat.format(msg, args));
+        super(ESMessageFormat.format(msg, args));
     }
 
     /**
@@ -71,7 +71,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * @param args  the arguments for the message
      */
     public ElasticsearchException(String msg, Throwable cause, Object... args) {
-        super(LoggerMessageFormat.format(msg, args), cause);
+        super(ESMessageFormat.format(msg, args), cause);
     }
 
     public ElasticsearchException(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/logging/support/AbstractESLogger.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/support/AbstractESLogger.java
@@ -19,7 +19,10 @@
 
 package org.elasticsearch.common.logging.support;
 
+import org.elasticsearch.common.ESMessageFormat;
 import org.elasticsearch.common.logging.ESLogger;
+
+import static org.elasticsearch.common.ESMessageFormat.formatWithPrefix;
 
 /**
  *
@@ -40,7 +43,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void trace(String msg, Object... params) {
         if (isTraceEnabled()) {
-            internalTrace(LoggerMessageFormat.format(prefix, msg, params));
+            internalTrace(formatWithPrefix(prefix, msg, params));
         }
     }
 
@@ -49,7 +52,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void trace(String msg, Throwable cause, Object... params) {
         if (isTraceEnabled()) {
-            internalTrace(LoggerMessageFormat.format(prefix, msg, params), cause);
+            internalTrace(formatWithPrefix(prefix, msg, params), cause);
         }
     }
 
@@ -59,7 +62,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void debug(String msg, Object... params) {
         if (isDebugEnabled()) {
-            internalDebug(LoggerMessageFormat.format(prefix, msg, params));
+            internalDebug(formatWithPrefix(prefix, msg, params));
         }
     }
 
@@ -68,7 +71,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void debug(String msg, Throwable cause, Object... params) {
         if (isDebugEnabled()) {
-            internalDebug(LoggerMessageFormat.format(prefix, msg, params), cause);
+            internalDebug(formatWithPrefix(prefix, msg, params), cause);
         }
     }
 
@@ -78,7 +81,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void info(String msg, Object... params) {
         if (isInfoEnabled()) {
-            internalInfo(LoggerMessageFormat.format(prefix, msg, params));
+            internalInfo(formatWithPrefix(prefix, msg, params));
         }
     }
 
@@ -87,7 +90,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void info(String msg, Throwable cause, Object... params) {
         if (isInfoEnabled()) {
-            internalInfo(LoggerMessageFormat.format(prefix, msg, params), cause);
+            internalInfo(formatWithPrefix(prefix, msg, params), cause);
         }
     }
 
@@ -97,7 +100,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void warn(String msg, Object... params) {
         if (isWarnEnabled()) {
-            internalWarn(LoggerMessageFormat.format(prefix, msg, params));
+            internalWarn(formatWithPrefix(prefix, msg, params));
         }
     }
 
@@ -106,7 +109,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void warn(String msg, Throwable cause, Object... params) {
         if (isWarnEnabled()) {
-            internalWarn(LoggerMessageFormat.format(prefix, msg, params), cause);
+            internalWarn(formatWithPrefix(prefix, msg, params), cause);
         }
     }
 
@@ -116,7 +119,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void error(String msg, Object... params) {
         if (isErrorEnabled()) {
-            internalError(LoggerMessageFormat.format(prefix, msg, params));
+            internalError(formatWithPrefix(prefix, msg, params));
         }
     }
 
@@ -125,7 +128,7 @@ public abstract class AbstractESLogger implements ESLogger {
     @Override
     public void error(String msg, Throwable cause, Object... params) {
         if (isErrorEnabled()) {
-            internalError(LoggerMessageFormat.format(prefix, msg, params), cause);
+            internalError(formatWithPrefix(prefix, msg, params), cause);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/script/Script.java
+++ b/core/src/main/java/org/elasticsearch/script/Script.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
-import org.elasticsearch.common.logging.support.LoggerMessageFormat;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -291,7 +290,7 @@ public class Script implements ToXContent, Streamable {
     public static class ScriptParseException extends ElasticsearchException {
 
         public ScriptParseException(String msg, Object... args) {
-            super(LoggerMessageFormat.format(msg, args));
+            super(msg, args);
         }
 
         public ScriptParseException(StreamInput in) throws IOException{

--- a/core/src/test/java/org/elasticsearch/common/ESMessageFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/common/ESMessageFormatTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ *
+ */
+public class ESMessageFormatTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testFormat() throws Exception {
+        Object arg1 = randomFrom("arg1", 1, 1.0, new long[] { 1L, 10L }, null);
+        Object arg2 = randomFrom("arg2", 2, 2.0, new long[] { 2L, 20L }, null);
+        StringBuilder pattern = new StringBuilder();
+        StringBuilder expected = new StringBuilder();
+        if (randomBoolean()) {
+            String text = randomAsciiOfLength(randomIntBetween(1, 10));
+            pattern.append(text);
+            expected.append(text);
+        }
+        if (randomBoolean()) {
+            pattern.append(" ");
+            expected.append(" ");
+        }
+        if (randomBoolean()) {
+            pattern.append("[]");
+            if (arg1 instanceof long[]) {
+                expected.append(Arrays.toString((long[]) arg1));
+            } else {
+                expected.append('[').append(String.valueOf(arg1)).append(']');
+            }
+        } else {
+            pattern.append("{}");
+            if (arg1 instanceof long[]) {
+                expected.append(Arrays.toString((long[]) arg1));
+            } else {
+                expected.append(String.valueOf(arg1));
+            }
+        }
+        if (randomBoolean()) {
+            String text = randomAsciiOfLength(randomIntBetween(1, 10));
+            pattern.append(text);
+            expected.append(text);
+        }
+        if (randomBoolean()) {
+            pattern.append("[]");
+            if (arg2 instanceof long[]) {
+                expected.append(Arrays.toString((long[]) arg2));
+            } else {
+                expected.append('[').append(String.valueOf(arg2)).append(']');
+            }
+        } else {
+            pattern.append("{}");
+            if (arg2 instanceof long[]) {
+                expected.append(Arrays.toString((long[]) arg2));
+            } else {
+                expected.append(String.valueOf(arg2));
+            }
+        }
+        if (randomBoolean()) {
+            assertThat(ESMessageFormat.format(pattern.toString(), arg1, arg2), is(expected.toString()));
+        } else {
+            assertThat(ESMessageFormat.formatWithPrefix("prefix-", pattern.toString(), arg1, arg2), is("prefix-" + expected.toString()));
+        }
+    }
+
+    @Test
+    public void testFormatWithoutPlaceholders() throws Exception {
+        String pattern = randomAsciiOfLength(10);
+        if (randomBoolean()) {
+            assertThat(ESMessageFormat.formatWithPrefix("prefix-", pattern), is("prefix-" + pattern));
+        } else {
+            assertThat(ESMessageFormat.format(pattern), is(pattern));
+        }
+    }
+}


### PR DESCRIPTION
formally known as `LoggerMessageFormat` now this message format is not only for logs but also for exceptions.

The format was enhanced to support `[]` place holders in addition to the tranditional `{}`. The `[]` place holders will automatically enclosed single parameters (i.e. non-array parameters) within brackets. For example:

pattern: "value []"
param: 34
output: "value [37]"

Note, array parameters will always be enclosed in brackets (regardless of whether `{}` or `[]` are used)
