### PR TITLE
Use junit4 for running integration tests, too

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1056,18 +1056,14 @@
                                 <ant antfile="${elasticsearch.tools.directory}/ant/integration-tests.xml"
                                      target="stop-external-cluster"/>
                             </target>
+                            <!-- TODO: remove this and the xslt when junit4 is fixed -->
+                            <xslt in="${project.build.directory}/failsafe-reports/failsafe-summary-buggy.xml"
+                                  out="${project.build.directory}/failsafe-reports/failsafe-summary.xml"
+                                  style="${elasticsearch.tools.directory}/ant/fixup-failsafe-summary.xslt">
+                            </xslt>
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <tests.cluster>127.0.0.1:9300</tests.cluster>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
         </plugins>
       <pluginManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1039,8 +1039,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <ant antfile="${elasticsearch.tools.directory}/ant/integration-tests.xml"
-                                     target="start-external-cluster"/>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster"/>
                             </target>
                         </configuration>
                     </execution>
@@ -1053,13 +1052,9 @@
                         </goals>
                         <configuration>
                             <target>
-                                <ant antfile="${elasticsearch.tools.directory}/ant/integration-tests.xml"
-                                     target="stop-external-cluster"/>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="stop-external-cluster"/>
                                 <!-- TODO: remove this and the xslt when junit4 is fixed -->
-                                <xslt in="${project.build.directory}/failsafe-reports/failsafe-summary-buggy.xml"
-                                  out="${project.build.directory}/failsafe-reports/failsafe-summary.xml"
-                                  style="${elasticsearch.tools.directory}/ant/fixup-failsafe-summary.xslt">
-                                </xslt>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="fixup-failsafe-summary"/>
                             </target>
                         </configuration>
                     </execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1055,12 +1055,12 @@
                             <target>
                                 <ant antfile="${elasticsearch.tools.directory}/ant/integration-tests.xml"
                                      target="stop-external-cluster"/>
-                            </target>
-                            <!-- TODO: remove this and the xslt when junit4 is fixed -->
-                            <xslt in="${project.build.directory}/failsafe-reports/failsafe-summary-buggy.xml"
+                                <!-- TODO: remove this and the xslt when junit4 is fixed -->
+                                <xslt in="${project.build.directory}/failsafe-reports/failsafe-summary-buggy.xml"
                                   out="${project.build.directory}/failsafe-reports/failsafe-summary.xml"
                                   style="${elasticsearch.tools.directory}/ant/fixup-failsafe-summary.xslt">
-                            </xslt>
+                                </xslt>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/dev-tools/src/main/resources/ant/fixup-failsafe-summary.xslt
+++ b/dev-tools/src/main/resources/ant/fixup-failsafe-summary.xslt
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- remove this when junit4 summary format is fixed -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <failsafe-summary>
+      <xsl:attribute name="timeout">
+        <xsl:value-of select="failsafe-summary/@timeout"/>
+      </xsl:attribute>
+      <completed><xsl:value-of select="failsafe-summary/@completed"/></completed>
+      <errors><xsl:value-of select="failsafe-summary/@errors"/></errors>
+      <failures><xsl:value-of select="failsafe-summary/@failures"/></failures>
+      <skipped><xsl:value-of select="failsafe-summary/@skipped"/></skipped>
+      <failureMessage><xsl:value-of select="failsafe-summary/@failureMessage"/></failureMessage>
+    </failsafe-summary>
+  </xsl:template>
+</xsl:stylesheet>

--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -164,4 +164,12 @@
     </exec>
     <delete file="${integ.pidfile}"/>
   </target>
+
+  <!-- TODO: remove this and the xslt when junit4 is fixed -->
+  <target name="fixup-failsafe-summary" unless="${shouldskip}">
+    <xslt in="${project.build.directory}/failsafe-reports/failsafe-summary-buggy.xml"
+          out="${project.build.directory}/failsafe-reports/failsafe-summary.xml"
+          style="${elasticsearch.tools.directory}/ant/fixup-failsafe-summary.xslt"/>
+  </target>
+
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -21,8 +21,6 @@
     <properties>
         <elasticsearch.assembly.descriptor>${basedir}/src/main/assemblies/plugin.xml</elasticsearch.assembly.descriptor>
         <elasticsearch.assembly.appendId>false</elasticsearch.assembly.appendId>
