### PR TITLE
Use IndexWriter.hasPendingChanges() to detect if a flush is needed.

### DIFF
--- a/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -90,9 +90,6 @@ public class InternalEngine extends Engine {
     private final SearcherFactory searcherFactory;
     private final SearcherManager searcherManager;
 
-    // we use flushNeeded here, since if there are no changes, then the commit won't write
-    // will not really happen, and then the commitUserData and the new translog will not be reflected
-    private volatile boolean flushNeeded = false;
     private final Lock flushLock = new ReentrantLock();
     private final ReentrantLock optimizeLock = new ReentrantLock();
 
@@ -262,7 +259,6 @@ public class InternalEngine extends Engine {
                     innerCreate(create);
                 }
             }
-            flushNeeded = true;
         } catch (OutOfMemoryError | IllegalStateException | IOException t) {
             maybeFailEngine("create", t);
             throw new CreateFailedEngineException(shardId, create, t);
@@ -368,7 +364,6 @@ public class InternalEngine extends Engine {
                     innerIndex(index);
                 }
             }
-            flushNeeded = true;
         } catch (OutOfMemoryError | IllegalStateException | IOException t) {
             maybeFailEngine("index", t);
             throw new IndexFailedEngineException(shardId, index, t);
@@ -460,7 +455,6 @@ public class InternalEngine extends Engine {
             ensureOpen();
             // NOTE: we don't throttle this when merges fall behind because delete-by-id does not create new segments:
             innerDelete(delete);
-            flushNeeded = true;
         } catch (OutOfMemoryError | IllegalStateException | IOException t) {
             maybeFailEngine("delete", t);
             throw new DeleteFailedEngineException(shardId, delete, t);
@@ -553,7 +547,6 @@ public class InternalEngine extends Engine {
 
             indexWriter.deleteDocuments(query);
             translog.add(new Translog.DeleteByQuery(delete));
-            flushNeeded = true;
         } catch (Throwable t) {
             maybeFailEngine("delete_by_query", t);
             throw new DeleteByQueryFailedEngineException(shardId, delete, t);
@@ -668,8 +661,7 @@ public class InternalEngine extends Engine {
                         throw new FlushNotAllowedEngineException(shardId, "recovery is in progress, flush is not allowed");
                     }
 
-                    if (flushNeeded || force) {
-                        flushNeeded = false;
+                    if (indexWriter.hasUncommittedChanges() || force) {
                         try {
                             long translogId = translogIdGenerator.incrementAndGet();
                             translog.newTransientTranslog(translogId);


### PR DESCRIPTION
This is required to ensure we flush the indexwriter / commit all changes
even if no docs are indexed. This is important if a merge happend after
the last flush and no further docs have been added. Otherwise merges
will not be committed if no docs where added/updated/deleted.

This is equivalent to what master does today.

Closes #12134
