### PR TITLE
Do not kill process on service shutdown

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -175,8 +175,7 @@ case "$1" in
 	# Start Daemon
 	start-stop-daemon -d $ES_HOME --start -b --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
 	return=$?
-	if [ $return -eq 0 ]
-	then
+	if [ $return -eq 0 ]; then
 		i=0
 		timeout=10
 		# Wait for the process to be properly started before exiting
@@ -189,9 +188,9 @@ case "$1" in
 				exit 1
 			fi
 		done
-	else
-		log_end_msg $return
 	fi
+	log_end_msg $return
+	exit $return
 	;;
   stop)
 	log_daemon_msg "Stopping $DESC"
@@ -199,7 +198,8 @@ case "$1" in
 	if [ -f "$PID_FILE" ]; then
 		start-stop-daemon --stop --pidfile "$PID_FILE" \
 			--user "$ES_USER" \
-			--retry=TERM/20/KILL/5 >/dev/null
+			--quiet \
+			--retry forever/TERM/20 > /dev/null
 		if [ $? -eq 1 ]; then
 			log_progress_msg "$DESC is not running but pid file exists, cleaning up"
 		elif [ $? -eq 3 ]; then

--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -120,7 +120,7 @@ start() {
 stop() {
     echo -n $"Stopping $prog: "
     # stop it here, often "killproc $prog"
-    killproc -p $pidfile -d 20 $prog
+    killproc -p $pidfile -d ${packaging.elasticsearch.stopping.timeout} $prog
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile

--- a/distribution/rpm/src/main/packaging/packaging.properties
+++ b/distribution/rpm/src/main/packaging/packaging.properties
@@ -14,3 +14,6 @@ packaging.type=rpm
 # Custom header for package scripts
 packaging.scripts.header=
 packaging.scripts.footer=# Built for ${project.name}-${project.version} (${packaging.type})
+
+# Maximum time to wait for elasticsearch to stop (default to 1 day)
+packaging.elasticsearch.stopping.timeout=86400

--- a/distribution/src/main/packaging/scripts/postrm
+++ b/distribution/src/main/packaging/scripts/postrm
@@ -8,8 +8,8 @@ ${packaging.scripts.header}
 #       $1=purge     : indicates an upgrade
 #
 #   On RedHat,
-#       $1=1         : indicates an new install
-#       $1=2         : indicates an upgrade
+#       $1=0         : indicates a removal
+#       $1=1         : indicates an upgrade
 
 
 
@@ -39,7 +39,7 @@ case "$1" in
         REMOVE_SERVICE=true
         REMOVE_USER_AND_GROUP=true
     ;;
-    2)
+    1)
         # If $1=1 this is an upgrade
         IS_UPGRADE=true
     ;;

--- a/distribution/src/main/packaging/scripts/prerm
+++ b/distribution/src/main/packaging/scripts/prerm
@@ -47,13 +47,13 @@ esac
 if [ "$STOP_REQUIRED" = "true" ]; then
     echo -n "Stopping elasticsearch service..."
     if command -v systemctl >/dev/null; then
-        systemctl --no-reload stop elasticsearch.service > /dev/null 2>&1 || true
+        systemctl --no-reload stop elasticsearch.service
 
     elif [ -x /etc/init.d/elasticsearch ]; then
         if command -v invoke-rc.d >/dev/null; then
-            invoke-rc.d elasticsearch stop || true
+            invoke-rc.d elasticsearch stop
         else
-            /etc/init.d/elasticsearch stop || true
+            /etc/init.d/elasticsearch stop
         fi
 
     # older suse linux distributions do not ship with systemd
@@ -61,7 +61,7 @@ if [ "$STOP_REQUIRED" = "true" ]; then
     # this tries to start the elasticsearch service on these
     # as well without failing this script
     elif [ -x /etc/rc.d/init.d/elasticsearch ] ; then
-        /etc/rc.d/init.d/elasticsearch stop || true
+        /etc/rc.d/init.d/elasticsearch stop
     fi
     echo " OK"
 fi

--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -32,9 +32,6 @@ StandardOutput=null
 # Connects standard error to journal
 StandardError=journal
 
-# When a JVM receives a SIGTERM signal it exits with code 143
-SuccessExitStatus=143
-
 # Specifies the maximum file descriptor number that can be opened by this process
 LimitNOFILE=${packaging.os.max.open.files}
 
@@ -43,8 +40,17 @@ LimitNOFILE=${packaging.os.max.open.files}
 # in elasticsearch.yml and 'MAX_LOCKED_MEMORY=unlimited' in ${packaging.env.file}
 #LimitMEMLOCK=infinity
 
-# Shutdown delay in seconds, before process is tried to be killed with KILL (if configured)
-TimeoutStopSec=20
+# Disable timeout logic and wait until process is stopped
+TimeoutStopSec=0
+
+# SIGTERM signal is used to stop the Java process
+KillSignal=SIGTERM
+
+# Java process is never killed
+SendSIGKILL=no
+
+# When a JVM receives a SIGTERM signal it exits with code 143
+SuccessExitStatus=143
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When installed as a service with a DEB or RPM package, we should gently wait for elasticsearch to stop (flushing indices on closing can take some time) and never kill the process.

Closes #11248 
