### PR TITLE
[test] list of plugins should have well-defined order

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginInfo.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.admin.cluster.node.info;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsInfo.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsInfo.java
@@ -28,6 +28,8 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class PluginsInfo implements Streamable, ToXContent {
@@ -45,7 +47,17 @@ public class PluginsInfo implements Streamable, ToXContent {
         infos = new ArrayList<>(size);
     }
 
+    /**
+     * @return an ordered list based on plugins name
+     */
     public List<PluginInfo> getInfos() {
+        Collections.sort(infos, new Comparator<PluginInfo>() {
+            @Override
+            public int compare(final PluginInfo o1, final PluginInfo o2) {
+                return o1.getName().compareTo(o2.getName());
+            }
+        });
+
         return infos;
     }
 
@@ -70,7 +82,7 @@ public class PluginsInfo implements Streamable, ToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeInt(infos.size());
-        for (PluginInfo plugin : infos) {
+        for (PluginInfo plugin : getInfos()) {
             plugin.writeTo(out);
         }
     }
@@ -78,7 +90,7 @@ public class PluginsInfo implements Streamable, ToXContent {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(Fields.PLUGINS);
-        for (PluginInfo pluginInfo : infos) {
+        for (PluginInfo pluginInfo : getInfos()) {
             pluginInfo.toXContent(builder, params);
         }
         builder.endArray();

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/info/PluginsInfoTest.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/info/PluginsInfoTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.info;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+
+public class PluginsInfoTest extends ElasticsearchTestCase {
+
+    @Test
+    public void testPluginListSorted() {
+        PluginsInfo pluginsInfo = new PluginsInfo(5);
+        pluginsInfo.add(new PluginInfo("c", "foo", true, true, "dummy"));
+        pluginsInfo.add(new PluginInfo("b", "foo", true, true, "dummy"));
+        pluginsInfo.add(new PluginInfo("e", "foo", true, true, "dummy"));
+        pluginsInfo.add(new PluginInfo("a", "foo", true, true, "dummy"));
+        pluginsInfo.add(new PluginInfo("d", "foo", true, true, "dummy"));
+
+        final List<PluginInfo> infos = pluginsInfo.getInfos();
+        List<String> names = Lists.transform(infos, new Function<PluginInfo, String>() {
+            @Override
+            public String apply(PluginInfo input) {
+                return input.getName();
+            }
+        });
+        assertThat(names, contains("a", "b", "c", "d", "e"));
+    }
+}


### PR DESCRIPTION
We now return list of plugins sorted by name.

Closes #12174.
