### PR TITLE
Cleanup TransportSingleShardAction and TransportInstanceSingleOperationAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -126,12 +126,10 @@ public class BulkRequest extends ActionRequest<BulkRequest> implements Composite
      * Adds an {@link UpdateRequest} to the list of actions to execute.
      */
     public BulkRequest add(UpdateRequest request) {
-        request.beforeLocalFork();
         return internalAdd(request, null);
     }
 
     public BulkRequest add(UpdateRequest request, @Nullable Object payload) {
-        request.beforeLocalFork();
         return internalAdd(request, payload);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
@@ -44,6 +44,8 @@ public abstract class InstanceShardOperationRequest<T extends InstanceShardOpera
     // -1 means its not set, allows to explicitly direct a request to a specific shard
     protected int shardId = -1;
 
+    private String concreteIndex;
+
     protected InstanceShardOperationRequest() {
     }
 
@@ -100,13 +102,21 @@ public abstract class InstanceShardOperationRequest<T extends InstanceShardOpera
         return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
     }
 
+    public String concreteIndex() {
+        return concreteIndex;
+    }
+
+    void concreteIndex(String concreteIndex) {
+        this.concreteIndex = concreteIndex;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         index = in.readString();
         shardId = in.readInt();
         timeout = TimeValue.readTimeValue(in);
-        // no need to pass threading over the network, they are always false when coming throw a thread pool
+        concreteIndex = in.readOptionalString();
     }
 
     @Override
@@ -115,9 +125,8 @@ public abstract class InstanceShardOperationRequest<T extends InstanceShardOpera
         out.writeString(index);
         out.writeInt(shardId);
         timeout.writeTo(out);
+        out.writeOptionalString(concreteIndex);
     }
 
-    public void beforeLocalFork() {
-    }
 }
 

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -101,11 +101,11 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     }
 
     @Override
