### PR TITLE
Failure during the fetch phase of scan should invoke the failed fetch…

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -296,7 +296,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
                     contextProcessedSuccessfully(context);
                 }
             } catch (Throwable e) {
-                shardSearchStats.onFailedQueryPhase(context);
+                shardSearchStats.onFailedFetchPhase(context);
                 throw ExceptionsHelper.convertToRuntime(e);
             }
             shardSearchStats.onFetchPhase(context, System.nanoTime() - queryFinishTime);


### PR DESCRIPTION
… phase handler.

This commit fixes an issue where during a failure in the fetch phase of a scan the wrong failure handler was invoked.

Closes #12086