-        <elasticsearch.integ.antfile.default>${elasticsearch.tools.directory}/ant/integration-tests.xml</elasticsearch.integ.antfile.default>
-        <elasticsearch.integ.antfile>${elasticsearch.integ.antfile.default}</elasticsearch.integ.antfile>
     </properties>
 
     <dependencies>
@@ -309,8 +307,7 @@
                             </goals>
                             <configuration>
                                 <target>
-                                    <ant antfile="${elasticsearch.integ.antfile}"
-                                         target="start-external-cluster-with-plugin"/>
+                                    <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster-with-plugin"/>
                                 </target>
                             </configuration>
                         </execution>
@@ -323,13 +320,9 @@
                             </goals>
                             <configuration>
                                 <target>
-                                    <ant antfile="${elasticsearch.integ.antfile}"
-                                         target="stop-external-cluster"/>
+                                    <ant antfile="${elasticsearch.integ.antfile}" target="stop-external-cluster"/>
                                     <!-- TODO: remove this and the xslt when junit4 is fixed -->
-                                    <xslt in="${project.build.directory}/failsafe-reports/failsafe-summary-buggy.xml" 
-                                          out="${project.build.directory}/failsafe-reports/failsafe-summary.xml" 
-                                          style="${elasticsearch.tools.directory}/ant/fixup-failsafe-summary.xslt">
-                                    </xslt>
+                                    <ant antfile="${elasticsearch.integ.antfile}" target="fixup-failsafe-summary"/>
                                 </target>
                             </configuration>
                         </execution>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -325,19 +325,15 @@
                                 <target>
                                     <ant antfile="${elasticsearch.integ.antfile}"
                                          target="stop-external-cluster"/>
+                                    <!-- TODO: remove this and the xslt when junit4 is fixed -->
+                                    <xslt in="${project.build.directory}/failsafe-reports/failsafe-summary-buggy.xml" 
+                                          out="${project.build.directory}/failsafe-reports/failsafe-summary.xml" 
+                                          style="${elasticsearch.tools.directory}/ant/fixup-failsafe-summary.xslt">
+                                    </xslt>
                                 </target>
                             </configuration>
                         </execution>
                     </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <configuration>
-                        <systemPropertyVariables>
-                            <tests.cluster>127.0.0.1:9300</tests.cluster>
-                        </systemPropertyVariables>
-                    </configuration>
                 </plugin>
         </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!-- libraries -->
         <lucene.version>5.2.1</lucene.version>
         <lucene.maven.version>5.2.1</lucene.maven.version>
-        <testframework.version>2.1.14</testframework.version>
+        <testframework.version>2.1.15</testframework.version>
         <jackson.version>2.5.3</jackson.version>
         <slf4j.version>1.6.2</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
@@ -477,6 +477,11 @@
                     <groupId>com.carrotsearch.randomizedtesting</groupId>
                     <artifactId>junit4-maven-plugin</artifactId>
                 </plugin>
+                <!-- we only use failsafe's "verify" right now -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
@@ -566,6 +571,116 @@
                     <groupId>com.carrotsearch.randomizedtesting</groupId>
                     <artifactId>junit4-maven-plugin</artifactId>
                     <version>${testframework.version}</version>
