### PR TITLE
Add date math support in index names

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -155,6 +155,7 @@ import org.elasticsearch.action.suggest.SuggestAction;
 import org.elasticsearch.action.suggest.TransportSuggestAction;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.termvectors.*;
 import org.elasticsearch.action.termvectors.dfs.TransportDfsOnlyAction;
@@ -221,6 +222,7 @@ public class ActionModule extends AbstractModule {
             actionFilterMultibinder.addBinding().to(actionFilter);
         }
         bind(ActionFilters.class).asEagerSingleton();
+        bind(AutoCreateIndex.class).asEagerSingleton();
         registerAction(NodesInfoAction.INSTANCE, TransportNodesInfoAction.class);
         registerAction(NodesStatsAction.INSTANCE, TransportNodesStatsAction.class);
         registerAction(NodesHotThreadsAction.INSTANCE, TransportNodesHotThreadsAction.class);

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -74,13 +74,14 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
     @Inject
     public TransportBulkAction(Settings settings, ThreadPool threadPool, TransportService transportService, ClusterService clusterService,
                                TransportShardBulkAction shardBulkAction, TransportCreateIndexAction createIndexAction,
-                               ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+                               ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                               AutoCreateIndex autoCreateIndex) {
         super(settings, BulkAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, BulkRequest.class);
         this.clusterService = clusterService;
         this.shardBulkAction = shardBulkAction;
         this.createIndexAction = createIndexAction;
 
-        this.autoCreateIndex = new AutoCreateIndex(settings);
+        this.autoCreateIndex = autoCreateIndex;
         this.allowIdGeneration = this.settings.getAsBoolean("action.bulk.action.allow_id_generation", true);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -60,17 +60,19 @@ public class TransportDeleteAction extends TransportReplicationAction<DeleteRequ
     public TransportDeleteAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                  IndicesService indicesService, ThreadPool threadPool, ShardStateAction shardStateAction,
                                  TransportCreateIndexAction createIndexAction, ActionFilters actionFilters,
-                                 IndexNameExpressionResolver indexNameExpressionResolver, MappingUpdatedAction mappingUpdatedAction) {
+                                 IndexNameExpressionResolver indexNameExpressionResolver, MappingUpdatedAction mappingUpdatedAction,
+                                 AutoCreateIndex autoCreateIndex) {
         super(settings, DeleteAction.NAME, transportService, clusterService, indicesService, threadPool, shardStateAction,
                 mappingUpdatedAction, actionFilters, indexNameExpressionResolver,
                 DeleteRequest.class, DeleteRequest.class, ThreadPool.Names.INDEX);
         this.createIndexAction = createIndexAction;
-        this.autoCreateIndex = new AutoCreateIndex(settings);
+        this.autoCreateIndex = autoCreateIndex;
     }
 
     @Override
     protected void doExecute(final DeleteRequest request, final ActionListener<DeleteResponse> listener) {
-        if (autoCreateIndex.shouldAutoCreate(request.index(), clusterService.state())) {
+        ClusterState state = clusterService.state();
+        if (autoCreateIndex.shouldAutoCreate(request.index(), state)) {
             createIndexAction.execute(new CreateIndexRequest(request).index(request.index()).cause("auto(delete api)").masterNodeTimeout(request.timeout()), new ActionListener<CreateIndexResponse>() {
                 @Override
                 public void onResponse(CreateIndexResponse result) {

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -115,7 +115,10 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
 
             clusterState.blocks().globalBlockedRaiseException(ClusterBlockLevel.READ);
 
-            String[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterState, request.indicesOptions(), request.indices());
+            // TODO: I think startTime() should become part of ActionRequest and that should be used both for index name
+            // date math expressions and $now in scripts. This way all apis will deal with now in the same way instead
+            // of just for the _search api
+            String[] concreteIndices = indexNameExpressionResolver.concreteIndices(clusterState, request.indicesOptions(), startTime(), request.indices());
 
             for (String index : concreteIndices) {
                 clusterState.blocks().indexBlockedRaiseException(ClusterBlockLevel.READ, index);

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -75,14 +75,14 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     public TransportUpdateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
                                  TransportIndexAction indexAction, TransportDeleteAction deleteAction, TransportCreateIndexAction createIndexAction,
                                  UpdateHelper updateHelper, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                 IndicesService indicesService) {
+                                 IndicesService indicesService, AutoCreateIndex autoCreateIndex) {
         super(settings, UpdateAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver, UpdateRequest.class);
         this.indexAction = indexAction;
         this.deleteAction = deleteAction;
         this.createIndexAction = createIndexAction;
         this.updateHelper = updateHelper;
         this.indicesService = indicesService;
-        this.autoCreateIndex = new AutoCreateIndex(settings);
+        this.autoCreateIndex = autoCreateIndex;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationTests.java
@@ -694,7 +694,7 @@ public class ShardReplicationTests extends ElasticsearchTestCase {
                ThreadPool threadPool) {
             super(settings, actionName, transportService, clusterService, null, threadPool,
                     new ShardStateAction(settings, clusterService, transportService, null, null), null,
-                    new ActionFilters(new HashSet<ActionFilter>()), new IndexNameExpressionResolver(), Request.class, Request.class, ThreadPool.Names.SAME);
+                    new ActionFilters(new HashSet<ActionFilter>()), new IndexNameExpressionResolver(Settings.EMPTY), Request.class, Request.class, ThreadPool.Names.SAME);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterHealthResponsesTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchTestCase;
@@ -46,7 +47,7 @@ import static org.hamcrest.Matchers.*;
 
 public class ClusterHealthResponsesTests extends ElasticsearchTestCase {
 
-    private final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
+    private final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(Settings.EMPTY);
 
     private void assertIndexHealth(ClusterIndexHealth indexHealth, ShardCounter counter, IndexMetaData indexMetaData) {
         assertThat(indexHealth.getStatus(), equalTo(counter.status()));

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.Context;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.DateMathExpressionResolver;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.joda.time.DateTimeZone.UTC;
+
+public class DateMathExpressionResolverTests extends ElasticsearchTestCase {
+
+    private final DateMathExpressionResolver expressionResolver = new DateMathExpressionResolver(Settings.EMPTY);
+    private final Context context = new Context(
+            ClusterState.builder(new ClusterName("_name")).build(), IndicesOptions.strictExpand()
+    );
+
+    public void testNormal() throws Exception {
+        int numIndexExpressions = randomIntBetween(1, 9);
+        List<String> indexExpressions = new ArrayList<>(numIndexExpressions);
+        for (int i = 0; i < numIndexExpressions; i++) {
+            indexExpressions.add(randomAsciiOfLength(10));
+        }
+        List<String> result = expressionResolver.resolve(context, indexExpressions);
+        assertThat(result.size(), equalTo(indexExpressions.size()));
+        for (int i = 0; i < indexExpressions.size(); i++) {
+            assertThat(result.get(i), equalTo(indexExpressions.get(i)));
+        }
+    }
+
+    public void testExpression() throws Exception {
+        List<String> indexExpressions = Arrays.asList("<.marvel-{now}>", "<.watch_history-{now}>", "<logstash-{now}>");
+        List<String> result = expressionResolver.resolve(context, indexExpressions);
+        assertThat(result.size(), equalTo(3));
+        assertThat(result.get(0), equalTo(".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+        assertThat(result.get(1), equalTo(".watch_history-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+        assertThat(result.get(2), equalTo("logstash-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+    }
+
+    public void testEmpty() throws Exception {
+        List<String> result = expressionResolver.resolve(context, Collections.<String>emptyList());
+        assertThat(result.size(), equalTo(0));
+    }
+
+    public void testExpression_Static() throws Exception {
+        List<String> result = expressionResolver.resolve(context, Arrays.asList("<.marvel-test>"));
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0), equalTo(".marvel-test"));
+    }
+
+    public void testExpression_MultiParts() throws Exception {
+        List<String> result = expressionResolver.resolve(context, Arrays.asList("<.text1-{now/d}-text2-{now/M}>"));
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0), equalTo(".text1-"
+                + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))
+                + "-text2-"
+                + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC).withDayOfMonth(1))));
+    }
+
+    public void testExpression_CustomFormat() throws Exception {
+        List<String> results = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{YYYY.MM.dd}}>"));
+        assertThat(results.size(), equalTo(1));
+        assertThat(results.get(0), equalTo(".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+    }
+
+    public void testExpression_EscapeStatic() throws Exception {
+        List<String> result = expressionResolver.resolve(context, Arrays.asList("<.mar\\{v\\}el-{now/d}>"));
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0), equalTo(".mar{v}el-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+    }
+
+    public void testExpression_EscapeDateFormat() throws Exception {
+        List<String> result = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{'\\{year\\}'YYYY}}>"));
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0), equalTo(".marvel-" + DateTimeFormat.forPattern("'{year}'YYYY").print(new DateTime(context.getStartTime(), UTC))));
+    }
+
+    public void testExpression_MixedArray() throws Exception {
+        List<String> result = expressionResolver.resolve(context, Arrays.asList(
+                "name1", "<.marvel-{now/d}>", "name2", "<.logstash-{now/M{YYYY.MM}}>"
+        ));
+        assertThat(result.size(), equalTo(4));
+        assertThat(result.get(0), equalTo("name1"));
+        assertThat(result.get(1), equalTo(".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(new DateTime(context.getStartTime(), UTC))));
+        assertThat(result.get(2), equalTo("name2"));
+        assertThat(result.get(3), equalTo(".logstash-" + DateTimeFormat.forPattern("YYYY.MM").print(new DateTime(context.getStartTime(), UTC).withDayOfMonth(1))));
+    }
+
+    public void testExpression_CustomTimeZoneInSetting() throws Exception {
+        DateTimeZone timeZone;
+        int hoursOffset;
+        int minutesOffset = 0;
+        if (randomBoolean()) {
+            hoursOffset = randomIntBetween(-12, 14);
+            timeZone = DateTimeZone.forOffsetHours(hoursOffset);
+        } else {
+            hoursOffset = randomIntBetween(-11, 13);
+            minutesOffset = randomIntBetween(0, 59);
+            timeZone = DateTimeZone.forOffsetHoursMinutes(hoursOffset, minutesOffset);
+        }
+        DateTime now;
+        if (hoursOffset >= 0) {
+            // rounding to next day 00:00
+            now = DateTime.now(UTC).plusHours(hoursOffset).plusMinutes(minutesOffset).withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0);
+        } else {
+            // rounding to today 00:00
+            now = DateTime.now(UTC).withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0);
+        }
+        Settings settings = Settings.builder()
+                .put("date_math_expression_resolver.default_time_zone", timeZone.getID())
+                .build();
+        DateMathExpressionResolver expressionResolver = new DateMathExpressionResolver(settings);
+        Context context = new Context(this.context.getState(), this.context.getOptions(), now.getMillis());
+        List<String> results = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{YYYY.MM.dd}}>"));
+        assertThat(results.size(), equalTo(1));
+        logger.info("timezone: [{}], now [{}], name: [{}]", timeZone, now, results.get(0));
+        assertThat(results.get(0), equalTo(".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(now.withZone(timeZone))));
+    }
+
+    public void testExpression_CustomTimeZoneInIndexName() throws Exception {
+        DateTimeZone timeZone;
+        int hoursOffset;
+        int minutesOffset = 0;
+        if (randomBoolean()) {
+            hoursOffset = randomIntBetween(-12, 14);
+            timeZone = DateTimeZone.forOffsetHours(hoursOffset);
+        } else {
+            hoursOffset = randomIntBetween(-11, 13);
+            minutesOffset = randomIntBetween(0, 59);
+            timeZone = DateTimeZone.forOffsetHoursMinutes(hoursOffset, minutesOffset);
+        }
+        DateTime now;
+        if (hoursOffset >= 0) {
+            // rounding to next day 00:00
+            now = DateTime.now(UTC).plusHours(hoursOffset).plusMinutes(minutesOffset).withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0);
+        } else {
+            // rounding to today 00:00
+            now = DateTime.now(UTC).withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0);
+        }
+        Context context = new Context(this.context.getState(), this.context.getOptions(), now.getMillis());
+        List<String> results = expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{YYYY.MM.dd|" + timeZone.getID() + "}}>"));
+        assertThat(results.size(), equalTo(1));
+        logger.info("timezone: [{}], now [{}], name: [{}]", timeZone, now, results.get(0));
+        assertThat(results.get(0), equalTo(".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(now.withZone(timeZone))));
+    }
+
+    @Test(expected = ElasticsearchParseException.class)
+    public void testExpression_Invalid_Unescaped() throws Exception {
+        expressionResolver.resolve(context, Arrays.asList("<.mar}vel-{now/d}>"));
+    }
+
+    @Test(expected = ElasticsearchParseException.class)
+    public void testExpression_Invalid_DateMathFormat() throws Exception {
+        expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{}>"));
+    }
+
+    @Test(expected = ElasticsearchParseException.class)
+    public void testExpression_Invalid_EmptyDateMathFormat() throws Exception {
+        expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{}}>"));
+    }
+
+    @Test(expected = ElasticsearchParseException.class)
+    public void testExpression_Invalid_OpenEnded() throws Exception {
+        expressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d>"));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData.State;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
@@ -42,6 +43,8 @@ import static org.hamcrest.Matchers.*;
  */
 public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
 
+    private final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(Settings.EMPTY);
+
     @Test
     public void testIndexOptions_strict() {
         MetaData.Builder mdBuilder = MetaData.builder()
@@ -51,7 +54,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
 
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         IndicesOptions[] indicesOptions = new IndicesOptions[]{ IndicesOptions.strictExpandOpen(), IndicesOptions.strictExpand()};
         for (IndicesOptions options : indicesOptions) {
@@ -141,7 +143,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("foofoo-closed").state(IndexMetaData.State.CLOSE))
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         IndicesOptions lenientExpand = IndicesOptions.fromOptions(true, true, true, true);
         IndicesOptions[] indicesOptions = new IndicesOptions[]{ IndicesOptions.lenientExpandOpen(), lenientExpand};
@@ -210,7 +211,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("foofoo-closed").state(IndexMetaData.State.CLOSE))
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         IndicesOptions expandOpen = IndicesOptions.fromOptions(true, false, true, false);
         IndicesOptions expand = IndicesOptions.fromOptions(true, false, true, true);
@@ -260,7 +260,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("bar"))
                 .put(indexBuilder("foobar").putAlias(AliasMetaData.builder("barbaz")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         // Only closed
         IndicesOptions options = IndicesOptions.fromOptions(false, true, false, true);
@@ -333,7 +332,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("foofoo-closed").state(IndexMetaData.State.CLOSE))
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         //ignore unavailable and allow no indices
         {
@@ -428,7 +426,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("foofoo-closed").state(IndexMetaData.State.CLOSE))
                 .put(indexBuilder("foofoo").putAlias(AliasMetaData.builder("barbaz")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         //error on both unavailable and no indices + every alias needs to expand to a single index
 
@@ -482,7 +479,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
     @Test
     public void testIndexOptions_emptyCluster() {
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(MetaData.builder().build()).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         IndicesOptions options = IndicesOptions.strictExpandOpen();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, options);
@@ -532,7 +528,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpandOpen());
 
         indexNameExpressionResolver.concreteIndices(context, "testZZZ");
@@ -544,7 +539,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.lenientExpandOpen());
 
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndices(context, "testXXX", "testZZZ")), equalTo(newHashSet("testXXX")));
@@ -556,7 +550,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpandOpen());
 
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndices(context, "testMo", "testMahdy")), equalTo(newHashSet("testXXX")));
@@ -568,9 +561,7 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testXXX"))
                 .put(indexBuilder("kuku"));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.lenientExpandOpen());
-
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndices(context, new String[]{})), equalTo(Sets.newHashSet("kuku", "testXXX")));
     }
 
