### PR TITLE
Add integration test harness for plugins

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1038,34 +1038,8 @@
                         </goals>
                         <configuration>
                             <target>
-                              <!-- unzip release artifact -->
-                              <property name="integ.finalname" value="${project.artifactId}-${project.version}"/>
-                              <property name="integ.scratch" location="${project.build.directory}/integ-tests"/>
-                              <unzip src="${project.build.directory}/releases/${integ.finalname}.zip"
-                                     dest="${integ.scratch}"/>
-
-                              <property name="integ.home" location="${integ.scratch}/${integ.finalname}"/>
-
-                              <!-- execute -->
-                              <property name="integ.args"
-                                        value="-Des.node.name=smoke_tester -Des.cluster.name=prepare_release
-                                               -Des.discovery.zen.ping.multicast.enabled=false -Des.script.inline=on
-                                               -Des.script.indexed=on"/>
-
-                              <echo>Starting up external cluster...</echo>
-                              <exec executable="cmd" osfamily="winnt" dir="${integ.home}" spawn="true">
-                                <arg value="/c"/>
-                                <arg value="${integ.home}/bin/elasticsearch.bat"/>
-                                <arg line="${integ.args}"/>
-                              </exec>
-                              <exec executable="sh" osfamily="unix" dir="${integ.home}" spawn="true">
-                                <arg value="${integ.home}/bin/elasticsearch"/>
-                                <arg line="${integ.args}"/>
-                              </exec>
-                              <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
-                                 <http url="http://127.0.0.1:9200"/>
-                              </waitfor>
-                              <echo>External cluster started</echo>
+                                <ant antfile="${elasticsearch.tools.directory}/ant/integration-tests.xml"
+                                     target="start-external-cluster"/>
                             </target>
                         </configuration>
                     </execution>
@@ -1078,31 +1052,8 @@
                         </goals>
                         <configuration>
                             <target>
-                              <!-- TODO: this is brutal, specify and read our pid file instead -->
-                              <!-- find ES processes with jps, then shoot them with 50 cal -->
-                              <exec executable="jps">
-                                <arg value="-l"/>
-                                <redirector outputproperty="process.pid">
-                                  <outputfilterchain>
-                                    <linecontains>
-                                      <contains value="org.elasticsearch.bootstrap.Elasticsearch"/>
-                                    </linecontains>
-                                    <replacestring from=" org.elasticsearch.bootstrap.Elasticsearch"/>
-                                  </outputfilterchain>
-                                </redirector>
-                              </exec>
-                              <echo>Shutting down external cluster</echo>
-                              <exec executable="taskkill" osfamily="winnt">
-                                <arg value="/F"/>
-                                <arg value="/PID"/>
-                                <arg value="${process.pid}"/>
-                              </exec>
-                              <exec executable="kill" osfamily="unix">
-                                <arg value="-9"/>
-                                <arg value="${process.pid}"/>
-                              </exec>
-                              <!-- best effort cleanup. 'clean' will take care in all cases -->
-                              <delete dir="${project.build.directory}/integ-tests" failonerror="false"/>
+                                <ant antfile="${elasticsearch.tools.directory}/ant/integration-tests.xml"
+                                     target="stop-external-cluster"/>
                             </target>
                         </configuration>
                     </execution>

--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <project name="elasticsearch-integration-tests">
 
+ <!-- this is all to not run tests for 'pom' packaging. maven you fail -->
+  <condition property="shouldskip">
+    <istrue value="${skip.integ.tests}"/>
+  </condition>
+
   <!-- runs an OS script -->
   <macrodef name="run-script">
       <attribute name="script"/>
@@ -22,7 +27,7 @@
   </macrodef>
 
   <!-- unzip core release artifact and start ES -->
-  <target name="start-external-cluster">
+  <target name="start-external-cluster" unless="${shouldskip}">
     <property name="integ.finalname" value="${project.artifactId}-${project.version}"/>
     <property name="integ.scratch" location="${project.build.directory}/integ-tests"/>
 
@@ -48,7 +53,7 @@
   </target>
 
   <!-- unzip core release artifact, install plugin, then start ES -->
