### PR TITLE
Update Netty to version 3.10.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.10.0.Final</version>
+                <version>3.10.3.Final</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
There a version mismatch between master (previously 3.10.0.Final) and 1.7 branch (3.10.3.Final)
