### PR TITLE
BulkRequestBuilder.add() has typo in JavaDoc.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequestBuilder.java
@@ -77,7 +77,7 @@ public class BulkRequestBuilder extends ActionRequestBuilder<BulkRequest, BulkRe
 
 
     /**
-     * Adds an {@link DeleteRequest} to the list of actions to execute.
+     * Adds an {@link UpdateRequest} to the list of actions to execute.
      */
     public BulkRequestBuilder add(UpdateRequest request) {
         super.request.add(request);
@@ -85,7 +85,7 @@ public class BulkRequestBuilder extends ActionRequestBuilder<BulkRequest, BulkRe
     }
 
     /**
-     * Adds an {@link DeleteRequest} to the list of actions to execute.
+     * Adds an {@link UpdateRequest} to the list of actions to execute.
      */
     public BulkRequestBuilder add(UpdateRequestBuilder request) {
         super.request.add(request.request());


### PR DESCRIPTION
Closes #12138
