### PR TITLE
Docs: index.compound_format uses Lucene's default 0.1

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -1,4 +1,4 @@
 The Elasticsearch docs are in AsciiDoc format and can be built using the Elasticsearch documentation build process
 
-See: https://github.com/elasticsearch/docs
+See: https://github.com/elastic/docs
 

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -18,18 +18,20 @@ specific module. These include:
 [[index-compound-format]]`index.compound_format`::
 
         experimental[]
-	Should the compound file format be used (boolean setting).
+	Should the compound file format be used (boolean or float setting).
 	The compound format was created to reduce the number of open
-	file handles when using file based storage. However, by default it is set
-	to `false` as the non-compound format gives better performance. It is important
-	that OS is configured to give Elasticsearch ``enough'' file handles.
+	file handles when using file based storage.  If you set this
+        to `false` be sure the OS is also configured to give
+	Elasticsearch ``enough'' file handles.
     See <<file-descriptors>>.
 +
 Alternatively, `compound_format` can be set to a number between `0` and
-`1`, where `0` means `false`, `1` means `true` and a number inbetween
+`1`, where `0` means `false`, `1` means `true` and a number in between
 represents a percentage: if the merged segment is less than this
 percentage of the total index, then it is written in compound format,
 otherwise it is written in non-compound format.
++
+Default is 0.1.
 
 [[index-compound-on-flush]]`index.compound_on_flush`::
 


### PR DESCRIPTION
Just correcting the docs for 1.7.0 ...
