### PR TITLE
Don't special-case on ElasticsearchWrapperException in toXContent

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -246,7 +246,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        if (this instanceof ElasticsearchWrapperException) {
+        Throwable ex = ExceptionsHelper.unwrapCause(this);
+        if (ex != this) {
             toXContent(builder, params, this);
         } else {
             builder.field("type", getExceptionName());


### PR DESCRIPTION
the specialization can cause stack overflows if an exception is a
ElasticsearchWrapperException as well as a ElasticsearchException.
This commit just relies on the unwrap logic now to find the cause and only
renders if we the rendering exception is the cause otherwise forwards
to the generic exception rendering.

Closes #11994
