### PR TITLE
WIP: GeoDistanceQueryBuilder/-Parser refactoring

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/Numbers.java
+++ b/core/src/main/java/org/elasticsearch/common/Numbers.java
@@ -171,4 +171,13 @@ public final class Numbers {
         return longToBytes(Double.doubleToRawLongBits(val));
     }
 
+    /** Returns true if value is neither NaN nor infinite. */
+    public static boolean isValidDouble(double value) {
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            return false;
+        }
+        return true;
+    }
+
+
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -19,11 +19,17 @@
 
 package org.elasticsearch.common.geo;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+
 
 /**
  *
  */
-public final class GeoPoint {
+public final class GeoPoint implements Writeable<GeoPoint> {
 
     private double lat;
     private double lon;
@@ -44,6 +50,10 @@ public final class GeoPoint {
     public GeoPoint(double lat, double lon) {
         this.lat = lat;
         this.lon = lon;
+    }
+
+    public GeoPoint(GeoPoint template) {
+        this(template.getLat(), template.getLon());
     }
 
     public GeoPoint reset(double lat, double lon) {
@@ -135,5 +145,18 @@ public final class GeoPoint {
         GeoPoint point = new GeoPoint();
         point.resetFromString(latLon);
         return point;
+    }
+
+    @Override
+    public GeoPoint readFrom(StreamInput in) throws IOException {
+        double lat = in.readDouble();
+        double lon = in.readDouble();
+        return new GeoPoint(lat, lon);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeDouble(lat);
+        out.writeDouble(lon);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -23,6 +23,7 @@ import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.util.SloppyMath;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
@@ -34,10 +35,19 @@ import java.io.IOException;
  */
 public class GeoUtils {
 
+    /** Maximum valid latitude in degrees. */
+    public static final double MAX_LAT = 90.0;
+    /** Minimum valid latitude in degrees. */
+    public static final double MIN_LAT = -90.0;
+    /** Maximum valid longitude in degrees. */
+    public static final double MAX_LON = 180.0;
+    /** Minimum valid longitude in degrees. */
+    public static final double MIN_LON = -180.0;
+
     public static final String LATITUDE = GeoPointFieldMapper.Names.LAT;
     public static final String LONGITUDE = GeoPointFieldMapper.Names.LON;
     public static final String GEOHASH = GeoPointFieldMapper.Names.GEOHASH;
-    
+
     /** Earth ellipsoid major axis defined by WGS 84 in meters */
     public static final double EARTH_SEMI_MAJOR_AXIS = 6378137.0;      // meters (WGS 84)
 
@@ -55,6 +65,22 @@ public class GeoUtils {
 
     /** Earth ellipsoid polar distance in meters */
     public static final double EARTH_POLAR_DISTANCE = Math.PI * EARTH_SEMI_MINOR_AXIS;
+
+    /** Returns true if latitude is actually a valid latitude value.*/
+    public static boolean isValidLatitude(double latitude) {
+        if (Numbers.isValidDouble(latitude) == false || latitude < GeoUtils.MIN_LAT || latitude > GeoUtils.MAX_LAT) {
+            return false;
+        }
+        return true;
+    }
+
+    /** Returns true if longitude is actually a valid longitude value. */
+    public static boolean isValidLongitude(double longitude) {
+        if (Numbers.isValidDouble(longitude) == false || longitude < GeoUtils.MIN_LON || longitude > GeoUtils.MAX_LON) {
+            return false;
+        }
+        return true;
+    }
 
     /**
      * Return an approximate value of the diameter of the earth (in meters) at the given latitude (in radians).

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -19,78 +19,139 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxQuery;
+import org.elasticsearch.index.search.geo.IndexedGeoBoundingBoxQuery;
 
 import java.io.IOException;
+import java.util.Objects;
 
+/**
+ * Creates a Lucene query that will filter for all documents that lie within the specified
+ * bounding box.
+ *
+ * This query can only operate on fields of type geo_point that have latitude and longitude
+ * enabled.
+ * */
 public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBoundingBoxQueryBuilder> {
-
+    /** Name of the query. */
     public static final String NAME = "geo_bbox";
+    /** Default for geo point coerce (as of this writing false). */
+    public static final boolean DEFAULT_COERCE = false;
+    /** Default for skipping geo point validation (as of this writing false). */
+    public static final boolean DEFAULT_IGNORE_MALFORMED = false;
+    /** Default type for executing this query (memory as of this writing). */
+    public static final Type DEFAULT_TYPE = Type.MEMORY;
+    /** Needed for serialization. */
+    static final GeoBoundingBoxQueryBuilder PROTOTYPE = new GeoBoundingBoxQueryBuilder();
 
-    public static final String TOP_LEFT = GeoBoundingBoxQueryParser.TOP_LEFT;
-    public static final String BOTTOM_RIGHT = GeoBoundingBoxQueryParser.BOTTOM_RIGHT;
+    /** Name of field holding geo coordinates to compute the bounding box on.*/
+    private final String fieldName;
+    /** Top left corner coordinates of bounding box. */
+    private GeoPoint topLeft = new GeoPoint(Double.NaN, Double.NaN);
+    /** Bottom right corner coordinates of bounding box.*/
+    private GeoPoint bottomRight = new GeoPoint(Double.NaN, Double.NaN);
+    /** Whether or not to infer correct coordinates for wrapping bounding boxes.*/
+    private boolean coerce = DEFAULT_COERCE;
+    /** Whether or not to skip geo point validation. */
+    private boolean ignoreMalformed = DEFAULT_IGNORE_MALFORMED;
+    /** How the query should be run. */
+    private Type type = DEFAULT_TYPE;
 
-    private static final int TOP = 0;
-    private static final int LEFT = 1;
-    private static final int BOTTOM = 2;
-    private static final int RIGHT = 3;
+    /**
+     * For serialization only.
+     * */
+    private GeoBoundingBoxQueryBuilder() {
+        this.fieldName = null;
+    }
 
-    private final String name;
-
-    private double[] box = {Double.NaN, Double.NaN, Double.NaN, Double.NaN};
-
-    private String type;
-    private Boolean coerce;
-    private Boolean ignoreMalformed;
-
-    static final GeoBoundingBoxQueryBuilder PROTOTYPE = new GeoBoundingBoxQueryBuilder(null);
-
-    public GeoBoundingBoxQueryBuilder(String name) {
-        this.name = name;
+    /**
+     * Create new bounding box query.
+     * @param fieldName name of index field containing geo coordinates to operate on.
+     * */
+    public GeoBoundingBoxQueryBuilder(String fieldName) {
+        if (Strings.isEmpty(fieldName)) {
+            throw new IllegalArgumentException("Field name must not be empty.");
+        }
+        this.fieldName = fieldName;
     }
 
     /**
      * Adds top left point.
-     *
      * @param lat The latitude
      * @param lon The longitude
      */
     public GeoBoundingBoxQueryBuilder topLeft(double lat, double lon) {
-        box[TOP] = lat;
-        box[LEFT] = lon;
+        topLeft.reset(lat, lon);
         return this;
     }
 
+    /**
+     * Adds top left point.
+     * @param point point to add.
+     * */
     public GeoBoundingBoxQueryBuilder topLeft(GeoPoint point) {
-        return topLeft(point.lat(), point.lon());
+        return topLeft(point.getLat(), point.getLon());
     }
 
+    /**
+     * Adds top left point
+     * @param geohash GeoHash to derive the point from.
+     * */
     public GeoBoundingBoxQueryBuilder topLeft(String geohash) {
         return topLeft(GeoHashUtils.decode(geohash));
     }
 
+    /** Returns the top left corner of the bounding box. */
+    public GeoPoint topLeft() {
+        return topLeft;
+    }
+
     /**
      * Adds bottom right corner.
-     *
      * @param lat The latitude
      * @param lon The longitude
      */
     public GeoBoundingBoxQueryBuilder bottomRight(double lat, double lon) {
-        box[BOTTOM] = lat;
-        box[RIGHT] = lon;
+        this.bottomRight.reset(lat, lon);
         return this;
     }
 
+    /**
+     * Adds bottom right corner.
+     * @param point the corner coordinates.
+     */
     public GeoBoundingBoxQueryBuilder bottomRight(GeoPoint point) {
-        return bottomRight(point.lat(), point.lon());
+        return bottomRight(point.getLat(), point.getLon());
     }
 
+    /**
+     * Adds bottom right corner.
+     * @param geohash the corner coordinates.
+     */
     public GeoBoundingBoxQueryBuilder bottomRight(String geohash) {
         return bottomRight(GeoHashUtils.decode(geohash));
     }
 
+    /** Returns the bottom right corner of the bounding box. */
+    public GeoPoint bottomRight() {
+        return bottomRight;
+    }
     /**
      * Adds bottom left corner.
      *
@@ -98,87 +159,243 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
      * @param lon The longitude
      */
     public GeoBoundingBoxQueryBuilder bottomLeft(double lat, double lon) {
-        box[BOTTOM] = lat;
-        box[LEFT] = lon;
+        bottomRight.resetLat(lat);
+        topLeft.resetLon(lon);
         return this;
     }
 
+    /**
+     * Adds bottom left corner.
+     *
+     * @param point bottom left corner of bounding box.
+     */
     public GeoBoundingBoxQueryBuilder bottomLeft(GeoPoint point) {
         return bottomLeft(point.lat(), point.lon());
     }
 
+    /**
+     * Adds bottom left corner.
+     *
+     * @param point bottom left corner of bounding box.
+     */
     public GeoBoundingBoxQueryBuilder bottomLeft(String geohash) {
         return bottomLeft(GeoHashUtils.decode(geohash));
     }
 
     /**
-     * Adds top right point.
+     * Adds top right corner.
      *
-     * @param lat The latitude
-     * @param lon The longitude
+     * @param lat latitude of top right corner.
+     * @param lon longitude of top right corner.
      */
     public GeoBoundingBoxQueryBuilder topRight(double lat, double lon) {
-        box[TOP] = lat;
-        box[RIGHT] = lon;
+        topLeft.resetLat(lat);
+        bottomRight.resetLon(lon);
         return this;
     }
 
+    /**
+     * Adds top right corner.
+     *
+     * @param point topRight corner of bounding box.
+     */
     public GeoBoundingBoxQueryBuilder topRight(GeoPoint point) {
         return topRight(point.lat(), point.lon());
     }
 
+    /**
+     * Adds top right corner.
+     *
+     * @param geohash topRight corner of bounding box.
+     */
     public GeoBoundingBoxQueryBuilder topRight(String geohash) {
         return topRight(GeoHashUtils.decode(geohash));
     }
 
+    /**
+     * Specify whether or not to try and fix broken/wrapping bounding boxes.
+     * If set to true, also enables ignoreMalformed thus disabling geo point
+     * validation altogether.
+     **/
     public GeoBoundingBoxQueryBuilder coerce(boolean coerce) {
+        if (coerce) {
+            this.ignoreMalformed = true;
+        }
         this.coerce = coerce;
         return this;
     }
 
+    /** Returns whether or not to try and fix broken/wrapping bounding boxes. */
+    public boolean coerce() {
+        return this.coerce;
+    }
+
+    /**
+     * Specify whether or not to ignore validation errors of bounding boxes.
+     * Can only be set if coerce set to false, otherwise calling this
+     * method has no effect.
+     **/
     public GeoBoundingBoxQueryBuilder ignoreMalformed(boolean ignoreMalformed) {
-        this.ignoreMalformed = ignoreMalformed;
+        if (coerce == false) {
+            this.ignoreMalformed = ignoreMalformed;
+        }
         return this;
+    }
+
+    /** Returns whether or not to skip bounding box validation. */
+    public boolean ignoreMalformed() {
+        return ignoreMalformed;
     }
 
     /**
      * Sets the type of executing of the geo bounding box. Can be either `memory` or `indexed`. Defaults
      * to `memory`.
      */
-    public GeoBoundingBoxQueryBuilder type(String type) {
-        this.type = type;
+    public GeoBoundingBoxQueryBuilder type(Type type) {
+        this.type = (type != null) ? type : DEFAULT_TYPE;
         return this;
+    }
+
+    /**
+     * For BWC: Parse type from type name.
+     * */
+    public GeoBoundingBoxQueryBuilder type(String type) {
+        this.type = Type.fromString(type);
+        return this;
+    }
+    /** Returns the execution type of the geo bounding box.*/
+    public Type type() {
+        return type;
+    }
+
+    /** Returns the name of the field to base the bounding box computation on. */
+    public String fieldName() {
+        return this.fieldName;
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        QueryValidationException validationException = null;
+        // validation was not available prior to 2.x, so to support bwc percolation queries we only ignore_malformed on 2.x created indexes
+        if (!ignoreMalformed) {
+            if (Numbers.isValidDouble(topLeft.getLat()) == false) {
+                validationException = addValidationError("top latitude is invalid number: " + topLeft.getLat(), validationException);
+            }
+            if (Numbers.isValidDouble(topLeft.getLon()) == false) {
+                validationException = addValidationError("left longitude is invalid number: " + topLeft.getLon(), validationException);
+            }
+            if (Numbers.isValidDouble(bottomRight.getLat()) == false) {
+                validationException = addValidationError("bottom latitude is invalid number: " + bottomRight.getLat(), validationException);
+            }
+            if (Numbers.isValidDouble(bottomRight.getLon()) == false) {
+                validationException = addValidationError("right longitude is invalid number: " + bottomRight.getLon(), validationException);
+            }
+
+            if (validationException == null) {
+                // all corners are valid after above checks - make sure they are in the right relation
+                if (topLeft.getLat() < bottomRight.getLat()) {
+                    validationException = addValidationError("top is below bottom corner: " +
+                            topLeft.getLat() + " vs. " + bottomRight.getLat(), validationException);
+                }
+
+                // we do not check longitudes as the query generation code can deal with flipped left/right values
+            }
+        }
+
+        if (Strings.isEmpty(fieldName)) {
+            validationException = addValidationError("field name must be non-null and non-empty", validationException);
+        }
+        return validationException;
+    }
+
+    QueryValidationException validate(boolean indexCreatedBeforeV2_0) {
+        if (ignoreMalformed || indexCreatedBeforeV2_0) {
+            return null;
+        }
+
+        QueryValidationException validationException = null;
+        // For everything post 2.0 validate latitude and longitude unless validation was explicitly turned off
+        if (GeoUtils.isValidLatitude(topLeft.getLat()) == false) {
+            validationException = addValidationError("top latitude is invalid: " + topLeft.getLat(),
+                    validationException);
+        }
+        if (GeoUtils.isValidLongitude(topLeft.getLon()) == false) {
+            validationException = addValidationError("left longitude is invalid: " + topLeft.getLon(),
+                    validationException);
+        }
+        if (GeoUtils.isValidLatitude(bottomRight.getLat()) == false) {
+            validationException = addValidationError("bottom latitude is invalid: " + bottomRight.getLat(),
+                    validationException);
+        }
+        if (GeoUtils.isValidLongitude(bottomRight.getLon()) == false) {
+            validationException = addValidationError("right longitude is invalid: " + bottomRight.getLon(),
+                    validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public Query doToQuery(QueryShardContext context) {
+        QueryValidationException exception = validate(context.indexVersionCreated().before(Version.V_2_0_0));
+        if (exception != null) {
+            throw new QueryShardException(context, "couldn't validate latitude/ longitude values", exception);
+        }
+
+        GeoPoint luceneTopLeft = new GeoPoint(topLeft);
+        GeoPoint luceneBottomRight = new GeoPoint(bottomRight);
+        if (coerce) {
+            // Special case: if the difference between the left and right is 360 and the right is greater than the left, we are asking for
+            // the complete longitude range so need to set longitude to the complete longditude range
+            double right = luceneBottomRight.getLon();
+            double left = luceneTopLeft.getLon();
+
+            boolean completeLonRange = ((right - left) % 360 == 0 && right > left);
+            GeoUtils.normalizePoint(luceneTopLeft, true, !completeLonRange);
+            GeoUtils.normalizePoint(luceneBottomRight, true, !completeLonRange);
+            if (completeLonRange) {
+                luceneTopLeft.resetLon(-180);
+                luceneBottomRight.resetLon(180);
+            }
+        }
+
+        MappedFieldType fieldType = context.fieldMapper(fieldName);
+        if (fieldType == null) {
+            throw new QueryShardException(context, "failed to find geo_point field [" + fieldName + "]");
+        }
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+            throw new QueryShardException(context, "field [" + fieldName + "] is not a geo_point field");
+        }
+        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+
+        Query result;
+        switch(type) {
+            case INDEXED:
+                result = IndexedGeoBoundingBoxQuery.create(luceneTopLeft, luceneBottomRight, geoFieldType);
+                break;
+            case MEMORY:
+                IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
+                result = new InMemoryGeoBoundingBoxQuery(luceneTopLeft, luceneBottomRight, indexFieldData);
+                break;
+            default:
+                // Someone extended the type enum w/o adjusting this switch statement.
+                throw new QueryShardException(context, "geo bounding box type [" + type
+                    + "] not supported.");
+        }
+
+        return result;
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        // check values
-        if(Double.isNaN(box[TOP])) {
-            throw new IllegalArgumentException("geo_bounding_box requires top latitude to be set");
-        } else if(Double.isNaN(box[BOTTOM])) {
-            throw new IllegalArgumentException("geo_bounding_box requires bottom latitude to be set");
-        } else if(Double.isNaN(box[RIGHT])) {
-            throw new IllegalArgumentException("geo_bounding_box requires right longitude to be set");
-        } else if(Double.isNaN(box[LEFT])) {
-            throw new IllegalArgumentException("geo_bounding_box requires left longitude to be set");
-        }
-
         builder.startObject(NAME);
 
-        builder.startObject(name);
-        builder.array(TOP_LEFT, box[LEFT], box[TOP]);
-        builder.array(BOTTOM_RIGHT, box[RIGHT], box[BOTTOM]);
+        builder.startObject(fieldName);
+        builder.array(GeoBoundingBoxQueryParser.TOP_LEFT, topLeft.getLon(), topLeft.getLat());
+        builder.array(GeoBoundingBoxQueryParser.BOTTOM_RIGHT, bottomRight.getLon(), bottomRight.getLat());
         builder.endObject();
-
-        if (type != null) {
-            builder.field("type", type);
-        }
-        if (coerce != null) {
-            builder.field("coerce", coerce);
-        }
-        if (ignoreMalformed != null) {
-            builder.field("ignore_malformed", ignoreMalformed);
-        }
+        builder.field("coerce", coerce);
+        builder.field("ignore_malformed", ignoreMalformed);
+        builder.field("type", type);
 
         printBoostAndQueryName(builder);
 
@@ -186,7 +403,89 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
     }
 
     @Override
+    public boolean doEquals(GeoBoundingBoxQueryBuilder other) {
+        return Objects.equals(topLeft, other.topLeft) &&
+                Objects.equals(bottomRight, other.bottomRight) &&
+                Objects.equals(type, other.type) &&
+                Objects.equals(coerce, other.coerce) &&
+                Objects.equals(ignoreMalformed, other.ignoreMalformed) &&
+                Objects.equals(fieldName, other.fieldName);
+    }
+
+    @Override
+    public int doHashCode() {
+        return Objects.hash(topLeft, bottomRight, type, coerce, ignoreMalformed, fieldName);
+    }
+
+    @Override
+    public GeoBoundingBoxQueryBuilder doReadFrom(StreamInput in) throws IOException {
+        String fieldName = in.readString();
+        GeoBoundingBoxQueryBuilder geo = new GeoBoundingBoxQueryBuilder(fieldName);
+        geo.topLeft = geo.topLeft.readFrom(in);
+        geo.bottomRight = geo.bottomRight.readFrom(in);
+        geo.type = Type.readTypeFrom(in);
+        geo.coerce = in.readBoolean();
+        geo.ignoreMalformed = in.readBoolean();
+        return geo;
+    }
+
+    @Override
+    public void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        topLeft.writeTo(out);
+        bottomRight.writeTo(out);
+        type.writeTo(out);
+        out.writeBoolean(coerce);
+        out.writeBoolean(ignoreMalformed);
+    }
+
+    @Override
     public String getWriteableName() {
         return NAME;
+    }
+
+    /** Specifies how the bounding box query should be run. */
+    public enum Type implements Writeable<Type> {
+        MEMORY(0), INDEXED(1);
+
+        private final int ordinal;
+
+        private static final Type PROTOTYPE = MEMORY;
+
+        Type(int ordinal) {
+            this.ordinal = ordinal;
+        }
+
+        @Override
+        public Type readFrom(StreamInput in) throws IOException {
+            int ord = in.readVInt();
+            switch(ord) {
+                case(0): return MEMORY;
+                case(1): return INDEXED;
+            }
+            throw new ElasticsearchException("unknown serialized type [" + ord + "]");
+        }
+
+        public static Type readTypeFrom(StreamInput in) throws IOException {
+            return PROTOTYPE.readFrom(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(this.ordinal);
+        }
+
+        public static Type fromString(String typeName) {
+            if (typeName == null) {
+                throw new IllegalArgumentException("cannot parse type from null string");
+            }
+
+            for (Type type : Type.values()) {
+                if (type.name().equalsIgnoreCase(typeName)) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("no type can be parsed from ordinal " + typeName);
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -19,42 +19,46 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
-import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxQuery;
-import org.elasticsearch.index.search.geo.IndexedGeoBoundingBoxQuery;
+import org.elasticsearch.index.query.GeoBoundingBoxQueryBuilder.Type;
 
 import java.io.IOException;
 
-/**
- *
- */
-public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
+public class GeoBoundingBoxQueryParser extends BaseQueryParser {
 
     public static final String NAME = "geo_bbox";
 
+    /** Key to refer to the top of the bounding box. */
     public static final String TOP = "top";
+    /** Key to refer to the left of the bounding box. */
     public static final String LEFT = "left";
+    /** Key to refer to the right of the bounding box. */
     public static final String RIGHT = "right";
+    /** Key to refer to the bottom of the bounding box. */
     public static final String BOTTOM = "bottom";
 
+    /** Key to refer to top_left corner of bounding box. */
     public static final String TOP_LEFT = TOP + "_" + LEFT;
-    public static final String TOP_RIGHT = TOP + "_" + RIGHT;
-    public static final String BOTTOM_LEFT = BOTTOM + "_" + LEFT;
+    /** Key to refer to bottom_right corner of bounding box. */
     public static final String BOTTOM_RIGHT = BOTTOM + "_" + RIGHT;
+    /** Key to refer to top_right corner of bounding box. */
+    public static final String TOP_RIGHT = TOP + "_" + RIGHT;
+    /** Key to refer to bottom left corner of bounding box.  */
+    public static final String BOTTOM_LEFT = BOTTOM + "_" + LEFT;
 
+    /** Key to refer to top_left corner of bounding box. */
     public static final String TOPLEFT = "topLeft";
-    public static final String TOPRIGHT = "topRight";
-    public static final String BOTTOMLEFT = "bottomLeft";
+    /** Key to refer to bottom_right corner of bounding box. */
     public static final String BOTTOMRIGHT = "bottomRight";
+    /** Key to refer to top_right corner of bounding box. */
+    public static final String TOPRIGHT = "topRight";
+    /** Key to refer to bottom left corner of bounding box.  */
+    public static final String BOTTOMLEFT = "bottomLeft";
 
     public static final String FIELD = "field";
 
@@ -68,8 +72,7 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
     }
 
     @Override
-    public Query parse(QueryShardContext context) throws IOException, QueryParsingException {
-        QueryParseContext parseContext = context.parseContext();
+    public QueryBuilder<GeoBoundingBoxQueryBuilder> fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         String fieldName = null;
@@ -83,9 +86,8 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
         String queryName = null;
         String currentFieldName = null;
         XContentParser.Token token;
-        final boolean indexCreatedBeforeV2_0 = parseContext.shardContext().indexVersionCreated().before(Version.V_2_0_0);
-        boolean coerce = false;
-        boolean ignoreMalformed = false;
+        boolean coerce = GeoBoundingBoxQueryBuilder.DEFAULT_COERCE;
+        boolean ignoreMalformed = GeoBoundingBoxQueryBuilder.DEFAULT_IGNORE_MALFORMED;
 
         GeoPoint sparse = new GeoPoint();
 
@@ -143,14 +145,14 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
                     queryName = parser.text();
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
-                } else if ("coerce".equals(currentFieldName) || (indexCreatedBeforeV2_0 && "normalize".equals(currentFieldName))) {
+                } else if ("coerce".equals(currentFieldName) || ("normalize".equals(currentFieldName))) {
                     coerce = parser.booleanValue();
                     if (coerce) {
                         ignoreMalformed = true;
                     }
                 } else if ("type".equals(currentFieldName)) {
                     type = parser.text();
-                } else if ("ignore_malformed".equals(currentFieldName) && coerce == false) {
+                } else if ("ignore_malformed".equals(currentFieldName)) {
                     ignoreMalformed = parser.booleanValue();
                 } else {
                     throw new QueryParsingException(parseContext, "failed to parse [{}] query. unexpected field [{}]", NAME, currentFieldName);
@@ -161,59 +163,15 @@ public class GeoBoundingBoxQueryParser extends BaseQueryParserTemp {
         final GeoPoint topLeft = sparse.reset(top, left);  //just keep the object
         final GeoPoint bottomRight = new GeoPoint(bottom, right);
 
-        // validation was not available prior to 2.x, so to support bwc percolation queries we only ignore_malformed on 2.x created indexes
-        if (!indexCreatedBeforeV2_0 && !ignoreMalformed) {
-            if (topLeft.lat() > 90.0 || topLeft.lat() < -90.0) {
-                throw new QueryParsingException(parseContext, "illegal latitude value [{}] for [{}]", topLeft.lat(), NAME);
-            }
-            if (topLeft.lon() > 180.0 || topLeft.lon() < -180) {
-                throw new QueryParsingException(parseContext, "illegal longitude value [{}] for [{}]", topLeft.lon(), NAME);
-            }
-            if (bottomRight.lat() > 90.0 || bottomRight.lat() < -90.0) {
-                throw new QueryParsingException(parseContext, "illegal latitude value [{}] for [{}]", bottomRight.lat(), NAME);
-            }
-            if (bottomRight.lon() > 180.0 || bottomRight.lon() < -180) {
-                throw new QueryParsingException(parseContext, "illegal longitude value [{}] for [{}]", bottomRight.lon(), NAME);
-            }
-        }
-
-        if (coerce) {
-            // Special case: if the difference between the left and right is 360 and the right is greater than the left, we are asking for
-            // the complete longitude range so need to set longitude to the complete longditude range
-            boolean completeLonRange = ((right - left) % 360 == 0 && right > left);
-            GeoUtils.normalizePoint(topLeft, true, !completeLonRange);
-            GeoUtils.normalizePoint(bottomRight, true, !completeLonRange);
-            if (completeLonRange) {
-                topLeft.resetLon(-180);
-                bottomRight.resetLon(180);
-            }
-        }
-
-        MappedFieldType fieldType = context.fieldMapper(fieldName);
-        if (fieldType == null) {
-            throw new QueryParsingException(parseContext, "failed to parse [{}] query. could not find [{}] field [{}]", NAME, GeoPointFieldMapper.CONTENT_TYPE, fieldName);
-        }
-        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
-            throw new QueryParsingException(parseContext, "failed to parse [{}] query. field [{}] is expected to be of type [{}], but is of [{}] type instead", NAME, fieldName, GeoPointFieldMapper.CONTENT_TYPE, fieldType.typeName());
-        }
-        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
-
-        Query filter;
-        if ("indexed".equals(type)) {
-            filter = IndexedGeoBoundingBoxQuery.create(topLeft, bottomRight, geoFieldType);
-        } else if ("memory".equals(type)) {
-            IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
-            filter = new InMemoryGeoBoundingBoxQuery(topLeft, bottomRight, indexFieldData);
-        } else {
-            throw new QueryParsingException(parseContext, "failed to parse [{}] query. geo bounding box type [{}] is not supported. either [indexed] or [memory] are allowed", NAME, type);
-        }
-        if (filter != null) {
-            filter.setBoost(boost);
-        }
-        if (queryName != null) {
-            context.addNamedQuery(queryName, filter);
-        }
-        return filter;
+        GeoBoundingBoxQueryBuilder builder = new GeoBoundingBoxQueryBuilder(fieldName);
+        builder.topLeft(topLeft);
+        builder.bottomRight(bottomRight);
+        builder.queryName(queryName);
+        builder.boost(boost);
+        builder.type(Type.fromString(type));
+        builder.coerce(coerce);
+        builder.ignoreMalformed(ignoreMalformed);
+        return builder;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -91,6 +91,9 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
      * @param fieldName name of indexed geo field to operate distance computation on.
      * */
     public GeoDistanceQueryBuilder(String name) {
+        if (Strings.isEmpty(name)) {
+            throw new IllegalArgumentException("Fieldname must not be null or empty");
+        }
         this.fieldName = name;
     }
 
@@ -268,7 +271,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
     public boolean doEquals(GeoDistanceQueryBuilder other) {
         return Objects.equals(this.fieldName, other.fieldName) &&
                 (this.distance == other.distance) &&
-                (this.coerce = other.coerce) &&
+                (this.coerce == other.coerce) &&
                 (this.ignoreMalformed == other.ignoreMalformed) &&
                 Objects.equals(center, other.center) &&
                 Objects.equals(optimizeBbox, other.optimizeBbox) &&

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -19,100 +19,234 @@
 
 package org.elasticsearch.index.query;
 
+import com.google.common.base.Preconditions;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 
+/**
+ * Filter results of a query to include only those within a specific distance to some
+ * geo point.
+ * */
 public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQueryBuilder> {
 
+    /** Name of the query in the query dsl. */
     public static final String NAME = "geo_distance";
+    /** Default for distance unit computation. */
+    public static final DistanceUnit DEFAULT_DISTANCE_UNIT = DistanceUnit.DEFAULT;
+    /** Default for geo distance computation. */
+    public static final GeoDistance DEFAULT_GEO_DISTANCE = GeoDistance.DEFAULT;
+    /** Default for optimising query through pre computed bounding box query. */
+    public static final String DEFAULT_OPTIMIZE_BBOX = "memory";
 
-    private final String name;
+    public static final boolean DEFAULT_COERCE = false;
+    public static final boolean DEFAULT_IGNORE_MALFORMED = false;
 
-    private String distance;
+    private final String fieldName;
+    /** Distance from center to cover. */
+    private double distance;
+    /** Point to use as center. */
+    private GeoPoint center = new GeoPoint(Double.NaN, Double.NaN);
+    /** Algorithm to use for distance computation. */
+    private GeoDistance geoDistance = DEFAULT_GEO_DISTANCE;
+    /** Whether or not to use a bbox for pre-filtering. TODO change to enum? */
+    private String optimizeBbox = DEFAULT_OPTIMIZE_BBOX;
 
-    private double lat;
+    private boolean coerce = DEFAULT_COERCE;
 
-    private double lon;
+    private boolean ignoreMalformed = DEFAULT_IGNORE_MALFORMED;
 
-    private String geohash;
 
-    private GeoDistance geoDistance;
+    static final GeoDistanceQueryBuilder PROTOTYPE = new GeoDistanceQueryBuilder();
 
-    private String optimizeBbox;
+    /** For serialization purposes only. */
+    private GeoDistanceQueryBuilder() {
+        this.fieldName = null;
+    }
 
-    static final GeoDistanceQueryBuilder PROTOTYPE = new GeoDistanceQueryBuilder(null);
+    /** Name of the field this query is operating on. */
+    public String fieldName() {
+        return this.fieldName;
+    }
 
-    private Boolean coerce;
-
-    private Boolean ignoreMalformed;
-
+    /**
+     * Construct new GeoDistanceQueryBuilder.
+     * @param fieldName name of indexed geo field to operate distance computation on.
+     * */
     public GeoDistanceQueryBuilder(String name) {
-        this.name = name;
+        this.fieldName = name;
     }
 
+    /** Sets the center point for the query. 
+     * @param point the center of the query
+     **/
+    public GeoDistanceQueryBuilder point(GeoPoint point) {
+        this.center = point;
+        return this;
+    }
+
+    /**
+     * Sets the center point of the query.
+     * @param lat latitude of center
+     * @param lon longitude of center
+     * */
     public GeoDistanceQueryBuilder point(double lat, double lon) {
-        this.lat = lat;
-        this.lon = lon;
+        this.center = new GeoPoint(lat, lon);
         return this;
     }
 
+    /** Sets the latitude of the center. */
     public GeoDistanceQueryBuilder lat(double lat) {
-        this.lat = lat;
+        if (this.center == null) {
+            this.center = new GeoPoint(lat, Double.NaN);
+        } else {
+            this.center.resetLat(lat);
+        }
         return this;
     }
 
+    /** Sets the longitude of the center. */
     public GeoDistanceQueryBuilder lon(double lon) {
-        this.lon = lon;
+        if (this.center == null) {
+            this.center = new GeoPoint(Double.NaN, lon);
+        } else {
+            this.center.resetLon(lon);
+        }
         return this;
     }
+//
+    /** Returns the center point of the distance query. */
+    public GeoPoint point() {
+        return this.center;
+    }
 
+    /** Sets the distance from the center using the default distance unit.*/
     public GeoDistanceQueryBuilder distance(String distance) {
-        this.distance = distance;
+        return this.distance(distance, DistanceUnit.DEFAULT);
+    }
+
+    /** Sets the distance from the center for this query. */
+    public GeoDistanceQueryBuilder distance(String distance, DistanceUnit unit) {
+        this.distance = DistanceUnit.parse(distance, unit, DistanceUnit.DEFAULT);
         return this;
     }
 
+    /** Sets the distance from the center for this query. */
     public GeoDistanceQueryBuilder distance(double distance, DistanceUnit unit) {
-        this.distance = unit.toString(distance);
+        this.distance = DistanceUnit.DEFAULT.convert(distance, unit);
         return this;
     }
 
+    /** Returns the distance configured as radius. */
+    public double distance() {
+        return distance;
+    }
+
+    /** Sets the center point for this query. */
     public GeoDistanceQueryBuilder geohash(String geohash) {
-        this.geohash = geohash;
+        this.center.resetFromGeoHash(geohash);
         return this;
     }
 
+    /** Which type of geo distance calculation method to use. */
     public GeoDistanceQueryBuilder geoDistance(GeoDistance geoDistance) {
-        this.geoDistance = geoDistance;
+        this.geoDistance = (geoDistance != null) ? geoDistance : DEFAULT_GEO_DISTANCE;
         return this;
     }
 
+    /** Returns geo distance calculation type to use. */
+    public GeoDistance geoDistance() {
+        return this.geoDistance;
+    }
+
+    /** 
+     * Set this to memory or indexed if before running the distance
+     * calculation you want to limit the candidates to hits in the
+     * enclosing bounding box.
+     **/
     public GeoDistanceQueryBuilder optimizeBbox(String optimizeBbox) {
-        this.optimizeBbox = optimizeBbox;
+        this.optimizeBbox = (optimizeBbox != null) ? optimizeBbox : DEFAULT_OPTIMIZE_BBOX;
         return this;
+    }
+
+    /**
+     * Returns whether or not to run a BoundingBox query prior to
+     * distance query for optimization purposes.*/
+    public String optimizeBbox() {
+        return this.optimizeBbox;
     }
 
     public GeoDistanceQueryBuilder coerce(boolean coerce) {
         this.coerce = coerce;
+        if (this.coerce) {
+            this.ignoreMalformed = true;
+        }
         return this;
+    }
+    
+    public boolean coerce() {
+        return this.coerce;
     }
 
     public GeoDistanceQueryBuilder ignoreMalformed(boolean ignoreMalformed) {
-        this.ignoreMalformed = ignoreMalformed;
+        if (this.coerce == false) {
+            this.ignoreMalformed = ignoreMalformed;
+        }
         return this;
+    }
+    
+    public boolean ignoreMalformed() {
+        return this.ignoreMalformed;
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        QueryValidationException exception = validate(context.indexVersionCreated().before(Version.V_2_0_0));
+        if (exception != null) {
+            throw new QueryShardException(context, "couldn't validate latitude/ longitude values", exception);
+        }
+
+        double normDistance = geoDistance.normalize(this.distance, DistanceUnit.DEFAULT);
+
+        if (coerce) {
+            GeoUtils.normalizePoint(center, true, true);
+        }
+
+        MappedFieldType fieldType = context.fieldMapper(fieldName);
+        if (fieldType == null) {
+            throw new QueryShardException(context, "failed to find geo_point field [" + fieldName + "]");
+        }
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+            throw new QueryShardException(context, "field [" + fieldName + "] is not a geo_point field");
+        }
+        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+
+        IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
+        Query query = new GeoDistanceRangeQuery(center, null, normDistance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
+        return query;
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
-        if (geohash != null) {
-            builder.field(name, geohash);
-        } else {
-            builder.startArray(name).value(lon).value(lat).endArray();
-        }
+        builder.startArray(fieldName).value(center.lon()).value(center.lat()).endArray();
         builder.field("distance", distance);
         if (geoDistance != null) {
             builder.field("distance_type", geoDistance.name().toLowerCase(Locale.ROOT));
@@ -120,14 +254,89 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
         if (optimizeBbox != null) {
             builder.field("optimize_bbox", optimizeBbox);
         }
-        if (coerce != null) {
-            builder.field("coerce", coerce);
-        }
-        if (ignoreMalformed != null) {
-            builder.field("ignore_malformed", ignoreMalformed);
-        }
+        builder.field("coerce", coerce);
+        builder.field("ignore_malformed", ignoreMalformed);
         printBoostAndQueryName(builder);
         builder.endObject();
+    }
+
+    public int doHashCode() {
+        return Objects.hash(center, geoDistance, optimizeBbox, distance, coerce, ignoreMalformed);
+    }
+
+    @Override
+    public boolean doEquals(GeoDistanceQueryBuilder other) {
+        return Objects.equals(this.fieldName, other.fieldName) &&
+                (this.distance == other.distance) &&
+                (this.coerce = other.coerce) &&
+                (this.ignoreMalformed == other.ignoreMalformed) &&
+                Objects.equals(center, other.center) &&
+                Objects.equals(optimizeBbox, other.optimizeBbox) &&
+                Objects.equals(geoDistance, other.geoDistance);
+    }
+
+    @Override
+    protected GeoDistanceQueryBuilder doReadFrom(StreamInput in) throws IOException {
+        String fieldName = in.readString();
+        GeoDistanceQueryBuilder result = new GeoDistanceQueryBuilder(fieldName);
+        result.distance = in.readDouble();
+        result.coerce = in.readBoolean();
+        result.ignoreMalformed = in.readBoolean();
+        double lat = in.readDouble();
+        double lon = in.readDouble();
+        result.point(lat, lon);
+        result.optimizeBbox = in.readString();
+        result.geoDistance = GeoDistance.readGeoDistanceFrom(in);
+        return result;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeDouble(distance);
+        out.writeBoolean(coerce);
+        out.writeBoolean(ignoreMalformed);
+        out.writeDouble(center.getLat());
+        out.writeDouble(center.getLon());
+        out.writeString(optimizeBbox);
+        geoDistance.writeTo(out);
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        QueryValidationException validationException = null;
+        // validation was not available prior to 2.x, so to support bwc percolation queries we only ignore_malformed on 2.x created indexes
+        if (!ignoreMalformed) {
+            if (Numbers.isValidDouble(center.getLat()) == false) {
+                validationException = addValidationError("top latitude is invalid number: " + center.getLat(), validationException);
+            }
+            if (Numbers.isValidDouble(center.getLon()) == false) {
+                validationException = addValidationError("left longitude is invalid number: " + center.getLon(), validationException);
+            }
+        }
+
+        if (Strings.isEmpty(fieldName)) {
+            validationException = addValidationError("field name must be non-null and non-empty", validationException);
+        }
+        return validationException;
+    }
+
+    QueryValidationException validate(boolean indexCreatedBeforeV2_0) {
+        if (ignoreMalformed || indexCreatedBeforeV2_0) {
+            return null;
+        }
+
+        QueryValidationException validationException = null;
+        // For everything post 2.0 validate latitude and longitude unless validation was explicitly turned off
+        if (GeoUtils.isValidLatitude(center.getLat()) == false) {
+            validationException = addValidationError("top latitude is invalid: " + center.getLat(),
+                    validationException);
+        }
+        if (GeoUtils.isValidLongitude(center.getLon()) == false) {
+            validationException = addValidationError("left longitude is invalid: " + center.getLon(),
+                    validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -19,23 +19,19 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
-import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
 import java.io.IOException;
 
 /**
+ * Parses a GeoDistanceQuery. See also 
+ * 
  * <pre>
  * {
  *     "name.lat" : 1.1,
@@ -43,11 +39,7 @@ import java.io.IOException;
  * }
  * </pre>
  */
-public class GeoDistanceQueryParser extends BaseQueryParserTemp {
-
-    @Inject
-    public GeoDistanceQueryParser() {
-    }
+public class GeoDistanceQueryParser extends BaseQueryParser {
 
     @Override
     public String[] names() {
@@ -55,25 +47,24 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
     }
 
     @Override
-    public Query parse(QueryShardContext context) throws IOException, QueryParsingException {
-        QueryParseContext parseContext = context.parseContext();
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         XContentParser.Token token;
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String queryName = null;
-        String currentFieldName = null;
+        String currentFieldName = "";
         GeoPoint point = new GeoPoint();
         String fieldName = null;
-        double distance = 0;
         Object vDistance = null;
-        DistanceUnit unit = DistanceUnit.DEFAULT;
-        GeoDistance geoDistance = GeoDistance.DEFAULT;
-        String optimizeBbox = "memory";
-        final boolean indexCreatedBeforeV2_0 = parseContext.shardContext().indexVersionCreated().before(Version.V_2_0_0);
-        boolean coerce = false;
-        boolean ignoreMalformed = false;
+
+        DistanceUnit unit = GeoDistanceQueryBuilder.DEFAULT_DISTANCE_UNIT;
+        GeoDistance geoDistance = GeoDistanceQueryBuilder.DEFAULT_GEO_DISTANCE;
+        String optimizeBbox = GeoDistanceQueryBuilder.DEFAULT_OPTIMIZE_BBOX;
+        boolean coerce = GeoDistanceQueryBuilder.DEFAULT_COERCE;
+        boolean ignoreMalformed = GeoDistanceQueryBuilder.DEFAULT_IGNORE_MALFORMED;
+        
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -103,15 +94,15 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
                     }
                 }
             } else if (token.isValue()) {
-                if (currentFieldName.equals("distance")) {
+                if ("distance".equals(currentFieldName)) {
                     if (token == XContentParser.Token.VALUE_STRING) {
                         vDistance = parser.text(); // a String
                     } else {
                         vDistance = parser.numberValue(); // a Number
                     }
-                } else if (currentFieldName.equals("unit")) {
+                } else if ("unit".equals(currentFieldName)) {
                     unit = DistanceUnit.fromString(parser.text());
-                } else if (currentFieldName.equals("distance_type") || currentFieldName.equals("distanceType")) {
+                } else if ("distance_type".equals(currentFieldName) || "distanceType".equals(currentFieldName)) {
                     geoDistance = GeoDistance.fromString(parser.text());
                 } else if (currentFieldName.endsWith(GeoPointFieldMapper.Names.LAT_SUFFIX)) {
                     point.resetLat(parser.doubleValue());
@@ -128,12 +119,9 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
                     boost = parser.floatValue();
                 } else if ("optimize_bbox".equals(currentFieldName) || "optimizeBbox".equals(currentFieldName)) {
                     optimizeBbox = parser.textOrNull();
-                } else if ("coerce".equals(currentFieldName) || (indexCreatedBeforeV2_0 && "normalize".equals(currentFieldName))) {
+                } else if ("coerce".equals(currentFieldName) || ("normalize".equals(currentFieldName))) {
                     coerce = parser.booleanValue();
-                    if (coerce == true) {
-                        ignoreMalformed = true;
-                    }
-                } else if ("ignore_malformed".equals(currentFieldName) && coerce == false) {
+                } else if ("ignore_malformed".equals(currentFieldName)) {
                     ignoreMalformed = parser.booleanValue();
                 } else {
                     point.resetFromString(parser.text());
@@ -142,50 +130,21 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
             }
         }
 
-        // validation was not available prior to 2.x, so to support bwc percolation queries we only ignore_malformed on 2.x created indexes
-        if (!indexCreatedBeforeV2_0 && !ignoreMalformed) {
-            if (point.lat() > 90.0 || point.lat() < -90.0) {
-                throw new QueryParsingException(parseContext, "illegal latitude value [{}] for [{}]", point.lat(), GeoDistanceQueryBuilder.NAME);
-            }
-            if (point.lon() > 180.0 || point.lon() < -180) {
-                throw new QueryParsingException(parseContext, "illegal longitude value [{}] for [{}]", point.lon(), GeoDistanceQueryBuilder.NAME);
-            }
-        }
-
-        if (coerce) {
-            GeoUtils.normalizePoint(point, coerce, coerce);
-        }
-
-        if (vDistance == null) {
-            throw new QueryParsingException(parseContext, "geo_distance requires 'distance' to be specified");
-        } else if (vDistance instanceof Number) {
-            distance = DistanceUnit.DEFAULT.convert(((Number) vDistance).doubleValue(), unit);
-        } else {
-            distance = DistanceUnit.parse((String) vDistance, unit, DistanceUnit.DEFAULT);
-        }
-        distance = geoDistance.normalize(distance, DistanceUnit.DEFAULT);
-
-        MappedFieldType fieldType = parseContext.shardContext().fieldMapper(fieldName);
-        if (fieldType == null) {
-            throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
-        }
-        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
-            throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
-        }
-        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
-
-
-        IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
-        Query query = new GeoDistanceRangeQuery(point, null, distance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
-        if (queryName != null) {
-            context.addNamedQuery(queryName, query);
-        }
-        query.setBoost(boost);
-        return query;
+        GeoDistanceQueryBuilder qb = new GeoDistanceQueryBuilder(fieldName);
+        qb.distance((String) vDistance, unit);
+        qb.point(point);
+        qb.coerce(coerce);
+        qb.ignoreMalformed(ignoreMalformed);
+        qb.optimizeBbox(optimizeBbox);
+        qb.geoDistance(geoDistance);
+        qb.boost(boost);
+        qb.queryName(queryName);
+        return qb;
     }
 
     @Override
     public GeoDistanceQueryBuilder getBuilderPrototype() {
         return GeoDistanceQueryBuilder.PROTOTYPE;
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
@@ -79,7 +79,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
 
     final IndexCache indexCache;
 
-    final IndexFieldDataService fieldDataService;
+    protected IndexFieldDataService fieldDataService;
 
     final ClusterService clusterService;
 

--- a/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -172,7 +172,6 @@ public abstract class BaseQueryTestCase<QB extends AbstractQueryBuilder<QB>> ext
                         bind(ClusterService.class).toProvider(Providers.of(clusterService));
                         bind(CircuitBreakerService.class).to(NoneCircuitBreakerService.class);
                         bind(NamedWriteableRegistry.class).asEagerSingleton();
-                        bind(IndexFieldDataService.class).to(MockIndexFieldDataService.class);
                     }
                 }
         ).createInjector();
@@ -581,21 +580,4 @@ public abstract class BaseQueryTestCase<QB extends AbstractQueryBuilder<QB>> ext
     protected static boolean isNumericFieldName(String fieldName) {
         return INT_FIELD_NAME.equals(fieldName) || DOUBLE_FIELD_NAME.equals(fieldName);
     }
-    
-    /** Mocks IndexFieldDataService to enable checking the "MEMORY"*/
-    public static class MockIndexFieldDataService extends IndexFieldDataService {
-
-        @Inject
-        public MockIndexFieldDataService(Index index, Settings settings) {
-            super(index, settings, null, null);
-        }
-
-        public <IFD extends IndexFieldData<?>> IFD getForField(MappedFieldType ignored) {
-            MappedFieldType.Names names = new MappedFieldType.Names(index.getName());
-            IndexFieldData fieldData = new GeoPointDoubleArrayIndexFieldData(index, indexSettings(), names, null, null, null);
-            return (IFD) fieldData;
-        }
-    }
-
-
 }

--- a/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTest.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import com.spatial4j.core.io.GeohashUtils;
+import com.spatial4j.core.shape.Rectangle;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.NumericRangeQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.index.query.GeoBoundingBoxQueryBuilder.Type;
+import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxQuery;
+import org.elasticsearch.test.geo.RandomShapeGenerator;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class GeoBoundingBoxQueryBuilderTest extends BaseQueryTestCase<GeoBoundingBoxQueryBuilder> {
+    /** Randomly generate either NaN or one of the two infinity values. */
+    private static Double[] invalidDoubles = {Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY};
+
+    @Override
+    protected GeoBoundingBoxQueryBuilder doCreateTestQueryBuilder() {
+        GeoBoundingBoxQueryBuilder builder = new GeoBoundingBoxQueryBuilder("mapped_geo");
+        Rectangle box = RandomShapeGenerator.xRandomRectangle(getRandom(), RandomShapeGenerator.xRandomPoint(getRandom()));
+
+        if (frequently()) {
+            // check the top-left/bottom-right combination of setters
+            int path = randomIntBetween(0, 2);
+            switch (path) {
+            case 0:
+                builder.topLeft(new GeoPoint(box.getMaxY(), box.getMinX()));
+                break;
+            case 1:
+                builder.topLeft(GeohashUtils.encodeLatLon(box.getMaxY(), box.getMinX()));
+                break;
+            default:
+                builder.topLeft(box.getMaxY(), box.getMinX());
+            }
+
+            path = randomIntBetween(0, 2);
+            switch (path) {
+            case 0:
+                builder.bottomRight(new GeoPoint(box.getMinY(), box.getMaxX()));
+                break;
+            case 1:
+                builder.bottomRight(GeohashUtils.encodeLatLon(box.getMinY(), box.getMaxX()));
+                break;
+            default:
+                builder.bottomRight(box.getMinY(), box.getMaxX());
+            }
+        } else {
+            // check the deprecated top-right/bottom-left combination of setters
+            int path = randomIntBetween(0, 2);
+            switch (path) {
+            case 0:
+                builder.topRight(new GeoPoint(box.getMaxY(), box.getMaxX()));
+                break;
+            case 1:
+                builder.topRight(GeohashUtils.encodeLatLon(box.getMaxY(), box.getMaxX()));
+                break;
+            default:
+                builder.topRight(box.getMaxY(), box.getMaxX());
+            }
+
+            path = randomIntBetween(0, 2);
+            switch (path) {
+            case 0:
+                builder.bottomLeft(new GeoPoint(box.getMinY(), box.getMinX()));
+                break;
+            case 1:
+                builder.bottomLeft(GeohashUtils.encodeLatLon(box.getMinY(), box.getMinX()));
+                break;
+            default:
+                builder.bottomLeft(box.getMinY(), box.getMinX());
+            }
+        }
+
+        if (randomBoolean()) {
+            builder.coerce(randomBoolean());
+        }
+        if (randomBoolean()) {
+            builder.ignoreMalformed(randomBoolean());
+        }
+
+        builder.type(randomFrom(Type.values()));
+        return builder;
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidation_empty_fieldname() {
+        new GeoBoundingBoxQueryBuilder("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidation_null_fieldname() {
+        new GeoBoundingBoxQueryBuilder(null);
+    }
+
+    @Test
+    @Override
+    public void testToQuery() throws IOException {
+        QueryShardContext context = createShardContext();
+        if (context.mapperService().smartNameFieldType("mapped_geo", context.getTypes()) == null) {
+            try {
+                createTestQueryBuilder().toQuery(context);
+                fail("Expected exception when there's no geo mapping.");
+            } catch(QueryShardException e) {
+                // all well
+            }
+        } else {
+            doTestToQuery(context);
+        }
+    }
+
+    @Test
+    public void testValidation() {
+
+        PointTester[] testers = { new TopTester(), new LeftTester(), new BottomTester(), new RightTester() };
+        for (PointTester tester : testers) {
+            GeoBoundingBoxQueryBuilder builder = createTestQueryBuilder();
+            QueryValidationException except = null;
+            builder = tester.invalidateCoordinate(builder);
+            except = builder.coerce(true).validate(true);
+            assertNull("Inner post 2.0 validation w/ coerce should ignore invalid top coordinate: " + tester.getInvalidCoordinate() + " ",
+                    except);
+
+            except = builder.coerce(true).validate(false);
+            assertNull("Inner pre 2.0 validation w/ coerce should ignore invalid top coordinate: " + tester.getInvalidCoordinate() + " ",
+                    except);
+
+            except = builder.coerce(true).validate();
+            assertNull("Validation w/ coerce should detect invalid top coordinate: " + tester.getInvalidCoordinate() + " ", except);
+
+            except = builder.coerce(false).ignoreMalformed(false).validate(false);
+            assertEquals("Inner post 2.0 validation w/o coerce should ignore invalid top coordinate: " + tester.getInvalidCoordinate(),
+                    1,
+                    except.validationErrors().size());
+
+            except = builder.coerce(false).ignoreMalformed(false).validate(true);
+            assertNull("Inner pre 2.0 validation w/o coerce should ignore invalid top coordinate: " + tester.getInvalidCoordinate(),
+                    except);
+
+            except = builder.coerce(false).ignoreMalformed(false).validate();
+            assertNull("Validation w/o coerce should ignore invalid top coordinate: " + tester.getInvalidCoordinate(),
+                    except);
+
+            double brokenDouble = randomFrom(invalidDoubles);
+            tester.breakCoordinate(brokenDouble, builder);
+            except = builder.coerce(true).validate(false);
+            assertNull("Inner post 2.0 validation should not detect broken coordinates: " + brokenDouble,
+                    except);
+
+            except = builder.coerce(true).validate(true);
+            assertNull("Inner pre 2.0 validation should not detect broken coordinates: " + brokenDouble,
+                    except);
+
+            except = builder.coerce(true).validate();
+            assertNull("Validation w/ coerce should detect broken top coordinate: " + brokenDouble, 
+                    except);
+
+            except = builder.coerce(false).ignoreMalformed(false).validate(false);
+            assertEquals("Inner post 2.0 validation should detect broken coordinates: " + brokenDouble,
+                    1,
+                    except.validationErrors().size());
+
+            except = builder.coerce(false).ignoreMalformed(false).validate(true);
+            assertNull("Inner pre 2.0 validation should not detect broken coordinates: " + brokenDouble,
+                    except);
+
+            except = builder.coerce(false).ignoreMalformed(false).validate();
+            assertEquals(
+                    "Validation w/o normalization should detect broken top coordinate: " + brokenDouble + " " + except.validationErrors(),
+                    1, except.validationErrors().size());
+        }
+
+        // flipping top and bottom should be detected as error
+        GeoBoundingBoxQueryBuilder builder = createTestQueryBuilder();
+        double top = builder.topLeft().getLat();
+        double left = builder.topLeft().getLon();
+        double bottom = builder.bottomRight().getLat();
+        double right = builder.bottomRight().getLon();
+
+        builder.topLeft(bottom, left).bottomRight(top, right);
+
+        builder.coerce(true);
+        assertNull("Validation w/ coerce should not detect flipped topLeft/bottomRight lat corners: " + "topLeft: " + builder.topLeft() + " vs. bottomRight:"
+                + builder.bottomRight() + " ", builder.validate());
+        assertNull("Inner validation should not check for flipped lat corners.", builder.validate(true));
+        assertNull("Inner validation should not check for flipped lat corners.", builder.validate(false));
+
+        builder.coerce(false).ignoreMalformed(false);
+        assertNotNull("Validation should not detect flipped topLeft/bottomRight lat corners: " + "topLeft: " + builder.topLeft() + " vs. bottomRight:"
+                + builder.bottomRight() + " ", builder.validate());
+        assertNull("Inner validation should not check for flipped lat corners.", builder.validate(true));
+        assertNull("Inner validation should not check for flipped lat corners.", builder.validate(false));
+
+        // flipping left and right should be allowed
+        builder.topLeft(top, right).bottomRight(bottom, left);
+        builder.coerce(true);
+        assertNull("Validation should not detect flipped topLeft/bottomRight lon corners: " + "topLeft: " + builder.topLeft() + " vs. bottomRight:"
+                + builder.bottomRight() + " ", builder.validate(false));
+        assertNull("Inner validation should not check for flipped lat corners.", builder.validate(true));
+        assertNull("Inner validation should not check for flipped lat corners.", builder.validate(false));
+
+        builder.coerce(false).ignoreMalformed(false);
+        assertNull("Validation should not detect flipped topLeft/bottomRight lon corners: " + "topLeft: " + builder.topLeft() + " vs. bottomRight:"
+                + builder.bottomRight() + " ", builder.validate(false));
+        assertNull("Inner validation should not check for flipped lat corners.", builder.validate(true));
+        assertNull("Inner validation should not check for flipped lat corners.", builder.validate(false));
+    }
+
+    @Test
+    public void testNormalization() throws IOException {
+        GeoBoundingBoxQueryBuilder qb = createTestQueryBuilder();
+        if (getCurrentTypes().length != 0 && "mapped_geo".equals(qb.fieldName())) {
+            // only execute this test if we are running on a valid geo field
+            qb.topLeft(200, 200);
+            qb.coerce(true);
+            Query query = qb.toQuery(createShardContext());
+            if (query instanceof ConstantScoreQuery) {
+                ConstantScoreQuery result = (ConstantScoreQuery) query;
+                BooleanQuery bboxFilter = (BooleanQuery) result.getQuery();
+                for (BooleanClause clause : bboxFilter.clauses()) {
+                    NumericRangeQuery boundary = (NumericRangeQuery) clause.getQuery();
+                    if (boundary.getMax() != null) {
+                        assertTrue("If defined, non of the maximum range values should be larger than 180", boundary.getMax().intValue() <= 180);
+                    }
+                }
+            } else {
+                assertTrue("memory queries should result in InMemoryGeoBoundingBoxQuery", query instanceof InMemoryGeoBoundingBoxQuery);
+            }
+        }
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(GeoBoundingBoxQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        if (getCurrentTypes().length == 0 || "mapped_geo".equals(queryBuilder.fieldName()) == false) {
+            assertTrue("For non geo fields expect MatchNoDocsQuery.", query instanceof MatchNoDocsQuery);
+        } else if (queryBuilder.type() == Type.INDEXED) {
+            assertTrue("Found no indexed geo query.", query instanceof ConstantScoreQuery);
+        } else {
+            assertTrue("Found no indexed geo query.", query instanceof InMemoryGeoBoundingBoxQuery);
+        }
+    }
+
+    // Java really could do with function pointers - is there any Java8 feature that would help me here which I don't know of?
+    private abstract class PointTester {
+        protected double coordinate;
+        
+        public double getInvalidCoordinate() {
+            return coordinate;
+        }
+        
+        public abstract GeoBoundingBoxQueryBuilder invalidateCoordinate(GeoBoundingBoxQueryBuilder qb);
+
+        public abstract GeoBoundingBoxQueryBuilder breakCoordinate(double coordinate, GeoBoundingBoxQueryBuilder qb);
+    }
+
+    private class TopTester extends PointTester {
+        private double coordinate = randomDoubleBetween(GeoUtils.MAX_LAT, Double.MAX_VALUE, false);
+
+
+        @Override
+        public GeoBoundingBoxQueryBuilder invalidateCoordinate(GeoBoundingBoxQueryBuilder qb) {
+            qb.topLeft(coordinate, qb.topLeft().getLon());
+            return qb;
+        }
+
+        @Override
+        public GeoBoundingBoxQueryBuilder breakCoordinate(double coordinate, GeoBoundingBoxQueryBuilder qb) {
+            qb.topLeft(coordinate, qb.topLeft().getLon());
+            return qb;
+        }
+    }
+
+    private class LeftTester extends PointTester {
+        private double coordinate = randomDoubleBetween(-Double.MAX_VALUE, GeoUtils.MIN_LON, true);
+
+        @Override
+        public GeoBoundingBoxQueryBuilder invalidateCoordinate(GeoBoundingBoxQueryBuilder qb) {
+            qb.topLeft(qb.topLeft().getLat(), coordinate);
+            return qb;
+        }
+
+        @Override
+        public GeoBoundingBoxQueryBuilder breakCoordinate(double coordinate, GeoBoundingBoxQueryBuilder qb) {
+            qb.topLeft(qb.topLeft().getLat(), coordinate);
+            return qb;
+        }
+    }
+
+    private class BottomTester extends PointTester {
+        private double coordinate = randomDoubleBetween(GeoUtils.MAX_LAT, Double.MAX_VALUE, false);
+
+        @Override
+        public GeoBoundingBoxQueryBuilder invalidateCoordinate(GeoBoundingBoxQueryBuilder qb) {
+            qb.topLeft(coordinate, qb.bottomRight().getLon());
+            return qb;
+        }
+
+        @Override
+        public GeoBoundingBoxQueryBuilder breakCoordinate(double coordinate, GeoBoundingBoxQueryBuilder qb) {
+            qb.topLeft(coordinate, qb.bottomRight().getLon());
+            return qb;
+        }
+    }
+
+    private class RightTester extends PointTester {
+        private double coordinate = randomDoubleBetween(-Double.MAX_VALUE, GeoUtils.MIN_LON, true);
+
+        @Override
+        public GeoBoundingBoxQueryBuilder invalidateCoordinate(GeoBoundingBoxQueryBuilder qb) {
+            qb.topLeft(qb.topLeft().getLat(), coordinate);
+            return qb;
+        }
+
+        @Override
+        public GeoBoundingBoxQueryBuilder breakCoordinate(double coordinate, GeoBoundingBoxQueryBuilder qb) {
+            qb.topLeft(qb.topLeft().getLat(), coordinate);
+            return qb;
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDataGenerator.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDataGenerator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+/** Helper class for generating geo related data. */
+public class GeoDataGenerator {
+
+    /** Generate a valid random geo point. */
+    public static GeoPoint randomGeoPoint() {
+        double lat = ElasticsearchTestCase.randomDoubleBetween(GeoUtils.MIN_LAT, GeoUtils.MAX_LAT, true);
+        double lon = ElasticsearchTestCase.randomDoubleBetween(GeoUtils.MIN_LON, GeoUtils.MAX_LON, true);
+        return new GeoPoint(lat, lon);
+    }
+
+    /** Generate a valid random bounding box. */
+    public static BoundingBox randomBoundingBox() {
+        double bottom = ElasticsearchTestCase.randomDoubleBetween(GeoUtils.MIN_LAT, GeoUtils.MAX_LAT, true);
+        double top = ElasticsearchTestCase.randomDoubleBetween(bottom, GeoUtils.MAX_LAT, true);
+        double left = ElasticsearchTestCase.randomDoubleBetween(GeoUtils.MIN_LON, GeoUtils.MAX_LON, true);
+        double right = ElasticsearchTestCase.randomDoubleBetween(left, GeoUtils.MAX_LON, true);
+
+        if (ElasticsearchTestCase.rarely()) {
+            // Rarely check everything works as expected also when hitting the lat/lon boundaries
+            if (ElasticsearchTestCase.randomBoolean()) {
+                top = GeoUtils.MAX_LAT;
+            }
+            if (ElasticsearchTestCase.randomBoolean()) {
+                right = GeoUtils.MAX_LON;
+            }
+        }
+        return new BoundingBox(top, left, bottom, right);
+    }
+
+    /** Generate a double that lies outside the given interval, includes NaN and pos/neg infinity. */
+    public static double invalidRandomDouble(double validStart, double validEnd) {
+        Double[] values = new Double[6];
+        values[0] = Double.NaN;
+        values[1] = Double.POSITIVE_INFINITY;
+        values[2] = Double.NEGATIVE_INFINITY;
+        values[3] = ElasticsearchTestCase.randomDoubleBetween(-Double.MAX_VALUE, validStart, true);
+        values[4] = ElasticsearchTestCase.randomDoubleBetween(validEnd, Double.MAX_VALUE, false);
+        values[5] = Double.MAX_VALUE;
+        return ElasticsearchTestCase.randomFrom(values);
+    }
+
+    public static class BoundingBox {
+        public GeoPoint topLeft;
+        public GeoPoint bottomRight;
+
+        public BoundingBox(double top, double left, double bottom, double right) {
+            this.topLeft = new GeoPoint(top, left);
+            this.bottomRight = new GeoPoint(bottom, right);
+        }
+        public double top() {
+            return topLeft.getLat();
+        }
+
+        public double left() {
+            return topLeft.getLon();
+        }
+
+        public double bottom() {
+            return bottomRight.getLat();
+        }
+
+        public double right() {
+            return bottomRight.getLon();
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDataGenerator.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDataGenerator.java
@@ -21,31 +21,31 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.test.ElasticsearchTestCase;
+import org.elasticsearch.test.ESTestCase;
 
 /** Helper class for generating geo related data. */
 public class GeoDataGenerator {
 
     /** Generate a valid random geo point. */
     public static GeoPoint randomGeoPoint() {
-        double lat = ElasticsearchTestCase.randomDoubleBetween(GeoUtils.MIN_LAT, GeoUtils.MAX_LAT, true);
-        double lon = ElasticsearchTestCase.randomDoubleBetween(GeoUtils.MIN_LON, GeoUtils.MAX_LON, true);
+        double lat = ESTestCase.randomDoubleBetween(GeoUtils.MIN_LAT, GeoUtils.MAX_LAT, true);
+        double lon = ESTestCase.randomDoubleBetween(GeoUtils.MIN_LON, GeoUtils.MAX_LON, true);
         return new GeoPoint(lat, lon);
     }
 
     /** Generate a valid random bounding box. */
     public static BoundingBox randomBoundingBox() {
-        double bottom = ElasticsearchTestCase.randomDoubleBetween(GeoUtils.MIN_LAT, GeoUtils.MAX_LAT, true);
-        double top = ElasticsearchTestCase.randomDoubleBetween(bottom, GeoUtils.MAX_LAT, true);
-        double left = ElasticsearchTestCase.randomDoubleBetween(GeoUtils.MIN_LON, GeoUtils.MAX_LON, true);
-        double right = ElasticsearchTestCase.randomDoubleBetween(left, GeoUtils.MAX_LON, true);
+        double bottom = ESTestCase.randomDoubleBetween(GeoUtils.MIN_LAT, GeoUtils.MAX_LAT, true);
+        double top = ESTestCase.randomDoubleBetween(bottom, GeoUtils.MAX_LAT, true);
+        double left = ESTestCase.randomDoubleBetween(GeoUtils.MIN_LON, GeoUtils.MAX_LON, true);
+        double right = ESTestCase.randomDoubleBetween(left, GeoUtils.MAX_LON, true);
 
-        if (ElasticsearchTestCase.rarely()) {
+        if (ESTestCase.rarely()) {
             // Rarely check everything works as expected also when hitting the lat/lon boundaries
-            if (ElasticsearchTestCase.randomBoolean()) {
+            if (ESTestCase.randomBoolean()) {
                 top = GeoUtils.MAX_LAT;
             }
-            if (ElasticsearchTestCase.randomBoolean()) {
+            if (ESTestCase.randomBoolean()) {
                 right = GeoUtils.MAX_LON;
             }
         }
@@ -58,10 +58,10 @@ public class GeoDataGenerator {
         values[0] = Double.NaN;
         values[1] = Double.POSITIVE_INFINITY;
         values[2] = Double.NEGATIVE_INFINITY;
-        values[3] = ElasticsearchTestCase.randomDoubleBetween(-Double.MAX_VALUE, validStart, true);
-        values[4] = ElasticsearchTestCase.randomDoubleBetween(validEnd, Double.MAX_VALUE, false);
+        values[3] = ESTestCase.randomDoubleBetween(-Double.MAX_VALUE, validStart, true);
+        values[4] = ESTestCase.randomDoubleBetween(validEnd, Double.MAX_VALUE, false);
         values[5] = Double.MAX_VALUE;
-        return ElasticsearchTestCase.randomFrom(values);
+        return ESTestCase.randomFrom(values);
     }
 
     public static class BoundingBox {

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class GeoDistanceQueryBuilderTest extends BaseQueryTestCase<GeoDistanceQueryBuilder> {
+
+    @Override
+    protected GeoDistanceQueryBuilder doCreateTestQueryBuilder() {
+        GeoDistanceQueryBuilder qb = new GeoDistanceQueryBuilder("mapped_geo");
+        String distance = "" + randomDouble();
+        if (randomBoolean()) {
+            DistanceUnit unit = randomFrom(DistanceUnit.values());
+            distance = distance + unit.toString();
+        }
+        int selector = randomIntBetween(0, 2);
+        switch (selector) {
+            case 0:
+                qb.distance(randomDouble(), randomFrom(DistanceUnit.values()));
+                break;
+            case 1:
+                qb.distance(distance, randomFrom(DistanceUnit.values()));
+                break;
+            case 2:
+                qb.distance(distance);
+                break;
+        }
+
+        qb.point(GeoDataGenerator.randomGeoPoint());
+
+        if (randomBoolean()) {
+            qb.normalizeLat(randomBoolean());
+        }
+
+        if (randomBoolean()) {
+            qb.normalizeLon(randomBoolean());
+        }
+
+        // TODO not testing memory here as it would need an entire test node pulled up
+        qb.optimizeBbox(randomFrom("indexed"));
+
+        if (randomBoolean()) {
+            qb.geoDistance(randomFrom(GeoDistance.values()));
+        }
+        return qb;
+    }
+
+    @Override
+    protected Query doCreateExpectedQuery(GeoDistanceQueryBuilder qb, QueryParseContext parseContext) throws IOException {
+        double normDistance = qb.geoDistance().normalize(qb.distance(), DistanceUnit.DEFAULT);
+
+        if (qb.normalizeLat() || qb.normalizeLon()) {
+            GeoUtils.normalizePoint(qb.point(), qb.normalizeLat(), qb.normalizeLon());
+        }
+
+        MappedFieldType fieldType = parseContext.fieldMapper(qb.fieldName());
+        if (fieldType == null) {
+            throw new QueryParsingException(parseContext, "failed to find geo_point field [" + qb.fieldName() + "]");
+        }
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+            throw new QueryParsingException(parseContext, "field [" + qb.fieldName() + "] is not a geo_point field");
+        }
+        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+
+        IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
+        Query query = new GeoDistanceRangeQuery(qb.point(), null, normDistance, true, false, qb.geoDistance(), geoFieldType, indexFieldData, qb.optimizeBbox());
+        return query;
+    }
+
+    @Test
+    public void testValidate() {
+        
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSettingFieldToNullDisallowed() {
+        new GeoDistanceQueryBuilder(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSettingFieldToEmptyDisallowed() {
+        new GeoDistanceQueryBuilder("");
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/search/geo/GeoDistanceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/geo/GeoDistanceTests.java
@@ -25,11 +25,8 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-/**
- */
 public class GeoDistanceTests extends ESTestCase {
 
     @Test

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoBoundingBoxIT.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoBoundingBoxIT.java
@@ -22,12 +22,12 @@ package org.elasticsearch.search.geo;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.GeoBoundingBoxQueryBuilder.Type;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.QueryBuilders.geoBoundingBoxQuery;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.anyOf;
@@ -99,7 +99,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         }
 
         searchResponse = client().prepareSearch() // from NY
-                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(40.73, -74.1).bottomRight(40.717, -73.99).type("indexed")))
+                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(40.73, -74.1).bottomRight(40.717, -73.99).type(Type.INDEXED)))
                 .execute().actionGet();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
         assertThat(searchResponse.getHits().hits().length, equalTo(2));
@@ -165,7 +165,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("2"));
         searchResponse = client().prepareSearch()
-                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(41, -11).bottomRight(40, 9).type("indexed")))
+                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(41, -11).bottomRight(40, 9).type(Type.INDEXED)))
                 .execute().actionGet();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
@@ -178,7 +178,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("3"));
         searchResponse = client().prepareSearch()
-                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(41, -9).bottomRight(40, 11).type("indexed")))
+                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(41, -9).bottomRight(40, 11).type(Type.INDEXED)))
                 .execute().actionGet();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
@@ -191,7 +191,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("5"));
         searchResponse = client().prepareSearch()
-                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(11, 171).bottomRight(1, -169).type("indexed")))
+                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(11, 171).bottomRight(1, -169).type(Type.INDEXED)))
                 .execute().actionGet();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
@@ -204,7 +204,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("9"));
         searchResponse = client().prepareSearch()
-                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(9, 169).bottomRight(-1, -171).type("indexed")))
+                .setQuery(filteredQuery(matchAllQuery(), geoBoundingBoxQuery("location").topLeft(9, 169).bottomRight(-1, -171).type(Type.INDEXED)))
                 .execute().actionGet();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
@@ -244,7 +244,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(
                         filteredQuery(termQuery("userid", 880),
-                                geoBoundingBoxQuery("location").topLeft(74.579421999999994, 143.5).bottomRight(-66.668903999999998, 113.96875).type("indexed"))
+                                geoBoundingBoxQuery("location").topLeft(74.579421999999994, 143.5).bottomRight(-66.668903999999998, 113.96875).type(Type.INDEXED))
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
 
@@ -257,7 +257,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(
                         filteredQuery(termQuery("userid", 534),
-                                geoBoundingBoxQuery("location").topLeft(74.579421999999994, 143.5).bottomRight(-66.668903999999998, 113.96875).type("indexed"))
+                                geoBoundingBoxQuery("location").topLeft(74.579421999999994, 143.5).bottomRight(-66.668903999999998, 113.96875).type(Type.INDEXED))
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
     }
@@ -295,7 +295,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(
                         filteredQuery(matchAllQuery(),
-                                geoBoundingBoxQuery("location").coerce(true).topLeft(50, -180).bottomRight(-50, 180).type("indexed"))
+                                geoBoundingBoxQuery("location").coerce(true).topLeft(50, -180).bottomRight(-50, 180).type(Type.INDEXED))
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
         searchResponse = client().prepareSearch()
@@ -307,7 +307,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(
                         filteredQuery(matchAllQuery(),
-                                geoBoundingBoxQuery("location").coerce(true).topLeft(90, -180).bottomRight(-90, 180).type("indexed"))
+                                geoBoundingBoxQuery("location").coerce(true).topLeft(90, -180).bottomRight(-90, 180).type(Type.INDEXED))
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
 
@@ -320,7 +320,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(
                         filteredQuery(matchAllQuery(),
-                                geoBoundingBoxQuery("location").coerce(true).topLeft(50, 0).bottomRight(-50, 360).type("indexed"))
+                                geoBoundingBoxQuery("location").coerce(true).topLeft(50, 0).bottomRight(-50, 360).type(Type.INDEXED))
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
         searchResponse = client().prepareSearch()
@@ -332,7 +332,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(
                         filteredQuery(matchAllQuery(),
-                                geoBoundingBoxQuery("location").coerce(true).topLeft(90, 0).bottomRight(-90, 360).type("indexed"))
+                                geoBoundingBoxQuery("location").coerce(true).topLeft(90, 0).bottomRight(-90, 360).type(Type.INDEXED))
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
     }

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoDistanceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoDistanceIT.java
@@ -60,8 +60,6 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-/**
- */
 public class GeoDistanceIT extends ESIntegTestCase {
 
     @Test

--- a/core/src/test/java/org/elasticsearch/test/ESTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESTestCase.java
@@ -320,6 +320,35 @@ public abstract class ESTestCase extends LuceneTestCase {
         return random().nextDouble();
     }
 
+    /**
+     * Returns a double value in the interval [start, end) if lowerInclusive is set to true,
+     * (start, end) otherwise.
+     *
+     * @param start lower bound of interval to draw uniformly distributed random numbers from
+     * @param end upper bound
+     * @param lowerInclusive whether or not to include lower end of the interval
+     * */
+    public static double randomDoubleBetween(double start, double end, boolean lowerInclusive) {
+        double result = 0.0;
+
+        if (start == -Double.MAX_VALUE || end == Double.MAX_VALUE) {
+            // formula below does not work with very large doubles
+            result = Double.longBitsToDouble(randomLong());
+            while(result < start || result > end || Double.isNaN(result)) {
+                result = Double.longBitsToDouble(randomLong());
+            }
+        } else {
+            result = randomDouble();
+            if (lowerInclusive == false) {
+                while (result <= 0.0) {
+                    result = randomDouble();
+                }
+            }
+            result = result * end + (1.0 - result) * start;
+        }
+        return result;
+    }
+
     public static long randomLong() {
         return random().nextLong();
     }

--- a/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
+++ b/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
@@ -229,7 +229,7 @@ public class RandomShapeGenerator {
         }
     }
 
-    protected static Point xRandomPoint(Random r) {
+    public static Point xRandomPoint(Random r) {
         return xRandomPointIn(r, ctx.getWorldBounds());
     }
 
@@ -243,7 +243,7 @@ public class RandomShapeGenerator {
         return p;
     }
 
-    protected static Rectangle xRandomRectangle(Random r, Point nearP) {
+    public static Rectangle xRandomRectangle(Random r, Point nearP) {
         Rectangle bounds = ctx.getWorldBounds();
         if (nearP == null)
             nearP = xRandomPointIn(r, bounds);


### PR DESCRIPTION
This is pretty much work in progress (e.g. misses validation). It comes with two questions/issues I ran into and need help with/ feedback for:
1. In order to make JSON (de-)serialization roundtrip I believe in QueryBuilder:doXContent I need to be able to generate JSON that can subsequently be parsed here: https://github.com/elastic/elasticsearch/blob/9fa69bd663206c0d7800d866acd7afe40bb6d9ce/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java#L128 - we seem to parse two consecutive boolean values stored as one value in a field. I didn't find a way of generating valid JSON that can be parsed by this line though.
2. When checking the code for query generation I ran into the same issue as with #11969 - except this time (if I'm reading things correctly) we always need a valid indexService.
