### PR TITLE
Tests: Explicitly use newer junit runner for maven integ tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -719,6 +719,13 @@
                             </goals>
                         </execution>
                     </executions>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>2.18.1</version>
+                      </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The older runner (junit 4.0?) hides exceptions in static initialization
(and runs the tests anyways!). With this change, the actual cause
of the recent windows integ test failures with security manager
are shown.
