### PR TITLE
Query refactoring: SpanOrQueryBuilder and Parser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * Doesn't support conversion to {@link org.elasticsearch.common.xcontent.XContent} via {@link #doXContent(XContentBuilder, Params)}.
  */
 //norelease to be removed once all queries support separate fromXContent and toQuery methods. Make AbstractQueryBuilder#toQuery final as well then.
-public class QueryWrappingQueryBuilder extends AbstractQueryBuilder<QueryWrappingQueryBuilder> implements MultiTermQueryBuilder<QueryWrappingQueryBuilder> {
+public class QueryWrappingQueryBuilder extends AbstractQueryBuilder<QueryWrappingQueryBuilder> implements SpanQueryBuilder<QueryWrappingQueryBuilder>, MultiTermQueryBuilder<QueryWrappingQueryBuilder>{
 
     private Query query;
 

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -19,22 +19,36 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanOrQuery;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder> implements SpanQueryBuilder<SpanOrQueryBuilder> {
 
     public static final String NAME = "span_or";
 
-    private ArrayList<SpanQueryBuilder> clauses = new ArrayList<>();
+    private final ArrayList<SpanQueryBuilder> clauses = new ArrayList<>();
 
     static final SpanOrQueryBuilder PROTOTYPE = new SpanOrQueryBuilder();
 
     public SpanOrQueryBuilder clause(SpanQueryBuilder clause) {
-        clauses.add(clause);
+        clauses.add(Objects.requireNonNull(clause));
         return this;
+    }
+
+    /**
+     * @return the {@link SpanQueryBuilder} clauses that were set for this query
+     */
+    public List<SpanQueryBuilder> clauses() {
+        return this.clauses;
     }
 
     @Override
@@ -50,6 +64,55 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
         builder.endArray();
         printBoostAndQueryName(builder);
         builder.endObject();
+    }
+
+    @Override
+    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+        SpanQuery[] spanQueries = new SpanQuery[clauses.size()];
+        for (int i = 0; i < clauses.size(); i++) {
+            Query query = clauses.get(i).toQuery(parseContext);
+            assert query instanceof SpanQuery;
+            spanQueries[i] = (SpanQuery) query;
+        }
+        return new SpanOrQuery(spanQueries);
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        QueryValidationException validationExceptions = null;
+        if (clauses.isEmpty()) {
+            validationExceptions =  addValidationError("query must include [clauses]", validationExceptions);
+        }
+        for (SpanQueryBuilder innerClause : clauses) {
+            validationExceptions = validateInnerQuery(innerClause, validationExceptions);
+        }
+        return validationExceptions;
+    }
+
+    @Override
+    protected SpanOrQueryBuilder doReadFrom(StreamInput in) throws IOException {
+        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder();
+        List<SpanQueryBuilder> clauses = in.readNamedWriteableList();
+        for (SpanQueryBuilder subClause : clauses) {
+            queryBuilder.clause(subClause);
+        }
+        return queryBuilder;
+
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteableList(clauses);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(clauses);
+    }
+
+    @Override
+    protected boolean doEquals(SpanOrQueryBuilder other) {
+        return Objects.equals(clauses, other.clauses);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -56,9 +56,6 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        if (clauses.isEmpty()) {
-            throw new IllegalArgumentException("Must have at least one clause when building a spanOr query");
-        }
         builder.startObject(NAME);
         builder.startArray("clauses");
         for (SpanQueryBuilder clause : clauses) {

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -31,6 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Span query that matches the union of its clauses. Maps to {@link SpanOrQuery}.
+ */
 public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder> implements SpanQueryBuilder<SpanOrQueryBuilder> {
 
     public static final String NAME = "span_or";

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -28,14 +27,7 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 
-/**
- *
- */
 public class SpanOrQueryParser extends BaseQueryParser {
-
-    @Inject
-    public SpanOrQueryParser() {
-    }
 
     @Override
     public String[] names() {

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.spans.SpanOrQuery;
-import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -34,7 +31,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  *
  */
-public class SpanOrQueryParser extends BaseQueryParserTemp {
+public class SpanOrQueryParser extends BaseQueryParser {
 
     @Inject
     public SpanOrQueryParser() {
@@ -46,13 +43,13 @@ public class SpanOrQueryParser extends BaseQueryParserTemp {
     }
 
     @Override
-    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String queryName = null;
 
-        List<SpanQuery> clauses = newArrayList();
+        List<SpanQueryBuilder> clauses = newArrayList();
 
         String currentFieldName = null;
         XContentParser.Token token;
@@ -62,11 +59,11 @@ public class SpanOrQueryParser extends BaseQueryParserTemp {
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("clauses".equals(currentFieldName)) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        Query query = parseContext.parseInnerQuery();
-                        if (!(query instanceof SpanQuery)) {
+                        QueryBuilder query = parseContext.parseInnerQueryBuilder();
+                        if (!(query instanceof SpanQueryBuilder)) {
                             throw new QueryParsingException(parseContext, "spanOr [clauses] must be of type span query");
                         }
-                        clauses.add((SpanQuery) query);
+                        clauses.add((SpanQueryBuilder) query);
                     }
                 } else {
                     throw new QueryParsingException(parseContext, "[span_or] query does not support [" + currentFieldName + "]");
@@ -85,12 +82,13 @@ public class SpanOrQueryParser extends BaseQueryParserTemp {
             throw new QueryParsingException(parseContext, "spanOr must include [clauses]");
         }
 
-        SpanOrQuery query = new SpanOrQuery(clauses.toArray(new SpanQuery[clauses.size()]));
-        query.setBoost(boost);
-        if (queryName != null) {
-            parseContext.addNamedQuery(queryName, query);
+        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder();
+        for (SpanQueryBuilder clause : clauses) {
+            queryBuilder.clause(clause);
         }
-        return query;
+        queryBuilder.boost(boost);
+        queryBuilder.queryName(queryName);
+        return queryBuilder;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -322,4 +322,20 @@ public abstract class BaseQueryTestCase<QB extends AbstractQueryBuilder<QB>> ext
             assertThat(queryValidationException, nullValue());
         }
     }
+
+    /**
+     * create a random value for either {@link BaseQueryTestCase#BOOLEAN_FIELD_NAME}, {@link BaseQueryTestCase#INT_FIELD_NAME},
+     * {@link BaseQueryTestCase#DOUBLE_FIELD_NAME} or {@link BaseQueryTestCase#STRING_FIELD_NAME}, or a String value by default
+     */
+    protected static Object randomValueForField(String fieldName) {
+        Object value;
+        switch (fieldName) {
+            case BOOLEAN_FIELD_NAME: value = randomBoolean(); break;
+            case INT_FIELD_NAME: value = randomInt(); break;
+            case DOUBLE_FIELD_NAME: value = randomDouble(); break;
+            case STRING_FIELD_NAME: value = randomAsciiOfLengthBetween(1, 10); break;
+            default : value = randomAsciiOfLengthBetween(1, 10);
+        }
+        return value;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
@@ -37,11 +37,8 @@ public class SpanContainingQueryBuilderTest extends BaseQueryTestCase<SpanContai
 
     @Override
     protected SpanContainingQueryBuilder doCreateTestQueryBuilder() {
-        SpanTermQueryBuilder bigQuery = new SpanTermQueryBuilderTest().createTestQueryBuilder();
-        // we need same field name and value type as bigQuery for little query
-        String fieldName = bigQuery.fieldName();
-        SpanTermQueryBuilder littleQuery = new SpanTermQueryBuilder(fieldName, randomValueForField(fieldName));
-        return new SpanContainingQueryBuilder(bigQuery, littleQuery);
+        SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(2);
+        return new SpanContainingQueryBuilder(spanTermQueries[0], spanTermQueries[1]);
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
@@ -40,15 +40,7 @@ public class SpanContainingQueryBuilderTest extends BaseQueryTestCase<SpanContai
         SpanTermQueryBuilder bigQuery = new SpanTermQueryBuilderTest().createTestQueryBuilder();
         // we need same field name and value type as bigQuery for little query
         String fieldName = bigQuery.fieldName();
-        Object littleValue;
-        switch (fieldName) {
-            case BOOLEAN_FIELD_NAME: littleValue = randomBoolean(); break;
-            case INT_FIELD_NAME: littleValue = randomInt(); break;
-            case DOUBLE_FIELD_NAME: littleValue = randomDouble(); break;
-            case STRING_FIELD_NAME: littleValue = randomAsciiOfLengthBetween(1, 10); break;
-            default : littleValue = randomAsciiOfLengthBetween(1, 10);
-        }
-        SpanTermQueryBuilder littleQuery = new SpanTermQueryBuilder(fieldName, littleValue);
+        SpanTermQueryBuilder littleQuery = new SpanTermQueryBuilder(fieldName, randomValueForField(fieldName));
         return new SpanContainingQueryBuilder(bigQuery, littleQuery);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTest.java
@@ -36,8 +36,8 @@ public class SpanFirstQueryBuilderTest extends BaseQueryTestCase<SpanFirstQueryB
 
     @Override
     protected SpanFirstQueryBuilder doCreateTestQueryBuilder() {
-        SpanTermQueryBuilder innerQueryBuilder = new SpanTermQueryBuilderTest().createTestQueryBuilder();
-        return new SpanFirstQueryBuilder(innerQueryBuilder, randomIntBetween(0, 1000));
+        SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(1);
+        return new SpanFirstQueryBuilder(spanTermQueries[0], randomIntBetween(0, 1000));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTest.java
@@ -45,12 +45,9 @@ public class SpanNearQueryBuilderTest extends BaseQueryTestCase<SpanNearQueryBui
     @Override
     protected SpanNearQueryBuilder doCreateTestQueryBuilder() {
         SpanNearQueryBuilder queryBuilder = new SpanNearQueryBuilder(randomIntBetween(-10, 10));
-        int clauses = randomIntBetween(1, 6);
-        // we use one random SpanTermQueryBuilder to determine same field name for subsequent clauses
-        String fieldName = new SpanTermQueryBuilderTest().createTestQueryBuilder().fieldName();
-        for (int i = 0; i < clauses; i++) {
-            // we need same field name in all clauses, so we only randomize value
-            queryBuilder.clause(new SpanTermQueryBuilder(fieldName, randomValueForField(fieldName)));
+        SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(randomIntBetween(1, 6));
+        for (SpanTermQueryBuilder clause : spanTermQueries) {
+            queryBuilder.clause(clause);
         }
         queryBuilder.inOrder(randomBoolean());
         queryBuilder.collectPayloads(randomBoolean());

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTest.java
@@ -50,15 +50,7 @@ public class SpanNearQueryBuilderTest extends BaseQueryTestCase<SpanNearQueryBui
         String fieldName = new SpanTermQueryBuilderTest().createTestQueryBuilder().fieldName();
         for (int i = 0; i < clauses; i++) {
             // we need same field name in all clauses, so we only randomize value
-            Object value;
-            switch (fieldName) {
-                case BOOLEAN_FIELD_NAME: value = randomBoolean(); break;
-                case INT_FIELD_NAME: value = randomInt(); break;
-                case DOUBLE_FIELD_NAME: value = randomDouble(); break;
-                case STRING_FIELD_NAME: value = randomAsciiOfLengthBetween(1, 10); break;
-                default : value = randomAsciiOfLengthBetween(1, 10);
-            }
-            queryBuilder.clause(new SpanTermQueryBuilder(fieldName, value));
+            queryBuilder.clause(new SpanTermQueryBuilder(fieldName, randomValueForField(fieldName)));
         }
         queryBuilder.inOrder(randomBoolean());
         queryBuilder.collectPayloads(randomBoolean());

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTest.java
@@ -45,19 +45,8 @@ public class SpanNotQueryBuilderTest extends BaseQueryTestCase<SpanNotQueryBuild
 
     @Override
     protected SpanNotQueryBuilder doCreateTestQueryBuilder() {
-        SpanTermQueryBuilder includeQuery = new SpanTermQueryBuilderTest().createTestQueryBuilder();
-        // we need same field name and value type as bigQuery for little query
-        String fieldName = includeQuery.fieldName();
-        Object value;
-        switch (fieldName) {
-            case BOOLEAN_FIELD_NAME: value = randomBoolean(); break;
-            case INT_FIELD_NAME: value = randomInt(); break;
-            case DOUBLE_FIELD_NAME: value = randomDouble(); break;
-            case STRING_FIELD_NAME: value = randomAsciiOfLengthBetween(1, 10); break;
-            default : value = randomAsciiOfLengthBetween(1, 10);
-        }
-        SpanTermQueryBuilder excludeQuery = new SpanTermQueryBuilder(fieldName, value);
-        SpanNotQueryBuilder queryBuilder = new SpanNotQueryBuilder(includeQuery, excludeQuery);
+        SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(2);
+        SpanNotQueryBuilder queryBuilder = new SpanNotQueryBuilder(spanTermQueries[0], spanTermQueries[1]);
         if (randomBoolean()) {
             // also test negative values, they should implicitly be changed to 0
             queryBuilder.dist(randomIntBetween(-2, 10));

--- a/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanOrQuery;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class SpanOrQueryBuilderTest extends BaseQueryTestCase<SpanOrQueryBuilder> {
+
+    @Override
+    protected Query doCreateExpectedQuery(SpanOrQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+        List<SpanQueryBuilder> clauses = testQueryBuilder.clauses();
+        SpanQuery[] spanQueries = new SpanQuery[clauses.size()];
+        for (int i = 0; i < clauses.size(); i++) {
+            Query query = clauses.get(i).toQuery(context);
+            assert query instanceof SpanQuery;
+            spanQueries[i] = (SpanQuery) query;
+        }
+        return new SpanOrQuery(spanQueries);
+    }
+
+    @Override
+    protected SpanOrQueryBuilder doCreateTestQueryBuilder() {
+        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder();
+        int clauses = randomIntBetween(1, 6);
+        // we use one random SpanTermQueryBuilder to determine same field name for subsequent clauses
+        String fieldName = new SpanTermQueryBuilderTest().createTestQueryBuilder().fieldName();
+        for (int i = 0; i < clauses; i++) {
+            // we need same field name in all clauses, so we only randomize value
+            Object value;
+            switch (fieldName) {
+                case BOOLEAN_FIELD_NAME: value = randomBoolean(); break;
+                case INT_FIELD_NAME: value = randomInt(); break;
+                case DOUBLE_FIELD_NAME: value = randomDouble(); break;
+                case STRING_FIELD_NAME: value = randomAsciiOfLengthBetween(1, 10); break;
+                default : value = randomAsciiOfLengthBetween(1, 10);
+            }
+            queryBuilder.clause(new SpanTermQueryBuilder(fieldName, value));
+        }
+        return queryBuilder;
+    }
+
+    @Test
+    public void testValidate() {
+        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder();
+        assertValidate(queryBuilder, 1); // empty clause list
+
+        int totalExpectedErrors = 0;
+        int clauses = randomIntBetween(1, 10);
+        for (int i = 0; i < clauses; i++) {
+            if (randomBoolean()) {
+                queryBuilder.clause(new SpanTermQueryBuilder("", "test"));
+                totalExpectedErrors++;
+            } else {
+                queryBuilder.clause(new SpanTermQueryBuilder("name", "value"));
+            }
+        }
+        assertValidate(queryBuilder, totalExpectedErrors);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
@@ -49,15 +49,7 @@ public class SpanOrQueryBuilderTest extends BaseQueryTestCase<SpanOrQueryBuilder
         String fieldName = new SpanTermQueryBuilderTest().createTestQueryBuilder().fieldName();
         for (int i = 0; i < clauses; i++) {
             // we need same field name in all clauses, so we only randomize value
-            Object value;
-            switch (fieldName) {
-                case BOOLEAN_FIELD_NAME: value = randomBoolean(); break;
-                case INT_FIELD_NAME: value = randomInt(); break;
-                case DOUBLE_FIELD_NAME: value = randomDouble(); break;
-                case STRING_FIELD_NAME: value = randomAsciiOfLengthBetween(1, 10); break;
-                default : value = randomAsciiOfLengthBetween(1, 10);
-            }
-            queryBuilder.clause(new SpanTermQueryBuilder(fieldName, value));
+            queryBuilder.clause(new SpanTermQueryBuilder(fieldName, randomValueForField(fieldName)));
         }
         return queryBuilder;
     }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
@@ -44,12 +44,9 @@ public class SpanOrQueryBuilderTest extends BaseQueryTestCase<SpanOrQueryBuilder
     @Override
     protected SpanOrQueryBuilder doCreateTestQueryBuilder() {
         SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder();
-        int clauses = randomIntBetween(1, 6);
-        // we use one random SpanTermQueryBuilder to determine same field name for subsequent clauses
-        String fieldName = new SpanTermQueryBuilderTest().createTestQueryBuilder().fieldName();
-        for (int i = 0; i < clauses; i++) {
-            // we need same field name in all clauses, so we only randomize value
-            queryBuilder.clause(new SpanTermQueryBuilder(fieldName, randomValueForField(fieldName)));
+        SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(randomIntBetween(1, 6));
+        for (SpanTermQueryBuilder clause : spanTermQueries) {
+            queryBuilder.clause(clause);
         }
         return queryBuilder;
     }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTest.java
@@ -34,4 +34,26 @@ public class SpanTermQueryBuilderTest extends BaseTermQueryTestCase<SpanTermQuer
     protected Query createLuceneTermQuery(Term term) {
         return new SpanTermQuery(term);
     }
+
+    /**
+     * @param amount the number of clauses that will be returned
+     * @return an array of random {@link SpanTermQueryBuilder} with same field name
+     */
+    public SpanTermQueryBuilder[] createSpanTermQueryBuilders(int amount) {
+        SpanTermQueryBuilder[] clauses = new SpanTermQueryBuilder[amount];
+        SpanTermQueryBuilder first = createTestQueryBuilder();
+        clauses[0] = first;
+        for (int i = 1; i < amount; i++) {
+            // we need same field name in all clauses, so we only randomize value
+            SpanTermQueryBuilder spanTermQuery = new SpanTermQueryBuilder(first.fieldName(), randomValueForField(first.fieldName()));
+            if (randomBoolean()) {
+                spanTermQuery.boost(2.0f / randomIntBetween(1, 20));
+            }
+            if (randomBoolean()) {
+                spanTermQuery.queryName(randomAsciiOfLengthBetween(1, 10));
+            }
+            clauses[i] = spanTermQuery;
+        }
+        return clauses;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
@@ -37,19 +37,8 @@ public class SpanWithinQueryBuilderTest extends BaseQueryTestCase<SpanWithinQuer
 
     @Override
     protected SpanWithinQueryBuilder doCreateTestQueryBuilder() {
-        SpanTermQueryBuilder bigQuery = new SpanTermQueryBuilderTest().createTestQueryBuilder();
-        // we need same field name and value type as bigQuery for little query
-        String fieldName = bigQuery.fieldName();
-        Object littleValue;
-        switch (fieldName) {
-            case BOOLEAN_FIELD_NAME: littleValue = randomBoolean(); break;
-            case INT_FIELD_NAME: littleValue = randomInt(); break;
-            case DOUBLE_FIELD_NAME: littleValue = randomDouble(); break;
-            case STRING_FIELD_NAME: littleValue = randomAsciiOfLengthBetween(1, 10); break;
-            default : littleValue = randomAsciiOfLengthBetween(1, 10);
-        }
-        SpanTermQueryBuilder littleQuery = new SpanTermQueryBuilder(fieldName, littleValue);
-        return new SpanWithinQueryBuilder(bigQuery, littleQuery);
+        SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(2);
+        return new SpanWithinQueryBuilder(spanTermQueries[0], spanTermQueries[1]);
     }
 
     @Test


### PR DESCRIPTION
Moving the query building functionality from the parser to the builders
new doToQuery() method analogous to other recent query refactorings.

Relates to #10217
