### PR TITLE
Refactor geo_point validate_* and normalize_* for 1.7

### DIFF
--- a/docs/reference/mapping/types/geo-point-type.asciidoc
+++ b/docs/reference/mapping/types/geo-point-type.asciidoc
@@ -143,20 +143,8 @@ longitude (default is `true`). *Note*: Validation only works when
 normalization has been disabled. This option will be deprecated and removed
 in upcoming releases.
 
-|`validate_lat` |Set to `false` to accept geo points with an invalid
-latitude (default is `true`). This option will be deprecated and removed
-in upcoming releases.
-
-|`validate_lon` |Set to `false` to accept geo points with an invalid
-longitude (default is `true`). This option will be deprecated and removed
-in upcoming releases.
-
 |`normalize` |Set to `true` to normalize latitude and longitude (default
 is `true`).
-
-|`normalize_lat` |Set to `true` to normalize latitude.
-
-|`normalize_lon` |Set to `true` to normalize longitude.
 
 |`precision_step` |The precision step (influences the number of terms 
 generated for each number value) for `.lat` and `.lon` fields 

--- a/docs/reference/mapping/types/geo-point-type.asciidoc
+++ b/docs/reference/mapping/types/geo-point-type.asciidoc
@@ -138,13 +138,12 @@ but also all its parent cells (true prefixes) will be indexed as well. The
 number of terms that will be indexed depends on the `geohash_precision`.
 Defaults to `false`. *Note*: This option implicitly enables `geohash`.
 
-|`validate` |Set to `false` to accept geo points with invalid latitude or
-longitude (default is `true`). *Note*: Validation only works when
-normalization has been disabled. This option will be deprecated and removed
-in upcoming releases.
+|`ignore_malformed` |Formerly `validate`. Set to `true` to
+accept geo points with invalid latitude or longitude (default is `false`).
 
-|`normalize` |Set to `true` to normalize latitude and longitude (default
-is `true`).
+|`coerce` |Formerly `normalize`. Set to `true` to normalize longitude and
+latitude values to a standard -180:180 / -90:90 coordinate system. (default
+is `false`).
 
 |`precision_step` |The precision step (influences the number of terms 
 generated for each number value) for `.lat` and `.lon` fields 

--- a/docs/reference/query-dsl/filters/geo-bounding-box-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-bounding-box-filter.asciidoc
@@ -45,6 +45,33 @@ Then the following simple query can be executed with a
 --------------------------------------------------
 
 [float]
+==== Filter Options
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Option |Description
+|`_name` |Optional name field to identify the filter
+
+|`_cache` |Set to `true` to cache the *result* of the filter.
+Defaults to `false`. See <<Caching,Caching>> below for further details.
+
+|`_cache_key` |Associate a unique custom cache key to use instead of
+the actual filter.
+
+|`validate` |Set to `false` to accept geo points with invalid latitude or
+longitude (default is `true`). *Note*: Validation only works when
+normalization has been disabled. This option will be deprecated and removed
+in upcoming releases.
+
+|`normalize` |Set to `true` to normalize latitude and longitude (default
+is `true`).
+
+|`type` |Set to one of `indexed` or `memory` to defines whether this filter will
+be executed in memory or indexed. See <<Type,Type>> below for further details
+Default is `memory`.
+|=======================================================================
+
+[float]
 ==== Accepted Formats
 
 In much the same way the geo_point type can accept different

--- a/docs/reference/query-dsl/filters/geo-bounding-box-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-bounding-box-filter.asciidoc
@@ -58,13 +58,11 @@ Defaults to `false`. See <<Caching,Caching>> below for further details.
 |`_cache_key` |Associate a unique custom cache key to use instead of
 the actual filter.
 
-|`validate` |Set to `false` to accept geo points with invalid latitude or
-longitude (default is `true`). *Note*: Validation only works when
-normalization has been disabled. This option will be deprecated and removed
-in upcoming releases.
+|`ignore_malformed` |Set to `true` to
+accept geo points with invalid latitude or longitude (default is `false`).
 
