### PR TITLE
Fix pluginmanager permissions for bin/ scripts

### DIFF
--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
@@ -116,6 +116,8 @@ public class PluginManagerTests extends ElasticsearchIntegrationTest {
                 PosixFileAttributes attributes = view.readAttributes();
                 assertTrue("unexpected permissions: " + attributes.permissions(),
                            attributes.permissions().contains(PosixFilePermission.OWNER_EXECUTE));
+                assertTrue("unexpected permissions: " + attributes.permissions(),
+                        attributes.permissions().contains(PosixFilePermission.OWNER_READ));
             }
         } finally {
             // we need to clean up the copied dirs


### PR DESCRIPTION
Today it will remove all permissions and only set execute bit:

```
---x--x--x
```

Instead we should preserve existing permissions, and just add
read and execute to whatever is there.

Closes #12142
