### PR TITLE
Get integration tests working on windows.

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -14,23 +14,29 @@
 
   <!-- arguments passed to elasticsearch when running -->
   <property name="integ.args"
-            value="-d -Des.node.name=smoke_tester -Des.cluster.name=prepare_release
+            value="-Des.node.name=smoke_tester -Des.cluster.name=prepare_release
                    -Des.discovery.zen.ping.multicast.enabled=false -Des.script.inline=on
-                   -Des.script.indexed=on -p ${integ.pidfile}"/>
+                   -Des.script.indexed=on -Des.pidfile=${integ.pidfile}"/>
 
   <!-- runs an OS script -->
   <macrodef name="run-script">
       <attribute name="script"/>
       <attribute name="dir"/>
       <attribute name="args"/>
+      <attribute name="spawn" default="false"/>
     <sequential>
-      <exec executable="cmd" osfamily="winnt" dir="@{dir}" failonerror="true">
+      <local name="failonerror"/>
+      <condition property="failonerror">
+          <isfalse value="@{spawn}"/>
+      </condition>
+
+      <exec executable="cmd" osfamily="winnt" dir="@{dir}" failonerror="${failonerror}" spawn="@{spawn}">
         <arg value="/c"/>
         <arg value="@{dir}/@{script}.bat"/>
         <arg line="@{args}"/>
       </exec>
 
-      <exec executable="sh" osfamily="unix" dir="@{dir}" failonerror="true">
+      <exec executable="sh" osfamily="unix" dir="@{dir}" failonerror="${failonerror}" spawn="@{spawn}">
         <arg value="@{dir}/@{script}"/>
         <arg line="@{args}"/>
       </exec>
@@ -67,7 +73,8 @@
 
     <!-- execute -->
     <echo>Starting up external cluster...</echo>
-    <run-script dir="${integ.home}" script="bin/elasticsearch" args="${integ.args} -Des.path.repo=${integ.repo.home}"/>
+    <run-script dir="${integ.home}" script="bin/elasticsearch" spawn="true"
+                args="${integ.args} -Des.path.repo=${integ.repo.home}" />
 
     <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
       <http url="http://127.0.0.1:9200"/>
@@ -94,11 +101,13 @@
     <makeurl property="integ.plugin.url" file="${project.build.directory}/releases/${project.artifactId}-${project.version}.zip"/>
 
     <echo>Installing plugin ${project.artifactId}...</echo>
-    <run-script dir="${integ.home}" script="bin/plugin" args="-u ${integ.plugin.url} -i ${project.artifactId}/${project.version}"/>
+    <run-script dir="${integ.home}" script="bin/plugin"
+                args="-u ${integ.plugin.url} -i ${project.artifactId}/${project.version}"/>
 
     <!-- execute -->
     <echo>Starting up external cluster...</echo>
-    <run-script dir="${integ.home}" script="bin/elasticsearch" args="${integ.args} -Des.path.repo=${integ.repo.home}"/>
+    <run-script dir="${integ.home}" script="bin/elasticsearch" spawn="true"
+                args="${integ.args} -Des.path.repo=${integ.repo.home}"/>
 
     <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
       <http url="http://127.0.0.1:9200"/>

--- a/dev-tools/src/main/resources/license-check/check_license_and_sha.pl
+++ b/dev-tools/src/main/resources/license-check/check_license_and_sha.pl
@@ -41,7 +41,7 @@ sub check_shas_and_licenses {
         }
 
         unless ( $old_sha eq $new{$jar} ) {
-            say STDERR "$jar: SHA has changed";
+            say STDERR "$jar: SHA has changed, expected $old_sha but found $new{$jar}";
             $error++;
             $sha_error++;
             next;

--- a/pom.xml
+++ b/pom.xml
@@ -1176,7 +1176,8 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                                         <available file="${basedir}/licenses" type="dir"/>
                                     </condition>
                                     <echo taskName="license check">Running license check</echo>
-                                    <exec failonerror="${licenses.exists}" executable="perl" dir="${elasticsearch.tools.directory}/license-check" >
+                                    <!-- on windows checksums are calculated wrong -->
+                                    <exec failonerror="${licenses.exists}" executable="perl" dir="${elasticsearch.tools.directory}/license-check" osfamily="unix" >
                                         <arg value="check_license_and_sha.pl"/>
                                         <arg value="--check"/>
                                         <arg value="${basedir}"/>


### PR DESCRIPTION
We also run our license checker in `mvn verify`, but there
are problems with checksum calculation on windows there, so I've
disabled the license checker on windows to prevent those false fails.
