### PR TITLE
enable system assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -606,7 +606,7 @@
                                     </report-text>
                                 <report-execution-times historyLength="20" file="${basedir}/${execution.hint.file}"/>
                                 </listeners>
-                                <assertions>
+                                <assertions enableSystemAssertions="true">
                                     <enable/>
                                     <disable package="${tests.assertion.disabled}"/>
                                     <!-- pass org.elasticsearch to run without assertions -->


### PR DESCRIPTION
This has found problems before with lucene tests at least, when something goes horribly wrong inside jdk. might as well enable any checks we can get in unit tests.