-    protected boolean resolveRequest(ClusterState state, InternalRequest request, ActionListener<UpdateResponse> listener) {
-        request.request().routing((state.metaData().resolveIndexRouting(request.request().routing(), request.request().index())));
+    protected boolean resolveRequest(ClusterState state, UpdateRequest request, ActionListener<UpdateResponse> listener) {
+        request.routing((state.metaData().resolveIndexRouting(request.routing(), request.index())));
         // Fail fast on the node that received the request, rather than failing when translating on the index or delete request.
-        if (request.request().routing() == null && state.getMetaData().routingRequired(request.concreteIndex(), request.request().type())) {
-            throw new RoutingMissingException(request.concreteIndex(), request.request().type(), request.request().id());
+        if (request.routing() == null && state.getMetaData().routingRequired(request.concreteIndex(), request.type())) {
+            throw new RoutingMissingException(request.concreteIndex(), request.type(), request.id());
         }
         return true;
     }
@@ -114,7 +114,6 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     protected void doExecute(final UpdateRequest request, final ActionListener<UpdateResponse> listener) {
         // if we don't have a master, we don't have metadata, that's fine, let it find a master using create index API
         if (autoCreateIndex.shouldAutoCreate(request.index(), clusterService.state())) {
-            request.beforeLocalFork(); // we fork on another thread...
             createIndexAction.execute(new CreateIndexRequest(request).index(request.index()).cause("auto(update api)").masterNodeTimeout(request.timeout()), new ActionListener<CreateIndexResponse>() {
                 @Override
                 public void onResponse(CreateIndexResponse result) {
@@ -145,12 +144,12 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     }
 
     @Override
-    protected ShardIterator shards(ClusterState clusterState, InternalRequest request) {
-        if (request.request().shardId() != -1) {
-            return clusterState.routingTable().index(request.concreteIndex()).shard(request.request().shardId()).primaryShardIt();
+    protected ShardIterator shards(ClusterState clusterState, UpdateRequest request) {
+        if (request.shardId() != -1) {
+            return clusterState.routingTable().index(request.concreteIndex()).shard(request.shardId()).primaryShardIt();
         }
         ShardIterator shardIterator = clusterService.operationRouting()
-                .indexShards(clusterState, request.concreteIndex(), request.request().type(), request.request().id(), request.request().routing());
+                .indexShards(clusterState, request.concreteIndex(), request.type(), request.id(), request.routing());
         ShardRouting shard;
         while ((shard = shardIterator.nextOrNull()) != null) {
             if (shard.primary()) {
@@ -161,26 +160,26 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     }
 
     @Override
-    protected void shardOperation(final InternalRequest request, final ActionListener<UpdateResponse> listener) {
+    protected void shardOperation(final UpdateRequest request, final ActionListener<UpdateResponse> listener) {
         shardOperation(request, listener, 0);
     }
 
-    protected void shardOperation(final InternalRequest request, final ActionListener<UpdateResponse> listener, final int retryCount) {
+    protected void shardOperation(final UpdateRequest request, final ActionListener<UpdateResponse> listener, final int retryCount) {
         IndexService indexService = indicesService.indexServiceSafe(request.concreteIndex());
-        IndexShard indexShard = indexService.shardSafe(request.request().shardId());
-        final UpdateHelper.Result result = updateHelper.prepare(request.request(), indexShard);
+        IndexShard indexShard = indexService.shardSafe(request.shardId());
+        final UpdateHelper.Result result = updateHelper.prepare(request, indexShard);
         switch (result.operation()) {
             case UPSERT:
-                IndexRequest upsertRequest = new IndexRequest((IndexRequest)result.action(), request.request());
+                IndexRequest upsertRequest = new IndexRequest((IndexRequest)result.action(), request);
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
                 final BytesReference upsertSourceBytes = upsertRequest.source();
                 indexAction.execute(upsertRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
                         UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getIndex(), response.getType(), response.getId(), response.getVersion(), response.isCreated());
-                        if (request.request().fields() != null && request.request().fields().length > 0) {
+                        if (request.fields() != null && request.fields().length > 0) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(upsertSourceBytes, true);
-                            update.setGetResult(updateHelper.extractGetResult(request.request(), request.concreteIndex(), response.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), upsertSourceBytes));
+                            update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), upsertSourceBytes));
                         } else {
                             update.setGetResult(null);
                         }
@@ -191,7 +190,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                     public void onFailure(Throwable e) {
                         e = ExceptionsHelper.unwrapCause(e);
                         if (e instanceof VersionConflictEngineException || e instanceof DocumentAlreadyExistsException) {
-                            if (retryCount < request.request().retryOnConflict()) {
+                            if (retryCount < request.retryOnConflict()) {
                                 threadPool.executor(executor()).execute(new ActionRunnable<UpdateResponse>(listener) {
                                     @Override
                                     protected void doRun() {
@@ -206,14 +205,14 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 });
                 break;
             case INDEX:
-                IndexRequest indexRequest = new IndexRequest((IndexRequest)result.action(), request.request());
+                IndexRequest indexRequest = new IndexRequest((IndexRequest)result.action(), request);
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
                 final BytesReference indexSourceBytes = indexRequest.source();
                 indexAction.execute(indexRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
                         UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getIndex(), response.getType(), response.getId(), response.getVersion(), response.isCreated());
-                        update.setGetResult(updateHelper.extractGetResult(request.request(), request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
+                        update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
                         listener.onResponse(update);
                     }
 
@@ -221,7 +220,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                     public void onFailure(Throwable e) {
                         e = ExceptionsHelper.unwrapCause(e);
                         if (e instanceof VersionConflictEngineException) {
-                            if (retryCount < request.request().retryOnConflict()) {
+                            if (retryCount < request.retryOnConflict()) {
                                 threadPool.executor(executor()).execute(new ActionRunnable<UpdateResponse>(listener) {
                                     @Override
                                     protected void doRun() {
@@ -236,12 +235,12 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 });
                 break;
             case DELETE:
-                DeleteRequest deleteRequest = new DeleteRequest((DeleteRequest)result.action(), request.request());
+                DeleteRequest deleteRequest = new DeleteRequest((DeleteRequest)result.action(), request);
                 deleteAction.execute(deleteRequest, new ActionListener<DeleteResponse>() {
                     @Override
                     public void onResponse(DeleteResponse response) {
                         UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getIndex(), response.getType(), response.getId(), response.getVersion(), false);
-                        update.setGetResult(updateHelper.extractGetResult(request.request(), request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));
+                        update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));
                         listener.onResponse(update);
                     }
 
@@ -249,7 +248,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                     public void onFailure(Throwable e) {
                         e = ExceptionsHelper.unwrapCause(e);
                         if (e instanceof VersionConflictEngineException) {
-                            if (retryCount < request.request().retryOnConflict()) {
+                            if (retryCount < request.retryOnConflict()) {
                                 threadPool.executor(executor()).execute(new ActionRunnable<UpdateResponse>(listener) {
                                     @Override
                                     protected void doRun() {
@@ -267,9 +266,9 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 UpdateResponse update = result.action();
                 IndexService indexServiceOrNull = indicesService.indexService(request.concreteIndex());
                 if (indexServiceOrNull !=  null) {
-                    IndexShard shard = indexService.shard(request.request().shardId());
+                    IndexShard shard = indexService.shard(request.shardId());
                     if (shard != null) {
-                        shard.indexingService().noopUpdate(request.request().type());
+                        shard.indexingService().noopUpdate(request.type());
                     }
                 }
                 listener.onResponse(update);

--- a/core/src/test/java/org/elasticsearch/action/IndicesRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/IndicesRequestTests.java
@@ -220,7 +220,7 @@ public class IndicesRequestTests extends ElasticsearchIntegrationTest {
     @Test
     public void testUpdate() {
         //update action goes to the primary, index op gets executed locally, then replicated
-        String[] updateShardActions = new String[]{UpdateAction.NAME, IndexAction.NAME + "[r]"};
+        String[] updateShardActions = new String[]{UpdateAction.NAME + "[s]", IndexAction.NAME + "[r]"};
         interceptTransportActions(updateShardActions);
 
         String indexOrAlias = randomIndexOrAlias();
@@ -236,7 +236,7 @@ public class IndicesRequestTests extends ElasticsearchIntegrationTest {
     @Test
     public void testUpdateUpsert() {
         //update action goes to the primary, index op gets executed locally, then replicated
-        String[] updateShardActions = new String[]{UpdateAction.NAME, IndexAction.NAME + "[r]"};
+        String[] updateShardActions = new String[]{UpdateAction.NAME + "[s]", IndexAction.NAME + "[r]"};
         interceptTransportActions(updateShardActions);
 
         String indexOrAlias = randomIndexOrAlias();
@@ -251,7 +251,7 @@ public class IndicesRequestTests extends ElasticsearchIntegrationTest {
     @Test
     public void testUpdateDelete() {
         //update action goes to the primary, delete op gets executed locally, then replicated
-        String[] updateShardActions = new String[]{UpdateAction.NAME, DeleteAction.NAME + "[r]"};
+        String[] updateShardActions = new String[]{UpdateAction.NAME + "[s]", DeleteAction.NAME + "[r]"};
         interceptTransportActions(updateShardActions);
 
         String indexOrAlias = randomIndexOrAlias();


### PR DESCRIPTION
Remove custom execute local logic in TransportSingleShardAction and TransportInstanceSingleOperationAction and rely on transport service to execute locally. (forking thread etc.)
