### PR TITLE
Remove double call to elect primaries

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -175,8 +175,6 @@ public class AllocationService extends AbstractComponent {
         // now allocate all the unassigned to available nodes
         if (allocation.routingNodes().hasUnassigned()) {
             changed |= shardsAllocators.allocateUnassigned(allocation);
-            // elect primaries again, in case this is needed with unassigned allocation
-            changed |= electPrimariesAndUnassignedDanglingReplicas(allocation);
         }
 
         // move shards that no longer can be allocated


### PR DESCRIPTION
There is no need to call the elect logic twice, we used to need it, but no longer since we handle dangling replicas for unassigned primaries properly
