### PR TITLE
Render structured exceptions in mget / mpercolate

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -661,4 +661,19 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         }
         return null;
     }
+
+    public static void renderThrowable(XContentBuilder builder, Params params, Throwable t) throws IOException {
+        builder.startObject("error");
+        final ElasticsearchException[] rootCauses = ElasticsearchException.guessRootCauses(t);
+        builder.field("root_cause");
+        builder.startArray();
+        for (ElasticsearchException rootCause : rootCauses){
+            builder.startObject();
+            rootCause.toXContent(builder, new ToXContent.DelegatingMapParams(Collections.singletonMap(ElasticsearchException.REST_EXCEPTION_SKIP_CAUSE, "true"), params));
+            builder.endObject();
+        }
+        builder.endArray();
+        ElasticsearchException.toXContent(builder, params, t);
+        builder.endObject();
+    }
 }

--- a/core/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -65,14 +66,14 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
         for (int i = 0; i < request.items.size(); i++) {
             MultiGetRequest.Item item = request.items.get(i);
             if (!clusterState.metaData().hasConcreteIndex(item.index())) {
-                responses.set(i, new MultiGetItemResponse(null, new MultiGetResponse.Failure(item.index(), item.type(), item.id(), "[" + item.index() + "] missing")));
+                responses.set(i, new MultiGetItemResponse(null, new MultiGetResponse.Failure(item.index(), item.type(), item.id(), new IndexNotFoundException(item.index()))));
                 continue;
             }
             item.routing(clusterState.metaData().resolveIndexRouting(item.routing(), item.index()));
             String concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, item);
             if (item.routing() == null && clusterState.getMetaData().routingRequired(concreteSingleIndex, item.type())) {
                 responses.set(i, new MultiGetItemResponse(null, new MultiGetResponse.Failure(concreteSingleIndex, item.type(), item.id(),
-                        "routing is required for [" + concreteSingleIndex + "]/[" + item.type() + "]/[" + item.id() + "]")));
+                        new IllegalArgumentException("routing is required for [" + concreteSingleIndex + "]/[" + item.type() + "]/[" + item.id() + "]"))));
                 continue;
             }
             ShardId shardId = clusterService.operationRouting()
@@ -107,11 +108,10 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
                 @Override
                 public void onFailure(Throwable e) {
                     // create failures for all relevant requests
-                    String message = ExceptionsHelper.detailedMessage(e);
                     for (int i = 0; i < shardRequest.locations.size(); i++) {
                         MultiGetRequest.Item item = shardRequest.items.get(i);
                         responses.set(shardRequest.locations.get(i), new MultiGetItemResponse(null,
-                                new MultiGetResponse.Failure(shardRequest.index(), item.type(), item.id(), message)));
+                                new MultiGetResponse.Failure(shardRequest.index(), item.type(), item.id(), e)));
                     }
                     if (counter.decrementAndGet() == 0) {
                         finishHim();

--- a/core/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -105,7 +105,7 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
                     throw (ElasticsearchException) t;
                 } else {
                     logger.debug("{} failed to execute multi_get for [{}]/[{}]", t, shardId, item.type(), item.id());
-                    response.add(request.locations.get(i), new MultiGetResponse.Failure(request.index(), item.type(), item.id(), ExceptionsHelper.detailedMessage(t)));
+                    response.add(request.locations.get(i), new MultiGetResponse.Failure(request.index(), item.type(), item.id(), t));
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.percolate;
 
 import com.carrotsearch.hppc.IntArrayList;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.get.*;
@@ -312,9 +311,9 @@ public class TransportMultiPercolateAction extends HandledTransportAction<MultiP
                 if (element instanceof PercolateResponse) {
                     finalResponse[slot] = new MultiPercolateResponse.Item((PercolateResponse) element);
                 } else if (element instanceof Throwable) {
-                    finalResponse[slot] = new MultiPercolateResponse.Item(ExceptionsHelper.detailedMessage((Throwable) element));
+                    finalResponse[slot] = new MultiPercolateResponse.Item((Throwable)element);
                 } else if (element instanceof MultiGetResponse.Failure) {
-                    finalResponse[slot] = new MultiPercolateResponse.Item(((MultiGetResponse.Failure)element).getMessage());
+                    finalResponse[slot] = new MultiPercolateResponse.Item(((MultiGetResponse.Failure)element).getFailure());
                 }
             }
             finalListener.onResponse(new MultiPercolateResponse(finalResponse));

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -154,27 +154,13 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(Fields.RESPONSES);
         for (Item item : items) {
+            builder.startObject();
             if (item.isFailure()) {
-                builder.startObject();
-                builder.startObject(Fields.ERROR);
-                final Throwable t = item.getFailure();
-                final ElasticsearchException[] rootCauses = ElasticsearchException.guessRootCauses(t);
-                builder.field(Fields.ROOT_CAUSE);
-                builder.startArray();
-                for (ElasticsearchException rootCause : rootCauses){
-                    builder.startObject();
-                    rootCause.toXContent(builder, new ToXContent.DelegatingMapParams(Collections.singletonMap(ElasticsearchException.REST_EXCEPTION_SKIP_CAUSE, "true"), params));
-                    builder.endObject();
-                }
-                builder.endArray();
-                ElasticsearchException.toXContent(builder, params, t);
-                builder.endObject();
-                builder.endObject();
+                ElasticsearchException.renderThrowable(builder, params, item.getFailure());
             } else {
-                builder.startObject();
                 item.getResponse().toXContent(builder, params);
-                builder.endObject();
             }
+            builder.endObject();
         }
         builder.endArray();
         return builder;

