### PR TITLE
QueryString ignores maxDeterminizedStates when creating a WildcardQuery

### DIFF
--- a/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -28,6 +28,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.automaton.RegExp;
+import org.apache.lucene.util.Version;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -755,6 +756,15 @@ public class MapperQueryParser extends QueryParser {
         }
 
         return super.getWildcardQuery(field, aggStr.toString());
+    }
+
+    @Override
+    protected WildcardQuery newWildcardQuery(Term t) {
+        // Backport: https://issues.apache.org/jira/browse/LUCENE-6677
+        assert Version.LATEST == Version.LUCENE_4_10_4;
+        WildcardQuery query = new WildcardQuery(t, maxDeterminizedStates);
+        query.setRewriteMethod(multiTermRewriteMethod);
+        return query;
     }
 
     @Override


### PR DESCRIPTION
This patch backports https://issues.apache.org/jira/browse/LUCENE-6677 in MapperQueryParser

Closes #12266
