### PR TITLE
[DOCS] Simple patch to make creating aliases with glob patterns clearer

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -63,6 +63,23 @@ curl -XPOST 'http://localhost:9200/_aliases' -d '
 }'
 --------------------------------------------------
 
+Alternatively, you can use a glob pattern to associate an alias to
+more than one index that share a common name:
+
+[source,js]
+--------------------------------------------------
+curl -XPOST 'http://localhost:9200/_aliases' -d '
+{
+    "actions" : [
+        { "add" : { "index" : "test*", "alias" : "all" } }
+    ]
+}'
+--------------------------------------------------
+
+In this case, the alias is a point-in-time alias that will group all
+current indices that match, it will not automatically update as new
+indices that match this pattern are added/removed.
+
 It is an error to index to an alias which points to more than one index.
 
 [float]


### PR DESCRIPTION
This PR is a simple doc patch to explicitly mention with an example of
how to create an alias using a glob pattern.  This comes up from
time-to-time with our customers and in the community and although
mentioned in the documentation already, is not obvious.

Also mention that the alias will not auto-update as indices matching the
glob change.

Closes #12175