--- a/core/src/test/java/org/elasticsearch/get/GetActionTests.java
+++ b/core/src/test/java/org/elasticsearch/get/GetActionTests.java
@@ -54,13 +54,7 @@ import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.*;
 
 public class GetActionTests extends ElasticsearchIntegrationTest {
 
@@ -600,7 +594,8 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         assertThat(response.getResponses()[1].getResponse().getSourceAsMap().get("field").toString(), equalTo("value1"));
         assertThat(response.getResponses()[2].getFailure(), notNullValue());
         assertThat(response.getResponses()[2].getFailure().getId(), equalTo("1"));
-        assertThat(response.getResponses()[2].getFailure().getMessage(), startsWith("VersionConflictEngineException"));
+        assertThat(response.getResponses()[2].getFailure().getMessage(), startsWith("[type1][1]: version conflict, current [1], provided [2]"));
+        assertThat(response.getResponses()[2].getFailure().getFailure(), instanceOf(VersionConflictEngineException.class));
 
         //Version from Lucene index
         refresh();
@@ -622,7 +617,9 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         assertThat(response.getResponses()[1].getResponse().getSourceAsMap().get("field").toString(), equalTo("value1"));
         assertThat(response.getResponses()[2].getFailure(), notNullValue());
         assertThat(response.getResponses()[2].getFailure().getId(), equalTo("1"));
-        assertThat(response.getResponses()[2].getFailure().getMessage(), startsWith("VersionConflictEngineException"));
+        assertThat(response.getResponses()[2].getFailure().getMessage(), startsWith("[type1][1]: version conflict, current [1], provided [2]"));
+        assertThat(response.getResponses()[2].getFailure().getFailure(), instanceOf(VersionConflictEngineException.class));
+
 
 
         for (int i = 0; i < 3; i++) {
@@ -645,7 +642,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         assertThat(response.getResponses()[1].getFailure(), notNullValue());
         assertThat(response.getResponses()[1].getFailure().getId(), equalTo("2"));
         assertThat(response.getResponses()[1].getIndex(), equalTo("test"));
-        assertThat(response.getResponses()[1].getFailure().getMessage(), startsWith("VersionConflictEngineException"));
+        assertThat(response.getResponses()[1].getFailure().getMessage(), startsWith("[type1][2]: version conflict, current [2], provided [1]"));
         assertThat(response.getResponses()[2].getId(), equalTo("2"));
         assertThat(response.getResponses()[2].getIndex(), equalTo("test"));
         assertThat(response.getResponses()[2].getFailure(), nullValue());
@@ -671,7 +668,7 @@ public class GetActionTests extends ElasticsearchIntegrationTest {
         assertThat(response.getResponses()[1].getFailure(), notNullValue());
         assertThat(response.getResponses()[1].getFailure().getId(), equalTo("2"));
         assertThat(response.getResponses()[1].getIndex(), equalTo("test"));
-        assertThat(response.getResponses()[1].getFailure().getMessage(), startsWith("VersionConflictEngineException"));
+        assertThat(response.getResponses()[1].getFailure().getMessage(), startsWith("[type1][2]: version conflict, current [2], provided [1]"));
         assertThat(response.getResponses()[2].getId(), equalTo("2"));
         assertThat(response.getResponses()[2].getIndex(), equalTo("test"));
         assertThat(response.getResponses()[2].getFailure(), nullValue());

--- a/core/src/test/java/org/elasticsearch/mget/SimpleMgetTests.java
+++ b/core/src/test/java/org/elasticsearch/mget/SimpleMgetTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.mget;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetRequest;
@@ -57,7 +58,8 @@ public class SimpleMgetTests extends ElasticsearchIntegrationTest {
 
         assertThat(mgetResponse.getResponses()[1].getIndex(), is("nonExistingIndex"));
         assertThat(mgetResponse.getResponses()[1].isFailed(), is(true));
-        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), is("[nonExistingIndex] missing"));
+        assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), is("no such index"));
+        assertThat(((ElasticsearchException)mgetResponse.getResponses()[1].getFailure().getFailure()).getIndex(), is("nonExistingIndex"));
 
 
         mgetResponse = client().prepareMultiGet()
