### PR TITLE
Make sure filter is correctly parsed for multi-term vectors

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -167,6 +167,7 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
         this.version = other.version();
         this.versionType = VersionType.fromValue(other.versionType().getValue());
         this.startTime = other.startTime();
+        this.filterSettings = other.filterSettings();
     }
 
     public TermVectorsRequest(MultiGetRequest.Item item) {

--- a/core/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
@@ -302,8 +302,8 @@ public class TermVectorsUnitTests extends ElasticsearchTestCase {
         request = new MultiTermVectorsRequest();
         request.add(new TermVectorsRequest(), bytes);
         checkParsedParameters(request);
-        
     }
+
     void checkParsedParameters(MultiTermVectorsRequest request) {
         Set<String> ids = new HashSet<>();
         ids.add("1");
@@ -324,5 +324,31 @@ public class TermVectorsUnitTests extends ElasticsearchTestCase {
             assertThat(singleRequest.selectedFields(), equalTo(fields));
         }
     }
-    
+
+    @Test // issue #12311
+    public void testMultiParserFilter() throws Exception {
+        byte[] data = Streams.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest3.json");
+        BytesReference bytes = new BytesArray(data);
+        MultiTermVectorsRequest request = new MultiTermVectorsRequest();
+        request.add(new TermVectorsRequest(), bytes);
+        checkParsedFilterParameters(request);
+    }
+
+    void checkParsedFilterParameters(MultiTermVectorsRequest multiRequest) {
+        int id = 1;
+        for (TermVectorsRequest request : multiRequest.requests) {
+            assertThat(request.index(), equalTo("testidx"));
+            assertThat(request.type(), equalTo("test"));
+            assertThat(request.id(), equalTo(id+""));
+            assertNotNull(request.filterSettings());
+            assertThat(request.filterSettings().maxNumTerms, equalTo(20));
+            assertThat(request.filterSettings().minTermFreq, equalTo(1));
+            assertThat(request.filterSettings().maxTermFreq, equalTo(20));
+            assertThat(request.filterSettings().minDocFreq, equalTo(1));
+            assertThat(request.filterSettings().maxDocFreq, equalTo(20));
+            assertThat(request.filterSettings().minWordLength, equalTo(1));
+            assertThat(request.filterSettings().maxWordLength, equalTo(20));
+            id++;
+        }
+    }
 }

--- a/core/src/test/java/org/elasticsearch/action/termvectors/multiRequest3.json
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/multiRequest3.json
@@ -1,0 +1,16 @@
+{
+   "ids": ["1","2"],
+   "parameters": {
+      "_index": "testidx",
+      "_type": "test",
+      "filter": {
+         "max_num_terms": 20,
+         "min_term_freq": 1,
+         "max_term_freq": 20,
+         "min_doc_freq": 1,
+         "max_doc_freq": 20,
+         "min_word_length": 1,
+         "max_word_length": 20
+      }
+   }
+}


### PR DESCRIPTION
This makes sure the `filter` parameter is correctly parsed in a multi-term
vector request when using `ids` and `parameters`.

Closes #12311
