### PR TITLE
Integ setup should unzip org.elasticsearch:elasticsearch:zip

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -55,7 +55,7 @@
   <target name="start-external-cluster-with-plugin" unless="${shouldskip}">
     <property name="integ.scratch" location="${project.build.directory}/integ-tests"/>
 
-    <unzip src="${settings.localRepository}/org/elasticsearch/elasticsearch/${elasticsearch.version}/elasticsearch-${elasticsearch.version}.zip"
+    <unzip src="${org.elasticsearch:elasticsearch:zip}"
            dest="${integ.scratch}"/>
 
     <property name="integ.home" location="${integ.scratch}/elasticsearch-${elasticsearch.version}"/>


### PR DESCRIPTION
This property is set by maven, and unlike the current hack, during
a multimodule build will be set to the correct thing.

Otherwise today sometimes we run integ tests with outdated ES
artifacts, which makes for incredibly confusing failures.

Closes #12101
