### PR TITLE
strip elasticsearch- and es- from any plugin name

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -758,19 +758,20 @@ public class PluginManager {
                 }
             }
 
+            String endname = repo;
+            if (repo.startsWith("elasticsearch-")) {
+                // remove elasticsearch- prefix
+                endname = repo.substring("elasticsearch-".length());
+            } else if (repo.startsWith("es-")) {
+                // remove es- prefix
+                endname = repo.substring("es-".length());
+            }
+
             if (isOfficialPlugin(repo, user, version)) {
-                String endname = repo;
-                if (repo.startsWith("elasticsearch-")) {
-                    // remove elasticsearch- prefix
-                    endname = repo.substring("elasticsearch-".length());
-                } else if (name.startsWith("es-")) {
-                    // remove es- prefix
-                    endname = repo.substring("es-".length());
-                }
                 return new PluginHandle(endname, Version.CURRENT.number(), null, repo);
             }
 
-            return new PluginHandle(repo, version, user, repo);
+            return new PluginHandle(endname, version, user, repo);
         }
 
         static boolean isOfficialPlugin(String repo, String user, String version) {

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -69,7 +69,7 @@ public class PluginManagerUnitTests extends ElasticsearchTestCase {
     }
 
     @Test
-    public void testTrimmingElasticsearchFromPluginName() throws IOException {
+    public void testTrimmingElasticsearchFromOfficialPluginName() throws IOException {
         String randomName = randomAsciiOfLength(10);
         String pluginName = randomFrom("elasticsearch-", "es-") + randomName;
         PluginManager.PluginHandle handle = PluginManager.PluginHandle.parse(pluginName);
@@ -77,6 +77,18 @@ public class PluginManagerUnitTests extends ElasticsearchTestCase {
         assertThat(handle.urls(), hasSize(1));
         URL expected = new URL("http", "download.elastic.co", "/org.elasticsearch.plugins/" + pluginName + "/" +
                 pluginName + "-" + Version.CURRENT.number() + ".zip");
+        assertThat(handle.urls().get(0), is(expected));
+    }
+
+    @Test
+    public void testTrimmingElasticsearchFromGithubPluginName() throws IOException {
+        String user = randomAsciiOfLength(6);
+        String randomName = randomAsciiOfLength(10);
+        String pluginName = randomFrom("elasticsearch-", "es-") + randomName;
+        PluginManager.PluginHandle handle = PluginManager.PluginHandle.parse(user + "/" + pluginName);
+        assertThat(handle.name, is(randomName));
+        assertThat(handle.urls(), hasSize(1));
+        URL expected = new URL("https", "github.com", "/" + user + "/" + pluginName + "/" + "archive/master.zip");
         assertThat(handle.urls().get(0), is(expected));
     }
 }


### PR DESCRIPTION
#12158 only partially fixed #12143 by removing the prefix from official plugin names. This change

removes the prefixes from any plugin names.
