### PR TITLE
Clean up handling of missing values when merging shard results on the coordinating node.

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHit.java
@@ -64,7 +64,6 @@ import static org.elasticsearch.search.internal.InternalSearchHitField.readSearc
 public class InternalSearchHit implements SearchHit {
 
     private static final Object[] EMPTY_SORT_VALUES = new Object[0];
-    private static final Text MAX_TERM_AS_TEXT = new StringAndBytesText(BytesRefFieldComparatorSource.MAX_TERM.utf8ToString());
 
     private transient int docId;
 
@@ -506,13 +505,7 @@ public class InternalSearchHit implements SearchHit {
         if (sortValues != null && sortValues.length > 0) {
             builder.startArray(Fields.SORT);
             for (Object sortValue : sortValues) {
-                if (sortValue != null && sortValue.equals(MAX_TERM_AS_TEXT)) {
-                    // We don't display MAX_TERM in JSON responses in case some clients have UTF-8 parsers that wouldn't accept a
-                    // non-character in the response, even though this is valid UTF-8
-                    builder.nullValue();
-                } else {
-                    builder.value(sortValue);
-                }
+                builder.value(sortValue);
             }
             builder.endArray();
         }

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTests.java
@@ -247,9 +247,9 @@ public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests 
         assertThat(topDocs.scoreDocs[5].doc, equalTo(6));
         assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[5]).fields[0]).utf8ToString(), equalTo("08"));
         assertThat(topDocs.scoreDocs[6].doc, equalTo(1));
-        assertThat((BytesRef) ((FieldDoc) topDocs.scoreDocs[6]).fields[0], equalTo(XFieldComparatorSource.MAX_TERM));
+        assertThat((BytesRef) ((FieldDoc) topDocs.scoreDocs[6]).fields[0], equalTo(null));
         assertThat(topDocs.scoreDocs[7].doc, equalTo(5));
-        assertThat((BytesRef) ((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(XFieldComparatorSource.MAX_TERM));
+        assertThat((BytesRef) ((FieldDoc) topDocs.scoreDocs[7]).fields[0], equalTo(null));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10,
                 new Sort(new SortField("value", indexFieldData.comparatorSource(null, MultiValueMode.MAX, null), true)));

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTests.java
@@ -443,13 +443,11 @@ public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImpl
             if (cmpValue == null) {
                 if ("_first".equals(missingValue)) {
                     cmpValue = new BytesRef();
-                } else if ("_last".equals(missingValue)) {
-                    cmpValue = XFieldComparatorSource.MAX_TERM;
-                } else {
+                } else if ("_last".equals(missingValue) == false) {
                     cmpValue = (BytesRef) missingValue;
                 }
             }
-            if (previous != null) {
+            if (previous != null && cmpValue != null) {
                 assertTrue(previous.utf8ToString() + "   /   " + cmpValue.utf8ToString(), previous.compareTo(cmpValue) <= 0);
             }
             previous = cmpValue;

--- a/core/src/test/java/org/elasticsearch/index/fielddata/ParentChildFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/ParentChildFieldDataTests.java
@@ -185,7 +185,7 @@ public class ParentChildFieldDataTests extends AbstractFieldDataTests {
         assertThat(topDocs.scoreDocs[6].doc, equalTo(6));
         assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[6]).fields[0]).utf8ToString(), equalTo("2"));
         assertThat(topDocs.scoreDocs[7].doc, equalTo(7));
-        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[7]).fields[0]), equalTo(XFieldComparatorSource.MAX_TERM));
+        assertThat(((BytesRef) ((FieldDoc) topDocs.scoreDocs[7]).fields[0]), equalTo(null));
 
         topDocs = searcher.search(new MatchAllDocsQuery(), 10, new Sort(new SortField(ParentFieldMapper.NAME, comparator, true)));
         assertThat(topDocs.totalHits, equalTo(8));

--- a/core/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/SimpleSortTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
@@ -2017,10 +2016,9 @@ public class SimpleSortTests extends ElasticsearchIntegrationTest {
                 .addSort(fieldSort("str_field").order(SortOrder.ASC).unmappedType("string"))
                 .addSort(fieldSort("str_field2").order(SortOrder.DESC).unmappedType("string")).get();
 
-        final StringAndBytesText maxTerm = new StringAndBytesText(IndexFieldData.XFieldComparatorSource.MAX_TERM.utf8ToString());
         assertSortValues(resp,
                 new Object[] {new StringAndBytesText("bcd"), null},
-                new Object[] {maxTerm, null});
+                new Object[] {null, null});
 
         resp = client().prepareSearch("test1", "test2")
                 .addSort(fieldSort("long_field").order(SortOrder.ASC).unmappedType("long"))


### PR DESCRIPTION
Today shards are responsible for producing one sort value per document, which
is later used on the coordinating node to resolve the global top documents.
However, this is problematic on string fields with
`missing: _first, order: desc` or `missing: _last, order: asc` given that there
is no such thing as a string that compares greater than any other string. Today
we use a string containing a single code point which is the maximum allowed code
point but this is a hack: instead we should inform the coordinating node that
the document had no value and let it figure out how it should be sorted
depending on whether missing values should be sorted first or last.

Close #9155
