### PR TITLE
Query refactoring: SpanContainingQueryBuilder and Parser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -329,9 +329,13 @@ public abstract class QueryBuilders {
         return new SpanWithinQueryBuilder();
     }
 
-    /** Creates a new {@code span_containing} builder. */
-    public static SpanContainingQueryBuilder spanContainingQuery() {
-        return new SpanContainingQueryBuilder();
+    /**
+     * Creates a new {@code span_containing} builder.
+     * @param big the big clause, it must enclose {@code little} for a match.
+     * @param little the little clause, it must be contained within {@code big} for a match.
+     */
+    public static SpanContainingQueryBuilder spanContainingQuery(SpanQueryBuilder big, SpanQueryBuilder little) {
+        return new SpanContainingQueryBuilder(big, little);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1344,10 +1344,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         IndexQueryParserService queryParser = queryParser();
         Query expectedQuery = new SpanContainingQuery(new SpanTermQuery(new Term("age", longToPrefixCoded(34, 0))),
                                                       new SpanTermQuery(new Term("age", longToPrefixCoded(35, 0))));
-        Query actualQuery = queryParser.parse(spanContainingQuery()
-                                              .big(spanTermQuery("age", 34))
-                                              .little(spanTermQuery("age", 35)))
-                                              .query();
+        Query actualQuery = queryParser.parse(spanContainingQuery(spanTermQuery("age", 34), spanTermQuery("age", 35))).query();
         assertEquals(expectedQuery, actualQuery);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
@@ -39,18 +39,16 @@ public class SpanContainingQueryBuilderTest extends BaseQueryTestCase<SpanContai
     protected SpanContainingQueryBuilder doCreateTestQueryBuilder() {
         SpanTermQueryBuilder bigQuery = new SpanTermQueryBuilderTest().createTestQueryBuilder();
         // we need same field name and value type as bigQuery for little query
-        Object bigValue = bigQuery.value;
+        String fieldName = bigQuery.fieldName();
         Object littleValue;
-        if (bigValue instanceof Boolean) {
-            littleValue = randomBoolean();
-        } else if (bigValue instanceof Integer) {
-            littleValue = randomInt();
-        } else if (bigValue instanceof Double) {
-            littleValue = randomDouble();
-        } else {
-            littleValue = randomAsciiOfLengthBetween(1, 10);
+        switch (fieldName) {
+            case BOOLEAN_FIELD_NAME: littleValue = randomBoolean(); break;
+            case INT_FIELD_NAME: littleValue = randomInt(); break;
+            case DOUBLE_FIELD_NAME: littleValue = randomDouble(); break;
+            case STRING_FIELD_NAME: littleValue = randomAsciiOfLengthBetween(1, 10); break;
+            default : littleValue = randomAsciiOfLengthBetween(1, 10);
         }
-        SpanTermQueryBuilder littleQuery = new SpanTermQueryBuilder(bigQuery.fieldName(), littleValue);
+        SpanTermQueryBuilder littleQuery = new SpanTermQueryBuilder(fieldName, littleValue);
         return new SpanContainingQueryBuilder(bigQuery, littleQuery);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanContainingQuery;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class SpanContainingQueryBuilderTest extends BaseQueryTestCase<SpanContainingQueryBuilder> {
+
+    @Override
+    protected Query doCreateExpectedQuery(SpanContainingQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+        SpanQuery big = (SpanQuery) testQueryBuilder.big().toQuery(context);
+        SpanQuery little = (SpanQuery) testQueryBuilder.little().toQuery(context);
+        return new SpanContainingQuery(big, little);
+    }
+
+    @Override
+    protected SpanContainingQueryBuilder doCreateTestQueryBuilder() {
+        SpanTermQueryBuilder bigQuery = new SpanTermQueryBuilderTest().createTestQueryBuilder();
+        // we need same field name and value type as bigQuery for little query
+        Object bigValue = bigQuery.value;
+        Object littleValue;
+        if (bigValue instanceof Boolean) {
+            littleValue = randomBoolean();
+        } else if (bigValue instanceof Integer) {
+            littleValue = randomInt();
+        } else if (bigValue instanceof Double) {
+            littleValue = randomDouble();
+        } else {
+            littleValue = randomAsciiOfLengthBetween(1, 10);
+        }
+        SpanTermQueryBuilder littleQuery = new SpanTermQueryBuilder(bigQuery.fieldName(), littleValue);
+        return new SpanContainingQueryBuilder(bigQuery, littleQuery);
+    }
+
+    @Test
+    public void testValidate() {
+        int totalExpectedErrors = 0;
+        SpanQueryBuilder bigSpanQueryBuilder;
+        if (randomBoolean()) {
+            bigSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            totalExpectedErrors++;
+        } else {
+            bigSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
+        }
+        SpanQueryBuilder littleSpanQueryBuilder;
+        if (randomBoolean()) {
+            littleSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            totalExpectedErrors++;
+        } else {
+            littleSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
+        }
+        SpanContainingQueryBuilder queryBuilder = new SpanContainingQueryBuilder(bigSpanQueryBuilder, littleSpanQueryBuilder);
+        assertValidate(queryBuilder, totalExpectedErrors);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testNullBig() {
+        new SpanContainingQueryBuilder(null, new SpanTermQueryBuilder("name", "value"));
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testNullLittle() {
+        new SpanContainingQueryBuilder(new SpanTermQueryBuilder("name", "value"), null);
+    }
+}

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -11,6 +11,12 @@ on the query-refactoring feature branch.
 Removed setters for mandatory positive/negative query. Both arguments now have
 to be supplied at construction time already and have to be non-null.
 
+==== SpanContainingQueryBuilder
+
+Removed setters for mandatory big/little inner span queries. Both arguments now have
+to be supplied at construction time already and have to be non-null. Updated
+static factory methods in QueryBuilders accordingly.
+
 ==== QueryFilterBuilder
 
 Removed the setter `queryName(String queryName)` since this field is not supported


### PR DESCRIPTION
Moving the query building functionality from the parser to the builders
new toQuery() method analogous to other recent query refactorings.

PR is against query refactoring branch.

Relates to #10217 