+                    <!-- general test configuration, used for both unit and integ tests -->
+                    <configuration>
+                        <jvm>${jvm.executable}</jvm>
+                        <argLine>${tests.jvm.argline}</argLine>
+                        <heartbeat>10</heartbeat>
+                        <jvmOutputAction>warn</jvmOutputAction>
+                        <leaveTemporary>true</leaveTemporary>
+                        <parallelism>${tests.jvms}</parallelism>
+                        <ifNoTests>${tests.ifNoTests}</ifNoTests>
+                        <report-execution-times historyLength="20" file="${basedir}/${execution.hint.file}"/>
+                        <assertions enableSystemAssertions="true">
+                            <enable/>
+                            <disable package="${tests.assertion.disabled}"/>
+                            <!-- pass org.elasticsearch to run without assertions -->
+                        </assertions>
+                        <balancers>
+                            <execution-times>
+                                <fileset dir="${basedir}" includes="${execution.hint.file}"/>
+                            </execution-times>
+                        </balancers>
+                        <jvmArgs>
+                            <param>-Xmx${tests.heap.size}</param>
+                            <param>-Xms${tests.heap.size}</param>
+                            <param>${java.permGenSpace}</param>
+                            <param>-XX:MaxDirectMemorySize=512m</param>
+                            <param>-Des.logger.prefix=</param>
+                            <param>-XX:+HeapDumpOnOutOfMemoryError</param>
+                            <param>-XX:HeapDumpPath=${tests.heapdump.path}</param>
+                        </jvmArgs>
+                        <shuffleOnSlave>${tests.shuffle}</shuffleOnSlave>
+                        <sysouts>${tests.verbose}</sysouts>
+                        <seed>${tests.seed}</seed>
+                        <!-- enforce unique suite names, or reporting stuff can be screwed up -->
+                        <uniqueSuiteNames>true</uniqueSuiteNames>
+                        <systemProperties>
+                            <!-- we use './temp' since this is per JVM and tests are forbidden from writing to CWD -->
+                            <java.io.tmpdir>./temp</java.io.tmpdir>
+                            <!-- RandomizedTesting library system properties -->
+                            <tests.bwc>${tests.bwc}</tests.bwc>
+                            <tests.bwc.path>${tests.bwc.path}</tests.bwc.path>
+                            <tests.bwc.version>${tests.bwc.version}</tests.bwc.version>
+                            <tests.jvm.argline>${tests.jvm.argline}</tests.jvm.argline>
+                            <tests.appendseed>${tests.appendseed}</tests.appendseed>
+                            <tests.cluster>${tests.cluster}</tests.cluster>
+                            <tests.iters>${tests.iters}</tests.iters>
+                            <tests.maxfailures>${tests.maxfailures}</tests.maxfailures>
+                            <tests.failfast>${tests.failfast}</tests.failfast>
+                            <tests.class>${tests.class}</tests.class>
+                            <tests.method>${tests.method}</tests.method>
+                            <tests.nightly>${tests.nightly}</tests.nightly>
+                            <tests.verbose>${tests.verbose}</tests.verbose>
+                            <tests.badapples>${tests.badapples}</tests.badapples>
+                            <tests.weekly>${tests.weekly}</tests.weekly>
+                            <haltOnFailure>${tests.failfast}</haltOnFailure>
+                            <tests.awaitsfix>${tests.awaitsfix}</tests.awaitsfix>
+                            <tests.slow>${tests.slow}</tests.slow>
+                            <tests.timeoutSuite>${tests.timeoutSuite}</tests.timeoutSuite>
+                            <tests.showSuccess>${tests.showSuccess}</tests.showSuccess>
+                            <tests.integration>${tests.integration}</tests.integration>
+                            <tests.thirdparty>${tests.thirdparty}</tests.thirdparty>
+                            <tests.config>${tests.config}</tests.config>
+                            <tests.client.ratio>${tests.client.ratio}</tests.client.ratio>
+                            <tests.enable_mock_modules>${tests.enable_mock_modules}</tests.enable_mock_modules>
+                            <tests.assertion.disabled>${tests.assertion.disabled}</tests.assertion.disabled>
+                            <tests.rest>${tests.rest}</tests.rest>
+                            <tests.rest.suite>${tests.rest.suite}</tests.rest.suite>
+                            <tests.rest.blacklist>${tests.rest.blacklist}</tests.rest.blacklist>
+                            <tests.rest.spec>${tests.rest.spec}</tests.rest.spec>
+                            <tests.network>${tests.network}</tests.network>
+                            <tests.heap.size>${tests.heap.size}</tests.heap.size>
+                            <tests.filter>${tests.filter}</tests.filter>
+                            <tests.version>${elasticsearch.version}</tests.version>
+                            <tests.locale>${tests.locale}</tests.locale>
+                            <tests.rest.load_packaged>${tests.rest.load_packaged}</tests.rest.load_packaged>
+                            <tests.timezone>${tests.timezone}</tests.timezone>
+                            <es.node.local>${env.ES_TEST_LOCAL}</es.node.local>
+                            <es.node.mode>${es.node.mode}</es.node.mode>
+                            <es.logger.level>${es.logger.level}</es.logger.level>
+                            <tests.security.manager>${tests.security.manager}</tests.security.manager>
+                            <tests.compatibility>${tests.compatibility}</tests.compatibility>
+                            <java.awt.headless>true</java.awt.headless>
+                            <!-- true if we are running tests from maven (as opposed to IDE, etc).
+                                 allows us to assert certain things work, like libsigar -->
+                            <tests.maven>true</tests.maven>
+                        </systemProperties>
+                        <listeners>
+                            <report-text
+                                    showThrowable="true"
+                                    showStackTraces="true"
+                                    showOutput="${tests.output}"
+                                    showStatusOk="false"
+                                    showStatusError="true"
+                                    showStatusFailure="true"
+                                    showStatusIgnored="true"
+                                    showSuiteSummary="true"
+                                    timestamps="false">
+                                <filtertrace>
+                                    <!-- custom filters: we carefully only omit test infra noise here -->
+                                    <containsstring contains=".SlaveMain." />
+                                    <containsregex pattern="^(\s+at )(org\.junit\.)" />
+                                    <!-- also includes anonymous classes inside these two: -->
+                                    <containsregex pattern="^(\s+at )(com\.carrotsearch\.randomizedtesting.RandomizedRunner)" />
+                                    <containsregex pattern="^(\s+at )(com\.carrotsearch\.randomizedtesting.ThreadLeakControl)" />
+                                    <containsregex pattern="^(\s+at )(com\.carrotsearch\.randomizedtesting.rules\.)" />
+                                    <containsregex pattern="^(\s+at )(org\.apache\.lucene.util\.TestRule)" />
+                                    <containsregex pattern="^(\s+at )(org\.apache\.lucene.util\.AbstractBeforeAfterRule)" />
+                                </filtertrace>
+                            </report-text>
+                        </listeners>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>tests</id>
@@ -574,51 +689,11 @@
                                 <goal>junit4</goal>
                             </goals>
                             <configuration>
