### PR TITLE
Simplify handling of ignored unassigned shards

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -52,9 +52,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     private final Map<String, RoutingNode> nodesToShards = newHashMap();
 
-    private final UnassignedShards unassignedShards = new UnassignedShards();
-
-    private final List<ShardRouting> ignoredUnassignedShards = newArrayList();
+    private final UnassignedShards unassignedShards = new UnassignedShards(this);
 
     private final Map<ShardId, List<ShardRouting>> assignedShards = newHashMap();
 
@@ -183,10 +181,6 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     public boolean hasUnassigned() {
         return !unassignedShards.isEmpty();
-    }
-
-    public List<ShardRouting> ignoredUnassigned() {
-        return this.ignoredUnassignedShards;
     }
 
     public UnassignedShards unassigned() {
@@ -526,9 +520,11 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     }
 
-    public final static class UnassignedShards implements Iterable<ShardRouting>  {
+    public static final class UnassignedShards implements Iterable<ShardRouting>  {
 
+        private final RoutingNodes nodes;
         private final List<ShardRouting> unassigned;
+        private final List<ShardRouting> ignored;
 
         private int primaries = 0;
         private long transactionId = 0;
@@ -536,14 +532,18 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         private final long sourceTransactionId;
 
         public UnassignedShards(UnassignedShards other) {
+            this.nodes = other.nodes;
             source = other;
             sourceTransactionId = other.transactionId;
             unassigned = new ArrayList<>(other.unassigned);
+            ignored = new ArrayList<>(other.ignored);
             primaries = other.primaries;
         }
 
-        public UnassignedShards() {
+        public UnassignedShards(RoutingNodes nodes) {
+            this.nodes = nodes;
             unassigned = new ArrayList<>();
+            ignored = new ArrayList<>();
             source = null;
             sourceTransactionId = -1;
         }
@@ -554,12 +554,6 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             }
             unassigned.add(shardRouting);
             transactionId++;
-        }
-
-        public void addAll(Collection<ShardRouting> mutableShardRoutings) {
-            for (ShardRouting r : mutableShardRoutings) {
-                add(r);
-            }
         }
 
         public void sort(Comparator<ShardRouting> comparator) {
@@ -575,29 +569,87 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         }
 
         @Override
-        public Iterator<ShardRouting> iterator() {
-            final Iterator<ShardRouting> iterator = unassigned.iterator();
-            return new Iterator<ShardRouting>() {
-                private ShardRouting current;
-                @Override
-                public boolean hasNext() {
-                    return iterator.hasNext();
-                }
+        public UnassignedIterator iterator() {
+            return new UnassignedIterator();
+        }
 
-                @Override
-                public ShardRouting next() {
-                    return current = iterator.next();
-                }
+        /**
+         * The list of ignored unassigned shards (read only). The ignored unassigned shards
+         * are not part of the formal unassigned list, but are kept around and used to build
+         * back the list of unassigned shards as part of the routing table.
+         */
+        public List<ShardRouting> ignored() {
+            return Collections.unmodifiableList(ignored);
+        }
 
-                @Override
-                public void remove() {
-                    iterator.remove();
-                    if (current.primary()) {
-                        primaries--;
-                    }
-                    transactionId++;
+        /**
+         * Adds a shard to the ignore unassigned list. Should be used with caution, typically,
+         * the correct usage is to removeAndIgnore from the iterator.
+         */
+        public void ignoreShard(ShardRouting shard) {
+            ignored.add(shard);
+            transactionId++;
+        }
+
+        public class UnassignedIterator implements Iterator<ShardRouting> {
+
+            private final Iterator<ShardRouting> iterator;
+            private ShardRouting current;
+
+            public UnassignedIterator() {
+                this.iterator = unassigned.iterator();
+            }
+
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public ShardRouting next() {
+                return current = iterator.next();
+            }
+
+            /**
+             * Initializes the current unassigned shard and moves it from the unassigned list.
+             */
+            public void initialize(String nodeId) {
+                initialize(nodeId, current.version());
+            }
+
+            /**
+             * Initializes the current unassigned shard and moves it from the unassigned list.
+             */
+            public void initialize(String nodeId, long version) {
+                innerRemove();
+                nodes.initialize(new ShardRouting(current, version), nodeId);
+            }
+
+            /**
+             * Removes and ignores the unassigned shard (will be ignored for this run, but
+             * will be added back to unassigned once the metadata is constructed again).
+             */
+            public void removeAndIgnore() {
+                innerRemove();
+                ignoreShard(current);
+            }
+
+            /**
+             * Unsupported operation, just there for the interface. Use {@link #removeAndIgnore()} or
+             * {@link #initialize(String)}.
+             */
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("remove is not supported in unassigned iterator, use removeAndIgnore or initialize");
+            }
+
+            private void innerRemove() {
+                iterator.remove();
+                if (current.primary()) {
+                    primaries--;
                 }
-            };
+                transactionId++;
+            }
         }
 
         public boolean isEmpty() {
@@ -611,16 +663,19 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         public void clear() {
             transactionId++;
             unassigned.clear();
+            ignored.clear();
             primaries = 0;
         }
 
         public void transactionEnd(UnassignedShards shards) {
-           assert shards.source == this && shards.sourceTransactionId == transactionId :
-                   "Expected ID: " + shards.sourceTransactionId + " actual: " + transactionId + " Expected Source: " + shards.source + " actual: " + this;
-           transactionId++;
-           this.unassigned.clear();
-           this.unassigned.addAll(shards.unassigned);
-           this.primaries = shards.primaries;
+            assert shards.source == this && shards.sourceTransactionId == transactionId :
+                    "Expected ID: " + shards.sourceTransactionId + " actual: " + transactionId + " Expected Source: " + shards.source + " actual: " + this;
+            transactionId++;
+            this.unassigned.clear();
+            this.unassigned.addAll(shards.unassigned);
+            this.ignored.clear();
+            this.ignored.addAll(shards.ignored);
+            this.primaries = shards.primaries;
         }
 
         public UnassignedShards transactionBegin() {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -362,7 +362,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                     indexBuilder.addShard(refData, shardRoutingEntry);
                 }
             }
-            for (ShardRouting shardRoutingEntry : Iterables.concat(routingNodes.unassigned(), routingNodes.ignoredUnassigned())) {
+            for (ShardRouting shardRoutingEntry : Iterables.concat(routingNodes.unassigned(), routingNodes.unassigned().ignored())) {
                 String index = shardRoutingEntry.index();
                 IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index);
                 if (indexBuilder == null) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -460,22 +460,6 @@ public class AllocationService extends AbstractComponent {
                 }
             }
 
-            // move all the shards matching the failed shard to the end of the unassigned list
-            // so we give a chance for other allocations and won't create poison failed allocations
-            // that can keep other shards from being allocated (because of limits applied on how many
-            // shards we can start per node)
-            List<ShardRouting> shardsToMove = Lists.newArrayList();
-            for (Iterator<ShardRouting> unassignedIt = routingNodes.unassigned().iterator(); unassignedIt.hasNext(); ) {
-                ShardRouting unassignedShardRouting = unassignedIt.next();
-                if (unassignedShardRouting.shardId().equals(failedShard.shardId())) {
-                    unassignedIt.remove();
-                    shardsToMove.add(unassignedShardRouting);
-                }
-            }
-            if (!shardsToMove.isEmpty()) {
-                routingNodes.unassigned().addAll(shardsToMove);
-            }
-
             matchedNode.moveToUnassigned(unassignedInfo);
         }
         assert matchedNode.isRemoved() : "failedShard " + failedShard + " was matched but wasn't removed";

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateAllocationCommand.java
@@ -220,12 +220,11 @@ public class AllocateAllocationCommand implements AllocationCommand {
             throw new IllegalArgumentException("[allocate] allocation of " + shardId + " on node " + discoNode + " is not allowed, reason: " + decision);
         }
         // go over and remove it from the unassigned
-        for (Iterator<ShardRouting> it = routingNodes.unassigned().iterator(); it.hasNext(); ) {
+        for (RoutingNodes.UnassignedShards.UnassignedIterator it = routingNodes.unassigned().iterator(); it.hasNext(); ) {
             if (it.next() != shardRouting) {
                 continue;
             }
-            it.remove();
-            routingNodes.initialize(shardRouting, routingNode.nodeId());
+            it.initialize(routingNode.nodeId());
             if (shardRouting.primary()) {
                 // we need to clear the post allocation flag, since its an explicit allocation of the primary shard
                 // and we want to force allocate it (and create a new index for it)

--- a/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -77,8 +77,8 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders());
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(1));
-        assertThat(allocation.routingNodes().ignoredUnassigned().get(0).shardId(), equalTo(shardId));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
     }
 
     /**
@@ -90,8 +90,8 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         testAllocator.addData(node1, -1);
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(1));
-        assertThat(allocation.routingNodes().ignoredUnassigned().get(0).shardId(), equalTo(shardId));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
     }
 
     /**
@@ -103,8 +103,8 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         testAllocator.addData(node1, 3, new CorruptIndexException("test", "test"));
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(1));
-        assertThat(allocation.routingNodes().ignoredUnassigned().get(0).shardId(), equalTo(shardId));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
     }
 
     /**
@@ -116,7 +116,7 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         testAllocator.addData(node1, 10);
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(true));
-        assertThat(allocation.routingNodes().ignoredUnassigned().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node1.id()));
     }
@@ -131,8 +131,8 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         testAllocator.addData(node1, 10);
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(1));
-        assertThat(allocation.routingNodes().ignoredUnassigned().get(0).shardId(), equalTo(shardId));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
     }
 
     /**
@@ -145,7 +145,7 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         testAllocator.addData(node1, 10);
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(true));
-        assertThat(allocation.routingNodes().ignoredUnassigned().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node1.id()));
     }
@@ -159,7 +159,7 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         testAllocator.addData(node1, 10).addData(node2, 12);
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(true));
-        assertThat(allocation.routingNodes().ignoredUnassigned().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node2.id()));
     }
@@ -185,7 +185,7 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         testAllocator.addData(node1, -1).addData(node2, -1);
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().isEmpty(), equalTo(true));
+        assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(true));
     }
 
     /**
@@ -208,23 +208,23 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         RoutingAllocation allocation = new RoutingAllocation(yesAllocationDeciders(), state.routingNodes(), state.nodes(), null);
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(1));
-        assertThat(allocation.routingNodes().ignoredUnassigned().get(0).shardId(), equalTo(shardId));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
 
         testAllocator.addData(node1, 1);
         allocation = new RoutingAllocation(yesAllocationDeciders(), state.routingNodes(), state.nodes(), null);
         changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(1));
-        assertThat(allocation.routingNodes().ignoredUnassigned().get(0).shardId(), equalTo(shardId));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
 
         testAllocator.addData(node2, 1);
         allocation = new RoutingAllocation(yesAllocationDeciders(), state.routingNodes(), state.nodes(), null);
         changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(true));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(0));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(0));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), anyOf(equalTo(node2.id()), equalTo(node1.id())));
@@ -250,23 +250,23 @@ public class PrimaryShardAllocatorTests extends ElasticsearchAllocationTestCase 
         RoutingAllocation allocation = new RoutingAllocation(yesAllocationDeciders(), state.routingNodes(), state.nodes(), null);
         boolean changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(1));
-        assertThat(allocation.routingNodes().ignoredUnassigned().get(0).shardId(), equalTo(shardId));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
 
         testAllocator.addData(node1, 1);
         allocation = new RoutingAllocation(yesAllocationDeciders(), state.routingNodes(), state.nodes(), null);
         changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(false));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(1));
-        assertThat(allocation.routingNodes().ignoredUnassigned().get(0).shardId(), equalTo(shardId));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(1));
+        assertThat(allocation.routingNodes().unassigned().ignored().get(0).shardId(), equalTo(shardId));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
 
         testAllocator.addData(node2, 2);
         allocation = new RoutingAllocation(yesAllocationDeciders(), state.routingNodes(), state.nodes(), null);
         changed = testAllocator.allocateUnassigned(allocation);
         assertThat(changed, equalTo(true));
-        assertThat(allocation.routingNodes().ignoredUnassigned().size(), equalTo(0));
+        assertThat(allocation.routingNodes().unassigned().ignored().size(), equalTo(0));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(2)); // replicas
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
         assertThat(allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING).get(0).currentNodeId(), equalTo(node2.id()));

--- a/core/src/test/java/org/elasticsearch/gateway/PriorityComparatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PriorityComparatorTests.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class PriorityComparatorTests extends ElasticsearchTestCase {
 
     public void testPriorityComparatorSort() {
-        RoutingNodes.UnassignedShards shards = new RoutingNodes.UnassignedShards();
+        RoutingNodes.UnassignedShards shards = new RoutingNodes.UnassignedShards((RoutingNodes) null);
         int numIndices = randomIntBetween(3, 99);
         IndexMeta[] indices = new IndexMeta[numIndices];
         final Map<String, IndexMeta> map = new HashMap<>();


### PR DESCRIPTION
Fold ignored unassigned to a UnassignedShards and have simpler handling of them. Also remove the trappy way of adding an ignored unassigned shards today directly to the list, and have dedicated methods for it.