@@ -66,7 +68,9 @@ public class SimpleMgetTests extends ElasticsearchIntegrationTest {
         assertThat(mgetResponse.getResponses().length, is(1));
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("nonExistingIndex"));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(true));
-        assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), is("[nonExistingIndex] missing"));
+        assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), is("no such index"));
+        assertThat(((ElasticsearchException)mgetResponse.getResponses()[0].getFailure().getFailure()).getIndex(), is("nonExistingIndex"));
+
 
     }
 

--- a/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorTests.java
@@ -85,33 +85,33 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
                 .execute().actionGet();
 
         MultiPercolateResponse.Item item = response.getItems()[0];
-        assertMatchCount(item.response(), 2l);
+        assertMatchCount(item.getResponse(), 2l);
         assertThat(item.getResponse().getMatches(), arrayWithSize(2));
-        assertThat(item.errorMessage(), nullValue());
+        assertThat(item.getErrorMessage(), nullValue());
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("1", "4"));
 
         item = response.getItems()[1];
-        assertThat(item.errorMessage(), nullValue());
+        assertThat(item.getErrorMessage(), nullValue());
 
-        assertMatchCount(item.response(), 2l);
+        assertMatchCount(item.getResponse(), 2l);
         assertThat(item.getResponse().getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
 
         item = response.getItems()[2];
-        assertThat(item.errorMessage(), nullValue());
-        assertMatchCount(item.response(), 4l);
+        assertThat(item.getErrorMessage(), nullValue());
+        assertMatchCount(item.getResponse(), 4l);
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4"));
 
         item = response.getItems()[3];
-        assertThat(item.errorMessage(), nullValue());
-        assertMatchCount(item.response(), 1l);
+        assertThat(item.getErrorMessage(), nullValue());
+        assertMatchCount(item.getResponse(), 1l);
         assertThat(item.getResponse().getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContaining("4"));
 
         item = response.getItems()[4];
         assertThat(item.getResponse(), nullValue());
-        assertThat(item.errorMessage(), notNullValue());
-        assertThat(item.errorMessage(), containsString("document missing"));
+        assertThat(item.getErrorMessage(), notNullValue());
+        assertThat(item.getErrorMessage(), containsString("document missing"));
     }
 
     @Test
@@ -164,33 +164,33 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
                 .execute().actionGet();
 
         MultiPercolateResponse.Item item = response.getItems()[0];
-        assertMatchCount(item.response(), 2l);
+        assertMatchCount(item.getResponse(), 2l);
         assertThat(item.getResponse().getMatches(), arrayWithSize(2));
-        assertThat(item.errorMessage(), nullValue());
+        assertThat(item.getErrorMessage(), nullValue());
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("1", "4"));
 
         item = response.getItems()[1];
-        assertThat(item.errorMessage(), nullValue());
+        assertThat(item.getErrorMessage(), nullValue());
 