-                                <jvm>${jvm.executable}</jvm>
-                                <argLine>${tests.jvm.argline}</argLine>
                                 <skipTests>${skip.unit.tests}</skipTests>
-                                <heartbeat>10</heartbeat>
-                                <jvmOutputAction>warn</jvmOutputAction>
-                                <leaveTemporary>true</leaveTemporary>
-                                <ifNoTests>${tests.ifNoTests}</ifNoTests>
                                 <listeners>
                                     <report-ant-xml mavenExtensions="true"
                                                     dir="${project.build.directory}/surefire-reports"/>
-                                    <report-text
-                                            showThrowable="true"
-                                            showStackTraces="true"
-                                            showOutput="${tests.output}"
-                                            showStatusOk="false"
-                                            showStatusError="true"
-                                            showStatusFailure="true"
-                                            showStatusIgnored="true"
-                                            showSuiteSummary="true"
-                                            timestamps="false">
-                                      <filtertrace>
-                                         <!-- custom filters: we carefully only omit test infra noise here -->
-                                         <containsstring contains=".SlaveMain." />
-                                         <containsregex pattern="^(\s+at )(org\.junit\.)" />
-                                         <!-- also includes anonymous classes inside these two: -->
-                                         <containsregex pattern="^(\s+at )(com\.carrotsearch\.randomizedtesting.RandomizedRunner)" />
-                                         <containsregex pattern="^(\s+at )(com\.carrotsearch\.randomizedtesting.ThreadLeakControl)" />
-                                         <containsregex pattern="^(\s+at )(com\.carrotsearch\.randomizedtesting.rules\.)" />
-                                         <containsregex pattern="^(\s+at )(org\.apache\.lucene.util\.TestRule)" />
-                                         <containsregex pattern="^(\s+at )(org\.apache\.lucene.util\.AbstractBeforeAfterRule)" />
-                                      </filtertrace>
-                                    </report-text>
-                                <report-execution-times historyLength="20" file="${basedir}/${execution.hint.file}"/>
                                 </listeners>
-                                <assertions enableSystemAssertions="true">
-                                    <enable/>
-                                    <disable package="${tests.assertion.disabled}"/>
-                                    <!-- pass org.elasticsearch to run without assertions -->
-                                </assertions>
-                                <parallelism>${tests.jvms}</parallelism>
-                                <balancers>
-                                    <execution-times>
-                                        <fileset dir="${basedir}" includes="${execution.hint.file}"/>
-                                    </execution-times>
-                                </balancers>
                                 <includes>
                                     <include>**/*Tests.class</include>
                                     <include>**/*Test.class</include>
