### PR TITLE
Properly fix the default regex flag to ALL for RegexpQueryParser and Builder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -32,7 +32,7 @@ public class RegexpQueryBuilder extends MultiTermQueryBuilder implements Boostab
     private final String name;
     private final String regexp;
 
-    private int flags = -1;
+    private int flags = RegexpQueryParser.DEFAULT_FLAGS_VALUE;
     private float boost = -1;
     private String rewrite;
     private String queryName;

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -39,6 +39,8 @@ public class RegexpQueryParser implements QueryParser {
 
     public static final String NAME = "regexp";
 
+    public static final int DEFAULT_FLAGS_VALUE = RegexpFlag.ALL.value();
+
     @Inject
     public RegexpQueryParser() {
     }
@@ -57,7 +59,7 @@ public class RegexpQueryParser implements QueryParser {
 
         Object value = null;
         float boost = 1.0f;
-        int flagsValue = -1;
+        int flagsValue = DEFAULT_FLAGS_VALUE;
         int maxDeterminizedStates = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
         String queryName = null;
         String currentFieldName = null;


### PR DESCRIPTION
The documentation mentions that the default flag is `ALL` while the code sets it to `-1`.

Relates to #11896
