### PR TITLE
Use time with nanosecond resolution calculated at the executing node

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
+++ b/core/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
@@ -175,7 +175,7 @@ public final class ShardSearchStats {
 
     public void onFreeScrollContext(SearchContext context) {
         totalStats.scrollCurrent.dec();
-        totalStats.scrollMetric.inc(TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis() - context.nowInMillis()));
+        totalStats.scrollMetric.inc(System.nanoTime() - context.getOriginNanoTime());
     }
 
     public void onRefreshSettings(Settings settings) {

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -98,6 +98,7 @@ public class PercolateContext extends SearchContext {
     private final ConcurrentMap<BytesRef, Query> percolateQueries;
     private final int numberOfShards;
     private final Query aliasFilter;
+    private final long originNanoTime = System.nanoTime();
     private final long startTime;
     private String[] types;
 
@@ -335,6 +336,11 @@ public class PercolateContext extends SearchContext {
     @Override
     public SearchContext queryBoost(float queryBoost) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getOriginNanoTime() {
+        return originNanoTime;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -122,6 +122,7 @@ public class DefaultSearchContext extends SearchContext {
     private boolean queryRewritten;
     private volatile long keepAlive;
     private ScoreDoc lastEmittedDoc;
+    private final long originNanoTime = System.nanoTime();
     private volatile long lastAccessTime = -1;
     private InnerHitsContext innerHitsContext;
 
@@ -267,6 +268,11 @@ public class DefaultSearchContext extends SearchContext {
     public SearchContext queryBoost(float queryBoost) {
         this.queryBoost = queryBoost;
         return this;
+    }
+
+    @Override
+    public long getOriginNanoTime() {
+        return originNanoTime;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -140,6 +140,11 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
+    public long getOriginNanoTime() {
+        return in.getOriginNanoTime();
+    }
+
+    @Override
     protected long nowInMillisImpl() {
         return in.nowInMillisImpl();
     }

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -142,6 +142,8 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     public abstract SearchContext queryBoost(float queryBoost);
 
+    public abstract long getOriginNanoTime();
+
     public final long nowInMillis() {
         nowInMillisUsed = true;
         return nowInMillisImpl();

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -82,6 +82,8 @@ public class TestSearchContext extends SearchContext {
     private String[] types;
     private SearchContextAggregations aggregations;
 
+    private final long originNanoTime = System.nanoTime();
+
     public TestSearchContext(ThreadPool threadPool,PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, IndexService indexService, QueryCache filterCache, IndexFieldDataService indexFieldDataService) {
         super(ParseFieldMatcher.STRICT);
         this.pageCacheRecycler = pageCacheRecycler;
@@ -168,6 +170,11 @@ public class TestSearchContext extends SearchContext {
     @Override
     public SearchContext queryBoost(float queryBoost) {
         return null;
+    }
+
+    @Override
+    public long getOriginNanoTime() {
+        return originNanoTime;
     }
 
     @Override


### PR DESCRIPTION
Use time with nanosecond resolution calculated at the executing node to measure the time that contexts are held open

Closes #12345
