### PR TITLE
Adds new script API to ValuesSourceMetricsAggregationBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/ValuesSourceMetricsAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/ValuesSourceMetricsAggregationBuilder.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import com.google.common.collect.Maps;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.script.Script;
 
 import java.io.IOException;
 import java.util.Map;
@@ -32,10 +33,14 @@ import java.util.Map;
 public abstract class ValuesSourceMetricsAggregationBuilder<B extends ValuesSourceMetricsAggregationBuilder<B>> extends MetricsAggregationBuilder<B> {
 
     private String field;
-    private String script;
-    private String lang;
+    private Script script;
+    @Deprecated
+    private String scriptString; // TODO Remove in 3.0
+    @Deprecated
+    private String lang; // TODO Remove in 3.0
+    @Deprecated
+    private Map<String, Object> params; // TODO Remove in 3.0
     private String format;
-    private Map<String, Object> params;
     private Object missing;
 
     protected ValuesSourceMetricsAggregationBuilder(String name, String type) {
@@ -48,24 +53,39 @@ public abstract class ValuesSourceMetricsAggregationBuilder<B extends ValuesSour
         return (B) this;
     }
 
+    /**
+     * The script to use for this aggregation
+     */
     @SuppressWarnings("unchecked")
-    public B script(String script) {
+    public B script(Script script) {
         this.script = script;
         return (B) this;
     }
 
+    /**
+     * @deprecated use {@link #script(Script)} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public B script(String script) {
+        this.scriptString = script;
+        return (B) this;
+    }
+
+    /**
+     * @deprecated use {@link #script(Script)} instead.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public B lang(String lang) {
         this.lang = lang;
         return (B) this;
     }
 
-    @SuppressWarnings("unchecked")
-    public B format(String format) {
-        this.format = format;
-        return (B) this;
-    }
-
+    /**
+     * @deprecated use {@link #script(Script)} instead.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public B params(Map<String, Object> params) {
         if (this.params == null) {
@@ -76,12 +96,22 @@ public abstract class ValuesSourceMetricsAggregationBuilder<B extends ValuesSour
         return (B) this;
     }
 
+    /**
+     * @deprecated use {@link #script(Script)} instead.
+     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public B param(String name, Object value) {
         if (this.params == null) {
             this.params = Maps.newHashMap();
         }
         this.params.put(name, value);
+        return (B) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public B format(String format) {
+        this.format = format;
         return (B) this;
     }
 
@@ -101,6 +131,10 @@ public abstract class ValuesSourceMetricsAggregationBuilder<B extends ValuesSour
 
         if (script != null) {
             builder.field("script", script);
+        }
+
+        if (scriptString != null) {
+            builder.field("script", scriptString);
         }
 
         if (lang != null) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTests.java
@@ -103,5 +103,24 @@ public abstract class AbstractNumericTests extends ElasticsearchIntegrationTest 
 
     public abstract void testScript_MultiValued_WithParams() throws Exception;
 
+    public abstract void testSingleValuedField_WithValueScript_OldScriptAPI() throws Exception;
+
+    public abstract void testSingleValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception;
+
+    public abstract void testMultiValuedField_WithValueScript_OldScriptAPI() throws Exception;
+
+    public abstract void testMultiValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception;
+
+    public abstract void testScript_SingleValued_OldScriptAPI() throws Exception;
+
+    public abstract void testScript_SingleValued_WithParams_OldScriptAPI() throws Exception;
+
+    public abstract void testScript_ExplicitSingleValued_WithParams_OldScriptAPI() throws Exception;
+
+    public abstract void testScript_MultiValued_OldScriptAPI() throws Exception;
+
+    public abstract void testScript_ExplicitMultiValued_OldScriptAPI() throws Exception;
+
+    public abstract void testScript_MultiValued_WithParams_OldScriptAPI() throws Exception;
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgTests.java
@@ -19,10 +19,15 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
@@ -136,7 +141,7 @@ public class AvgTests extends AbstractNumericTests {
     public void testSingleValuedField_WithValueScript() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").field("value").script("_value + 1"))
+                .addAggregation(avg("avg").field("value").script(new Script("_value + 1")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -150,9 +155,11 @@ public class AvgTests extends AbstractNumericTests {
     @Override
     @Test
     public void testSingleValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").field("value").script("_value + inc").param("inc", 1))
+                .addAggregation(avg("avg").field("value").script(new Script("_value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -197,7 +204,7 @@ public class AvgTests extends AbstractNumericTests {
     public void testMultiValuedField_WithValueScript() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").field("values").script("_value + 1"))
+                .addAggregation(avg("avg").field("values").script(new Script("_value + 1")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -211,9 +218,11 @@ public class AvgTests extends AbstractNumericTests {
     @Override
     @Test
     public void testMultiValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").field("values").script("_value + inc").param("inc", 1))
+                .addAggregation(avg("avg").field("values").script(new Script("_value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -229,7 +238,7 @@ public class AvgTests extends AbstractNumericTests {
     public void testScript_SingleValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").script("doc['value'].value"))
+                .addAggregation(avg("avg").script(new Script("doc['value'].value")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -243,9 +252,11 @@ public class AvgTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_SingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").script("doc['value'].value + inc").param("inc", 1))
+                .addAggregation(avg("avg").script(new Script("doc['value'].value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -259,9 +270,11 @@ public class AvgTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_ExplicitSingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").script("doc['value'].value + inc").param("inc", 1))
+                .addAggregation(avg("avg").script(new Script("doc['value'].value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -277,7 +290,7 @@ public class AvgTests extends AbstractNumericTests {
     public void testScript_MultiValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").script("[ doc['value'].value, doc['value'].value + 1 ]"))
+                .addAggregation(avg("avg").script(new Script("[ doc['value'].value, doc['value'].value + 1 ]")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -293,7 +306,7 @@ public class AvgTests extends AbstractNumericTests {
     public void testScript_ExplicitMultiValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(avg("avg").script("[ doc['value'].value, doc['value'].value + 1 ]"))
+                .addAggregation(avg("avg").script(new Script("[ doc['value'].value, doc['value'].value + 1 ]")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -307,6 +320,199 @@ public class AvgTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_MultiValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        avg("avg").script(new Script("[ doc['value'].value, doc['value'].value + inc ]", ScriptType.INLINE, null, params)))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (1+2+2+3+3+4+4+5+5+6+6+7+7+8+8+9+9+10+10+11) / 20));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").field("value").script("_value + 1"))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (2+3+4+5+6+7+8+9+10+11) / 10));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").field("value").script("_value + inc").param("inc", 1))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (2+3+4+5+6+7+8+9+10+11) / 10));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").field("values").script("_value + 1"))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (3+4+4+5+5+6+6+7+7+8+8+9+9+10+10+11+11+12+12+13) / 20));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").field("values").script("_value + inc").param("inc", 1))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (3+4+4+5+5+6+6+7+7+8+8+9+9+10+10+11+11+12+12+13) / 20));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").script("doc['value'].value"))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (1+2+3+4+5+6+7+8+9+10) / 10));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").script("doc['value'].value + inc").param("inc", 1))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (2+3+4+5+6+7+8+9+10+11) / 10));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitSingleValued_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").script("doc['value'].value + inc").param("inc", 1))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (2+3+4+5+6+7+8+9+10+11) / 10));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").script("[ doc['value'].value, doc['value'].value + 1 ]"))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (1+2+2+3+3+4+4+5+5+6+6+7+7+8+8+9+9+10+10+11) / 20));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitMultiValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(avg("avg").script("[ doc['value'].value, doc['value'].value + 1 ]"))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Avg avg = searchResponse.getAggregations().get("avg");
+        assertThat(avg, notNullValue());
+        assertThat(avg.getName(), equalTo("avg"));
+        assertThat(avg.getValue(), equalTo((double) (1+2+2+3+3+4+4+5+5+6+6+7+7+8+8+9+9+10+10+11) / 20));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_WithParams_OldScriptAPI() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(avg("avg").script("[ doc['value'].value, doc['value'].value + inc ]").param("inc", 1))
@@ -319,5 +525,4 @@ public class AvgTests extends AbstractNumericTests {
         assertThat(avg.getName(), equalTo("avg"));
         assertThat(avg.getValue(), equalTo((double) (1+2+2+3+3+4+4+5+5+6+6+7+7+8+8+9+9+10+10+11) / 20));
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -323,7 +324,8 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedStringScript() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
-                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).script("doc['str_value'].value"))
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).script(new Script("doc['str_value'].value")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -337,7 +339,8 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Test
     public void multiValuedStringScript() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
-                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).script("doc['str_values'].values"))
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).script(new Script("doc['str_values'].values")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -351,7 +354,9 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedNumericScript() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
-                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).script("doc['" + singleNumericField(false) + "'].value"))
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).script(
+                                new Script("doc['" + singleNumericField(false) + "'].value")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -365,7 +370,9 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Test
     public void multiValuedNumericScript() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
-                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).script("doc['" + multiNumericField(false) + "'].values"))
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).script(
+                                new Script("doc['" + multiNumericField(false) + "'].values")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -379,7 +386,8 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedStringValueScript() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
-                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).field("str_value").script("_value"))
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).field("str_value").script(new Script("_value")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -393,7 +401,8 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Test
     public void multiValuedStringValueScript() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
-                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).field("str_values").script("_value"))
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).field("str_values").script(new Script("_value")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -407,7 +416,9 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Test
     public void singleValuedNumericValueScript() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
-                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).field(singleNumericField(false)).script("_value"))
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).field(singleNumericField(false))
+                                .script(new Script("_value")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -421,7 +432,9 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
     @Test
     public void multiValuedNumericValueScript() throws Exception {
         SearchResponse response = client().prepareSearch("idx").setTypes("type")
-                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).field(multiNumericField(false)).script("_value"))
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).field(multiNumericField(false))
+                                .script(new Script("_value")))
                 .execute().actionGet();
 
         assertSearchResponse(response);
@@ -468,6 +481,154 @@ public class CardinalityTests extends ElasticsearchIntegrationTest {
             assertThat(count.getName(), equalTo("cardinality"));
             assertCount(count, 2);
         }
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void singleValuedStringScript_OldScriptAPI() throws Exception {
+        SearchResponse response = client().prepareSearch("idx").setTypes("type")
+                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).script("doc['str_value'].value"))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertThat(count, notNullValue());
+        assertThat(count.getName(), equalTo("cardinality"));
+        assertCount(count, numDocs);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void multiValuedStringScript_OldScriptAPI() throws Exception {
+        SearchResponse response = client().prepareSearch("idx").setTypes("type")
+                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).script("doc['str_values'].values"))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertThat(count, notNullValue());
+        assertThat(count.getName(), equalTo("cardinality"));
+        assertCount(count, numDocs * 2);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void singleValuedNumericScript_OldScriptAPI() throws Exception {
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .setTypes("type")
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).script(
+                                "doc['" + singleNumericField(false) + "'].value")).execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertThat(count, notNullValue());
+        assertThat(count.getName(), equalTo("cardinality"));
+        assertCount(count, numDocs);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void multiValuedNumericScript_OldScriptAPI() throws Exception {
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .setTypes("type")
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).script(
+                                "doc['" + multiNumericField(false) + "'].values")).execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertThat(count, notNullValue());
+        assertThat(count.getName(), equalTo("cardinality"));
+        assertCount(count, numDocs * 2);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void singleValuedStringValueScript_OldScriptAPI() throws Exception {
+        SearchResponse response = client().prepareSearch("idx").setTypes("type")
+                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).field("str_value").script("_value"))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertThat(count, notNullValue());
+        assertThat(count.getName(), equalTo("cardinality"));
+        assertCount(count, numDocs);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void multiValuedStringValueScript_OldScriptAPI() throws Exception {
+        SearchResponse response = client().prepareSearch("idx").setTypes("type")
+                .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).field("str_values").script("_value"))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertThat(count, notNullValue());
+        assertThat(count.getName(), equalTo("cardinality"));
+        assertCount(count, numDocs * 2);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void singleValuedNumericValueScript_OldScriptAPI() throws Exception {
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .setTypes("type")
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).field(singleNumericField(false)).script("_value"))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertThat(count, notNullValue());
+        assertThat(count.getName(), equalTo("cardinality"));
+        assertCount(count, numDocs);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void multiValuedNumericValueScript_OldScriptAPI() throws Exception {
+        SearchResponse response = client()
+                .prepareSearch("idx")
+                .setTypes("type")
+                .addAggregation(
+                        cardinality("cardinality").precisionThreshold(precisionThreshold).field(multiNumericField(false)).script("_value"))
+                .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertThat(count, notNullValue());
+        assertThat(count.getName(), equalTo("cardinality"));
+        assertCount(count, numDocs * 2);
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsTests.java
@@ -20,10 +20,15 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
@@ -218,7 +223,7 @@ public class ExtendedStatsTests extends AbstractNumericTests {
         double expectedMaxValue = 10.0;
         assertThat(stats.getMax(), equalTo(expectedMaxValue));
         assertThat((double) global.getProperty("stats.max"), equalTo(expectedMaxValue));
-        double expectedSumValue = (double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10);
+        double expectedSumValue = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10;
         assertThat(stats.getSum(), equalTo(expectedSumValue));
         assertThat((double) global.getProperty("stats.sum"), equalTo(expectedSumValue));
         long expectedCountValue = 10;
@@ -266,7 +271,7 @@ public class ExtendedStatsTests extends AbstractNumericTests {
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").field("value").script("_value + 1").sigma(sigma))
+                .addAggregation(extendedStats("stats").field("value").script(new Script("_value + 1")).sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -288,10 +293,14 @@ public class ExtendedStatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testSingleValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").field("value").script("_value + inc").param("inc", 1).sigma(sigma))
+                .addAggregation(
+                        extendedStats("stats").field("value").script(new Script("_value + inc", ScriptType.INLINE, null, params))
+                                .sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -341,7 +350,7 @@ public class ExtendedStatsTests extends AbstractNumericTests {
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").field("values").script("_value - 1").sigma(sigma))
+                .addAggregation(extendedStats("stats").field("values").script(new Script("_value - 1")).sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -363,10 +372,14 @@ public class ExtendedStatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testMultiValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").field("values").script("_value - dec").param("dec", 1).sigma(sigma))
+                .addAggregation(
+                        extendedStats("stats").field("values").script(new Script("_value - dec", ScriptType.INLINE, null, params))
+                                .sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -391,7 +404,7 @@ public class ExtendedStatsTests extends AbstractNumericTests {
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").script("doc['value'].value").sigma(sigma))
+                .addAggregation(extendedStats("stats").script(new Script("doc['value'].value")).sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -413,10 +426,13 @@ public class ExtendedStatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_SingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").script("doc['value'].value + inc").param("inc", 1).sigma(sigma))
+                .addAggregation(
+                        extendedStats("stats").script(new Script("doc['value'].value + inc", ScriptType.INLINE, null, params)).sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -438,10 +454,13 @@ public class ExtendedStatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_ExplicitSingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").script("doc['value'].value + inc").param("inc", 1).sigma(sigma))
+                .addAggregation(
+                        extendedStats("stats").script(new Script("doc['value'].value + inc", ScriptType.INLINE, null, params)).sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -466,7 +485,7 @@ public class ExtendedStatsTests extends AbstractNumericTests {
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").script("doc['values'].values").sigma(sigma))
+                .addAggregation(extendedStats("stats").script(new Script("doc['values'].values")).sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -491,7 +510,7 @@ public class ExtendedStatsTests extends AbstractNumericTests {
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").script("doc['values'].values").sigma(sigma))
+                .addAggregation(extendedStats("stats").script(new Script("doc['values'].values")).sigma(sigma))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -515,10 +534,15 @@ public class ExtendedStatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_MultiValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         double sigma = randomDouble() * randomIntBetween(1, 10);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(extendedStats("stats").script("[ doc['value'].value, doc['value'].value - dec ]").param("dec", 1).sigma(sigma))
+                .addAggregation(
+                        extendedStats("stats").script(
+                                new Script("[ doc['value'].value, doc['value'].value - dec ]", ScriptType.INLINE, null, params))
+                                .sigma(sigma))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -552,6 +576,285 @@ public class ExtendedStatsTests extends AbstractNumericTests {
     private void checkUpperLowerBounds(ExtendedStats stats, double sigma) {
         assertThat(stats.getStdDeviationBound(ExtendedStats.Bounds.UPPER), equalTo(stats.getAvg() + (stats.getStdDeviation() * sigma)));
         assertThat(stats.getStdDeviationBound(ExtendedStats.Bounds.LOWER), equalTo(stats.getAvg() - (stats.getStdDeviation() * sigma)));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").field("value").script("_value + 1").sigma(sigma)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
+        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        checkUpperLowerBounds(stats, sigma);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").field("value").script("_value + inc").param("inc", 1).sigma(sigma)).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
+        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        checkUpperLowerBounds(stats, sigma);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").field("values").script("_value - 1").sigma(sigma)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(),
+                equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 20));
+        assertThat(stats.getMin(), equalTo(1.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 4 + 9 + 16 + 25 + 36 + 49 + 64
+                + 81 + 100 + 121));
+        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        checkUpperLowerBounds(stats, sigma);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").field("values").script("_value - dec").param("dec", 1).sigma(sigma)).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(),
+                equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 20));
+        assertThat(stats.getMin(), equalTo(1.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 4 + 9 + 16 + 25 + 36 + 49 + 64
+                + 81 + 100 + 121));
+        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        checkUpperLowerBounds(stats, sigma);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").script("doc['value'].value").sigma(sigma)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+        assertThat(stats.getMin(), equalTo(1.0));
+        assertThat(stats.getMax(), equalTo(10.0));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
+        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+        checkUpperLowerBounds(stats, sigma);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_WithParams_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").script("doc['value'].value + inc").param("inc", 1).sigma(sigma)).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
+        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        checkUpperLowerBounds(stats, sigma);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitSingleValued_WithParams_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").script("doc['value'].value + inc").param("inc", 1).sigma(sigma)).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
+        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+        checkUpperLowerBounds(stats, sigma);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").script("doc['values'].values").sigma(sigma)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(),
+                equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12) / 20));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(12.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12));
+        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 9 + 16 + 25 + 36 + 49 + 64
+                + 81 + 100 + 121 + 144));
+        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
+        checkUpperLowerBounds(stats, sigma);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitMultiValued_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").script("doc['values'].values").sigma(sigma)).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(),
+                equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12) / 20));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(12.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12));
+        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 9 + 16 + 25 + 36 + 49 + 64
+                + 81 + 100 + 121 + 144));
+        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
+        checkUpperLowerBounds(stats, sigma);
+
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_WithParams_OldScriptAPI() throws Exception {
+        double sigma = randomDouble() * randomIntBetween(1, 10);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        extendedStats("stats").script("[ doc['value'].value, doc['value'].value - dec ]").param("dec", 1).sigma(sigma))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        ExtendedStats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9) / 20));
+        assertThat(stats.getMin(), equalTo(0.0));
+        assertThat(stats.getMax(), equalTo(10.0));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9));
+        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 0 + 1 + 4 + 9 + 16 + 25 + 36
+                + 49 + 64 + 81));
+        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
+        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
+        checkUpperLowerBounds(stats, sigma);
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxTests.java
@@ -19,10 +19,15 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.max.Max;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
@@ -150,7 +155,7 @@ public class MaxTests extends AbstractNumericTests {
     public void testSingleValuedField_WithValueScript() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").field("value").script("_value + 1"))
+                .addAggregation(max("max").field("value").script(new Script("_value + 1")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -164,9 +169,11 @@ public class MaxTests extends AbstractNumericTests {
     @Override
     @Test
     public void testSingleValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").field("value").script("_value + inc").param("inc", 1))
+                .addAggregation(max("max").field("value").script(new Script("_value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -198,7 +205,7 @@ public class MaxTests extends AbstractNumericTests {
     public void testMultiValuedField_WithValueScript() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").field("values").script("_value + 1"))
+                .addAggregation(max("max").field("values").script(new Script("_value + 1")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -212,9 +219,11 @@ public class MaxTests extends AbstractNumericTests {
     @Override
     @Test
     public void testMultiValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").field("values").script("_value + inc").param("inc", 1))
+                .addAggregation(max("max").field("values").script(new Script("_value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -230,7 +239,7 @@ public class MaxTests extends AbstractNumericTests {
     public void testScript_SingleValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").script("doc['value'].value"))
+                .addAggregation(max("max").script(new Script("doc['value'].value")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -244,9 +253,11 @@ public class MaxTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_SingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").script("doc['value'].value + inc").param("inc", 1))
+                .addAggregation(max("max").script(new Script("doc['value'].value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -260,9 +271,11 @@ public class MaxTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_ExplicitSingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").script("doc['value'].value + inc").param("inc", 1))
+                .addAggregation(max("max").script(new Script("doc['value'].value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -278,7 +291,7 @@ public class MaxTests extends AbstractNumericTests {
     public void testScript_MultiValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").script("doc['values'].values"))
+                .addAggregation(max("max").script(new Script("doc['values'].values")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -294,7 +307,7 @@ public class MaxTests extends AbstractNumericTests {
     public void testScript_ExplicitMultiValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(max("max").script("doc['values'].values"))
+                .addAggregation(max("max").script(new Script("doc['values'].values")))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -308,9 +321,11 @@ public class MaxTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_MultiValued_WithParams() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx")
-                .setQuery(matchAllQuery())
-                .addAggregation(max("max").script("[ doc['value'].value, doc['value'].value + inc ]").param("inc", 1))
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                        max("max").script(new Script("[ doc['value'].value, doc['value'].value + inc ]", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
@@ -321,5 +336,176 @@ public class MaxTests extends AbstractNumericTests {
         assertThat(max.getValue(), equalTo(11.0));
     }
 
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").field("value").script("_value + 1")).execute().actionGet();
 
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(11.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").field("value").script("_value + inc").param("inc", 1)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(11.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").field("values").script("_value + 1")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(13.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(max("max").field("values").script("_value + inc").param("inc", 1)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(13.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").script("doc['value'].value")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(10.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").script("doc['value'].value + inc").param("inc", 1))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(11.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitSingleValued_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").script("doc['value'].value + inc").param("inc", 1)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(11.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").script("doc['values'].values")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(12.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitMultiValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").script("doc['values'].values")).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(12.0));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(max("max").script("[ doc['value'].value, doc['value'].value + inc ]").param("inc", 1)).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Max max = searchResponse.getAggregations().get("max");
+        assertThat(max, notNullValue());
+        assertThat(max.getName(), equalTo("max"));
+        assertThat(max.getValue(), equalTo(11.0));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksTests.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Lists;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Order;
@@ -31,7 +33,9 @@ import org.elasticsearch.search.aggregations.metrics.percentiles.PercentileRanks
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
@@ -49,7 +53,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class PercentileRanksTests extends AbstractNumericTests {
 
     private static double[] randomPercents(long minValue, long maxValue) {
-        
+
         final int length = randomIntBetween(1, 20);
         final double[] percents = new double[length];
         for (int i = 0; i < percents.length; ++i) {
@@ -229,7 +233,7 @@ public class PercentileRanksTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .field("value").script("_value - 1")
+.field("value").script(new Script("_value - 1"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -242,11 +246,14 @@ public class PercentileRanksTests extends AbstractNumericTests {
     @Override
     @Test
     public void testSingleValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .field("value").script("_value - dec").param("dec", 1)
+.field("value")
+                                .script(new Script("_value - dec", ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -280,7 +287,7 @@ public class PercentileRanksTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .field("values").script("_value - 1")
+.field("values").script(new Script("_value - 1"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -296,7 +303,7 @@ public class PercentileRanksTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .field("values").script("_value * -1")
+.field("values").script(new Script("_value * -1"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -309,11 +316,14 @@ public class PercentileRanksTests extends AbstractNumericTests {
     @Override
     @Test
     public void testMultiValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .field("values").script("_value - dec").param("dec", 1)
+.field("values")
+                                .script(new Script("_value - dec", ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -330,7 +340,7 @@ public class PercentileRanksTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .script("doc['value'].value")
+.script(new Script("doc['value'].value"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -343,11 +353,14 @@ public class PercentileRanksTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_SingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .script("doc['value'].value - dec").param("dec", 1)
+.script(
+                                new Script("doc['value'].value - dec", ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -360,11 +373,14 @@ public class PercentileRanksTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_ExplicitSingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercents(minValue -1 , maxValue - 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .script("doc['value'].value - dec").param("dec", 1)
+.script(
+                                new Script("doc['value'].value - dec", ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -381,7 +397,7 @@ public class PercentileRanksTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .script("doc['values'].values")
+.script(new Script("doc['values'].values"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -398,7 +414,7 @@ public class PercentileRanksTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .script("doc['values'].values")
+.script(new Script("doc['values'].values"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -411,11 +427,15 @@ public class PercentileRanksTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_MultiValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks"))
-                        .script("List values = doc['values'].values; double[] res = new double[values.size()]; for (int i = 0; i < res.length; i++) { res[i] = values.get(i) - dec; }; return res;").param("dec", 1)
+                                .script(new Script(
+                                        "List values = doc['values'].values; double[] res = new double[values.size()]; for (int i = 0; i < res.length; i++) { res[i] = values.get(i) - dec; }; return res;",
+                                        ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -450,6 +470,217 @@ public class PercentileRanksTests extends AbstractNumericTests {
             }
             previous = p99;
         }
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentileRanks("percentile_ranks")).field("value").script("_value - 1").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentileRanks("percentile_ranks")).field("value").script("_value - dec").param("dec", 1)
+                                .percentiles(pcts)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentileRanks("percentile_ranks")).field("values").script("_value - 1").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void testMultiValuedField_WithValueScript_Reverse_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(-maxValues, -minValues);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentileRanks("percentile_ranks")).field("values").script("_value * -1").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, -maxValues, -minValues);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentileRanks("percentile_ranks")).field("values").script("_value - dec").param("dec", 1)
+                                .percentiles(pcts)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValue, maxValue);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentileRanks("percentile_ranks")).script("doc['value'].value").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValue, maxValue);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentileRanks("percentile_ranks")).script("doc['value'].value - dec").param("dec", 1)
+                                .percentiles(pcts)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitSingleValued_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentileRanks("percentile_ranks")).script("doc['value'].value - dec").param("dec", 1)
+                                .percentiles(pcts)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValues, maxValues);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentileRanks("percentile_ranks")).script("doc['values'].values").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValues, maxValues);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitMultiValued_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValues, maxValues);
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentileRanks("percentile_ranks")).script("doc['values'].values").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValues, maxValues);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentileRanks("percentile_ranks"))
+                                .script("List values = doc['values'].values; double[] res = new double[values.size()]; for (int i = 0; i < res.length; i++) { res[i] = values.get(i) - dec; }; return res;")
+                                .param("dec", 1).percentiles(pcts)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final PercentileRanks percentiles = searchResponse.getAggregations().get("percentile_ranks");
+        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1);
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Lists;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Order;
@@ -31,7 +33,9 @@ import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesBuil
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
@@ -212,7 +216,7 @@ public class PercentilesTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .field("value").script("_value - 1")
+.field("value").script(new Script("_value - 1"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -225,11 +229,14 @@ public class PercentilesTests extends AbstractNumericTests {
     @Override
     @Test
     public void testSingleValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercentiles();
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .field("value").script("_value - dec").param("dec", 1)
+.field("value")
+                                .script(new Script("_value - dec", ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -263,7 +270,7 @@ public class PercentilesTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .field("values").script("_value - 1")
+.field("values").script(new Script("_value - 1"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -279,7 +286,7 @@ public class PercentilesTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .field("values").script("_value * -1")
+.field("values").script(new Script("_value * -1"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -292,11 +299,14 @@ public class PercentilesTests extends AbstractNumericTests {
     @Override
     @Test
     public void testMultiValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercentiles();
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .field("values").script("_value - dec").param("dec", 1)
+.field("values")
+                                .script(new Script("_value - dec", ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -313,7 +323,7 @@ public class PercentilesTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .script("doc['value'].value")
+.script(new Script("doc['value'].value"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -326,11 +336,14 @@ public class PercentilesTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_SingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercentiles();
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .script("doc['value'].value - dec").param("dec", 1)
+.script(
+                                new Script("doc['value'].value - dec", ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -343,11 +356,14 @@ public class PercentilesTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_ExplicitSingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercentiles();
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .script("doc['value'].value - dec").param("dec", 1)
+.script(
+                                new Script("doc['value'].value - dec", ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -364,7 +380,7 @@ public class PercentilesTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .script("doc['values'].values")
+.script(new Script("doc['values'].values"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -381,7 +397,7 @@ public class PercentilesTests extends AbstractNumericTests {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .script("doc['values'].values")
+.script(new Script("doc['values'].values"))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -394,11 +410,15 @@ public class PercentilesTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_MultiValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         final double[] pcts = randomPercentiles();
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
-                        .script("List values = doc['values'].values; double[] res = new double[values.size()]; for (int i = 0; i < res.length; i++) { res[i] = values.get(i) - dec; }; return res;").param("dec", 1)
+                                .script(new Script(
+                                        "List values = doc['values'].values; double[] res = new double[values.size()]; for (int i = 0; i < res.length; i++) { res[i] = values.get(i) - dec; }; return res;",
+                                        ScriptType.INLINE, null, params))
                         .percentiles(pcts))
                 .execute().actionGet();
 
@@ -433,6 +453,208 @@ public class PercentilesTests extends AbstractNumericTests {
             }
             previous = p99;
         }
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentiles("percentiles")).field("value").script("_value - 1").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentiles("percentiles")).field("value").script("_value - dec").param("dec", 1)
+                                .percentiles(pcts)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentiles("percentiles")).field("values").script("_value - 1").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Test
+    public void testMultiValuedField_WithValueScript_Reverse_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentiles("percentiles")).field("values").script("_value * -1").percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, -maxValues, -minValues);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentiles("percentiles")).field("values").script("_value - dec").param("dec", 1)
+                                .percentiles(pcts)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentiles("percentiles")).script("doc['value'].value").percentiles(pcts)).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValue, maxValue);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentiles("percentiles")).script("doc['value'].value - dec").param("dec", 1).percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitSingleValued_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentiles("percentiles")).script("doc['value'].value - dec").param("dec", 1).percentiles(pcts))
+                .execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentiles("percentiles")).script("doc['values'].values").percentiles(pcts)).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValues, maxValues);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitMultiValued_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(randomCompression(percentiles("percentiles")).script("doc['values'].values").percentiles(pcts)).execute()
+                .actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValues, maxValues);
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_WithParams_OldScriptAPI() throws Exception {
+        final double[] pcts = randomPercentiles();
+        SearchResponse searchResponse = client()
+                .prepareSearch("idx")
+                .setQuery(matchAllQuery())
+                .addAggregation(
+                        randomCompression(percentiles("percentiles"))
+                                .script("List values = doc['values'].values; double[] res = new double[values.size()]; for (int i = 0; i < res.length; i++) { res[i] = values.get(i) - dec; }; return res;")
+                                .param("dec", 1).percentiles(pcts)).execute().actionGet();
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
+        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1);
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsTests.java
@@ -20,10 +20,15 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.global;
@@ -163,7 +168,7 @@ public class StatsTests extends AbstractNumericTests {
         double expectedMaxValue = 10.0;
         assertThat(stats.getMax(), equalTo(expectedMaxValue));
         assertThat((double) global.getProperty("stats.max"), equalTo(expectedMaxValue));
-        double expectedSumValue = (double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10);
+        double expectedSumValue = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10;
         assertThat(stats.getSum(), equalTo(expectedSumValue));
         assertThat((double) global.getProperty("stats.sum"), equalTo(expectedSumValue));
         long expectedCountValue = 10;
@@ -198,7 +203,7 @@ public class StatsTests extends AbstractNumericTests {
     public void testSingleValuedField_WithValueScript() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").field("value").script("_value + 1"))
+                .addAggregation(stats("stats").field("value").script(new Script("_value + 1")))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -218,9 +223,11 @@ public class StatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testSingleValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").field("value").script("_value + inc").param("inc", 1))
+                .addAggregation(stats("stats").field("value").script(new Script("_value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -264,7 +271,7 @@ public class StatsTests extends AbstractNumericTests {
     public void testMultiValuedField_WithValueScript() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").field("values").script("_value - 1"))
+                .addAggregation(stats("stats").field("values").script(new Script("_value - 1")))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -284,9 +291,11 @@ public class StatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testMultiValuedField_WithValueScript_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").field("values").script("_value - dec").param("dec", 1))
+                .addAggregation(stats("stats").field("values").script(new Script("_value - dec", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -308,7 +317,7 @@ public class StatsTests extends AbstractNumericTests {
     public void testScript_SingleValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").script("doc['value'].value"))
+                .addAggregation(stats("stats").script(new Script("doc['value'].value")))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -328,9 +337,11 @@ public class StatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_SingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").script("doc['value'].value + inc").param("inc", 1))
+                .addAggregation(stats("stats").script(new Script("doc['value'].value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -350,9 +361,11 @@ public class StatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_ExplicitSingleValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("inc", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").script("doc['value'].value + inc").param("inc", 1))
+                .addAggregation(stats("stats").script(new Script("doc['value'].value + inc", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -374,7 +387,7 @@ public class StatsTests extends AbstractNumericTests {
     public void testScript_MultiValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").script("doc['values'].values"))
+                .addAggregation(stats("stats").script(new Script("doc['values'].values")))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -396,7 +409,7 @@ public class StatsTests extends AbstractNumericTests {
     public void testScript_ExplicitMultiValued() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").script("doc['values'].values"))
+                .addAggregation(stats("stats").script(new Script("doc['values'].values")))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -416,9 +429,13 @@ public class StatsTests extends AbstractNumericTests {
     @Override
     @Test
     public void testScript_MultiValued_WithParams() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("dec", 1);
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(stats("stats").script("[ doc['value'].value, doc['value'].value - dec ]").param("dec", 1))
+                .addAggregation(
+                        stats("stats").script(
+                                new Script("[ doc['value'].value, doc['value'].value - dec ]", ScriptType.INLINE, null, params)))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
@@ -445,5 +462,240 @@ public class StatsTests extends AbstractNumericTests {
             fail("Unexpected shard failures!");
         }
         assertThat("Not all shards are initialized", response.getSuccessfulShards(), equalTo(response.getTotalShards()));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").field("value").script("_value + 1")).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(10l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testSingleValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").field("value").script("_value + inc").param("inc", 1)).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(10l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").field("values").script("_value - 1")).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(),
+                equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 20));
+        assertThat(stats.getMin(), equalTo(1.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(20l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testMultiValuedField_WithValueScript_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").field("values").script("_value - dec").param("dec", 1)).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(),
+                equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 20));
+        assertThat(stats.getMin(), equalTo(1.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(20l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").script("doc['value'].value")).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+        assertThat(stats.getMin(), equalTo(1.0));
+        assertThat(stats.getMax(), equalTo(10.0));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+        assertThat(stats.getCount(), equalTo(10l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_SingleValued_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").script("doc['value'].value + inc").param("inc", 1)).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(10l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitSingleValued_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").script("doc['value'].value + inc").param("inc", 1)).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(11.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+        assertThat(stats.getCount(), equalTo(10l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").script("doc['values'].values")).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(),
+                equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12) / 20));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(12.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12));
+        assertThat(stats.getCount(), equalTo(20l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_ExplicitMultiValued_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").script("doc['values'].values")).execute().actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(),
+                equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12) / 20));
+        assertThat(stats.getMin(), equalTo(2.0));
+        assertThat(stats.getMax(), equalTo(12.0));
+        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12));
+        assertThat(stats.getCount(), equalTo(20l));
+    }
+
+    /*
+     * TODO Remove in 3.0
+     */
+    @Override
+    @Test
+    public void testScript_MultiValued_WithParams_OldScriptAPI() throws Exception {
+        SearchResponse searchResponse = client().prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(stats("stats").script("[ doc['value'].value, doc['value'].value - dec ]").param("dec", 1)).execute()
+                .actionGet();
+
+        assertShardExecutionState(searchResponse, 0);
+
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(10l));
+
+        Stats stats = searchResponse.getAggregations().get("stats");
+        assertThat(stats, notNullValue());
+        assertThat(stats.getName(), equalTo("stats"));
+        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9) / 20));
+        assertThat(stats.getMin(), equalTo(0.0));
+        assertThat(stats.getMax(), equalTo(10.0));
+        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9));
+        assertThat(stats.getCount(), equalTo(20l));
     }
 }


### PR DESCRIPTION
A method for the new Script API were missing in the ValuesSourceMetricsAggregationBuilder. This change adds the missing method and deprecates the old Script API methods
