### PR TITLE
Consistently name Groovy scripts with the same content

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.script.groovy;
 
+import com.google.common.base.Charsets;
+import com.google.common.hash.Hashing;
 import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.Script;
@@ -49,7 +51,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Provides the infrastructure for Groovy as a scripting language for Elasticsearch
@@ -57,7 +58,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class GroovyScriptEngineService extends AbstractComponent implements ScriptEngineService {
 
     public static final String NAME = "groovy";
-    private final AtomicLong counter = new AtomicLong();
     private final GroovyClassLoader loader;
 
     @Inject
@@ -111,7 +111,7 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
     @Override
     public Object compile(String script) {
         try {
-            return loader.parseClass(script, generateScriptName());
+            return loader.parseClass(script, Hashing.sha1().hashString(script, Charsets.UTF_8).toString());
         } catch (Throwable e) {
             if (logger.isTraceEnabled()) {
                 logger.trace("exception compiling Groovy script:", e);
@@ -188,10 +188,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
     @Override
     public Object unwrap(Object value) {
         return value;
-    }
-
-    private String generateScriptName() {
-        return "Script" + counter.incrementAndGet() + ".groovy";
     }
 
     public static final class GroovyScript implements ExecutableScript, LeafSearchScript {


### PR DESCRIPTION
When adding a script to the Groovy classloader, the script name is used
as the class identifier in the classloader. This means that in order not
to break JVM Classloader convention, that script must always be
available by that name. As a result, modifying a script with the same
content over and over causes it to be loaded with a different name (due
to the incrementing integer).

This is particularly bad when something like chef or puppet replaces the
on-disk script file with the same content over and over every time a
machine is converged.

This change makes the script name the SHA1 hash of the script itself,
meaning that replacing a script with the same text will use the same
script name.

Resolves #12212 

As a test for this, I did the following:
- Configure the resource watcher to check for new scripts more frequently (every 100ms)

``` yaml
watcher.interval.low: 100ms
watcher.interval.medium: 100ms
watcher.interval.high: 100ms
resource.reload.interval.low: 100ms
resource.reload.interval.medium: 100ms
resource.reload.interval.high: 100ms
```
- Start ES with a 1.7 JVM (since 1.8 removed permgen)
- Run a script that constantly updated a script file with the same content over and over, causing it to be re-compiled by Elasticsearch:

``` bash
while true; do
  echo "ctx._source.counter += 1" > config/scripts/myscript.groovy
  echo "ctx._source.counter += 2" > config/scripts/myscript.groovy
done
```

Without this change, permgen grows linearly, then the ES node hits OOME in permgen:

![screenshot from 2015-07-16 12-42-15](https://cloud.githubusercontent.com/assets/19060/8732340/05647a40-2bba-11e5-8b08-b5c7a12156f9.png)

And with this change, the classes are able to be unloaded, because they share the same class name (SHA1 of the content):

![screenshot from 2015-07-16 12-34-20](https://cloud.githubusercontent.com/assets/19060/8732348/1851baa0-2bba-11e5-85f2-8b1740efe5da.png)
