### PR TITLE
Refactor MetaData to split off the concrete index name logic to a dedicated service

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/DocumentRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/DocumentRequest.java
@@ -25,7 +25,7 @@ import org.elasticsearch.action.support.IndicesOptions;
  *
  * Forces this class return index/type/id getters
  */
-public interface DocumentRequest<T> {
+public interface DocumentRequest<T> extends IndicesRequest {
 
     /**
      * Get the index that this request operates on

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
@@ -44,9 +45,10 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
     private final GatewayAllocator gatewayAllocator;
 
     @Inject
-    public TransportClusterHealthAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                        ClusterName clusterName, ActionFilters actionFilters, GatewayAllocator gatewayAllocator) {
-        super(settings, ClusterHealthAction.NAME, transportService, clusterService, threadPool, actionFilters, ClusterHealthRequest.class);
+    public TransportClusterHealthAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                        ThreadPool threadPool, ClusterName clusterName, ActionFilters actionFilters,
+                                        IndexNameExpressionResolver indexNameExpressionResolver, GatewayAllocator gatewayAllocator) {
+        super(settings, ClusterHealthAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, ClusterHealthRequest.class);
         this.clusterName = clusterName;
         this.gatewayAllocator = gatewayAllocator;
     }
@@ -199,7 +201,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         }
         if (request.indices().length > 0) {
             try {
-                clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), request.indices());
+                indexNameExpressionResolver.concreteIndices(clusterState, IndicesOptions.strictExpand(), request.indices());
                 waitForCounter++;
             } catch (IndexMissingException e) {
                 response.status = ClusterHealthStatus.RED; // no indices, make sure its RED
@@ -266,7 +268,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
 
         String[] concreteIndices;
         try {
-            concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
+            concreteIndices = indexNameExpressionResolver.concreteIndices(clusterState, request);
         } catch (IndexMissingException e) {
             // one of the specified indices is not there - treat it as RED.
             ClusterHealthResponse response = new ClusterHealthResponse(clusterName.value(), Strings.EMPTY_ARRAY, clusterState,

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -45,9 +46,10 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<NodesHo
 
     @Inject
     public TransportNodesHotThreadsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
-                                          ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+                                          ClusterService clusterService, TransportService transportService,
+                                          ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, NodesHotThreadsAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters,
-                NodesHotThreadsRequest.class, NodeRequest.class, ThreadPool.Names.GENERIC);
+                indexNameExpressionResolver, NodesHotThreadsRequest.class, NodeRequest.class, ThreadPool.Names.GENERIC);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -47,9 +48,9 @@ public class TransportNodesInfoAction extends TransportNodesAction<NodesInfoRequ
     @Inject
     public TransportNodesInfoAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                     ClusterService clusterService, TransportService transportService,
-                                    NodeService nodeService, ActionFilters actionFilters) {
+                                    NodeService nodeService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, NodesInfoAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters,
-                NodesInfoRequest.class, NodeInfoRequest.class, ThreadPool.Names.MANAGEMENT);
+                indexNameExpressionResolver, NodesInfoRequest.class, NodeInfoRequest.class, ThreadPool.Names.MANAGEMENT);
         this.nodeService = nodeService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -47,8 +48,8 @@ public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRe
     @Inject
     public TransportNodesStatsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                      ClusterService clusterService, TransportService transportService,
-                                     NodeService nodeService, ActionFilters actionFilters) {
-        super(settings, NodesStatsAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters,
+                                     NodeService nodeService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, NodesStatsAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 NodesStatsRequest.class, NodeStatsRequest.class, ThreadPool.Names.MANAGEMENT);
         this.nodeService = nodeService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -42,8 +43,9 @@ public class TransportDeleteRepositoryAction extends TransportMasterNodeAction<D
 
     @Inject
     public TransportDeleteRepositoryAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                           RepositoriesService repositoriesService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, DeleteRepositoryAction.NAME, transportService, clusterService, threadPool, actionFilters, DeleteRepositoryRequest.class);
+                                           RepositoriesService repositoriesService, ThreadPool threadPool, ActionFilters actionFilters,
+                                           IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, DeleteRepositoryAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, DeleteRepositoryRequest.class);
         this.repositoriesService = repositoriesService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoriesMetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
@@ -43,8 +44,8 @@ public class TransportGetRepositoriesAction extends TransportMasterNodeReadActio
 
     @Inject
     public TransportGetRepositoriesAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                          ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, GetRepositoriesAction.NAME, transportService, clusterService, threadPool, actionFilters, GetRepositoriesRequest.class);
+                                          ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetRepositoriesAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, GetRepositoriesRequest.class);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -42,8 +43,9 @@ public class TransportPutRepositoryAction extends TransportMasterNodeAction<PutR
 
     @Inject
     public TransportPutRepositoryAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                        RepositoriesService repositoriesService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, PutRepositoryAction.NAME, transportService, clusterService, threadPool, actionFilters, PutRepositoryRequest.class);
+                                        RepositoriesService repositoriesService, ThreadPool threadPool, ActionFilters actionFilters,
+                                        IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, PutRepositoryAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, PutRepositoryRequest.class);
         this.repositoriesService = repositoriesService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/TransportVerifyRepositoryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/TransportVerifyRepositoryAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -45,8 +46,9 @@ public class TransportVerifyRepositoryAction extends TransportMasterNodeAction<V
 
     @Inject
     public TransportVerifyRepositoryAction(Settings settings, ClusterName clusterName, TransportService transportService, ClusterService clusterService,
-                                           RepositoriesService repositoriesService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, VerifyRepositoryAction.NAME, transportService, clusterService, threadPool, actionFilters, VerifyRepositoryRequest.class);
+                                           RepositoriesService repositoriesService, ThreadPool threadPool, ActionFilters actionFilters,
+                                           IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, VerifyRepositoryAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, VerifyRepositoryRequest.class);
         this.repositoriesService = repositoriesService;
         this.clusterName = clusterName;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.RoutingExplanations;
@@ -44,8 +45,8 @@ public class TransportClusterRerouteAction extends TransportMasterNodeAction<Clu
 
     @Inject
     public TransportClusterRerouteAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                         AllocationService allocationService, ActionFilters actionFilters) {
-        super(settings, ClusterRerouteAction.NAME, transportService, clusterService, threadPool, actionFilters, ClusterRerouteRequest.class);
+                                         AllocationService allocationService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ClusterRerouteAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, ClusterRerouteRequest.class);
         this.allocationService = allocationService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -57,8 +58,9 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
 
     @Inject
     public TransportClusterUpdateSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                                AllocationService allocationService, @ClusterDynamicSettings DynamicSettings dynamicSettings, ActionFilters actionFilters) {
-        super(settings, ClusterUpdateSettingsAction.NAME, transportService, clusterService, threadPool, actionFilters, ClusterUpdateSettingsRequest.class);
+                                                AllocationService allocationService, @ClusterDynamicSettings DynamicSettings dynamicSettings,
+                                                ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ClusterUpdateSettingsAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, ClusterUpdateSettingsRequest.class);
         this.allocationService = allocationService;
         this.dynamicSettings = dynamicSettings;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -42,8 +43,9 @@ public class TransportCreateSnapshotAction extends TransportMasterNodeAction<Cre
 
     @Inject
     public TransportCreateSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                         ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters) {
-        super(settings, CreateSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters, CreateSnapshotRequest.class);
+                                         ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters,
+                                         IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, CreateSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, CreateSnapshotRequest.class);
         this.snapshotsService = snapshotsService;
     }
 
@@ -64,7 +66,7 @@ public class TransportCreateSnapshotAction extends TransportMasterNodeAction<Cre
         if (clusterBlockException != null) {
             return clusterBlockException;
         }
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.READ, state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.READ, indexNameExpressionResolver.concreteIndices(state, request));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -41,8 +42,9 @@ public class TransportDeleteSnapshotAction extends TransportMasterNodeAction<Del
 
     @Inject
     public TransportDeleteSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                         ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters) {
-        super(settings, DeleteSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters, DeleteSnapshotRequest.class);
+                                         ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters,
+                                         IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, DeleteSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, DeleteSnapshotRequest.class);
         this.snapshotsService = snapshotsService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -46,8 +47,9 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
 
     @Inject
     public TransportGetSnapshotsAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                       ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters) {
-        super(settings, GetSnapshotsAction.NAME, transportService, clusterService, threadPool, actionFilters, GetSnapshotsRequest.class);
+                                       ThreadPool threadPool, SnapshotsService snapshotsService, ActionFilters actionFilters,
+                                       IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetSnapshotsAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, GetSnapshotsRequest.class);
         this.snapshotsService = snapshotsService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -42,8 +43,9 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<Re
 
     @Inject
     public TransportRestoreSnapshotAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                          ThreadPool threadPool, RestoreService restoreService, ActionFilters actionFilters) {
-        super(settings, RestoreSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters, RestoreSnapshotRequest.class);
+                                          ThreadPool threadPool, RestoreService restoreService, ActionFilters actionFilters,
+                                          IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, RestoreSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, RestoreSnapshotRequest.class);
         this.restoreService = restoreService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.*;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
@@ -55,8 +56,11 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
     private final SnapshotShardsService snapshotShardsService;
 
     @Inject
-    public TransportNodesSnapshotsStatus(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, SnapshotShardsService snapshotShardsService, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters,
+    public TransportNodesSnapshotsStatus(Settings settings, ClusterName clusterName, ThreadPool threadPool,
+                                         ClusterService clusterService, TransportService transportService,
+                                         SnapshotShardsService snapshotShardsService, ActionFilters actionFilters,
+                                         IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 Request.class, NodeRequest.class, ThreadPool.Names.GENERIC);
         this.snapshotShardsService = snapshotShardsService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.common.Strings;
@@ -57,8 +58,11 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
     private final TransportNodesSnapshotsStatus transportNodesSnapshotsStatus;
 
     @Inject
-    public TransportSnapshotsStatusAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, SnapshotsService snapshotsService, TransportNodesSnapshotsStatus transportNodesSnapshotsStatus, ActionFilters actionFilters) {
-        super(settings, SnapshotsStatusAction.NAME, transportService, clusterService, threadPool, actionFilters, SnapshotsStatusRequest.class);
+    public TransportSnapshotsStatusAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                          ThreadPool threadPool, SnapshotsService snapshotsService,
+                                          TransportNodesSnapshotsStatus transportNodesSnapshotsStatus,
+                                          ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, SnapshotsStatusAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, SnapshotsStatusRequest.class);
         this.snapshotsService = snapshotsService;
         this.transportNodesSnapshotsStatus = transportNodesSnapshotsStatus;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.MetaData.Custom;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -45,8 +46,8 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
 
     @Inject
     public TransportClusterStateAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                       ClusterName clusterName, ActionFilters actionFilters) {
-        super(settings, ClusterStateAction.NAME, transportService, clusterService, threadPool, actionFilters, ClusterStateRequest.class);
+                                       ClusterName clusterName, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ClusterStateAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, ClusterStateRequest.class);
         this.clusterName = clusterName;
     }
 
@@ -105,7 +106,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
             }
 
             if (request.indices().length > 0) {
-                String[] indices = currentState.metaData().concreteIndices(request.indicesOptions(), request.indices());
+                String[] indices = indexNameExpressionResolver.concreteIndices(currentState, request);
                 for (String filteredIndex : indices) {
                     IndexMetaData indexMetaData = currentState.metaData().index(filteredIndex);
                     if (indexMetaData != null) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -65,9 +66,10 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     @Inject
     public TransportClusterStatsAction(Settings settings, ClusterName clusterName, ThreadPool threadPool,
                                        ClusterService clusterService, TransportService transportService,
-                                       NodeService nodeService, IndicesService indicesService, ActionFilters actionFilters) {
+                                       NodeService nodeService, IndicesService indicesService,
+                                       ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, ClusterStatsAction.NAME, clusterName, threadPool, clusterService, transportService, actionFilters,
-                ClusterStatsRequest.class, ClusterStatsNodeRequest.class, ThreadPool.Names.MANAGEMENT);
+                indexNameExpressionResolver, ClusterStatsRequest.class, ClusterStatsNodeRequest.class, ThreadPool.Names.MANAGEMENT);
         this.nodeService = nodeService;
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -38,8 +39,9 @@ public class TransportPendingClusterTasksAction extends TransportMasterNodeReadA
     private final ClusterService clusterService;
 
     @Inject
-    public TransportPendingClusterTasksAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, PendingClusterTasksAction.NAME, transportService, clusterService, threadPool, actionFilters, PendingClusterTasksRequest.class);
+    public TransportPendingClusterTasksAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                              ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, PendingClusterTasksAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, PendingClusterTasksRequest.class);
         this.clusterService = clusterService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataIndexAliasesService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -48,8 +49,9 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
 
     @Inject
     public TransportIndicesAliasesAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                         ThreadPool threadPool, MetaDataIndexAliasesService indexAliasesService, ActionFilters actionFilters) {
-        super(settings, IndicesAliasesAction.NAME, transportService, clusterService, threadPool, actionFilters, IndicesAliasesRequest.class);
+                                         ThreadPool threadPool, MetaDataIndexAliasesService indexAliasesService,
+                                         ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, IndicesAliasesAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, IndicesAliasesRequest.class);
         this.indexAliasesService = indexAliasesService;
     }
 
@@ -85,7 +87,7 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
         Set<String> aliases = new HashSet<>();
         for (AliasActions action : actions) {
             //expand indices
-            String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), action.indices());
+            String[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request.indicesOptions(), action.indices());
             //collect the aliases
             Collections.addAll(aliases, action.aliases());
             for (String index : concreteIndices) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -34,14 +34,14 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.analysis.*;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
@@ -63,8 +63,9 @@ public class TransportAnalyzeAction extends TransportSingleCustomOperationAction
 
     @Inject
     public TransportAnalyzeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                  IndicesService indicesService, IndicesAnalysisService indicesAnalysisService, ActionFilters actionFilters) {
-        super(settings, AnalyzeAction.NAME, threadPool, clusterService, transportService, actionFilters, AnalyzeRequest.class, ThreadPool.Names.INDEX);
+                                  IndicesService indicesService, IndicesAnalysisService indicesAnalysisService, ActionFilters actionFilters,
+                                  IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, AnalyzeAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver, AnalyzeRequest.class, ThreadPool.Names.INDEX);
         this.indicesService = indicesService;
         this.indicesAnalysisService = indicesAnalysisService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -55,8 +56,9 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastAction<C
     @Inject
     public TransportClearIndicesCacheAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                             TransportService transportService, IndicesService indicesService,
-                                            IndicesRequestCache indicesQueryCache, ActionFilters actionFilters) {
-        super(settings, ClearIndicesCacheAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                            IndicesRequestCache indicesQueryCache, ActionFilters actionFilters,
+                                            IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ClearIndicesCacheAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 ClearIndicesCacheRequest.class, ShardClearIndicesCacheRequest.class, ThreadPool.Names.MANAGEMENT);
         this.indicesService = indicesService;
         this.indicesRequestCache = indicesQueryCache;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataIndexStateService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -45,8 +46,10 @@ public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIn
 
     @Inject
     public TransportCloseIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                     ThreadPool threadPool, MetaDataIndexStateService indexStateService, NodeSettingsService nodeSettingsService, ActionFilters actionFilters) {
-        super(settings, CloseIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, CloseIndexRequest.class);
+                                     ThreadPool threadPool, MetaDataIndexStateService indexStateService,
+                                     NodeSettingsService nodeSettingsService, ActionFilters actionFilters,
+                                     IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, CloseIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, CloseIndexRequest.class);
         this.indexStateService = indexStateService;
         this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
     }
@@ -70,12 +73,12 @@ public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIn
 
     @Override
     protected ClusterBlockException checkBlock(CloseIndexRequest request, ClusterState state) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indexNameExpressionResolver.concreteIndices(state, request));
     }
 
     @Override
     protected void masterOperation(final CloseIndexRequest request, final ClusterState state, final ActionListener<CloseIndexResponse> listener) {
-        final String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), request.indices());
+        final String[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         CloseIndexClusterStateUpdateRequest updateRequest = new CloseIndexClusterStateUpdateRequest()
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .indices(concreteIndices);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -43,8 +44,9 @@ public class TransportCreateIndexAction extends TransportMasterNodeAction<Create
 
     @Inject
     public TransportCreateIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                      ThreadPool threadPool, MetaDataCreateIndexService createIndexService, ActionFilters actionFilters) {
-        super(settings, CreateIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, CreateIndexRequest.class);
+                                      ThreadPool threadPool, MetaDataCreateIndexService createIndexService,
+                                      ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, CreateIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, CreateIndexRequest.class);
         this.createIndexService = createIndexService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -50,8 +51,10 @@ public class TransportFlushAction extends TransportBroadcastAction<FlushRequest,
     private final IndicesService indicesService;
 
     @Inject
-    public TransportFlushAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, IndicesService indicesService, ActionFilters actionFilters) {
-        super(settings, FlushAction.NAME, threadPool, clusterService, transportService, actionFilters,
+    public TransportFlushAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+                                TransportService transportService, IndicesService indicesService,
+                                ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, FlushAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 FlushRequest.class, ShardFlushRequest.class, ThreadPool.Names.FLUSH);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -47,8 +48,8 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
 
     @Inject
     public TransportGetIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                   ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, GetIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, GetIndexRequest.class);
+                                   ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, GetIndexRequest.class);
     }
 
     @Override
@@ -59,7 +60,7 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
 
     @Override
     protected ClusterBlockException checkBlock(GetIndexRequest request, ClusterState state) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, indexNameExpressionResolver.concreteIndices(state, request));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -42,8 +43,10 @@ public class TransportGetFieldMappingsAction extends HandledTransportAction<GetF
     private final TransportGetFieldMappingsIndexAction shardAction;
 
     @Inject
-    public TransportGetFieldMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, TransportGetFieldMappingsIndexAction shardAction, ActionFilters actionFilters) {
-        super(settings, GetFieldMappingsAction.NAME, threadPool, transportService, actionFilters, GetFieldMappingsRequest.class);
+    public TransportGetFieldMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                           ThreadPool threadPool, TransportGetFieldMappingsIndexAction shardAction,
+                                           ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetFieldMappingsAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, GetFieldMappingsRequest.class);
         this.clusterService = clusterService;
         this.shardAction = shardAction;
     }
@@ -51,7 +54,7 @@ public class TransportGetFieldMappingsAction extends HandledTransportAction<GetF
     @Override
     protected void doExecute(GetFieldMappingsRequest request, final ActionListener<GetFieldMappingsResponse> listener) {
         ClusterState clusterState = clusterService.state();
-        String[] concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterState, request);
         final AtomicInteger indexCounter = new AtomicInteger();
         final AtomicInteger completionCounter = new AtomicInteger(concreteIndices.length);
         final AtomicReferenceArray<Object> indexResponses = new AtomicReferenceArray<>(concreteIndices.length);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Inject;
@@ -65,11 +66,10 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleCustomO
     private final IndicesService indicesService;
 
     @Inject
-    public TransportGetFieldMappingsIndexAction(Settings settings, ClusterService clusterService,
-                                                TransportService transportService,
-                                                IndicesService indicesService,
-                                                ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters, GetFieldMappingsIndexRequest.class, ThreadPool.Names.MANAGEMENT);
+    public TransportGetFieldMappingsIndexAction(Settings settings, ClusterService clusterService, TransportService transportService,
+                                                IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters,
+                                                IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver, GetFieldMappingsIndexRequest.class, ThreadPool.Names.MANAGEMENT);
         this.clusterService = clusterService;
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
@@ -38,8 +39,9 @@ import org.elasticsearch.transport.TransportService;
 public class TransportGetMappingsAction extends TransportClusterInfoAction<GetMappingsRequest, GetMappingsResponse> {
 
     @Inject
-    public TransportGetMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, GetMappingsAction.NAME, transportService, clusterService, threadPool, actionFilters, GetMappingsRequest.class);
+    public TransportGetMappingsAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                      ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetMappingsAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, GetMappingsRequest.class);
     }
 
     @Override
@@ -50,7 +52,7 @@ public class TransportGetMappingsAction extends TransportClusterInfoAction<GetMa
 
     @Override
     protected ClusterBlockException checkBlock(GetMappingsRequest request, ClusterState state) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, indexNameExpressionResolver.concreteIndices(state, request));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/optimize/TransportOptimizeAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -51,8 +52,9 @@ public class TransportOptimizeAction extends TransportBroadcastAction<OptimizeRe
 
     @Inject
     public TransportOptimizeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                   TransportService transportService, IndicesService indicesService, ActionFilters actionFilters) {
-        super(settings, OptimizeAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                   TransportService transportService, IndicesService indicesService,
+                                   ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, OptimizeAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 OptimizeRequest.class, ShardOptimizeRequest.class, ThreadPool.Names.OPTIMIZE);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -57,8 +58,9 @@ public class TransportRecoveryAction extends TransportBroadcastAction<RecoveryRe
 
     @Inject
     public TransportRecoveryAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                   TransportService transportService, IndicesService indicesService, ActionFilters actionFilters) {
-        super(settings, RecoveryAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                   TransportService transportService, IndicesService indicesService,
+                                   ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, RecoveryAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 RecoveryRequest.class, ShardRecoveryRequest.class, ThreadPool.Names.MANAGEMENT);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -51,8 +52,9 @@ public class TransportRefreshAction extends TransportBroadcastAction<RefreshRequ
 
     @Inject
     public TransportRefreshAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                  TransportService transportService, IndicesService indicesService, ActionFilters actionFilters) {
-        super(settings, RefreshAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                  TransportService transportService, IndicesService indicesService,
+                                  ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, RefreshAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 RefreshRequest.class, ShardRefreshRequest.class, ThreadPool.Names.REFRESH);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -57,8 +58,8 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastAction<Ind
 
     @Inject
     public TransportIndicesSegmentsAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                          IndicesService indicesService, ActionFilters actionFilters) {
-        super(settings, IndicesSegmentsAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                          IndicesService indicesService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, IndicesSegmentsAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 IndicesSegmentsRequest.class, TransportIndicesSegmentsAction.IndexShardSegmentRequest.class, ThreadPool.Names.MANAGEMENT);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -57,9 +58,10 @@ public class TransportIndicesStatsAction extends TransportBroadcastAction<Indice
     private final IndicesService indicesService;
 
     @Inject
-    public TransportIndicesStatsAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                       IndicesService indicesService, ActionFilters actionFilters) {
-        super(settings, IndicesStatsAction.NAME, threadPool, clusterService, transportService, actionFilters,
+    public TransportIndicesStatsAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+                                       TransportService transportService, IndicesService indicesService,
+                                       ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, IndicesStatsAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 IndicesStatsRequest.class, IndexShardStatsRequest.class, ThreadPool.Names.MANAGEMENT);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataIndexTemplateService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -40,8 +41,9 @@ public class TransportDeleteIndexTemplateAction extends TransportMasterNodeActio
 
     @Inject
     public TransportDeleteIndexTemplateAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                              ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService, ActionFilters actionFilters) {
-        super(settings, DeleteIndexTemplateAction.NAME, transportService, clusterService, threadPool, actionFilters, DeleteIndexTemplateRequest.class);
+                                              ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService,
+                                              ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, DeleteIndexTemplateAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, DeleteIndexTemplateRequest.class);
         this.indexTemplateService = indexTemplateService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
@@ -42,8 +43,9 @@ import java.util.List;
 public class TransportGetIndexTemplatesAction extends TransportMasterNodeReadAction<GetIndexTemplatesRequest, GetIndexTemplatesResponse> {
 
     @Inject
-    public TransportGetIndexTemplatesAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, GetIndexTemplatesAction.NAME, transportService, clusterService, threadPool, actionFilters, GetIndexTemplatesRequest.class);
+    public TransportGetIndexTemplatesAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                            ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetIndexTemplatesAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, GetIndexTemplatesRequest.class);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataIndexTemplateService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -40,8 +41,9 @@ public class TransportPutIndexTemplateAction extends TransportMasterNodeAction<P
 
     @Inject
     public TransportPutIndexTemplateAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                           ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService, ActionFilters actionFilters) {
-        super(settings, PutIndexTemplateAction.NAME, transportService, clusterService, threadPool, actionFilters, PutIndexTemplateRequest.class);
+                                           ThreadPool threadPool, MetaDataIndexTemplateService indexTemplateService,
+                                           ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, PutIndexTemplateAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, PutIndexTemplateRequest.class);
         this.indexTemplateService = indexTemplateService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/TransportUpgradeStatusAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/TransportUpgradeStatusAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -56,8 +57,8 @@ public class TransportUpgradeStatusAction extends TransportBroadcastAction<Upgra
 
     @Inject
     public TransportUpgradeStatusAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                        IndicesService indicesService, ActionFilters actionFilters) {
-        super(settings, UpgradeStatusAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                        IndicesService indicesService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, UpgradeStatusAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 UpgradeStatusRequest.class, IndexShardUpgradeStatusRequest.class, ThreadPool.Names.MANAGEMENT);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.inject.Inject;
@@ -61,8 +62,8 @@ public class TransportUpgradeAction extends TransportBroadcastAction<UpgradeRequ
     @Inject
     public TransportUpgradeAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                   TransportService transportService, IndicesService indicesService, ActionFilters actionFilters,
-                                  TransportUpgradeSettingsAction upgradeSettingsAction) {
-        super(settings, UpgradeAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                  IndexNameExpressionResolver indexNameExpressionResolver, TransportUpgradeSettingsAction upgradeSettingsAction) {
+        super(settings, UpgradeAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 UpgradeRequest.class, ShardUpgradeRequest.class, ThreadPool.Names.OPTIMIZE);
         this.indicesService = indicesService;
         this.upgradeSettingsAction = upgradeSettingsAction;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeSettingsAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataUpdateSettingsService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -42,8 +43,8 @@ public class TransportUpgradeSettingsAction extends TransportMasterNodeAction<Up
 
     @Inject
     public TransportUpgradeSettingsAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                          MetaDataUpdateSettingsService updateSettingsService, ActionFilters actionFilters) {
-        super(settings, UpgradeSettingsAction.NAME, transportService, clusterService, threadPool, actionFilters, UpgradeSettingsRequest.class);
+                                          MetaDataUpdateSettingsService updateSettingsService, IndexNameExpressionResolver indexNameExpressionResolver, ActionFilters actionFilters) {
+        super(settings, UpgradeSettingsAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, UpgradeSettingsRequest.class);
         this.updateSettingsService = updateSettingsService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/template/TransportRenderSearchTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/template/TransportRenderSearchTemplateAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.validate.template;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -38,8 +39,8 @@ public class TransportRenderSearchTemplateAction extends HandledTransportAction<
 
     @Inject
     protected TransportRenderSearchTemplateAction(ScriptService scriptService, Settings settings, ThreadPool threadPool,
-            TransportService transportService, ActionFilters actionFilters) {
-        super(settings, RenderSearchTemplateAction.NAME, threadPool, transportService, actionFilters, RenderSearchTemplateRequest.class);
+            TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, RenderSearchTemplateAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, RenderSearchTemplateRequest.class);
         this.scriptService = scriptService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
@@ -50,8 +51,9 @@ import java.util.List;
 public class TransportDeleteWarmerAction extends TransportMasterNodeAction<DeleteWarmerRequest, DeleteWarmerResponse> {
 
     @Inject
-    public TransportDeleteWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, DeleteWarmerAction.NAME, transportService, clusterService, threadPool, actionFilters, DeleteWarmerRequest.class);
+    public TransportDeleteWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                       ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, DeleteWarmerAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, DeleteWarmerRequest.class);
     }
 
     @Override
@@ -67,12 +69,12 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
 
     @Override
     protected ClusterBlockException checkBlock(DeleteWarmerRequest request, ClusterState state) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, clusterService.state().metaData().concreteIndices(request.indicesOptions(), request.indices()));
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indexNameExpressionResolver.concreteIndices(state, request));
     }
 
     @Override
     protected void masterOperation(final DeleteWarmerRequest request, final ClusterState state, final ActionListener<DeleteWarmerResponse> listener) {
-        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(request.indicesOptions(), request.indices());
+        final String[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         clusterService.submitStateUpdateTask("delete_warmer [" + Arrays.toString(request.names()) + "]", new AckedClusterStateUpdateTask<DeleteWarmerResponse>(request, listener) {
 
             @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/TransportGetWarmersAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/TransportGetWarmersAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -42,8 +43,9 @@ import org.elasticsearch.transport.TransportService;
 public class TransportGetWarmersAction extends TransportClusterInfoAction<GetWarmersRequest, GetWarmersResponse> {
 
     @Inject
-    public TransportGetWarmersAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, GetWarmersAction.NAME, transportService, clusterService, threadPool, actionFilters, GetWarmersRequest.class);
+    public TransportGetWarmersAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                     ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetWarmersAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, GetWarmersRequest.class);
     }
 
     @Override
@@ -54,7 +56,7 @@ public class TransportGetWarmersAction extends TransportClusterInfoAction<GetWar
 
     @Override
     protected ClusterBlockException checkBlock(GetWarmersRequest request, ClusterState state) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, state.metaData().concreteIndices(request.indicesOptions(), request.indices()));
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, indexNameExpressionResolver.concreteIndices(state, request));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/TransportPutWarmerAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
@@ -57,8 +58,8 @@ public class TransportPutWarmerAction extends TransportMasterNodeAction<PutWarme
 
     @Inject
     public TransportPutWarmerAction(Settings settings, TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                    TransportSearchAction searchAction, ActionFilters actionFilters) {
-        super(settings, PutWarmerAction.NAME, transportService, clusterService, threadPool, actionFilters, PutWarmerRequest.class);
+                                    TransportSearchAction searchAction, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, PutWarmerAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, PutWarmerRequest.class);
         this.searchAction = searchAction;
     }
 
@@ -74,7 +75,7 @@ public class TransportPutWarmerAction extends TransportMasterNodeAction<PutWarme
 
     @Override
     protected ClusterBlockException checkBlock(PutWarmerRequest request, ClusterState state) {
-        String[] concreteIndices = clusterService.state().metaData().concreteIndices(request.searchRequest().indicesOptions(), request.searchRequest().indices());
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         ClusterBlockException status = state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices);
         if (status != null) {
             return status;
@@ -112,7 +113,7 @@ public class TransportPutWarmerAction extends TransportMasterNodeAction<PutWarme
                     @Override
                     public ClusterState execute(ClusterState currentState) {
                         MetaData metaData = currentState.metaData();
-                        String[] concreteIndices = metaData.concreteIndices(request.searchRequest().indicesOptions(), request.searchRequest().indices());
+                        String[] concreteIndices = indexNameExpressionResolver.concreteIndices(currentState, request.searchRequest().indicesOptions(), request.searchRequest().indices());
 
                         BytesReference source = null;
                         if (request.searchRequest().source() != null && request.searchRequest().source().length() > 0) {

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -78,9 +79,10 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
     @Inject
     public TransportShardBulkAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                     IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
-                                    MappingUpdatedAction mappingUpdatedAction, UpdateHelper updateHelper, ActionFilters actionFilters) {
+                                    MappingUpdatedAction mappingUpdatedAction, UpdateHelper updateHelper, ActionFilters actionFilters,
+                                    IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, mappingUpdatedAction,
-                actionFilters,
+                actionFilters, indexNameExpressionResolver,
                 BulkShardRequest.class, BulkShardRequest.class, ThreadPool.Names.BULK);
         this.updateHelper = updateHelper;
         this.allowIdGeneration = settings.getAsBoolean("action.allow_id_generation", true);

--- a/core/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.collect.Tuple;
@@ -59,9 +60,9 @@ public class TransportDeleteAction extends TransportReplicationAction<DeleteRequ
     public TransportDeleteAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                  IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
                                  TransportCreateIndexAction createIndexAction, ActionFilters actionFilters,
-                                 MappingUpdatedAction mappingUpdatedAction) {
+                                 IndexNameExpressionResolver indexNameExpressionResolver, MappingUpdatedAction mappingUpdatedAction) {
         super(settings, DeleteAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction,
-                mappingUpdatedAction, actionFilters,
+                mappingUpdatedAction, actionFilters, indexNameExpressionResolver,
                 DeleteRequest.class, DeleteRequest.class, ThreadPool.Names.INDEX);
         this.createIndexAction = createIndexAction;
         this.autoCreateIndex = new AutoCreateIndex(settings);

--- a/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -70,8 +71,8 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
     public TransportExplainAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                   TransportService transportService, IndicesService indicesService,
                                   ScriptService scriptService, PageCacheRecycler pageCacheRecycler,
-                                  BigArrays bigArrays, ActionFilters actionFilters) {
-        super(settings, ExplainAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                  BigArrays bigArrays, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ExplainAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 ExplainRequest.class, ThreadPool.Names.GET);
         this.indicesService = indicesService;
         this.scriptService = scriptService;
@@ -92,7 +93,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
 
     @Override
     protected void resolveRequest(ClusterState state, InternalRequest request) {
-        request.request().filteringAlias(state.metaData().filteringAliases(request.concreteIndex(), request.request().index()));
+        request.request().filteringAlias(indexNameExpressionResolver.filteringAliases(state, request.concreteIndex(), request.request().index()));
         // Fail fast on the node that received the request.
         if (request.request().routing() == null && state.getMetaData().routingRequired(request.concreteIndex(), request.request().type())) {
             throw new RoutingMissingException(request.concreteIndex(), request.request().type(), request.request().id());

--- a/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
@@ -55,8 +56,10 @@ public class TransportFieldStatsTransportAction extends TransportBroadcastAction
     private final IndicesService indicesService;
 
     @Inject
-    public TransportFieldStatsTransportAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters, IndicesService indicesService) {
-        super(settings, FieldStatsAction.NAME, threadPool, clusterService, transportService, actionFilters, FieldStatsRequest.class, FieldStatsShardRequest.class, ThreadPool.Names.MANAGEMENT);
+    public TransportFieldStatsTransportAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+                                              TransportService transportService, ActionFilters actionFilters,
+                                              IndexNameExpressionResolver indexNameExpressionResolver, IndicesService indicesService) {
+        super(settings, FieldStatsAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver, FieldStatsRequest.class, FieldStatsShardRequest.class, ThreadPool.Names.MANAGEMENT);
         this.indicesService = indicesService;
     }
 
@@ -171,7 +174,7 @@ public class TransportFieldStatsTransportAction extends TransportBroadcastAction
 
     @Override
     protected GroupShardsIterator shards(ClusterState clusterState, FieldStatsRequest request, String[] concreteIndices) {
-        return clusterService.operationRouting().searchShards(clusterState, request.indices(), concreteIndices, null, null);
+        return clusterService.operationRouting().searchShards(clusterState, concreteIndices, null, null);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportGetAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.Preference;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
@@ -47,8 +48,9 @@ public class TransportGetAction extends TransportSingleShardAction<GetRequest, G
 
     @Inject
     public TransportGetAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                              IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, GetAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                              IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters,
+                              IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 GetRequest.class, ThreadPool.Names.GET);
         this.indicesService = indicesService;
 

--- a/core/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -47,8 +48,9 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
 
     @Inject
     public TransportShardMultiGetAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                        IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters,
+                                        IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters,
+                                        IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 MultiGetShardRequest.class, ThreadPool.Names.GET);
         this.indicesService = indicesService;
 

--- a/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.ShardIterator;
@@ -72,9 +73,10 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
     @Inject
     public TransportIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                 IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
-                                TransportCreateIndexAction createIndexAction, MappingUpdatedAction mappingUpdatedAction, ActionFilters actionFilters) {
+                                TransportCreateIndexAction createIndexAction, MappingUpdatedAction mappingUpdatedAction,
+                                ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, IndexAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, mappingUpdatedAction,
-                actionFilters, IndexRequest.class, IndexRequest.class, ThreadPool.Names.INDEX);
+                actionFilters, indexNameExpressionResolver, IndexRequest.class, IndexRequest.class, ThreadPool.Names.INDEX);
         this.createIndexAction = createIndexAction;
         this.autoCreateIndex = new AutoCreateIndex(settings);
         this.allowIdGeneration = settings.getAsBoolean("action.allow_id_generation", true);

--- a/core/src/main/java/org/elasticsearch/action/indexedscripts/delete/TransportDeleteIndexedScriptAction.java
+++ b/core/src/main/java/org/elasticsearch/action/indexedscripts/delete/TransportDeleteIndexedScriptAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DelegatingActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService;
@@ -39,8 +40,8 @@ public class TransportDeleteIndexedScriptAction extends HandledTransportAction<D
 
     @Inject
     public TransportDeleteIndexedScriptAction(Settings settings, ThreadPool threadPool, ScriptService scriptService,
-                                              TransportService transportService, ActionFilters actionFilters) {
-        super(settings, DeleteIndexedScriptAction.NAME, threadPool, transportService, actionFilters, DeleteIndexedScriptRequest.class);
+                                              TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, DeleteIndexedScriptAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, DeleteIndexedScriptRequest.class);
         this.scriptService = scriptService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
+++ b/core/src/main/java/org/elasticsearch/action/indexedscripts/get/TransportGetIndexedScriptAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService;
@@ -38,8 +39,8 @@ public class TransportGetIndexedScriptAction extends HandledTransportAction<GetI
 
     @Inject
     public TransportGetIndexedScriptAction(Settings settings, ThreadPool threadPool, ScriptService scriptService,
-                                           TransportService transportService, ActionFilters actionFilters) {
-        super(settings, GetIndexedScriptAction.NAME, threadPool,transportService,  actionFilters, GetIndexedScriptRequest.class);
+                                           TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, GetIndexedScriptAction.NAME, threadPool,transportService,  actionFilters, indexNameExpressionResolver, GetIndexedScriptRequest.class);
         this.scriptService = scriptService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/indexedscripts/put/TransportPutIndexedScriptAction.java
+++ b/core/src/main/java/org/elasticsearch/action/indexedscripts/put/TransportPutIndexedScriptAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DelegatingActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService;
@@ -38,9 +39,10 @@ public class TransportPutIndexedScriptAction extends HandledTransportAction<PutI
     private final ScriptService scriptService;
 
     @Inject
-    public TransportPutIndexedScriptAction(Settings settings, ThreadPool threadPool,
-                                           ScriptService scriptService, TransportService transportService, ActionFilters actionFilters) {
-        super(settings, PutIndexedScriptAction.NAME, threadPool, transportService, actionFilters, PutIndexedScriptRequest.class);
+    public TransportPutIndexedScriptAction(Settings settings, ThreadPool threadPool, ScriptService scriptService,
+                                           TransportService transportService, ActionFilters actionFilters,
+                                           IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, PutIndexedScriptAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, PutIndexedScriptRequest.class);
         this.scriptService = scriptService;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedE
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
@@ -59,8 +60,8 @@ public class TransportMultiPercolateAction extends HandledTransportAction<MultiP
     @Inject
     public TransportMultiPercolateAction(Settings settings, ThreadPool threadPool, TransportShardMultiPercolateAction shardMultiPercolateAction,
                                          ClusterService clusterService, TransportService transportService, PercolatorService percolatorService,
-                                         TransportMultiGetAction multiGetAction, ActionFilters actionFilters) {
-        super(settings, MultiPercolateAction.NAME, threadPool, transportService, actionFilters, MultiPercolateRequest.class);
+                                         TransportMultiGetAction multiGetAction, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, MultiPercolateAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, MultiPercolateRequest.class);
         this.shardMultiPercolateAction = shardMultiPercolateAction;
         this.clusterService = clusterService;
         this.percolatorService = percolatorService;
@@ -164,17 +165,17 @@ public class TransportMultiPercolateAction extends HandledTransportAction<MultiP
                     PercolateRequest percolateRequest = (PercolateRequest) element;
                     String[] concreteIndices;
                     try {
-                         concreteIndices = clusterState.metaData().concreteIndices(percolateRequest.indicesOptions(), percolateRequest.indices());
+                         concreteIndices = indexNameExpressionResolver.concreteIndices(clusterState, percolateRequest);
                     } catch (IndexMissingException e) {
                         reducedResponses.set(slot, e);
                         responsesByItemAndShard.set(slot, new AtomicReferenceArray(0));
                         expectedOperationsPerItem.set(slot, new AtomicInteger(0));
                         continue;
                     }
-                    Map<String, Set<String>> routing = clusterState.metaData().resolveSearchRouting(percolateRequest.routing(), percolateRequest.indices());
+                    Map<String, Set<String>> routing = indexNameExpressionResolver.resolveSearchRouting(clusterState, percolateRequest.routing(), percolateRequest.indices());
                     // TODO: I only need shardIds, ShardIterator(ShardRouting) is only needed in TransportShardMultiPercolateAction
                     GroupShardsIterator shards = clusterService.operationRouting().searchShards(
-                            clusterState, percolateRequest.indices(), concreteIndices, routing, percolateRequest.preference()
+                            clusterState, concreteIndices, routing, percolateRequest.preference()
                     );
                     if (shards.size() == 0) {
                         reducedResponses.set(slot, new UnavailableShardsException(null, "No shards available"));
@@ -184,7 +185,7 @@ public class TransportMultiPercolateAction extends HandledTransportAction<MultiP
                     }
 
                     // The shard id is used as index in the atomic ref array, so we need to find out how many shards there are regardless of routing:
-                    int numShards = clusterService.operationRouting().searchShardsCount(clusterState, percolateRequest.indices(), concreteIndices, null, null);
+                    int numShards = clusterService.operationRouting().searchShardsCount(clusterState, concreteIndices, null);
                     responsesByItemAndShard.set(slot, new AtomicReferenceArray(numShards));
                     expectedOperationsPerItem.set(slot, new AtomicInteger(shards.size()));
                     for (ShardIterator shard : shards) {

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -60,9 +61,9 @@ public class TransportPercolateAction extends TransportBroadcastAction<Percolate
     @Inject
     public TransportPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                     TransportService transportService, PercolatorService percolatorService,
-                                    TransportGetAction getAction, ActionFilters actionFilters) {
+                                    TransportGetAction getAction, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, PercolateAction.NAME, threadPool, clusterService, transportService, actionFilters,
-                PercolateRequest.class, PercolateShardRequest.class, ThreadPool.Names.PERCOLATE);
+                indexNameExpressionResolver, PercolateRequest.class, PercolateShardRequest.class, ThreadPool.Names.PERCOLATE);
         this.percolatorService = percolatorService;
         this.getAction = getAction;
     }
@@ -167,8 +168,8 @@ public class TransportPercolateAction extends TransportBroadcastAction<Percolate
 
     @Override
     protected GroupShardsIterator shards(ClusterState clusterState, PercolateRequest request, String[] concreteIndices) {
-        Map<String, Set<String>> routingMap = clusterState.metaData().resolveSearchRouting(request.routing(), request.indices());
-        return clusterService.operationRouting().searchShards(clusterState, request.indices(), concreteIndices, routingMap, request.preference());
+        Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(clusterState, request.routing(), request.indices());
+        return clusterService.operationRouting().searchShards(clusterState, concreteIndices, routingMap, request.preference());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -56,8 +57,10 @@ public class TransportShardMultiPercolateAction extends TransportSingleShardActi
     private static final String ACTION_NAME = MultiPercolateAction.NAME + "[shard]";
 
     @Inject
-    public TransportShardMultiPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, PercolatorService percolatorService, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters,
+    public TransportShardMultiPercolateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
+                                              TransportService transportService, PercolatorService percolatorService,
+                                              ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 Request.class, ThreadPool.Names.PERCOLATE);
         this.percolatorService = percolatorService;
     }

--- a/core/src/main/java/org/elasticsearch/action/search/TransportClearScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportClearScrollAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.collect.Tuple;
@@ -50,8 +51,10 @@ public class TransportClearScrollAction extends HandledTransportAction<ClearScro
     private final SearchServiceTransportAction searchServiceTransportAction;
 
     @Inject
-    public TransportClearScrollAction(Settings settings, TransportService transportService, ThreadPool threadPool, ClusterService clusterService, SearchServiceTransportAction searchServiceTransportAction, ActionFilters actionFilters) {
-        super(settings, ClearScrollAction.NAME, threadPool, transportService, actionFilters, ClearScrollRequest.class);
+    public TransportClearScrollAction(Settings settings, TransportService transportService, ThreadPool threadPool,
+                                      ClusterService clusterService, SearchServiceTransportAction searchServiceTransportAction,
+                                      ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ClearScrollAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, ClearScrollRequest.class);
         this.clusterService = clusterService;
         this.searchServiceTransportAction = searchServiceTransportAction;
     }

--- a/core/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
@@ -42,8 +42,10 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
     private final TransportSearchAction searchAction;
 
     @Inject
-    public TransportMultiSearchAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService, TransportSearchAction searchAction, ActionFilters actionFilters) {
-        super(settings, MultiSearchAction.NAME, threadPool, transportService, actionFilters, MultiSearchRequest.class);
+    public TransportMultiSearchAction(Settings settings, ThreadPool threadPool, TransportService transportService,
+                                      ClusterService clusterService, TransportSearchAction searchAction,
+                                      ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, MultiSearchAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, MultiSearchRequest.class);
         this.clusterService = clusterService;
         this.searchAction = searchAction;
     }

--- a/core/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.type.TransportSearchScrollQueryThenFetchA
 import org.elasticsearch.action.search.type.TransportSearchScrollScanAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -47,8 +48,9 @@ public class TransportSearchScrollAction extends HandledTransportAction<SearchSc
     public TransportSearchScrollAction(Settings settings, ThreadPool threadPool, TransportService transportService,
                                        TransportSearchScrollQueryThenFetchAction queryThenFetchAction,
                                        TransportSearchScrollQueryAndFetchAction queryAndFetchAction,
-                                       TransportSearchScrollScanAction scanAction, ActionFilters actionFilters) {
-        super(settings, SearchScrollAction.NAME, threadPool, transportService, actionFilters, SearchScrollRequest.class);
+                                       TransportSearchScrollScanAction scanAction, ActionFilters actionFilters,
+                                       IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, SearchScrollAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, SearchScrollRequest.class);
         this.queryThenFetchAction = queryThenFetchAction;
         this.queryAndFetchAction = queryAndFetchAction;
         this.scanAction = scanAction;

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -45,8 +46,9 @@ public class TransportSearchCountAction extends TransportSearchTypeAction {
 
     @Inject
     public TransportSearchCountAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                      SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
+                                      SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController,
+                                      ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters, indexNameExpressionResolver);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -50,8 +51,9 @@ public class TransportSearchDfsQueryAndFetchAction extends TransportSearchTypeAc
 
     @Inject
     public TransportSearchDfsQueryAndFetchAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                                 SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
+                                                 SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController,
+                                                 ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters, indexNameExpressionResolver);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -56,8 +57,9 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
 
     @Inject
     public TransportSearchDfsQueryThenFetchAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                                  SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
+                                                  SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController,
+                                                  ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters, indexNameExpressionResolver);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -47,8 +48,9 @@ public class TransportSearchQueryAndFetchAction extends TransportSearchTypeActio
 
     @Inject
     public TransportSearchQueryAndFetchAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                              SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
+                                              SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController,
+                                              ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters, indexNameExpressionResolver);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -52,8 +53,9 @@ public class TransportSearchQueryThenFetchAction extends TransportSearchTypeActi
 
     @Inject
     public TransportSearchQueryThenFetchAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                               SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
+                                               SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController,
+                                               ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters, indexNameExpressionResolver);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -43,8 +44,9 @@ public class TransportSearchScanAction extends TransportSearchTypeAction {
 
     @Inject
     public TransportSearchScanAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
-                                     SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController, ActionFilters actionFilters) {
-        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters);
+                                     SearchServiceTransportAction searchService, SearchPhaseController searchPhaseController,
+                                     ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, threadPool, clusterService, searchService, searchPhaseController, actionFilters, indexNameExpressionResolver);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/core/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -65,8 +66,9 @@ public class TransportSuggestAction extends TransportBroadcastAction<SuggestRequ
 
     @Inject
     public TransportSuggestAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                  IndicesService indicesService, SuggestPhase suggestPhase, ActionFilters actionFilters) {
-        super(settings, SuggestAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                  IndicesService indicesService, SuggestPhase suggestPhase, ActionFilters actionFilters,
+                                  IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, SuggestAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 SuggestRequest.class, ShardSuggestRequest.class, ThreadPool.Names.SUGGEST);
         this.indicesService = indicesService;
         this.suggestPhase = suggestPhase;
@@ -84,8 +86,8 @@ public class TransportSuggestAction extends TransportBroadcastAction<SuggestRequ
 
     @Override
     protected GroupShardsIterator shards(ClusterState clusterState, SuggestRequest request, String[] concreteIndices) {
-        Map<String, Set<String>> routingMap = clusterState.metaData().resolveSearchRouting(request.routing(), request.indices());
-        return clusterService.operationRouting().searchShards(clusterState, request.indices(), concreteIndices, routingMap, request.preference());
+        Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(clusterState, request.routing(), request.indices());
+        return clusterService.operationRouting().searchShards(clusterState, concreteIndices, routingMap, request.preference());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.support;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportChannel;
@@ -32,8 +33,8 @@ import org.elasticsearch.transport.TransportService;
  */
 public abstract class HandledTransportAction<Request extends ActionRequest, Response extends ActionResponse> extends TransportAction<Request,Response>{
 
-    protected HandledTransportAction(Settings settings, String actionName, ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters, Class<Request> request) {
-        super(settings, actionName, threadPool, actionFilters);
+    protected HandledTransportAction(Settings settings, String actionName, ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, Class<Request> request) {
+        super(settings, actionName, threadPool, actionFilters, indexNameExpressionResolver);
         transportService.registerRequestHandler(actionName, request, ThreadPool.Names.SAME, new TransportHandler());
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.action.*;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.logging.ESLogger;
@@ -39,13 +40,16 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
     protected final String actionName;
     private final ActionFilter[] filters;
     protected final ParseFieldMatcher parseFieldMatcher;
+    protected final IndexNameExpressionResolver indexNameExpressionResolver;
 
-    protected TransportAction(Settings settings, String actionName, ThreadPool threadPool, ActionFilters actionFilters) {
+    protected TransportAction(Settings settings, String actionName, ThreadPool threadPool, ActionFilters actionFilters,
+                              IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings);
-        this.parseFieldMatcher = new ParseFieldMatcher(settings);
+        this.threadPool = threadPool;
         this.actionName = actionName;
         this.filters = actionFilters.filters();
-        this.threadPool = threadPool;
+        this.parseFieldMatcher = new ParseFieldMatcher(settings);
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
     }
 
     public final ActionFuture<Response> execute(Request request) {

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
@@ -52,9 +53,10 @@ public abstract class TransportBroadcastAction<Request extends BroadcastRequest,
 
     final String transportShardAction;
 
-    protected TransportBroadcastAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
+    protected TransportBroadcastAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService,
+                                       TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                        Class<Request> request, Class<ShardRequest> shardRequest, String shardExecutor) {
-        super(settings, actionName, threadPool, transportService, actionFilters, request);
+        super(settings, actionName, threadPool, transportService, actionFilters, indexNameExpressionResolver, request);
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.threadPool = threadPool;
@@ -108,7 +110,7 @@ public abstract class TransportBroadcastAction<Request extends BroadcastRequest,
                 throw blockException;
             }
             // update to concrete indices
-            String[] concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
+            String[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterState, request);
             blockException = checkRequestBlock(clusterState, request, concreteIndices);
             if (blockException != null) {
                 throw blockException;

--- a/core/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -51,9 +52,10 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
 
     final String executor;
 
-    protected TransportMasterNodeAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,
-                                        Class<Request> request) {
-        super(settings, actionName, threadPool, transportService, actionFilters, request);
+    protected TransportMasterNodeAction(Settings settings, String actionName, TransportService transportService,
+                                        ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,
+                                        IndexNameExpressionResolver indexNameExpressionResolver, Class<Request> request) {
+        super(settings, actionName, threadPool, transportService, actionFilters, indexNameExpressionResolver, request);
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.executor = executor();

--- a/core/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.support.master;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -36,8 +37,10 @@ public abstract class TransportMasterNodeReadAction<Request extends MasterNodeRe
 
     private Boolean forceLocal;
 
-    protected TransportMasterNodeReadAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters, Class<Request> request) {
-        super(settings, actionName, transportService, clusterService, threadPool, actionFilters,request);
+    protected TransportMasterNodeReadAction(Settings settings, String actionName, TransportService transportService,
+                                            ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,
+                                            IndexNameExpressionResolver indexNameExpressionResolver, Class<Request> request) {
+        super(settings, actionName, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver,request);
         this.forceLocal = settings.getAsBoolean(FORCE_LOCAL_SETTING, null);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -32,8 +33,10 @@ import org.elasticsearch.transport.TransportService;
  */
 public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest, Response extends ActionResponse> extends TransportMasterNodeReadAction<Request, Response> {
 
-    public TransportClusterInfoAction(Settings settings, String actionName, TransportService transportService, ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters, Class<Request> request) {
-        super(settings, actionName, transportService, clusterService, threadPool, actionFilters, request);
+    public TransportClusterInfoAction(Settings settings, String actionName, TransportService transportService,
+                                      ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,
+                                      IndexNameExpressionResolver indexNameExpressionResolver, Class<Request> request) {
+        super(settings, actionName, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, request);
     }
 
     @Override
@@ -44,7 +47,7 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
 
     @Override
     protected final void masterOperation(final Request request, final ClusterState state, final ActionListener<Response> listener) {
-        String[] concreteIndices = state.metaData().concreteIndices(request.indicesOptions(), request.indices());
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         doMasterOperation(request, concreteIndices, state, listener);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
@@ -49,8 +50,9 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
 
     protected TransportNodesAction(Settings settings, String actionName, ClusterName clusterName, ThreadPool threadPool,
                                    ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
-                                   Class<NodesRequest> request, Class<NodeRequest> nodeRequest, String nodeExecutor) {
-        super(settings, actionName, threadPool, transportService, actionFilters, request);
+                                   IndexNameExpressionResolver indexNameExpressionResolver, Class<NodesRequest> request, Class<NodeRequest> nodeRequest,
+                                   String nodeExecutor) {
+        super(settings, actionName, threadPool, transportService, actionFilters, indexNameExpressionResolver, request);
         this.clusterName = clusterName;
         this.clusterService = clusterService;
         this.transportService = transportService;

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.Nullable;
@@ -92,8 +93,9 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
                                          ClusterService clusterService, IndicesService indicesService,
                                          ThreadPool threadPool, ShardStateAction shardStateAction,
                                          MappingUpdatedAction mappingUpdatedAction, ActionFilters actionFilters,
-                                         Class<Request> request, Class<ReplicaRequest> replicaRequest, String executor) {
-        super(settings, actionName, threadPool, actionFilters);
+                                         IndexNameExpressionResolver indexNameExpressionResolver, Class<Request> request,
+                                         Class<ReplicaRequest> replicaRequest, String executor) {
+        super(settings, actionName, threadPool, actionFilters, indexNameExpressionResolver);
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.indicesService = indicesService;
@@ -398,7 +400,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
                 return false;
             }
             if (resolveIndex()) {
-                internalRequest.concreteIndex(observer.observedState().metaData().concreteSingleIndex(internalRequest.request().index(), internalRequest.request().indicesOptions()));
+                internalRequest.concreteIndex(indexNameExpressionResolver.concreteSingleIndex(observer.observedState(), internalRequest.request()));
             } else {
                 internalRequest.concreteIndex(internalRequest.request().index());
             }

--- a/core/src/main/java/org/elasticsearch/action/support/single/custom/TransportSingleCustomOperationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/custom/TransportSingleCustomOperationAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -48,9 +49,11 @@ public abstract class TransportSingleCustomOperationAction<Request extends Singl
     final String transportShardAction;
     final String executor;
 
-    protected TransportSingleCustomOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
+    protected TransportSingleCustomOperationAction(Settings settings, String actionName, ThreadPool threadPool,
+                                                   ClusterService clusterService, TransportService transportService,
+                                                   ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                                    Class<Request> request, String executor) {
-        super(settings, actionName, threadPool, transportService, actionFilters, request);
+        super(settings, actionName, threadPool, transportService, actionFilters, indexNameExpressionResolver, request);
         this.clusterService = clusterService;
         this.transportService = transportService;
 
@@ -110,7 +113,7 @@ public abstract class TransportSingleCustomOperationAction<Request extends Singl
 
             String concreteSingleIndex;
             if (resolveIndex(request)) {
-                concreteSingleIndex = clusterState.metaData().concreteSingleIndex(request.index(), request.indicesOptions());
+                concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, request);
             } else {
                 concreteSingleIndex = request.index();
             }

--- a/core/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.ShardIterator;
@@ -53,8 +54,10 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
 
     final String executor;
 
-    protected TransportInstanceSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters, Class<Request> request) {
-        super(settings, actionName, threadPool, transportService, actionFilters, request);
+    protected TransportInstanceSingleOperationAction(Settings settings, String actionName, ThreadPool threadPool,
+                                                     ClusterService clusterService, TransportService transportService,
+                                                     ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, Class<Request> request) {
+        super(settings, actionName, threadPool, transportService, actionFilters, indexNameExpressionResolver, request);
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.executor = executor();
@@ -128,7 +131,7 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
                         throw blockException;
                     }
                 }
-                internalRequest.concreteIndex(observer.observedState().metaData().concreteSingleIndex(internalRequest.request().index(), internalRequest.request().indicesOptions()));
+                internalRequest.concreteIndex(indexNameExpressionResolver.concreteSingleIndex(observer.observedState(), internalRequest.request()));
                 // check if we need to execute, and if not, return
                 if (!resolveRequest(observer.observedState(), internalRequest, listener)) {
                     return true;

--- a/core/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.ShardIterator;
@@ -53,9 +54,10 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
     final String transportShardAction;
     final String executor;
 
-    protected TransportSingleShardAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
+    protected TransportSingleShardAction(Settings settings, String actionName, ThreadPool threadPool, ClusterService clusterService,
+                                         TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                          Class<Request> request, String executor) {
-        super(settings, actionName, threadPool, actionFilters);
+        super(settings, actionName, threadPool, actionFilters, indexNameExpressionResolver);
         this.clusterService = clusterService;
         this.transportService = transportService;
 
@@ -125,7 +127,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
 
             String concreteSingleIndex;
             if (resolveIndex()) {
-                concreteSingleIndex = clusterState.metaData().concreteSingleIndex(request.index(), request.indicesOptions());
+                concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, request);
             } else {
                 concreteSingleIndex = request.index();
             }

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -44,8 +45,9 @@ public class TransportShardMultiTermsVectorAction extends TransportSingleShardAc
 
     @Inject
     public TransportShardMultiTermsVectorAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                                IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters,
+                                                IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters,
+                                                IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ACTION_NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 MultiTermVectorsShardRequest.class, ThreadPool.Names.GET);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -50,8 +51,9 @@ public class TransportTermVectorsAction extends TransportSingleShardAction<TermV
 
     @Inject
     public TransportTermVectorsAction(Settings settings, ClusterService clusterService, TransportService transportService,
-                                      IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters) {
-        super(settings, TermVectorsAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                                      IndicesService indicesService, ThreadPool threadPool, ActionFilters actionFilters,
+                                      IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, TermVectorsAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 TermVectorsRequest.class, ThreadPool.Names.GET);
         this.indicesService = indicesService;
     }

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.single.instance.TransportInstanceSingleOperationAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.PlainShardIterator;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -73,8 +74,9 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     @Inject
     public TransportUpdateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                  TransportIndexAction indexAction, TransportDeleteAction deleteAction, TransportCreateIndexAction createIndexAction,
-                                 UpdateHelper updateHelper, ActionFilters actionFilters, IndicesService indicesService) {
-        super(settings, UpdateAction.NAME, threadPool, clusterService, transportService, actionFilters, UpdateRequest.class);
+                                 UpdateHelper updateHelper, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                                 IndicesService indicesService) {
+        super(settings, UpdateAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver, UpdateRequest.class);
         this.indexAction = indexAction;
         this.deleteAction = deleteAction;
         this.createIndexAction = createIndexAction;

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -79,6 +79,7 @@ public class ClusterModule extends AbstractModule implements SpawnModules {
         bind(MetaDataIndexAliasesService.class).asEagerSingleton();
         bind(MetaDataUpdateSettingsService.class).asEagerSingleton();
         bind(MetaDataIndexTemplateService.class).asEagerSingleton();
+        bind(IndexNameExpressionResolver.class).asEagerSingleton();
 
         bind(RoutingService.class).asEagerSingleton();
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -1,0 +1,606 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.indices.IndexClosedException;
+import org.elasticsearch.indices.IndexMissingException;
+
+import java.util.*;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+
+public class IndexNameExpressionResolver {
+
+    private final ImmutableList<ExpressionResolver> expressionResolvers;
+
+    @Inject
+    public IndexNameExpressionResolver() {
+        expressionResolvers = ImmutableList.<ExpressionResolver>of(new WildcardExpressionResolver());
+    }
+
+    /**
+     * Same as {@link #concreteIndices(ClusterState, IndicesOptions, String...)}, but the index expressions and options
+     * are encapsulated in the specified request.
+     */
+    public String[] concreteIndices(ClusterState state, IndicesRequest request) throws IndexMissingException, IllegalArgumentException {
+        Context context = new Context(state, request.indicesOptions());
+        return concreteIndices(context, request.indices());
+    }
+
+    /**
+     * Translates the provided index expression into actual concrete indices.
+     *
+     * @param state             the cluster state containing all the data to resolve to expressions to concrete indices
+     * @param options           defines how the aliases or indices need to be resolved to concrete indices
+     * @param indexExpressions  expressions that can be resolved to alias or index names.
+     * @return the resolved concrete indices based on the cluster state, indices options and index expressions
+     * @throws IndexMissingException if one of the index expressions is pointing to a missing index or alias and the
+     * provided indices options in the context don't allow such a case, or if the final result of the indices resolution
+     * contains no indices and the indices options in the context don't allow such a case.
+     * @throws IllegalArgumentException if one of the aliases resolve to multiple indices and the provided
+     * indices options in the context don't allow such a case.
+     */
+    public String[] concreteIndices(ClusterState state, IndicesOptions options, String... indexExpressions) throws IndexMissingException, IllegalArgumentException {
+        Context context = new Context(state, options);
+        return concreteIndices(context, indexExpressions);
+    }
+
+    String[] concreteIndices(Context context, String... indexExpressions) throws IndexMissingException, IllegalArgumentException {
+        if (indexExpressions == null || indexExpressions.length == 0) {
+            indexExpressions = new String[]{MetaData.ALL};
+        }
+        MetaData metaData = context.getState().metaData();
+        IndicesOptions options = context.getOptions();
+        boolean failClosed = options.forbidClosedIndices() && options.ignoreUnavailable() == false;
+        boolean failNoIndices = options.ignoreUnavailable() == false;
+        // If only one index is specified then whether we fail a request if an index is missing depends on the allow_no_indices
+        // option. At some point we should change this, because there shouldn't be a reason why whether a single index
+        // or multiple indices are specified yield different behaviour.
+        if (indexExpressions.length == 1) {
+            failNoIndices = options.allowNoIndices() == false;
+        }
+
+        List<String> expressions = Arrays.asList(indexExpressions);
+        for (ExpressionResolver expressionResolver : expressionResolvers) {
+            expressions = expressionResolver.resolve(context, expressions);
+        }
+
+        if (expressions.isEmpty()) {
+            if (!options.allowNoIndices()) {
+                throw new IndexMissingException(new Index(Arrays.toString(indexExpressions)));
+            } else {
+                return Strings.EMPTY_ARRAY;
+            }
+        }
+
+        List<String> concreteIndices = new ArrayList<>(expressions.size());
+        for (String expression : expressions) {
+            List<IndexMetaData> indexMetaDatas;
+            IndexMetaData indexMetaData = metaData.getIndices().get(expression);
+            if (indexMetaData == null) {
+                ImmutableOpenMap<String, AliasMetaData> indexAliasMap = metaData.aliases().get(expression);
+                if (indexAliasMap == null) {
+                    if (failNoIndices) {
+                        throw new IndexMissingException(new Index(expression));
+                    } else {
+                        continue;
+                    }
+                }
+                if (indexAliasMap.size() > 1 && !options.allowAliasesToMultipleIndices()) {
+                    throw new IllegalArgumentException("Alias [" + expression + "] has more than one indices associated with it [" + Arrays.toString(indexAliasMap.keys().toArray(String.class)) + "], can't execute a single index op");
+                }
+                indexMetaDatas = new ArrayList<>(indexAliasMap.size());
+                for (ObjectObjectCursor<String, AliasMetaData> cursor : indexAliasMap) {
+                    indexMetaDatas.add(metaData.getIndices().get(cursor.key));
+                }
+            } else {
+                indexMetaDatas = Collections.singletonList(indexMetaData);
+            }
+
+            for (IndexMetaData found : indexMetaDatas) {
+                if (found.getState() == IndexMetaData.State.CLOSE) {
+                    if (failClosed) {
+                        throw new IndexClosedException(new Index(found.getIndex()));
+                    } else {
+                        if (options.forbidClosedIndices() == false) {
+                            concreteIndices.add(found.getIndex());
+                        }
+                    }
+                } else if (found.getState() == IndexMetaData.State.OPEN) {
+                    concreteIndices.add(found.getIndex());
+                } else {
+                    throw new IllegalStateException("index state [" + found.getState() + "] not supported");
+                }
+            }
+        }
+
+        if (options.allowNoIndices() == false && concreteIndices.isEmpty()) {
+            throw new IndexMissingException(new Index(Arrays.toString(indexExpressions)));
+        }
+        return concreteIndices.toArray(new String[concreteIndices.size()]);
+    }
+
+    /**
+     * Utility method that allows to resolve an index expression to its corresponding single concrete index.
+     * Callers should make sure they provide proper {@link org.elasticsearch.action.support.IndicesOptions}
+     * that require a single index as a result. The indices resolution must in fact return a single index when
+     * using this method, an {@link IllegalArgumentException} gets thrown otherwise.
+     *
+     * @param request   request containing the index or alias to be resolved to concrete index and
+     *                  the indices options to be used for the index resolution
+     * @throws IndexMissingException    if the resolved index or alias provided doesn't exist
+     * @throws IllegalArgumentException if the index resolution lead to more than one index
+     * @return the concrete index obtained as a result of the index resolution
+     */
+    public String concreteSingleIndex(ClusterState state, IndicesRequest request) throws IndexMissingException, IllegalArgumentException {
+        String indexOrAlias = request.indices() != null && request.indices().length > 0 ? request.indices()[0] : null;
+        String[] indices = concreteIndices(state, request.indicesOptions(), indexOrAlias);
+        if (indices.length != 1) {
+            throw new IllegalArgumentException("unable to return a single index as the index and options provided got resolved to multiple indices");
+        }
+        return indices[0];
+    }
+
+    /**
+     * Iterates through the list of indices and selects the effective list of filtering aliases for the
+     * given index.
+     * <p/>
+     * <p>Only aliases with filters are returned. If the indices list contains a non-filtering reference to
+     * the index itself - null is returned. Returns <tt>null</tt> if no filtering is required.</p>
+     */
+    public String[] filteringAliases(ClusterState state, String index, String... expressions) {
+        // expand the aliases wildcard
+        List<String> resolvedExpressions = Arrays.asList(expressions);
+        Context context = new Context(state, IndicesOptions.lenientExpandOpen());
+        for (ExpressionResolver expressionResolver : expressionResolvers) {
+            resolvedExpressions = expressionResolver.resolve(context, resolvedExpressions);
+        }
+
+        if (isAllIndices(resolvedExpressions)) {
+            return null;
+        }
+        // optimize for the most common single index/alias scenario
+        if (resolvedExpressions.size() == 1) {
+            String alias = resolvedExpressions.get(0);
+            IndexMetaData indexMetaData = state.metaData().getIndices().get(index);
+            if (indexMetaData == null) {
+                // Shouldn't happen
+                throw new IndexMissingException(new Index(index));
+            }
+            AliasMetaData aliasMetaData = indexMetaData.aliases().get(alias);
+            boolean filteringRequired = aliasMetaData != null && aliasMetaData.filteringRequired();
+            if (!filteringRequired) {
+                return null;
+            }
+            return new String[]{alias};
+        }
+        List<String> filteringAliases = null;
+        for (String alias : resolvedExpressions) {
+            if (alias.equals(index)) {
+                return null;
+            }
+
+            IndexMetaData indexMetaData = state.metaData().getIndices().get(index);
+            if (indexMetaData == null) {
+                // Shouldn't happen
+                throw new IndexMissingException(new Index(index));
+            }
+
+            AliasMetaData aliasMetaData = indexMetaData.aliases().get(alias);
+            // Check that this is an alias for the current index
+            // Otherwise - skip it
+            if (aliasMetaData != null) {
+                boolean filteringRequired = aliasMetaData.filteringRequired();
+                if (filteringRequired) {
+                    // If filtering required - add it to the list of filters
+                    if (filteringAliases == null) {
+                        filteringAliases = newArrayList();
+                    }
+                    filteringAliases.add(alias);
+                } else {
+                    // If not, we have a non filtering alias for this index - no filtering needed
+                    return null;
+                }
+            }
+        }
+        if (filteringAliases == null) {
+            return null;
+        }
+        return filteringAliases.toArray(new String[filteringAliases.size()]);
+    }
+
+    /**
+     * Resolves the search routing if in the expression aliases are used. If expressions point to concrete indices
+     * or aliases with no routing defined the specified routing is used.
+     *
+     * @return routing values grouped by concrete index
+     */
+    public Map<String, Set<String>> resolveSearchRouting(ClusterState state, @Nullable String routing, String... expressions) {
+        List<String> resolvedExpressions = expressions != null ? Arrays.asList(expressions) : Collections.<String>emptyList();
+        Context context = new Context(state, IndicesOptions.lenientExpandOpen());
+        for (ExpressionResolver expressionResolver : expressionResolvers) {
+            resolvedExpressions = expressionResolver.resolve(context, resolvedExpressions);
+        }
+
+        if (isAllIndices(resolvedExpressions)) {
+            return resolveSearchRoutingAllIndices(state.metaData(), routing);
+        }
+
+        if (resolvedExpressions.size() == 1) {
+            return resolveSearchRoutingSingleValue(state.metaData(), routing, resolvedExpressions.get(0));
+        }
+
+        Map<String, Set<String>> routings = null;
+        Set<String> paramRouting = null;
+        // List of indices that don't require any routing
+        Set<String> norouting = new HashSet<>();
+        if (routing != null) {
+            paramRouting = Strings.splitStringByCommaToSet(routing);
+        }
+
+        for (String expression : resolvedExpressions) {
+            ImmutableOpenMap<String, AliasMetaData> indexToRoutingMap = state.metaData().getAliases().get(expression);
+            if (indexToRoutingMap != null && !indexToRoutingMap.isEmpty()) {
+                for (ObjectObjectCursor<String, AliasMetaData> indexRouting : indexToRoutingMap) {
+                    if (!norouting.contains(indexRouting.key)) {
+                        if (!indexRouting.value.searchRoutingValues().isEmpty()) {
+                            // Routing alias
+                            if (routings == null) {
+                                routings = newHashMap();
+                            }
+                            Set<String> r = routings.get(indexRouting.key);
+                            if (r == null) {
+                                r = new HashSet<>();
+                                routings.put(indexRouting.key, r);
+                            }
+                            r.addAll(indexRouting.value.searchRoutingValues());
+                            if (paramRouting != null) {
+                                r.retainAll(paramRouting);
+                            }
+                            if (r.isEmpty()) {
+                                routings.remove(indexRouting.key);
+                            }
+                        } else {
+                            // Non-routing alias
+                            if (!norouting.contains(indexRouting.key)) {
+                                norouting.add(indexRouting.key);
+                                if (paramRouting != null) {
+                                    Set<String> r = new HashSet<>(paramRouting);
+                                    if (routings == null) {
+                                        routings = newHashMap();
+                                    }
+                                    routings.put(indexRouting.key, r);
+                                } else {
+                                    if (routings != null) {
+                                        routings.remove(indexRouting.key);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Index
+                if (!norouting.contains(expression)) {
+                    norouting.add(expression);
+                    if (paramRouting != null) {
+                        Set<String> r = new HashSet<>(paramRouting);
+                        if (routings == null) {
+                            routings = newHashMap();
+                        }
+                        routings.put(expression, r);
+                    } else {
+                        if (routings != null) {
+                            routings.remove(expression);
+                        }
+                    }
+                }
+            }
+
+        }
+        if (routings == null || routings.isEmpty()) {
+            return null;
+        }
+        return routings;
+    }
+
+    private Map<String, Set<String>> resolveSearchRoutingSingleValue(MetaData metaData, @Nullable String routing, String aliasOrIndex) {
+        Map<String, Set<String>> routings = null;
+        Set<String> paramRouting = null;
+        if (routing != null) {
+            paramRouting = Strings.splitStringByCommaToSet(routing);
+        }
+
+        ImmutableOpenMap<String, AliasMetaData> indexToRoutingMap = metaData.getAliases().get(aliasOrIndex);
+        if (indexToRoutingMap != null && !indexToRoutingMap.isEmpty()) {
+            // It's an alias
+            for (ObjectObjectCursor<String, AliasMetaData> indexRouting : indexToRoutingMap) {
+                if (!indexRouting.value.searchRoutingValues().isEmpty()) {
+                    // Routing alias
+                    Set<String> r = new HashSet<>(indexRouting.value.searchRoutingValues());
+                    if (paramRouting != null) {
+                        r.retainAll(paramRouting);
+                    }
+                    if (!r.isEmpty()) {
+                        if (routings == null) {
+                            routings = newHashMap();
+                        }
+                        routings.put(indexRouting.key, r);
+                    }
+                } else {
+                    // Non-routing alias
+                    if (paramRouting != null) {
+                        Set<String> r = new HashSet<>(paramRouting);
+                        if (routings == null) {
+                            routings = newHashMap();
+                        }
+                        routings.put(indexRouting.key, r);
+                    }
+                }
+            }
+        } else {
+            // It's an index
+            if (paramRouting != null) {
+                routings = ImmutableMap.of(aliasOrIndex, paramRouting);
+            }
+        }
+        return routings;
+    }
+
+    /**
+     * Sets the same routing for all indices
+     */
+    private Map<String, Set<String>> resolveSearchRoutingAllIndices(MetaData metaData, String routing) {
+        if (routing != null) {
+            Set<String> r = Strings.splitStringByCommaToSet(routing);
+            Map<String, Set<String>> routings = newHashMap();
+            String[] concreteIndices = metaData.concreteAllIndices();
+            for (String index : concreteIndices) {
+                routings.put(index, r);
+            }
+            return routings;
+        }
+        return null;
+    }
+
+    /**
+     * Identifies whether the array containing index names given as argument refers to all indices
+     * The empty or null array identifies all indices
+     *
+     * @param aliasesOrIndices the array containing index names
+     * @return true if the provided array maps to all indices, false otherwise
+     */
+    static boolean isAllIndices(List<String> aliasesOrIndices) {
+        return aliasesOrIndices == null || aliasesOrIndices.isEmpty() || isExplicitAllPattern(aliasesOrIndices);
+    }
+
+    /**
+     * Identifies whether the array containing index names given as argument explicitly refers to all indices
+     * The empty or null array doesn't explicitly map to all indices
+     *
+     * @param aliasesOrIndices the array containing index names
+     * @return true if the provided array explicitly maps to all indices, false otherwise
+     */
+    static boolean isExplicitAllPattern(List<String> aliasesOrIndices) {
+        return aliasesOrIndices != null && aliasesOrIndices.size() == 1 && MetaData.ALL.equals(aliasesOrIndices.get(0));
+    }
+
+    /**
+     * Identifies whether the first argument (an array containing index names) is a pattern that matches all indices
+     *
+     * @param indicesOrAliases the array containing index names
+     * @param concreteIndices  array containing the concrete indices that the first argument refers to
+     * @return true if the first argument is a pattern that maps to all available indices, false otherwise
+     */
+    boolean isPatternMatchingAllIndices(MetaData metaData, String[] indicesOrAliases, String[] concreteIndices) {
+        // if we end up matching on all indices, check, if its a wildcard parameter, or a "-something" structure
+        if (concreteIndices.length == metaData.concreteAllIndices().length && indicesOrAliases.length > 0) {
+
+            //we might have something like /-test1,+test1 that would identify all indices
+            //or something like /-test1 with test1 index missing and IndicesOptions.lenient()
+            if (indicesOrAliases[0].charAt(0) == '-') {
+                return true;
+            }
+
+            //otherwise we check if there's any simple regex
+            for (String indexOrAlias : indicesOrAliases) {
+                if (Regex.isSimpleMatchPattern(indexOrAlias)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    final static class Context {
+
+        private final ClusterState state;
+        private final IndicesOptions options;
+
+        Context(ClusterState state, IndicesOptions options) {
+            this.state = state;
+            this.options = options;
+        }
+
+        public ClusterState getState() {
+            return state;
+        }
+
+        public IndicesOptions getOptions() {
+            return options;
+        }
+    }
+
+    private interface ExpressionResolver {
+
+        /**
+         * Resolves the list of expressions into other expressions if possible (possible concrete indices and aliases, but
+         * that isn't required). The provided implementations can also be left untouched.
+         *
+         * @return a new list with expressions based on the provided expressions
+         */
+        List<String> resolve(Context context, List<String> expressions);
+
+    }
+
+    /**
+     * Resolves alias/index name expressions with wildcards into the corresponding concrete indices/aliases
+     */
+    final static class WildcardExpressionResolver implements ExpressionResolver {
+
+        @Override
+        public List<String> resolve(Context context, List<String> expressions) {
+            IndicesOptions options = context.getOptions();
+            MetaData metaData = context.getState().metaData();
+            if (options.expandWildcardsClosed() == false && options.expandWildcardsOpen() == false) {
+                return expressions;
+            }
+
+            if (expressions.isEmpty() || (expressions.size() == 1 && MetaData.ALL.equals(expressions.get(0)))) {
+                if (options.expandWildcardsOpen() && options.expandWildcardsClosed()) {
+                    return Arrays.asList(metaData.concreteAllIndices());
+                } else if (options.expandWildcardsOpen()) {
+                    return Arrays.asList(metaData.concreteAllOpenIndices());
+                } else if (options.expandWildcardsClosed()) {
+                    return Arrays.asList(metaData.concreteAllClosedIndices());
+                } else {
+                    return Collections.emptyList();
+                }
+            }
+
+            Set<String> result = null;
+            for (int i = 0; i < expressions.size(); i++) {
+                String aliasOrIndex = expressions.get(i);
+                if (metaData.getAliasAndIndexMap().containsKey(aliasOrIndex)) {
+                    if (result != null) {
+                        result.add(aliasOrIndex);
+                    }
+                    continue;
+                }
+                boolean add = true;
+                if (aliasOrIndex.charAt(0) == '+') {
+                    // if its the first, add empty result set
+                    if (i == 0) {
+                        result = new HashSet<>();
+                    }
+                    add = true;
+                    aliasOrIndex = aliasOrIndex.substring(1);
+                } else if (aliasOrIndex.charAt(0) == '-') {
+                    // if its the first, fill it with all the indices...
+                    if (i == 0) {
+                        String[] concreteIndices;
+                        if (options.expandWildcardsOpen() && options.expandWildcardsClosed()) {
+                            concreteIndices = metaData.concreteAllIndices();
+                        } else if (options.expandWildcardsOpen()) {
+                            concreteIndices = metaData.concreteAllOpenIndices();
+                        } else if (options.expandWildcardsClosed()) {
+                            concreteIndices = metaData.concreteAllClosedIndices();
+                        } else {
+                            assert false : "Shouldn't end up here";
+                            concreteIndices = Strings.EMPTY_ARRAY;
+                        }
+                        result = new HashSet<>(Arrays.asList(concreteIndices));
+                    }
+                    add = false;
+                    aliasOrIndex = aliasOrIndex.substring(1);
+                }
+                if (!Regex.isSimpleMatchPattern(aliasOrIndex)) {
+                    if (!options.ignoreUnavailable() && !metaData.getAliasAndIndexMap().containsKey(aliasOrIndex)) {
+                        throw new IndexMissingException(new Index(aliasOrIndex));
+                    }
+                    if (result != null) {
+                        if (add) {
+                            result.add(aliasOrIndex);
+                        } else {
+                            result.remove(aliasOrIndex);
+                        }
+                    }
+                    continue;
+                }
+                if (result == null) {
+                    // add all the previous ones...
+                    result = new HashSet<>();
+                    result.addAll(expressions.subList(0, i));
+                }
+                String[] indices;
+                if (options.expandWildcardsOpen() && options.expandWildcardsClosed()) {
+                    indices = metaData.concreteAllIndices();
+                } else if (options.expandWildcardsOpen()) {
+                    indices = metaData.concreteAllOpenIndices();
+                } else if (options.expandWildcardsClosed()) {
+                    indices = metaData.concreteAllClosedIndices();
+                } else {
+                    assert false : "this shouldn't get called if wildcards expand to none";
+                    indices = Strings.EMPTY_ARRAY;
+                }
+                boolean found = false;
+                // iterating over all concrete indices and see if there is a wildcard match
+                for (String index : indices) {
+                    if (Regex.simpleMatch(aliasOrIndex, index)) {
+                        found = true;
+                        if (add) {
+                            result.add(index);
+                        } else {
+                            result.remove(index);
+                        }
+                    }
+                }
+                // iterating over all aliases and see if there is a wildcard match
+                for (ObjectCursor<String> cursor : metaData.getAliases().keys()) {
+                    String alias = cursor.value;
+                    if (Regex.simpleMatch(aliasOrIndex, alias)) {
+                        found = true;
+                        if (add) {
+                            result.add(alias);
+                        } else {
+                            result.remove(alias);
+                        }
+                    }
+                }
+                if (!found && !options.allowNoIndices()) {
+                    throw new IndexMissingException(new Index(aliasOrIndex));
+                }
+            }
+            if (result == null) {
+                return expressions;
+            }
+            if (result.isEmpty() && !options.allowNoIndices()) {
+                throw new IndexMissingException(new Index(StringUtils.join(expressions.iterator(), ',')));
+            }
+            return new ArrayList<>(result);
+        }
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -25,11 +25,12 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.base.Predicate;
 import com.google.common.collect.*;
-
 import org.apache.lucene.util.CollectionUtil;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.cluster.*;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.cluster.Diffable;
+import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.DiffableUtils.KeyedReader;
+import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
@@ -47,7 +48,6 @@ import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.xcontent.*;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.store.IndicesStore;
@@ -58,8 +58,6 @@ import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 import java.io.IOException;
 import java.util.*;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.common.settings.Settings.*;
 
 public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData> {
@@ -281,6 +279,10 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData> {
         return aliases();
     }
 
+    public ImmutableOpenMap<String, String[]> getAliasAndIndexMap() {
+        return aliasAndIndexToIndexMap;
+    }
+
     /**
      * Finds the specific index aliases that match with the specified aliases directly or partially via wildcards and
      * that point to the specified concrete indices or match partially with the indices via wildcards.
@@ -471,6 +473,8 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData> {
     /**
      * Returns indexing routing for the given index.
      */
+    // TODO: This can be moved to IndexNameExpressionResolver too, but this means that we will support wildcards and other expressions
+    // in the index,bulk,update and delete apis.
     public String resolveIndexRouting(@Nullable String routing, String aliasOrIndex) {
         // Check if index is specified by an alias
         ImmutableOpenMap<String, AliasMetaData> indexAliases = aliases.get(aliasOrIndex);
@@ -495,441 +499,6 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData> {
             }
         }
         return routing;
-    }
-
-    public Map<String, Set<String>> resolveSearchRouting(@Nullable String routing, String aliasOrIndex) {
-        return resolveSearchRouting(routing, convertFromWildcards(new String[]{aliasOrIndex}, IndicesOptions.lenientExpandOpen()));
-    }
-
-    public Map<String, Set<String>> resolveSearchRouting(@Nullable String routing, String[] aliasesOrIndices) {
-        if (isAllIndices(aliasesOrIndices)) {
-            return resolveSearchRoutingAllIndices(routing);
-        }
-
-        aliasesOrIndices = convertFromWildcards(aliasesOrIndices, IndicesOptions.lenientExpandOpen());
-
-        if (aliasesOrIndices.length == 1) {
-            return resolveSearchRoutingSingleValue(routing, aliasesOrIndices[0]);
-        }
-
-        Map<String, Set<String>> routings = null;
-        Set<String> paramRouting = null;
-        // List of indices that don't require any routing
-        Set<String> norouting = new HashSet<>();
-        if (routing != null) {
-            paramRouting = Strings.splitStringByCommaToSet(routing);
-        }
-
-        for (String aliasOrIndex : aliasesOrIndices) {
-            ImmutableOpenMap<String, AliasMetaData> indexToRoutingMap = aliases.get(aliasOrIndex);
-            if (indexToRoutingMap != null && !indexToRoutingMap.isEmpty()) {
-                for (ObjectObjectCursor<String, AliasMetaData> indexRouting : indexToRoutingMap) {
-                    if (!norouting.contains(indexRouting.key)) {
-                        if (!indexRouting.value.searchRoutingValues().isEmpty()) {
-                            // Routing alias
-                            if (routings == null) {
-                                routings = newHashMap();
-                            }
-                            Set<String> r = routings.get(indexRouting.key);
-                            if (r == null) {
-                                r = new HashSet<>();
-                                routings.put(indexRouting.key, r);
-                            }
-                            r.addAll(indexRouting.value.searchRoutingValues());
-                            if (paramRouting != null) {
-                                r.retainAll(paramRouting);
-                            }
-                            if (r.isEmpty()) {
-                                routings.remove(indexRouting.key);
-                            }
-                        } else {
-                            // Non-routing alias
-                            if (!norouting.contains(indexRouting.key)) {
-                                norouting.add(indexRouting.key);
-                                if (paramRouting != null) {
-                                    Set<String> r = new HashSet<>(paramRouting);
-                                    if (routings == null) {
-                                        routings = newHashMap();
-                                    }
-                                    routings.put(indexRouting.key, r);
-                                } else {
-                                    if (routings != null) {
-                                        routings.remove(indexRouting.key);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            } else {
-                // Index
-                if (!norouting.contains(aliasOrIndex)) {
-                    norouting.add(aliasOrIndex);
-                    if (paramRouting != null) {
-                        Set<String> r = new HashSet<>(paramRouting);
-                        if (routings == null) {
-                            routings = newHashMap();
-                        }
-                        routings.put(aliasOrIndex, r);
-                    } else {
-                        if (routings != null) {
-                            routings.remove(aliasOrIndex);
-                        }
-                    }
-                }
-            }
-
-        }
-        if (routings == null || routings.isEmpty()) {
-            return null;
-        }
-        return routings;
-    }
-
-    private Map<String, Set<String>> resolveSearchRoutingSingleValue(@Nullable String routing, String aliasOrIndex) {
-        Map<String, Set<String>> routings = null;
-        Set<String> paramRouting = null;
-        if (routing != null) {
-            paramRouting = Strings.splitStringByCommaToSet(routing);
-        }
-
-        ImmutableOpenMap<String, AliasMetaData> indexToRoutingMap = aliases.get(aliasOrIndex);
-        if (indexToRoutingMap != null && !indexToRoutingMap.isEmpty()) {
-            // It's an alias
-            for (ObjectObjectCursor<String, AliasMetaData> indexRouting : indexToRoutingMap) {
-                if (!indexRouting.value.searchRoutingValues().isEmpty()) {
-                    // Routing alias
-                    Set<String> r = new HashSet<>(indexRouting.value.searchRoutingValues());
-                    if (paramRouting != null) {
-                        r.retainAll(paramRouting);
-                    }
-                    if (!r.isEmpty()) {
-                        if (routings == null) {
-                            routings = newHashMap();
-                        }
-                        routings.put(indexRouting.key, r);
-                    }
-                } else {
-                    // Non-routing alias
-                    if (paramRouting != null) {
-                        Set<String> r = new HashSet<>(paramRouting);
-                        if (routings == null) {
-                            routings = newHashMap();
-                        }
-                        routings.put(indexRouting.key, r);
-                    }
-                }
-            }
-        } else {
-            // It's an index
-            if (paramRouting != null) {
-                routings = ImmutableMap.of(aliasOrIndex, paramRouting);
-            }
-        }
-        return routings;
-    }
-
-    /**
-     * Sets the same routing for all indices
-     */
-    private Map<String, Set<String>> resolveSearchRoutingAllIndices(String routing) {
-        if (routing != null) {
-            Set<String> r = Strings.splitStringByCommaToSet(routing);
-            Map<String, Set<String>> routings = newHashMap();
-            String[] concreteIndices = concreteAllIndices();
-            for (String index : concreteIndices) {
-                routings.put(index, r);
-            }
-            return routings;
-        }
-        return null;
-    }
-
-
-    /**
-     * Translates the provided indices or aliases, eventually containing wildcard expressions, into actual indices.
-     *
-     * @param indicesOptions   how the aliases or indices need to be resolved to concrete indices
-     * @param aliasesOrIndices the aliases or indices to be resolved to concrete indices
-     * @return the obtained concrete indices
-     * @throws IndexMissingException if one of the aliases or indices is missing and the provided indices options
-     * don't allow such a case, or if the final result of the indices resolution is no indices and the indices options
-     * don't allow such a case.
-     * @throws IllegalArgumentException if one of the aliases resolve to multiple indices and the provided
-     * indices options don't allow such a case.
-     */
-    public String[] concreteIndices(IndicesOptions indicesOptions, String... aliasesOrIndices) throws IndexMissingException, IllegalArgumentException {
-        if (indicesOptions.expandWildcardsOpen() || indicesOptions.expandWildcardsClosed()) {
-            if (isAllIndices(aliasesOrIndices)) {
-                String[] concreteIndices;
-                if (indicesOptions.expandWildcardsOpen() && indicesOptions.expandWildcardsClosed()) {
-                    concreteIndices = concreteAllIndices();
-                } else if (indicesOptions.expandWildcardsOpen()) {
-                    concreteIndices = concreteAllOpenIndices();
-                } else {
-                    concreteIndices = concreteAllClosedIndices();
-                }
-
-                if (!indicesOptions.allowNoIndices() && concreteIndices.length == 0) {
-                    throw new IndexMissingException(new Index("_all"));
-                }
-                return concreteIndices;
-            }
-
-            aliasesOrIndices = convertFromWildcards(aliasesOrIndices, indicesOptions);
-        }
-
-        if (aliasesOrIndices == null || aliasesOrIndices.length == 0) {
-            if (!indicesOptions.allowNoIndices()) {
-                throw new IllegalArgumentException("no indices were specified and wildcard expansion is disabled.");
-            } else {
-                return Strings.EMPTY_ARRAY;
-            }
-        }
-
-        boolean failClosed = indicesOptions.forbidClosedIndices() && !indicesOptions.ignoreUnavailable();
-
-        // optimize for single element index (common case)
-        if (aliasesOrIndices.length == 1) {
-            return concreteIndices(aliasesOrIndices[0], indicesOptions, !indicesOptions.allowNoIndices());
-        }
-
-        // check if its a possible aliased index, if not, just return the passed array
-        boolean possiblyAliased = false;
-        boolean closedIndices = false;
-        for (String index : aliasesOrIndices) {
-            IndexMetaData indexMetaData = indices.get(index);
-            if (indexMetaData == null) {
-                possiblyAliased = true;
-                break;
-            } else {
-                if (indicesOptions.forbidClosedIndices() && indexMetaData.getState() == IndexMetaData.State.CLOSE) {
-                    if (failClosed) {
-                        throw new IndexClosedException(new Index(index));
-                    } else {
-                        closedIndices = true;
-                    }
-                }
-            }
-        }
-        if (!possiblyAliased) {
-            if (closedIndices) {
-                Set<String> actualIndices = new HashSet<>(Arrays.asList(aliasesOrIndices));
-                actualIndices.retainAll(new HashSet<Object>(Arrays.asList(allOpenIndices)));
-                return actualIndices.toArray(new String[actualIndices.size()]);
-            } else {
-                return aliasesOrIndices;
-            }
-        }
-
-        Set<String> actualIndices = new HashSet<>();
-        for (String aliasOrIndex : aliasesOrIndices) {
-            String[] indices = concreteIndices(aliasOrIndex, indicesOptions, !indicesOptions.ignoreUnavailable());
-            Collections.addAll(actualIndices, indices);
-        }
-
-        if (!indicesOptions.allowNoIndices() && actualIndices.isEmpty()) {
-            throw new IndexMissingException(new Index(Arrays.toString(aliasesOrIndices)));
-        }
-        return actualIndices.toArray(new String[actualIndices.size()]);
-    }
-
-    /**
-     * Utility method that allows to resolve an index or alias to its corresponding single concrete index.
-     * Callers should make sure they provide proper {@link org.elasticsearch.action.support.IndicesOptions}
-     * that require a single index as a result. The indices resolution must in fact return a single index when
-     * using this method, an {@link IllegalArgumentException} gets thrown otherwise.
-     *
-     * @param indexOrAlias   the index or alias to be resolved to concrete index
-     * @param indicesOptions the indices options to be used for the index resolution
-     * @return the concrete index obtained as a result of the index resolution
-     * @throws IndexMissingException                 if the index or alias provided doesn't exist
-     * @throws IllegalArgumentException if the index resolution lead to more than one index
-     */
-    public String concreteSingleIndex(String indexOrAlias, IndicesOptions indicesOptions) throws IndexMissingException, IllegalArgumentException {
-        String[] indices = concreteIndices(indicesOptions, indexOrAlias);
-        if (indices.length != 1) {
-            throw new IllegalArgumentException("unable to return a single index as the index and options provided got resolved to multiple indices");
-        }
-        return indices[0];
-    }
-
-    private String[] concreteIndices(String aliasOrIndex, IndicesOptions options, boolean failNoIndices) throws IndexMissingException, IllegalArgumentException {
-        boolean failClosed = options.forbidClosedIndices() && !options.ignoreUnavailable();
-
-        // a quick check, if this is an actual index, if so, return it
-        IndexMetaData indexMetaData = indices.get(aliasOrIndex);
-        if (indexMetaData != null) {
-            if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
-                if (failClosed) {
-                    throw new IndexClosedException(new Index(aliasOrIndex));
-                } else {
-                    return options.forbidClosedIndices() ? Strings.EMPTY_ARRAY : new String[]{aliasOrIndex};
-                }
-            } else {
-                return new String[]{aliasOrIndex};
-            }
-        }
-        // not an actual index, fetch from an alias
-        String[] indices = aliasAndIndexToIndexMap.getOrDefault(aliasOrIndex, Strings.EMPTY_ARRAY);
-        if (indices.length == 0 && failNoIndices) {
-            throw new IndexMissingException(new Index(aliasOrIndex));
-        }
-        if (indices.length > 1 && !options.allowAliasesToMultipleIndices()) {
-            throw new IllegalArgumentException("Alias [" + aliasOrIndex + "] has more than one indices associated with it [" + Arrays.toString(indices) + "], can't execute a single index op");
-        }
-
-        // No need to check whether indices referred by aliases are closed, because there are no closed indices.
-        if (allClosedIndices.length == 0) {
-            return indices;
-        }
-
-        switch (indices.length) {
-            case 0:
-                return indices;
-            case 1:
-                indexMetaData = this.indices.get(indices[0]);
-                if (indexMetaData != null && indexMetaData.getState() == IndexMetaData.State.CLOSE) {
-                    if (failClosed) {
-                        throw new IndexClosedException(new Index(indexMetaData.getIndex()));
-                    } else {
-                        if (options.forbidClosedIndices()) {
-                            return Strings.EMPTY_ARRAY;
-                        }
-                    }
-                }
-                return indices;
-            default:
-                ObjectArrayList<String> concreteIndices = new ObjectArrayList<>();
-                for (String index : indices) {
-                    indexMetaData = this.indices.get(index);
-                    if (indexMetaData != null) {
-                        if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
-                            if (failClosed) {
-                                throw new IndexClosedException(new Index(indexMetaData.getIndex()));
-                            } else if (!options.forbidClosedIndices()) {
-                                concreteIndices.add(index);
-                            }
-                        } else if (indexMetaData.getState() == IndexMetaData.State.OPEN) {
-                            concreteIndices.add(index);
-                        } else {
-                            throw new IllegalStateException("index state [" + indexMetaData.getState() + "] not supported");
-                        }
-                    }
-                }
-                return concreteIndices.toArray(String.class);
-        }
-    }
-
-    /**
-     * Converts a list of indices or aliases wildcards, and special +/- signs, into their respective full matches. It
-     * won't convert only to indices, but also to aliases. For example, alias_* will expand to alias_1 and alias_2, not
-     * to the respective indices those aliases point to.
-     */
-    public String[] convertFromWildcards(String[] aliasesOrIndices, IndicesOptions indicesOptions) {
-        if (aliasesOrIndices == null) {
-            return null;
-        }
-        Set<String> result = null;
-        for (int i = 0; i < aliasesOrIndices.length; i++) {
-            String aliasOrIndex = aliasesOrIndices[i];
-            if (aliasAndIndexToIndexMap.containsKey(aliasOrIndex)) {
-                if (result != null) {
-                    result.add(aliasOrIndex);
-                }
-                continue;
-            }
-            boolean add = true;
-            if (aliasOrIndex.charAt(0) == '+') {
-                // if its the first, add empty result set
-                if (i == 0) {
-                    result = new HashSet<>();
-                }
-                add = true;
-                aliasOrIndex = aliasOrIndex.substring(1);
-            } else if (aliasOrIndex.charAt(0) == '-') {
-                // if its the first, fill it with all the indices...
-                if (i == 0) {
-                    String[] concreteIndices;
-                    if (indicesOptions.expandWildcardsOpen() && indicesOptions.expandWildcardsClosed()) {
-                        concreteIndices = concreteAllIndices();
-                    } else if (indicesOptions.expandWildcardsOpen()) {
-                        concreteIndices = concreteAllOpenIndices();
-                    } else if (indicesOptions.expandWildcardsClosed()) {
-                        concreteIndices = concreteAllClosedIndices();
-                    } else {
-                        assert false : "Shouldn't end up here";
-                        concreteIndices = Strings.EMPTY_ARRAY;
-                    }
-                    result = new HashSet<>(Arrays.asList(concreteIndices));
-                }
-                add = false;
-                aliasOrIndex = aliasOrIndex.substring(1);
-            }
-            if (!Regex.isSimpleMatchPattern(aliasOrIndex)) {
-                if (!indicesOptions.ignoreUnavailable() && !aliasAndIndexToIndexMap.containsKey(aliasOrIndex)) {
-                    throw new IndexMissingException(new Index(aliasOrIndex));
-                }
-                if (result != null) {
-                    if (add) {
-                        result.add(aliasOrIndex);
-                    } else {
-                        result.remove(aliasOrIndex);
-                    }
-                }
-                continue;
-            }
-            if (result == null) {
-                // add all the previous ones...
-                result = new HashSet<>();
-                result.addAll(Arrays.asList(aliasesOrIndices).subList(0, i));
-            }
-            String[] indices;
-            if (indicesOptions.expandWildcardsOpen() && indicesOptions.expandWildcardsClosed()) {
-                indices = concreteAllIndices();
-            } else if (indicesOptions.expandWildcardsOpen()) {
-                indices = concreteAllOpenIndices();
-            } else if (indicesOptions.expandWildcardsClosed()) {
-                indices = concreteAllClosedIndices();
-            } else {
-                assert false : "convertFromWildcards shouldn't get called if wildcards expansion is disabled";
-                indices = Strings.EMPTY_ARRAY;
-            }
-            boolean found = false;
-            // iterating over all concrete indices and see if there is a wildcard match
-            for (String index : indices) {
-                if (Regex.simpleMatch(aliasOrIndex, index)) {
-                    found = true;
-                    if (add) {
-                        result.add(index);
-                    } else {
-                        result.remove(index);
-                    }
-                }
-            }
-            // iterating over all aliases and see if there is a wildcard match
-            for (ObjectCursor<String> cursor : aliases.keys()) {
-                String alias = cursor.value;
-                if (Regex.simpleMatch(aliasOrIndex, alias)) {
-                    found = true;
-                    if (add) {
-                        result.add(alias);
-                    } else {
-                        result.remove(alias);
-                    }
-                }
-            }
-            if (!found && !indicesOptions.allowNoIndices()) {
-                throw new IndexMissingException(new Index(aliasOrIndex));
-            }
-        }
-        if (result == null) {
-            return aliasesOrIndices;
-        }
-        if (result.isEmpty() && !indicesOptions.allowNoIndices()) {
-            throw new IndexMissingException(new Index(Arrays.toString(aliasesOrIndices)));
-        }
-        return result.toArray(new String[result.size()]);
     }
 
     public boolean hasIndex(String index) {
@@ -988,129 +557,26 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData> {
         return numberOfShards();
     }
 
-
-    /**
-     * Iterates through the list of indices and selects the effective list of filtering aliases for the
-     * given index.
-     * <p/>
-     * <p>Only aliases with filters are returned. If the indices list contains a non-filtering reference to
-     * the index itself - null is returned. Returns <tt>null</tt> if no filtering is required.</p>
-     */
-    public String[] filteringAliases(String index, String... indicesOrAliases) {
-        // expand the aliases wildcard
-        indicesOrAliases = convertFromWildcards(indicesOrAliases, IndicesOptions.lenientExpandOpen());
-
-        if (isAllIndices(indicesOrAliases)) {
-            return null;
-        }
-        // optimize for the most common single index/alias scenario
-        if (indicesOrAliases.length == 1) {
-            String alias = indicesOrAliases[0];
-            IndexMetaData indexMetaData = this.indices.get(index);
-            if (indexMetaData == null) {
-                // Shouldn't happen
-                throw new IndexMissingException(new Index(index));
-            }
-            AliasMetaData aliasMetaData = indexMetaData.aliases().get(alias);
-            boolean filteringRequired = aliasMetaData != null && aliasMetaData.filteringRequired();
-            if (!filteringRequired) {
-                return null;
-            }
-            return new String[]{alias};
-        }
-        List<String> filteringAliases = null;
-        for (String alias : indicesOrAliases) {
-            if (alias.equals(index)) {
-                return null;
-            }
-
-            IndexMetaData indexMetaData = this.indices.get(index);
-            if (indexMetaData == null) {
-                // Shouldn't happen
-                throw new IndexMissingException(new Index(index));
-            }
-
-            AliasMetaData aliasMetaData = indexMetaData.aliases().get(alias);
-            // Check that this is an alias for the current index
-            // Otherwise - skip it
-            if (aliasMetaData != null) {
-                boolean filteringRequired = aliasMetaData.filteringRequired();
-                if (filteringRequired) {
-                    // If filtering required - add it to the list of filters
-                    if (filteringAliases == null) {
-                        filteringAliases = newArrayList();
-                    }
-                    filteringAliases.add(alias);
-                } else {
-                    // If not, we have a non filtering alias for this index - no filtering needed
-                    return null;
-                }
-            }
-        }
-        if (filteringAliases == null) {
-            return null;
-        }
-        return filteringAliases.toArray(new String[filteringAliases.size()]);
-    }
-
-    /**
-     * Identifies whether the array containing index names given as argument refers to all indices
-     * The empty or null array identifies all indices
-     *
-     * @param aliasesOrIndices the array containing index names
-     * @return true if the provided array maps to all indices, false otherwise
-     */
-    public static boolean isAllIndices(String[] aliasesOrIndices) {
-        return aliasesOrIndices == null || aliasesOrIndices.length == 0 || isExplicitAllPattern(aliasesOrIndices);
-    }
-
     /**
      * Identifies whether the array containing type names given as argument refers to all types
      * The empty or null array identifies all types
      *
-     * @param types the array containing index names
-     * @return true if the provided array maps to all indices, false otherwise
+     * @param types the array containing types
+     * @return true if the provided array maps to all types, false otherwise
      */
     public static boolean isAllTypes(String[] types) {
-        return types == null || types.length == 0 || isExplicitAllPattern(types);
+        return types == null || types.length == 0 || isExplicitAllType(types);
     }
 
     /**
-     * Identifies whether the array containing index names given as argument explicitly refers to all indices
-     * The empty or null array doesn't explicitly map to all indices
+     * Identifies whether the array containing type names given as argument explicitly refers to all types
+     * The empty or null array doesn't explicitly map to all types
      *
-     * @param aliasesOrIndices the array containing index names
-     * @return true if the provided array explicitly maps to all indices, false otherwise
+     * @param types the array containing index names
+     * @return true if the provided array explicitly maps to all types, false otherwise
      */
-    public static boolean isExplicitAllPattern(String[] aliasesOrIndices) {
-        return aliasesOrIndices != null && aliasesOrIndices.length == 1 && ALL.equals(aliasesOrIndices[0]);
-    }
-
-    /**
-     * Identifies whether the first argument (an array containing index names) is a pattern that matches all indices
-     *
-     * @param indicesOrAliases the array containing index names
-     * @param concreteIndices  array containing the concrete indices that the first argument refers to
-     * @return true if the first argument is a pattern that maps to all available indices, false otherwise
-     */
-    public boolean isPatternMatchingAllIndices(String[] indicesOrAliases, String[] concreteIndices) {
-        // if we end up matching on all indices, check, if its a wildcard parameter, or a "-something" structure
-        if (concreteIndices.length == concreteAllIndices().length && indicesOrAliases.length > 0) {
-
-            //we might have something like /-test1,+test1 that would identify all indices
-            //or something like /-test1 with test1 index missing and IndicesOptions.lenient()
-            if (indicesOrAliases[0].charAt(0) == '-') {
-                return true;
-            }
-
-            //otherwise we check if there's any simple regex
-            for (String indexOrAlias : indicesOrAliases) {
-                if (Regex.isSimpleMatchPattern(indexOrAlias)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+    public static boolean isExplicitAllType(String[] types) {
+        return types != null && types.length == 1 && ALL.equals(types[0]);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -58,10 +58,13 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
     private final DynamicSettings dynamicSettings;
 
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+
     @Inject
-    public MetaDataUpdateSettingsService(Settings settings, ClusterService clusterService, AllocationService allocationService, @IndexDynamicSettings DynamicSettings dynamicSettings) {
+    public MetaDataUpdateSettingsService(Settings settings, ClusterService clusterService, AllocationService allocationService, @IndexDynamicSettings DynamicSettings dynamicSettings, IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings);
         this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.clusterService.add(this);
         this.allocationService = allocationService;
         this.dynamicSettings = dynamicSettings;
@@ -215,7 +218,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
             @Override
             public ClusterState execute(ClusterState currentState) {
-                String[] actualIndices = currentState.metaData().concreteIndices(IndicesOptions.strictExpand(), request.indices());
+                String[] actualIndices = indexNameExpressionResolver.concreteIndices(currentState, IndicesOptions.strictExpand(), request.indices());
                 RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
                 MetaData.Builder metaDataBuilder = MetaData.builder(currentState.metaData());
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -77,12 +77,12 @@ public class OperationRouting extends AbstractComponent {
         return indexRoutingTable(clusterState, index).groupByShardsIt();
     }
 
-    public int searchShardsCount(ClusterState clusterState, String[] indices, String[] concreteIndices, @Nullable Map<String, Set<String>> routing, @Nullable String preference) throws IndexMissingException {
+    public int searchShardsCount(ClusterState clusterState, String[] concreteIndices, @Nullable Map<String, Set<String>> routing) throws IndexMissingException {
         final Set<IndexShardRoutingTable> shards = computeTargetedShards(clusterState, concreteIndices, routing);
         return shards.size();
     }
 
-    public GroupShardsIterator searchShards(ClusterState clusterState, String[] indices, String[] concreteIndices, @Nullable Map<String, Set<String>> routing, @Nullable String preference) throws IndexMissingException {
+    public GroupShardsIterator searchShards(ClusterState clusterState, String[] concreteIndices, @Nullable Map<String, Set<String>> routing, @Nullable String preference) throws IndexMissingException {
         final Set<IndexShardRoutingTable> shards = computeTargetedShards(clusterState, concreteIndices, routing);
         final Set<ShardIterator> set = new HashSet<>(shards.size());
         for (IndexShardRoutingTable shard : shards) {

--- a/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.*;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
@@ -52,9 +53,11 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
     private GatewayMetaState metaState;
 
     @Inject
-    public TransportNodesListGatewayMetaState(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters) {
+    public TransportNodesListGatewayMetaState(Settings settings, ClusterName clusterName, ThreadPool threadPool,
+                                              ClusterService clusterService, TransportService transportService,
+                                              ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters,
-                Request.class, NodeRequest.class, ThreadPool.Names.GENERIC);
+                indexNameExpressionResolver, Request.class, NodeRequest.class, ThreadPool.Names.GENERIC);
     }
 
     TransportNodesListGatewayMetaState init(GatewayMetaState metaState) {

--- a/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -58,8 +59,10 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
     private final NodeEnvironment nodeEnv;
 
     @Inject
-    public TransportNodesListGatewayStartedShards(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService, ActionFilters actionFilters, NodeEnvironment env) {
-        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters,
+    public TransportNodesListGatewayStartedShards(Settings settings, ClusterName clusterName, ThreadPool threadPool,
+                                                  ClusterService clusterService, TransportService transportService,
+                                                  ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, NodeEnvironment env) {
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 Request.class, NodeRequest.class, ThreadPool.Names.FETCH_SHARD_STARTED);
         this.nodeEnv = env;
     }

--- a/core/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
@@ -44,10 +45,12 @@ public class IndicesQueryParser implements QueryParser {
 
     @Nullable
     private final ClusterService clusterService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     @Inject
-    public IndicesQueryParser(@Nullable ClusterService clusterService) {
+    public IndicesQueryParser(@Nullable ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver) {
         this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
     }
 
     @Override
@@ -150,7 +153,7 @@ public class IndicesQueryParser implements QueryParser {
     }
 
     protected boolean matchesIndices(String currentIndex, String... indices) {
-        final String[] concreteIndices = clusterService.state().metaData().concreteIndices(IndicesOptions.lenientExpandOpen(), indices);
+        final String[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterService.state(), IndicesOptions.lenientExpandOpen(), indices);
         for (String index : concreteIndices) {
             if (Regex.simpleMatch(index, currentIndex)) {
                 return true;

--- a/core/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -70,8 +71,9 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
     @Inject
     public TransportNodesListShardStoreMetaData(Settings settings, ClusterName clusterName, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                                IndicesService indicesService, NodeEnvironment nodeEnv, ActionFilters actionFilters) {
-        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters,
+                                                IndicesService indicesService, NodeEnvironment nodeEnv, ActionFilters actionFilters,
+                                                IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ACTION_NAME, clusterName, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver,
                 Request.class, NodeRequest.class, ThreadPool.Names.FETCH_SHARD_STORE);
         this.indicesService = indicesService;
         this.nodeEnv = nodeEnv;

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -34,6 +34,7 @@ import org.elasticsearch.action.percolate.PercolateShardResponse;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -92,6 +93,7 @@ public class PercolatorService extends AbstractComponent {
     public final static float NO_SCORE = Float.NEGATIVE_INFINITY;
     public final static String TYPE_NAME = ".percolator";
 
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final IndicesService indicesService;
     private final IntObjectHashMap<PercolatorType> percolatorTypes;
     private final PageCacheRecycler pageCacheRecycler;
@@ -112,12 +114,13 @@ public class PercolatorService extends AbstractComponent {
     private final ParseFieldMatcher parseFieldMatcher;
 
     @Inject
-    public PercolatorService(Settings settings, IndicesService indicesService,
+    public PercolatorService(Settings settings, IndexNameExpressionResolver indexNameExpressionResolver, IndicesService indicesService,
                              PageCacheRecycler pageCacheRecycler, BigArrays bigArrays,
                              HighlightPhase highlightPhase, ClusterService clusterService,
                              AggregationPhase aggregationPhase, ScriptService scriptService,
                              MappingUpdatedAction mappingUpdatedAction) {
         super(settings);
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.parseFieldMatcher = new ParseFieldMatcher(settings);
         this.indicesService = indicesService;
         this.pageCacheRecycler = pageCacheRecycler;
@@ -164,7 +167,10 @@ public class PercolatorService extends AbstractComponent {
         shardPercolateService.prePercolate();
         long startTime = System.nanoTime();
 
-        String[] filteringAliases = clusterService.state().getMetaData().filteringAliases(
+        // TODO: The filteringAliases should be looked up at the coordinating node and serialized with all shard request,
+        // just like is done in other apis.
+        String[] filteringAliases = indexNameExpressionResolver.filteringAliases(
+                clusterService.state(),
                 indexShard.shardId().index().name(),
                 request.indices()
         );

--- a/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -64,7 +64,7 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
 
         String actionName = randomAsciiOfLength(randomInt(30));
         ActionFilters actionFilters = new ActionFilters(filters);
-        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters) {
+        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters, null) {
             @Override
             protected void doExecute(TestRequest request, ActionListener<TestResponse> listener) {
                 listener.onResponse(new TestResponse());
@@ -146,7 +146,7 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
 
         String actionName = randomAsciiOfLength(randomInt(30));
         ActionFilters actionFilters = new ActionFilters(filters);
-        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters) {
+        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters, null) {
             @Override
             protected void doExecute(TestRequest request, ActionListener<TestResponse> listener) {
                 listener.onResponse(new TestResponse());
@@ -231,7 +231,7 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
 
         String actionName = randomAsciiOfLength(randomInt(30));
         ActionFilters actionFilters = new ActionFilters(filters);
-        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters) {
+        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters, null) {
             @Override
             protected void doExecute(TestRequest request, ActionListener<TestResponse> listener) {
                 listener.onResponse(new TestResponse());
@@ -289,7 +289,7 @@ public class TransportActionFilterChainTests extends ElasticsearchTestCase {
 
         String actionName = randomAsciiOfLength(randomInt(30));
         ActionFilters actionFilters = new ActionFilters(filters);
-        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters) {
+        TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters, null) {
             @Override
             protected void doExecute(TestRequest request, ActionListener<TestResponse> listener) {
                 listener.onResponse(new TestResponse());

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -693,7 +694,7 @@ public class ShardReplicationTests extends ElasticsearchTestCase {
                ThreadPool threadPool) {
             super(settings, actionName, transportService, clusterService, null, threadPool,
                     new ShardStateAction(settings, clusterService, transportService, null, null), null,
-                    new ActionFilters(new HashSet<ActionFilter>()), Request.class, Request.class, ThreadPool.Names.SAME);
+                    new ActionFilters(new HashSet<ActionFilter>()), new IndexNameExpressionResolver(), Request.class, Request.class, ThreadPool.Names.SAME);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/client/node/NodeClientHeadersTests.java
+++ b/core/src/test/java/org/elasticsearch/client/node/NodeClientHeadersTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.client.node;
 
-import com.google.common.collect.ImmutableSet;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.GenericAction;
@@ -63,7 +61,7 @@ public class NodeClientHeadersTests extends AbstractClientHeadersTests {
     private static class InternalTransportAction extends TransportAction {
 
         private InternalTransportAction(Settings settings, String actionName, ThreadPool threadPool) {
-            super(settings, actionName, threadPool, EMPTY_FILTERS);
+            super(settings, actionName, threadPool, EMPTY_FILTERS, null);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterIndexHealth;
 import org.elasticsearch.action.admin.cluster.health.ClusterShardHealth;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -45,6 +46,7 @@ import static org.hamcrest.Matchers.*;
 
 public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
 
+    private final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
     private void assertIndexHealth(ClusterIndexHealth indexHealth, ShardCounter counter, IndexMetaData indexMetaData) {
         assertThat(indexHealth.getStatus(), equalTo(counter.status()));
@@ -196,7 +198,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         int inFlight = randomIntBetween(0, 200);
         int delayedUnassigned = randomIntBetween(0, 200);
         TimeValue pendingTaskInQueueTime = TimeValue.timeValueMillis(randomIntBetween(1000, 100000));
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, pendingTasks, inFlight, delayedUnassigned, pendingTaskInQueueTime);
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", indexNameExpressionResolver.concreteIndices(clusterState, IndicesOptions.strictExpand(), (String[]) null), clusterState, pendingTasks, inFlight, delayedUnassigned, pendingTaskInQueueTime);
         logger.info("cluster status: {}, expected {}", clusterHealth.getStatus(), counter.status());
         clusterHealth = maybeSerialize(clusterHealth);
         assertClusterHealth(clusterHealth, counter);
@@ -232,7 +234,7 @@ public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
         metaData.put(indexMetaData, true);
         routingTable.add(indexRoutingTable);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", clusterState.metaData().concreteIndices(IndicesOptions.strictExpand(), (String[]) null), clusterState, 0, 0, 0, TimeValue.timeValueMillis(0));
+        ClusterHealthResponse clusterHealth = new ClusterHealthResponse("bla", indexNameExpressionResolver.concreteIndices(clusterState, IndicesOptions.strictExpand(), (String[]) null), clusterState, 0, 0, 0, TimeValue.timeValueMillis(0));
         clusterHealth = maybeSerialize(clusterHealth);
         // currently we have no cluster level validation failures as index validation issues are reported per index.
         assertThat(clusterHealth.getValidationFailures(), Matchers.hasSize(0));

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static org.hamcrest.Matchers.equalTo;
+
+public class WildcardExpressionResolverTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testConvertWildcardsJustIndicesTests() {
+        MetaData.Builder mdBuilder = MetaData.builder()
+                .put(indexBuilder("testXXX"))
+                .put(indexBuilder("testXYY"))
+                .put(indexBuilder("testYYY"))
+                .put(indexBuilder("kuku"));
+        ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
+        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
+
+        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.lenientExpandOpen());
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX"))), equalTo(newHashSet("testXXX")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX", "testYYY"))), equalTo(newHashSet("testXXX", "testYYY")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testXXX", "ku*"))), equalTo(newHashSet("testXXX", "kuku")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("test*"))), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testX*"))), equalTo(newHashSet("testXXX", "testXYY")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testX*", "kuku"))), equalTo(newHashSet("testXXX", "testXYY", "kuku")));
+    }
+
+    @Test
+    public void testConvertWildcardsTests() {
+        MetaData.Builder mdBuilder = MetaData.builder()
+                .put(indexBuilder("testXXX").putAlias(AliasMetaData.builder("alias1")).putAlias(AliasMetaData.builder("alias2")))
+                .put(indexBuilder("testXYY").putAlias(AliasMetaData.builder("alias2")))
+                .put(indexBuilder("testYYY").putAlias(AliasMetaData.builder("alias3")))
+                .put(indexBuilder("kuku"));
+        ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
+        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
+
+        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.lenientExpandOpen());
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testYY*", "alias*"))), equalTo(newHashSet("alias1", "alias2", "alias3", "testYYY")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("-kuku"))), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("+test*", "-testYYY"))), equalTo(newHashSet("testXXX", "testXYY")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("+testX*", "+testYYY"))), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("+testYYY", "+testX*"))), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
+    }
+
+    @Test
+    public void testConvertWildcardsOpenClosedIndicesTests() {
+        MetaData.Builder mdBuilder = MetaData.builder()
+                .put(indexBuilder("testXXX").state(IndexMetaData.State.OPEN))
+                .put(indexBuilder("testXXY").state(IndexMetaData.State.OPEN))
+                .put(indexBuilder("testXYY").state(IndexMetaData.State.CLOSE))
+                .put(indexBuilder("testYYY").state(IndexMetaData.State.OPEN))
+                .put(indexBuilder("testYYX").state(IndexMetaData.State.CLOSE))
+                .put(indexBuilder("kuku").state(IndexMetaData.State.OPEN));
+        ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
+        IndexNameExpressionResolver.WildcardExpressionResolver resolver = new IndexNameExpressionResolver.WildcardExpressionResolver();
+
+        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, true, true));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testX*"))), equalTo(newHashSet("testXXX", "testXXY", "testXYY")));
+        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, false, true));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testX*"))), equalTo(newHashSet("testXYY")));
+        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, true, false));
+        assertThat(newHashSet(resolver.resolve(context, Arrays.asList("testX*"))), equalTo(newHashSet("testXXX", "testXXY")));
+    }
+
+    private IndexMetaData.Builder indexBuilder(String index) {
+        return IndexMetaData.builder(index).settings(settings(Version.CURRENT).put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
@@ -352,31 +352,31 @@ public class RoutingIteratorTests extends ElasticsearchAllocationTestCase {
 
         OperationRouting operationRouting = new OperationRouting(Settings.Builder.EMPTY_SETTINGS, new AwarenessAllocationDecider());
 
-        GroupShardsIterator shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, new String[]{"test"}, null, "_shards:0");
+        GroupShardsIterator shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, null, "_shards:0");
         assertThat(shardIterators.size(), equalTo(1));
         assertThat(shardIterators.iterator().next().shardId().id(), equalTo(0));
 
-        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, new String[]{"test"}, null, "_shards:1");
+        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, null, "_shards:1");
         assertThat(shardIterators.size(), equalTo(1));
         assertThat(shardIterators.iterator().next().shardId().id(), equalTo(1));
 
         //check node preference, first without preference to see they switch
-        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, new String[]{"test"}, null, "_shards:0;");
+        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, null, "_shards:0;");
         assertThat(shardIterators.size(), equalTo(1));
         assertThat(shardIterators.iterator().next().shardId().id(), equalTo(0));
         String firstRoundNodeId = shardIterators.iterator().next().nextOrNull().currentNodeId();
 
-        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, new String[]{"test"}, null, "_shards:0");
+        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, null, "_shards:0");
         assertThat(shardIterators.size(), equalTo(1));
         assertThat(shardIterators.iterator().next().shardId().id(), equalTo(0));
         assertThat(shardIterators.iterator().next().nextOrNull().currentNodeId(), not(equalTo(firstRoundNodeId)));
 
-        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, new String[]{"test"}, null, "_shards:0;_prefer_node:node1");
+        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, null, "_shards:0;_prefer_node:node1");
         assertThat(shardIterators.size(), equalTo(1));
         assertThat(shardIterators.iterator().next().shardId().id(), equalTo(0));
         assertThat(shardIterators.iterator().next().nextOrNull().currentNodeId(), equalTo("node1"));
 
-        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, new String[]{"test"}, null, "_shards:0;_prefer_node:node1");
+        shardIterators = operationRouting.searchShards(clusterState, new String[]{"test"}, null, "_shards:0;_prefer_node:node1");
         assertThat(shardIterators.size(), equalTo(1));
         assertThat(shardIterators.iterator().next().shardId().id(), equalTo(0));
         assertThat(shardIterators.iterator().next().nextOrNull().currentNodeId(), equalTo("node1"));

--- a/core/src/test/java/org/elasticsearch/routing/AliasResolveRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/routing/AliasResolveRoutingTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.routing;
 
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
@@ -90,36 +92,38 @@ public class AliasResolveRoutingTests extends ElasticsearchIntegrationTest {
         client().admin().indices().prepareAliases().addAliasAction(newAddAliasAction("test1", "alias0").routing("0")).execute().actionGet();
         client().admin().indices().prepareAliases().addAliasAction(newAddAliasAction("test2", "alias0").routing("0")).execute().actionGet();
 
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, "alias"), nullValue());
-        assertThat(clusterService().state().metaData().resolveSearchRouting("0,1", "alias"), equalTo(newMap("test1", newSet("0", "1"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, "alias10"), equalTo(newMap("test1", newSet("0"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, "alias10"), equalTo(newMap("test1", newSet("0"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting("0", "alias10"), equalTo(newMap("test1", newSet("0"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting("1", "alias10"), nullValue());
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, "alias0"), equalTo(newMap("test1", newSet("0"), "test2", newSet("0"))));
+        ClusterState state = clusterService().state();
+        IndexNameExpressionResolver indexNameExpressionResolver = internalCluster().getInstance(IndexNameExpressionResolver.class);
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, "alias"), nullValue());
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "0,1", "alias"), equalTo(newMap("test1", newSet("0", "1"))));
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, "alias10"), equalTo(newMap("test1", newSet("0"))));
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, "alias10"), equalTo(newMap("test1", newSet("0"))));
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "0", "alias10"), equalTo(newMap("test1", newSet("0"))));
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "1", "alias10"), nullValue());
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, "alias0"), equalTo(newMap("test1", newSet("0"), "test2", newSet("0"))));
 
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, new String[]{"alias10", "alias20"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, new String[]{"alias10", "alias20"}),
                 equalTo(newMap("test1", newSet("0"), "test2", newSet("0"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, new String[]{"alias10", "alias21"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, new String[]{"alias10", "alias21"}),
                 equalTo(newMap("test1", newSet("0"), "test2", newSet("1"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, new String[]{"alias20", "alias21"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, new String[]{"alias20", "alias21"}),
                 equalTo(newMap("test2", newSet("0", "1"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, new String[]{"test1", "alias10"}), nullValue());
-        assertThat(clusterService().state().metaData().resolveSearchRouting(null, new String[]{"alias10", "test1"}), nullValue());
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, new String[]{"test1", "alias10"}), nullValue());
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, null, new String[]{"alias10", "test1"}), nullValue());
 
 
-        assertThat(clusterService().state().metaData().resolveSearchRouting("0", new String[]{"alias10", "alias20"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "0", new String[]{"alias10", "alias20"}),
                 equalTo(newMap("test1", newSet("0"), "test2", newSet("0"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting("0,1", new String[]{"alias10", "alias20"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "0,1", new String[]{"alias10", "alias20"}),
                 equalTo(newMap("test1", newSet("0"), "test2", newSet("0"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting("1", new String[]{"alias10", "alias20"}), nullValue());
-        assertThat(clusterService().state().metaData().resolveSearchRouting("0", new String[]{"alias10", "alias21"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "1", new String[]{"alias10", "alias20"}), nullValue());
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "0", new String[]{"alias10", "alias21"}),
                 equalTo(newMap("test1", newSet("0"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting("1", new String[]{"alias10", "alias21"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "1", new String[]{"alias10", "alias21"}),
                 equalTo(newMap("test2", newSet("1"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting("0,1,2", new String[]{"alias10", "alias21"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "0,1,2", new String[]{"alias10", "alias21"}),
                 equalTo(newMap("test1", newSet("0"), "test2", newSet("1"))));
-        assertThat(clusterService().state().metaData().resolveSearchRouting("0,1,2", new String[]{"test1", "alias10", "alias21"}),
+        assertThat(indexNameExpressionResolver.resolveSearchRouting(state, "0,1,2", new String[]{"test1", "alias10", "alias21"}),
                 equalTo(newMap("test1", newSet("0", "1", "2"), "test2", newSet("1"))));
     }
 

--- a/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
+++ b/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.search.*;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -59,8 +60,9 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
     protected TransportDeleteByQueryAction(Settings settings, ThreadPool threadPool, Client client,
                                            TransportSearchAction transportSearchAction,
                                            TransportSearchScrollAction transportSearchScrollAction,
-                                           TransportService transportService, ActionFilters actionFilters) {
-        super(settings, DeleteByQueryAction.NAME, threadPool, transportService, actionFilters, DeleteByQueryRequest.class);
+                                           TransportService transportService, ActionFilters actionFilters,
+                                           IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, DeleteByQueryAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, DeleteByQueryRequest.class);
         this.searchAction = transportSearchAction;
         this.scrollAction = transportSearchScrollAction;
         this.client = client;


### PR DESCRIPTION
Changes in a nutshell:
- All expression logic is now encapsulated by `ExpressionResolver` interface.
- `MetaData#convertFromWildcards()` gets replaced by `WildcardExpressionResolver`.
- All of the indices expansion methods are being moved from `MetaData` class to the new `IndexNameExpressionResolver` class.
- All single index expansion optimisations are removed.

The logic for resolving a concrete index name from an expression has been moved from the MetaData class to IndexNameExpressionResolver class. The logic has been cleaned up and simplified were was possible without breaking bwc. Mainly the logic that deals if there is just one index expression is no more, mainly to make to code simpler. Also the notion of aliasOrIndex has been changed to index expression.

The IndexNameExpressionResolver translates index name expressions into concrete indices. The list of index name expressions are first delegated to the known IndexExpressionFilter. An IndexExpressionFilter is responsible for translating if possible an expression into a concrete indices or aliases otherwise the expression is left untouched. Concretely this means converting wildcard expressions into concrete indices or aliases, but in the future other implementations could convert expressions based on different rules.

Beyond this there is also some follow up work to do:
- Replace SnapshotUtils#filterIndices by using the IndexNameExpressionResolver
- During the lifetime of a request index expressions or resolved to concrete indices multiple times. (finding the search routing, whether aliases have filters, checking for cluster blocks and just resolving the index name expressions to concrete indices) This can be reduced to a single lookup. 
- Revise the in memory data structures used by MetaData. This is interesting in the case of many indices and aliases. For example I think that `MetaData#aliasAndIndexToIndexMap` can be removed in order to save heap memory at the cost of some extra look ups at request time. Also a completely different approach can be taken to store index and aliases with their respective IndexMetaData and AliasMetaData into a FST.
