### PR TITLE
allow settings to be passed to client for external test cluster

### DIFF
--- a/core/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
+++ b/core/src/test/java/org/elasticsearch/test/ElasticsearchIntegrationTest.java
@@ -1650,7 +1650,11 @@ public abstract class ElasticsearchIntegrationTest extends ElasticsearchTestCase
                 throw new IllegalArgumentException("port is not valid, expected number but was [" + split[1] + "]");
             }
         }
-        return new ExternalTestCluster(createTempDir(), transportAddresses);
+        return new ExternalTestCluster(createTempDir(), externalClusterClientSettings(), transportAddresses);
+    }
+
+    protected Settings externalClusterClientSettings() {
+        return Settings.EMPTY;
     }
 
     protected TestCluster buildTestCluster(Scope scope, long seed) throws IOException {

--- a/core/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -65,9 +65,10 @@ public final class ExternalTestCluster extends TestCluster {
     private final int numDataNodes;
     private final int numMasterAndDataNodes;
 
-    public ExternalTestCluster(Path tempDir, TransportAddress... transportAddresses) {
+    public ExternalTestCluster(Path tempDir, Settings additionalSettings, TransportAddress... transportAddresses) {
         super(0);
         Settings clientSettings = Settings.settingsBuilder()
+                .put(additionalSettings)
                 .put("name", InternalTestCluster.TRANSPORT_CLIENT_PREFIX + EXTERNAL_CLUSTER_PREFIX + counter.getAndIncrement())
                 .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // prevents any settings to be replaced by system properties.
                 .put("client.transport.ignore_cluster_name", true)


### PR DESCRIPTION
This change allows custom settings to be passed to the client for the external test cluster,
which is necessary when additional settings need to be passed to the client in order to
properly communicate with the external test cluster.
