### PR TITLE
add integration test harness to maven build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1053,9 +1053,98 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <!-- start up external cluster -->
+                    <execution>
+                        <id>integ-setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                              <!-- unzip release artifact -->
+                              <property name="integ.finalname" value="${project.artifactId}-${project.version}"/>
+                              <property name="integ.scratch" location="${project.build.directory}/integ-tests"/>
+                              <unzip src="${project.build.directory}/releases/${integ.finalname}.zip"
+                                     dest="${integ.scratch}"/>
+
+                              <property name="integ.home" location="${integ.scratch}/${integ.finalname}"/>
+
+                              <!-- execute -->
+                              <property name="integ.args"
+                                        value="-Des.node.name=smoke_tester -Des.cluster.name=prepare_release
+                                               -Des.discovery.zen.ping.multicast.enabled=false -Des.script.inline=on
+                                               -Des.script.indexed=on"/>
+
+                              <echo>Starting up external cluster...</echo>
+                              <exec executable="cmd" osfamily="winnt" dir="${integ.home}" spawn="true">
+                                <arg value="/c"/>
+                                <arg value="${integ.home}/bin/elasticsearch.bat"/>
+                                <arg line="${integ.args}"/>
+                              </exec>
+                              <exec executable="sh" osfamily="unix" dir="${integ.home}" spawn="true">
+                                <arg value="${integ.home}/bin/elasticsearch"/>
+                                <arg line="${integ.args}"/>
+                              </exec>
+                              <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
+                                 <http url="http://127.0.0.1:9200"/>
+                              </waitfor>
+                              <echo>External cluster started</echo>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- shut down external cluster -->
+                    <execution>
+                        <id>integ-teardown</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                              <!-- TODO: this is brutal, specify and read our pid file instead -->
+                              <!-- find ES processes with jps, then shoot them with 50 cal -->
+                              <exec executable="jps">
+                                <arg value="-l"/>
+                                <redirector outputproperty="process.pid">
+                                  <outputfilterchain>
+                                    <linecontains>
+                                      <contains value="org.elasticsearch.bootstrap.Elasticsearch"/>
+                                    </linecontains>
+                                    <replacestring from=" org.elasticsearch.bootstrap.Elasticsearch"/>
+                                  </outputfilterchain>
+                                </redirector>
+                              </exec>
+                              <echo>Shutting down external cluster</echo>
+                              <exec executable="taskkill" osfamily="winnt">
+                                <arg value="/F"/>
+                                <arg value="/PID"/>
+                                <arg value="${process.pid}"/>
+                              </exec>
+                              <exec executable="kill" osfamily="unix">
+                                <arg value="-9"/>
+                                <arg value="${process.pid}"/>
+                              </exec>
+                              <!-- best effort cleanup. 'clean' will take care in all cases -->
+                              <delete dir="${project.build.directory}/integ-tests" failonerror="false"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <tests.cluster>127.0.0.1:9300</tests.cluster>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
       <pluginManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1053,6 +1053,10 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
         </plugins>
       <pluginManagement>
         <plugins>

--- a/core/src/test/java/org/elasticsearch/test/rest/RestIT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/RestIT.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+
+import java.io.IOException;
+
+/** Rest integration test. runs against external cluster in 'mvn verify' */
+public class RestIT extends ElasticsearchRestTestCase {
+    public RestIT(RestTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+    // we run them all sequentially: start simple!
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
+        return createParameters(0, 1);
+    }
+}

--- a/dev-tools/build_release.py
+++ b/dev-tools/build_release.py
@@ -466,7 +466,7 @@ def smoke_test_release(release, files, expected_hash, plugins):
           if version['build_hash'].strip() !=  expected_hash:
             raise RuntimeError('HEAD hash does not match expected [%s] but got [%s]' % (expected_hash, version['build_hash']))
           print('  Running REST Spec tests against package [%s]' % release_file)
-          run_mvn('test -Dtests.cluster=%s -Dtests.class=*.*RestTests' % ("127.0.0.1:9300"))
+          run_mvn('test -Dtests.cluster=%s -Dtests.jvms=1 -Dtests.class=*.*RestTests' % ("127.0.0.1:9300"))
           print('  Verify if plugins are listed in _nodes')
           conn.request('GET', '/_nodes?plugin=true&pretty=true')
           res = conn.getresponse()

--- a/pom.xml
+++ b/pom.xml
@@ -717,10 +717,14 @@
                     </configuration>
                     <executions>
                         <execution>
-                            <id>run-tests</id>
-                            <phase>integration-test</phase>
+                            <id>integration-test</id>
                             <goals>
                                 <goal>integration-test</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>verify</id>
+                            <goals>
                                 <goal>verify</goal>
                             </goals>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     </scm>
 
     <properties>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- elasticsearch stack -->
         <elasticsearch.version>2.0.0-SNAPSHOT</elasticsearch.version>
         <jvm.executable>${java.home}${file.separator}bin${file.separator}java</jvm.executable>
@@ -101,6 +102,8 @@
         <tests.security.manager>true</tests.security.manager>
         <tests.compatibility></tests.compatibility>
         <tests.ifNoTests>fail</tests.ifNoTests>
+        <skip.unit.tests>${skipTests}</skip.unit.tests>
+        <skip.integ.tests>${skipTests}</skip.integ.tests>
     </properties>
 
     <repositories>
@@ -570,6 +573,7 @@
                             <configuration>
                                 <jvm>${jvm.executable}</jvm>
                                 <argLine>${tests.jvm.argline}</argLine>
+                                <skipTests>${skip.unit.tests}</skipTests>
                                 <heartbeat>10</heartbeat>
                                 <jvmOutputAction>warn</jvmOutputAction>
                                 <leaveTemporary>true</leaveTemporary>
@@ -700,6 +704,27 @@
                     <configuration>
                         <skip>true</skip>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.18.1</version>
+                    <configuration>
+                       <skipTests>${skip.integ.tests}</skipTests>
+                       <systemPropertyVariables>
+                           <es.logger.level>${es.logger.level}</es.logger.level>
+                       </systemPropertyVariables>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>run-tests</id>
+                            <phase>integration-test</phase>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1239,7 +1264,7 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                             <id>tests-top-hints</id>
                             <phase>test</phase>
                             <configuration>
-                                <skip>${skipTests}</skip>
+                                <skip>${skip.unit.tests}</skip>
                                 <!-- don't run if we skip the tests -->
                                 <failOnError>false</failOnError>
                                 <target>


### PR DESCRIPTION
Our unit testing setup is designed for unit tests, and its not really appropriate for integration tests (its not totally realistic).

Instead I think we should add real integration test setup, with the maven plugins designed to do that, that runs after packaging, unzips elasticsearch, starts up external cluster, runs rest tests against it, and then shuts down the cluster. People already know the rest tests framework and we already have a bunch of tests.

I need this kind of thing to fix stuff like jar hell issues for good, and to have more confidence in stuff like security manager and other tricky things.

Today we kind of have it, but its wierd and run from a python release script. Instead I think integ tests should be a regular part of our build.

I made a very simple initial impl and it finds bugs already ;)

As a followup I would like to extend this to plugins (I will start with delete-by-query, it already has rest tests defined). So please don't worry too much about where the logic currently is, we can refactor as needed after that.