-|`normalize` |Set to `true` to normalize latitude and longitude (default
-is `true`).
+|`coerce` |Set to `true` to normalize longitude and latitude values to a
+standard -180:180 / -90:90 coordinate system. (default is `false`).
 
 |`type` |Set to one of `indexed` or `memory` to defines whether this filter will
 be executed in memory or indexed. See <<Type,Type>> below for further details

--- a/docs/reference/query-dsl/filters/geo-distance-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-distance-filter.asciidoc
@@ -171,16 +171,15 @@ The following are options allowed on the filter:
 
     Associate a unique custom cache key to use instead of the actual filter.
 
-`validate`::
+`ignore_malformed`::
 
-    Set to `false` to accept geo points with invalid latitude or
-    longitude (default is `true`). *Note*: Validation only works when
-    normalization has been disabled. This option will be deprecated and removed
-    in upcoming releases.
+    Set to `true` to accept geo points with invalid latitude or
+    longitude (default is `false`).
 
-`normalize`::
+`coerce`::
 
-    Set to `true` to normalize latitude and longitude. Defaults to `true`.
+    Set to `true` to normalize longitude and latitude values to a standard -180:180 / -90:90
+    coordinate system. (default is `false`).
 
 [float]
 ==== geo_point Type

--- a/docs/reference/query-dsl/filters/geo-distance-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-distance-filter.asciidoc
@@ -158,6 +158,29 @@ The following are options allowed on the filter:
     sure the `geo_point` type index lat lon in this case), or `none` which
     disables bounding box optimization.
 
+`_name`::
+
+    Optional name field to identify the filter
+
+`_cache`::
+
+    Set to `true` to cache the *result* of the filter.
+    Defaults to `false`. See <<Caching,Caching>> below for further details.
+
+`_cache_key`::
+
+    Associate a unique custom cache key to use instead of the actual filter.
+
+`validate`::
+
+    Set to `false` to accept geo points with invalid latitude or
+    longitude (default is `true`). *Note*: Validation only works when
+    normalization has been disabled. This option will be deprecated and removed
+    in upcoming releases.
+
+`normalize`::
+
+    Set to `true` to normalize latitude and longitude. Defaults to `true`.
 
 [float]
 ==== geo_point Type

--- a/docs/reference/query-dsl/filters/geo-distance-range-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-distance-range-filter.asciidoc
@@ -24,7 +24,7 @@ Filters documents that exists within a range from a specific point:
 }
 --------------------------------------------------
 
-Supports the same point location parameter as the
+Supports the same point location parameter and filter options as the
 <<query-dsl-geo-distance-filter,geo_distance>>
 filter. And also support the common parameters for range (lt, lte, gt,
 gte, from, to, include_upper and include_lower).

--- a/docs/reference/query-dsl/filters/geo-polygon-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-polygon-filter.asciidoc
@@ -27,6 +27,30 @@ points. Here is an example:
 --------------------------------------------------
 
 [float]
+==== Filter Options
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Option |Description
+|`_name` |Optional name field to identify the filter
+
+|`_cache` |Set to `true` to cache the *result* of the filter.
+Defaults to `false`. See <<Caching,Caching>> below.
+
+|`_cache_key` |Associate a unique custom cache key to use instead of
+the actual filter.
+
+|`validate` |Set to `false` to accept geo points with invalid latitude or
+longitude (default is `true`). *Note*: Validation only works when
+normalization has been disabled. This option will be deprecated and removed
+in upcoming releases.
+
+|`normalize` |Set to `false` to prevent latitude and longitude from auto converting
+to proper lat/lon bounds.
+Default is `true'.
+|=======================================================================
+
+[float]
 ==== Allowed Formats
 
 [float]

--- a/docs/reference/query-dsl/filters/geo-polygon-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/geo-polygon-filter.asciidoc
@@ -40,14 +40,11 @@ Defaults to `false`. See <<Caching,Caching>> below.
 |`_cache_key` |Associate a unique custom cache key to use instead of
 the actual filter.
 
-|`validate` |Set to `false` to accept geo points with invalid latitude or
-longitude (default is `true`). *Note*: Validation only works when
-normalization has been disabled. This option will be deprecated and removed
-in upcoming releases.
+|`ignore_malformed` |Set to `true` to accept geo points with invalid latitude or
+longitude (default is `false`).
 
-|`normalize` |Set to `false` to prevent latitude and longitude from auto converting
-to proper lat/lon bounds.
-Default is `true'.
+|`coerce` |Set to `true` to normalize longitude and latitude values to a
+standard -180:180 / -90:90 coordinate system. (default is `false`).
 |=======================================================================
 
 [float]

