### PR TITLE
Remove index name from mapping parser

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -457,7 +457,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
             if (item.request() instanceof IndexRequest) {
                 IndexRequest indexRequest = (IndexRequest) item.request();
                 try {
-                    SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.REPLICA, indexRequest.source()).type(indexRequest.type()).id(indexRequest.id())
+                    SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.REPLICA, indexRequest.source()).index(shardId.getIndex()).type(indexRequest.type()).id(indexRequest.id())
                             .routing(indexRequest.routing()).parent(indexRequest.parent()).timestamp(indexRequest.timestamp()).ttl(indexRequest.ttl());
 
                     final Engine.IndexingOperation operation;

--- a/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -180,7 +180,7 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
     protected void shardOperationOnReplica(ShardId shardId, IndexRequest request) {
         IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         IndexShard indexShard = indexService.shardSafe(shardId.id());
-        SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.REPLICA, request.source()).type(request.type()).id(request.id())
+        SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.REPLICA, request.source()).index(shardId.getIndex()).type(request.type()).id(request.id())
                 .routing(request.routing()).parent(request.parent()).timestamp(request.timestamp()).ttl(request.ttl());
 
         final Engine.IndexingOperation operation;

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -1048,7 +1048,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
     /** Utility method to create either an index or a create operation depending
      *  on the {@link OpType} of the request. */
     private final Engine.IndexingOperation prepareIndexOperationOnPrimary(BulkShardRequest shardRequest, IndexRequest request, IndexShard indexShard) {
-        SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.PRIMARY, request.source()).type(request.type()).id(request.id())
+        SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.PRIMARY, request.source()).index(request.index()).type(request.type()).id(request.id())
                 .routing(request.routing()).parent(request.parent()).timestamp(request.timestamp()).ttl(request.ttl());
         boolean canHaveDuplicates = request.canHaveDuplicates();
         if (shardRequest != null) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -326,11 +326,6 @@ public class DocumentMapper implements ToXContent {
         return parse(SourceToParse.source(source).index(index).type(type).id(id));
     }
 