-  <target name="start-external-cluster-with-plugin">
+  <target name="start-external-cluster-with-plugin" unless="${shouldskip}">
     <property name="integ.scratch" location="${project.build.directory}/integ-tests"/>
 
     <unzip src="${settings.localRepository}/org/elasticsearch/elasticsearch/${elasticsearch.version}/elasticsearch-${elasticsearch.version}.zip"

--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -1,6 +1,24 @@
 <?xml version="1.0"?>
 <project name="elasticsearch-integration-tests">
 
+  <macrodef name="run-script">
+      <attribute name="script"/>
+      <attribute name="dir"/>
+      <attribute name="args"/>
+    <sequential>
+      <exec executable="cmd" osfamily="winnt" dir="@{dir}" spawn="true">
+        <arg value="/c"/>
+        <arg value="@{dir}/@{script}.bat"/>
+        <arg line="@{args}"/>
+      </exec>
+
+      <exec executable="sh" osfamily="unix" dir="@{dir}" spawn="true">
+        <arg value="@{dir}/@{script}"/>
+        <arg line="@{args}"/>
+      </exec>
+    </sequential>
+  </macrodef>
+
   <!-- unzip release artifact -->
   <target name="start-external-cluster">
     <property name="integ.finalname" value="${project.artifactId}-${project.version}"/>
@@ -18,16 +36,7 @@
 
     <echo>Starting up external cluster...</echo>
 
-    <exec executable="cmd" osfamily="winnt" dir="${integ.home}" spawn="true">
-      <arg value="/c"/>
-      <arg value="${integ.home}/bin/elasticsearch.bat"/>
-      <arg line="${integ.args}"/>
-    </exec>
-
-    <exec executable="sh" osfamily="unix" dir="${integ.home}" spawn="true">
-      <arg value="${integ.home}/bin/elasticsearch"/>
-      <arg line="${integ.args}"/>
-    </exec>
+    <run-script dir="${integ.home}" script="bin/elasticsearch" args="${integ.args}"/>
 
     <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
       <http url="http://127.0.0.1:9200"/>

--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<project name="elasticsearch-integration-tests">
+
+  <!-- unzip release artifact -->
+  <target name="start-external-cluster">
+    <property name="integ.finalname" value="${project.artifactId}-${project.version}"/>
+    <property name="integ.scratch" location="${project.build.directory}/integ-tests"/>
+    <unzip src="${project.build.directory}/releases/${integ.finalname}.zip"
+           dest="${integ.scratch}"/>
+
+    <property name="integ.home" location="${integ.scratch}/${integ.finalname}"/>
+
+    <!-- execute -->
+    <property name="integ.args"
+              value="-Des.node.name=smoke_tester -Des.cluster.name=prepare_release
+                     -Des.discovery.zen.ping.multicast.enabled=false -Des.script.inline=on
+                     -Des.script.indexed=on"/>
+
+    <echo>Starting up external cluster...</echo>
+
+    <exec executable="cmd" osfamily="winnt" dir="${integ.home}" spawn="true">
+      <arg value="/c"/>
+      <arg value="${integ.home}/bin/elasticsearch.bat"/>
+      <arg line="${integ.args}"/>
+    </exec>
+
+    <exec executable="sh" osfamily="unix" dir="${integ.home}" spawn="true">
+      <arg value="${integ.home}/bin/elasticsearch"/>
+      <arg line="${integ.args}"/>
+    </exec>
+
+    <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
+      <http url="http://127.0.0.1:9200"/>
+    </waitfor>
+
+    <echo>External cluster started</echo>
+  </target>
+
+  <target name="stop-external-cluster">
+    <!-- TODO: this is brutal, specify and read our pid file instead -->
+    <!-- find ES processes with jps, then shoot them with 50 cal -->
+    <exec executable="jps">
+      <arg value="-l"/>
+      <redirector outputproperty="process.pid">
+        <outputfilterchain>
+          <linecontains>
+            <contains value="org.elasticsearch.bootstrap.Elasticsearch"/>
+          </linecontains>
+          <replacestring from=" org.elasticsearch.bootstrap.Elasticsearch"/>
+        </outputfilterchain>
+      </redirector>
+    </exec>
+
+    <echo>Shutting down external cluster</echo>
+
+    <exec executable="taskkill" osfamily="winnt">
+      <arg value="/F"/>
+      <arg value="/PID"/>
+      <arg value="${process.pid}"/>
+    </exec>
+    <exec executable="kill" osfamily="unix">
+      <arg value="-9"/>
+      <arg value="${process.pid}"/>
+    </exec>
+
+    <!-- best effort cleanup. 'clean' will take care in all cases -->
+    <delete dir="${project.build.directory}/integ-tests" failonerror="false"/>
+  </target>
+</project>

