### PR TITLE
Cleanup the data structures used in MetaData class for alias and index lookups

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import com.google.common.collect.UnmodifiableIterator;
+import org.elasticsearch.common.collect.Tuple;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Encapsulates the  {@link IndexMetaData} instances of a concrete index or indices an alias is pointing to.
+ */
+public interface AliasOrIndex {
+
+    /**
+     * @return whether this an alias or concrete index
+     */
+    boolean isAlias();
+
+    /**
+     * @return All {@link IndexMetaData} of all concrete indices this alias is referring to or if this is a concrete index its {@link IndexMetaData}
+     */
+    List<IndexMetaData> getIndices();
+
+    /**
+     * Represents an concrete index and encapsulates its {@link IndexMetaData}
+     */
+    class Index implements AliasOrIndex {
+
+        private final IndexMetaData concreteIndex;
+
+        public Index(IndexMetaData indexMetaData) {
+            this.concreteIndex = indexMetaData;
+        }
+
+        @Override
+        public boolean isAlias() {
+            return false;
+        }
+
+        @Override
+        public List<IndexMetaData> getIndices() {
+            return Collections.singletonList(concreteIndex);
+        }
+
+        /**
+         * @return If this is an concrete index, its {@link IndexMetaData}
+         */
+        public IndexMetaData getIndex() {
+            return concreteIndex;
+        }
+
+    }
+
+    /**
+     * Represents an alias and groups all {@link IndexMetaData} instances sharing the same alias name together.
+     */
+    class Alias implements AliasOrIndex {
+
+        private final String aliasName;
+        private final List<IndexMetaData> referenceIndexMetaDatas;
+
+        public Alias(AliasMetaData aliasMetaData, IndexMetaData indexMetaData) {
+            this.aliasName = aliasMetaData.getAlias();
+            this.referenceIndexMetaDatas = new ArrayList<>();
+            this.referenceIndexMetaDatas.add(indexMetaData);
+        }
+
+        @Override
+        public boolean isAlias() {
+            return true;
+        }
+
+        @Override
+        public List<IndexMetaData> getIndices() {
+            return referenceIndexMetaDatas;
+        }
+
+        /**
+         * Returns the unique alias metadata per concrete index.
+         *
+         * (note that although alias can point to the same concrete indices, each alias reference may have its own routing
+         * and filters)
+         */
+        public Iterable<Tuple<String, AliasMetaData>> getConcreteIndexAndAliasMetaDatas() {
+            return new Iterable<Tuple<String, AliasMetaData>>() {
+                @Override
+                public Iterator<Tuple<String, AliasMetaData>> iterator() {
+                    return new UnmodifiableIterator<Tuple<String,AliasMetaData>>() {
+
+                        int index = 0;
+
+                        @Override
+                        public boolean hasNext() {
+                            return index < referenceIndexMetaDatas.size();
+                        }
+
+                        @Override
+                        public Tuple<String, AliasMetaData> next() {
+                            IndexMetaData indexMetaData = referenceIndexMetaDatas.get(index++);
+                            return new Tuple<>(indexMetaData.getIndex(), indexMetaData.getAliases().get(aliasName));
+                        }
+
+                    };
+                }
+            };
+        }
+
+        public AliasMetaData getFirstAliasMetaData() {
+            return referenceIndexMetaDatas.get(0).getAliases().get(aliasName);
+        }
+
+        void addIndex(IndexMetaData indexMetaData) {
+            this.referenceIndexMetaDatas.add(indexMetaData);
+        }
+
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -19,16 +19,14 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.Index;
@@ -38,6 +36,7 @@ import org.elasticsearch.indices.IndexClosedException;
 import java.util.*;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.filterEntries;
 import static com.google.common.collect.Maps.newHashMap;
 
 public class IndexNameExpressionResolver {
@@ -108,44 +107,40 @@ public class IndexNameExpressionResolver {
 
         List<String> concreteIndices = new ArrayList<>(expressions.size());
         for (String expression : expressions) {
-            List<IndexMetaData> indexMetaDatas;
-            IndexMetaData indexMetaData = metaData.getIndices().get(expression);
-            if (indexMetaData == null) {
-                ImmutableOpenMap<String, AliasMetaData> indexAliasMap = metaData.aliases().get(expression);
-                if (indexAliasMap == null) {
-                    if (failNoIndices) {
-                        IndexNotFoundException infe = new IndexNotFoundException(expression);
-                        infe.setResources("index_expression", expression);
-                        throw infe;
-
-                    } else {
-                        continue;
-                    }
+            AliasOrIndex aliasOrIndex = metaData.getAliasAndIndexLookup().get(expression);
+            if (aliasOrIndex == null) {
+                if (failNoIndices) {
+                    IndexNotFoundException infe = new IndexNotFoundException(expression);
+                    infe.setResources("index_expression", expression);
+                    throw infe;
+                } else {
+                    continue;
                 }
-                if (indexAliasMap.size() > 1 && !options.allowAliasesToMultipleIndices()) {
-                    throw new IllegalArgumentException("Alias [" + expression + "] has more than one indices associated with it [" + Arrays.toString(indexAliasMap.keys().toArray(String.class)) + "], can't execute a single index op");
-                }
-                indexMetaDatas = new ArrayList<>(indexAliasMap.size());
-                for (ObjectObjectCursor<String, AliasMetaData> cursor : indexAliasMap) {
-                    indexMetaDatas.add(metaData.getIndices().get(cursor.key));
-                }
-            } else {
-                indexMetaDatas = Collections.singletonList(indexMetaData);
             }
 
-            for (IndexMetaData found : indexMetaDatas) {
-                if (found.getState() == IndexMetaData.State.CLOSE) {
+            Collection<IndexMetaData> resolvedIndices = aliasOrIndex.getIndices();
+            if (resolvedIndices.size() > 1 && !options.allowAliasesToMultipleIndices()) {
+                String[] indexNames = new String[resolvedIndices.size()];
+                int i = 0;
+                for (IndexMetaData indexMetaData : resolvedIndices) {
+                    indexNames[i++] = indexMetaData.getIndex();
+                }
+                throw new IllegalArgumentException("Alias [" + expression + "] has more than one indices associated with it [" + Arrays.toString(indexNames) + "], can't execute a single index op");
+            }
+
+            for (IndexMetaData index : resolvedIndices) {
+                if (index.getState() == IndexMetaData.State.CLOSE) {
                     if (failClosed) {
-                        throw new IndexClosedException(new Index(found.getIndex()));
+                        throw new IndexClosedException(new Index(index.getIndex()));
                     } else {
                         if (options.forbidClosedIndices() == false) {
-                            concreteIndices.add(found.getIndex());
+                            concreteIndices.add(index.getIndex());
                         }
                     }
-                } else if (found.getState() == IndexMetaData.State.OPEN) {
-                    concreteIndices.add(found.getIndex());
+                } else if (index.getState() == IndexMetaData.State.OPEN) {
+                    concreteIndices.add(index.getIndex());
                 } else {
-                    throw new IllegalStateException("index state [" + found.getState() + "] not supported");
+                    throw new IllegalStateException("index state [" + index.getState() + "] not supported");
                 }
             }
         }
@@ -264,10 +259,6 @@ public class IndexNameExpressionResolver {
             return resolveSearchRoutingAllIndices(state.metaData(), routing);
         }
 
-        if (resolvedExpressions.size() == 1) {
-            return resolveSearchRoutingSingleValue(state.metaData(), routing, resolvedExpressions.get(0));
-        }
-
         Map<String, Set<String>> routings = null;
         Set<String> paramRouting = null;
         // List of indices that don't require any routing
@@ -277,40 +268,43 @@ public class IndexNameExpressionResolver {
         }
 
         for (String expression : resolvedExpressions) {
-            ImmutableOpenMap<String, AliasMetaData> indexToRoutingMap = state.metaData().getAliases().get(expression);
-            if (indexToRoutingMap != null && !indexToRoutingMap.isEmpty()) {
-                for (ObjectObjectCursor<String, AliasMetaData> indexRouting : indexToRoutingMap) {
-                    if (!norouting.contains(indexRouting.key)) {
-                        if (!indexRouting.value.searchRoutingValues().isEmpty()) {
+            AliasOrIndex aliasOrIndex = state.metaData().getAliasAndIndexLookup().get(expression);
+            if (aliasOrIndex != null && aliasOrIndex.isAlias()) {
+                AliasOrIndex.Alias alias = (AliasOrIndex.Alias) aliasOrIndex;
+                for (Tuple<String, AliasMetaData> item : alias.getConcreteIndexAndAliasMetaDatas()) {
+                    String concreteIndex = item.v1();
+                    AliasMetaData aliasMetaData = item.v2();
+                    if (!norouting.contains(concreteIndex)) {
+                        if (!aliasMetaData.searchRoutingValues().isEmpty()) {
                             // Routing alias
                             if (routings == null) {
                                 routings = newHashMap();
                             }
-                            Set<String> r = routings.get(indexRouting.key);
+                            Set<String> r = routings.get(concreteIndex);
                             if (r == null) {
                                 r = new HashSet<>();
-                                routings.put(indexRouting.key, r);
+                                routings.put(concreteIndex, r);
                             }
-                            r.addAll(indexRouting.value.searchRoutingValues());
+                            r.addAll(aliasMetaData.searchRoutingValues());
                             if (paramRouting != null) {
                                 r.retainAll(paramRouting);
                             }
                             if (r.isEmpty()) {
-                                routings.remove(indexRouting.key);
+                                routings.remove(concreteIndex);
                             }
                         } else {
                             // Non-routing alias
-                            if (!norouting.contains(indexRouting.key)) {
-                                norouting.add(indexRouting.key);
+                            if (!norouting.contains(concreteIndex)) {
+                                norouting.add(concreteIndex);
                                 if (paramRouting != null) {
                                     Set<String> r = new HashSet<>(paramRouting);
                                     if (routings == null) {
                                         routings = newHashMap();
                                     }
-                                    routings.put(indexRouting.key, r);
+                                    routings.put(concreteIndex, r);
                                 } else {
                                     if (routings != null) {
-                                        routings.remove(indexRouting.key);
+                                        routings.remove(concreteIndex);
                                     }
                                 }
                             }
@@ -338,49 +332,6 @@ public class IndexNameExpressionResolver {
         }
         if (routings == null || routings.isEmpty()) {
             return null;
-        }
-        return routings;
-    }
-
-    private Map<String, Set<String>> resolveSearchRoutingSingleValue(MetaData metaData, @Nullable String routing, String aliasOrIndex) {
-        Map<String, Set<String>> routings = null;
-        Set<String> paramRouting = null;
-        if (routing != null) {
-            paramRouting = Strings.splitStringByCommaToSet(routing);
-        }
-
-        ImmutableOpenMap<String, AliasMetaData> indexToRoutingMap = metaData.getAliases().get(aliasOrIndex);
-        if (indexToRoutingMap != null && !indexToRoutingMap.isEmpty()) {
-            // It's an alias
-            for (ObjectObjectCursor<String, AliasMetaData> indexRouting : indexToRoutingMap) {
-                if (!indexRouting.value.searchRoutingValues().isEmpty()) {
-                    // Routing alias
-                    Set<String> r = new HashSet<>(indexRouting.value.searchRoutingValues());
-                    if (paramRouting != null) {
-                        r.retainAll(paramRouting);
-                    }
-                    if (!r.isEmpty()) {
-                        if (routings == null) {
-                            routings = newHashMap();
-                        }
-                        routings.put(indexRouting.key, r);
-                    }
-                } else {
-                    // Non-routing alias
-                    if (paramRouting != null) {
-                        Set<String> r = new HashSet<>(paramRouting);
-                        if (routings == null) {
-                            routings = newHashMap();
-                        }
-                        routings.put(indexRouting.key, r);
-                    }
-                }
-            }
-        } else {
-            // It's an index
-            if (paramRouting != null) {
-                routings = ImmutableMap.of(aliasOrIndex, paramRouting);
-            }
         }
         return routings;
     }
@@ -494,7 +445,7 @@ public class IndexNameExpressionResolver {
                 return expressions;
             }
 
-            if (expressions.isEmpty() || (expressions.size() == 1 && MetaData.ALL.equals(expressions.get(0)))) {
+            if (expressions.isEmpty() || (expressions.size() == 1 && (MetaData.ALL.equals(expressions.get(0))) || Regex.isMatchAllPattern(expressions.get(0)))) {
                 if (options.expandWildcardsOpen() && options.expandWildcardsClosed()) {
                     return Arrays.asList(metaData.concreteAllIndices());
                 } else if (options.expandWildcardsOpen()) {
@@ -508,22 +459,22 @@ public class IndexNameExpressionResolver {
 
             Set<String> result = null;
             for (int i = 0; i < expressions.size(); i++) {
-                String aliasOrIndex = expressions.get(i);
-                if (metaData.getAliasAndIndexMap().containsKey(aliasOrIndex)) {
+                String expression = expressions.get(i);
+                if (metaData.getAliasAndIndexLookup().containsKey(expression)) {
                     if (result != null) {
-                        result.add(aliasOrIndex);
+                        result.add(expression);
                     }
                     continue;
                 }
                 boolean add = true;
-                if (aliasOrIndex.charAt(0) == '+') {
+                if (expression.charAt(0) == '+') {
                     // if its the first, add empty result set
                     if (i == 0) {
                         result = new HashSet<>();
                     }
                     add = true;
-                    aliasOrIndex = aliasOrIndex.substring(1);
-                } else if (aliasOrIndex.charAt(0) == '-') {
+                    expression = expression.substring(1);
+                } else if (expression.charAt(0) == '-') {
                     // if its the first, fill it with all the indices...
                     if (i == 0) {
                         String[] concreteIndices;
@@ -540,19 +491,19 @@ public class IndexNameExpressionResolver {
                         result = new HashSet<>(Arrays.asList(concreteIndices));
                     }
                     add = false;
-                    aliasOrIndex = aliasOrIndex.substring(1);
+                    expression = expression.substring(1);
                 }
-                if (!Regex.isSimpleMatchPattern(aliasOrIndex)) {
-                    if (!options.ignoreUnavailable() && !metaData.getAliasAndIndexMap().containsKey(aliasOrIndex)) {
-                        IndexNotFoundException infe = new IndexNotFoundException(aliasOrIndex);
-                        infe.setResources("index_or_alias", aliasOrIndex);
+                if (!Regex.isSimpleMatchPattern(expression)) {
+                    if (!options.ignoreUnavailable() && !metaData.getAliasAndIndexLookup().containsKey(expression)) {
+                        IndexNotFoundException infe = new IndexNotFoundException(expression);
+                        infe.setResources("index_or_alias", expression);
                         throw infe;
                     }
                     if (result != null) {
                         if (add) {
-                            result.add(aliasOrIndex);
+                            result.add(expression);
                         } else {
-                            result.remove(aliasOrIndex);
+                            result.remove(expression);
                         }
                     }
                     continue;
@@ -562,44 +513,60 @@ public class IndexNameExpressionResolver {
                     result = new HashSet<>();
                     result.addAll(expressions.subList(0, i));
                 }
-                String[] indices;
-                if (options.expandWildcardsOpen() && options.expandWildcardsClosed()) {
-                    indices = metaData.concreteAllIndices();
-                } else if (options.expandWildcardsOpen()) {
-                    indices = metaData.concreteAllOpenIndices();
-                } else if (options.expandWildcardsClosed()) {
-                    indices = metaData.concreteAllClosedIndices();
+
+                final IndexMetaData.State excludeState;
+                if (options.expandWildcardsOpen() && options.expandWildcardsClosed()){
+                    excludeState = null;
+                } else if (options.expandWildcardsOpen() && options.expandWildcardsClosed() == false) {
+                    excludeState = IndexMetaData.State.CLOSE;
+                } else if (options.expandWildcardsClosed() && options.expandWildcardsOpen() == false) {
+                    excludeState = IndexMetaData.State.OPEN;
                 } else {
                     assert false : "this shouldn't get called if wildcards expand to none";
-                    indices = Strings.EMPTY_ARRAY;
+                    excludeState = null;
                 }
-                boolean found = false;
-                // iterating over all concrete indices and see if there is a wildcard match
-                for (String index : indices) {
-                    if (Regex.simpleMatch(aliasOrIndex, index)) {
-                        found = true;
-                        if (add) {
-                            result.add(index);
-                        } else {
-                            result.remove(index);
+
+                final Map<String, AliasOrIndex> matches;
+                if (Regex.isMatchAllPattern(expression)) {
+                    // Can only happen if the expressions was initially: '-*'
+                    matches = metaData.getAliasAndIndexLookup();
+                } else if (expression.endsWith("*")) {
+                    // Suffix wildcard:
+                    assert expression.length() >= 2 : "expression [" + expression + "] should have at least a length of 2";
+                    String fromPrefix = expression.substring(0, expression.length() - 1);
+                    char[] toPrefixCharArr = fromPrefix.toCharArray();
+                    toPrefixCharArr[toPrefixCharArr.length - 1]++;
+                    String toPrefix = new String(toPrefixCharArr);
+                    matches = metaData.getAliasAndIndexLookup().subMap(fromPrefix, toPrefix);
+                } else {
+                    // Other wildcard expressions:
+                    final String pattern = expression;
+                    matches = filterEntries(metaData.getAliasAndIndexLookup(), new Predicate<Map.Entry<String, AliasOrIndex>>() {
+                        @Override
+                        public boolean apply(@Nullable Map.Entry<String, AliasOrIndex> input) {
+                            return Regex.simpleMatch(pattern, input.getKey());
+                        }
+                    });
+                }
+                for (Map.Entry<String, AliasOrIndex> entry : matches.entrySet()) {
+                    AliasOrIndex aliasOrIndex = entry.getValue();
+                    if (aliasOrIndex.isAlias() == false) {
+                        AliasOrIndex.Index index = (AliasOrIndex.Index) aliasOrIndex;
+                        if (excludeState != null && index.getIndex().getState() == excludeState) {
+                            continue;
                         }
                     }
-                }
-                // iterating over all aliases and see if there is a wildcard match
-                for (ObjectCursor<String> cursor : metaData.getAliases().keys()) {
-                    String alias = cursor.value;
-                    if (Regex.simpleMatch(aliasOrIndex, alias)) {
-                        found = true;
-                        if (add) {
-                            result.add(alias);
-                        } else {
-                            result.remove(alias);
-                        }
+
+                    if (add) {
+                        result.add(entry.getKey());
+                    } else {
+                        result.remove(entry.getKey());
                     }
                 }
-                if (!found && !options.allowNoIndices()) {
-                    IndexNotFoundException infe = new IndexNotFoundException(aliasOrIndex);
-                    infe.setResources("index_or_alias", aliasOrIndex);
+
+                if (matches.isEmpty() && options.allowNoIndices() == false) {
+                    IndexNotFoundException infe = new IndexNotFoundException(expression);
+                    infe.setResources("index_or_alias", expression);
                     throw infe;
                 }
             }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -181,7 +181,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     "index name is too long, (" + byteCount +
                     " > " + MAX_INDEX_NAME_BYTES + ")");
         }
-        if (state.metaData().aliases().containsKey(index)) {
+        if (state.metaData().hasAlias(index)) {
             throw new InvalidIndexNameException(new Index(index), index, "already exists as alias");
         }
     }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -145,7 +145,7 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                         ClusterState updatedState = ClusterState.builder(currentState).metaData(builder).build();
                         // even though changes happened, they resulted in 0 actual changes to metadata
                         // i.e. remove and add the same alias to the same index
-                        if (!updatedState.metaData().aliases().equals(currentState.metaData().aliases())) {
+                        if (!updatedState.metaData().equalsAliases(currentState.metaData())) {
                             return updatedState;
                         }
                     }

--- a/core/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/core/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -128,7 +128,7 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
                         if (currentState.metaData().hasIndex(indexMetaData.index())) {
                             continue;
                         }
-                        if (currentState.metaData().aliases().containsKey(indexMetaData.index())) {
+                        if (currentState.metaData().hasAlias(indexMetaData.index())) {
                             logger.warn("ignoring dangled index [{}] on node [{}] due to an existing alias with the same name",
                                     indexMetaData.index(), request.fromNode);
                             continue;

--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -438,7 +438,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
     }
 
     private boolean aliasesChanged(ClusterChangedEvent event) {
-        return !event.state().metaData().aliases().equals(event.previousState().metaData().aliases()) ||
+        return !event.state().metaData().equalsAliases(event.previousState().metaData()) ||
                 !event.state().routingTable().equals(event.previousState().routingTable());
     }
 

--- a/core/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
+++ b/core/src/test/java/org/elasticsearch/aliases/IndexAliasesTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasAction;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.AliasOrIndex;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.settings.Settings;
@@ -518,7 +519,7 @@ public class IndexAliasesTests extends ElasticsearchIntegrationTest {
         assertThat(stopWatch.stop().lastTaskTime().millis(), lessThan(timeout.millis()));
 
         logger.info("--> verify that filter was updated");
-        AliasMetaData aliasMetaData = internalCluster().clusterService().state().metaData().aliases().get("alias1").get("test");
+        AliasMetaData aliasMetaData = ((AliasOrIndex.Alias) internalCluster().clusterService().state().metaData().getAliasAndIndexLookup().get("alias1")).getFirstAliasMetaData();
         assertThat(aliasMetaData.getFilter().toString(), equalTo("{\"term\":{\"name\":\"bar\"}}"));
 
         logger.info("--> deleting alias1");

--- a/core/src/test/java/org/elasticsearch/benchmark/aliases/AliasesBenchmark.java
+++ b/core/src/test/java/org/elasticsearch/benchmark/aliases/AliasesBenchmark.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
+import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 
@@ -39,7 +40,7 @@ public class AliasesBenchmark {
     private final static String INDEX_NAME = "my-index";
 
     public static void main(String[] args) throws IOException {
-        int NUM_ADDITIONAL_NODES = 0;
+        int NUM_ADDITIONAL_NODES = 1;
         int BASE_ALIAS_COUNT = 100000;
         int NUM_ADD_ALIAS_REQUEST = 1000;
 
@@ -104,6 +105,7 @@ public class AliasesBenchmark {
             if (i != numberOfAliases && i % 100 == 0) {
                 long avgTime = totalTime / 100;
                 System.out.println("Added [" + (i - numberOfAliases) + "] aliases. Avg create time: "  + avgTime + " ms");
+                System.out.println("Heap used [" + JvmStats.jvmStats().getMem().getHeapUsed() + "]");
                 totalTime = 0;
             }
 
@@ -113,6 +115,8 @@ public class AliasesBenchmark {
                     .execute().actionGet();
             totalTime += System.currentTimeMillis() - time;
         }
+        System.gc();
+        System.out.println("Final heap used [" + JvmStats.jvmStats().getMem().getHeapUsed() + "]");
         System.out.println("Number of aliases: " + countAliases(client));
 
         client.close();

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffTests.java
@@ -51,6 +51,7 @@ import static org.elasticsearch.test.XContentTestUtils.convertToMap;
 import static org.elasticsearch.test.XContentTestUtils.mapsEqualIgnoringArrayOrder;
 import static org.elasticsearch.test.VersionUtils.randomVersion;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 
 @ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 0, numClientNodes = 0)
@@ -147,7 +148,7 @@ public class ClusterStateDiffTests extends ElasticsearchIntegrationTest {
                 assertThat(clusterStateFromDiffs.metaData().indices(), equalTo(clusterState.metaData().indices()));
                 assertThat(clusterStateFromDiffs.metaData().templates(), equalTo(clusterState.metaData().templates()));
                 assertThat(clusterStateFromDiffs.metaData().customs(), equalTo(clusterState.metaData().customs()));
-                assertThat(clusterStateFromDiffs.metaData().aliases(), equalTo(clusterState.metaData().aliases()));
+                assertThat(clusterStateFromDiffs.metaData().equalsAliases(clusterState.metaData()), is(true));
 
                 // JSON Serialization test - make sure that both states produce similar JSON
                 assertThat(mapsEqualIgnoringArrayOrder(convertToMap(clusterStateFromDiffs), convertToMap(clusterState)), equalTo(true));

--- a/core/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ack/AckTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.AliasOrIndex;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.RoutingNode;
@@ -310,7 +311,7 @@ public class AckTests extends ElasticsearchIntegrationTest {
             assertAcked(client().admin().indices().prepareAliases().addAlias("test", "alias"));
 
             for (Client client : clients()) {
-                AliasMetaData aliasMetaData = getLocalClusterState(client).metaData().aliases().get("alias").get("test");
+                AliasMetaData aliasMetaData = ((AliasOrIndex.Alias) getLocalClusterState(client).metaData().getAliasAndIndexLookup().get("alias")).getFirstAliasMetaData();
                 assertThat(aliasMetaData.alias(), equalTo("alias"));
             }
         }


### PR DESCRIPTION
Major changes:
- Replaced the two maps in MetaData (`aliases` and `aliasAndIndexToIndexMap`) with a single map for alias and index resolving / wildcard expansion (MetaData#aliasAndIndexLookup). This has a positive impact on the used heap memory for building the the alias / index name lookup and the memory ES takes just having this.
- Instead of using a normal map this change use a TreeMap instead. This significantly speeds up wildcard suffix expansions of index/alias names.
- Moved the building of the alias / index lookup to the metadata builder.
