### PR TITLE
Wait on incoming joins before electing local node as master

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
@@ -134,7 +134,7 @@ public class RoutingService extends AbstractLifecycleComponent<RoutingService> i
     }
 
     // visible for testing
-    void performReroute(String reason) {
+    protected void performReroute(String reason) {
         try {
             if (lifecycle.stopped()) {
                 return;

--- a/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.discovery.zen;
+
+import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ProcessedClusterStateUpdateTask;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.discovery.zen.membership.MembershipAction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class NodeJoinController {
+
+    final ESLogger logger;
+    final ClusterService clusterService;
+    final RoutingService routingService;
+    final DiscoverySettings discoverySettings;
+    final AtomicBoolean accumulateJoins = new AtomicBoolean(false);
+
+    // this is site while trying to become a master
+    final AtomicReference<ElectionContext> electionContext = new AtomicReference<>();
+
+
+    protected final BlockingQueue<Tuple<DiscoveryNode, MembershipAction.JoinCallback>> pendingJoinRequests = ConcurrentCollections.newBlockingQueue();
+
+    public NodeJoinController(ClusterService clusterService, RoutingService routingService, DiscoverySettings discoverySettings, ESLogger logger) {
+        this.clusterService = clusterService;
+        this.logger = logger;
+        this.routingService = routingService;
+        this.discoverySettings = discoverySettings;
+    }
+
+    public void waitToBeElectedAsMaster(int requiredJoins, TimeValue timeValue, final Callback callback) {
+        final CountDownLatch done = new CountDownLatch(1);
+        final ElectionContext newContext = new ElectionContext();
+        newContext.requiredJoins = requiredJoins;
+        newContext.callback = new Callback() {
+            @Override
+            public void onElectedAsMaster(ClusterState state) {
+                done.countDown();
+                if (electionContext.compareAndSet(newContext, null)) {
+                    callback.onElectedAsMaster(state);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                done.countDown();
+                if (electionContext.compareAndSet(newContext, null)) {
+                    callback.onFailure(t);
+                }
+            }
+        };
+
+        if (electionContext.compareAndSet(null, newContext) == false) {
+            // should never happen, but be conservative
+            callback.onFailure(new IllegalStateException("double waiting for election"));
+            return;
+        }
+
+        // check what we have so far..
+        checkAndElect();
+
+        try {
+            if (done.await(timeValue.millis(), TimeUnit.MILLISECONDS)) {
+                // callback handles everything
+                return;
+            }
+        } catch (InterruptedException e) {
+
+        }
+        if (electionContext.compareAndSet(newContext, null)) {
+            logger.trace("timed out waiting to be elected. waited [{}]. pending joins [{}]", timeValue, pendingJoinRequests.size());
+            newContext.callback.onFailure(new ElasticsearchTimeoutException("timed out waiting to be elected"));
+        }
+    }
+
+    public void startAccumulatingJoins() {
+        boolean b = accumulateJoins.getAndSet(true);
+        assert b == false : "double startAccumulatingJoins() calls";
+        assert electionContext.get() == null : "startAccumulatingJoins() called, but there is an ongoing election context";
+    }
+
+    public void stopAccumulatingJoins() {
+        assert electionContext.get() == null : "stopAccumulatingJoins() called, but there is an ongoing election context";
+        boolean b = accumulateJoins.getAndSet(false);
+        assert b : "stopAccumulatingJoins() called but not accumulating";
+        if (pendingJoinRequests.size() > 0) {
+            processJoins("stopping to accumulate joins");
+        }
+    }
+
+    public void handleJoinRequest(final DiscoveryNode node, final MembershipAction.JoinCallback callback) {
+        pendingJoinRequests.add(new Tuple<>(node, callback));
+        if (accumulateJoins.get() == false) {
+            processJoins("join from node[" + node + "]");
+        } else {
+            checkAndElect();
+        }
+    }
+
+    private void checkAndElect() {
+        assert accumulateJoins.get() : "election check requested but we are not accumulating joins";
+        final ElectionContext context = electionContext.get();
+        if (context == null) {
+            return;
+        }
+        final int pendingJoins = pendingJoinRequests.size();
+        if (pendingJoins < context.requiredJoins) {
+            logger.trace("not enough joins for election. Got [{}], required [{}]", pendingJoins, context.requiredJoins);
+            return;
+        }
+        final String source = "zen-disco-join(elected_as_master, [" + pendingJoins + "] joins received)";
+        clusterService.submitStateUpdateTask(source, Priority.IMMEDIATE, new ProcessJoinsTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                // Take into account the previous known nodes, if they happen not to be available
+                // then fault detection will remove these nodes.
+
+                if (currentState.nodes().masterNode() != null) {
+                    // TODO can we tie break here? we don't have a remote master cluster state version to decide on
+                    logger.trace("join thread elected local node as master, but there is already a master in place: {}", currentState.nodes().masterNode());
+                    throw new NotMasterException("Node [" + clusterService.localNode() + "] not master for join request");
+                }
+
+                DiscoveryNodes.Builder builder = new DiscoveryNodes.Builder(currentState.nodes()).masterNodeId(currentState.nodes().localNode().id());
+                // update the fact that we are the master...
+                ClusterBlocks clusterBlocks = ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(discoverySettings.getNoMasterBlock()).build();
+                currentState = ClusterState.builder(currentState).nodes(builder).blocks(clusterBlocks).build();
+
+                // add the incoming join requests and reroute
+                return super.execute(currentState);
+            }
+
+            @Override
+            public boolean runOnlyOnMaster() {
+                return false;
+            }
+
+            @Override
+            public void onFailure(String source, Throwable t) {
+                super.onFailure(source, t);
+                context.callback.onFailure(t);
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                super.clusterStateProcessed(source, oldState, newState);
+                context.callback.onElectedAsMaster(newState);
+            }
+        });
+    }
+
+    private void processJoins(String reason) {
+        clusterService.submitStateUpdateTask("zen-disco-join(" + reason + ")", Priority.URGENT, new ProcessJoinsTask());
+    }
+
+
+    public interface Callback {
+        void onElectedAsMaster(ClusterState state);
+
+        void onFailure(Throwable t);
+    }
+
+    static class ElectionContext {
+        Callback callback;
+        int requiredJoins;
+    }
+
+
+    class ProcessJoinsTask extends ProcessedClusterStateUpdateTask {
+
+        private final List<Tuple<DiscoveryNode, MembershipAction.JoinCallback>> joinRequestsToProcess = new ArrayList<>();
+        private boolean nodeAdded = false;
+
+        @Override
+        public ClusterState execute(ClusterState currentState) {
+            pendingJoinRequests.drainTo(joinRequestsToProcess);
+            if (joinRequestsToProcess.isEmpty()) {
+                return currentState;
+            }
+
+            DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(currentState.nodes());
+            for (Tuple<DiscoveryNode, MembershipAction.JoinCallback> task : joinRequestsToProcess) {
+                DiscoveryNode node = task.v1();
+                if (currentState.nodes().nodeExists(node.id())) {
+                    logger.debug("received a join request for an existing node [{}]", node);
+                } else {
+                    nodeAdded = true;
+                    nodesBuilder.put(node);
+                    for (DiscoveryNode existingNode : currentState.nodes()) {
+                        if (node.address().equals(existingNode.address())) {
+                            nodesBuilder.remove(existingNode.id());
+                            logger.warn("received join request from node [{}], but found existing node {} with same address, removing existing node", node, existingNode);
+                        }
+                    }
+                }
+            }
+
+            // we must return a new cluster state instance to force publishing. This is important
+            // for the joining node to finalize it's join and set us as a master
+            final ClusterState.Builder newState = ClusterState.builder(currentState);
+            if (nodeAdded) {
+                newState.nodes(nodesBuilder);
+            }
+
+            return newState.build();
+        }
+
+        @Override
+        public void onNoLongerMaster(String source) {
+            // we are rejected, so drain all pending task (execute never run)
+            pendingJoinRequests.drainTo(joinRequestsToProcess);
+            Exception e = new NotMasterException("Node [" + clusterService.localNode() + "] not master for join request");
+            innerOnFailure(e);
+        }
+
+        void innerOnFailure(Throwable t) {
+            for (Tuple<DiscoveryNode, MembershipAction.JoinCallback> drainedTask : joinRequestsToProcess) {
+                try {
+                    drainedTask.v2().onFailure(t);
+                } catch (Exception e) {
+                    logger.error("error during task failure", e);
+                }
+            }
+        }
+
+        @Override
+        public void onFailure(String source, Throwable t) {
+            logger.error("unexpected failure during [{}]", t, source);
+            innerOnFailure(t);
+        }
+
+        @Override
+        public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+            if (nodeAdded) {
+                // we reroute not in the same cluster state update since in certain areas we rely on
+                // the node to be in the cluster state (sampled from ClusterService#state) to be there, also
+                // shard transitions need to better be handled in such cases
+                routingService.reroute("post_node_add");
+            }
+            for (Tuple<DiscoveryNode, MembershipAction.JoinCallback> drainedTask : joinRequestsToProcess) {
+                try {
+                    drainedTask.v2().onSuccess();
+                } catch (Exception e) {
+                    logger.error("unexpected error during [{}]", e, source);
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/NodeJoinController.java
@@ -109,12 +109,14 @@ public class NodeJoinController {
     }
 
     public void startAccumulatingJoins() {
+        logger.trace("starting to accumulate joins");
         boolean b = accumulateJoins.getAndSet(true);
         assert b == false : "double startAccumulatingJoins() calls";
         assert electionContext.get() == null : "startAccumulatingJoins() called, but there is an ongoing election context";
     }
 
     public void stopAccumulatingJoins() {
+        logger.trace("stopping joins accumulation");
         assert electionContext.get() == null : "stopAccumulatingJoins() called, but there is an ongoing election context";
         boolean b = accumulateJoins.getAndSet(false);
         assert b : "stopAccumulatingJoins() called but not accumulating";

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -375,7 +375,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                     new NodeJoinController.Callback() {
                         @Override
                         public void onElectedAsMaster(ClusterState state) {
-                            nodeJoinController.stopAccumulatingJoins();
                             joinThreadControl.markThreadAsDone(currentThread);
                             // we only starts nodesFD if we are master (it may be that we received a cluster state while pinging)
                             nodesFD.updateNodesAndPing(state); // start the nodes FD
@@ -387,7 +386,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                         @Override
                         public void onFailure(Throwable t) {
                             logger.trace("failed while waiting for nodes to join, rejoining", t);
-                            nodeJoinController.stopAccumulatingJoins();
                             joinThreadControl.markThreadAsDoneAndStartNew(currentThread);
                         }
                     }

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -874,8 +874,8 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             return;
         }
         if (!currentNodes.masterNodeId().equals(newClusterState.nodes().masterNodeId())) {
-            logger.warn("received a cluster state from a different master then the current one, rejecting (received {}, current {})", newClusterState.nodes().masterNode(), currentNodes.masterNode());
-            throw new IllegalStateException("cluster state from a different master then the current one, rejecting (received " + newClusterState.nodes().masterNode() + ", current " + currentNodes.masterNode() + ")");
+            logger.warn("received a cluster state from a different master that the one we are following, rejecting (received {}, following {})", newClusterState.nodes().masterNode(), currentNodes.masterNode());
+            throw new IllegalStateException("cluster state from a different master, rejecting (received " + newClusterState.nodes().masterNode() + ", following " + currentNodes.masterNode() + ")");
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -855,7 +855,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         }
         if (!currentState.nodes().masterNodeId().equals(newClusterState.nodes().masterNodeId())) {
             logger.warn("received a cluster state from a different master then the current one, rejecting (received {}, current {})", newClusterState.nodes().masterNode(), currentState.nodes().masterNode());
-            throw new IllegalStateException("cluster state from a different master then the current one, rejecting (received " + newClusterState.nodes().masterNode() + ", current " + currentState.nodes().masterNode() + ")");
+            throw new IllegalStateException("cluster state from a different master than the current one, rejecting (received " + newClusterState.nodes().masterNode() + ", current " + currentState.nodes().masterNode() + ")");
         } else if (newClusterState.version() < currentState.version()) {
             // if the new state has a smaller version, and it has the same master node, then no need to process it
             logger.debug("received a cluster state that has a lower version than the current one, ignoring (received {}, current {})", newClusterState.version(), currentState.version());

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -234,7 +234,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         nodesFD.setLocalNode(clusterService.localNode());
         joinThreadControl.start();
         pingService.start();
-        this.nodeJoinController = new NodeJoinController(clusterService, routingService, discoverySettings, logger);
+        this.nodeJoinController = new NodeJoinController(clusterService, routingService, discoverySettings, settings);
 
         // start the join thread from a cluster state update. See {@link JoinThreadControl} for details.
         clusterService.submitStateUpdateTask("initial_join", new ClusterStateNonMasterUpdateTask() {

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingServiceTests.java
@@ -142,7 +142,7 @@ public class RoutingServiceTests extends ElasticsearchAllocationTestCase {
         }
 
         @Override
-        void performReroute(String reason) {
+        protected void performReroute(String reason) {
             rerouted.set(true);
         }
     }

--- a/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
@@ -18,75 +18,172 @@
  */
 package org.elasticsearch.discovery.zen;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingService;
-import org.elasticsearch.cluster.settings.DynamicSettings;
-import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.common.transport.LocalTransportAddress;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.discovery.DiscoverySettings;
-import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.discovery.zen.membership.MembershipAction;
-import org.elasticsearch.discovery.zen.ping.ZenPingService;
 import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.elasticsearch.test.cluster.TestClusterService;
-import org.elasticsearch.test.transport.CapturingTransport;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportService;
-import org.junit.After;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Before;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.equalTo;
+
+@TestLogging("discovery.zen:TRACE")
 public class NodeJoinControllerTests extends ElasticsearchTestCase {
 
+    TestClusterService clusterService;
+    NodeJoinController nodeJoinController;
 
-    public void testNormalJoin() {
-        final TestClusterService clusterService = new TestClusterService();
-        NodeJoinController nodeJoinController = new NodeJoinController(clusterService, null, new DiscoverySettings(Settings.EMPTY, new NodeSettingsService(Settings.EMPTY)), logger);
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        clusterService = new TestClusterService();
+        final DiscoveryNodes initialNodes = clusterService.state().nodes();
+        final DiscoveryNode localNode = initialNodes.localNode();
+        // make sure we have a master
+        clusterService.setState(ClusterState.builder(clusterService.state()).nodes(DiscoveryNodes.builder(initialNodes).masterNodeId(localNode.id())));
+        nodeJoinController = new NodeJoinController(clusterService, new NoopRoutingService(Settings.EMPTY),
+                new DiscoverySettings(Settings.EMPTY, new NodeSettingsService(Settings.EMPTY)), logger);
+    }
 
+    public void testNormalConcurrentJoins() throws InterruptedException {
+        Thread[] threads = new Thread[3 + randomInt(5)];
+        ArrayList<DiscoveryNode> nodes = new ArrayList<>();
+        nodes.add(clusterService.localNode());
+        final CyclicBarrier barrier = new CyclicBarrier(threads.length);
+        final List<Throwable> backgroundExceptions = new CopyOnWriteArrayList<>();
+        for (int i = 0; i < threads.length; i++) {
+            final DiscoveryNode node = newNode(i);
+            final int iterations = rarely() ? randomIntBetween(1, 4) : 1;
+            nodes.add(node);
+            threads[i] = new Thread(new AbstractRunnable() {
+                @Override
+                public void onFailure(Throwable t) {
+                    logger.error("unexpected error in join thread", t);
+                    backgroundExceptions.add(t);
+                }
+
+                @Override
+                protected void doRun() throws Exception {
+                    barrier.await();
+                    for (int i = 0; i < iterations; i++) {
+                        logger.debug("{} joining", node);
+                        joinNode(node);
+                    }
+                }
+            }, "t_" + i);
+            threads[i].start();
+        }
+
+        logger.info("--> waiting for joins to complete");
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertNodesInCurrentState(nodes);
+    }
+
+    public void testSimpleJoinAccumulation() throws InterruptedException {
+        List<DiscoveryNode> nodes = new ArrayList<>();
+        nodes.add(clusterService.localNode());
+
+        int nodeId = 0;
+        for (int i = randomInt(5); i > 0; i--) {
+            DiscoveryNode node = newNode(nodeId++);
+            nodes.add(node);
+            joinNode(node);
+        }
+        nodeJoinController.startAccumulatingJoins();
+        for (int i = randomInt(5); i > 0; i--) {
+            DiscoveryNode node = newNode(nodeId++);
+            nodes.add(node);
+            joinNode(node);
+        }
+        nodeJoinController.stopAccumulatingJoins();
+        for (int i = randomInt(5); i > 0; i--) {
+            DiscoveryNode node = newNode(nodeId++);
+            nodes.add(node);
+            joinNode(node);
+        }
+        assertNodesInCurrentState(nodes);
     }
 
     public void testNewClusterStateOnExistingNodeJoin() throws InterruptedException {
-        final TestClusterService clusterService = new TestClusterService();
-        NodeJoinController nodeJoinController = new NodeJoinController(clusterService, null, new DiscoverySettings(Settings.EMPTY, new NodeSettingsService(Settings.EMPTY)), logger);
         ClusterState state = clusterService.state();
         final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(state.nodes());
-        nodesBuilder.masterNodeId(state.nodes().localNodeId());
         final DiscoveryNode other_node = new DiscoveryNode("other_node", DummyTransportAddress.INSTANCE, Version.CURRENT);
         nodesBuilder.put(other_node);
         clusterService.setState(ClusterState.builder(state).nodes(nodesBuilder));
 
         state = clusterService.state();
+        joinNode(other_node);
+        assertTrue("failed to publish a new state upon existing join", clusterService.state() != state);
+    }
+
+
+    static class NoopRoutingService extends RoutingService {
+
+        public NoopRoutingService(Settings settings) {
+            super(settings, null, null, null);
+        }
+
+        @Override
+        protected void performReroute(String reason) {
+
+        }
+    }
+
+    protected void assertNodesInCurrentState(List<DiscoveryNode> expectedNodes) {
+        DiscoveryNodes discoveryNodes = clusterService.state().nodes();
+        assertThat(discoveryNodes.prettyPrint() + "\nexpected: " + expectedNodes.toString(), discoveryNodes.size(), equalTo(expectedNodes.size()));
+        for (DiscoveryNode node : expectedNodes) {
+            assertThat("missing " + node + "\n" + discoveryNodes.prettyPrint(), discoveryNodes.get(node.id()), equalTo(node));
+        }
+    }
+
+    private Future<> joinNodeAsync(final DiscoveryNode node) throws InterruptedException {
+    }
+
+    private void joinNode(final DiscoveryNode node) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> exception = new AtomicReference<>();
-        nodeJoinController.handleJoinRequest(other_node, new MembershipAction.JoinCallback() {
+        final AtomicReference<Throwable> backgroundException = new AtomicReference<>();
+        nodeJoinController.handleJoinRequest(node, new MembershipAction.JoinCallback() {
             @Override
             public void onSuccess() {
+                logger.debug("node join completed for {}", node);
                 latch.countDown();
             }
 
             @Override
             public void onFailure(Throwable t) {
-                exception.set(t);
-                logger.error("unexpected exception during join", t);
+                logger.error("unexpected error while joining {}", t, node);
+                backgroundException.set(t);
                 latch.countDown();
             }
         });
-
         latch.await();
-        if (exception.get() != null) {
-            fail("unexpected exception during join: " + exception.get().getMessage());
-        }
-
-        assertTrue("failed to publish a new state upon existing join", clusterService.state() != state);
+        ExceptionsHelper.reThrowIfNotNull(backgroundException.get());
     }
 
+    protected DiscoveryNode newNode(int i) {
+        return new DiscoveryNode("node_" + i, new LocalTransportAddress("test_" + i), Version.CURRENT);
+    }
 }

--- a/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.discovery.zen;
 
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
@@ -27,7 +28,9 @@ import org.elasticsearch.cluster.routing.RoutingService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.elasticsearch.common.transport.LocalTransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.BaseFuture;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.membership.MembershipAction;
 import org.elasticsearch.node.settings.NodeSettingsService;
@@ -37,14 +40,14 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Before;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 @TestLogging("discovery.zen:TRACE")
 public class NodeJoinControllerTests extends ElasticsearchTestCase {
@@ -62,6 +65,240 @@ public class NodeJoinControllerTests extends ElasticsearchTestCase {
         clusterService.setState(ClusterState.builder(clusterService.state()).nodes(DiscoveryNodes.builder(initialNodes).masterNodeId(localNode.id())));
         nodeJoinController = new NodeJoinController(clusterService, new NoopRoutingService(Settings.EMPTY),
                 new DiscoverySettings(Settings.EMPTY, new NodeSettingsService(Settings.EMPTY)), logger);
+    }
+
+    public void testSimpleJoinAccumulation() throws InterruptedException, ExecutionException {
+        List<DiscoveryNode> nodes = new ArrayList<>();
+        nodes.add(clusterService.localNode());
+
+        int nodeId = 0;
+        for (int i = randomInt(5); i > 0; i--) {
+            DiscoveryNode node = newNode(nodeId++);
+            nodes.add(node);
+            joinNode(node);
+        }
+        nodeJoinController.startAccumulatingJoins();
+        ArrayList<Future<Void>> pendingJoins = new ArrayList<>();
+        for (int i = randomInt(5); i > 0; i--) {
+            DiscoveryNode node = newNode(nodeId++);
+            nodes.add(node);
+            pendingJoins.add(joinNodeAsync(node));
+        }
+        nodeJoinController.stopAccumulatingJoins();
+        for (int i = randomInt(5); i > 0; i--) {
+            DiscoveryNode node = newNode(nodeId++);
+            nodes.add(node);
+            joinNode(node);
+        }
+        assertNodesInCurrentState(nodes);
+        for (Future<Void> joinFuture : pendingJoins) {
+            assertThat(joinFuture.isDone(), equalTo(true));
+        }
+    }
+
+    public void testFailingJoinsWhenNotMaster() throws ExecutionException, InterruptedException {
+        // remove current master flag
+        DiscoveryNodes.Builder nodes = DiscoveryNodes.builder(clusterService.state().nodes()).masterNodeId(null);
+        clusterService.setState(ClusterState.builder(clusterService.state()).nodes(nodes));
+        int nodeId = 0;
+        try {
+            joinNode(newNode(nodeId++));
+            fail("failed to fail node join when not a master");
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(NotMasterException.class));
+        }
+
+        logger.debug("--> testing joins fail post accumulation");
+        ArrayList<Future<Void>> pendingJoins = new ArrayList<>();
+        nodeJoinController.startAccumulatingJoins();
+        for (int i = 1 + randomInt(5); i > 0; i--) {
+            DiscoveryNode node = newNode(nodeId++);
+            final Future<Void> future = joinNodeAsync(node);
+            pendingJoins.add(future);
+            assertThat(future.isDone(), equalTo(false));
+        }
+        nodeJoinController.stopAccumulatingJoins();
+        for (Future<Void> future : pendingJoins) {
+            try {
+                future.get();
+                fail("failed to fail accumulated node join when not a master");
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(NotMasterException.class));
+            }
+        }
+    }
+
+    public void testSimpleMasterElection() throws InterruptedException, ExecutionException {
+        DiscoveryNodes.Builder nodes = DiscoveryNodes.builder(clusterService.state().nodes()).masterNodeId(null);
+        clusterService.setState(ClusterState.builder(clusterService.state()).nodes(nodes));
+        int nodeId = 0;
+        final int requiredJoins = randomInt(5);
+        logger.debug("--> using requiredJoins [{}]", requiredJoins);
+        // initial (failing) joins shouldn't count
+        for (int i = randomInt(5); i > 0; i--) {
+            try {
+                joinNode(newNode(nodeId++));
+                fail("failed to fail node join when not a master");
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(NotMasterException.class));
+            }
+        }
+
+        nodeJoinController.startAccumulatingJoins();
+        final SimpleFuture electionFuture = new SimpleFuture("master election");
+        final Thread masterElection = new Thread(new AbstractRunnable() {
+            @Override
+            public void onFailure(Throwable t) {
+                logger.error("unexpected error from waitToBeElectedAsMaster", t);
+                electionFuture.markAsFailed(t);
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                nodeJoinController.waitToBeElectedAsMaster(requiredJoins, TimeValue.timeValueHours(30), new NodeJoinController.Callback() {
+                    @Override
+                    public void onElectedAsMaster(ClusterState state) {
+                        assertThat("callback called with elected as master, but state disagrees", state.nodes().localNodeMaster(), equalTo(true));
+                        electionFuture.markAsDone();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        logger.error("unexpected error while waiting to be elected as master", t);
+                        electionFuture.markAsFailed(t);
+                    }
+                });
+            }
+        });
+        masterElection.start();
+        if (requiredJoins == 0) {
+            logger.debug("--> requiredJoins is set to 0. verifying election finished");
+            electionFuture.get();
+            return;
+        }
+        assertThat("election finished immediately but required joins is [" + requiredJoins + "]", electionFuture.isDone(), equalTo(false));
+
+        final int initialJoins = randomIntBetween(0, requiredJoins - 1);
+        final ArrayList<SimpleFuture> pendingJoins = new ArrayList<>();
+        ArrayList<DiscoveryNode> nodesToJoin = new ArrayList<>();
+        for (int i = 0; i < initialJoins; i++) {
+            DiscoveryNode node = newNode(nodeId++);
+            for (int j = 1 + randomInt(3); j > 0; j--) {
+                nodesToJoin.add(node);
+            }
+        }
+        Collections.shuffle(nodesToJoin);
+        logger.debug("--> joining [{}] nodes, with repetition a total of [{}]", initialJoins, nodesToJoin.size());
+        for (DiscoveryNode node : nodesToJoin) {
+            pendingJoins.add(joinNodeAsync(node));
+        }
+
+        logger.debug("--> asserting master election didn't finish yet");
+        assertThat("election finished after [" + initialJoins + "] but required joins is [" + requiredJoins + "]", electionFuture.isDone(), equalTo(false));
+
+        final int finalJoins = requiredJoins - initialJoins + randomInt(5);
+        nodesToJoin.clear();
+        for (int i = 0; i < finalJoins; i++) {
+            DiscoveryNode node = newNode(nodeId++);
+            for (int j = 1 + randomInt(3); j > 0; j--) {
+                nodesToJoin.add(node);
+            }
+        }
+        Collections.shuffle(nodesToJoin);
+        logger.debug("--> joining [{}] nodes, with repetition a total of [{}]", finalJoins, nodesToJoin.size());
+        for (DiscoveryNode node : nodesToJoin) {
+            pendingJoins.add(joinNodeAsync(node));
+        }
+        logger.debug("--> asserting master election finished with no exception");
+        assertThat("master election didn't finish despite of [" + (initialJoins + finalJoins) + "] joins. required [" + requiredJoins + "]",
+                electionFuture.isDone(), equalTo(true));
+        electionFuture.get(); // throw any exception
+
+        logger.debug("--> waiting on all joins to be processed");
+        for (SimpleFuture future : pendingJoins) {
+            logger.debug("waiting on {}", future);
+            future.get(); // throw any exception
+        }
+
+        logger.debug("--> testing accumulation stopped");
+        nodeJoinController.startAccumulatingJoins();
+        nodeJoinController.stopAccumulatingJoins();
+
+    }
+
+    public void testMasterElectionTimeout() throws InterruptedException {
+        DiscoveryNodes.Builder nodes = DiscoveryNodes.builder(clusterService.state().nodes()).masterNodeId(null);
+        clusterService.setState(ClusterState.builder(clusterService.state()).nodes(nodes));
+        int nodeId = 0;
+        final int requiredJoins = 1 + randomInt(5);
+        logger.debug("--> using requiredJoins [{}]", requiredJoins);
+        // initial (failing) joins shouldn't count
+        for (int i = randomInt(5); i > 0; i--) {
+            try {
+                joinNode(newNode(nodeId++));
+                fail("failed to fail node join when not a master");
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(NotMasterException.class));
+            }
+        }
+
+        nodeJoinController.startAccumulatingJoins();
+        final int initialJoins = randomIntBetween(0, requiredJoins - 1);
+        final ArrayList<SimpleFuture> pendingJoins = new ArrayList<>();
+        ArrayList<DiscoveryNode> nodesToJoin = new ArrayList<>();
+        for (int i = 0; i < initialJoins; i++) {
+            DiscoveryNode node = newNode(nodeId++);
+            for (int j = 1 + randomInt(3); j > 0; j--) {
+                nodesToJoin.add(node);
+            }
+        }
+        Collections.shuffle(nodesToJoin);
+        logger.debug("--> joining [{}] nodes, with repetition a total of [{}]", initialJoins, nodesToJoin.size());
+        for (DiscoveryNode node : nodesToJoin) {
+            pendingJoins.add(joinNodeAsync(node));
+        }
+
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        nodeJoinController.waitToBeElectedAsMaster(requiredJoins, TimeValue.timeValueMillis(30), new NodeJoinController.Callback() {
+            @Override
+            public void onElectedAsMaster(ClusterState state) {
+                assertThat("callback called with elected as master, but state disagrees", state.nodes().localNodeMaster(), equalTo(true));
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                failure.set(t);
+                latch.countDown();
+            }
+        });
+        latch.await();
+        logger.debug("--> verifying election timed out");
+        assertThat(failure.get(), instanceOf(ElasticsearchTimeoutException.class));
+
+        logger.debug("--> verifying all joins are failed");
+        for (SimpleFuture future : pendingJoins) {
+            logger.debug("waiting on {}", future);
+            try {
+                future.get(); // throw any exception
+                fail("failed to fail node join [" + future + "]");
+            } catch (ExecutionException e) {
+                assertThat(e.getCause(), instanceOf(NotMasterException.class));
+            }
+        }
+    }
+
+    public void testNewClusterStateOnExistingNodeJoin() throws InterruptedException, ExecutionException {
+        ClusterState state = clusterService.state();
+        final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(state.nodes());
+        final DiscoveryNode other_node = new DiscoveryNode("other_node", DummyTransportAddress.INSTANCE, Version.CURRENT);
+        nodesBuilder.put(other_node);
+        clusterService.setState(ClusterState.builder(state).nodes(nodesBuilder));
+
+        state = clusterService.state();
+        joinNode(other_node);
+        assertTrue("failed to publish a new state upon existing join", clusterService.state() != state);
     }
 
     public void testNormalConcurrentJoins() throws InterruptedException {
@@ -101,41 +338,69 @@ public class NodeJoinControllerTests extends ElasticsearchTestCase {
         assertNodesInCurrentState(nodes);
     }
 
-    public void testSimpleJoinAccumulation() throws InterruptedException {
-        List<DiscoveryNode> nodes = new ArrayList<>();
-        nodes.add(clusterService.localNode());
+    public void testElectionWithConcurrentJoins() throws InterruptedException, BrokenBarrierException {
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(clusterService.state().nodes()).masterNodeId(null);
+        clusterService.setState(ClusterState.builder(clusterService.state()).nodes(nodesBuilder));
 
-        int nodeId = 0;
-        for (int i = randomInt(5); i > 0; i--) {
-            DiscoveryNode node = newNode(nodeId++);
-            nodes.add(node);
-            joinNode(node);
-        }
         nodeJoinController.startAccumulatingJoins();
-        for (int i = randomInt(5); i > 0; i--) {
-            DiscoveryNode node = newNode(nodeId++);
+
+        Thread[] threads = new Thread[3 + randomInt(5)];
+        final int requiredJoins = randomInt(threads.length);
+        ArrayList<DiscoveryNode> nodes = new ArrayList<>();
+        nodes.add(clusterService.localNode());
+        final CyclicBarrier barrier = new CyclicBarrier(threads.length + 1);
+        final List<Throwable> backgroundExceptions = new CopyOnWriteArrayList<>();
+        for (int i = 0; i < threads.length; i++) {
+            final DiscoveryNode node = newNode(i);
+            final int iterations = rarely() ? randomIntBetween(1, 4) : 1;
             nodes.add(node);
-            joinNode(node);
+            threads[i] = new Thread(new AbstractRunnable() {
+                @Override
+                public void onFailure(Throwable t) {
+                    logger.error("unexpected error in join thread", t);
+                    backgroundExceptions.add(t);
+                }
+
+                @Override
+                protected void doRun() throws Exception {
+                    barrier.await();
+                    for (int i = 0; i < iterations; i++) {
+                        logger.debug("{} joining", node);
+                        joinNode(node);
+                    }
+                }
+            }, "t_" + i);
+            threads[i].start();
         }
-        nodeJoinController.stopAccumulatingJoins();
-        for (int i = randomInt(5); i > 0; i--) {
-            DiscoveryNode node = newNode(nodeId++);
-            nodes.add(node);
-            joinNode(node);
+
+        barrier.await();
+        logger.info("--> waiting to be elected as master (required joins [{}])", requiredJoins);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        nodeJoinController.waitToBeElectedAsMaster(requiredJoins, TimeValue.timeValueHours(30), new NodeJoinController.Callback() {
+            @Override
+            public void onElectedAsMaster(ClusterState state) {
+                assertThat("callback called with elected as master, but state disagrees", state.nodes().localNodeMaster(), equalTo(true));
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                logger.error("unexpected error while waiting to be elected as master", t);
+                failure.set(t);
+                latch.countDown();
+            }
+        });
+        latch.await();
+        ExceptionsHelper.reThrowIfNotNull(failure.get());
+
+
+        logger.info("--> waiting for joins to complete");
+        for (Thread thread : threads) {
+            thread.join();
         }
+
         assertNodesInCurrentState(nodes);
-    }
-
-    public void testNewClusterStateOnExistingNodeJoin() throws InterruptedException {
-        ClusterState state = clusterService.state();
-        final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(state.nodes());
-        final DiscoveryNode other_node = new DiscoveryNode("other_node", DummyTransportAddress.INSTANCE, Version.CURRENT);
-        nodesBuilder.put(other_node);
-        clusterService.setState(ClusterState.builder(state).nodes(nodesBuilder));
-
-        state = clusterService.state();
-        joinNode(other_node);
-        assertTrue("failed to publish a new state upon existing join", clusterService.state() != state);
     }
 
 
@@ -159,28 +424,50 @@ public class NodeJoinControllerTests extends ElasticsearchTestCase {
         }
     }
 
-    private Future<> joinNodeAsync(final DiscoveryNode node) throws InterruptedException {
+    static class SimpleFuture extends BaseFuture<Void> {
+        final String description;
+
+        SimpleFuture(String description) {
+            this.description = description;
+        }
+
+        public void markAsDone() {
+            set(null);
+        }
+
+        public void markAsFailed(Throwable t) {
+            setException(t);
+        }
+
+        @Override
+        public String toString() {
+            return "future [" + description + "]";
+        }
     }
 
-    private void joinNode(final DiscoveryNode node) throws InterruptedException {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Throwable> backgroundException = new AtomicReference<>();
+    final static AtomicInteger joinId = new AtomicInteger();
+
+    private SimpleFuture joinNodeAsync(final DiscoveryNode node) throws InterruptedException {
+        final SimpleFuture future = new SimpleFuture("join of " + node + " (id [" + joinId.incrementAndGet() + "]");
+        logger.debug("starting {}", future);
         nodeJoinController.handleJoinRequest(node, new MembershipAction.JoinCallback() {
             @Override
             public void onSuccess() {
-                logger.debug("node join completed for {}", node);
-                latch.countDown();
+                logger.debug("{} completed", future);
+                future.markAsDone();
             }
 
             @Override
             public void onFailure(Throwable t) {
-                logger.error("unexpected error while joining {}", t, node);
-                backgroundException.set(t);
-                latch.countDown();
+                logger.error("unexpected error for {}", t, future);
+                future.markAsFailed(t);
             }
         });
-        latch.await();
-        ExceptionsHelper.reThrowIfNotNull(backgroundException.get());
+        return future;
+    }
+
+    private void joinNode(final DiscoveryNode node) throws InterruptedException, ExecutionException {
+        joinNodeAsync(node).get();
     }
 
     protected DiscoveryNode newNode(int i) {

--- a/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
@@ -54,8 +54,8 @@ import static org.hamcrest.Matchers.instanceOf;
 @TestLogging("discovery.zen:TRACE")
 public class NodeJoinControllerTests extends ElasticsearchTestCase {
 
-    TestClusterService clusterService;
-    NodeJoinController nodeJoinController;
+    private TestClusterService clusterService;
+    private NodeJoinController nodeJoinController;
 
     @Before
     public void setUp() throws Exception {

--- a/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/NodeJoinControllerTests.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.discovery.zen;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingService;
+import org.elasticsearch.cluster.settings.DynamicSettings;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.discovery.zen.elect.ElectMasterService;
+import org.elasticsearch.discovery.zen.membership.MembershipAction;
+import org.elasticsearch.discovery.zen.ping.ZenPingService;
+import org.elasticsearch.node.settings.NodeSettingsService;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.cluster.TestClusterService;
+import org.elasticsearch.test.transport.CapturingTransport;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class NodeJoinControllerTests extends ElasticsearchTestCase {
+
+
+    public void testNormalJoin() {
+        final TestClusterService clusterService = new TestClusterService();
+        NodeJoinController nodeJoinController = new NodeJoinController(clusterService, null, new DiscoverySettings(Settings.EMPTY, new NodeSettingsService(Settings.EMPTY)), logger);
+
+    }
+
+    public void testNewClusterStateOnExistingNodeJoin() throws InterruptedException {
+        final TestClusterService clusterService = new TestClusterService();
+        NodeJoinController nodeJoinController = new NodeJoinController(clusterService, null, new DiscoverySettings(Settings.EMPTY, new NodeSettingsService(Settings.EMPTY)), logger);
+        ClusterState state = clusterService.state();
+        final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(state.nodes());
+        nodesBuilder.masterNodeId(state.nodes().localNodeId());
+        final DiscoveryNode other_node = new DiscoveryNode("other_node", DummyTransportAddress.INSTANCE, Version.CURRENT);
+        nodesBuilder.put(other_node);
+        clusterService.setState(ClusterState.builder(state).nodes(nodesBuilder));
+
+        state = clusterService.state();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> exception = new AtomicReference<>();
+        nodeJoinController.handleJoinRequest(other_node, new MembershipAction.JoinCallback() {
+            @Override
+            public void onSuccess() {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                exception.set(t);
+                logger.error("unexpected exception during join", t);
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+        if (exception.get() != null) {
+            fail("unexpected exception during join: " + exception.get().getMessage());
+        }
+
+        assertTrue("failed to publish a new state upon existing join", clusterService.state() != state);
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryTests.java
@@ -219,7 +219,7 @@ public class ZenDiscoveryTests extends ElasticsearchIntegrationTest {
         });
         latch.await();
         assertThat(reference.get(), notNullValue());
-        assertThat(ExceptionsHelper.detailedMessage(reference.get()), containsString("cluster state from a different master then the current one, rejecting "));
+        assertThat(ExceptionsHelper.detailedMessage(reference.get()), containsString("cluster state from a different master, rejecting"));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryTests.java
@@ -219,7 +219,7 @@ public class ZenDiscoveryTests extends ElasticsearchIntegrationTest {
         });
         latch.await();
         assertThat(reference.get(), notNullValue());
-        assertThat(ExceptionsHelper.detailedMessage(reference.get()), containsString("cluster state from a different master, rejecting"));
+        assertThat(ExceptionsHelper.detailedMessage(reference.get()), containsString("cluster state from a different master than the current one, rejecting"));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTest.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTest.java
@@ -75,7 +75,7 @@ public class ZenDiscoveryUnitTest extends ElasticsearchTestCase {
             shouldIgnoreOrRejectNewClusterState(logger, currentState.build(), newState.build());
             fail("should ignore, because current state's master is not equal to new state's master");
         } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), containsString("cluster state from a different master, rejecting"));
+            assertThat(e.getMessage(), containsString("cluster state from a different master than the current one, rejecting"));
         }
 
         currentNodes = DiscoveryNodes.builder();

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTest.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTest.java
@@ -75,7 +75,7 @@ public class ZenDiscoveryUnitTest extends ElasticsearchTestCase {
             shouldIgnoreOrRejectNewClusterState(logger, currentState.build(), newState.build());
             fail("should ignore, because current state's master is not equal to new state's master");
         } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), containsString("cluster state from a different master then the current one, rejecting"));
+            assertThat(e.getMessage(), containsString("cluster state from a different master, rejecting"));
         }
 
         currentNodes = DiscoveryNodes.builder();

--- a/core/src/test/java/org/elasticsearch/test/cluster/TestClusterService.java
+++ b/core/src/test/java/org/elasticsearch/test/cluster/TestClusterService.java
@@ -184,6 +184,11 @@ public class TestClusterService implements ClusterService {
     @Override
     synchronized public void submitStateUpdateTask(String source, Priority priority, ClusterStateUpdateTask updateTask) {
         logger.debug("processing [{}]", source);
+        if (state().nodes().localNodeMaster() == false && updateTask.runOnlyOnMaster()) {
+            updateTask.onNoLongerMaster(source);
+            logger.debug("failed [{}], no longer master", source);
+            return;
+        }
         ClusterState newState;
         ClusterState previousClusterState = state;
         try {

--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -88,10 +88,14 @@ Nodes can be excluded from becoming a master by setting `node.master` to
 automatically set to `false`).
 
 The `discovery.zen.minimum_master_nodes` sets the minimum
-number of master eligible nodes a node should "see" in order to win a master election.
-It must be set to a quorum of your master eligible nodes. It is recommended to avoid
+number of master eligible nodes that need to join a newly elected master in order for an election to
+complete and for the elected node to accept it's mastership. The same setting controls the minimum number of
+active master eligible nodes that should be a part of any active cluster. If this requirement is not met the
+active master node will step down and a new mastser election will be begin.
+
+This setting must be set to a quorum of your master eligible nodes. It is recommended to avoid
 having only two master eligible nodes, since a quorum of two is two. Therefore, a loss
-of either master node will result in an inoperable cluster
+of either master node will result in an inoperable cluster.
 
 [float]
 [[fault-detection]]

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -97,7 +97,7 @@ nodes. Based on this information the node either discovers an existing master or
 elected as master will currently update it the cluster state to indicate the result of the election. Other nodes will submit
 a join request to the newly elected master node. Instead of immediately processing the election result, the elected master
 node should wait for the incoming joins from other nodes, thus validating the elections result is properly applied. As soon as enough
-nodes have sent their joins request (based on the `minimum_master_nodes` settings) the cluster state is modified.
+nodes have sent their joins request (based on the `minimum_master_nodes` settings) the cluster state is updated.
 {GIT}12161{#12161}
 
 

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -98,7 +98,7 @@ elected as master will currently update it the cluster state to indicate the res
 a join request to the newly elected master node. Instead of immediately processing the election result, the elected master
 node should wait for the incoming joins from other nodes, thus validating the elections result is properly applied. As soon as enough
 nodes have sent their joins request (based on the `minimum_master_nodes` settings) the cluster state is modified.
-{GIT}TBD{#TBD}
+{GIT}12161{#12161}
 
 
 [float]

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -93,12 +93,12 @@ See {GIT}9967[#9967]. (STATUS: ONGOING)
 
 During master election each node pings in order to discover other nodes and validate the liveness of existing
 nodes. Based on this information the node either discovers an existing master or, if enough nodes are found
-(see <<master-election,`discovery.zen.minimum_master_nodes>>) a new master will be elected. Currently, the node that is
-elected as master will currently update it the cluster state to indicate the result of the election. Other nodes will submit
+(see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#master-election[`discovery.zen.minimum_master_nodes`]) a new master will be elected. Currently, the node that is
+elected as master will update the cluster state to indicate the result of the election. Other nodes will submit
 a join request to the newly elected master node. Instead of immediately processing the election result, the elected master
-node should wait for the incoming joins from other nodes, thus validating the elections result is properly applied. As soon as enough
+node should wait for the incoming joins from other nodes, thus validating that the result of the election is properly applied. As soon as enough
 nodes have sent their joins request (based on the `minimum_master_nodes` settings) the cluster state is updated.
-{GIT}12161{#12161}
+{GIT}12161[#12161]
 
 
 [float]

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -89,6 +89,19 @@ Further issues remain with the retry mechanism:
 See {GIT}9967[#9967]. (STATUS: ONGOING)
 
 [float]
+=== Wait on incoming joins before electing local node as master (STATUS: ONGOING)
+
+During master election each node pings in order to discover other nodes and validate the liveness of existing
+nodes. Based on this information the node either discovers an existing master or, if enough nodes are found
+(see <<master-election,`discovery.zen.minimum_master_nodes>>) a new master will be elected. Currently, the node that is
+elected as master will currently update it the cluster state to indicate the result of the election. Other nodes will submit
+a join request to the newly elected master node. Instead of immediately processing the election result, the elected master
+node should wait for the incoming joins from other nodes, thus validating the elections result is properly applied. As soon as enough
+nodes have sent their joins request (based on the `minimum_master_nodes` settings) the cluster state is modified.
+{GIT}TBD{#TBD}
+
+
+[float]
 === Write index metadata on data nodes where shards allocated (STATUS: ONGOING)
 
 Today, index metadata is written only on nodes that are master-eligible, not on


### PR DESCRIPTION
During master election each node pings in order to discover other nodes and validate the liveness of existing nodes. Based on this information the node either discovers an existing master or, if enough nodes are found (based on `discovery.zen.minimum_master_nodes>>) a new master will be elected.  

Currently, the node that is elected as master will currently update it the cluster state to indicate the result of the election. Other nodes will submit a join request to the newly elected master node. Instead of immediately processing the election result, the elected master
node should wait for the incoming joins from other nodes, thus validating the elections result is properly applied. As soon as enough nodes have sent their joins request (based on the `minimum_master_nodes` settings) the cluster state is modified.

Note that if `minimum_master_nodes` is not set, this change has no effect.