--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -1,42 +1,74 @@
 <?xml version="1.0"?>
 <project name="elasticsearch-integration-tests">
 
+  <!-- runs an OS script -->
   <macrodef name="run-script">
       <attribute name="script"/>
       <attribute name="dir"/>
       <attribute name="args"/>
+      <attribute name="spawn"/>
     <sequential>
-      <exec executable="cmd" osfamily="winnt" dir="@{dir}" spawn="true">
+      <exec executable="cmd" osfamily="winnt" dir="@{dir}" spawn="@{spawn}">
         <arg value="/c"/>
         <arg value="@{dir}/@{script}.bat"/>
         <arg line="@{args}"/>
       </exec>
 
-      <exec executable="sh" osfamily="unix" dir="@{dir}" spawn="true">
+      <exec executable="sh" osfamily="unix" dir="@{dir}" spawn="@{spawn}">
         <arg value="@{dir}/@{script}"/>
         <arg line="@{args}"/>
       </exec>
     </sequential>
   </macrodef>
 
-  <!-- unzip release artifact -->
+  <!-- unzip core release artifact and start ES -->
   <target name="start-external-cluster">
     <property name="integ.finalname" value="${project.artifactId}-${project.version}"/>
     <property name="integ.scratch" location="${project.build.directory}/integ-tests"/>
+
     <unzip src="${project.build.directory}/releases/${integ.finalname}.zip"
            dest="${integ.scratch}"/>
 
     <property name="integ.home" location="${integ.scratch}/${integ.finalname}"/>
-
-    <!-- execute -->
+    <property name="integ.repo.home" location="${integ.home}/repo"/>
     <property name="integ.args"
               value="-Des.node.name=smoke_tester -Des.cluster.name=prepare_release
                      -Des.discovery.zen.ping.multicast.enabled=false -Des.script.inline=on
-                     -Des.script.indexed=on"/>
+                     -Des.script.indexed=on -Des.path.repo=${integ.repo.home}"/>
 
+    <!-- execute -->
     <echo>Starting up external cluster...</echo>
+    <run-script dir="${integ.home}" script="bin/elasticsearch" args="${integ.args}" spawn="true"/>
 
-    <run-script dir="${integ.home}" script="bin/elasticsearch" args="${integ.args}"/>
+    <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
+      <http url="http://127.0.0.1:9200"/>
+    </waitfor>
+
+    <echo>External cluster started</echo>
+  </target>
+
+  <!-- unzip core release artifact, install plugin, then start ES -->
+  <target name="start-external-cluster-with-plugin">
+    <property name="integ.scratch" location="${project.build.directory}/integ-tests"/>
+
+    <unzip src="${settings.localRepository}/org/elasticsearch/elasticsearch/${elasticsearch.version}/elasticsearch-${elasticsearch.version}.zip"
+           dest="${integ.scratch}"/>
+
+    <property name="integ.home" location="${integ.scratch}/elasticsearch-${elasticsearch.version}"/>
+    <property name="integ.repo.home" location="${integ.home}/repo"/>
+    <property name="integ.args"
+              value="-Des.node.name=smoke_tester -Des.cluster.name=prepare_release
+                     -Des.discovery.zen.ping.multicast.enabled=false -Des.script.inline=on
+                     -Des.script.indexed=on -Des.path.repo=${integ.repo.home}"/>
+
+    <makeurl property="integ.plugin.url" file="${project.build.directory}/releases/${project.artifactId}-${project.version}.zip"/>
+
+    <echo>Installing plugin ${project.artifactId}...</echo>
+    <run-script dir="${integ.home}" script="bin/plugin" args="-u ${integ.plugin.url} -i ${project.artifactId}/${project.version}" spawn="false"/>
+
+    <!-- execute -->
+    <echo>Starting up external cluster...</echo>
+    <run-script dir="${integ.home}" script="bin/elasticsearch" args="${integ.args}" spawn="true"/>
 
     <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
       <http url="http://127.0.0.1:9200"/>