-    // TODO: remove this, replace all uses with version including index above
-    public ParsedDocument parse(String type, String id, BytesReference source) throws MapperParsingException {
-        return parse(SourceToParse.source(source).type(type).id(id));
-    }
-
     public ParsedDocument parse(SourceToParse source) throws MapperParsingException {
         return documentParser.parseDocument(source);
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -56,11 +56,9 @@ import java.util.Map;
 
 import static org.elasticsearch.index.mapper.MapperBuilders.doc;
 
-/**
- *
- */
-public class DocumentMapperParser extends AbstractIndexComponent {
+public class DocumentMapperParser {
 
+    private final Settings indexSettings;
     final MapperService mapperService;
     final AnalysisService analysisService;
     private static final ESLogger logger = Loggers.getLogger(DocumentMapperParser.class);
@@ -76,9 +74,9 @@ public class DocumentMapperParser extends AbstractIndexComponent {
     private volatile ImmutableMap<String, Mapper.TypeParser> typeParsers;
     private volatile ImmutableMap<String, Mapper.TypeParser> rootTypeParsers;
 
-    public DocumentMapperParser(Index index, @IndexSettings Settings indexSettings, MapperService mapperService, AnalysisService analysisService,
+    public DocumentMapperParser(@IndexSettings Settings indexSettings, MapperService mapperService, AnalysisService analysisService,
                                 SimilarityLookupService similarityLookupService, ScriptService scriptService) {
-        super(index, indexSettings);
+        this.indexSettings = indexSettings;
         this.parseFieldMatcher = new ParseFieldMatcher(indexSettings);
         this.mapperService = mapperService;
         this.analysisService = analysisService;
@@ -205,7 +203,7 @@ public class DocumentMapperParser extends AbstractIndexComponent {
 
         Mapper.TypeParser.ParserContext parserContext = parserContext();
         // parse RootObjectMapper
-        DocumentMapper.Builder docBuilder = doc(index.name(), indexSettings, (RootObjectMapper.Builder) rootObjectTypeParser.parse(type, mapping, parserContext), mapperService);
+        DocumentMapper.Builder docBuilder = doc(indexSettings, (RootObjectMapper.Builder) rootObjectTypeParser.parse(type, mapping, parserContext), mapperService);
         Iterator<Map.Entry<String, Object>> iterator = mapping.entrySet().iterator();
         // parse DocumentMapper
         while(iterator.hasNext()) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -56,18 +56,16 @@ class DocumentParser implements Closeable {
     private CloseableThreadLocal<ParseContext.InternalParseContext> cache = new CloseableThreadLocal<ParseContext.InternalParseContext>() {
         @Override
         protected ParseContext.InternalParseContext initialValue() {
-            return new ParseContext.InternalParseContext(index, indexSettings, docMapperParser, docMapper, new ContentPath(0));
+            return new ParseContext.InternalParseContext(indexSettings, docMapperParser, docMapper, new ContentPath(0));
         }
     };
 
-    private final String index;
     private final Settings indexSettings;
     private final DocumentMapperParser docMapperParser;
     private final DocumentMapper docMapper;
     private final ReleasableLock parseLock;
 
-    public DocumentParser(String index, Settings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper, ReleasableLock parseLock) {
-        this.index = index;
+    public DocumentParser(Settings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper, ReleasableLock parseLock) {
         this.indexSettings = indexSettings;
         this.docMapperParser = docMapperParser;
         this.docMapper = docMapper;

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperBuilders.java
@@ -32,8 +32,8 @@ public final class MapperBuilders {
 
     private MapperBuilders() {}
 
-    public static DocumentMapper.Builder doc(String index, Settings settings, RootObjectMapper.Builder objectBuilder, MapperService mapperService) {
-        return new DocumentMapper.Builder(index, settings, objectBuilder, mapperService);
+    public static DocumentMapper.Builder doc(Settings settings, RootObjectMapper.Builder objectBuilder, MapperService mapperService) {
+        return new DocumentMapper.Builder(settings, objectBuilder, mapperService);
     }
 
     public static RootObjectMapper.Builder rootObject(String name) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -146,7 +146,7 @@ public class MapperService extends AbstractIndexComponent  {
         this.analysisService = analysisService;
         this.fieldDataService = fieldDataService;
         this.fieldTypes = new FieldTypeLookup();
-        this.documentParser = new DocumentMapperParser(index, indexSettings, this, analysisService, similarityLookupService, scriptService);
+        this.documentParser = new DocumentMapperParser(indexSettings, this, analysisService, similarityLookupService, scriptService);
         this.indexAnalyzer = new MapperAnalyzerWrapper(analysisService.defaultIndexAnalyzer(), INDEX_ANALYZER_EXTRACTOR);
         this.searchAnalyzer = new MapperAnalyzerWrapper(analysisService.defaultSearchAnalyzer(), SEARCH_ANALYZER_EXTRACTOR);
         this.searchQuoteAnalyzer = new MapperAnalyzerWrapper(analysisService.defaultSearchQuoteAnalyzer(), SEARCH_QUOTE_ANALYZER_EXTRACTOR);

--- a/core/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -380,8 +380,6 @@ public abstract class ParseContext {
 
         private List<Document> documents = Lists.newArrayList();
 
-        private final String index;
-
         @Nullable
         private final Settings indexSettings;
 
@@ -402,8 +400,7 @@ public abstract class ParseContext {
 
         private Mapper dynamicMappingsUpdate = null;
 
-        public InternalParseContext(String index, @Nullable Settings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper, ContentPath path) {
-            this.index = index;
+        public InternalParseContext(@Nullable Settings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper, ContentPath path) {
             this.indexSettings = indexSettings;
             this.docMapper = docMapper;
             this.docMapperParser = docMapperParser;
@@ -443,7 +440,7 @@ public abstract class ParseContext {
 
         @Override
         public String index() {
-            return this.index;
+            return sourceToParse.index();
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/SourceToParse.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/SourceToParse.java
@@ -47,6 +47,8 @@ public class SourceToParse {
 
     private boolean flyweight = false;
 
+    private String index;
+
     private String type;
 
     private String id;
@@ -59,13 +61,13 @@ public class SourceToParse {
 
     private long ttl;
 
-    public SourceToParse(Origin origin, XContentParser parser) {
+    private SourceToParse(Origin origin, XContentParser parser) {
         this.origin = origin;
         this.parser = parser;
         this.source = null;
     }
 
-    public SourceToParse(Origin origin, BytesReference source) {
+    private SourceToParse(Origin origin, BytesReference source) {
         this.origin = origin;
         // we always convert back to byte array, since we store it and Field only supports bytes..
         // so, we might as well do it here, and improve the performance of working with direct byte arrays
@@ -83,6 +85,15 @@ public class SourceToParse {
 
     public BytesReference source() {
         return this.source;
+    }
+
+    public String index() {
+        return this.index;
+    }
+
+    public SourceToParse index(String index) {
+        this.index = index;
+        return this;
     }
 
     public String type() {

--- a/core/src/main/java/org/elasticsearch/index/shard/TranslogRecoveryPerformer.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/TranslogRecoveryPerformer.java
@@ -145,7 +145,7 @@ public class TranslogRecoveryPerformer {
                 case CREATE:
                     Translog.Create create = (Translog.Create) operation;
                     Engine.Create engineCreate = IndexShard.prepareCreate(docMapper(create.type()),
-                            source(create.source()).type(create.type()).id(create.id())
+                            source(create.source()).index(shardId.getIndex()).type(create.type()).id(create.id())
                                     .routing(create.routing()).parent(create.parent()).timestamp(create.timestamp()).ttl(create.ttl()),
                             create.version(), create.versionType().versionTypeForReplicationAndRecovery(), Engine.Operation.Origin.RECOVERY, true, false);
                     maybeAddMappingUpdate(engineCreate.type(), engineCreate.parsedDoc().dynamicMappingsUpdate(), engineCreate.id(), allowMappingUpdates);

--- a/core/src/main/java/org/elasticsearch/index/termvectors/ShardTermVectorsService.java
+++ b/core/src/main/java/org/elasticsearch/index/termvectors/ShardTermVectorsService.java
@@ -309,7 +309,7 @@ public class ShardTermVectorsService extends AbstractIndexShardComponent {
 
         // TODO: make parsing not dynamically create fields not in the original mapping
         Tuple<DocumentMapper, Mapping> docMapper = mapperService.documentMapperWithAutoCreate(type);
-        ParsedDocument parsedDocument = docMapper.v1().parse(source(doc).type(type).flyweight(true));
+        ParsedDocument parsedDocument = docMapper.v1().parse(source(doc).index(index).type(type).flyweight(true));
         if (docMapper.v2() != null) {
             parsedDocument.addDynamicMappingsUpdate(docMapper.v2());
         }

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1924,8 +1924,8 @@ public class InternalEngineTests extends ElasticsearchTestCase {
             AnalysisService analysisService = new AnalysisService(index, settings);
             SimilarityLookupService similarityLookupService = new SimilarityLookupService(index, settings);
             MapperService mapperService = new MapperService(index, settings, analysisService, null, similarityLookupService, null);
-            DocumentMapper.Builder b = new DocumentMapper.Builder(indexName, settings, rootBuilder, mapperService);
-            DocumentMapperParser parser = new DocumentMapperParser(index, settings, mapperService, analysisService, similarityLookupService, null);
+            DocumentMapper.Builder b = new DocumentMapper.Builder(settings, rootBuilder, mapperService);
+            DocumentMapperParser parser = new DocumentMapperParser(settings, mapperService, analysisService, similarityLookupService, null);
             this.docMapper = b.build(mapperService, parser);
 
         }

--- a/core/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
@@ -60,16 +60,16 @@ public class BinaryDVFieldDataTests extends AbstractFieldDataTests {
         bytesList1.add(randomBytes());
         bytesList1.add(randomBytes());
         XContentBuilder doc = XContentFactory.jsonBuilder().startObject().startArray("field").value(bytesList1.get(0)).value(bytesList1.get(1)).endArray().endObject();
-        ParsedDocument d = mapper.parse("test", "1", doc.bytes());
+        ParsedDocument d = mapper.parse("test", "test", "1", doc.bytes());
         writer.addDocument(d.rootDoc());
 
         byte[] bytes1 = randomBytes();
         doc = XContentFactory.jsonBuilder().startObject().field("field", bytes1).endObject();
-        d = mapper.parse("test", "2", doc.bytes());
+        d = mapper.parse("test", "test", "2", doc.bytes());
         writer.addDocument(d.rootDoc());
 
         doc = XContentFactory.jsonBuilder().startObject().endObject();
-        d = mapper.parse("test", "3", doc.bytes());
+        d = mapper.parse("test", "test", "3", doc.bytes());
         writer.addDocument(d.rootDoc());
 
         // test remove duplicate value
@@ -77,7 +77,7 @@ public class BinaryDVFieldDataTests extends AbstractFieldDataTests {
         bytesList2.add(randomBytes());
         bytesList2.add(randomBytes());
         doc = XContentFactory.jsonBuilder().startObject().startArray("field").value(bytesList2.get(0)).value(bytesList2.get(1)).value(bytesList2.get(0)).endArray().endObject();
-        d = mapper.parse("test", "4", doc.bytes());
+        d = mapper.parse("test", "test", "4", doc.bytes());
         writer.addDocument(d.rootDoc());
 
         LeafReaderContext reader = refreshReader();

--- a/core/src/test/java/org/elasticsearch/index/fielddata/DuelFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/DuelFieldDataTests.java
@@ -77,7 +77,7 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
 
             doc = doc.endObject();
 
-            final ParsedDocument d = mapper.parse("type", Integer.toString(i), doc.bytes());
+            final ParsedDocument d = mapper.parse("test", "type", Integer.toString(i), doc.bytes());
 
             writer.addDocument(d.rootDoc());
 
@@ -169,7 +169,7 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
             }
             doc = doc.endObject();
 
-            final ParsedDocument d = mapper.parse("type", Integer.toString(i), doc.bytes());
+            final ParsedDocument d = mapper.parse("test", "type", Integer.toString(i), doc.bytes());
 
             writer.addDocument(d.rootDoc());
             if (random.nextInt(10) == 0) {
@@ -255,7 +255,7 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
             }
             doc = doc.endArray().endObject();
 
-            final ParsedDocument d = mapper.parse("type", Integer.toString(i), doc.bytes());
+            final ParsedDocument d = mapper.parse("test", "type", Integer.toString(i), doc.bytes());
 
             writer.addDocument(d.rootDoc());
             if (random.nextInt(10) == 0) {
@@ -423,7 +423,7 @@ public class DuelFieldDataTests extends AbstractFieldDataTests {
                 }
             }
             doc = doc.endArray().endObject();
-            final ParsedDocument d = mapper.parse("type", Integer.toString(i), doc.bytes());
+            final ParsedDocument d = mapper.parse("test", "type", Integer.toString(i), doc.bytes());
 
             writer.addDocument(d.rootDoc());
             if (random.nextInt(10) == 0) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -52,7 +52,7 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", jsonBuilder()
                 .startObject()
                 .field("field1", "value1")
                 .field("field2", "value2")
@@ -72,7 +72,7 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", jsonBuilder()
                 .startObject()
                 .field("field1", "value1")
                 .field("field2", "value2")
@@ -94,7 +94,7 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
         try {
-            defaultMapper.parse("type", "1", jsonBuilder()
+            defaultMapper.parse("test", "type", "1", jsonBuilder()
                     .startObject()
                     .field("field1", "value1")
                     .field("field2", "value2")
@@ -105,7 +105,7 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("field1", "value1")
                     .field("field2", (String) null)
@@ -128,7 +128,7 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", jsonBuilder()
                 .startObject().startObject("obj1")
                 .field("field1", "value1")
                 .field("field2", "value2")
@@ -152,7 +152,7 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
         try {
-            defaultMapper.parse("type", "1", jsonBuilder()
+            defaultMapper.parse("test", "type", "1", jsonBuilder()
                     .startObject().startObject("obj1")
                     .field("field1", "value1")
                     .field("field2", "value2")

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -197,7 +197,7 @@ public class DynamicMappingTests extends ElasticsearchSingleNodeTest {
 
     private Mapper parse(DocumentMapper mapper, DocumentMapperParser parser, XContentBuilder builder) throws Exception {
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        ParseContext.InternalParseContext ctx = new ParseContext.InternalParseContext("test", settings, parser, mapper, new ContentPath(0));
+        ParseContext.InternalParseContext ctx = new ParseContext.InternalParseContext(settings, parser, mapper, new ContentPath(0));
         SourceToParse source = SourceToParse.source(builder.bytes());
         ctx.reset(XContentHelper.createParser(source.source()), new ParseContext.Document(), source);
         assertEquals(XContentParser.Token.START_OBJECT, ctx.parser().nextToken());

--- a/core/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
@@ -74,7 +74,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/all/mapping.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = docMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         // One field is boosted so we should see AllTokenStream used:
         assertThat(field.tokenStream(docMapper.mappers().indexAnalyzer(), null), Matchers.instanceOf(AllTokenStream.class));
@@ -93,7 +93,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         IndexService index = createIndex("test");
         DocumentMapper docMapper = index.mapperService().documentMapperParser().parse(mapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = docMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         AllEntries allEntries = field.getAllEntries();
         assertThat(allEntries.fields().size(), equalTo(3));
@@ -107,7 +107,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/all/mapping_omit_positions_on_all.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = docMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         AllEntries allEntries = field.getAllEntries();
         assertThat(allEntries.fields().size(), equalTo(3));
@@ -125,7 +125,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/all/mapping_offsets_on_all.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = docMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         // _all field indexes positions, and mapping has boosts, so we should see AllTokenStream:
         assertThat(field.tokenStream(docMapper.mappers().indexAnalyzer(), null), Matchers.instanceOf(AllTokenStream.class));
@@ -144,7 +144,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/all/mapping_boost_omit_positions_on_all.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = docMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         // _all field omits positions, so we should not get AllTokenStream even though fields are boosted
         assertThat(field.tokenStream(docMapper.mappers().indexAnalyzer(), null), Matchers.not(Matchers.instanceOf(AllTokenStream.class)));
@@ -155,7 +155,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/all/noboost-mapping.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = docMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         // no fields have boost, so we should not see AllTokenStream:
         assertThat(field.tokenStream(docMapper.mappers().indexAnalyzer(), null), Matchers.not(Matchers.instanceOf(AllTokenStream.class)));
@@ -169,7 +169,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         // reparse it
         DocumentMapper builtDocMapper = parser.parse(builtMapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = builtDocMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = builtDocMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
 
         AllField field = (AllField) doc.getField("_all");
         AllEntries allEntries = field.getAllEntries();
@@ -184,7 +184,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/all/store-mapping.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = docMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         AllEntries allEntries = field.getAllEntries();
         assertThat(allEntries.fields().size(), equalTo(2));
@@ -204,7 +204,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         // reparse it
         DocumentMapper builtDocMapper = parser.parse(builtMapping);
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/all/test1.json");
-        Document doc = builtDocMapper.parse("person", "1", new BytesArray(json)).rootDoc();
+        Document doc = builtDocMapper.parse("test", "person", "1", new BytesArray(json)).rootDoc();
 
         AllField field = (AllField) doc.getField("_all");
         AllEntries allEntries = field.getAllEntries();
@@ -277,7 +277,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
                 .field("foo", "bar")
                 .field("foobar", "foobar")
                 .endObject().bytes().toBytes();
-        Document doc = builtDocMapper.parse("test", "1", new BytesArray(json)).rootDoc();
+        Document doc = builtDocMapper.parse("test", "test", "1", new BytesArray(json)).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         if (enabled) {
             assertThat(field.fieldType().omitNorms(), equalTo(omitNorms));
@@ -325,7 +325,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
                     .endObject()
                 .endObject();
 
-        Document doc = docMapper.parse("test", "1", builder.bytes()).rootDoc();
+        Document doc = docMapper.parse("test", "test", "1", builder.bytes()).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         AllEntries allEntries = field.getAllEntries();
         assertThat(allEntries.fields(), empty());
@@ -343,7 +343,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject()
                 .endObject();
 
-        Document doc = docMapper.parse("test", "1", builder.bytes()).rootDoc();
+        Document doc = docMapper.parse("test", "test", "1", builder.bytes()).rootDoc();
         AllField field = (AllField) doc.getField("_all");
         AllEntries allEntries = field.getAllEntries();
         assertThat(allEntries.fields(), hasSize(1));
@@ -448,7 +448,7 @@ public class SimpleAllMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = jsonBuilder().startObject().startObject("type").endObject().endObject().string();
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
         DocumentMapper docMapper = createIndex("test", settings).mapperService().documentMapperParser().parse(mapping);
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
             .startObject().field("_all", "foo").endObject().bytes());
 
         assertNull(doc.rootDoc().get("_all"));

--- a/core/src/test/java/org/elasticsearch/index/mapper/binary/BinaryMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/binary/BinaryMappingTests.java
@@ -85,7 +85,7 @@ public class BinaryMappingTests extends ElasticsearchSingleNodeTest {
         assertTrue(CompressorFactory.isCompressed(new BytesArray(binaryValue2)));
         
         for (byte[] value : Arrays.asList(binaryValue1, binaryValue2)) {
-            ParsedDocument doc = mapper.parse("type", "id", XContentFactory.jsonBuilder().startObject().field("field", value).endObject().bytes());
+            ParsedDocument doc = mapper.parse("test", "type", "id", XContentFactory.jsonBuilder().startObject().field("field", value).endObject().bytes());
             BytesRef indexedValue = doc.rootDoc().getBinaryValue("field");
             assertEquals(new BytesRef(value), indexedValue);
             FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper("field");
@@ -116,7 +116,7 @@ public class BinaryMappingTests extends ElasticsearchSingleNodeTest {
         final byte[] binaryValue = out.bytes().toBytes();
         assertTrue(CompressorFactory.isCompressed(new BytesArray(binaryValue)));
         
-        ParsedDocument doc = mapper.parse("type", "id", XContentFactory.jsonBuilder().startObject().field("field", binaryValue).endObject().bytes());
+        ParsedDocument doc = mapper.parse("test", "type", "id", XContentFactory.jsonBuilder().startObject().field("field", binaryValue).endObject().bytes());
         BytesRef indexedValue = doc.rootDoc().getBinaryValue("field");
         assertEquals(new BytesRef(binaryValue), indexedValue);
         FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper("field");

--- a/core/src/test/java/org/elasticsearch/index/mapper/boost/CustomBoostMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/boost/CustomBoostMappingTests.java
@@ -44,7 +44,7 @@ public class CustomBoostMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper mapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .startObject("s_field").field("value", "s_value").field("boost", 2.0f).endObject()
                 .startObject("l_field").field("value", 1l).field("boost", 3.0f).endObject()
                 .startObject("i_field").field("value", 1).field("boost", 4.0f).endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/boost/FieldLevelBoostTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/boost/FieldLevelBoostTests.java
@@ -58,7 +58,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
                 .startObject("long_field").field("boost", 8.0).field("value", 50).endObject()
                 .startObject("short_field").field("boost", 9.0).field("value", 60).endObject()
                 .bytes();
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
 
         IndexableField f = doc.getField("str_field");
         assertThat((double) f.boost(), closeTo(2.0, 0.001));
@@ -100,7 +100,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         try {
-            docMapper.parse("person", "1", XContentFactory.jsonBuilder().startObject()
+            docMapper.parse("test", "person", "1", XContentFactory.jsonBuilder().startObject()
                     .startObject("str_field").field("foo", "bar")
                     .endObject().bytes()).rootDoc();
             fail();
@@ -109,7 +109,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            docMapper.parse("person", "1", XContentFactory.jsonBuilder().startObject()
+            docMapper.parse("test", "person", "1", XContentFactory.jsonBuilder().startObject()
                     .startObject("int_field").field("foo", "bar")
                     .endObject().bytes()).rootDoc();
             fail();
@@ -118,7 +118,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            docMapper.parse("person", "1", XContentFactory.jsonBuilder().startObject()
+            docMapper.parse("test", "person", "1", XContentFactory.jsonBuilder().startObject()
                     .startObject("byte_field").field("foo", "bar")
                     .endObject().bytes()).rootDoc();
             fail();
@@ -127,7 +127,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            docMapper.parse("person", "1", XContentFactory.jsonBuilder().startObject()
+            docMapper.parse("test", "person", "1", XContentFactory.jsonBuilder().startObject()
                     .startObject("date_field").field("foo", "bar")
                     .endObject().bytes()).rootDoc();
             fail();
@@ -136,7 +136,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            docMapper.parse("person", "1", XContentFactory.jsonBuilder().startObject()
+            docMapper.parse("test", "person", "1", XContentFactory.jsonBuilder().startObject()
                     .startObject("double_field").field("foo", "bar")
                     .endObject().bytes()).rootDoc();
             fail();
@@ -145,7 +145,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            docMapper.parse("person", "1", XContentFactory.jsonBuilder().startObject()
+            docMapper.parse("test", "person", "1", XContentFactory.jsonBuilder().startObject()
                     .startObject("float_field").field("foo", "bar")
                     .endObject().bytes()).rootDoc();
             fail();
@@ -154,7 +154,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            docMapper.parse("person", "1", XContentFactory.jsonBuilder().startObject()
+            docMapper.parse("test", "person", "1", XContentFactory.jsonBuilder().startObject()
                     .startObject("long_field").field("foo", "bar")
                     .endObject().bytes()).rootDoc();
             fail();
@@ -163,7 +163,7 @@ public class FieldLevelBoostTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            docMapper.parse("person", "1", XContentFactory.jsonBuilder().startObject()
+            docMapper.parse("test", "person", "1", XContentFactory.jsonBuilder().startObject()
                     .startObject("short_field").field("foo", "bar")
                     .endObject().bytes()).rootDoc();
             fail();

--- a/core/src/test/java/org/elasticsearch/index/mapper/camelcase/CamelCaseFieldNameTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/camelcase/CamelCaseFieldNameTests.java
@@ -40,7 +40,7 @@ public class CamelCaseFieldNameTests extends ElasticsearchSingleNodeTest {
         client().admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
         DocumentMapper documentMapper = index.mapperService().documentMapper("type");
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .field("thisIsCamelCase", "value1")
                 .endObject().bytes());
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/compound/CompoundTypesTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/compound/CompoundTypesTests.java
@@ -40,7 +40,7 @@ public class CompoundTypesTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field1", "value1")
                 .field("field2", "value2")
@@ -50,7 +50,7 @@ public class CompoundTypesTests extends ElasticsearchSingleNodeTest {
         assertThat((double) doc.rootDoc().getField("field1").boost(), closeTo(1.0d, 0.000001d));
         assertThat(doc.rootDoc().get("field2"), equalTo("value2"));
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("field1").field("value", "value1").field("boost", 2.0f).endObject()
                 .field("field2", "value2")
@@ -60,7 +60,7 @@ public class CompoundTypesTests extends ElasticsearchSingleNodeTest {
         assertThat((double) doc.rootDoc().getField("field1").boost(), closeTo(2.0d, 0.000001d));
         assertThat(doc.rootDoc().get("field2"), equalTo("value2"));
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field1", "value1")
                 .field("field2", "value2")

--- a/core/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
@@ -110,7 +110,7 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
                 .field("int_to_str_test", 42)
                 .endObject().bytes();
 
-        ParsedDocument parsedDoc = docMapper.parse("type1", "1", json);
+        ParsedDocument parsedDoc = docMapper.parse("test", "type1", "1", json);
         ParseContext.Document doc = parsedDoc.rootDoc();
         assertThat(doc.getFields("copy_test").length, equalTo(2));
         assertThat(doc.getFields("copy_test")[0].stringValue(), equalTo("foo"));
@@ -165,7 +165,7 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
                 .startObject("foo").startObject("bar").field("baz", "zoo").endObject().endObject()
                 .endObject().bytes();
 
-        ParseContext.Document doc = docMapper.parse("type1", "1", json).rootDoc();
+        ParseContext.Document doc = docMapper.parse("test", "type1", "1", json).rootDoc();
         assertThat(doc.getFields("copy_test").length, equalTo(1));
         assertThat(doc.getFields("copy_test")[0].stringValue(), equalTo("foo"));
 
@@ -193,7 +193,7 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
                 .endObject().bytes();
 
         try {
-            docMapper.parse("type1", "1", json).rootDoc();
+            docMapper.parse("test", "type1", "1", json).rootDoc();
             fail();
         } catch (MapperParsingException ex) {
             assertThat(ex.getMessage(), startsWith("attempt to copy value to non-existing object"));
@@ -313,7 +313,7 @@ public class CopyToMapperTests extends ElasticsearchSingleNodeTest {
                         .endArray()
                     .endObject();
 
-            ParsedDocument doc = mapper.parse("type", "1", jsonDoc.bytes());
+            ParsedDocument doc = mapper.parse("test", "type", "1", jsonDoc.bytes());
             assertEquals(6, doc.docs().size());
 
             Document nested = doc.docs().get(0);

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldMapperTests.java
@@ -59,7 +59,7 @@ public class BooleanFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = parser.parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", true)
                 .endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -67,9 +67,9 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .startObject("properties").endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
+        DocumentMapper defaultMapper = mapper("test", "type", mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field1", "2011/01/22")
                 .field("date_field2", "2011/01/22 00:00:00")
@@ -79,7 +79,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject()
                 .bytes());
         assertNotNull(doc.dynamicMappingsUpdate());
-        client().admin().indices().preparePutMapping("test-0").setType("type").setSource(doc.dynamicMappingsUpdate().toString()).get();
+        client().admin().indices().preparePutMapping("test").setType("type").setSource(doc.dynamicMappingsUpdate().toString()).get();
 
         FieldMapper fieldMapper = defaultMapper.mappers().smartNameFieldMapper("date_field1");
         assertThat(fieldMapper, instanceOf(DateFieldMapper.class));
@@ -132,8 +132,8 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                             .endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        DocumentMapper defaultMapper = mapper("test", "type", mapping);
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                   .field("date_field_en", "Wed, 06 Dec 2000 02:55:00 -0800")
                   .field("date_field_de", "Mi, 06 Dez 2000 02:55:00 -0800")
@@ -151,12 +151,11 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
 
     int i = 0;
 
-    private DocumentMapper mapper(String type, String mapping) throws IOException {
-        return mapper(type, mapping, Version.CURRENT);
+    private DocumentMapper mapper(String indexName, String type, String mapping) throws IOException {
+        return mapper(indexName, type, mapping, Version.CURRENT);
     }
 
-    private DocumentMapper mapper(String type, String mapping, Version version) throws IOException {
-        final String indexName = "test-" + (i++);
+    private DocumentMapper mapper(String indexName, String type, String mapping, Version version) throws IOException {
         IndexService index;
         if (version.equals(Version.CURRENT)) {
             index = createIndex(indexName);
@@ -194,10 +193,10 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .startObject("properties").startObject("date_field").field("type", "date").endObject().endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
+        DocumentMapper defaultMapper = mapper("test", "type", mapping);
         long value = System.currentTimeMillis();
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field", value)
                 .endObject()
@@ -212,9 +211,9 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .startObject("properties").startObject("date_field").field("type", "date").endObject().endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
+        DocumentMapper defaultMapper = mapper("test", "type", mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field", "2010-01-01")
                 .field("date_field_x", "2010-01-01")
@@ -231,13 +230,13 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .startObject("properties").startObject("date_field").field("type", "date").field("format", "HH:mm:ss").endObject().endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
+        DocumentMapper defaultMapper = mapper("test", "type", mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
-                .startObject()
-                .field("date_field", "10:00:00")
-                .endObject()
-                .bytes());
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+            .startObject()
+            .field("date_field", "10:00:00")
+            .endObject()
+            .bytes());
         assertThat(((LongFieldMapper.CustomLongNumericField) doc.rootDoc().getField("date_field")).numericAsString(), equalTo(Long.toString(new DateTime(TimeValue.timeValueHours(10).millis(), DateTimeZone.UTC).getMillis())));
 
         NumericRangeQuery<Long> rangeQuery;
@@ -257,9 +256,9 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .startObject("properties").startObject("date_field").field("type", "date").field("format", "MMM dd HH:mm:ss").endObject().endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
+        DocumentMapper defaultMapper = mapper("test", "type", mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field", "Jan 02 10:00:00")
                 .endObject()
@@ -286,9 +285,9 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
+        DocumentMapper defaultMapper = mapper("test", "type", mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field1", "a")
                 .field("field2", "2010-01-01")
@@ -298,7 +297,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(doc.rootDoc().getField("field2"), notNullValue());
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("field2", "a")
                     .endObject()
@@ -310,7 +309,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
 
         // Verify that the default is false
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("field3", "a")
                     .endObject()
@@ -323,7 +322,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         // Unless the global ignore_malformed option is set to true
         Settings indexSettings = settingsBuilder().put("index.mapping.ignore_malformed", true).build();
         defaultMapper = createIndex("test2", indexSettings).mapperService().documentMapperParser().parse(mapping);
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field3", "a")
                 .endObject()
@@ -332,7 +331,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
 
         // This should still throw an exception, since field2 is specifically set to ignore_malformed=false
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("field2", "a")
                     .endObject()
@@ -361,8 +360,8 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", initialMapping);
-        DocumentMapper mergeMapper = mapper("type", updatedMapping);
+        DocumentMapper defaultMapper = mapper("test1", "type", initialMapping);
+        DocumentMapper mergeMapper = mapper("test2", "type", updatedMapping);
 
         assertThat(defaultMapper.mappers().getMapper("field"), is(instanceOf(DateFieldMapper.class)));
         DateFieldMapper initialDateFieldMapper = (DateFieldMapper) defaultMapper.mappers().getMapper("field");
@@ -384,9 +383,9 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
             .startObject("properties").startObject("date_field").field("type", "date").endObject().endObject()
             .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
+        DocumentMapper defaultMapper = mapper("test", "type", mapping);
 
-        ParsedDocument parsedDoc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument parsedDoc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
             .startObject()
             .field("date_field", "2010-01-01")
             .endObject()
@@ -418,44 +417,47 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
 
     public void testNumericResolutionBackwardsCompat() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("date_field").field("type", "date").field("format", "date_time").field("numeric_resolution", "seconds").endObject().endObject()
-                .endObject().endObject().string();
+            .startObject("properties").startObject("date_field").field("type", "date").field("format", "date_time").field("numeric_resolution", "seconds").endObject().endObject()
+            .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping, Version.V_0_90_0);
+        DocumentMapper defaultMapper = mapper("test1", "type", mapping, Version.V_0_90_0);
 
         // provided as an int
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
-                .startObject()
-                .field("date_field", 42)
-                .endObject()
-                .bytes());
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
+            .startObject()
+            .field("date_field", 42)
+            .endObject()
+            .bytes());
         assertThat(getDateAsMillis(doc.rootDoc(), "date_field"), equalTo(42000L));
 
         // provided as a string
-        doc = defaultMapper.parse("type", "2", XContentFactory.jsonBuilder()
-                .startObject()
-                .field("date_field", "43")
-                .endObject()
-                .bytes());
+        doc = defaultMapper.parse("test", "type", "2", XContentFactory.jsonBuilder()
+            .startObject()
+            .field("date_field", "43")
+            .endObject()
+            .bytes());
         assertThat(getDateAsMillis(doc.rootDoc(), "date_field"), equalTo(43000L));
 
         // but formatted dates still parse as milliseconds
-        doc = defaultMapper.parse("type", "2", XContentFactory.jsonBuilder()
-                .startObject()
-                .field("date_field", "1970-01-01T00:00:44.000Z")
-                .endObject()
-                .bytes());
+        doc = defaultMapper.parse("test", "type", "2", XContentFactory.jsonBuilder()
+            .startObject()
+            .field("date_field", "1970-01-01T00:00:44.000Z")
+            .endObject()
+            .bytes());
         assertThat(getDateAsMillis(doc.rootDoc(), "date_field"), equalTo(44000L));
 
         // expected to fail due to field epoch date formatters not being set
-        DocumentMapper currentMapper = mapper("type", mapping);
+        DocumentMapper currentMapper = mapper("test2", "type", mapping);
         try {
-            currentMapper.parse("type", "2", XContentFactory.jsonBuilder()
+            currentMapper.parse("test", "type", "2", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("date_field", randomBoolean() ? "43" : 43)
                     .endObject()
                     .bytes());
-        } catch (MapperParsingException e) {}
+            fail("expected parse failure");
+        } catch (MapperParsingException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("failed to parse [date_field]"));
+        }
     }
 
     public void testThatEpochCanBeIgnoredWithCustomFormat() throws Exception {
@@ -463,19 +465,19 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
                 .startObject("properties").startObject("date_field").field("type", "date").field("format", "yyyyMMddHH").endObject().endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper defaultMapper = mapper("type", mapping);
+        DocumentMapper defaultMapper = mapper("test1", "type", mapping);
 
         XContentBuilder document = XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field", "2015060210")
                 .endObject();
-        ParsedDocument doc = defaultMapper.parse("type", "1", document.bytes());
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", document.bytes());
         assertThat(getDateAsMillis(doc.rootDoc(), "date_field"), equalTo(1433239200000L));
-        IndexResponse indexResponse = client().prepareIndex("test", "test").setSource(document).get();
+        IndexResponse indexResponse = client().prepareIndex("test2", "test").setSource(document).get();
         assertThat(indexResponse.isCreated(), is(true));
 
         // integers should always be parsed as well... cannot be sure it is a unix timestamp only
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field", 2015060210)
                 .endObject()
@@ -496,14 +498,14 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         assertDateFormat("epoch_millis||dateOptionalTime");
         DocumentMapper defaultMapper = index.mapperService().documentMapper("type");
 
-        defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field", "1-1-1T00:00:44.000Z")
                 .endObject()
                 .bytes());
 
         // also test normal date
-        defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field", "2015-06-06T00:00:44.000Z")
                 .endObject()
@@ -521,14 +523,14 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         DocumentMapper defaultMapper = index.mapperService().documentMapper("type");
 
         // also test normal date
-        defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("date_field", "2015-06-06T00:00:44.000Z")
                 .endObject()
                 .bytes());
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("date_field", "1-1-1T00:00:44.000Z")
                     .endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/genericstore/GenericStoreDynamicTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/genericstore/GenericStoreDynamicTemplateTests.java
@@ -46,7 +46,7 @@ public class GenericStoreDynamicTemplateTests extends ElasticsearchSingleNodeTes
         client().admin().indices().preparePutMapping("test").setType("person").setSource(mapping).get();
         DocumentMapper docMapper = index.mapperService().documentMapper("person");
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/dynamictemplate/genericstore/test-data.json");
-        ParsedDocument parsedDoc = docMapper.parse("person", "1", new BytesArray(json));
+        ParsedDocument parsedDoc = docMapper.parse("test", "person", "1", new BytesArray(json));
         client().admin().indices().preparePutMapping("test").setType("person").setSource(parsedDoc.dynamicMappingsUpdate().toString()).get();
         Document doc = parsedDoc.rootDoc();
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/pathmatch/PathMatchDynamicTemplateTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/pathmatch/PathMatchDynamicTemplateTests.java
@@ -47,7 +47,7 @@ public class PathMatchDynamicTemplateTests extends ElasticsearchSingleNodeTest {
         client().admin().indices().preparePutMapping("test").setType("person").setSource(mapping).get();
         DocumentMapper docMapper = index.mapperService().documentMapper("person");
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/dynamictemplate/pathmatch/test-data.json");
-        ParsedDocument parsedDoc = docMapper.parse("person", "1", new BytesArray(json));
+        ParsedDocument parsedDoc = docMapper.parse("test", "person", "1", new BytesArray(json));
         client().admin().indices().preparePutMapping("test").setType("person").setSource(parsedDoc.dynamicMappingsUpdate().toString()).get();
         Document doc = parsedDoc.rootDoc();
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/SimpleDynamicTemplatesTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/dynamictemplate/simple/SimpleDynamicTemplatesTests.java
@@ -52,7 +52,7 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         DocumentMapper docMapper = index.mapperService().documentMapper("person");
         builder = JsonXContent.contentBuilder();
         builder.startObject().field("s", "hello").field("l", 1).endObject();
-        ParsedDocument parsedDoc = docMapper.parse("person", "1", builder.bytes());
+        ParsedDocument parsedDoc = docMapper.parse("test", "person", "1", builder.bytes());
         client().admin().indices().preparePutMapping("test").setType("person").setSource(parsedDoc.dynamicMappingsUpdate().toString()).get();
 
         DocumentFieldMappers mappers = docMapper.mappers();
@@ -74,7 +74,7 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         client().admin().indices().preparePutMapping("test").setType("person").setSource(mapping).get();
         DocumentMapper docMapper = index.mapperService().documentMapper("person");
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/dynamictemplate/simple/test-data.json");
-        ParsedDocument parsedDoc = docMapper.parse("person", "1", new BytesArray(json));
+        ParsedDocument parsedDoc = docMapper.parse("test", "person", "1", new BytesArray(json));
         client().admin().indices().preparePutMapping("test").setType("person").setSource(parsedDoc.dynamicMappingsUpdate().toString()).get();
         Document doc = parsedDoc.rootDoc();
 
@@ -131,7 +131,7 @@ public class SimpleDynamicTemplatesTests extends ElasticsearchSingleNodeTest {
         client().admin().indices().preparePutMapping("test").setType("person").setSource(mapping).get();
         DocumentMapper docMapper = index.mapperService().documentMapper("person");
         byte[] json = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/dynamictemplate/simple/test-data.json");
-        ParsedDocument parsedDoc = docMapper.parse("person", "1", new BytesArray(json));
+        ParsedDocument parsedDoc = docMapper.parse("test", "person", "1", new BytesArray(json));
         client().admin().indices().preparePutMapping("test").setType("person").setSource(parsedDoc.dynamicMappingsUpdate().toString()).get();
         Document doc = parsedDoc.rootDoc();
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/SimpleExternalMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/SimpleExternalMappingTests.java
@@ -51,7 +51,7 @@ public class SimpleExternalMappingTests extends ElasticsearchSingleNodeTest {
             .endObject().endObject().string()
         );
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                     .field("field", "1234")
                 .endObject()
@@ -99,7 +99,7 @@ public class SimpleExternalMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().endObject()
                 .string());
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                     .field("field", "1234")
                 .endObject()
@@ -153,7 +153,7 @@ public class SimpleExternalMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().endObject()
                 .string());
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "1234")
                 .endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperTests.java
@@ -44,7 +44,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 1.2).field("lon", 1.3).endObject()
                 .endObject()
@@ -66,7 +66,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 1.2).field("lon", 1.3).endObject()
                 .endObject()
@@ -85,7 +85,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("point", "1.2,1.3")
                 .endObject()
@@ -104,7 +104,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("point", GeoHashUtils.encode(1.2, 1.3))
                 .endObject()
@@ -123,7 +123,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("point", GeoHashUtils.encode(1.2, 1.3))
                 .endObject()
@@ -143,7 +143,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 91).field("lon", 181).endObject()
                 .endObject()
@@ -151,7 +151,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.rootDoc().get("point"), equalTo("89.0,1.0"));
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", -91).field("lon", -181).endObject()
                 .endObject()
@@ -159,7 +159,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.rootDoc().get("point"), equalTo("-89.0,-1.0"));
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 181).field("lon", 361).endObject()
                 .endObject()
@@ -177,14 +177,14 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 90).field("lon", 1.3).endObject()
                 .endObject()
                 .bytes());
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("point").field("lat", -91).field("lon", 1.3).endObject()
                     .endObject()
@@ -195,7 +195,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("point").field("lat", 91).field("lon", 1.3).endObject()
                     .endObject()
@@ -206,7 +206,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("point").field("lat", 1.2).field("lon", -181).endObject()
                     .endObject()
@@ -217,7 +217,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
         }
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("point").field("lat", 1.2).field("lon", 181).endObject()
                     .endObject()
@@ -237,31 +237,31 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 90).field("lon", 1.3).endObject()
                 .endObject()
                 .bytes());
 
-        defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", -91).field("lon", 1.3).endObject()
                 .endObject()
                 .bytes());
 
-        defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 91).field("lon", 1.3).endObject()
                 .endObject()
                 .bytes());
 
-        defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 1.2).field("lon", -181).endObject()
                 .endObject()
                 .bytes());
 
-        defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 1.2).field("lon", 181).endObject()
                 .endObject()
@@ -276,7 +276,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 1.2).field("lon", 1.3).endObject()
                 .endObject()
@@ -298,7 +298,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startArray("point")
                 .startObject().field("lat", 1.2).field("lon", 1.3).endObject()
@@ -325,7 +325,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("point", "1.2,1.3")
                 .endObject()
@@ -344,7 +344,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("point", "1.2,1.3")
                 .endObject()
@@ -365,7 +365,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startArray("point")
                 .value("1.2,1.3")
@@ -392,7 +392,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startArray("point").value(1.3).value(1.2).endArray()
                 .endObject()
@@ -413,7 +413,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startArray("point").value(1.3).value(1.2).endArray()
                 .endObject()
@@ -432,7 +432,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startArray("point").value(1.3).value(1.2).endArray()
                 .endObject()
@@ -453,7 +453,7 @@ public class GeoPointFieldMapperTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startArray("point")
                 .startArray().value(1.3).value(1.2).endArray()

--- a/core/src/test/java/org/elasticsearch/index/mapper/geo/GeohashMappingGeoPointTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/geo/GeohashMappingGeoPointTests.java
@@ -43,7 +43,7 @@ public class GeohashMappingGeoPointTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("point").field("lat", 1.2).field("lon", 1.3).endObject()
                 .endObject()
@@ -62,7 +62,7 @@ public class GeohashMappingGeoPointTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("point", "1.2,1.3")
                 .endObject()
@@ -81,7 +81,7 @@ public class GeohashMappingGeoPointTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("point", GeoHashUtils.encode(1.2, 1.3))
                 .endObject()
@@ -125,7 +125,7 @@ public class GeohashMappingGeoPointTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("point", (Object) null)
                 .endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/id/IdMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/id/IdMappingTests.java
@@ -45,7 +45,7 @@ public class IdMappingTests extends ElasticsearchSingleNodeTest {
                 .endObject().endObject().string();
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .endObject()
                 .bytes());
@@ -54,7 +54,7 @@ public class IdMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(doc.rootDoc().get(IdFieldMapper.NAME), nullValue());
 
         try {
-            docMapper.parse("type", null, XContentFactory.jsonBuilder()
+            docMapper.parse("test", "type", null, XContentFactory.jsonBuilder()
                     .startObject()
                     .endObject()
                     .bytes());
@@ -71,7 +71,7 @@ public class IdMappingTests extends ElasticsearchSingleNodeTest {
         Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
         DocumentMapper docMapper = createIndex("test", indexSettings).mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .endObject()
                 .bytes());

--- a/core/src/test/java/org/elasticsearch/index/mapper/index/IndexTypeMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/index/IndexTypeMapperTests.java
@@ -41,7 +41,7 @@ public class IndexTypeMapperTests extends ElasticsearchSingleNodeTest {
         IndexFieldMapper indexMapper = docMapper.indexMapper();
         assertThat(indexMapper.enabled(), equalTo(true));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .endObject()
@@ -131,7 +131,7 @@ public class IndexTypeMapperTests extends ElasticsearchSingleNodeTest {
         assertThat(indexMapper.enabled(), equalTo(true));
         assertThat(indexMapper.fieldType().stored(), equalTo(true));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
             .startObject()
             .field("field", "value")
             .endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/index/IndexTypeMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/index/IndexTypeMapperTests.java
@@ -59,7 +59,7 @@ public class IndexTypeMapperTests extends ElasticsearchSingleNodeTest {
         IndexFieldMapper indexMapper = docMapper.rootMapper(IndexFieldMapper.class);
         assertThat(indexMapper.enabled(), equalTo(false));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .endObject()
@@ -76,7 +76,7 @@ public class IndexTypeMapperTests extends ElasticsearchSingleNodeTest {
         IndexFieldMapper indexMapper = docMapper.rootMapper(IndexFieldMapper.class);
         assertThat(indexMapper.enabled(), equalTo(false));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapperTests.java
@@ -80,7 +80,7 @@ public class FieldNamesFieldMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().endObject().string();
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                     .field("a", "100")
                     .startObject("b")
@@ -100,7 +100,7 @@ public class FieldNamesFieldMapperTests extends ElasticsearchSingleNodeTest {
         FieldNamesFieldMapper fieldNamesMapper = docMapper.rootMapper(FieldNamesFieldMapper.class);
         assertTrue(fieldNamesMapper.fieldType().isEnabled());
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
             .startObject()
             .field("field", "value")
             .endObject()
@@ -117,7 +117,7 @@ public class FieldNamesFieldMapperTests extends ElasticsearchSingleNodeTest {
         FieldNamesFieldMapper fieldNamesMapper = docMapper.rootMapper(FieldNamesFieldMapper.class);
         assertFalse(fieldNamesMapper.fieldType().isEnabled());
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
             .startObject()
             .field("field", "value")
             .endObject()
@@ -145,7 +145,7 @@ public class FieldNamesFieldMapperTests extends ElasticsearchSingleNodeTest {
         FieldNamesFieldMapper fieldNamesMapper = docMapper.rootMapper(FieldNamesFieldMapper.class);
         assertFalse(fieldNamesMapper.fieldType().isEnabled());
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
             .startObject()
             .field("field", "value")
             .endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/ip/SimpleIpMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ip/SimpleIpMappingTests.java
@@ -47,7 +47,7 @@ public class SimpleIpMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("ip", "127.0.0.1")
                 .endObject()
@@ -91,20 +91,20 @@ public class SimpleIpMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1",
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1",
                 XContentFactory.jsonBuilder().startObject().field("field1", "").field("field2", "10.20.30.40").endObject().bytes());
         assertThat(doc.rootDoc().getField("field1"), nullValue());
         assertThat(doc.rootDoc().getField("field2"), notNullValue());
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject().field("field2", "").endObject().bytes());
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject().field("field2", "").endObject().bytes());
         } catch (MapperParsingException e) {
             assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         }
 
         // Verify that the default is false
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject().field("field3", "").endObject().bytes());
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject().field("field3", "").endObject().bytes());
         } catch (MapperParsingException e) {
             assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         }
@@ -112,12 +112,12 @@ public class SimpleIpMappingTests extends ElasticsearchSingleNodeTest {
         // Unless the global ignore_malformed option is set to true
         Settings indexSettings = settingsBuilder().put("index.mapping.ignore_malformed", true).build();
         defaultMapper = createIndex("test2", indexSettings).mapperService().documentMapperParser().parse(mapping);
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject().field("field3", "").endObject().bytes());
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject().field("field3", "").endObject().bytes());
         assertThat(doc.rootDoc().getField("field3"), nullValue());
 
         // This should still throw an exception, since field2 is specifically set to ignore_malformed=false
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject().field("field2", "").endObject().bytes());
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject().field("field2", "").endObject().bytes());
         } catch (MapperParsingException e) {
             assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         }

--- a/core/src/test/java/org/elasticsearch/index/mapper/lucene/DoubleIndexingDocTest.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/lucene/DoubleIndexingDocTest.java
@@ -53,7 +53,7 @@ public class DoubleIndexingDocTest extends ElasticsearchSingleNodeTest {
         client().admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
         DocumentMapper mapper = index.mapperService().documentMapper("type");
 
-        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field1", "value1")
                 .field("field2", 1)

--- a/core/src/test/java/org/elasticsearch/index/mapper/lucene/StoredNumericValuesTest.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/lucene/StoredNumericValuesTest.java
@@ -65,7 +65,7 @@ public class StoredNumericValuesTest extends ElasticsearchSingleNodeTest {
                 .string();
         DocumentMapper mapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                     .field("field1", 1)
                     .field("field2", 1.1)

--- a/core/src/test/java/org/elasticsearch/index/mapper/merge/TestMergeMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/merge/TestMergeMapperTests.java
@@ -174,7 +174,7 @@ public class TestMergeMapperTests extends ElasticsearchSingleNodeTest {
                     barrier.await();
                     for (int i = 0; i < 200 && stopped.get() == false; i++) {
                         final String fieldName = Integer.toString(i);
-                        ParsedDocument doc = documentMapper.parse("test", fieldName, new BytesArray("{ \"" + fieldName + "\" : \"test\" }"));
+                        ParsedDocument doc = documentMapper.parse("test", "test", fieldName, new BytesArray("{ \"" + fieldName + "\" : \"test\" }"));
                         Mapping update = doc.dynamicMappingsUpdate();
                         assert update != null;
                         lastIntroducedFieldName.set(fieldName);
@@ -193,7 +193,7 @@ public class TestMergeMapperTests extends ElasticsearchSingleNodeTest {
             while(stopped.get() == false) {
                 final String fieldName = lastIntroducedFieldName.get();
                 final BytesReference source = new BytesArray("{ \"" + fieldName + "\" : \"test\" }");
-                ParsedDocument parsedDoc = documentMapper.parse("test", "random", source);
+                ParsedDocument parsedDoc = documentMapper.parse("test", "test", "random", source);
                 if (parsedDoc.dynamicMappingsUpdate() != null) {
                     // not in the mapping yet, try again
                     continue;

--- a/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
@@ -77,7 +77,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
     private void testMultiField(String mapping) throws Exception {
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/multifield/test-data.json"));
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
 
         IndexableField f = doc.getField("name");
         assertThat(f.name(), equalTo("name"));
@@ -164,7 +164,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
 
 
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/multifield/test-data.json"));
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
 
         IndexableField f = doc.getField("name");
         assertThat(f.name(), equalTo("name"));
@@ -191,7 +191,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/test-multi-field-type-no-default-field.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/multifield/test-data.json"));
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
 
         assertNull(doc.getField("name"));
         IndexableField f = doc.getField("name.indexed");
@@ -276,7 +276,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         BytesReference json = jsonBuilder().startObject()
                 .field("a", "-1,-1")
                 .endObject().bytes();
-        Document doc = docMapper.parse("type", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "type", "1", json).rootDoc();
 
         IndexableField f = doc.getField("a");
         assertThat(f, notNullValue());
@@ -307,7 +307,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         json = jsonBuilder().startObject()
                 .field("b", "-1,-1")
                 .endObject().bytes();
-        doc = docMapper.parse("type", "1", json).rootDoc();
+        doc = docMapper.parse("test", "type", "1", json).rootDoc();
 
         f = doc.getField("b");
         assertThat(f, notNullValue());
@@ -326,7 +326,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         json = jsonBuilder().startObject()
                 .startArray("b").startArray().value(-1).value(-1).endArray().startArray().value(-2).value(-2).endArray().endArray()
                 .endObject().bytes();
-        doc = docMapper.parse("type", "1", json).rootDoc();
+        doc = docMapper.parse("test", "type", "1", json).rootDoc();
 
         f = doc.getFields("b")[0];
         assertThat(f, notNullValue());
@@ -373,7 +373,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         BytesReference json = jsonBuilder().startObject()
                 .field("a", "complete me")
                 .endObject().bytes();
-        Document doc = docMapper.parse("type", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "type", "1", json).rootDoc();
 
         IndexableField f = doc.getField("a");
         assertThat(f, notNullValue());
@@ -404,7 +404,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         json = jsonBuilder().startObject()
                 .field("b", "complete me")
                 .endObject().bytes();
-        doc = docMapper.parse("type", "1", json).rootDoc();
+        doc = docMapper.parse("test", "type", "1", json).rootDoc();
 
         f = doc.getField("b");
         assertThat(f, notNullValue());

--- a/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
@@ -151,7 +151,7 @@ public class MultiFieldTests extends ElasticsearchSingleNodeTest {
         Settings settings = indexService.settingsService().getSettings();
         DocumentMapperParser mapperParser = indexService.mapperService().documentMapperParser();
 
-        DocumentMapper builderDocMapper = doc("test", settings, rootObject("person").add(
+        DocumentMapper builderDocMapper = doc(settings, rootObject("person").add(
                 stringField("name").store(true)
                         .addMultiField(stringField("indexed").index(true).tokenized(true))
                         .addMultiField(stringField("not_indexed").index(false).store(true))

--- a/core/src/test/java/org/elasticsearch/index/mapper/multifield/merge/JavaMultiFieldMergeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/multifield/merge/JavaMultiFieldMergeTests.java
@@ -53,7 +53,7 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
         assertThat(docMapper.mappers().getMapper("name.indexed"), nullValue());
 
         BytesReference json = XContentFactory.jsonBuilder().startObject().field("name", "some name").endObject().bytes();
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
         IndexableField f = doc.getField("name");
         assertThat(f, notNullValue());
         f = doc.getField("name.indexed");
@@ -75,7 +75,7 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
         assertThat(docMapper.mappers().getMapper("name.not_indexed2"), nullValue());
         assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
 
-        doc = docMapper.parse("person", "1", json).rootDoc();
+        doc = docMapper.parse("test", "person", "1", json).rootDoc();
         f = doc.getField("name");
         assertThat(f, notNullValue());
         f = doc.getField("name.indexed");
@@ -125,7 +125,7 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
         assertThat(docMapper.mappers().getMapper("name.indexed"), nullValue());
 
         BytesReference json = XContentFactory.jsonBuilder().startObject().field("name", "some name").endObject().bytes();
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
         IndexableField f = doc.getField("name");
         assertThat(f, notNullValue());
         f = doc.getField("name.indexed");
@@ -148,7 +148,7 @@ public class JavaMultiFieldMergeTests extends ElasticsearchSingleNodeTest {
         assertThat(docMapper.mappers().getMapper("name.not_indexed2"), nullValue());
         assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
 
-        doc = docMapper.parse("person", "1", json).rootDoc();
+        doc = docMapper.parse("test", "person", "1", json).rootDoc();
         f = doc.getField("name");
         assertThat(f, notNullValue());
         f = doc.getField("name.indexed");

--- a/core/src/test/java/org/elasticsearch/index/mapper/nested/NestedMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/nested/NestedMappingTests.java
@@ -41,7 +41,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .nullField("nested1")
@@ -50,7 +50,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.docs().size(), equalTo(1));
 
-        doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .startArray("nested").endArray()
@@ -72,7 +72,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
         ObjectMapper nested1Mapper = docMapper.objectMappers().get("nested1");
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .startObject("nested1").field("field1", "1").field("field2", "2").endObject()
@@ -87,7 +87,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(doc.docs().get(1).get("field"), equalTo("value"));
 
 
-        doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .startArray("nested1")
@@ -128,7 +128,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(nested2Mapper.nested().isIncludeInParent(), equalTo(false));
         assertThat(nested2Mapper.nested().isIncludeInRoot(), equalTo(false));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .startArray("nested1")
@@ -180,7 +180,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(nested2Mapper.nested().isIncludeInParent(), equalTo(true));
         assertThat(nested2Mapper.nested().isIncludeInRoot(), equalTo(false));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .startArray("nested1")
@@ -232,7 +232,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(nested2Mapper.nested().isIncludeInParent(), equalTo(true));
         assertThat(nested2Mapper.nested().isIncludeInRoot(), equalTo(false));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .startArray("nested1")
@@ -284,7 +284,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(nested2Mapper.nested().isIncludeInParent(), equalTo(false));
         assertThat(nested2Mapper.nested().isIncludeInRoot(), equalTo(true));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .startArray("nested1")
@@ -331,7 +331,7 @@ public class NestedMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(nested1Mapper.nested().isNested(), equalTo(true));
         assertThat(nested1Mapper.dynamic(), equalTo(Dynamic.STRICT));
 
-        ParsedDocument doc = docMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = docMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "value")
                 .startArray("nested1")

--- a/core/src/test/java/org/elasticsearch/index/mapper/numeric/SimpleNumericTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/numeric/SimpleNumericTests.java
@@ -63,7 +63,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
         client().admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
         DocumentMapper defaultMapper = index.mapperService().documentMapper("type");
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("s_long", "100")
                 .field("s_double", "100.0")
@@ -88,7 +88,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
         client().admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
         DocumentMapper defaultMapper = index.mapperService().documentMapper("type");
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("s_long", "100")
                 .field("s_double", "100.0")
@@ -116,7 +116,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field1", "a")
                 .field("field2", "1")
@@ -126,7 +126,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
         assertThat(doc.rootDoc().getField("field2"), notNullValue());
 
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("field2", "a")
                     .endObject()
@@ -137,7 +137,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
         // Verify that the default is false
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("field3", "a")
                     .endObject()
@@ -149,7 +149,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
         // Unless the global ignore_malformed option is set to true
         Settings indexSettings = settingsBuilder().put("index.mapping.ignore_malformed", true).build();
         defaultMapper = createIndex("test2", indexSettings).mapperService().documentMapperParser().parse(mapping);
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field3", "a")
                 .endObject()
@@ -158,7 +158,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
         // This should still throw an exception, since field2 is specifically set to ignore_malformed=false
         try {
-            defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("field2", "a")
                     .endObject()
@@ -190,7 +190,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
             //Test numbers passed as strings
             String invalidJsonNumberAsString="1";
-            ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("noErrorNoCoerceField", invalidJsonNumberAsString)
                     .field("noErrorCoerceField", invalidJsonNumberAsString)
@@ -204,7 +204,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
             
             //Test valid case of numbers passed as numbers
             int validNumber=1;
-            doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("noErrorNoCoerceField", validNumber)
                     .field("noErrorCoerceField", validNumber)
@@ -217,7 +217,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
             
             //Test valid case of negative numbers passed as numbers
             int validNegativeNumber=-1;
-            doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("noErrorNoCoerceField", validNegativeNumber)
                     .field("noErrorCoerceField", validNegativeNumber)
@@ -230,7 +230,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
             
 
             try {
-                defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+                defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                         .startObject()
                         .field("errorNoCoerce", invalidJsonNumberAsString)
                         .endObject()
@@ -243,7 +243,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
             //Test questionable case of floats passed to ints
             float invalidJsonForInteger=1.9f;
             int coercedFloatValue=1; //This is what the JSON parser will do to a float - truncate not round
-            doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+            doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("noErrorNoCoerceField", invalidJsonForInteger)
                     .field("noErrorCoerceField", invalidJsonForInteger)
@@ -256,7 +256,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
             assertEquals(coercedFloatValue,doc.rootDoc().getField("errorDefaultCoerce").numericValue().intValue());
             
             try {
-                defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+                defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                         .startObject()
                         .field("errorNoCoerce", invalidJsonForInteger)
                         .endObject()
@@ -288,7 +288,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument parsedDoc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument parsedDoc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("int", "1234")
                 .field("double", "1234")
@@ -324,7 +324,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument parsedDoc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument parsedDoc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                     .startArray("nested")
                         .startObject()
@@ -357,7 +357,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper mapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("long",   "100")
                 .field("double", "100.0")
@@ -408,7 +408,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper mapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         
-        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("int",    "100")
                 .field("float",  "100.0")
@@ -479,7 +479,7 @@ public class SimpleNumericTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper mapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         
-        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("int",    "100")
                 .field("float",  "100.0")

--- a/core/src/test/java/org/elasticsearch/index/mapper/object/NullValueObjectMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/object/NullValueObjectMappingTests.java
@@ -42,7 +42,7 @@ public class NullValueObjectMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("obj1").endObject()
                 .field("value1", "test1")
@@ -51,7 +51,7 @@ public class NullValueObjectMappingTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.rootDoc().get("value1"), equalTo("test1"));
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .nullField("obj1")
                 .field("value1", "test1")
@@ -60,7 +60,7 @@ public class NullValueObjectMappingTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.rootDoc().get("value1"), equalTo("test1"));
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("obj1").field("field", "value").endObject()
                 .field("value1", "test1")

--- a/core/src/test/java/org/elasticsearch/index/mapper/object/SimpleObjectMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/object/SimpleObjectMappingTests.java
@@ -38,7 +38,7 @@ public class SimpleObjectMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         try {
-            defaultMapper.parse("type", "1", new BytesArray(" {\n" +
+            defaultMapper.parse("test", "type", "1", new BytesArray(" {\n" +
                     "      \"object\": {\n" +
                     "        \"array\":[\n" +
                     "        {\n" +

--- a/core/src/test/java/org/elasticsearch/index/mapper/routing/RoutingTypeMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/routing/RoutingTypeMapperTests.java
@@ -120,6 +120,6 @@ public class RoutingTypeMapperTests extends ElasticsearchSingleNodeTest {
 
         // _routing in a document never worked, so backcompat is ignoring the field
         assertNull(request.routing());
-        assertNull(docMapper.parse("type", "1", doc.bytes()).rootDoc().get("_routing"));
+        assertNull(docMapper.parse("test", "type", "1", doc.bytes()).rootDoc().get("_routing"));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/simple/SimpleMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/simple/SimpleMapperTests.java
@@ -45,7 +45,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         IndexService indexService = createIndex("test");
         Settings settings = indexService.settingsService().getSettings();
         DocumentMapperParser mapperParser = indexService.mapperService().documentMapperParser();
-        DocumentMapper docMapper = doc("test", settings,
+        DocumentMapper docMapper = doc(settings,
                 rootObject("person")
                         .add(object("name").add(stringField("first").store(true).index(false))),
             indexService.mapperService()).build(indexService.mapperService(), mapperParser);
@@ -123,7 +123,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         IndexService indexService = createIndex("test");
         Settings settings = indexService.settingsService().getSettings();
         DocumentMapperParser mapperParser = indexService.mapperService().documentMapperParser();
-        DocumentMapper docMapper = doc("test", settings,
+        DocumentMapper docMapper = doc(settings,
                 rootObject("person")
                         .add(object("name").add(stringField("first").store(true).index(false))),
             indexService.mapperService()).build(indexService.mapperService(), mapperParser);

--- a/core/src/test/java/org/elasticsearch/index/mapper/simple/SimpleMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/simple/SimpleMapperTests.java
@@ -51,12 +51,12 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
             indexService.mapperService()).build(indexService.mapperService(), mapperParser);
 
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
 
         assertThat(doc.get(docMapper.mappers().getMapper("name.first").fieldType().names().indexName()), equalTo("shay"));
 //        System.out.println("Document: " + doc);
 //        System.out.println("Json: " + docMapper.sourceMapper().value(doc));
-        doc = docMapper.parse("person", "1", json).rootDoc();
+        doc = docMapper.parse("test", "person", "1", json).rootDoc();
 //        System.out.println("Document: " + doc);
 //        System.out.println("Json: " + docMapper.sourceMapper().value(doc));
     }
@@ -71,7 +71,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         // reparse it
         DocumentMapper builtDocMapper = parser.parse(builtMapping);
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
-        Document doc = builtDocMapper.parse("person", "1", json).rootDoc();
+        Document doc = builtDocMapper.parse("test", "person", "1", json).rootDoc();
         assertThat(doc.get(docMapper.uidMapper().fieldType().names().indexName()), equalTo(Uid.createUid("person", "1")));
         assertThat(doc.get(docMapper.mappers().getMapper("name.first").fieldType().names().indexName()), equalTo("shay"));
 //        System.out.println("Document: " + doc);
@@ -86,7 +86,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         assertThat((String) docMapper.meta().get("param1"), equalTo("value1"));
 
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
         assertThat(doc.get(docMapper.uidMapper().fieldType().names().indexName()), equalTo(Uid.createUid("person", "1")));
         assertThat(doc.get(docMapper.mappers().getMapper("name.first").fieldType().names().indexName()), equalTo("shay"));
 //        System.out.println("Document: " + doc);
@@ -98,7 +98,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/simple/test-mapping.json");
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1-notype-noid.json"));
-        Document doc = docMapper.parse("person", "1", json).rootDoc();
+        Document doc = docMapper.parse("test", "person", "1", json).rootDoc();
         assertThat(doc.get(docMapper.uidMapper().fieldType().names().indexName()), equalTo(Uid.createUid("person", "1")));
         assertThat(doc.get(docMapper.mappers().getMapper("name.first").fieldType().names().indexName()), equalTo("shay"));
 //        System.out.println("Document: " + doc);
@@ -130,7 +130,7 @@ public class SimpleMapperTests extends ElasticsearchSingleNodeTest {
 
         BytesReference json = new BytesArray("".getBytes(Charsets.UTF_8));
         try {
-            docMapper.parse("person", "1", json).rootDoc();
+            docMapper.parse("test", "person", "1", json).rootDoc();
             fail("this point is never reached");
         } catch (MapperParsingException e) {
             assertThat(e.getMessage(), equalTo("failed to parse, document is empty"));

--- a/core/src/test/java/org/elasticsearch/index/mapper/source/CompressSourceMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/source/CompressSourceMappingTests.java
@@ -47,7 +47,7 @@ public class CompressSourceMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper documentMapper = createIndex("test", settings).mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .field("field1", "value1")
                 .field("field2", "value2")
                 .endObject().bytes());
@@ -63,7 +63,7 @@ public class CompressSourceMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper documentMapper = createIndex("test", settings).mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .field("field1", "value1")
                 .field("field2", "value2")
                 .endObject().bytes());
@@ -80,14 +80,14 @@ public class CompressSourceMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper documentMapper = createIndex("test", settings).mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .field("field1", "value1")
                 .endObject().bytes());
 
         BytesRef bytes = doc.rootDoc().getBinaryValue("_source");
         assertThat(CompressorFactory.isCompressed(new BytesArray(bytes)), equalTo(false));
 
-        doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .field("field1", "value1")
                 .field("field2", "value2 xxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzz")
                 .field("field2", "value2 xxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzz")

--- a/core/src/test/java/org/elasticsearch/index/mapper/source/DefaultSourceMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/source/DefaultSourceMappingTests.java
@@ -49,14 +49,14 @@ public class DefaultSourceMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
         DocumentMapper documentMapper = parser.parse(mapping);
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .field("field", "value")
                 .endObject().bytes());
 
         assertThat(XContentFactory.xContentType(doc.source()), equalTo(XContentType.JSON));
 
         documentMapper = parser.parse(mapping);
-        doc = documentMapper.parse("type", "1", XContentFactory.smileBuilder().startObject()
+        doc = documentMapper.parse("test", "type", "1", XContentFactory.smileBuilder().startObject()
                 .field("field", "value")
                 .endObject().bytes());
 
@@ -70,14 +70,14 @@ public class DefaultSourceMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
         DocumentMapper documentMapper = parser.parse(mapping);
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .field("field", "value")
                 .endObject().bytes());
 
         assertThat(XContentFactory.xContentType(doc.source()), equalTo(XContentType.JSON));
 
         documentMapper = parser.parse(mapping);
-        doc = documentMapper.parse("type", "1", XContentFactory.smileBuilder().startObject()
+        doc = documentMapper.parse("test", "type", "1", XContentFactory.smileBuilder().startObject()
             .field("field", "value")
             .endObject().bytes());
 
@@ -92,7 +92,7 @@ public class DefaultSourceMappingTests extends ElasticsearchSingleNodeTest {
         Settings backcompatSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
         DocumentMapperParser parser = createIndex("test", backcompatSettings).mapperService().documentMapperParser();
         DocumentMapper documentMapper = parser.parse(mapping);
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .field("field", "value")
                 .endObject().bytes());
 
@@ -101,7 +101,7 @@ public class DefaultSourceMappingTests extends ElasticsearchSingleNodeTest {
         assertThat(XContentFactory.xContentType(uncompressed), equalTo(XContentType.JSON));
 
         documentMapper = parser.parse(mapping);
-        doc = documentMapper.parse("type", "1", XContentFactory.smileBuilder().startObject()
+        doc = documentMapper.parse("test", "type", "1", XContentFactory.smileBuilder().startObject()
                 .field("field", "value")
                 .endObject().bytes());
 
@@ -117,7 +117,7 @@ public class DefaultSourceMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper documentMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
             .startObject("path1").field("field1", "value1").endObject()
             .startObject("path2").field("field2", "value2").endObject()
             .endObject().bytes());
@@ -138,7 +138,7 @@ public class DefaultSourceMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper documentMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
 
-        ParsedDocument doc = documentMapper.parse("type", "1", XContentFactory.jsonBuilder().startObject()
+        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
             .startObject("path1").field("field1", "value1").endObject()
             .startObject("path2").field("field2", "value2").endObject()
             .endObject().bytes());

--- a/core/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/string/SimpleStringMappingTests.java
@@ -83,7 +83,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = parser.parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "1234")
                 .endObject()
@@ -91,7 +91,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.rootDoc().getField("field"), notNullValue());
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "12345")
                 .endObject()
@@ -99,7 +99,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         assertThat(doc.rootDoc().getField("field"), notNullValue());
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "123456")
                 .endObject()
@@ -128,7 +128,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
     private void assertParseIdemPotent(IndexableFieldType expected, DocumentMapper mapper) throws Exception {
         String mapping = mapper.toXContent(XContentFactory.jsonBuilder().startObject(), new ToXContent.MapParams(ImmutableMap.<String, String>of())).endObject().string();
         mapper = parser.parse(mapping);
-        ParsedDocument doc = mapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "2345")
                 .endObject()
@@ -144,7 +144,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = parser.parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "1234")
                 .endObject()
@@ -163,7 +163,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = parser.parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "1234")
                 .endObject()
@@ -186,7 +186,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         defaultMapper = parser.parse(mapping);
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "1234")
                 .endObject()
@@ -209,7 +209,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         defaultMapper = parser.parse(mapping);
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "1234")
                 .endObject()
@@ -329,7 +329,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = parser.parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field1", "1234")
                 .field("field2", "1234")
@@ -400,7 +400,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = parser.parse(mapping);
 
-        ParsedDocument parsedDoc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument parsedDoc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
             .startObject()
             .field("str1", "1234")
             .field("str2", "1234")
@@ -454,7 +454,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = parser.parse(mapping);
 
-        ParsedDocument parsedDoc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument parsedDoc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("str1", "1234")
                 .field("str2", "1234")
@@ -490,7 +490,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = parser.parse(mapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "1234")
                 .endObject()
@@ -505,7 +505,7 @@ public class SimpleStringMappingTests extends ElasticsearchSingleNodeTest {
         MergeResult mergeResult = defaultMapper.merge(parser.parse(updatedMapping).mapping(), false, false);
         assertFalse(Arrays.toString(mergeResult.buildConflicts()), mergeResult.hasConflicts());
 
-        doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("field", "1234")
                 .endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/timestamp/TimestampMappingTests.java
@@ -767,7 +767,7 @@ public class TimestampMappingTests extends ElasticsearchSingleNodeTest {
 
         // _timestamp in a document never worked, so backcompat is ignoring the field
         assertEquals(MappingMetaData.Timestamp.parseStringTimestamp("1970", Joda.forPattern("YYYY"), Version.V_1_4_2), request.timestamp());
-        assertNull(docMapper.parse("type", "1", doc.bytes()).rootDoc().get("_timestamp"));
+        assertNull(docMapper.parse("test", "type", "1", doc.bytes()).rootDoc().get("_timestamp"));
     }
 
     public void testThatEpochCanBeIgnoredWithCustomFormat() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/mapper/ttl/TTLMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ttl/TTLMappingTests.java
@@ -308,7 +308,7 @@ public class TTLMappingTests extends ElasticsearchSingleNodeTest {
 
         // _ttl in a document never worked, so backcompat is ignoring the field
         assertEquals(-1, request.ttl());
-        assertNull(docMapper.parse("type", "1", doc.bytes()).rootDoc().get("_ttl"));
+        assertNull(docMapper.parse("test", "type", "1", doc.bytes()).rootDoc().get("_ttl"));
     }
 
     private org.elasticsearch.common.xcontent.XContentBuilder getMappingWithTtlEnabled() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/mapper/typelevels/ParseDocumentTypeLevelsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/typelevels/ParseDocumentTypeLevelsTests.java
@@ -38,7 +38,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("test1", "value1")
                 .field("test2", "value2")
@@ -57,7 +57,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject().startObject("type")
                 .field("test1", "value1")
                 .field("test2", "value2")
@@ -76,7 +76,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("type", "value_type")
                 .field("test1", "value1")
@@ -97,7 +97,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject().startObject("type")
                 .field("type", "value_type")
                 .field("test1", "value1")
@@ -118,7 +118,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("type").field("type_field", "type_value").endObject()
                 .field("test1", "value1")
@@ -139,7 +139,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject().startObject("type")
                 .startObject("type").field("type_field", "type_value").endObject()
                 .field("test1", "value1")
@@ -160,7 +160,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject().startObject("type")
                 .field("test1", "value1")
                 .field("test2", "value2")
@@ -181,7 +181,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject().startObject("type")
                 .field("test1", "value1")
                 .field("type", "value_type")
@@ -202,7 +202,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
                 .field("test1", "value1")
                 .startObject("type").field("type_field", "type_value").endObject()
@@ -224,7 +224,7 @@ public class ParseDocumentTypeLevelsTests extends ElasticsearchSingleNodeTest {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(defaultMapping);
 
-        ParsedDocument doc = defaultMapper.parse("type", "1", XContentFactory.jsonBuilder()
+        ParsedDocument doc = defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject().startObject("type")
                 .field("test1", "value1")
                 .startObject("type").field("type_field", "type_value").endObject()

--- a/core/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterDateRangeFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterDateRangeFormatTests.java
@@ -59,7 +59,7 @@ public class IndexQueryParserFilterDateRangeFormatTests extends ElasticsearchSin
         MapperService mapperService = indexService.mapperService();
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/query/mapping.json");
         mapperService.merge("person", new CompressedXContent(mapping), true, false);
-        ParsedDocument doc = mapperService.documentMapper("person").parse("person", "1", new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/query/data.json")));
+        ParsedDocument doc = mapperService.documentMapper("person").parse("test", "person", "1", new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/query/data.json")));
         assertNotNull(doc.dynamicMappingsUpdate());
         client().admin().indices().preparePutMapping("test").setType("person").setSource(doc.dynamicMappingsUpdate().toString()).get();
         queryParser = injector.getInstance(IndexQueryParserService.class);

--- a/core/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterDateRangeTimezoneTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IndexQueryParserFilterDateRangeTimezoneTests.java
@@ -60,7 +60,7 @@ public class IndexQueryParserFilterDateRangeTimezoneTests extends ElasticsearchS
         MapperService mapperService = indexService.mapperService();
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/query/mapping.json");
         mapperService.merge("person", new CompressedXContent(mapping), true, false);
-        ParsedDocument doc = mapperService.documentMapper("person").parse("person", "1", new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/query/data.json")));
+        ParsedDocument doc = mapperService.documentMapper("person").parse("test", "person", "1", new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/query/data.json")));
         assertNotNull(doc.dynamicMappingsUpdate());
         client().admin().indices().preparePutMapping("test").setType("person").setSource(doc.dynamicMappingsUpdate().toString()).get();
         queryParser = injector.getInstance(IndexQueryParserService.class);

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -96,7 +96,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
 
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/query/mapping.json");
         mapperService.merge("person", new CompressedXContent(mapping), true, false);
-        ParsedDocument doc = mapperService.documentMapper("person").parse("person", "1", new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/query/data.json")));
+        ParsedDocument doc = mapperService.documentMapper("person").parse("test", "person", "1", new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/query/data.json")));
         assertNotNull(doc.dynamicMappingsUpdate());
         client().admin().indices().preparePutMapping("test").setType("person").setSource(doc.dynamicMappingsUpdate().toString()).get();
 


### PR DESCRIPTION
The index name was passed along through many levels of mapping parsing,
just so that it could be used for _index. However, the index name
is really metadata that should exist alongside things like type and
id in SourceToParse.

This change moves index name to SourceToParse, and eliminates it from the
DocumentMapperParser.
