### PR TITLE
Allow rpm to be build as part of package phase

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1112,6 +1112,31 @@
             <!-- not including license-maven-plugin is sufficent to expose default license -->
         </profile>
         <profile>
+            <id>package-rpm</id>
+            <activation>
+                <property>
+                    <name>package.rpm</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-rpm</id>
+                                <goals>
+                                    <goal>attached-rpm</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>sign-rpm</id>
             <activation>
                 <property>


### PR DESCRIPTION
This allows the creation of the RPM artifact as part of the
maven package phase. The result of this is that we get checksum and
name correction for-free as it's all build an installed into the m2
repository. This also publishes the RPM together with .deb to the mvn
mirror.

Note: this will only build the RPM as part of the package phase if
`-Dpackage.rpm=true` since the binaries to build the RPM are not
availabel on all platforms.
