### PR TITLE
Use enforcer:display-info to print version info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,13 @@
                                 </rules>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>print-versions</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>display-info</goal>
+                            </goals>
+                        </execution>
                     </executions>
                 </plugin>
                 <plugin>
@@ -1187,18 +1194,6 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                                         <arg value="--check"/>
                                         <arg value="${basedir}"/>
                                     </exec>
-                                </target>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>print-jvm</id>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>run</goal>
-                            </goals>
-                            <configuration>
-                                <target>
-                                    <echo taskname="JVM">Using ${java.runtime.name} ${java.runtime.version} ${java.vendor}</echo>
                                 </target>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Currently this is done with ant tasks, but this is simpler and designed for this purpose.

```
[INFO] --- maven-enforcer-plugin:1.0:display-info (print-versions) @ elasticsearch ---
[INFO] Maven Version: 3.2.1
[INFO] JDK Version: 1.8.0_45 normalized as: 1.8.0-45
[INFO] OS Info: Arch: amd64 Family: unix Name: linux Version: 3.19.0-15-generic
```
