### PR TITLE
Refactor ValuesSource to separate Parsing from Factory logic

### DIFF
--- a/core/src/main/java/org/elasticsearch/percolator/QueryCollector.java
+++ b/core/src/main/java/org/elasticsearch/percolator/QueryCollector.java
@@ -34,7 +34,6 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
@@ -83,8 +82,9 @@ abstract class QueryCollector extends SimpleCollector {
         if (context.aggregations() != null) {
             AggregationContext aggregationContext = new AggregationContext(context);
             context.aggregations().aggregationContext(aggregationContext);
+            context.aggregations().factories().init(aggregationContext);
 
-            Aggregator[] aggregators = context.aggregations().factories().createTopLevelAggregators(aggregationContext);
+            Aggregator[] aggregators = context.aggregations().factories().createTopLevelAggregators();
             for (int i = 0; i < aggregators.length; i++) {
                 if (!(aggregators[i] instanceof GlobalAggregator)) {
                     Aggregator aggregator = aggregators[i];

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -71,12 +71,13 @@ public class AggregationPhase implements SearchPhase {
         if (context.aggregations() != null) {
             AggregationContext aggregationContext = new AggregationContext(context);
             context.aggregations().aggregationContext(aggregationContext);
+            context.aggregations().factories().init(aggregationContext);
 
             List<Aggregator> collectors = new ArrayList<>();
             Aggregator[] aggregators;
             try {
                 AggregatorFactories factories = context.aggregations().factories();
-                aggregators = factories.createTopLevelAggregators(aggregationContext);
+                aggregators = factories.createTopLevelAggregators();
                 for (int i = 0; i < aggregators.length; i++) {
                     if (aggregators[i] instanceof GlobalAggregator == false) {
                         collectors.add(aggregators[i]);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -52,6 +52,12 @@ public class AggregatorFactories {
         this.pipelineAggregatorFactories = pipelineAggregators;
     }
 
+    public void init(AggregationContext context) {
+        for (AggregatorFactory factory : factories) {
+            factory.init(context);
+        }
+    }
+
     public List<PipelineAggregator> createPipelineAggregators() throws IOException {
         List<PipelineAggregator> pipelineAggregators = new ArrayList<>();
         for (PipelineAggregatorFactory factory : this.pipelineAggregatorFactories) {
@@ -72,18 +78,18 @@ public class AggregatorFactories {
             // propagate the fact that only bucket 0 will be collected with single-bucket
             // aggs
             final boolean collectsFromSingleBucket = false;
-            aggregators[i] = factories[i].create(parent.context(), parent, collectsFromSingleBucket);
+            aggregators[i] = factories[i].create(parent, collectsFromSingleBucket);
         }
         return aggregators;
     }
 
-    public Aggregator[] createTopLevelAggregators(AggregationContext ctx) throws IOException {
+    public Aggregator[] createTopLevelAggregators() throws IOException {
         // These aggregators are going to be used with a single bucket ordinal, no need to wrap the PER_BUCKET ones
         Aggregator[] aggregators = new Aggregator[factories.length];
         for (int i = 0; i < factories.length; i++) {
             // top-level aggs only get called with bucket 0
             final boolean collectsFromSingleBucket = true;
-            aggregators[i] = factories[i].create(ctx, null, collectsFromSingleBucket);
+            aggregators[i] = factories[i].create(null, collectsFromSingleBucket);
         }
         return aggregators;
     }
@@ -124,7 +130,7 @@ public class AggregatorFactories {
         }
 
         @Override
-        public Aggregator[] createTopLevelAggregators(AggregationContext ctx) {
+        public Aggregator[] createTopLevelAggregators() {
             return EMPTY_AGGREGATORS;
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ChildrenParser.java
@@ -18,18 +18,10 @@
  */
 package org.elasticsearch.search.aggregations.bucket.children;
 
-import org.apache.lucene.search.Filter;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.support.FieldContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -71,31 +63,7 @@ public class ChildrenParser implements Aggregator.Parser {
                     parser.getTokenLocation());
         }
 
-        ValuesSourceConfig<ValuesSource.Bytes.WithOrdinals.ParentChild> config = new ValuesSourceConfig<>(ValuesSource.Bytes.WithOrdinals.ParentChild.class);
-        DocumentMapper childDocMapper = context.mapperService().documentMapper(childType);
 
-        String parentType = null;
-        Filter parentFilter = null;
-        Filter childFilter = null;
-        if (childDocMapper != null) {
-            ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
-            if (!parentFieldMapper.active()) {
-                throw new SearchParseException(context, "[children] no [_parent] field not configured that points to a parent type", parser.getTokenLocation());
-            }
-            parentType = parentFieldMapper.type();
-            DocumentMapper parentDocMapper = context.mapperService().documentMapper(parentType);
-            if (parentDocMapper != null) {
-                // TODO: use the query API
-                parentFilter = new QueryWrapperFilter(parentDocMapper.typeFilter());
-                childFilter = new QueryWrapperFilter(childDocMapper.typeFilter());
-                ParentChildIndexFieldData parentChildIndexFieldData = context.fieldData().getForField(parentFieldMapper.fieldType());
-                config.fieldContext(new FieldContext(parentFieldMapper.fieldType().names().indexName(), parentChildIndexFieldData, parentFieldMapper.fieldType()));
-            } else {
-                config.unmapped(true);
-            }
-        } else {
-            config.unmapped(true);
-        }
-        return new ParentToChildrenAggregator.Factory(aggregationName, config, parentType, parentFilter, childFilter);
+        return new ParentToChildrenAggregator.Factory(aggregationName, childType);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ParentToChildrenAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ParentToChildrenAggregator.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
@@ -29,7 +30,11 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
+import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
 import org.elasticsearch.index.search.child.ConstantScorer;
+import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -38,9 +43,11 @@ import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -184,15 +191,19 @@ public class ParentToChildrenAggregator extends SingleBucketAggregator {
 
     public static class Factory extends ValuesSourceAggregatorFactory<ValuesSource.Bytes.WithOrdinals.ParentChild> {
 
-        private final String parentType;
-        private final Filter parentFilter;
-        private final Filter childFilter;
+        private String parentType;
+        private final String childType;
+        private Filter parentFilter;
+        private Filter childFilter;
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Bytes.WithOrdinals.ParentChild> config, String parentType, Filter parentFilter, Filter childFilter) {
-            super(name, InternalChildren.TYPE.name(), config);
-            this.parentType = parentType;
-            this.parentFilter = parentFilter;
-            this.childFilter = childFilter;
+        public Factory(String name, String childType) {
+            super(name, InternalChildren.TYPE.name(), new ValuesSourceParser.Input<ValuesSource.Bytes.WithOrdinals.ParentChild>());
+            this.childType = childType;
+        }
+
+        @Override
+        public void doInit(AggregationContext context) {
+            resolveConfig(context);
         }
 
         @Override
@@ -215,6 +226,34 @@ public class ParentToChildrenAggregator extends SingleBucketAggregator {
             long maxOrd = valuesSource.globalMaxOrd(aggregationContext.searchContext().searcher(), parentType);
             return new ParentToChildrenAggregator(name, factories, aggregationContext, parent, parentType, childFilter, parentFilter,
                     valuesSource, maxOrd, pipelineAggregators, metaData);
+        }
+
+        private void resolveConfig(AggregationContext aggregationContext) {
+            config = new ValuesSourceConfig<>(ValuesSource.Bytes.WithOrdinals.ParentChild.class);
+            DocumentMapper childDocMapper = aggregationContext.searchContext().mapperService().documentMapper(childType);
+
+            if (childDocMapper != null) {
+                ParentFieldMapper parentFieldMapper = childDocMapper.parentFieldMapper();
+                if (!parentFieldMapper.active()) {
+                    throw new SearchParseException(aggregationContext.searchContext(),
+                            "[children] no [_parent] field not configured that points to a parent type", null); // NOCOMMIT fix exception args
+                }
+                parentType = parentFieldMapper.type();
+                DocumentMapper parentDocMapper = aggregationContext.searchContext().mapperService().documentMapper(parentType);
+                if (parentDocMapper != null) {
+                    // TODO: use the query API
+                    parentFilter = new QueryWrapperFilter(parentDocMapper.typeFilter());
+                    childFilter = new QueryWrapperFilter(childDocMapper.typeFilter());
+                    ParentChildIndexFieldData parentChildIndexFieldData = aggregationContext.searchContext().fieldData()
+                            .getForField(parentFieldMapper.fieldType());
+                    config.fieldContext(new FieldContext(parentFieldMapper.fieldType().names().indexName(), parentChildIndexFieldData,
+                            parentFieldMapper.fieldType()));
+                } else {
+                    config.unmapped(true);
+                }
+            } else {
+                config.unmapped(true);
+            }
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramParser.java
@@ -31,9 +31,7 @@ import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValueType;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
-import org.elasticsearch.search.aggregations.support.format.ValueFormatter.DateTime;
 import org.elasticsearch.search.internal.SearchContext;
 import org.joda.time.DateTimeZone;
 
@@ -196,12 +194,9 @@ public class DateHistogramParser implements Aggregator.Parser {
                 .timeZone(timeZone)
                 .offset(offset).build();
 
-        ValuesSourceConfig config = vsParser.config();
-        if (config.formatter()!=null) {
-            ((DateTime) config.formatter()).setTimeZone(timeZone);
-        }
-        return new HistogramAggregator.Factory(aggregationName, config, rounding, order, keyed, minDocCount, extendedBounds,
-                new InternalDateHistogram.Factory());
+        ValuesSourceParser.Input input = vsParser.input();
+        return new HistogramAggregator.DateHistogramFactory(aggregationName, input, rounding, order, keyed, minDocCount, extendedBounds,
+                new InternalDateHistogram.Factory(), timeZone);
 
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramParser.java
@@ -127,7 +127,7 @@ public class HistogramParser implements Aggregator.Parser {
 
         Rounding rounding = new Rounding.Interval(interval);
         if (offset != 0) {
-            rounding = new Rounding.OffsetRounding((Rounding.Interval) rounding, offset);
+            rounding = new Rounding.OffsetRounding(rounding, offset);
         }
 
         if (extendedBounds != null) {
@@ -135,7 +135,7 @@ public class HistogramParser implements Aggregator.Parser {
             extendedBounds.processAndValidate(aggregationName, context, ValueParser.RAW);
         }
 
-        return new HistogramAggregator.Factory(aggregationName, vsParser.config(), rounding, order, keyed, minDocCount, extendedBounds,
+        return new HistogramAggregator.Factory(aggregationName, vsParser.input(), rounding, order, keyed, minDocCount, extendedBounds,
                 new InternalHistogram.Factory());
 
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
@@ -30,7 +30,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 import java.io.IOException;
 import java.util.List;
@@ -83,8 +83,8 @@ public class MissingAggregator extends SingleBucketAggregator {
 
     public static class Factory extends ValuesSourceAggregatorFactory<ValuesSource>  {
 
-        public Factory(String name, ValuesSourceConfig valueSourceConfig) {
-            super(name, InternalMissing.TYPE.name(), valueSourceConfig);
+        public Factory(String name, ValuesSourceParser.Input valueSourceInput) {
+            super(name, InternalMissing.TYPE.name(), valueSourceInput);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingParser.java
@@ -57,6 +57,6 @@ public class MissingParser implements Aggregator.Parser {
             }
         }
 
-        return new MissingAggregator.Factory(aggregationName, vsParser.config());
+        return new MissingAggregator.Factory(aggregationName, vsParser.input());
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -35,7 +35,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormat;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.elasticsearch.search.aggregations.support.format.ValueParser;
@@ -284,8 +284,9 @@ public class RangeAggregator extends BucketsAggregator {
         private final List<Range> ranges;
         private final boolean keyed;
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Numeric> valueSourceConfig, InternalRange.Factory rangeFactory, List<Range> ranges, boolean keyed) {
-            super(name, rangeFactory.type(), valueSourceConfig);
+        public Factory(String name, ValuesSourceParser.Input<ValuesSource.Numeric> valueSourceInput, InternalRange.Factory rangeFactory,
+                List<Range> ranges, boolean keyed) {
+            super(name, rangeFactory.type(), valueSourceInput);
             this.rangeFactory = rangeFactory;
             this.ranges = ranges;
             this.keyed = keyed;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeParser.java
@@ -110,6 +110,6 @@ public class RangeParser implements Aggregator.Parser {
                     parser.getTokenLocation());
         }
 
-        return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalRange.FACTORY, ranges, keyed);
+        return new RangeAggregator.Factory(aggregationName, vsParser.input(), InternalRange.FACTORY, ranges, keyed);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeParser.java
@@ -115,6 +115,6 @@ public class DateRangeParser implements Aggregator.Parser {
                     parser.getTokenLocation());
         }
 
-        return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalDateRange.FACTORY, ranges, keyed);
+        return new RangeAggregator.Factory(aggregationName, vsParser.input(), InternalDateRange.FACTORY, ranges, keyed);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -40,7 +40,6 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.GeoPointParser;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -161,7 +160,8 @@ public class GeoDistanceParser implements Aggregator.Parser {
                     parser.getTokenLocation());
         }
 
-        return new GeoDistanceFactory(aggregationName, vsParser.config(), InternalGeoDistance.FACTORY, origin, unit, distanceType, ranges, keyed);
+        return new GeoDistanceFactory(aggregationName, vsParser.input(), InternalGeoDistance.FACTORY, origin, unit, distanceType, ranges,
+                keyed);
     }
 
     private static class GeoDistanceFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {
@@ -173,10 +173,10 @@ public class GeoDistanceParser implements Aggregator.Parser {
         private final List<RangeAggregator.Range> ranges;
         private final boolean keyed;
 
-        public GeoDistanceFactory(String name, ValuesSourceConfig<ValuesSource.GeoPoint> valueSourceConfig,
+        public GeoDistanceFactory(String name, ValuesSourceParser.Input<ValuesSource.GeoPoint> valueSourceInput,
                                   InternalRange.Factory rangeFactory, GeoPoint origin, DistanceUnit unit, GeoDistance distanceType,
                                   List<RangeAggregator.Range> ranges, boolean keyed) {
-            super(name, rangeFactory.type(), valueSourceConfig);
+            super(name, rangeFactory.type(), valueSourceInput);
             this.origin = origin;
             this.unit = unit;
             this.distanceType = distanceType;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
@@ -120,7 +120,7 @@ public class IpRangeParser implements Aggregator.Parser {
                     parser.getTokenLocation());
         }
 
-        return new RangeAggregator.Factory(aggregationName, vsParser.config(), InternalIPv4Range.FACTORY, ranges, keyed);
+        return new RangeAggregator.Factory(aggregationName, vsParser.input(), InternalIPv4Range.FACTORY, ranges, keyed);
     }
 
     private static void parseMaskRange(String cidr, RangeAggregator.Range range, String aggregationName, SearchContext ctx) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerParser.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -88,9 +87,9 @@ public class SamplerParser implements Aggregator.Parser {
             }
         }
 
-        ValuesSourceConfig vsConfig = vsParser.config();
-        if (vsConfig.valid()) {
-            return new SamplerAggregator.DiversifiedFactory(aggregationName, shardSize, executionHint, vsConfig, maxDocsPerValue);
+        ValuesSourceParser.Input vsInput = vsParser.input();
+        if (vsInput.valid()) {
+            return new SamplerAggregator.DiversifiedFactory(aggregationName, shardSize, executionHint, vsInput, maxDocsPerValue);
         } else {
             if (diversityChoiceMade) {
                 throw new SearchParseException(context, "Sampler aggregation has " + MAX_DOCS_PER_VALUE_FIELD.getPreferredName()

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParser.java
@@ -77,6 +77,7 @@ public class SignificantTermsParser implements Aggregator.Parser {
         if (significanceHeuristic == null) {
             significanceHeuristic = JLHScore.INSTANCE;
         }
-        return new SignificantTermsAggregatorFactory(aggregationName, vsParser.config(), bucketCountThresholds, aggParser.getIncludeExclude(), aggParser.getExecutionHint(), aggParser.getFilter(), significanceHeuristic);
+        return new SignificantTermsAggregatorFactory(aggregationName, vsParser.input(), bucketCountThresholds,
+                aggParser.getIncludeExclude(), aggParser.getExecutionHint(), aggParser.getFilter(), significanceHeuristic);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -21,14 +21,18 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.search.aggregations.*;
+import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 import java.io.IOException;
 import java.util.List;
@@ -158,10 +162,10 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
     private final TermsAggregator.BucketCountThresholds bucketCountThresholds;
     private final boolean showTermDocCountError;
 
-    public TermsAggregatorFactory(String name, ValuesSourceConfig config, Terms.Order order,
+    public TermsAggregatorFactory(String name, ValuesSourceParser.Input input, Terms.Order order,
             TermsAggregator.BucketCountThresholds bucketCountThresholds, IncludeExclude includeExclude, String executionHint,
             SubAggCollectionMode executionMode, boolean showTermDocCountError) {
-        super(name, StringTerms.TYPE.name(), config);
+        super(name, StringTerms.TYPE.name(), input);
         this.order = order;
         this.includeExclude = includeExclude;
         this.executionHint = executionHint;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsParser.java
@@ -73,7 +73,8 @@ public class TermsParser implements Aggregator.Parser {
                     context.numberOfShards()));
         }
         bucketCountThresholds.ensureValidity();
-        return new TermsAggregatorFactory(aggregationName, vsParser.config(), order, bucketCountThresholds, aggParser.getIncludeExclude(), aggParser.getExecutionHint(), aggParser.getCollectionMode(), aggParser.showTermDocCountError());
+        return new TermsAggregatorFactory(aggregationName, vsParser.input(), order, bucketCountThresholds, aggParser.getIncludeExclude(),
+                aggParser.getExecutionHint(), aggParser.getCollectionMode(), aggParser.showTermDocCountError());
     }
 
     static Terms.Order resolveOrder(String key, boolean asc) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericValuesSourceMetricsAggregatorParser.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -63,8 +62,8 @@ public abstract class NumericValuesSourceMetricsAggregatorParser<S extends Inter
             }
         }
 
-        return createFactory(aggregationName, vsParser.config());
+        return createFactory(aggregationName, vsParser.input());
     }
 
-    protected abstract AggregatorFactory createFactory(String aggregationName, ValuesSourceConfig<ValuesSource.Numeric> config);
+    protected abstract AggregatorFactory createFactory(String aggregationName, ValuesSourceParser.Input<ValuesSource.Numeric> config);
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -33,7 +33,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -115,8 +115,8 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {
 
-        public Factory(String name, String type, ValuesSourceConfig<ValuesSource.Numeric> valuesSourceConfig) {
-            super(name, type, valuesSourceConfig);
+        public Factory(String name, String type, ValuesSourceParser.Input<ValuesSource.Numeric> valuesSourceInput) {
+            super(name, type, valuesSourceInput);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgParser.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations.metrics.avg;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.NumericValuesSourceMetricsAggregatorParser;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 /**
  *
@@ -33,8 +33,8 @@ public class AvgParser extends NumericValuesSourceMetricsAggregatorParser<Intern
     }
 
     @Override
-    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceConfig<ValuesSource.Numeric> config) {
-        return new AvgAggregator.Factory(aggregationName, type(), config);
+    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceParser.Input<ValuesSource.Numeric> input) {
+        return new AvgAggregator.Factory(aggregationName, type(), input);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/CardinalityParser.java
@@ -21,11 +21,10 @@ package org.elasticsearch.search.aggregations.metrics.cardinality;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.core.Murmur3FieldMapper;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -44,7 +43,8 @@ public class CardinalityParser implements Aggregator.Parser {
     @Override
     public AggregatorFactory parse(String name, XContentParser parser, SearchContext context) throws IOException {
 
-        ValuesSourceParser vsParser = ValuesSourceParser.any(name, InternalCardinality.TYPE, context).formattable(false).build();
+        ValuesSourceParser<ValuesSource> vsParser = ValuesSourceParser.any(name, InternalCardinality.TYPE, context).formattable(false)
+                .build();
 
         long precisionThreshold = -1;
         Boolean rehash = null;
@@ -70,15 +70,9 @@ public class CardinalityParser implements Aggregator.Parser {
             }
         }
 
-        ValuesSourceConfig<?> config = vsParser.config();
+        ValuesSourceParser.Input<ValuesSource> input = vsParser.input();
 
-        if (rehash == null && config.fieldContext() != null && config.fieldContext().fieldType() instanceof Murmur3FieldMapper.Murmur3FieldType) {
-            rehash = false;
-        } else if (rehash == null) {
-            rehash = true;
-        }
-
-        return new CardinalityAggregatorFactory(name, config, precisionThreshold, rehash);
+        return new CardinalityAggregatorFactory(name, input, precisionThreshold, rehash);
 
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsAggregator.java
@@ -34,7 +34,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 import java.io.IOException;
 import java.util.List;
@@ -160,7 +160,7 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
         return new InternalGeoBounds(name, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
                 Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, wrapLongitude, pipelineAggregators(), metaData());
     }
-    
+
     @Override
     public void doClose() {
         Releasables.close(tops, bottoms, posLefts, posRights, negLefts, negRights);
@@ -170,8 +170,8 @@ public final class GeoBoundsAggregator extends MetricsAggregator {
 
         private final boolean wrapLongitude;
 
-        protected Factory(String name, ValuesSourceConfig<ValuesSource.GeoPoint> config, boolean wrapLongitude) {
-            super(name, InternalGeoBounds.TYPE.name(), config);
+        protected Factory(String name, ValuesSourceParser.Input<ValuesSource.GeoPoint> input, boolean wrapLongitude) {
+            super(name, InternalGeoBounds.TYPE.name(), input);
             this.wrapLongitude = wrapLongitude;
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geobounds/GeoBoundsParser.java
@@ -51,7 +51,7 @@ public class GeoBoundsParser implements Aggregator.Parser {
                 currentFieldName = parser.currentName();
             } else if (vsParser.token(currentFieldName, token, parser)) {
                 continue;
-                
+
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("wrap_longitude".equals(currentFieldName) || "wrapLongitude".equals(currentFieldName)) {
                     wrapLongitude = parser.booleanValue();
@@ -64,7 +64,7 @@ public class GeoBoundsParser implements Aggregator.Parser {
                         + currentFieldName + "].", parser.getTokenLocation());
             }
         }
-        return new GeoBoundsAggregator.Factory(aggregationName, vsParser.config(), wrapLongitude);
+        return new GeoBoundsAggregator.Factory(aggregationName, vsParser.input(), wrapLongitude);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxAggregator.java
@@ -34,7 +34,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -116,8 +116,8 @@ public class MaxAggregator extends NumericMetricsAggregator.SingleValue {
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Numeric> valuesSourceConfig) {
-            super(name, InternalMax.TYPE.name(), valuesSourceConfig);
+        public Factory(String name, ValuesSourceParser.Input<ValuesSource.Numeric> valuesSourceInput) {
+            super(name, InternalMax.TYPE.name(), valuesSourceInput);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/max/MaxParser.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations.metrics.max;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.NumericValuesSourceMetricsAggregatorParser;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 /**
  *
@@ -33,8 +33,8 @@ public class MaxParser extends NumericValuesSourceMetricsAggregatorParser<Intern
     }
 
     @Override
-    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceConfig<ValuesSource.Numeric> config) {
-        return new MaxAggregator.Factory(aggregationName, config);
+    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceParser.Input<ValuesSource.Numeric> input) {
+        return new MaxAggregator.Factory(aggregationName, input);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinAggregator.java
@@ -34,7 +34,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -115,8 +115,8 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Numeric> valuesSourceConfig) {
-            super(name, InternalMin.TYPE.name(), valuesSourceConfig);
+        public Factory(String name, ValuesSourceParser.Input<ValuesSource.Numeric> valuesSourceInput) {
+            super(name, InternalMin.TYPE.name(), valuesSourceInput);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/min/MinParser.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations.metrics.min;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.NumericValuesSourceMetricsAggregatorParser;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 /**
  *
@@ -33,7 +33,7 @@ public class MinParser extends NumericValuesSourceMetricsAggregatorParser<Intern
     }
 
     @Override
-    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceConfig<ValuesSource.Numeric> config) {
-        return new MinAggregator.Factory(aggregationName, config);
+    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceParser.Input<ValuesSource.Numeric> input) {
+        return new MinAggregator.Factory(aggregationName, input);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesParser.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -44,14 +43,14 @@ public abstract class AbstractPercentilesParser implements Aggregator.Parser {
 
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
-    
+
         ValuesSourceParser<ValuesSource.Numeric> vsParser = ValuesSourceParser.numeric(aggregationName, InternalPercentiles.TYPE, context)
                 .formattable(formattable).build();
-    
+
         double[] keys = null;
         boolean keyed = true;
         double compression = 100;
-    
+
         XContentParser.Token token;
         String currentFieldName = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -91,10 +90,11 @@ public abstract class AbstractPercentilesParser implements Aggregator.Parser {
                         parser.getTokenLocation());
             }
         }
-        return buildFactory(context, aggregationName, vsParser.config(), keys, compression, keyed);
+        return buildFactory(context, aggregationName, vsParser.input(), keys, compression, keyed);
     }
 
-    protected abstract AggregatorFactory buildFactory(SearchContext context, String aggregationName, ValuesSourceConfig<Numeric> config, double[] cdfValues,
+    protected abstract AggregatorFactory buildFactory(SearchContext context, String aggregationName,
+            ValuesSourceParser.Input<Numeric> config, double[] cdfValues,
             double compression, boolean keyed);
 
     protected abstract String keysFieldName();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksAggregator.java
@@ -26,7 +26,7 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -76,9 +76,9 @@ public class PercentileRanksAggregator extends AbstractPercentilesAggregator {
         private final double compression;
         private final boolean keyed;
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Numeric> valuesSourceConfig,
+        public Factory(String name, ValuesSourceParser.Input<ValuesSource.Numeric> valuesSourceInput,
                 double[] values, double compression, boolean keyed) {
-            super(name, InternalPercentiles.TYPE.name(), valuesSourceConfig);
+            super(name, InternalPercentiles.TYPE.name(), valuesSourceInput);
             this.values = values;
             this.compression = compression;
             this.keyed = keyed;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentileRanksParser.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations.metrics.percentiles;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.internal.SearchContext;
 
 /**
@@ -42,13 +42,14 @@ public class PercentileRanksParser extends AbstractPercentilesParser {
     protected String keysFieldName() {
         return "values";
     }
-    
+
     @Override
-    protected AggregatorFactory buildFactory(SearchContext context, String aggregationName, ValuesSourceConfig<Numeric> valuesSourceConfig, double[] keys, double compression, boolean keyed) {
+    protected AggregatorFactory buildFactory(SearchContext context, String aggregationName,
+            ValuesSourceParser.Input<Numeric> valuesSourceInput, double[] keys, double compression, boolean keyed) {
         if (keys == null) {
             throw new SearchParseException(context, "Missing token values in [" + aggregationName + "].", null);
         }
-        return new PercentileRanksAggregator.Factory(aggregationName, valuesSourceConfig, keys, compression, keyed);
+        return new PercentileRanksAggregator.Factory(aggregationName, valuesSourceInput, keys, compression, keyed);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesAggregator.java
@@ -26,7 +26,7 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -76,9 +76,9 @@ public class PercentilesAggregator extends AbstractPercentilesAggregator {
         private final double compression;
         private final boolean keyed;
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Numeric> valuesSourceConfig,
+        public Factory(String name, ValuesSourceParser.Input<ValuesSource.Numeric> valuesSourceInput,
                 double[] percents, double compression, boolean keyed) {
-            super(name, InternalPercentiles.TYPE.name(), valuesSourceConfig);
+            super(name, InternalPercentiles.TYPE.name(), valuesSourceInput);
             this.percents = percents;
             this.compression = compression;
             this.keyed = keyed;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/PercentilesParser.java
@@ -20,7 +20,7 @@ package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.internal.SearchContext;
 
 /**
@@ -43,13 +43,14 @@ public class PercentilesParser extends AbstractPercentilesParser {
     protected String keysFieldName() {
         return "percents";
     }
-    
+
     @Override
-    protected AggregatorFactory buildFactory(SearchContext context, String aggregationName, ValuesSourceConfig<Numeric> valuesSourceConfig, double[] keys, double compression, boolean keyed) {
+    protected AggregatorFactory buildFactory(SearchContext context, String aggregationName,
+            ValuesSourceParser.Input<Numeric> valuesSourceInput, double[] keys, double compression, boolean keyed) {
         if (keys == null) {
             keys = DEFAULT_PERCENTS;
         }
-        return new PercentilesAggregator.Factory(aggregationName, valuesSourceConfig, keys, compression, keyed);
+        return new PercentilesAggregator.Factory(aggregationName, valuesSourceInput, keys, compression, keyed);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggegator.java
@@ -33,7 +33,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -157,8 +157,8 @@ public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Numeric> valuesSourceConfig) {
-            super(name, InternalStats.TYPE.name(), valuesSourceConfig);
+        public Factory(String name, ValuesSourceParser.Input<ValuesSource.Numeric> valuesSourceInput) {
+            super(name, InternalStats.TYPE.name(), valuesSourceInput);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsParser.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations.metrics.stats;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.NumericValuesSourceMetricsAggregatorParser;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 /**
  *
@@ -33,7 +33,7 @@ public class StatsParser extends NumericValuesSourceMetricsAggregatorParser<Inte
     }
 
     @Override
-    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceConfig<ValuesSource.Numeric> config) {
-        return new StatsAggegator.Factory(aggregationName, config);
+    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceParser.Input<ValuesSource.Numeric> input) {
+        return new StatsAggegator.Factory(aggregationName, input);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsAggregator.java
@@ -33,7 +33,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -192,8 +192,8 @@ public class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue
 
         private final double sigma;
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Numeric> valuesSourceConfig, double sigma) {
-            super(name, InternalExtendedStats.TYPE.name(), valuesSourceConfig);
+        public Factory(String name, ValuesSourceParser.Input<ValuesSource.Numeric> valuesSourceInput, double sigma) {
+            super(name, InternalExtendedStats.TYPE.name(), valuesSourceInput);
 
             this.sigma = sigma;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ExtendedStatsParser.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -42,8 +41,8 @@ public class ExtendedStatsParser  implements Aggregator.Parser {
         return InternalExtendedStats.TYPE.name();
     }
 
-    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceConfig<ValuesSource.Numeric> config, double sigma) {
-        return new ExtendedStatsAggregator.Factory(aggregationName, config, sigma);
+    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceParser.Input<ValuesSource.Numeric> input, double sigma) {
+        return new ExtendedStatsAggregator.Factory(aggregationName, input, sigma);
     }
 
     @Override
@@ -78,6 +77,6 @@ public class ExtendedStatsParser  implements Aggregator.Parser {
             throw new SearchParseException(context, "[sigma] must not be negative. Value provided was" + sigma, parser.getTokenLocation());
         }
 
-        return createFactory(aggregationName, vsParser.config(), sigma);
+        return createFactory(aggregationName, vsParser.input(), sigma);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumAggregator.java
@@ -32,7 +32,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -107,8 +107,8 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {
 
-        public Factory(String name, ValuesSourceConfig<ValuesSource.Numeric> valuesSourceConfig) {
-            super(name, InternalSum.TYPE.name(), valuesSourceConfig);
+        public Factory(String name, ValuesSourceParser.Input<ValuesSource.Numeric> valuesSourceInput) {
+            super(name, InternalSum.TYPE.name(), valuesSourceInput);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/SumParser.java
@@ -21,7 +21,7 @@ package org.elasticsearch.search.aggregations.metrics.sum;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.metrics.NumericValuesSourceMetricsAggregatorParser;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 
 /**
  *
@@ -33,7 +33,7 @@ public class SumParser extends NumericValuesSourceMetricsAggregatorParser<Intern
     }
 
     @Override
-    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceConfig<ValuesSource.Numeric> config) {
-        return new SumAggregator.Factory(aggregationName, config);
+    protected AggregatorFactory createFactory(String aggregationName, ValuesSourceParser.Input<ValuesSource.Numeric> input) {
+        return new SumAggregator.Factory(aggregationName, input);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -32,7 +32,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.io.IOException;
@@ -110,8 +110,8 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
     public static class Factory<VS extends ValuesSource> extends ValuesSourceAggregatorFactory.LeafOnly<VS> {
 
-        public Factory(String name, ValuesSourceConfig<VS> config) {
-            super(name, InternalValueCount.TYPE.name(), config);
+        public Factory(String name, ValuesSourceParser.Input<VS> input) {
+            super(name, InternalValueCount.TYPE.name(), input);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountParser.java
@@ -54,6 +54,6 @@ public class ValueCountParser implements Aggregator.Parser {
             }
         }
 
-        return new ValueCountAggregator.Factory(aggregationName, vsParser.config());
+        return new ValueCountAggregator.Factory(aggregationName, vsParser.input());
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -19,25 +19,13 @@
 
 package org.elasticsearch.search.aggregations.support;
 
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
-import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper;
-import org.elasticsearch.index.mapper.ip.IpFieldMapper;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.Script.ScriptField;
-import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptParameterParser;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
-import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.support.format.ValueFormat;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -66,7 +54,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
         return new Builder<>(aggName, aggType, context, ValuesSource.GeoPoint.class).targetValueType(ValueType.GEOPOINT).scriptable(false);
     }
 
-    private static class Input {
+    public static class Input<VS> {
         String field = null;
         Script script = null;
         @Deprecated
@@ -74,25 +62,29 @@ public class ValuesSourceParser<VS extends ValuesSource> {
         ValueType valueType = null;
         String format = null;
         Object missing = null;
+        Class<VS> valuesSourceType = null;
+        ValueType targetValueType = null;
+
+        public boolean valid() {
+            return field != null || script != null;
+        }
     }
 
     private final String aggName;
     private final InternalAggregation.Type aggType;
     private final SearchContext context;
-    private final Class<VS> valuesSourceType;
 
     private boolean scriptable = true;
     private boolean formattable = false;
-    private ValueType targetValueType = null;
     private ScriptParameterParser scriptParameterParser = new ScriptParameterParser();
 
-    private Input input = new Input();
+    private Input<VS> input = new Input<VS>();
 
     private ValuesSourceParser(String aggName, InternalAggregation.Type aggType, SearchContext context, Class<VS> valuesSourceType) {
         this.aggName = aggName;
         this.aggType = aggType;
         this.context = context;
-        this.valuesSourceType = valuesSourceType;
+        input.valuesSourceType = valuesSourceType;
     }
 
     public boolean token(String currentFieldName, XContentParser.Token token, XContentParser parser) throws IOException {
@@ -108,11 +100,10 @@ public class ValuesSourceParser<VS extends ValuesSource> {
             } else if (scriptable) {
                 if ("value_type".equals(currentFieldName) || "valueType".equals(currentFieldName)) {
                     input.valueType = ValueType.resolveForScript(parser.text());
-                    if (targetValueType != null && input.valueType.isNotA(targetValueType)) {
-                        throw new SearchParseException(context, aggType.name() + " aggregation [" + aggName +
-                                "] was configured with an incompatible value type [" + input.valueType + "]. [" + aggType +
-                                "] aggregation can only work on value of type [" + targetValueType + "]",
-                                parser.getTokenLocation());
+                    if (input.targetValueType != null && input.valueType.isNotA(input.targetValueType)) {
+                        throw new SearchParseException(context, aggType.name() + " aggregation [" + aggName
+                                + "] was configured with an incompatible value type [" + input.valueType + "]. [" + aggType
+                                + "] aggregation can only work on value of type [" + input.targetValueType + "]", parser.getTokenLocation());
                     }
                 } else if (!scriptParameterParser.token(currentFieldName, token, parser, context.parseFieldMatcher())) {
                     return false;
@@ -137,9 +128,9 @@ public class ValuesSourceParser<VS extends ValuesSource> {
         return false;
     }
 
-    public ValuesSourceConfig<VS> config() {
-
-        if (input.script == null) { // Didn't find anything using the new API so try using the old one instead
+    public Input<VS> input() {
+        if (input.script == null) { // Didn't find anything using the new API so
+                                    // try using the old one instead
             ScriptParameterValue scriptValue = scriptParameterParser.getDefaultScriptParameterValue();
             if (scriptValue != null) {
                 if (input.params == null) {
@@ -149,93 +140,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
             }
         }
 
-        ValueType valueType = input.valueType != null ? input.valueType : targetValueType;
-
-        if (input.field == null) {
-            if (input.script == null) {
-                ValuesSourceConfig<VS> config = new ValuesSourceConfig(ValuesSource.class);
-                config.format = resolveFormat(null, valueType);
-                return config;
-            }
-            Class valuesSourceType = valueType != null ? (Class<VS>) valueType.getValuesSourceType() : this.valuesSourceType;
-            if (valuesSourceType == null || valuesSourceType == ValuesSource.class) {
-                // the specific value source type is undefined, but for scripts, we need to have a specific value source
-                // type to know how to handle the script values, so we fallback on Bytes
-                valuesSourceType = ValuesSource.Bytes.class;
-            }
-            ValuesSourceConfig<VS> config = new ValuesSourceConfig<VS>(valuesSourceType);
-            config.missing = input.missing;
-            config.format = resolveFormat(input.format, valueType);
-            config.script = createScript();
-            config.scriptValueType = valueType;
-            return config;
-        }
-
-        MappedFieldType fieldType = context.smartNameFieldTypeFromAnyType(input.field);
-        if (fieldType == null) {
-            Class<VS> valuesSourceType = valueType != null ? (Class<VS>) valueType.getValuesSourceType() : this.valuesSourceType;
-            ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);
-            config.missing = input.missing;
-            config.format = resolveFormat(input.format, valueType);
-            config.unmapped = true;
-            if (valueType != null) {
-                // todo do we really need this for unmapped?
-                config.scriptValueType = valueType;
-            }
-            return config;
-        }
-
-        IndexFieldData<?> indexFieldData = context.fieldData().getForField(fieldType);
-
-        ValuesSourceConfig config;
-        if (valuesSourceType == ValuesSource.class) {
-            if (indexFieldData instanceof IndexNumericFieldData) {
-                config = new ValuesSourceConfig<>(ValuesSource.Numeric.class);
-            } else if (indexFieldData instanceof IndexGeoPointFieldData) {
-                config = new ValuesSourceConfig<>(ValuesSource.GeoPoint.class);
-            } else {
-                config = new ValuesSourceConfig<>(ValuesSource.Bytes.class);
-            }
-        } else {
-            config = new ValuesSourceConfig(valuesSourceType);
-        }
-
-        config.fieldContext = new FieldContext(input.field, indexFieldData, fieldType);
-        config.missing = input.missing;
-        config.script = createScript();
-        config.format = resolveFormat(input.format, fieldType);
-        return config;
-    }
-
-    private SearchScript createScript() {
-        return input.script == null ? null : context.scriptService().search(context.lookup(), input.script, ScriptContext.Standard.AGGS);
-    }
-
-    private static ValueFormat resolveFormat(@Nullable String format, @Nullable ValueType valueType) {
-        if (valueType == null) {
-            return ValueFormat.RAW; // we can't figure it out
-        }
-        ValueFormat valueFormat = valueType.defaultFormat;
-        if (valueFormat != null && valueFormat instanceof ValueFormat.Patternable && format != null) {
-            return ((ValueFormat.Patternable) valueFormat).create(format);
-        }
-        return valueFormat;
-    }
-
-    private static ValueFormat resolveFormat(@Nullable String format, MappedFieldType fieldType) {
-        if (fieldType instanceof  DateFieldMapper.DateFieldType) {
-            return format != null ? ValueFormat.DateTime.format(format) : ValueFormat.DateTime.mapper((DateFieldMapper.DateFieldType) fieldType);
-        }
-        if (fieldType instanceof IpFieldMapper.IpFieldType) {
-            return ValueFormat.IPv4;
-        }
-        if (fieldType instanceof BooleanFieldMapper.BooleanFieldType) {
-            return ValueFormat.BOOLEAN;
-        }
-        if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
-            return format != null ? ValueFormat.Number.format(format) : ValueFormat.RAW;
-        }
-        return ValueFormat.RAW;
+        return input;
     }
 
     public static class Builder<VS extends ValuesSource> {
@@ -257,7 +162,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
         }
 
         public Builder<VS> targetValueType(ValueType valueType) {
-            parser.targetValueType = valueType;
+            parser.input.targetValueType = valueType;
             return this;
         }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
@@ -34,7 +34,7 @@ public class AggregationCollectorTests extends ElasticsearchSingleNodeTest {
         IndexService index = createIndex("idx");
         client().prepareIndex("idx", "type", "1").setSource("f", 5).execute().get();
         client().admin().indices().prepareRefresh("idx").get();
-        
+
         // simple field aggregation, no scores needed
         String fieldAgg = "{ \"my_terms\": {\"terms\": {\"field\": \"f\"}}}";
         assertFalse(needsScores(index, fieldAgg));
@@ -62,7 +62,8 @@ public class AggregationCollectorTests extends ElasticsearchSingleNodeTest {
         SearchContext searchContext = createSearchContext(index);
         final AggregatorFactories factories = parser.parseAggregators(aggParser, searchContext);
         AggregationContext aggregationContext = new AggregationContext(searchContext);
-        final Aggregator[] aggregators = factories.createTopLevelAggregators(aggregationContext);
+        factories.init(aggregationContext);
+        final Aggregator[] aggregators = factories.createTopLevelAggregators();
         assertEquals(1, aggregators.length);
         return aggregators[0].needsScores();
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTest.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTest.java
@@ -125,7 +125,8 @@ public class NestedAggregatorTest extends ElasticsearchSingleNodeTest {
         builder.addAggregator(new NestedAggregator.Factory("test", "nested_field"));
         AggregatorFactories factories = builder.build();
         searchContext.aggregations(new SearchContextAggregations(factories));
-        Aggregator[] aggs = factories.createTopLevelAggregators(context);
+        factories.init(context);
+        Aggregator[] aggs = factories.createTopLevelAggregators();
         BucketCollector collector = BucketCollector.wrap(Arrays.asList(aggs));
         collector.preCollection();
         // A regular search always exclude nested docs, so we use NonNestedDocsFilter.INSTANCE here (otherwise MatchAllDocsQuery would be sufficient)


### PR DESCRIPTION
ValuesSourceConfig is now evaluated in the ValuesSourceAggregatorFactory instead of ValueSourceParser. This means that the ValueSourceParser purely deals with parsing the XContent and the logic requiring access to the mappings etc. on the shard is left to the ValuesSourceAggregatorFactory. This means that, in the future, the parsing logic can be moved to the coordinating node.
