### PR TITLE
[maven] change groupId / artifactId

### DIFF
--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -1,7 +1,7 @@
 <project>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.elasticsearch</groupId>
-  <artifactId>dev-tools</artifactId>
+  <artifactId>elasticsearch-dev-tools</artifactId>
   <version>2.0.0-SNAPSHOT</version>
   <name>Elasticsearch Build Resources</name>
   <parent>

--- a/plugins/analysis-icu/pom.xml
+++ b/plugins/analysis-icu/pom.xml
@@ -3,18 +3,16 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-analysis-icu</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch ICU Analysis plugin</name>
-    <description>The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.</description>
 
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-analysis-icu</artifactId>
+    <name>Elasticsearch ICU Analysis plugin</name>
+    <description>The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.</description>
 
     <properties>
         <tests.jvms>1</tests.jvms>

--- a/plugins/analysis-kuromoji/pom.xml
+++ b/plugins/analysis-kuromoji/pom.xml
@@ -4,18 +4,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-analysis-kuromoji</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch Japanese (kuromoji) Analysis plugin</name>
-    <description>The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-analysis-kuromoji</artifactId>
+    <packaging>jar</packaging>
+    <name>Elasticsearch Japanese (kuromoji) Analysis plugin</name>
+    <description>The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.</description>
 
     <properties>
         <!-- You can add any specific project property here -->

--- a/plugins/analysis-phonetic/pom.xml
+++ b/plugins/analysis-phonetic/pom.xml
@@ -4,18 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-analysis-phonetic</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch Phonetic Analysis plugin</name>
-    <description>The Phonetic Analysis plugin integrates phonetic token filter analysis with elasticsearch.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-analysis-phonetic</artifactId>
+    <name>Elasticsearch Phonetic Analysis plugin</name>
+    <description>The Phonetic Analysis plugin integrates phonetic token filter analysis with elasticsearch.</description>
 
     <properties>
         <!-- You can add any specific project property here -->

--- a/plugins/analysis-smartcn/pom.xml
+++ b/plugins/analysis-smartcn/pom.xml
@@ -4,18 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-analysis-smartcn</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch Smart Chinese Analysis plugin</name>
-    <description>Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-analysis-smartcn</artifactId>
+    <name>Elasticsearch Smart Chinese Analysis plugin</name>
+    <description>Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch.</description>
 
     <properties>
         <!-- You can add any specific project property here -->

--- a/plugins/analysis-stempel/pom.xml
+++ b/plugins/analysis-stempel/pom.xml
@@ -4,18 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-analysis-stempel</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch Stempel (Polish) Analysis plugin</name>
-    <description>The Stempel (Polish) Analysis plugin integrates Lucene stempel (polish) analysis module into elasticsearch.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-analysis-stempel</artifactId>
+    <name>Elasticsearch Stempel (Polish) Analysis plugin</name>
+    <description>The Stempel (Polish) Analysis plugin integrates Lucene stempel (polish) analysis module into elasticsearch.</description>
 
     <properties>
         <!-- You can add any specific project property here -->

--- a/plugins/cloud-aws/pom.xml
+++ b/plugins/cloud-aws/pom.xml
@@ -4,18 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-cloud-aws</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch AWS cloud plugin</name>
-    <description>The Amazon Web Service (AWS) Cloud plugin allows to use AWS API for the unicast discovery mechanism and add S3 repositories.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-cloud-aws</artifactId>
+    <name>Elasticsearch AWS cloud plugin</name>
+    <description>The Amazon Web Service (AWS) Cloud plugin allows to use AWS API for the unicast discovery mechanism and add S3 repositories.</description>
 
     <properties>
         <amazonaws.version>1.10.0</amazonaws.version>

--- a/plugins/cloud-azure/pom.xml
+++ b/plugins/cloud-azure/pom.xml
@@ -15,18 +15,15 @@ governing permissions and limitations under the License. -->
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-cloud-azure</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch Azure cloud plugin</name>
-    <description>The Azure Cloud plugin allows to use Azure API for the unicast discovery mechanism and add Azure storage repositories.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-cloud-azure</artifactId>
+    <name>Elasticsearch Azure cloud plugin</name>
+    <description>The Azure Cloud plugin allows to use Azure API for the unicast discovery mechanism and add Azure storage repositories.</description>
 
     <properties>
         <!-- You can add any specific project property here -->

--- a/plugins/cloud-gce/pom.xml
+++ b/plugins/cloud-gce/pom.xml
@@ -15,19 +15,15 @@ governing permissions and limitations under the License. -->
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-cloud-gce</artifactId>
-
-
-    <name>Elasticsearch Google Compute Engine cloud plugin</name>
-    <description>The Google Compute Engine (GCE) Cloud plugin allows to use GCE API for the unicast discovery mechanism.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
+    <artifactId>elasticsearch-cloud-gce</artifactId>
+    <name>Elasticsearch Google Compute Engine cloud plugin</name>
+    <description>The Google Compute Engine (GCE) Cloud plugin allows to use GCE API for the unicast discovery mechanism.</description>
 
     <properties>
         <google.gce.version>v1-rev59-1.20.0</google.gce.version>