@@ -583,7 +574,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("testYYY").state(State.OPEN))
                 .put(indexBuilder("testYYX").state(State.OPEN));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, true, false, false));
         assertThat(newHashSet(indexNameExpressionResolver.concreteIndices(context, "testX*")), equalTo(new HashSet<String>()));
@@ -615,7 +605,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
 
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
             ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(MetaData.builder().build()).build();
-            IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, indicesOptions);
 
             // with no indices, asking for all indices should return empty list or exception, depending on indices options
@@ -633,7 +622,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                     .put(indexBuilder("bbb").state(State.OPEN).putAlias(AliasMetaData.builder("bbb_alias1")))
                     .put(indexBuilder("ccc").state(State.CLOSE).putAlias(AliasMetaData.builder("ccc_alias1")));
             state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-            indexNameExpressionResolver = new IndexNameExpressionResolver();
             context = new IndexNameExpressionResolver.Context(state, indicesOptions);
             if (indicesOptions.expandWildcardsOpen() || indicesOptions.expandWildcardsClosed() || indicesOptions.allowNoIndices()) {
                 String[] concreteIndices = indexNameExpressionResolver.concreteIndices(context, allIndices);
@@ -676,7 +664,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                     .put(indexBuilder("bbb").state(State.OPEN).putAlias(AliasMetaData.builder("bbb_alias1")))
                     .put(indexBuilder("ccc").state(State.CLOSE).putAlias(AliasMetaData.builder("ccc_alias1")));
             ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-            IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, indicesOptions);
 
             // asking for non existing wildcard pattern should return empty list or exception
