### PR TITLE
Fix example curl command in docs for count query

### DIFF
--- a/docs/reference/search/count.asciidoc
+++ b/docs/reference/search/count.asciidoc
@@ -12,7 +12,7 @@ body. Here is an example:
 --------------------------------------------------
 $ curl -XGET 'http://localhost:9200/twitter/tweet/_count?q=user:kimchy'
 
-$ curl -XGET 'http://localhost:9200/twitter/tweet/_count' -d '
+$ curl -XPOST 'http://localhost:9200/twitter/tweet/_count' -d '
 {
     "query" : {
         "term" : { "user" : "kimchy" }


### PR DESCRIPTION
The method is GET but should be POST when using POST data with an ES count request.