--- a/plugins/delete-by-query/pom.xml
+++ b/plugins/delete-by-query/pom.xml
@@ -15,18 +15,15 @@ governing permissions and limitations under the License. -->
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-delete-by-query</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch Delete By Query plugin</name>
-    <description>The Delete By Query plugin allows to delete documents in Elasticsearch with a single query.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-delete-by-query</artifactId>
+    <name>Elasticsearch Delete By Query plugin</name>
+    <description>The Delete By Query plugin allows to delete documents in Elasticsearch with a single query.</description>
 
     <properties>
         <tests.ifNoTests>warn</tests.ifNoTests>

--- a/plugins/lang-javascript/pom.xml
+++ b/plugins/lang-javascript/pom.xml
@@ -4,18 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-lang-javascript</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch JavaScript language plugin</name>
-    <description>The JavaScript language plugin allows to have javascript as the language of scripts to execute.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-lang-javascript</artifactId>
+    <name>Elasticsearch JavaScript language plugin</name>
+    <description>The JavaScript language plugin allows to have javascript as the language of scripts to execute.</description>
 
     <properties>
         <!-- You can add any specific project property here -->

--- a/plugins/lang-python/pom.xml
+++ b/plugins/lang-python/pom.xml
@@ -4,18 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-lang-python</artifactId>
-
-    <packaging>jar</packaging>
-    <name>Elasticsearch Python language plugin</name>
-    <description>The Python language plugin allows to have python as the language of scripts to execute.</description>
-
     <parent>
-        <groupId>org.elasticsearch</groupId>
+        <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>elasticsearch-plugin</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>elasticsearch-lang-python</artifactId>
+    <name>Elasticsearch Python language plugin</name>
+    <description>The Python language plugin allows to have python as the language of scripts to execute.</description>
 
     <properties>
         <!-- You can add any specific project property here -->

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.elasticsearch.plugin</groupId>
     <artifactId>elasticsearch-plugin</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/rest-api-spec/pom.xml
+++ b/rest-api-spec/pom.xml
@@ -1,7 +1,7 @@
 <project>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.elasticsearch</groupId>
-  <artifactId>rest-api-spec</artifactId>
+  <artifactId>elasticsearch-rest-api-spec</artifactId>
   <version>2.0.0-SNAPSHOT</version>
   <name>Elasticsearch Rest API Spec</name>
   <parent>

--- a/securemock/pom.xml
+++ b/securemock/pom.xml
@@ -2,10 +2,10 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.elasticsearch</groupId>
-  <artifactId>securemock</artifactId>
+  <artifactId>elasticsearch-securemock</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>securemock</name>
+  <name>Elasticsearch Securemock</name>
   <description>Allows creating mocks in tests without having to grant dangerous permissions to all of your code.</description>
   <inceptionYear>2015</inceptionYear>
 


### PR DESCRIPTION
When we generate our project, we can get something like:

```
├── dev-tools
├── elasticsearch
├── elasticsearch-parent
├── elasticsearch-plugin
├── plugin
│   ├── elasticsearch-analysis-icu
│   ├── elasticsearch-analysis-kuromoji
│   ├── elasticsearch-analysis-phonetic
│   ├── elasticsearch-analysis-smartcn
│   ├── elasticsearch-analysis-stempel
│   ├── elasticsearch-cloud-aws
│   ├── elasticsearch-cloud-azure
│   ├── elasticsearch-cloud-gce
│   ├── elasticsearch-delete-by-query
│   ├── elasticsearch-lang-javascript
│   └── elasticsearch-lang-python
├── rest-api-spec
└── securemock
```

I propose here to use a common naming for artifacts: start always with `elasticsearch-`.
Also, move `elasticsearch-plugin` to `org.elasticsearch.plugin` groupId.

So we could have:

```
├── elasticsearch
├── elasticsearch-dev-tools
├── elasticsearch-parent
├── elasticsearch-rest-api-spec
├── elasticsearch-securemock
├── plugin
│   ├── elasticsearch-analysis-icu
│   ├── elasticsearch-analysis-kuromoji
│   ├── elasticsearch-analysis-phonetic
│   ├── elasticsearch-analysis-smartcn
│   ├── elasticsearch-analysis-stempel
│   ├── elasticsearch-cloud-aws
│   ├── elasticsearch-cloud-azure
│   ├── elasticsearch-cloud-gce
│   ├── elasticsearch-delete-by-query
│   ├── elasticsearch-lang-javascript
│   ├── elasticsearch-lang-python
│   └── elasticsearch-plugin
```
