### PR TITLE
[build] Update to Apache Maven PMD Plugin 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1104,7 +1104,7 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.5</version>
                     <configuration>
                         <rulesets>
                             <ruleset>${elasticsearch.tools.directory}/pmd/custom.xml</ruleset>


### PR DESCRIPTION
http://maven.apache.org/plugins/maven-pmd-plugin/

You should specify the version in your project's plugin configuration:

``` xml
<plugin>
 <groupId>org.apache.maven.plugins</groupId>
 <artifactId>maven-pmd-plugin</artifactId>
 <version>3.5</version>
</plugin>
```
## Release Notes - Apache Maven PMD Plugin - Version 3.5

Bug
- [MPMD-208] Warning about deprecated Rule name when using rulesets/maven.xml
- [MPMD-205] Javascript violations won't fail the build

Improvement
- [MPMD-211] Upgrade plexus-resources from 1.0-alpha-7 to 1.1
- [MPMD-209] Upgrade to PMD 5.3.2
- [MPMD-206] Make the sourceDirectories configurable

New Feature
- [MPMD-207] Support Javascript and JSP for CPD
