### PR TITLE
remove elasticsearch- from name of official plugins

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -759,19 +759,15 @@ public class PluginManager {
             }
 
             if (isOfficialPlugin(repo, user, version)) {
-                return new PluginHandle(repo, Version.CURRENT.number(), null, repo);
-            }
-
-            if (repo.startsWith("elasticsearch-")) {
-                // remove elasticsearch- prefix
-                String endname = repo.substring("elasticsearch-".length());
-                return new PluginHandle(endname, version, user, repo);
-            }
-
-            if (name.startsWith("es-")) {
-                // remove es- prefix
-                String endname = repo.substring("es-".length());
-                return new PluginHandle(endname, version, user, repo);
+                String endname = repo;
+                if (repo.startsWith("elasticsearch-")) {
+                    // remove elasticsearch- prefix
+                    endname = repo.substring("elasticsearch-".length());
+                } else if (name.startsWith("es-")) {
+                    // remove es- prefix
+                    endname = repo.substring("es-".length());
+                }
+                return new PluginHandle(endname, Version.CURRENT.number(), null, repo);
             }
 
             return new PluginHandle(repo, version, user, repo);

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -67,4 +67,16 @@ public class PluginManagerUnitTests extends ElasticsearchTestCase {
             pluginName + "-" + Version.CURRENT.number() + ".zip");
         assertThat(handle.urls().get(0), is(expected));
     }
+
+    @Test
+    public void testTrimmingElasticsearchFromPluginName() throws IOException {
+        String randomName = randomAsciiOfLength(10);
+        String pluginName = randomFrom("elasticsearch-", "es-") + randomName;
+        PluginManager.PluginHandle handle = PluginManager.PluginHandle.parse(pluginName);
+        assertThat(handle.name, is(randomName));
+        assertThat(handle.urls(), hasSize(1));
+        URL expected = new URL("http", "download.elastic.co", "/org.elasticsearch.plugins/" + pluginName + "/" +
+                pluginName + "-" + Version.CURRENT.number() + ".zip");
+        assertThat(handle.urls().get(0), is(expected));
+    }
 }


### PR DESCRIPTION
This change fixes the plugin manager to trim `elasticsearch-` and `es-` prefixes from plugin names
for our official plugins. This restores the old behavior prior to #11805.

Closes #12143
