### PR TITLE
Transport Tracer should exclude "cluster:monitor/nodes/liveness" by default

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -105,7 +105,7 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
         this.transport = transport;
         this.threadPool = threadPool;
         this.tracerLogInclude = settings.getAsArray(SETTING_TRACE_LOG_INCLUDE, Strings.EMPTY_ARRAY, true);
-        this.tracelLogExclude = settings.getAsArray(SETTING_TRACE_LOG_EXCLUDE, new String[]{"internal:discovery/zen/fd*"}, true);
+        this.tracelLogExclude = settings.getAsArray(SETTING_TRACE_LOG_EXCLUDE, new String[]{"internal:discovery/zen/fd*", "cluster:monitor/nodes/liveness"}, true);
         tracerLog = Loggers.getLogger(logger, ".tracer");
         adapter = createAdapter();
     }


### PR DESCRIPTION
This action is a liveness test added in #8763 . It should be excluded, just like the fault detection logic or things become overly chatty.
