### PR TITLE
Don't require fields in alias filters to exist in the mapping

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -145,7 +145,6 @@ public class AliasValidator extends AbstractComponent {
         QueryParseContext context = indexQueryParserService.getParseContext();
         try {
             context.reset(parser);
-            context.setAllowUnmappedFields(false);
             context.parseInnerFilter();
         } finally {
             context.reset(null);

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -770,3 +770,8 @@ For the record, official plugins which can use this new simplified form are:
 * elasticsearch-lang-javascript
 * elasticsearch-lang-python
 
+=== Aliases
+
+Fields used in alias filters no longer have to exist in the mapping upon alias creation time. Alias filters are now
+parsed at request time and then the fields in filters are resolved from the mapping, whereas before alias filters were
+parsed at alias creation time and the parsed form was kept around in memory.


### PR DESCRIPTION
Before alias filters were parsed at alias creation time. Therefor it was critical that fields used in alias filters  exist in the mapping, otherwise the the alias filter wouldn't work correctly.

Now that alias filters are parsed at request time, the restriction that a field needs to exist at alias creation time is no longer valid. This PR removes that restriction.