@@ -627,70 +702,33 @@
                                     <exclude>**/Abstract*.class</exclude>
                                     <exclude>**/*StressTest.class</exclude>
                                 </excludes>
-                                <jvmArgs>
-                                    <param>-Xmx${tests.heap.size}</param>
-                                    <param>-Xms${tests.heap.size}</param>
-                                    <param>${java.permGenSpace}</param>
-                                    <param>-XX:MaxDirectMemorySize=512m</param>
-                                    <param>-Des.logger.prefix=</param>
-                                    <param>-XX:+HeapDumpOnOutOfMemoryError</param>
-                                    <param>-XX:HeapDumpPath=${tests.heapdump.path}</param>
-                                </jvmArgs>
-                                <shuffleOnSlave>${tests.shuffle}</shuffleOnSlave>
-                                <sysouts>${tests.verbose}</sysouts>
-                                <seed>${tests.seed}</seed>
-                                <haltOnFailure>${tests.failfast}</haltOnFailure>
-                                <!-- enforce unique suite names, or reporting stuff can be screwed up -->
-                                <uniqueSuiteNames>true</uniqueSuiteNames>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>integ-tests</id>
+                            <phase>integration-test</phase>
+                            <goals>
+                                <goal>junit4</goal>
+                            </goals>
+                            <configuration>
+                                <haltOnFailure>false</haltOnFailure>
+                                <skipTests>${skip.integ.tests}</skipTests>
+                                <listeners>
+                                    <report-ant-xml 
+                                        mavenExtensions="true" 
+                                        summaryFile="${project.build.directory}/failsafe-reports/failsafe-summary-buggy.xml"
+                                        dir="${project.build.directory}/failsafe-reports"/>
+                                </listeners>
+                                <!-- currently only 1 cpu works, because integ tests don't make "unique" test directories? -->
+                                <parallelism>1</parallelism>
+                                <includes>
+                                    <include>**/*IT.class</include>
+                                </includes>
                                 <systemProperties>
-                                    <!-- we use './temp' since this is per JVM and tests are forbidden from writing to CWD -->
-                                    <java.io.tmpdir>./temp</java.io.tmpdir>
-                                    <!-- RandomizedTesting library system properties -->
-                                    <tests.bwc>${tests.bwc}</tests.bwc>
-                                    <tests.bwc.path>${tests.bwc.path}</tests.bwc.path>
-                                    <tests.bwc.version>${tests.bwc.version}</tests.bwc.version>
-                                    <tests.jvm.argline>${tests.jvm.argline}</tests.jvm.argline>
-                                    <tests.appendseed>${tests.appendseed}</tests.appendseed>
-                                    <tests.iters>${tests.iters}</tests.iters>
-                                    <tests.maxfailures>${tests.maxfailures}</tests.maxfailures>
-                                    <tests.failfast>${tests.failfast}</tests.failfast>
-                                    <tests.class>${tests.class}</tests.class>
-                                    <tests.method>${tests.method}</tests.method>
-                                    <tests.nightly>${tests.nightly}</tests.nightly>
-                                    <tests.verbose>${tests.verbose}</tests.verbose>
-                                    <tests.badapples>${tests.badapples}</tests.badapples>
-                                    <tests.weekly>${tests.weekly}</tests.weekly>
-                                    <tests.awaitsfix>${tests.awaitsfix}</tests.awaitsfix>
-                                    <tests.slow>${tests.slow}</tests.slow>
-                                    <tests.timeoutSuite>${tests.timeoutSuite}</tests.timeoutSuite>
-                                    <tests.showSuccess>${tests.showSuccess}</tests.showSuccess>
-                                    <tests.integration>${tests.integration}</tests.integration>
-                                    <tests.thirdparty>${tests.thirdparty}</tests.thirdparty>
-                                    <tests.config>${tests.config}</tests.config>
-                                    <tests.client.ratio>${tests.client.ratio}</tests.client.ratio>
-                                    <tests.enable_mock_modules>${tests.enable_mock_modules}</tests.enable_mock_modules>
-                                    <tests.assertion.disabled>${tests.assertion.disabled}</tests.assertion.disabled>
-                                    <tests.rest>${tests.rest}</tests.rest>
-                                    <tests.rest.suite>${tests.rest.suite}</tests.rest.suite>
-                                    <tests.rest.blacklist>${tests.rest.blacklist}</tests.rest.blacklist>
-                                    <tests.rest.spec>${tests.rest.spec}</tests.rest.spec>
-                                    <tests.network>${tests.network}</tests.network>
-                                    <tests.cluster>${tests.cluster}</tests.cluster>
-                                    <tests.heap.size>${tests.heap.size}</tests.heap.size>
-                                    <tests.filter>${tests.filter}</tests.filter>
-                                    <tests.version>${elasticsearch.version}</tests.version>
-                                    <tests.locale>${tests.locale}</tests.locale>
-                                    <tests.rest.load_packaged>${tests.rest.load_packaged}</tests.rest.load_packaged>
-                                    <tests.timezone>${tests.timezone}</tests.timezone>
-                                    <es.node.local>${env.ES_TEST_LOCAL}</es.node.local>
-                                    <es.node.mode>${es.node.mode}</es.node.mode>
-                                    <es.logger.level>${es.logger.level}</es.logger.level>
-                                    <tests.security.manager>${tests.security.manager}</tests.security.manager>
-                                    <tests.compatibility>${tests.compatibility}</tests.compatibility>
-                                    <java.awt.headless>true</java.awt.headless>
-                                    <!-- true if we are running tests from maven (as opposed to IDE, etc).
-                                         allows us to assert certain things work, like libsigar -->
-                                    <tests.maven>true</tests.maven>
+                                    <!-- integ tests are typically slow! -->
+                                    <tests.slow>true</tests.slow>
+                                    <!-- use external cluster -->
+                                    <tests.cluster>127.0.0.1:9300</tests.cluster>
                                 </systemProperties>
                             </configuration>
                         </execution>
