### PR TITLE
Free all pending search contexts if index is closed or removed

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -159,7 +159,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> {
         indicesService.indicesLifecycle().addListener(new IndicesLifecycle.Listener() {
 
             @Override
-            public void afterIndexDeleted(Index index, @IndexSettings Settings indexSettings) {
+            public void afterIndexClosed(Index index, @IndexSettings Settings indexSettings) {
                 // once an index is closed we can just clean up all the pending search context information
                 // to release memory and let references to the filesystem go etc.
                 freeAllContextForIndex(index);


### PR DESCRIPTION
Today we only clear search contexts for deleted indies. Yet, we should
do the same for closed indices to ensure they can be reopened quickly.

Closes #12116