-        assertMatchCount(item.response(), 2l);
+        assertMatchCount(item.getResponse(), 2l);
         assertThat(item.getResponse().getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
 
         item = response.getItems()[2];
-        assertThat(item.errorMessage(), nullValue());
-        assertMatchCount(item.response(), 4l);
+        assertThat(item.getErrorMessage(), nullValue());
+        assertMatchCount(item.getResponse(), 4l);
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4"));
 
         item = response.getItems()[3];
-        assertThat(item.errorMessage(), nullValue());
-        assertMatchCount(item.response(), 1l);
+        assertThat(item.getErrorMessage(), nullValue());
+        assertMatchCount(item.getResponse(), 1l);
         assertThat(item.getResponse().getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContaining("4"));
 
         item = response.getItems()[4];
         assertThat(item.getResponse(), nullValue());
-        assertThat(item.errorMessage(), notNullValue());
-        assertThat(item.errorMessage(), containsString("document missing"));
+        assertThat(item.getErrorMessage(), notNullValue());
+        assertThat(item.getErrorMessage(), containsString("document missing"));
     }
 
     @Test
@@ -222,7 +222,7 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
         assertThat(response.items().length, equalTo(numPercolateRequest));
         for (MultiPercolateResponse.Item item : response) {
             assertThat(item.isFailure(), equalTo(false));
-            assertMatchCount(item.response(), numQueries);
+            assertMatchCount(item.getResponse(), numQueries);
             assertThat(item.getResponse().getMatches().length, equalTo(numQueries));
         }
 
@@ -239,7 +239,7 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
         assertThat(response.items().length, equalTo(numPercolateRequest));
         for (MultiPercolateResponse.Item item : response) {
             assertThat(item.isFailure(), equalTo(true));
-            assertThat(item.errorMessage(), containsString("document missing"));
+            assertThat(item.getErrorMessage(), containsString("document missing"));
             assertThat(item.getResponse(), nullValue());
         }
 
@@ -259,7 +259,7 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
         response = builder.execute().actionGet();
         assertThat(response.items().length, equalTo(numPercolateRequest + 1));
         assertThat(response.items()[numPercolateRequest].isFailure(), equalTo(false));
-        assertMatchCount(response.items()[numPercolateRequest].response(), numQueries);
+        assertMatchCount(response.items()[numPercolateRequest].getResponse(), numQueries);
         assertThat(response.items()[numPercolateRequest].getResponse().getMatches().length, equalTo(numQueries));
     }
 
@@ -291,7 +291,7 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
         assertThat(response.items().length, equalTo(numPercolateRequest));
         for (MultiPercolateResponse.Item item : response) {
             assertThat(item.isFailure(), equalTo(false));
-            assertMatchCount(item.response(), numQueries);
+            assertMatchCount(item.getResponse(), numQueries);
             assertThat(item.getResponse().getMatches().length, equalTo(numQueries));
         }
 
@@ -332,7 +332,7 @@ public class MultiPercolatorTests extends ElasticsearchIntegrationTest {
         response = builder.execute().actionGet();
         assertThat(response.items().length, equalTo(numPercolateRequest + 1));
         assertThat(response.items()[numPercolateRequest].isFailure(), equalTo(false));
-        assertMatchCount(response.items()[numPercolateRequest].response(), numQueries);
+        assertMatchCount(response.items()[numPercolateRequest].getResponse(), numQueries);
         assertThat(response.items()[numPercolateRequest].getResponse().getMatches().length, equalTo(numQueries));
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mpercolate/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mpercolate/10_basic.yaml
@@ -37,5 +37,7 @@
               foo: bar
 
   - match:  { responses.0.total:     1  }
-  - match:  { responses.1.error: "/IndexNotFoundException.no.such.index./"  }
+  - match:  { responses.1.error.root_cause.0.type: index_not_found_exception }
+  - match:  { responses.1.error.root_cause.0.reason: "/no.such.index/" }
+  - match:  { responses.1.error.root_cause.0.index: percolator_index1 }
   - match:  { responses.2.total:     1  }


### PR DESCRIPTION
Instead of rendering only the exception message this commit
adds structured exception rendering to mget and mpercolate
