### PR TITLE
PluginManager: Support basic auth against proxies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -210,19 +210,6 @@
             <artifactId>jsr166e</artifactId>
             <version>1.1.0</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.littleshoot</groupId>
-            <artifactId>littleproxy</artifactId>
-            <version>1.0.0-beta7</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.barchart.udt</groupId>
-                    <artifactId>barchart-udt-bundle</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -211,6 +211,18 @@
             <version>1.1.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.littleshoot</groupId>
+            <artifactId>littleproxy</artifactId>
+            <version>1.0.0-beta7</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.barchart.udt</groupId>
+                    <artifactId>barchart-udt-bundle</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -102,10 +102,10 @@ public class PluginManager {
                 protected PasswordAuthentication getPasswordAuthentication() {
                     if (getRequestorType() == Authenticator.RequestorType.PROXY) {
                         String prot = getRequestingProtocol().toLowerCase(Locale.ROOT);
-                        String host = System.getProperty(prot + ".proxyHost", "");
-                        String port = System.getProperty(prot + ".proxyPort", "");
-                        String user = System.getProperty(prot + ".proxyUser", "");
-                        String password = System.getProperty(prot + ".proxyPassword", "");
+                        String host = System.getProperty(prot + ".proxyHost", System.getProperty("proxyHost", ""));
+                        String port = System.getProperty(prot + ".proxyPort", System.getProperty("proxyPort"));
+                        String user = System.getProperty(prot + ".proxyUser", System.getProperty("proxyUser", ""));
+                        String password = System.getProperty(prot + ".proxyPassword", System.getProperty("proxyPassword", ""));
 
                         boolean isPortCorrect = Strings.isNullOrEmpty(port) ? true : Integer.parseInt(port) == getRequestingPort();
                         if (getRequestingHost().toLowerCase(Locale.ROOT).equals(host.toLowerCase(Locale.ROOT)) && isPortCorrect) {

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManagerCliParser.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManagerCliParser.java
@@ -107,7 +107,7 @@ public class PluginManagerCliParser extends CliTool {
 
         @Override
         public ExitStatus execute(Settings settings, Environment env) throws Exception {
-            PluginManager pluginManager = new PluginManager(env, null, outputMode, DEFAULT_TIMEOUT);
+            PluginManager pluginManager = new PluginManager(env, null, outputMode, DEFAULT_TIMEOUT, null);
             pluginManager.listInstalledPlugins(terminal);
             return ExitStatus.OK;
         }
@@ -151,7 +151,7 @@ public class PluginManagerCliParser extends CliTool {
         @Override
         public ExitStatus execute(Settings settings, Environment env) throws Exception {
 
-            PluginManager pluginManager = new PluginManager(env, null, outputMode, DEFAULT_TIMEOUT);
+            PluginManager pluginManager = new PluginManager(env, null, outputMode, DEFAULT_TIMEOUT, null);
             terminal.println("-> Removing " + Strings.nullToEmpty(pluginName) + "...");
             pluginManager.removePlugin(pluginName, terminal);
             return ExitStatus.OK;
@@ -168,6 +168,7 @@ public class PluginManagerCliParser extends CliTool {
         private static final CliToolConfig.Cmd CMD = cmd(NAME, Install.class)
                 .options(option("u", "url").required(false).hasArg(true))
                 .options(option("t", "timeout").required(false).hasArg(false))
+                .options(option("p", "proxy").required(false).hasArg(true))
                 .build();
 
         static Command parse(Terminal terminal, CommandLine cli) {
@@ -188,25 +189,28 @@ public class PluginManagerCliParser extends CliTool {
                 outputMode = OutputMode.VERBOSE;
             }
 
-            return new Install(terminal, name, outputMode, url, timeout);
+            String proxy = cli.getOptionValue("p");
+            return new Install(terminal, name, outputMode, url, timeout, proxy);
         }
 
         final String name;
         private OutputMode outputMode;
         final String url;
         final TimeValue timeout;
+        private final String proxy;
 
-        Install(Terminal terminal, String name, OutputMode outputMode, String url, TimeValue timeout) {
+        Install(Terminal terminal, String name, OutputMode outputMode, String url, TimeValue timeout, String proxy) {
             super(terminal);
             this.name = name;
             this.outputMode = outputMode;
             this.url = url;
             this.timeout = timeout;
+            this.proxy = proxy;
         }
 
         @Override
         public ExitStatus execute(Settings settings, Environment env) throws Exception {
-            PluginManager pluginManager = new PluginManager(env, url, outputMode, timeout);
+            PluginManager pluginManager = new PluginManager(env, url, outputMode, timeout, proxy);
             terminal.println("-> Installing " + Strings.nullToEmpty(name) + "...");
             pluginManager.downloadAndExtract(name, terminal);
             return ExitStatus.OK;

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerProxyTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerProxyTests.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import io.netty.handler.codec.http.HttpRequest;
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.cli.Terminal;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
+import org.elasticsearch.plugins.PluginManager.OutputMode;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.littleshoot.proxy.HttpFilters;
+import org.littleshoot.proxy.HttpFiltersSourceAdapter;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.ProxyAuthenticator;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
+import static org.elasticsearch.plugins.PluginManager.DEFAULT_TIMEOUT;
+import static org.elasticsearch.plugins.PluginManager.setProxyPropertiesFromURL;
+import static org.hamcrest.Matchers.*;
+
+@LuceneTestCase.SuppressFileSystems("*") // due to jimfs, see PluginManagerTests
+public class PluginManagerProxyTests extends ElasticsearchTestCase {
+
+    public static final String PROXY_AUTH_USERNAME = "mySecretUser";
+    public static final String PROXY_AUTH_PASSWORD = "mySecretPassword";
+
+    private final int randomProxyPort = randomIntBetween(49152, 65535);
+    private final List<HttpRequest> requests = new ArrayList<>();
+    private Environment environment;
+
+    private final ProxyAuthenticator proxyAuthenticator = new ProxyAuthenticator() {
+        @Override
+        public boolean authenticate(String userName, String password) {
+            return PROXY_AUTH_USERNAME.equals(userName) && PROXY_AUTH_PASSWORD.equals(password);
+        }
+    };
+
+    private final HttpFiltersSourceAdapter filtersSource = new HttpFiltersSourceAdapter() {
+        @Override
+        public HttpFilters filterRequest(HttpRequest originalRequest) {
+            requests.add(originalRequest);
+            return super.filterRequest(originalRequest);
+        }
+    };
+
+    @Before
+    public void setupEnvironment() throws Exception {
+        Path homeDir = createTempDir();
+        Files.createDirectory(homeDir.resolve("config"));
+        Files.createDirectory(homeDir.resolve("plugins"));
+        System.setProperty("es.path.home", homeDir.toString());
+        environment = InternalSettingsPreparer.prepareSettings(EMPTY_SETTINGS, true, Terminal.DEFAULT).v2();
+    }
+
+    @After
+    public void clearProperties() throws Exception {
+        System.clearProperty("es.path.home");
+
+        for (String protocol : new String[]{"http.", "https.", ""}) {
+            System.clearProperty(protocol + "proxyHost");
+            System.clearProperty(protocol + "proxyPort");
+            System.clearProperty(protocol + "proxyUser");
+            System.clearProperty(protocol + "proxyPassword");
+        }
+    }
+
+    public void testThatProxyCanBeConfiguredViaProperty() throws Exception {
+        assumeTrue("test requires security manager to be disabled", System.getSecurityManager() == null);
+
+        System.setProperty("proxyHost", "localhost");
+        System.setProperty("proxyPort", "" + randomProxyPort);
+
+        HttpProxyServer server = DefaultHttpProxyServer.bootstrap()
+                .withPort(randomProxyPort)
+                .withFiltersSource(filtersSource)
+                .start();
+
+        try {
+            PluginManager pluginManager = new PluginManager(environment, null, OutputMode.DEFAULT, DEFAULT_TIMEOUT, null);
+            pluginManager.downloadAndExtract("elasticsearch/license/latest");
+
+            assertThat(requests, hasSize(1));
+        } finally {
+            server.stop();
+        }
+    }
+
+    public void testThatProxyCanContainBasicAuthInformation() throws Exception {
+        assumeTrue("test requires security manager to be disabled", System.getSecurityManager() == null);
+
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "" + randomProxyPort);
+        System.setProperty("http.proxyUser", PROXY_AUTH_USERNAME);
+        System.setProperty("http.proxyPassword", PROXY_AUTH_PASSWORD);
+
+        HttpProxyServer server = DefaultHttpProxyServer.bootstrap()
+                .withPort(randomProxyPort)
+                .withFiltersSource(filtersSource)
+                .withProxyAuthenticator(proxyAuthenticator)
+            .start();
+
+        try {
+            PluginManager pluginManager = new PluginManager(environment, null, OutputMode.VERBOSE, DEFAULT_TIMEOUT, null);
+            pluginManager.downloadAndExtract("elasticsearch/license/latest");
+
+            assertThat(requests, hasSize(1));
+        } finally {
+            server.stop();
+        }
+    }
+
+    public void testThatProxyCanContainBasicAuthInformationViaCommandline() throws Exception {
+        assumeTrue("test requires security manager to be disabled", System.getSecurityManager() == null);
+
+        HttpProxyServer server = DefaultHttpProxyServer.bootstrap()
+                .withPort(randomProxyPort)
+                .withFiltersSource(filtersSource)
+                .withProxyAuthenticator(proxyAuthenticator)
+                .start();
+
+        try {
+            String url = String.format(Locale.ROOT, "http://%s:%s@localhost:%s", PROXY_AUTH_USERNAME, PROXY_AUTH_PASSWORD, randomProxyPort);
+            PluginManager pluginManager = new PluginManager(environment, null, OutputMode.VERBOSE, DEFAULT_TIMEOUT, url);
+            pluginManager.downloadAndExtract("elasticsearch/license/latest");
+
+            assertThat(requests, hasSize(1));
+        } finally {
+            server.stop();
+        }
+    }
+
+    public void testThatPropertiesAreSetCorrectlyFromUrlString() throws Exception {
+        for (String protocol : new String[]{"http", "https"}) {
+            assertSystemProxyProperties(protocol + "://username:password@proxy.acme.corp:3128", protocol, "proxy.acme.corp", 3128, "username", "password");
+            assertSystemProxyProperties(protocol + "://proxy.acme.corp:3128", protocol, "proxy.acme.corp", 3128, null, null);
+            assertSystemProxyProperties(protocol + "://proxy.acme.corp", protocol, "proxy.acme.corp", null, null, null);
+            assertSystemProxyProperties(protocol + "://username@proxy.acme.corp:3128", protocol, "proxy.acme.corp", 3128, null, null);
+            assertSystemProxyProperties(protocol + "://:password@proxy.acme.corp:3128", protocol, "proxy.acme.corp", 3128, "", "password");
+            assertSystemProxyProperties(protocol + "://username:@proxy.acme.corp:3128", protocol, "proxy.acme.corp", 3128, "username", "");
+        }
+        assertSystemProxyProperties(null, null, null, null, null, null);
+
+        try {
+            assertSystemProxyProperties("proxy.acme.corp", "http", "proxy.acme.corp", 3128, "username", "password");
+            fail("Expected IllegalArgumentException but did not happen");
+        } catch (IllegalArgumentException e) {}
+    }
+
+    private void assertSystemProxyProperties(String uri, String protocol, String host, Integer port, String username, String password) throws Exception {
+        try {
+            setProxyPropertiesFromURL(uri);
+            assertThat(String.format(Locale.ROOT, "Expected %s.proxyHost to be %s", protocol, host), System.getProperty(protocol + ".proxyHost"), is(host));
+
+            if (port == null) {
+                assertThat(String.format(Locale.ROOT, "Expected %s.proxyPort to be null", protocol), System.getProperty(protocol + ".proxyPort"), is(nullValue()));
+            } else {
+                assertThat(String.format(Locale.ROOT, "Expected %s.proxyPort to be %s", protocol, port), System.getProperty(protocol + ".proxyPort"), is(String.valueOf(port)));
+            }
+
+            if (username == null) {
+                assertThat(String.format(Locale.ROOT, "Expected %s.proxyUser to be null", protocol, username), System.getProperty(protocol + ".proxyUser"), is(nullValue()));
+            } else {
+                assertThat(String.format(Locale.ROOT, "Expected %s.proxyUser to be %s", protocol, username), System.getProperty(protocol + ".proxyUser"), is(username));
+            }
+
+            if (password == null) {
+                assertThat(String.format(Locale.ROOT, "Expected %s.proxyPassword to be null", protocol, password), System.getProperty(protocol + ".proxyPassword"), is(nullValue()));
+            } else {
+                assertThat(String.format(Locale.ROOT, "Expected %s.proxyPassword to be %s", protocol, password), System.getProperty(protocol + ".proxyPassword"), is(password));
+            }
+        } finally {
+            clearProperties();
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
@@ -283,7 +283,6 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
         Environment env = initialSettings.v2();
         Path binDir = env.homeFile().resolve("bin");
         Path pluginBinDir = binDir.resolve(pluginName);
-
         assertStatusOk(String.format(Locale.ROOT, "install %s --url %s --verbose", pluginName, pluginUrl));
         assertThatPluginIsListed(pluginName);
         assertDirectoryExists(pluginBinDir);


### PR DESCRIPTION
In order to support basic auth against proxies, this
commit introduces support for this and also adds a
`--proxy` argument for the plugin manager.

it also changes the default authenticator (which is used by HttpUrlConnection) and adds the auth info, in case it is used. As the PluginManager is only loaded on `bin/plugin` I do not think this is a problem, but feel free to correct me here.

Closes #11001 

**Important**: This PR adds a new dependency for littleproxy, which in turn has a dependency on netty 4. This is not a problem from any classpath point of view as `org.jboss` is used in netty3 and `io.netty` in netty 4. However as I did not want to reimplement HTTP proxy functionality for now I opted on this. We could potentially replace this with Jetty or roll our own hopefully correct proxy impl. Would be happy if there are any opinions about this. Another problem is, that these tests only work with the security manager disabled.

TODO: Documentation, put the dependency into the right pom (only makes sense if there is consensus that this is the right testing approach). Add `@network` annotations
