### PR TITLE
Create $PID_DIR if not exists

### DIFF
--- a/core/src/packaging/deb/init.d/elasticsearch
+++ b/core/src/packaging/deb/init.d/elasticsearch
@@ -96,6 +96,8 @@ MAX_MAP_COUNT=262144
 
 # Elasticsearch PID file directory
 PID_DIR="${packaging.elasticsearch.pid.dir}"
+# Create $PID_DIR if not exists
+mkdir -p $PID_DIR
 
 # End of variables that can be overwritten in $DEFAULT
 


### PR DESCRIPTION
When you istall elasticsearch with the deb package (apt-get install elasticsearch), you have an error when starting elasticsearch :
sudo service elasticsearch start
[....] Starting Elasticsearch Server:touch: cannot touch `/var/run/elasticsearch                                                                    /elasticsearch.pid': No such file or directory
failed!

If the $PID_DIR doesn't exist, elasticsearch can't start.
