### PR TITLE
Term Query: Be more strict during parsing

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -63,6 +63,9 @@ public class TermQueryParser implements QueryParser {
                 // skip
             } else if (token == XContentParser.Token.START_OBJECT) {
                 // also support a format of "term" : {"field_name" : { ... }}
+                if (fieldName != null) {
+                    throw new QueryParsingException(parseContext, "[term] query does not support different field names, use [bool] query instead");
+                }
                 fieldName = currentFieldName;
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                     if (token == XContentParser.Token.FIELD_NAME) {
@@ -87,6 +90,9 @@ public class TermQueryParser implements QueryParser {
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
                 } else {
+                    if (fieldName != null) {
+                        throw new QueryParsingException(parseContext, "[term] query does not support different field names, use [bool] query instead");
+                    }
                     fieldName = currentFieldName;
                     value = parser.objectBytes();
                 }

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1205,6 +1205,28 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
     }
 
     @Test
+    public void testTermQueryParserShouldOnlyAllowSingleTerm() throws Exception {
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/term-filter-broken-multi-terms.json");
+        assertQueryParsingFailureDueToMultipleTermsInTermFilter(query);
+    }
+
+    @Test
+    public void testTermQueryParserShouldOnlyAllowSingleTermInAlternateFormat() throws Exception {
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/term-filter-broken-multi-terms-2.json");
+        assertQueryParsingFailureDueToMultipleTermsInTermFilter(query);
+    }
+
+    private void assertQueryParsingFailureDueToMultipleTermsInTermFilter(String query) throws IOException {
+        IndexQueryParserService queryParser = queryParser();
+        try {
+            queryParser.parse(query);
+            fail("Expected Query Parsing Exception but did not happen");
+        } catch (QueryParsingException e) {
+            assertThat(e.getMessage(), containsString("[term] query does not support different field names, use [bool] query instead"));
+        }
+    }
+
+    @Test
     public void testTermsFilterQueryBuilder() throws Exception {
         IndexQueryParserService queryParser = queryParser();
         Query parsedQuery = queryParser.parse(filteredQuery(termQuery("name.first", "shay"), termsQuery("name.last", "banon", "kimchy"))).query();

--- a/core/src/test/java/org/elasticsearch/index/query/term-filter-broken-multi-terms-2.json
+++ b/core/src/test/java/org/elasticsearch/index/query/term-filter-broken-multi-terms-2.json
@@ -1,0 +1,10 @@
+{
+  "filtered": {
+    "filter": {
+      "term": {
+        "name.first": { "value": "shay" },
+        "name.last": { "value": "banon" }
+      }
+    }
+  }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/term-filter-broken-multi-terms.json
+++ b/core/src/test/java/org/elasticsearch/index/query/term-filter-broken-multi-terms.json
@@ -1,0 +1,10 @@
+{
+  "filtered":{
+    "query":{
+      "term":{
+        "name.first": "shay",
+        "name.last" : "banon"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The term query parser was too lenient during parsing and allowed to specify
more than one field, even though this expected to filter only for a single field.

This commit returns an exception if a query has been specified more than once.

Closes #12184
