### PR TITLE
Create a directory during repository verification

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -221,10 +221,10 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
 
     @Override
     public void verify(String seed) {
-        BlobContainer testBlobContainer = blobStore.blobContainer(basePath);
+        BlobContainer testBlobContainer = blobStore.blobContainer(basePath.add(testBlobPrefix(seed)));
         DiscoveryNode localNode = clusterService.localNode();
-        if (testBlobContainer.blobExists(testBlobPrefix(seed) + "-master")) {
-            try (OutputStream outputStream = testBlobContainer.createOutput(testBlobPrefix(seed) + "-" + localNode.getId())) {
+        if (testBlobContainer.blobExists("master.dat")) {
+            try (OutputStream outputStream = testBlobContainer.createOutput("data-" + localNode.getId() + ".dat")) {
                 outputStream.write(Strings.toUTF8Bytes(seed));
             } catch (IOException exp) {
                 throw new RepositoryVerificationException(repositoryName, "store location [" + blobStore + "] is not accessible on the node [" + localNode + "]", exp);

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -624,12 +624,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
         try {
             String seed = Strings.randomBase64UUID();
             byte[] testBytes = Strings.toUTF8Bytes(seed);
-            String blobName = testBlobPrefix(seed) + "-master";
-            try (OutputStream outputStream = snapshotsBlobContainer.createOutput(blobName + "-temp")) {
+            BlobContainer testContainer = blobStore().blobContainer(basePath().add(testBlobPrefix(seed)));
+            String blobName = "master.dat";
+            try (OutputStream outputStream = testContainer.createOutput(blobName + "-temp")) {
                 outputStream.write(testBytes);
             }
             // Make sure that move is supported
-            snapshotsBlobContainer.move(blobName + "-temp", blobName);
+            testContainer.move(blobName + "-temp", blobName);
             return seed;
         } catch (IOException exp) {
             throw new RepositoryVerificationException(repositoryName, "path " + basePath() + " is not accessible on master node", exp);
@@ -639,7 +640,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
     @Override
     public void endVerification(String seed) {
         try {
-            snapshotsBlobContainer.deleteBlobsByPrefix(testBlobPrefix(seed));
+            blobStore().delete(basePath().add(testBlobPrefix(seed)));
         } catch (IOException exp) {
             throw new RepositoryVerificationException(repositoryName, "cannot delete test data at " + basePath(), exp);
         }


### PR DESCRIPTION
The repository verification process should create a subdirectory to make sure we check permission of newly created directories in case elasticsearch processes on different nodes are running using different uids and creating blobs with incompatible permissions.

Closes #11611