--- a/plugins/delete-by-query/src/test/java/org/elasticsearch/plugin/deletebyquery/test/rest/DeleteByQueryRestIT.java
+++ b/plugins/delete-by-query/src/test/java/org/elasticsearch/plugin/deletebyquery/test/rest/DeleteByQueryRestIT.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.deletebyquery.test.rest;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.elasticsearch.test.rest.ElasticsearchRestTestCase;
+import org.elasticsearch.test.rest.RestTestCandidate;
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+
+import java.io.IOException;
+
+public class DeleteByQueryRestIT extends ElasticsearchRestTestCase {
+
+    public DeleteByQueryRestIT(@Name("yaml") RestTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
+        return ElasticsearchRestTestCase.createParameters(0, 1);
+    }
+}
+

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -40,6 +40,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <type>zip</type>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Provided dependencies by elasticsearch itself  -->
         <dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -288,6 +288,53 @@
             </testResource>
         </testResources>
 
+        <plugins>
+           <!-- integration tests -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <executions>
+                        <!-- start up external cluster -->
+                        <execution>
+                            <id>integ-setup</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <ant antfile="${elasticsearch.tools.directory}/ant/integration-tests.xml"
+                                         target="start-external-cluster-with-plugin"/>
+                                </target>
+                            </configuration>
+                        </execution>
+                        <!-- shut down external cluster -->
+                        <execution>
+                            <id>integ-teardown</id>
+                            <phase>post-integration-test</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <ant antfile="${elasticsearch.tools.directory}/ant/integration-tests.xml"
+                                         target="stop-external-cluster"/>
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <tests.cluster>127.0.0.1:9300</tests.cluster>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,13 @@
             </dependency>
 
             <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch</artifactId>
+                <version>${elasticsearch.version}</version>
+                <type>zip</type>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>4.3.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,10 @@
         <tests.rest.suite></tests.rest.suite>
         <tests.rest.blacklist></tests.rest.blacklist>
         <tests.rest.spec></tests.rest.spec>
+        <tests.rest.load_packaged></tests.rest.load_packaged>
         <tests.network></tests.network>
         <tests.cluster></tests.cluster>
         <tests.filter></tests.filter>
-        <tests.rest.load_packaged></tests.rest.load_packaged>
         <env.ES_TEST_LOCAL></env.ES_TEST_LOCAL>
         <tests.security.manager>true</tests.security.manager>
         <tests.compatibility></tests.compatibility>
@@ -701,6 +701,10 @@
                        <skipTests>${skip.integ.tests}</skipTests>
                        <systemPropertyVariables>
                            <es.logger.level>${es.logger.level}</es.logger.level>
+                           <tests.rest.suite>${tests.rest.suite}</tests.rest.suite>
+                           <tests.rest.blacklist>${tests.rest.blacklist}</tests.rest.blacklist>
+                           <tests.rest.spec>${tests.rest.spec}</tests.rest.spec>
+                           <tests.rest.load_packaged>${tests.rest.load_packaged}</tests.rest.load_packaged>
                        </systemPropertyVariables>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1346,6 +1346,10 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                     <missing>${basedir}/src</missing>
                 </file>
             </activation>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+                <skip.integ.tests>true</skip.integ.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Similar to es-core integration tests, in `verify` we unzip ES, install the plugin, run any rest tests it might have against the external cluster, then shut down.

Even if a plugin doesn't have any rest tests, at least we install and start ES with it...