@@ -760,7 +747,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
         //even though it does identify all indices, it's not a pattern but just an explicit list of them
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
         MetaData metaData = metaDataBuilder(concreteIndices);
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metaData, concreteIndices, concreteIndices), equalTo(false));
     }
 
@@ -769,7 +755,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
         String[] indicesOrAliases = new String[]{"*"};
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
         MetaData metaData = metaDataBuilder(concreteIndices);
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metaData, indicesOrAliases, concreteIndices), equalTo(true));
     }
 
@@ -778,7 +763,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
         String[] indicesOrAliases = new String[]{"index*"};
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
         MetaData metaData = metaDataBuilder(concreteIndices);
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metaData, indicesOrAliases, concreteIndices), equalTo(true));
     }
 
@@ -788,7 +772,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
         String[] allConcreteIndices = new String[]{"index1", "index2", "index3", "a", "b"};
         MetaData metaData = metaDataBuilder(allConcreteIndices);
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metaData, indicesOrAliases, concreteIndices), equalTo(false));
     }
 
@@ -797,7 +780,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
         String[] indicesOrAliases = new String[]{"-index1", "+index1"};
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
         MetaData metaData = metaDataBuilder(concreteIndices);
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metaData, indicesOrAliases, concreteIndices), equalTo(true));
     }
 
