### PR TITLE
jsr166e was left out of shaded jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -392,6 +392,7 @@
                             <include>com.tdunning:t-digest</include>
                             <include>org.apache.commons:commons-lang3</include>
                             <include>commons-cli:commons-cli</include>
+                            <include>com.twitter:jsr166e</include>
                         </includes>
                     </artifactSet>
                     <transformers>


### PR DESCRIPTION
The classes in com.twitter.jsr166e were not getting included in the
shaded jar due to a missing configuration line.

Closes #12193
