### PR TITLE
Add url repository whitelist - backport of #11687 to 1.6 and 1.7

### DIFF
--- a/docs/reference/migration/migrate_1_6.asciidoc
+++ b/docs/reference/migration/migrate_1_6.asciidoc
@@ -30,3 +30,12 @@ path.repo: ["/mnt/daily", "/mnt/weekly"]
 If the file system repository location is specified as an absolute path it has to start with one of the locations
 specified in `path.repo`. If the location is specified as a relative path, it will be resolved against the first
 location specified in the `path.repo` setting.
+
+Starting with version 1.6.1 URL repositories with `http:`, `https:`, and `ftp:` URLs has to be whitelisted by specifying allowed URLs in the
+`repositories.url.allowed_urls` setting. This setting supports wildcards in the place of host, path, query, and
+fragment. For example:
+
+[source,yaml]
+-----------------------------------
+repositories.url.allowed_urls: ["http://www.example.org/root/*", "https://*.mydomain.com/*?*#*"]
+-----------------------------------

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -122,6 +122,19 @@ point to the root of the shared filesystem repository. The following settings ar
 [horizontal]
 `url`:: Location of the snapshots. Mandatory.
 
+URL Repository supports the following protocols: "http", "https", "ftp", "file" and "jar". URL repositories with `http:`,
+`https:`, and `ftp:` URLs has to be whitelisted by specifying allowed URLs in the `repositories.url.allowed_urls` setting.
+This setting supports wildcards in the place of host, path, query, and fragment. For example:
+
+[source,yaml]
+-----------------------------------
+repositories.url.allowed_urls: ["http://www.example.org/root/*", "https://*.mydomain.com/*?*#*"]
+-----------------------------------
+
+URL repositories with `file:` URLs can only point to locations registered in the `repo.path` setting similiar to
+shared file system repository.
+
+
 [float]
 ===== Common Repository Settings
 

