### PR TITLE
Persist all engine failure exceptions

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -691,7 +691,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
         private void failStoreIfCorrupted(Throwable t) {
             if (t instanceof CorruptIndexException || t instanceof IndexFormatTooOldException || t instanceof IndexFormatTooNewException) {
                 try {
-                    store.markStoreCorrupted((IOException) t);
+                    store.markStoreFailed((IOException) t);
                 } catch (IOException e) {
                     logger.warn("store cannot be marked as corrupted", e);
                 }
@@ -962,7 +962,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
                     success = true;
                 } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
                     try {
-                        store.markStoreCorrupted(ex);
+                        store.markStoreFailed(ex);
                     } catch (IOException e) {
                         logger.warn("store cannot be marked as corrupted", e);
                     }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -399,7 +399,7 @@ public class RecoveryTarget extends AbstractComponent {
                     // its content on disk if possible.
                     try {
                         try {
-                            store.removeCorruptionMarker();
+                            store.removeFailureMarker();
                         } finally {
                             Lucene.cleanLuceneIndex(store.directory()); // clean up and delete all files
                         }


### PR DESCRIPTION
Currently when an engine fails the shard state file is no longer deleted (see #11933)
and the underlying store is only marked as corrupted for index corruption exceptions.
This means that the store can be opened, even after it failed with IOE, OOM exceptions.

It would be useful to persist the engine failures that are not due to corruption for
inspection, these can be exposed later through #11545
