### PR TITLE
Calculate artifact checksums in maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1308,6 +1308,14 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.15</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                    <configuration>
+                        <createChecksum>true</createChecksum>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Today we calculate the checksums in a python scritp to do the release.
We can also do this way simpler in maven using an ant task.
