### PR TITLE
Deploy artifacts to S3 as well as sonatype when running a release

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1113,7 +1113,7 @@
             <!-- not including license-maven-plugin is sufficent to expose default license -->
         </profile>
         <profile>
-            <id>package-rpm</id>
+            <id>release</id> <!-- named after the parents release profile to be activated -->
             <activation>
                 <property>
                     <name>package.rpm</name>

--- a/pom.xml
+++ b/pom.xml
@@ -510,9 +510,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.2</version>
-                    <configuration>
-                        <deployAtEnd>true</deployAtEnd> <!-- all or nothing -->
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1238,6 +1235,13 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                 </plugin>
             </plugins>
         </pluginManagement>
+        <extensions>
+            <extension>
+                <groupId>org.springframework.build</groupId>
+                <artifactId>aws-maven</artifactId>
+                <version>5.0.0.RELEASE</version>
+            </extension>
+        </extensions>
     </build>
     <profiles>
         <profile>
@@ -1259,7 +1263,7 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
             <properties>
                 <package.rpm>true</package.rpm>
                 <no.commit.pattern>\bno(n|)(release|commit)\b</no.commit.pattern> <!-- check for no-commit / no-release -->
-                <forbidden.test.signatures>org.apache.lucene.util.LuceneTestCase$AwaitsFix @ Please fix all bugs before release</forbidden.test.signatures>
+                <forbidden.test.signatures>org.apache.lucene.util.LuceneTestCase$AwaitsFix @ Please fix all bugs before release or mark them as ignored</forbidden.test.signatures>
             </properties>
             <build>
                 <!-- sign the artifacts with GPG -->
@@ -1285,6 +1289,18 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                     </plugin>
                 </plugins>
             </build>
+            <distributionManagement>
+                <repository>
+                    <id>aws-release</id>
+                    <name>AWS Release Repository</name>
+                    <url>s3://download.elasticsearch.org/elasticsearch/release</url>
+                </repository>
+                <snapshotRepository>
+                    <id>aws-snapshot</id>
+                    <name>AWS Snapshot Repository</name>
+                    <url>s3://download.elasticsearch.org/elasticsearch/snapshot</url>
+                </snapshotRepository>
+            </distributionManagement>
         </profile>
         <!-- license profile, to generate third party license file -->
         <profile>


### PR DESCRIPTION
This change allows when running a release build with:

```
 mvn -Prelease deploy
```

To deploy all artifacts to S3 as well as to sonatype at the same time.
Both sources will be consistent in terms of content and no further action
is required to publish our artifacts including .rpm, .deb, .zip, .tar.gz, .jar
etc. on to out S3 download service. Albeit this changes the structure of our
downloads to pretty much matching the maven repository layout, this makes
releaseing core as well as the plugins extremely simple. This will allow to
remove most of our python script used for release and it will automatically
allow to release and integrate new modules without further interaction.

This also allows us to bascially streamline our release process on CI such that
CI builds can simply run maven deploy which is all we do during a release.

With this commit only the git related modifications like tagging, version bumping
on our pom files and publishing RPM and .deb in their dedicated repository is left
for the python script.

With this change our artifact are available as follows:

```
http://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/elasticsearch/2.0.0-beta1/elasticsearch-2.0.0-beta1.deb
http://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/elasticsearch/2.0.0-beta1/elasticsearch-2.0.0-beta1.zip
http://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/elasticsearch/2.0.0-beta1/elasticsearch-2.0.0-beta1.rpm
```

Plugins are deployed to URLs like this:

```
http://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/plugin/elasticsearch-analysis-icu/2.0.0-beta1/elasticsearch-analysis-icu-2.0.0-beta1.zip
```

All artifacts like .jar as well as their checksums and gpg signatures are also available next to it.
