### PR TITLE
[build] Update to maven-shade-plugin 2.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -870,7 +870,7 @@
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>2.4.1</version>
                 </plugin>
                 <plugin>
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->


### PR DESCRIPTION
``` xml
<plugin>
 <groupId>org.apache.maven.plugins</groupId>
 <artifactId>maven-shade-plugin</artifactId>
 <version>2.4.1</version>
</plugin>
```
## Release Notes - Maven Shade Plugin - Version 2.4.1

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317921&version=12332978

Bugs:
- [MSHADE-148] - Shade Plugin gets stuck in infinite loop building dependency reduced POM
- [MSHADE-194] - Reporting uses maven-invoker-plugin version 1.9 instead of 1.10
