### PR TITLE
Reset the `ShardTargetType` after serializing inner hits.

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsIT.java
@@ -122,6 +122,7 @@ public class InnerHitsIT extends ESIntegTestCase {
             assertNoFailures(response);
             assertHitCount(response, 1);
             assertSearchHit(response, 1, hasId("2"));
+            assertThat(response.getHits().getAt(0).getShard(), notNullValue());
             assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
             SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
             assertThat(innerHits.totalHits(), equalTo(3l));
@@ -223,6 +224,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().getHits().length, equalTo(numDocs));
         for (int i = 0; i < numDocs; i++) {
             SearchHit searchHit = searchResponse.getHits().getAt(i);
+            assertThat(searchHit.getShard(), notNullValue());
             SearchHits inner = searchHit.getInnerHits().get("a");
             assertThat(inner.totalHits(), equalTo((long) field1InnerObjects[i]));
             for (int j = 0; j < field1InnerObjects[i] && j < size; j++) {
@@ -275,6 +277,7 @@ public class InnerHitsIT extends ESIntegTestCase {
             assertNoFailures(response);
             assertHitCount(response, 1);
             assertSearchHit(response, 1, hasId("1"));
+            assertThat(response.getHits().getAt(0).getShard(), notNullValue());
 
             assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
             SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
@@ -411,6 +414,7 @@ public class InnerHitsIT extends ESIntegTestCase {
             SearchHit searchHit = searchResponse.getHits().getAt(parent);
             assertThat(searchHit.getType(), equalTo("parent"));
             assertThat(searchHit.getId(), equalTo(String.format(Locale.ENGLISH, "%03d", parent)));
+            assertThat(searchHit.getShard(), notNullValue());
 
             SearchHits inner = searchHit.getInnerHits().get("a");
             assertThat(inner.totalHits(), equalTo((long) child1InnerObjects[parent]));


### PR DESCRIPTION
This fixes a bug where only the first top level search hit has a shard target and any subsequent search hits don't.

This bug was reported in the forum: https://discuss.elastic.co/t/elasticsearch-innerhits-java-api-causing-npe/25532
