### PR TITLE
PluginManager: Fix bin/plugin calls in scripts/bats test

### DIFF
--- a/core/src/test/resources/packaging/scripts/25_tar_plugins.bats
+++ b/core/src/test/resources/packaging/scripts/25_tar_plugins.bats
@@ -36,14 +36,10 @@ setup() {
     # Cleans everything for every test execution
     clean_before_test
 
-    # Download Marvel and Shield
-    MARVEL_ZIP="$PWD/marvel.zip"
+    # Download Shield
     SHIELD_ZIP="$PWD/shield.zip"
 
     if [ "$BATS_TEST_NUMBER" -eq 1 ]; then
-        if [ ! -e "$MARVEL_ZIP" ]; then
-            wget --quiet -O "$MARVEL_ZIP" "http://download.elasticsearch.org/elasticsearch/marvel/marvel-latest.zip"
-        fi
         if [ ! -e "$SHIELD_ZIP" ]; then
             wget --quiet -O "$SHIELD_ZIP" "http://download.elasticsearch.org/elasticsearch/shield/shield-latest.zip"
         fi
@@ -53,87 +49,6 @@ setup() {
 ##################################
 # Install plugins with a tar archive
 ##################################
-@test "[TAR] install marvel plugin" {
-
-    # Install the archive
-    install_archive
-
-    # Checks that the archive is correctly installed
-    verify_archive_installation
-
-    # Checks that plugin archive is available
-    [ -e "$MARVEL_ZIP" ]
-
-    # Install Marvel
-    run /tmp/elasticsearch/bin/plugin -i elasticsearch/marvel/latest -u "file://$MARVEL_ZIP"
-    [ "$status" -eq 0 ]
-
-    # Checks that Marvel is correctly installed
-    assert_file_exist "/tmp/elasticsearch/plugins/marvel"
-
-    start_elasticsearch_service
-
-    run curl -XGET 'http://localhost:9200/_cat/plugins?v=false&h=component'
-    [ "$status" -eq 0 ]
-    echo "$output" | grep -w "marvel"
-
-    stop_elasticsearch_service
-
-    # Remove the plugin
-    run /tmp/elasticsearch/bin/plugin -r elasticsearch/marvel/latest
-    [ "$status" -eq 0 ]
-
-    # Checks that the plugin is correctly removed
-    assert_file_not_exist "/tmp/elasticsearch/plugins/marvel"
-}
-
-@test "[TAR] install marvel plugin with a custom path.plugins" {
-
-    # Install the archive
-    install_archive
-
-    # Checks that the archive is correctly installed
-    verify_archive_installation
-
-    # Creates a temporary directory
-    TEMP_PLUGINS_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'tmp'`
-
-    # Modify the path.plugins setting in configuration file
-    echo "path.plugins: $TEMP_PLUGINS_DIR" >> "/tmp/elasticsearch/config/elasticsearch.yml"
-
-    run chown -R elasticsearch:elasticsearch "$TEMP_PLUGINS_DIR"
-    [ "$status" -eq 0 ]
-
-    # Checks that plugin archive is available
-    [ -e "$MARVEL_ZIP" ]
-
-    # Install Marvel
-    run /tmp/elasticsearch/bin/plugin -i elasticsearch/marvel/latest -u "file://$MARVEL_ZIP"
-    [ "$status" -eq 0 ]
-
-    # Checks that Marvel is correctly installed
-    assert_file_exist "$TEMP_PLUGINS_DIR/marvel"
-
-    start_elasticsearch_service
-
-    run curl -XGET 'http://localhost:9200/_cat/plugins?v=false&h=component'
-    [ "$status" -eq 0 ]
-    echo "$output" | grep -w "marvel"
-
-    stop_elasticsearch_service
-
-    # Remove the plugin
-    run /tmp/elasticsearch/bin/plugin -r elasticsearch/marvel/latest
-    [ "$status" -eq 0 ]
-
-    # Checks that the plugin is correctly removed
-    assert_file_not_exist "$TEMP_PLUGINS_DIR/marvel"
-
-    # Delete the custom plugins directory
-    run rm -rf "$TEMP_PLUGINS_DIR"
-    [ "$status" -eq 0 ]
-}
-
 @test "[TAR] install shield plugin" {
 
     # Install the archive
@@ -146,7 +61,7 @@ setup() {
     [ -e "$SHIELD_ZIP" ]
 
     # Install Shield
-    run /tmp/elasticsearch/bin/plugin -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
+    run /tmp/elasticsearch/bin/plugin install elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
     [ "$status" -eq 0 ]
 
     # Checks that Shield is correctly installed
@@ -161,7 +76,7 @@ setup() {
     assert_file_exist "/tmp/elasticsearch/plugins/shield"
 
     # Remove the plugin
-    run /tmp/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    run /tmp/elasticsearch/bin/plugin remove elasticsearch/shield/latest
     [ "$status" -eq 0 ]
 
     # Checks that the plugin is correctly removed
@@ -195,7 +110,7 @@ setup() {
     [ -e "$SHIELD_ZIP" ]
 
     # Install Shield
-    run /tmp/elasticsearch/bin/plugin -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
+    run /tmp/elasticsearch/bin/plugin install elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
     [ "$status" -eq 0 ]
 
     # Checks that Shield is correctly installed
@@ -210,7 +125,7 @@ setup() {
     assert_file_exist "$TEMP_PLUGINS_DIR/shield"
 
     # Remove the plugin
-    run /tmp/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    run /tmp/elasticsearch/bin/plugin remove elasticsearch/shield/latest
     [ "$status" -eq 0 ]
 
     # Checks that the plugin is correctly removed
@@ -251,7 +166,7 @@ setup() {
     [ -e "$SHIELD_ZIP" ]
 
     # Install Shield with the CONF_DIR environment variable
-    run env "CONF_DIR=$TEMP_CONFIG_DIR" /tmp/elasticsearch/bin/plugin -i "elasticsearch/shield/latest" -u "file://$SHIELD_ZIP"
+    run env "CONF_DIR=$TEMP_CONFIG_DIR" /tmp/elasticsearch/bin/plugin install "elasticsearch/shield/latest" -u "file://$SHIELD_ZIP"
     [ "$status" -eq 0 ]
 
     # Checks that Shield is correctly installed
@@ -266,7 +181,7 @@ setup() {
     assert_file_exist "/tmp/elasticsearch/plugins/shield"
 
     # Remove the plugin
-    run /tmp/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    run /tmp/elasticsearch/bin/plugin remove elasticsearch/shield/latest
     [ "$status" -eq 0 ]
 
     # Checks that the plugin is correctly removed
@@ -311,7 +226,7 @@ setup() {
     [ -e "$SHIELD_ZIP" ]
 
     # Install Shield
-    run /tmp/elasticsearch/bin/plugin -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
+    run /tmp/elasticsearch/bin/plugin install elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
     [ "$status" -eq 0 ]
 
     # Checks that Shield is correctly installed
@@ -326,7 +241,7 @@ setup() {
     assert_file_exist "/tmp/elasticsearch/plugins/shield"
 
     # Remove the plugin
-    run /tmp/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    run /tmp/elasticsearch/bin/plugin remove elasticsearch/shield/latest
     [ "$status" -eq 0 ]
 
     # Checks that the plugin is correctly removed

--- a/core/src/test/resources/packaging/scripts/50_plugins.bats
+++ b/core/src/test/resources/packaging/scripts/50_plugins.bats
@@ -37,14 +37,10 @@ setup() {
     # Cleans everything for every test execution
     clean_before_test
 
-    # Download Marvel and Shield
-    MARVEL_ZIP="$PWD/marvel.zip"
+    # Download Shield
     SHIELD_ZIP="$PWD/shield.zip"
 
     if [ "$BATS_TEST_NUMBER" -eq 1 ]; then
-        if [ ! -e "$MARVEL_ZIP" ]; then
-            wget --quiet -O "$MARVEL_ZIP" "http://download.elasticsearch.org/elasticsearch/marvel/marvel-latest.zip"
-        fi
         if [ ! -e "$SHIELD_ZIP" ]; then
             wget --quiet -O "$SHIELD_ZIP" "http://download.elasticsearch.org/elasticsearch/shield/shield-latest.zip"
         fi
@@ -66,91 +62,6 @@ install_package() {
 ##################################
 # Install plugins with DEB/RPM package
 ##################################
-@test "[PLUGINS] install marvel plugin" {
-
-    # Install the package
-    install_package
-
-    # Checks that the package is correctly installed
-    verify_package_installation
-
-    # Checks that plugin archive is available
-    [ -e "$MARVEL_ZIP" ]
-
-    # Install Marvel
-    run /usr/share/elasticsearch/bin/plugin -i elasticsearch/marvel/latest -u "file://$MARVEL_ZIP"
-    [ "$status" -eq 0 ]
-
-    # Checks that Marvel is correctly installed
-    assert_file_exist "/usr/share/elasticsearch/plugins/marvel"
-
-    start_elasticsearch_service
-
-    run curl -XGET 'http://localhost:9200/_cat/plugins?v=false&h=component'
-    [ "$status" -eq 0 ]
-    echo "$output" | grep -w "marvel"
-
-    stop_elasticsearch_service
-
-    # Remove the plugin
-    run /usr/share/elasticsearch/bin/plugin -r elasticsearch/marvel/latest
-    [ "$status" -eq 0 ]
-
-    # Checks that the plugin is correctly removed
-    assert_file_not_exist "/usr/share/elasticsearch/plugins/marvel"
-}
-
-@test "[PLUGINS] install marvel plugin with a custom path.plugins" {
-
-    # Install the package
-    install_package
-
-    # Checks that the package is correctly installed
-    verify_package_installation
-
-    # Creates a temporary directory
-    TEMP_PLUGINS_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'tmp'`
-
-    # Modify the path.plugins setting in configuration file
-    echo "path.plugins: $TEMP_PLUGINS_DIR" >> "/etc/elasticsearch/elasticsearch.yml"
-
-    # Sets privileges
-    run chown -R root:elasticsearch "$TEMP_PLUGINS_DIR"
-    [ "$status" -eq 0 ]
-
-    run chmod -R 750 "$TEMP_PLUGINS_DIR"
-    [ "$status" -eq 0 ]
-
-    # Checks that plugin archive is available
-    [ -e "$MARVEL_ZIP" ]
-
-    # Install Marvel
-    run /usr/share/elasticsearch/bin/plugin -i elasticsearch/marvel/latest -u "file://$MARVEL_ZIP"
-    [ "$status" -eq 0 ]
-
-    # Checks that Marvel is correctly installed
-    assert_file_exist "$TEMP_PLUGINS_DIR/marvel"
-
-    start_elasticsearch_service
-
-    run curl -XGET 'http://localhost:9200/_cat/plugins?v=false&h=component'
-    [ "$status" -eq 0 ]
-    echo "$output" | grep -w "marvel"
-
-    stop_elasticsearch_service
-
-    # Remove the plugin
-    run /usr/share/elasticsearch/bin/plugin -r elasticsearch/marvel/latest
-    [ "$status" -eq 0 ]
-
-    # Checks that the plugin is correctly removed
-    assert_file_not_exist "$TEMP_PLUGINS_DIR/marvel"
-
-    # Delete the custom plugins directory
-    run rm -rf "$TEMP_PLUGINS_DIR"
-    [ "$status" -eq 0 ]
-}
-
 @test "[PLUGINS] install shield plugin" {
 
     # Install the package
@@ -163,7 +74,7 @@ install_package() {
     [ -e "$SHIELD_ZIP" ]
 
     # Install Shield
-    run /usr/share/elasticsearch/bin/plugin -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
+    run /usr/share/elasticsearch/bin/plugin install elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
     [ "$status" -eq 0 ]
 
     # Checks that Shield is correctly installed
@@ -178,7 +89,7 @@ install_package() {
     assert_file_exist "/usr/share/elasticsearch/plugins/shield"
 
     # Remove the plugin
-    run /usr/share/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    run /usr/share/elasticsearch/bin/plugin remove elasticsearch/shield/latest
     [ "$status" -eq 0 ]
 
     # Checks that the plugin is correctly removed
@@ -216,7 +127,7 @@ install_package() {
     [ -e "$SHIELD_ZIP" ]
 
     # Install Shield
-    run /usr/share/elasticsearch/bin/plugin -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
+    run /usr/share/elasticsearch/bin/plugin install elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
     [ "$status" -eq 0 ]
 
     # Checks that Shield is correctly installed
@@ -231,7 +142,7 @@ install_package() {
     assert_file_exist "$TEMP_PLUGINS_DIR/shield"
 
     # Remove the plugin
-    run /usr/share/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    run /usr/share/elasticsearch/bin/plugin remove elasticsearch/shield/latest
     [ "$status" -eq 0 ]
 
     # Checks that the plugin is correctly removed
@@ -241,7 +152,7 @@ install_package() {
     assert_file_exist "/etc/elasticsearch/shield/roles.yml"
     assert_file_exist "/etc/elasticsearch/shield/users"
     assert_file_exist "/etc/elasticsearch/shield/users_roles"
-    assert_file_not_exist "$TEMP_PLUGINS_DIR/marvel"
+    assert_file_not_exist "$TEMP_PLUGINS_DIR/shield"
 
     # Delete the custom plugins directory
     run rm -rf "$TEMP_PLUGINS_DIR"
@@ -283,7 +194,7 @@ install_package() {
     [ -e "$SHIELD_ZIP" ]
 
     # Install Shield
-    run /usr/share/elasticsearch/bin/plugin -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
+    run /usr/share/elasticsearch/bin/plugin install elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
     [ "$status" -eq 0 ]
 
     # Checks that Shield is correctly installed
@@ -298,7 +209,7 @@ install_package() {
     assert_file_exist "/usr/share/elasticsearch/plugins/shield"
 
     # Remove the plugin
-    run /usr/share/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    run /usr/share/elasticsearch/bin/plugin remove elasticsearch/shield/latest
     [ "$status" -eq 0 ]
 
     # Checks that the plugin is correctly removed
@@ -347,7 +258,7 @@ install_package() {
     [ -e "$SHIELD_ZIP" ]
 
     # Install Shield
-    run /usr/share/elasticsearch/bin/plugin -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
+    run /usr/share/elasticsearch/bin/plugin install elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
     [ "$status" -eq 0 ]
 
     # Checks that Shield is correctly installed
@@ -362,7 +273,7 @@ install_package() {
     assert_file_exist "/usr/share/elasticsearch/plugins/shield"
 
     # Remove the plugin
-    run /usr/share/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    run /usr/share/elasticsearch/bin/plugin remove elasticsearch/shield/latest
     [ "$status" -eq 0 ]
 
     # Checks that the plugin is correctly removed

--- a/dev-tools/build_release.py
+++ b/dev-tools/build_release.py
@@ -441,7 +441,7 @@ def smoke_test_release(release, files, expected_hash, plugins):
     plugin_names = {}
     for name, plugin  in plugins:
       print('  Install plugin [%s] from [%s]' % (name, plugin))
-      run('%s; %s %s %s' % (java_exe(), es_plugin_path, '-install', plugin))
+      run('%s; %s install %s' % (java_exe(), es_plugin_path, plugin))
       plugin_names[name] = True
 
     if release.startswith("0.90."):

--- a/dev-tools/smoke_test_plugins.py
+++ b/dev-tools/smoke_test_plugins.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
       if name not in ('target', 'pom.xml'):
         url = 'file://%s/plugins/%s/target/releases/elasticsearch-%s-2.0.0-SNAPSHOT.zip' % (os.path.abspath('.'), name, name)
         print('  install plugin %s...' % name)
-        run('%s; %s --url %s -install %s' % (JAVA_ENV, es_plugin_path, url, name))
+        run('%s; %s install %s --url %s' % (JAVA_ENV, es_plugin_path, name, url))
         installed_plugin_names.add(name)
 
     print('Start Elasticsearch')

--- a/docs/plugins/delete-by-query.asciidoc
+++ b/docs/plugins/delete-by-query.asciidoc
@@ -22,7 +22,7 @@ This plugin can be installed using the plugin manager:
 
 [source,sh]
 ----------------------------------------------------------------
-bin/plugin -i elasticsearch/elasticsearch-delete-by-query
+bin/plugin install elasticsearch/elasticsearch-delete-by-query
 ----------------------------------------------------------------
 
 The plugin must be installed on every node in the cluster, and each node must
@@ -34,7 +34,7 @@ The plugin can be removed with the following command:
 
 [source,sh]
 ----------------------------------------------------------------
-bin/plugin -r elasticsearch/elasticsearch-delete-by-query
+bin/plugin remove elasticsearch/elasticsearch-delete-by-query
 ----------------------------------------------------------------
 
 The node must be stopped before removing the plugin.

--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -49,7 +49,8 @@ bin/plugin install plugin-name --url file:///path/to/plugin
 -----------------------------------
 
 
-You can run `bin/plugin -h`.
+You can run `bin/plugin -h`, or `bin/plugin install -h` for help on the install command
+as well as `bin/plugin remove -h` for help on the remove command..
 
 [float]
 [[site-plugins]]


### PR DESCRIPTION
The release and smoke test python scripts used to install
plugins in the old fashion.

Also the BATS testing suite installed/removed plugins in that
way. Here the marvel tests have been removed, as marvel currently
does not work with the master branch.

In addition documentation has been updated as well, where it was
still missing.