--- a/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxFilterParser.java
@@ -85,8 +85,8 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
         String filterName = null;
         String currentFieldName = null;
         XContentParser.Token token;
-        boolean validate = true;
-        boolean normalize = true;
+        boolean ignoreMalformed = false;
+        boolean coerce = false;
 
         GeoPoint sparse = new GeoPoint();
         
@@ -144,10 +144,10 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
                     cache = parser.booleanValue();
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
-                } else if ("validate".equals(currentFieldName)) {
-                    validate = parser.booleanValue();
-                } else if ("normalize".equals(currentFieldName)) {
-                    normalize = parser.booleanValue();
+                } else if ("ignore_malformed".equals(currentFieldName)) {
+                    ignoreMalformed = parser.booleanValue();
+                } else if ("coerce".equals(currentFieldName)) {
+                    coerce = parser.booleanValue();
                 } else if ("type".equals(currentFieldName)) {
                     type = parser.text();
                 } else {
@@ -159,7 +159,7 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
         final GeoPoint topLeft = sparse.reset(top, left);  //just keep the object
         final GeoPoint bottomRight = new GeoPoint(bottom, right);
 
-        if (normalize) {
+        if (coerce) {
             // Special case: if the difference between the left and right is 360 and the right is greater than the left, we are asking for
             // the complete longitude range so need to set longitude to the complete longitude range
             boolean completeLonRange = ((right - left) % 360 == 0 && right > left);
@@ -169,7 +169,7 @@ public class GeoBoundingBoxFilterParser implements FilterParser {
                 topLeft.resetLon(-180);
                 bottomRight.resetLon(180);
             }
-        } else if (validate) {
+        } else if (!ignoreMalformed) {
             if (topLeft.lat() > 90.0 || topLeft.lat() < -90.0) {
                 throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + topLeft.lat() + "] for " + filterName);
             }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
@@ -77,8 +77,8 @@ public class GeoDistanceFilterParser implements FilterParser {
         GeoDistance geoDistance = GeoDistance.DEFAULT;
         String optimizeBbox = "memory";
 
-        boolean validate = true;
-        boolean normalize = true;
+        boolean ignoreMalformed = false;
+        boolean coerce = false;
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -133,10 +133,10 @@ public class GeoDistanceFilterParser implements FilterParser {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else if ("optimize_bbox".equals(currentFieldName) || "optimizeBbox".equals(currentFieldName)) {
                     optimizeBbox = parser.textOrNull();
-                } else if ("validate".equals(currentFieldName)) {
-                    validate = parser.booleanValue();
-                } else if ("normalize".equals(currentFieldName)) {
-                    normalize = parser.booleanValue();
+                } else if ("ignore_malformed".equals(currentFieldName)) {
+                    ignoreMalformed = parser.booleanValue();
+                } else if ("coerce".equals(currentFieldName)) {
+                    coerce = parser.booleanValue();
                 } else {
                     point.resetFromString(parser.text());
                     fieldName = currentFieldName;
@@ -144,9 +144,9 @@ public class GeoDistanceFilterParser implements FilterParser {
             }
         }
 
-        if (normalize) {
-            GeoUtils.normalizePoint(point, normalize, normalize);
-        } else if (validate) {
+        if (coerce) {
+            GeoUtils.normalizePoint(point, coerce, coerce);
+        } else if (!ignoreMalformed) {
             if (point.lat() > 90.0 || point.lat() < -90.0) {
                 throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + point.lat() + "] for " + filterName);
             }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceFilterParser.java
@@ -76,8 +76,10 @@ public class GeoDistanceFilterParser implements FilterParser {
         DistanceUnit unit = DistanceUnit.DEFAULT;
         GeoDistance geoDistance = GeoDistance.DEFAULT;
         String optimizeBbox = "memory";
-        boolean normalizeLon = true;
-        boolean normalizeLat = true;
+
+        boolean validate = true;
+        boolean normalize = true;
+
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -131,13 +133,25 @@ public class GeoDistanceFilterParser implements FilterParser {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else if ("optimize_bbox".equals(currentFieldName) || "optimizeBbox".equals(currentFieldName)) {
                     optimizeBbox = parser.textOrNull();
+                } else if ("validate".equals(currentFieldName)) {
+                    validate = parser.booleanValue();
                 } else if ("normalize".equals(currentFieldName)) {
-                    normalizeLat = parser.booleanValue();
-                    normalizeLon = parser.booleanValue();
+                    normalize = parser.booleanValue();
                 } else {
                     point.resetFromString(parser.text());
                     fieldName = currentFieldName;
                 }
+            }
+        }
+
+        if (normalize) {
+            GeoUtils.normalizePoint(point, normalize, normalize);
+        } else if (validate) {
+            if (point.lat() > 90.0 || point.lat() < -90.0) {
+                throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + point.lat() + "] for " + filterName);
+            }
+            if (point.lon() > 180.0 || point.lon() < -180) {
+                throw new QueryParsingException(parseContext.index(), "illegal longitude value [" + point.lon() + "] for " + filterName);
             }
         }
 
@@ -149,10 +163,6 @@ public class GeoDistanceFilterParser implements FilterParser {
             distance = DistanceUnit.parse((String) vDistance, unit, DistanceUnit.DEFAULT);
         }
         distance = geoDistance.normalize(distance, DistanceUnit.DEFAULT);
-
-        if (normalizeLat || normalizeLon) {
-            GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
-        }
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);
         if (smartMappers == null || !smartMappers.hasMapper()) {

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
@@ -78,8 +78,8 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
         DistanceUnit unit = DistanceUnit.DEFAULT;
         GeoDistance geoDistance = GeoDistance.DEFAULT;
         String optimizeBbox = "memory";
-        boolean validate = true;
-        boolean normalize = true;
+        boolean ignoreMalformed = false;
+        boolean coerce = false;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -162,10 +162,10 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else if ("optimize_bbox".equals(currentFieldName) || "optimizeBbox".equals(currentFieldName)) {
                     optimizeBbox = parser.textOrNull();
-                } else if ("validate".equals(currentFieldName)) {
-                    validate = parser.booleanValue();
-                } else if ("normalize".equals(currentFieldName)) {
-                    normalize = parser.booleanValue();
+                } else if ("ignore_malformed".equals(currentFieldName)) {
+                    ignoreMalformed = parser.booleanValue();
+                } else if ("coerce".equals(currentFieldName)) {
+                    coerce = parser.booleanValue();
                 } else {
                     point.resetFromString(parser.text());
                     fieldName = currentFieldName;
@@ -173,9 +173,9 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
             }
         }
 
-        if (normalize) {
-            GeoUtils.normalizePoint(point, normalize, normalize);
-        } else if (validate) {
+        if (coerce) {
+            GeoUtils.normalizePoint(point, coerce, coerce);
+        } else if (!ignoreMalformed) {
             if (point.lat() > 90.0 || point.lat() < -90.0) {
                 throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + point.lat() + "] for " + filterName);
             }

--- a/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeFilterParser.java
@@ -78,8 +78,8 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
         DistanceUnit unit = DistanceUnit.DEFAULT;
         GeoDistance geoDistance = GeoDistance.DEFAULT;
         String optimizeBbox = "memory";
-        boolean normalizeLon = true;
-        boolean normalizeLat = true;
+        boolean validate = true;
+        boolean normalize = true;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -162,13 +162,25 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
                 } else if ("optimize_bbox".equals(currentFieldName) || "optimizeBbox".equals(currentFieldName)) {
                     optimizeBbox = parser.textOrNull();
+                } else if ("validate".equals(currentFieldName)) {
+                    validate = parser.booleanValue();
                 } else if ("normalize".equals(currentFieldName)) {
-                    normalizeLat = parser.booleanValue();
-                    normalizeLon = parser.booleanValue();
+                    normalize = parser.booleanValue();
                 } else {
                     point.resetFromString(parser.text());
                     fieldName = currentFieldName;
                 }
+            }
+        }
+
+        if (normalize) {
+            GeoUtils.normalizePoint(point, normalize, normalize);
+        } else if (validate) {
+            if (point.lat() > 90.0 || point.lat() < -90.0) {
+                throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + point.lat() + "] for " + filterName);
+            }
+            if (point.lon() > 180.0 || point.lon() < -180) {
+                throw new QueryParsingException(parseContext.index(), "illegal longitude value [" + point.lon() + "] for " + filterName);
             }
         }
 
