### PR TITLE
allow dynamic template deletion by defining an empty template (based on master)

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-data-2.json
+++ b/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-data-2.json
@@ -1,0 +1,6 @@
+{
+    "name_2":"some other name",
+    "age_2":2,
+    "multi3":"multi 3",
+    "multi4":"multi 4"
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-mapping-remove.json
+++ b/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-mapping-remove.json
@@ -1,0 +1,9 @@
+{
+    "person":{
+        "dynamic_templates":[
+            {
+                "template_2":{}
+            }
+        ]
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-mapping.json
+++ b/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/test-mapping.json
@@ -2,7 +2,7 @@
     "person":{
         "dynamic_templates":[
             {
-                "tempalte_1":{
+                "template_1":{
                     "match":"multi*",
                     "mapping":{
                         "type":"{dynamic_type}",


### PR DESCRIPTION
allow dynamic template deletion by defining an empty template - TESTS FAIL due to improper handling of mergeresult simulation. See https://github.com/elastic/elasticsearch/pull/11677#issuecomment-121566538
