### PR TITLE
Allow shards to be allocated if leftover shard from different index exists

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -284,8 +284,20 @@ public class IndexService extends AbstractIndexComponent implements IndexCompone
         boolean success = false;
         Injector shardInjector = null;
         try {
-
-            ShardPath path = ShardPath.loadShardPath(logger, nodeEnv, shardId, indexSettings);
+            lock = nodeEnv.shardLock(shardId, TimeUnit.SECONDS.toMillis(5));
+            ShardPath path;
+            try {
+                path = ShardPath.loadShardPath(logger, nodeEnv, shardId, indexSettings);
+            } catch (IllegalStateException ex) {
+                logger.warn("{} failed to load shard path, trying to archive leftover", shardId);
+                try {
+                    ShardPath.deleteLeftoverShardDirectory(logger, nodeEnv, lock, indexSettings);
+                    path = ShardPath.loadShardPath(logger, nodeEnv, shardId, indexSettings);
+                } catch (Throwable t) {
+                    t.addSuppressed(ex);
+                    throw t;
+                }
+            }
             if (path == null) {
                 path = ShardPath.selectNewPathForShard(nodeEnv, shardId, indexSettings, getAvgShardSizeInBytes(), this);
                 logger.debug("{} creating using a new path [{}]", shardId, path);
@@ -293,7 +305,6 @@ public class IndexService extends AbstractIndexComponent implements IndexCompone
                 logger.debug("{} creating using an existing path [{}]", shardId, path);
             }
 
-            lock = nodeEnv.shardLock(shardId, TimeUnit.SECONDS.toMillis(5));
             if (shards.containsKey(shardId.id())) {
                 throw new IndexShardAlreadyExistsException(shardId + " already exists");
             }

--- a/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -18,10 +18,12 @@
  */
 package org.elasticsearch.index.shard;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.index.settings.IndexSettings;
 
 import java.io.IOException;
@@ -88,7 +90,7 @@ public final class ShardPath {
         for (Path path : paths) {
             ShardStateMetaData load = ShardStateMetaData.FORMAT.loadLatestState(logger, path);
             if (load != null) {
-                if ((load.indexUUID.equals(indexUUID) || IndexMetaData.INDEX_UUID_NA_VALUE.equals(load.indexUUID)) == false) {
+                if (load.indexUUID.equals(indexUUID) == false && IndexMetaData.INDEX_UUID_NA_VALUE.equals(load.indexUUID) == false) {
                     logger.warn("{} found shard on path: [{}] with a different index UUID - this shard seems to be leftover from a different index with the same name. Remove the leftover shard in order to reuse the path with the current index", shardId, path);
                     throw new IllegalStateException(shardId + " index UUID in shard state was: " + load.indexUUID + " expected: " + indexUUID + " on shard path: " + path);
                 }
@@ -112,6 +114,26 @@ public final class ShardPath {
             }
             logger.debug("{} loaded data path [{}], state path [{}]", shardId, dataPath, statePath);
             return new ShardPath(dataPath, statePath, indexUUID, shardId);
+        }
+    }
+
+    /**
+     * This method tries to delete left-over shards where the index name has been reused but the UUID is different
+     * to allow the new shard to be allocated.
+     */
+    public static void deleteLeftoverShardDirectory(ESLogger logger, NodeEnvironment env, ShardLock lock, @IndexSettings Settings indexSettings) throws IOException {
+        final String indexUUID = indexSettings.get(IndexMetaData.SETTING_INDEX_UUID, IndexMetaData.INDEX_UUID_NA_VALUE);
+        final Path[] paths = env.availableShardPaths(lock.getShardId());
+        for (Path path : paths) {
+            ShardStateMetaData load = ShardStateMetaData.FORMAT.loadLatestState(logger, path);
+            if (load != null) {
+                if (load.indexUUID.equals(indexUUID) == false && IndexMetaData.INDEX_UUID_NA_VALUE.equals(load.indexUUID) == false) {
+                    logger.warn("{} deleting leftover shard on path: [{}] with a different index UUID", lock.getShardId(), path);
+                    assert Files.isDirectory(path) : path + " is not a directory";
+                    NodeEnvironment.acquireFSLockForPaths(indexSettings, paths);
+                    IOUtils.rm(path);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
If an index name is reused but a leftover shard still exists on any node
we fail repeatedly to allocate the shard since we now check the index UUID
before reusing data. This commit allows to recover even if there is such a
leftover shard by deleting the leftover shard.

Closes #10677