@@ -189,10 +201,6 @@ public class GeoDistanceRangeFilterParser implements FilterParser {
                 to = DistanceUnit.parse((String) vTo, unit, DistanceUnit.DEFAULT);
             }
             to = geoDistance.normalize(to, DistanceUnit.DEFAULT);
-        }
-
-        if (normalizeLat || normalizeLon) {
-            GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
         }
 
         MapperService.SmartNameFieldMappers smartMappers = parseContext.smartFieldMappers(fieldName);

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -74,8 +74,8 @@ public class GeoPolygonFilterParser implements FilterParser {
 
         List<GeoPoint> shell = Lists.newArrayList();
 
-        boolean validate = true;
-        boolean normalize = true;
+        boolean ignoreMalformed = false;
+        boolean coerce = false;
 
         String filterName = null;
         String currentFieldName = null;
@@ -109,10 +109,10 @@ public class GeoPolygonFilterParser implements FilterParser {
                     cache = parser.booleanValue();
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
-                } else if ("validate".equals(currentFieldName)) {
-                    validate = parser.booleanValue();
-                } else if ("normalize".equals(currentFieldName)) {
-                    normalize = parser.booleanValue();
+                } else if ("ignore_malformed".equals(currentFieldName)) {
+                    ignoreMalformed = parser.booleanValue();
+                } else if ("coerce".equals(currentFieldName)) {
+                    coerce = parser.booleanValue();
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]");
                 }
