### PR TITLE
restrict the test unicast zen discovery to the port range of the JVM

### DIFF
--- a/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -164,8 +164,13 @@ public final class InternalTestCluster extends TestCluster {
      */
     public static final String SETTING_CLUSTER_NODE_SEED = "test.cluster.node.seed";
 
+    /**
+     * The number of ports in the range used for this JVM
+     */
+    public static final int PORTS_PER_JVM = 100;
+
     private static final int JVM_ORDINAL = Integer.parseInt(System.getProperty(SysGlobals.CHILDVM_SYSPROP_JVM_ID, "0"));
-    public static final int BASE_PORT = 9300 + 100 * (JVM_ORDINAL + 1);
+    public static final int BASE_PORT = 9300 + PORTS_PER_JVM * (JVM_ORDINAL + 1);
 
     private static final boolean ENABLE_MOCK_MODULES = RandomizedTest.systemPropertyAsBoolean(TESTS_ENABLE_MOCK_MODULES, true);
 

--- a/core/src/test/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
+++ b/core/src/test/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
@@ -142,11 +142,11 @@ public class ClusterDiscoveryConfiguration extends SettingsSource {
             int[] unicastHostPorts = new int[numHosts];
 
             final int basePort = calcBasePort();
-            final int maxPort = basePort + 1000;
+            final int maxPort = basePort + InternalTestCluster.PORTS_PER_JVM;
             int tries = 0;
             for (int i = 0; i < unicastHostPorts.length; i++) {
                 boolean foundPortInRange = false;
-                while (tries < 1000 && !foundPortInRange) {
+                while (tries < InternalTestCluster.PORTS_PER_JVM && !foundPortInRange) {
                     try (ServerSocket serverSocket = new ServerSocket()) {
                         // Set SO_REUSEADDR as we may bind here and not be able to reuse the address immediately without it.
                         serverSocket.setReuseAddress(NetworkUtils.defaultReuseAddress());


### PR DESCRIPTION
Today, the unicast zen test configuration will try to find a open port starting at the internal test cluster's
base port and continuing for 1000 ports. The internal test cluster class assigns a port range of 100 ports
to each JVM. This means that the unicast zen test configuration will try ports in the range for another JVM
and can lead to port conflicts. This change uses the same value for both so that the unicast configuration
does not go into another JVM's port range.