@@ -807,7 +789,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
         String[] concreteIndices = new String[]{"index2", "index3"};
         String[] allConcreteIndices = new String[]{"index1", "index2", "index3"};
         MetaData metaData = metaDataBuilder(allConcreteIndices);
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metaData, indicesOrAliases, concreteIndices), equalTo(false));
     }
 
@@ -816,7 +797,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
         String[] indicesOrAliases = new String[]{"index*", "-index1", "+index1"};
         String[] concreteIndices = new String[]{"index1", "index2", "index3"};
         MetaData metaData = metaDataBuilder(concreteIndices);
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metaData, indicesOrAliases, concreteIndices), equalTo(true));
     }
 
@@ -826,7 +806,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
         String[] concreteIndices = new String[]{"index2", "index3"};
         String[] allConcreteIndices = new String[]{"index1", "index2", "index3"};
         MetaData metaData = metaDataBuilder(allConcreteIndices);
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         assertThat(indexNameExpressionResolver.isPatternMatchingAllIndices(metaData, indicesOrAliases, concreteIndices), equalTo(false));
     }
 
@@ -837,7 +816,6 @@ public class IndexNameExpressionResolverTests extends ElasticsearchTestCase {
                 .put(indexBuilder("foo2-closed").state(IndexMetaData.State.CLOSE).putAlias(AliasMetaData.builder("foobar2-closed")))
                 .put(indexBuilder("foo3").putAlias(AliasMetaData.builder("foobar2-closed")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpandOpenAndForbidClosed());
         try {

--- a/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationTests.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class DateMathIndexExpressionsIntegrationTests extends ElasticsearchIntegrationTest {
+
+    public void testIndexNameDateMathExpressions() {
+        DateTime now = new DateTime(DateTimeZone.UTC);
+        String index1 = ".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(now);
+        String index2 = ".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(now.minusDays(1));
+        String index3 = ".marvel-" + DateTimeFormat.forPattern("YYYY.MM.dd").print(now.minusDays(2));
+        createIndex(index1, index2, index3);
+
+        String dateMathExp1 = "<.marvel-{now/d}>";
+        String dateMathExp2 = "<.marvel-{now/d-1d}>";
+        String dateMathExp3 = "<.marvel-{now/d-2d}>";
+        client().prepareIndex(dateMathExp1, "type", "1").setSource("{}").get();
+        client().prepareIndex(dateMathExp2, "type", "2").setSource("{}").get();
+        client().prepareIndex(dateMathExp3, "type", "3").setSource("{}").get();
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch(dateMathExp1, dateMathExp2, dateMathExp3).get();
+        ElasticsearchAssertions.assertHitCount(searchResponse, 3);
+        ElasticsearchAssertions.assertSearchHits(searchResponse, "1", "2", "3");
+
+        GetResponse getResponse = client().prepareGet(dateMathExp1, "type", "1").get();
+        assertThat(getResponse.isExists(), is(true));
+        assertThat(getResponse.getId(), equalTo("1"));
+
+        getResponse = client().prepareGet(dateMathExp2, "type", "2").get();
+        assertThat(getResponse.isExists(), is(true));
+        assertThat(getResponse.getId(), equalTo("2"));
+
+        getResponse = client().prepareGet(dateMathExp3, "type", "3").get();
+        assertThat(getResponse.isExists(), is(true));
+        assertThat(getResponse.getId(), equalTo("3"));
+
+        IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(dateMathExp1, dateMathExp2, dateMathExp3).get();
+        assertThat(indicesStatsResponse.getIndex(index1), notNullValue());
+        assertThat(indicesStatsResponse.getIndex(index2), notNullValue());
+        assertThat(indicesStatsResponse.getIndex(index3), notNullValue());
+
+        DeleteResponse deleteResponse = client().prepareDelete(dateMathExp1, "type", "1").get();
+        assertThat(deleteResponse.isFound(), equalTo(true));
+        assertThat(deleteResponse.getId(), equalTo("1"));
+
+        deleteResponse = client().prepareDelete(dateMathExp2, "type", "2").get();
+        assertThat(deleteResponse.isFound(), equalTo(true));
+        assertThat(deleteResponse.getId(), equalTo("2"));
+
+        deleteResponse = client().prepareDelete(dateMathExp3, "type", "3").get();
+        assertThat(deleteResponse.isFound(), equalTo(true));
+        assertThat(deleteResponse.getId(), equalTo("3"));
+    }
+
+}

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -9,6 +9,7 @@ The conventions listed in this chapter can be applied throughout the REST
 API, unless otherwise specified.
 
 * <<multi-index>>
+* <<date-math-index-names>>
 * <<common-options>>
 
 --
@@ -54,6 +55,76 @@ The defaults settings for the above parameters depend on the api being used.
 
 NOTE: Single index APIs such as the <<docs>> and the
 <<indices-aliases,single-index `alias` APIs>> do not support multiple indices.
+
+[[date-math-index-names]]
+== Date math support in index names
+
+Date math index name resolution enables you to search a range of time-series indices, rather
+than searching all of your time-series indices and filtering the results or maintaining aliases.
+Limiting the number of indices that are searched reduces the load on the cluster and improves
+execution performance. For example, if you are searching for errors in your
+daily logs, you can use a date math name template to restrict the search to the past
+two days.
+
+Almost all APIs that have an `index` parameter, support date math in the `index` parameter
+value.
+
+A date math index name takes the following form:
+
+[source,txt]
+----------------------------------------------------------------------
+<static_name{date_math_expr{date_format|time_zone}}>
+----------------------------------------------------------------------
+
+Where:
+
+[horizontal]
+`static_name`:: is the static text part of the name
+`date_math_expr`:: is a dynamic date math expression that computes the date dynamically
+`date_format`:: is the optional format in which the computed date should be rendered. Defaults to `YYYY.MM.dd`.
+`time_zone`:: is the optional time zone . Defaults to `utc`.
+
+You must enclose date math index name expressions within angle brackets. For example:
+
+[source,js]
+----------------------------------------------------------------------
+curl -XGET 'localhost:9200/<logstash-{now/d-2d}>/_search' {
+  "query" : {
+    ...
+  }
+}
+----------------------------------------------------------------------
+
+The following example shows different forms of date math index names and the final index names
+they resolve to given the current time is 22rd March 2024 noon utc.
+
+[options="header"]
+|======
+| Expression                		      |Resolves to
+| `<logstash-{now/d}>`      		      | `logstash-2024.03.22`
+| `<logstash-{now/M}>`      		      | `logstash-2024.03.01`
+| `<logstash-{now/M{YYYY.MM}}>`           | `logstash-2024.03`
+| `<logstash-{now/M-1M{YYYY.MM}}>`        | `logstash-2024.02`
+| `<logstash-{now/d{YYYY.MM.dd\|+12:00}}`  | `logstash-2024.03.23`
+|======
+
+To use the characters `{` and `}` in the static part of an index name template, escape them
+with a backslash `\`, for example:
+
+ * `<elastic\\{ON\\}-{now/M}>` resolves to `elastic{ON}-2024.03.01`
+
+The following example shows a search request that searches the Logstash indices for the past
+three days, assuming the indices use the default Logstash index name format,
+`logstash-YYYY.MM.dd`.
+
+[source,js]
+----------------------------------------------------------------------
+curl -XGET 'localhost:9200/<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search' {
+  "query" : {
+    ...
+  }
+}
+----------------------------------------------------------------------
 
 [[common-options]]
 == Common options


### PR DESCRIPTION
Date math index name resolution enables you to search a range of time-series indices, rather than searching all of your time-series indices and filtering the the results or maintaining aliases. Limiting the number of indices that are searched reduces the load on the cluster and improves execution performance. For example, if you are searching for errors in your daily logs, you can use a date math name template to restrict the search to the past two days.

The added `ExpressionResolver` implementation that is responsible for resolving date math expressions in index names. This resolver is evaluated before wildcard expressions are evaluated.

The supported format: `<static_name{date_math_expr{date_format|timezone_id}}>` and the date math expressions must be enclosed within angle brackets. The `date_format` is optional and defaults to `YYYY.MM.dd`. The `timezone_id` id is optional too and defaults to `utc`.

The `{` character can be escaped by places `\\` before it.

The following index names can be specified: (assuming now is 2024.03.22 noon utc)
- `<logstash-{now/d}>` translates into `logstash-2024.03.22`
- `<logstash-{now/M}>` translates into `logstash-2024.03.01`
- `<logstash-{now/M{YYYY.MM}}>` translates into `logstash-2024.03`
- `<logstash-{now/M-1M{YYYY.MM}}>` translates into `logstash-2024.02`
- `<logstash-{now/d{YYYY.MM.dd|+12:00}}>` translates into `logstash-2024.03.23`

The following example shows a search request that searches the Logstash indices for the past
three days:

``` bash
curl -XGET 'localhost:9200/<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search' {
  "query" : {
    ...
  }
}
```

PR for #12059