@@ -709,25 +747,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.18.1</version>
-                    <configuration>
-                       <skipTests>${skip.integ.tests}</skipTests>
-                       <systemPropertyVariables>
-                           <es.logger.level>${es.logger.level}</es.logger.level>
-                           <tests.rest.suite>${tests.rest.suite}</tests.rest.suite>
-                           <tests.rest.blacklist>${tests.rest.blacklist}</tests.rest.blacklist>
-                           <tests.rest.spec>${tests.rest.spec}</tests.rest.spec>
-                           <tests.rest.load_packaged>${tests.rest.load_packaged}</tests.rest.load_packaged>
-                           <java.io.tmpdir>${integ.temp}</java.io.tmpdir>
-                           <tests.security.manager>false</tests.security.manager>
-                       </systemPropertyVariables>
-                    </configuration>
                     <executions>
-                        <execution>
-                            <id>integration-test</id>
-                            <goals>
-                                <goal>integration-test</goal>
-                            </goals>
-                        </execution>
                         <execution>
                             <id>verify</id>
                             <goals>
@@ -735,13 +755,6 @@
                             </goals>
                         </execution>
                     </executions>
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>2.18.1</version>
-                      </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,8 @@
         <elasticsearch.thirdparty.config>unshaded</elasticsearch.thirdparty.config>
         <elasticsearch.license.header>${elasticsearch.tools.directory}/license-check/elasticsearch_license_header.txt</elasticsearch.license.header>
         <elasticsearch.license.headerDefinition>${elasticsearch.tools.directory}/license-check/license_header_definition.xml</elasticsearch.license.headerDefinition>
+        <elasticsearch.integ.antfile.default>${elasticsearch.tools.directory}/ant/integration-tests.xml</elasticsearch.integ.antfile.default>
+        <elasticsearch.integ.antfile>${elasticsearch.integ.antfile.default}</elasticsearch.integ.antfile>
 
         <!-- Test properties -->
         <tests.jvms>auto</tests.jvms>


### PR DESCRIPTION
failsafe uses surefire, which sucks. It also mean integ tests act alien right now.
I would rather have the consistency, e.g. things formatted the same way, running integ tests under security manager, etc.

@dweiss nicely added the summary file that failsafe expects to junit4. However it does have bug in the formatting, so we use an xslt hack as a temporary measure!