--- a/src/main/java/org/elasticsearch/common/util/URIPattern.java
+++ b/src/main/java/org/elasticsearch/common/util/URIPattern.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.elasticsearch.common.regex.Regex;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * URI Pattern matcher
+ *
+ * The pattern is URI in which authority, path, query and fragment can be replace with simple pattern.
+ *
+ * For example: foobar://*.local/some_path/*?*#* will match all uris with schema foobar in local domain
+ * with any port, with path that starts some_path and with any query and fragment.
+ */
+public class URIPattern {
+    private final URI uriPattern;
+
+    /**
+     * Constructs uri pattern
+     * @param pattern
+     */
+    public URIPattern(String pattern) {
+        try {
+            uriPattern = new URI(pattern);
+        } catch (URISyntaxException ex) {
+            throw new IllegalArgumentException("cannot parse URI pattern [" + pattern + "]");
+        }
+    }
+
+    /**
+     * Returns true if the given uri matches the pattern
+     */
+    public boolean match(URI uri) {
+        return matchNormalized(uri.normalize());
+    }
+
+    public static boolean match(URIPattern[] patterns, URI uri) {
+        URI normalized = uri.normalize();
+        for (URIPattern pattern : patterns) {
+            if (pattern.matchNormalized(normalized)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchNormalized(URI uri) {
+        if(uriPattern.isOpaque()) {
+            // This url only has scheme, scheme-specific part and fragment
+            return uri.isOpaque() &&
+                    match(uriPattern.getScheme(), uri.getScheme()) &&
+                    match(uriPattern.getSchemeSpecificPart(), uri.getSchemeSpecificPart()) &&
+                    match(uriPattern.getFragment(), uri.getFragment());
+
+        } else {
+            return match(uriPattern.getScheme(), uri.getScheme()) &&
+                    match(uriPattern.getAuthority(), uri.getAuthority()) &&
+                    match(uriPattern.getQuery(), uri.getQuery()) &&
+                    match(uriPattern.getPath(), uri.getPath()) &&
+                    match(uriPattern.getFragment(), uri.getFragment());
+        }
+    }
+
+    private boolean match(String pattern, String value) {
+        if (value == null) {
+            // If the pattern is empty or matches anything - it's a match
+            if (pattern == null || Regex.isMatchAllPattern(pattern)) {
+                return true;
+            }
+        }
+        return Regex.simpleMatch(pattern, value);
+    }
+
+    @Override
+    public String toString() {
+        return uriPattern.toString();
+    }
+}

--- a/src/main/java/org/elasticsearch/repositories/uri/URLRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/uri/URLRepository.java
@@ -21,18 +21,21 @@ package org.elasticsearch.repositories.uri;
 
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.cluster.metadata.SnapshotId;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.blobstore.url.URLBlobStore;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.URIPattern;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.snapshots.IndexShardRepository;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryName;
 import org.elasticsearch.repositories.RepositorySettings;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 /**
@@ -47,6 +50,18 @@ import java.net.URL;
 public class URLRepository extends BlobStoreRepository {
 
     public final static String TYPE = "url";
+
+    public final static String[] DEFAULT_SUPPORTED_PROTOCOLS = {"http", "https", "ftp", "file", "jar"};
+
+    public final static String SUPPORTED_PROTOCOLS_SETTING = "repositories.url.supported_protocols";
+
+    public final static String ALLOWED_URLS_SETTING = "repositories.url.allowed_urls";
+
+    private final String[] supportedProtocols;
+
+    private final URIPattern[] urlWhiteList;
+
+    private final Environment environment;
 
     private final URLBlobStore blobStore;
 
@@ -63,7 +78,7 @@ public class URLRepository extends BlobStoreRepository {
      * @throws IOException
      */
     @Inject
-    public URLRepository(RepositoryName name, RepositorySettings repositorySettings, IndexShardRepository indexShardRepository) throws IOException {
+    public URLRepository(RepositoryName name, RepositorySettings repositorySettings, IndexShardRepository indexShardRepository, Environment environment) throws IOException {
         super(name.getName(), repositorySettings, indexShardRepository);
         URL url;
         String path = repositorySettings.settings().get("url", componentSettings.get("url"));
@@ -72,8 +87,16 @@ public class URLRepository extends BlobStoreRepository {
         } else {
             url = new URL(path);
         }
+        supportedProtocols = settings.getAsArray(SUPPORTED_PROTOCOLS_SETTING, DEFAULT_SUPPORTED_PROTOCOLS);
+        String[] urlWhiteList = settings.getAsArray(ALLOWED_URLS_SETTING, Strings.EMPTY_ARRAY);
+        this.urlWhiteList = new URIPattern[urlWhiteList.length];
+        for (int i = 0; i < urlWhiteList.length; i++) {
+            this.urlWhiteList[i] = new URIPattern(urlWhiteList[i]);
+        }
+        this.environment = environment;
         listDirectories = repositorySettings.settings().getAsBoolean("list_directories", componentSettings.getAsBoolean("list_directories", true));
-        blobStore = new URLBlobStore(componentSettings, url);
+        URL normalizedURL = checkURL(url);
+        blobStore = new URLBlobStore(componentSettings, normalizedURL);
         basePath = BlobPath.cleanPath();
     }
 
@@ -112,6 +135,37 @@ public class URLRepository extends BlobStoreRepository {
     @Override
     public void endVerification(String seed) {
         throw new UnsupportedOperationException("shouldn't be called");
+    }
+
+    /**
+     * Makes sure that the url is white listed or if it points to the local file system it matches one on of the root path in path.repo
+     */
+    private URL checkURL(URL url) {
+        String protocol = url.getProtocol();
+        if (protocol == null) {
+            throw new RepositoryException(repositoryName, "unknown url protocol from URL [" + url + "]");
+        }
+        for (String supportedProtocol : supportedProtocols) {
+            if (supportedProtocol.equals(protocol)) {
+                try {
+                    if (URIPattern.match(urlWhiteList, url.toURI())) {
+                        // URL matches white list - no additional processing is needed
+                        return url;
+                    }
+                } catch (URISyntaxException ex) {
+                    logger.warn("cannot parse the specified url [{}]", url);
+                    throw new RepositoryException(repositoryName, "cannot parse the specified url [" + url + "]");
+                }
+                // We didn't match white list - try to resolve against repo.path
+                URL normalizedUrl = environment.resolveRepoURL(url);
+                if (normalizedUrl == null) {
+                    logger.warn("The specified url [{}] doesn't start with any repository paths specified by the path.repo setting: [{}] or by repositories.url.allowed_urls setting: [{}] ", url, environment.repoFiles());
+                    throw new RepositoryException(repositoryName, "file url [" + url + "] doesn't match any of the locations specified by path.repo or repositories.url.allowed_urls");
+                }
+                return normalizedUrl;
+            }
+        }
+        throw new RepositoryException(repositoryName, "unsupported url protocol [" + protocol + "] from URL [" + url + "]");
     }
 
 }

--- a/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatTests.java
+++ b/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.snapshots.AbstractSnapshotTests;
 import org.elasticsearch.snapshots.RestoreInfo;
@@ -39,6 +40,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -55,6 +57,20 @@ import static org.hamcrest.Matchers.*;
 @Slow
 @ClusterScope(scope = Scope.TEST)
 public class RestoreBackwardsCompatTests extends AbstractSnapshotTests {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        try {
+            URI repoDirUri = getClass().getResource(".").toURI();
+            URI repoJarPatternUri = new URI("jar:" + repoDirUri.toString() + "*.zip!/repo/");
+            return ImmutableSettings.settingsBuilder()
+                    .put(super.nodeSettings(nodeOrdinal))
+                    .putArray("repositories.url.allowed_urls", repoJarPatternUri.toString())
+                    .build();
+        } catch (URISyntaxException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
 
 
     @Test

--- a/src/test/java/org/elasticsearch/common/util/URIPatternTests.java
+++ b/src/test/java/org/elasticsearch/common/util/URIPatternTests.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.util;
+
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.net.URI;
+
+public class URIPatternTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testURIPattern() throws Exception {
+        assertTrue(new URIPattern("http://test.local/").match(new URI("http://test.local/")));
+        assertFalse(new URIPattern("http://test.local/somepath").match(new URI("http://test.local/")));
+        assertTrue(new URIPattern("http://test.local/somepath").match(new URI("http://test.local/somepath")));
+        assertFalse(new URIPattern("http://test.local/somepath").match(new URI("http://test.local/somepath/more")));
+        assertTrue(new URIPattern("http://test.local/somepath/*").match(new URI("http://test.local/somepath/more")));
+        assertTrue(new URIPattern("http://test.local/somepath/*").match(new URI("http://test.local/somepath/more/andmore")));
+        assertTrue(new URIPattern("http://test.local/somepath/*").match(new URI("http://test.local/somepath/more/andmore/../bitmore")));
+        assertFalse(new URIPattern("http://test.local/somepath/*").match(new URI("http://test.local/somepath/../more")));
+        assertFalse(new URIPattern("http://test.local/somepath/*").match(new URI("http://test.local/")));
+        assertFalse(new URIPattern("http://test.local/somepath/*").match(new URI("https://test.local/somepath/more")));
+        assertFalse(new URIPattern("http://test.local:1234/somepath/*").match(new URI("http://test.local/somepath/more")));
+        assertFalse(new URIPattern("http://test.local:1234/somepath/*").match(new URI("http://test.local/somepath/more")));
+        assertTrue(new URIPattern("http://test.local:1234/somepath/*").match(new URI("http://test.local:1234/somepath/more")));
+        assertTrue(new URIPattern("http://*.local:1234/somepath/*").match(new URI("http://foobar.local:1234/somepath/more")));
+        assertFalse(new URIPattern("http://*.local:1234/somepath/*").match(new URI("http://foobar.local:2345/somepath/more")));
+        assertTrue(new URIPattern("http://*.local:*/somepath/*").match(new URI("http://foobar.local:2345/somepath/more")));
+        assertFalse(new URIPattern("http://*.local:*/somepath/*").match(new URI("http://foobar.local:2345/somepath/more?par=val")));
+        assertTrue(new URIPattern("http://*.local:*/somepath/*?*").match(new URI("http://foobar.local:2345/somepath/more?par=val")));
+        assertFalse(new URIPattern("http://*.local:*/somepath/*?*").match(new URI("http://foobar.local:2345/somepath/more?par=val#frag")));
+        assertTrue(new URIPattern("http://*.local:*/somepath/*?*#*").match(new URI("http://foobar.local:2345/somepath/more?par=val#frag")));
+        assertTrue(new URIPattern("http://*.local/somepath/*?*#*").match(new URI("http://foobar.local/somepath/more")));
+    }
+}

--- a/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -25,8 +25,10 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 
@@ -56,6 +58,20 @@ public class EnvironmentTests extends ElasticsearchTestCase {
         assertThat(environment.resolveRepoFile("/test/repos/../repo1"), nullValue());
         assertThat(environment.resolveRepoFile("/test/repos/../repos/repo1"), notNullValue());
         assertThat(environment.resolveRepoFile("/somethingeles/repos/repo1"), nullValue());
+
+
+        assertThat(environment.resolveRepoURL(new URL("file:///test/repos/repo1")), notNullValue());
+        assertThat(environment.resolveRepoURL(new URL("file:/test/repos/repo1")), notNullValue());
+        assertThat(environment.resolveRepoURL(new URL("file://test/repos/repo1")), nullValue());
+        assertThat(environment.resolveRepoURL(new URL("file:///test/repos/../repo1")), nullValue());
+        assertThat(environment.resolveRepoURL(new URL("http://localhost/test/")), nullValue());
+
+        assertThat(environment.resolveRepoURL(new URL("jar:file:///test/repos/repo1!/repo/")), notNullValue());
+        assertThat(environment.resolveRepoURL(new URL("jar:file:/test/repos/repo1!/repo/")), notNullValue());
+        assertThat(environment.resolveRepoURL(new URL("jar:file:///test/repos/repo1!/repo/")).toString(), endsWith("repo1!/repo/"));
+        assertThat(environment.resolveRepoURL(new URL("jar:file:///test/repos/../repo1!/repo/")), nullValue());
+        assertThat(environment.resolveRepoURL(new URL("jar:http://localhost/test/../repo1?blah!/repo/")), nullValue());
+
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
+++ b/src/test/java/org/elasticsearch/test/rest/ElasticsearchRestTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.node.internal.InternalNode;
+import org.elasticsearch.repositories.uri.URLRepository;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.rest.client.RestException;
@@ -111,6 +112,7 @@ public class ElasticsearchRestTests extends ElasticsearchIntegrationTest {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return ImmutableSettings.builder()
+                .putArray(URLRepository.ALLOWED_URLS_SETTING, "http://snapshot.test*")
                 .put(InternalNode.HTTP_ENABLED, true)
                 .put(super.nodeSettings(nodeOrdinal)).build();
     }


### PR DESCRIPTION
Require urls for URL repository to be listed in repositories.url.allowed_urls setting. This change ensures that only authorized URLs can be accessed by elasticsearch.
