### PR TITLE
Fix RegexpQueryBuilder#maxDeterminizedStates

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -78,7 +78,6 @@ public class RegexpQueryBuilder extends MultiTermQueryBuilder implements Boostab
      */
     public RegexpQueryBuilder maxDeterminizedStates(int value) {
         this.maxDeterminizedStates = value;
-        this.maxDetermizedStatesSet = true;
         return this;
     }
 


### PR DESCRIPTION
Value was improperly set to `true`.

Relates to #11896
