### PR TITLE
[DOCS] Mention plugin version compatibility in upgrade guide

### DIFF
--- a/docs/reference/setup/upgrade.asciidoc
+++ b/docs/reference/setup/upgrade.asciidoc
@@ -29,7 +29,7 @@ consult this table:
 |1.x            |2.x            |<<restart-upgrade,Full cluster restart>>
 |=======================================================================
 
-TIP: Take plugins into consideration as well when upgrading. For example, some plugins require a specific version of Elasticsearch to be installed.
+TIP: Take plugins into consideration as well when upgrading. Most plugins will have to be upgraded alongside Elasticsearch, although some plugins accessed primarily through the browser (`_site` plugins) may continue to work given that API changes are compatible.
 
 include::backup.asciidoc[]
 

--- a/docs/reference/setup/upgrade.asciidoc
+++ b/docs/reference/setup/upgrade.asciidoc
@@ -29,6 +29,8 @@ consult this table:
 |1.x            |2.x            |<<restart-upgrade,Full cluster restart>>
 |=======================================================================
 
+TIP: Take plugins into consideration as well when upgrading. For example, some plugins require a specific version of Elasticsearch to be installed.
+
 include::backup.asciidoc[]
 
 include::rolling_upgrade.asciidoc[]


### PR DESCRIPTION
Add note regarding plugin version compatibility - for example, the AWS plugin can crash a node at startup when versions mismatch.
