### PR TITLE
Default fuzzy transpositions to true

### DIFF
--- a/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -428,8 +428,7 @@ public class MapperQueryParser extends QueryParser {
         currentFieldType = parseContext.fieldMapper(field);
         if (currentFieldType != null) {
             try {
-                //LUCENE 4 UPGRADE I disabled transpositions here by default - maybe this needs to be changed
-                return currentFieldType.fuzzyQuery(termStr, Fuzziness.build(minSimilarity), fuzzyPrefixLength, settings.fuzzyMaxExpansions(), false);
+                return currentFieldType.fuzzyQuery(termStr, Fuzziness.build(minSimilarity), fuzzyPrefixLength, settings.fuzzyMaxExpansions(), FuzzyQuery.defaultTranspositions);
             } catch (RuntimeException e) {
                 if (settings.lenient()) {
                     return null;
@@ -444,8 +443,7 @@ public class MapperQueryParser extends QueryParser {
     protected Query newFuzzyQuery(Term term, float minimumSimilarity, int prefixLength) {
         String text = term.text();
         int numEdits = FuzzyQuery.floatToEdits(minimumSimilarity, text.codePointCount(0, text.length()));
-        //LUCENE 4 UPGRADE I disabled transpositions here by default - maybe this needs to be changed 
-        FuzzyQuery query = new FuzzyQuery(term, numEdits, prefixLength, settings.fuzzyMaxExpansions(), false);
+        FuzzyQuery query = new FuzzyQuery(term, numEdits, prefixLength, settings.fuzzyMaxExpansions(), FuzzyQuery.defaultTranspositions);
         QueryParsers.setRewriteMethod(query, settings.fuzzyRewriteMethod());
         return query;
     }

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -66,7 +66,7 @@ public class FuzzyQueryParser implements QueryParser {
         Fuzziness fuzziness = DEFAULT_FUZZINESS;
         int prefixLength = FuzzyQuery.defaultPrefixLength;
         int maxExpansions = FuzzyQuery.defaultMaxExpansions;
-        boolean transpositions = false;
+        boolean transpositions = FuzzyQuery.defaultTranspositions;
         String queryName = null;
         MultiTermQuery.RewriteMethod rewriteMethod = null;
         if (parseContext.isFilter()) {

--- a/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -65,9 +65,8 @@ public class MatchQuery {
     protected int fuzzyPrefixLength = FuzzyQuery.defaultPrefixLength;
     
     protected int maxExpansions = FuzzyQuery.defaultMaxExpansions;
-    
-    //LUCENE 4 UPGRADE we need a default value for this!
-    protected boolean transpositions = false;
+
+    protected boolean transpositions = FuzzyQuery.defaultTranspositions;
 
     protected MultiTermQuery.RewriteMethod rewriteMethod;
 


### PR DESCRIPTION
This commit defaults fuzzy_transpositions on fuzzy queries to true. This means that by default, tranpositions will now count as a single
edit.

Closes #9278
