### PR TITLE
RangeQuery on date field cannot be nested inside SpanMultiTermQuery

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -124,6 +124,7 @@ public class DateFieldMapper extends NumberFieldMapper {
             return fieldMapper;
         }
 
+        @Override
         protected void setupFieldType(BuilderContext context) {
             if (Version.indexCreated(context.indexSettings()).before(Version.V_2_0_0) &&
                 !fieldType().dateTimeFormatter().format().contains("epoch_")) {
@@ -195,7 +196,7 @@ public class DateFieldMapper extends NumberFieldMapper {
 
     public static class DateFieldType extends NumberFieldType {
 
-        final class LateParsingQuery extends Query {
+        public final class LateParsingQuery extends Query {
 
             final Object lowerTerm;
             final Object upperTerm;
@@ -277,6 +278,7 @@ public class DateFieldMapper extends NumberFieldMapper {
             this.dateMathParser = ref.dateMathParser;
         }
 
+        @Override
         public DateFieldType clone() {
             return new DateFieldType(this);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.index.mapper.core.DateFieldMapper;
 
 import java.io.IOException;
 
@@ -60,6 +61,9 @@ public class SpanMultiTermQueryParser implements QueryParser {
         }
 
         Query subQuery = parseContext.parseInnerQuery();
+        if (subQuery instanceof DateFieldMapper.DateFieldType.LateParsingQuery) {
+            subQuery = ((DateFieldMapper.DateFieldType.LateParsingQuery) subQuery).rewrite(null);
+        }
         if (!(subQuery instanceof MultiTermQuery)) {
             throw new QueryParsingException(parseContext, "spanMultiTerm [" + MATCH_NAME + "] must be of type multi term query");
         }

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -1595,6 +1595,7 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
         client().prepareIndex("test", "test", "2").setSource("description", "foo other anything", "count", 2).get();
         client().prepareIndex("test", "test", "3").setSource("description", "foo other", "count", 3).get();
         client().prepareIndex("test", "test", "4").setSource("description", "fop", "count", 4).get();
+        client().prepareIndex("test", "test", "5").setSource("date", "2010-02-02").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
@@ -1613,6 +1614,11 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
                 .setQuery(spanOrQuery().clause(spanMultiTermQueryBuilder(QueryBuilders.rangeQuery("description").from("ffa").to("foo"))))
                 .execute().actionGet();
         assertHitCount(response, 3);
+
+        response = client().prepareSearch("test")
+                .setQuery(spanOrQuery().clause(spanMultiTermQueryBuilder(QueryBuilders.rangeQuery("date").from("2010-01-01").to("2011-01-01"))))
+                .execute().actionGet();
+        assertHitCount(response, 1);
 
         response = client().prepareSearch("test")
                 .setQuery(spanOrQuery().clause(spanMultiTermQueryBuilder(regexpQuery("description", "fo{2}")))).get();

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -1588,7 +1588,8 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
 
     @Test
     public void testSpanMultiTermQuery() throws IOException {
-        createIndex("test");
+        assertAcked(prepareCreate("test")
+                .addMapping("test", "date", "type=date"));
         ensureGreen();
 
         client().prepareIndex("test", "test", "1").setSource("description", "foo other anything bar", "count", 1).get();


### PR DESCRIPTION
This PR explains the issue in #12122 by adding an integration test to SearchQueryTests. The additional query setup triggers the following internal parsing exception.

```
nested: SearchParseException[failed to parse search source [{"query":{"span_or":{"clauses":[{"span_multi":{"match":{"range":{"date":{"from":"2010-01-01","to":"2011-01-01","include_lower":true,"include_upper":true}}}}}]}}}]]; nested: QueryParsingException[spanMultiTerm [match] must be of type multi term query]; 
```

This PR only adds the test code for #12122 since I have no idea for a fix yet. Mainly to illustrate the problem and discuss solutions.