@@ -136,11 +136,11 @@ public class GeoPolygonFilterParser implements FilterParser {
             }
         }
 
-        if (normalize) {
+        if (coerce) {
             for (GeoPoint point : shell) {
-                GeoUtils.normalizePoint(point, normalize, normalize);
+                GeoUtils.normalizePoint(point, coerce, coerce);
             }
-        } else if (validate) {
+        } else if (!ignoreMalformed) {
             for (GeoPoint point : shell) {
                 if (point.lat() > 90.0 || point.lat() < -90.0) {
                     throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + point.lat() + "] for " + filterName);

--- a/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/GeoPolygonFilterParser.java
@@ -74,8 +74,8 @@ public class GeoPolygonFilterParser implements FilterParser {
 
         List<GeoPoint> shell = Lists.newArrayList();
 
-        boolean normalizeLon = true;
-        boolean normalizeLat = true;
+        boolean validate = true;
+        boolean normalize = true;
 
         String filterName = null;
         String currentFieldName = null;
@@ -109,9 +109,10 @@ public class GeoPolygonFilterParser implements FilterParser {
                     cache = parser.booleanValue();
                 } else if ("_cache_key".equals(currentFieldName) || "_cacheKey".equals(currentFieldName)) {
                     cacheKey = new CacheKeyFilter.Key(parser.text());
+                } else if ("validate".equals(currentFieldName)) {
+                    validate = parser.booleanValue();
                 } else if ("normalize".equals(currentFieldName)) {
-                    normalizeLat = parser.booleanValue();
-                    normalizeLon = parser.booleanValue();
+                    normalize = parser.booleanValue();
                 } else {
                     throw new QueryParsingException(parseContext.index(), "[geo_polygon] filter does not support [" + currentFieldName + "]");
                 }
@@ -135,9 +136,18 @@ public class GeoPolygonFilterParser implements FilterParser {
             }
         }
 
-        if (normalizeLat || normalizeLon) {
+        if (normalize) {
             for (GeoPoint point : shell) {
-                GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
+                GeoUtils.normalizePoint(point, normalize, normalize);
+            }
+        } else if (validate) {
+            for (GeoPoint point : shell) {
+                if (point.lat() > 90.0 || point.lat() < -90.0) {
+                    throw new QueryParsingException(parseContext.index(), "illegal latitude value [" + point.lat() + "] for " + filterName);
+                }
+                if (point.lon() > 180.0 || point.lon() < -180) {
+                    throw new QueryParsingException(parseContext.index(), "illegal longitude value [" + point.lon() + "] for " + filterName);
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -66,8 +66,8 @@ public class GeoDistanceSortParser implements SortParser {
         MultiValueMode sortMode = null;
         NestedInnerQueryParseSupport nestedHelper = null;
 
-        boolean normalizeLon = true;
-        boolean normalizeLat = true;
+        boolean validate = true;
+        boolean normalize = true;
 
         XContentParser.Token token;
         String currentName = parser.currentName();
@@ -100,9 +100,10 @@ public class GeoDistanceSortParser implements SortParser {
                     unit = DistanceUnit.fromString(parser.text());
                 } else if (currentName.equals("distance_type") || currentName.equals("distanceType")) {
                     geoDistance = GeoDistance.fromString(parser.text());
+                } else if ("validate".equals(currentName)) {
+                    validate = parser.booleanValue();
                 } else if ("normalize".equals(currentName)) {
-                    normalizeLat = parser.booleanValue();
-                    normalizeLon = parser.booleanValue();
+                    normalize = parser.booleanValue();
                 } else if ("sort_mode".equals(currentName) || "sortMode".equals(currentName) || "mode".equals(currentName)) {
                     sortMode = MultiValueMode.fromString(parser.text());
                 } else if ("nested_path".equals(currentName) || "nestedPath".equals(currentName)) {
@@ -119,9 +120,18 @@ public class GeoDistanceSortParser implements SortParser {
             }
         }
 
-        if (normalizeLat || normalizeLon) {
+        if (normalize) {
             for (GeoPoint point : geoPoints) {
-                GeoUtils.normalizePoint(point, normalizeLat, normalizeLon);
+                GeoUtils.normalizePoint(point, normalize, normalize);
+            }
+        } else if (validate) {
+            for (GeoPoint point : geoPoints) {
+                if (point.lat() > 90.0 || point.lat() < -90.0) {
+                    throw new ElasticsearchIllegalArgumentException("illegal latitude value [" + point.lat() + "] for geo distance sort");
+                }
+                if (point.lon() > 180.0 || point.lon() < -180) {
+                    throw new ElasticsearchIllegalArgumentException("illegal longitude value [" + point.lon() + "] for geo distance sort");
+                }
             }
         }
 

--- a/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -66,8 +66,8 @@ public class GeoDistanceSortParser implements SortParser {
         MultiValueMode sortMode = null;
         NestedInnerQueryParseSupport nestedHelper = null;
 
-        boolean validate = true;
-        boolean normalize = true;
+        boolean ignoreMalformed = false;
+        boolean coerce = false;
 
         XContentParser.Token token;
         String currentName = parser.currentName();
@@ -100,10 +100,10 @@ public class GeoDistanceSortParser implements SortParser {
                     unit = DistanceUnit.fromString(parser.text());
                 } else if (currentName.equals("distance_type") || currentName.equals("distanceType")) {
                     geoDistance = GeoDistance.fromString(parser.text());
-                } else if ("validate".equals(currentName)) {
-                    validate = parser.booleanValue();
-                } else if ("normalize".equals(currentName)) {
-                    normalize = parser.booleanValue();
+                } else if ("ignore_malformed".equals(currentName)) {
+                    ignoreMalformed = parser.booleanValue();
+                } else if ("coerce".equals(currentName)) {
+                    coerce = parser.booleanValue();
                 } else if ("sort_mode".equals(currentName) || "sortMode".equals(currentName) || "mode".equals(currentName)) {
                     sortMode = MultiValueMode.fromString(parser.text());
                 } else if ("nested_path".equals(currentName) || "nestedPath".equals(currentName)) {
@@ -120,11 +120,11 @@ public class GeoDistanceSortParser implements SortParser {
             }
         }
 
-        if (normalize) {
+        if (coerce) {
             for (GeoPoint point : geoPoints) {
-                GeoUtils.normalizePoint(point, normalize, normalize);
+                GeoUtils.normalizePoint(point, coerce, coerce);
             }
-        } else if (validate) {
+        } else if (!ignoreMalformed) {
             for (GeoPoint point : geoPoints) {
                 if (point.lat() > 90.0 || point.lat() < -90.0) {
                     throw new ElasticsearchIllegalArgumentException("illegal latitude value [" + point.lat() + "] for geo distance sort");

--- a/src/test/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperTests.java
@@ -488,9 +488,9 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper.MergeResult mergeResult = stage1.merge(stage2, mergeFlags().simulate(false));
         assertThat(mergeResult.hasConflicts(), equalTo(true));
-        assertThat(mergeResult.conflicts().length, equalTo(2));
+        assertThat(mergeResult.conflicts().length, equalTo(1));
         // todo better way of checking conflict?
-        assertThat("mapper [point] has different validate_lat", isIn(new ArrayList<>(Arrays.asList(mergeResult.conflicts()))));
+        assertThat("mapper [point] has different validate", isIn(new ArrayList<>(Arrays.asList(mergeResult.conflicts()))));
 
         // correct mapping and ensure no failures
         stage2Mapping = XContentFactory.jsonBuilder().startObject().startObject("type")

--- a/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java
+++ b/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java
@@ -339,8 +339,7 @@ public class GeoUtilsTests extends ElasticsearchTestCase {
     @Test
     public void testNormalizePoint_outsideNormalRange_withOptions() {
         for (int i = 0; i < 100; i++) {
-            boolean normLat = randomBoolean();
-            boolean normLon = randomBoolean();
+            boolean normalize = randomBoolean();
             double normalisedLat = (randomDouble() * 180.0) - 90.0;
             double normalisedLon = (randomDouble() * 360.0) - 180.0;
             int shiftLat = randomIntBetween(1, 10000);
@@ -350,23 +349,19 @@ public class GeoUtilsTests extends ElasticsearchTestCase {
 
             double expectedLat;
             double expectedLon;
-            if (normLat) {
+            if (normalize) {
                 expectedLat = normalisedLat * (shiftLat % 2 == 0 ? 1 : -1);
-            } else {
-                expectedLat = testLat;
-            }
-            if (normLon) {
-                expectedLon = normalisedLon + ((normLat && shiftLat % 2 == 1) ? 180 : 0);
+                expectedLon = normalisedLon + ((shiftLat % 2 == 1) ? 180 : 0);
                 if (expectedLon > 180.0) {
                     expectedLon -= 360;
                 }
             } else {
-                double shiftValue = normalisedLon > 0 ? -180 : 180;
-                expectedLon = testLon + ((normLat && shiftLat % 2 == 1) ? shiftValue : 0);
+                expectedLat = testLat;
+                expectedLon = testLon;
             }
             GeoPoint testPoint = new GeoPoint(testLat, testLon);
             GeoPoint expectedPoint = new GeoPoint(expectedLat, expectedLon);
-            GeoUtils.normalizePoint(testPoint, normLat, normLon);
+            GeoUtils.normalizePoint(testPoint, normalize, normalize);
             assertThat("Unexpected Latitude", testPoint.lat(), closeTo(expectedPoint.lat(), MAX_ACCEPTABLE_ERROR));
             assertThat("Unexpected Longitude", testPoint.lon(), closeTo(expectedPoint.lon(), MAX_ACCEPTABLE_ERROR));
         }


### PR DESCRIPTION
This PR deprecates validate_\* and normalize_\* options for `geo_point` field mapping in favor of  more straight-forward `validate` and `normalize` parameters. This PR is for 1.7 only. 2.0 will completely remove these parameters.
