### PR TITLE
Changes in unassigned info and version might not be transferred as part of cluster state diffs

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -608,7 +608,12 @@ public final class ShardRouting implements Streamable, ToXContent {
             return false;
         }
         ShardRouting that = (ShardRouting) o;
-        // TODO: add version + unassigned info check. see #12387
+        if (version != that.version) {
+            return false;
+        }
+        if (unassignedInfo != null ? !unassignedInfo.equals(that.unassignedInfo) : that.unassignedInfo != null) {
+            return false;
+        }
         return equalsIgnoringMetaData(that);
     }
 
@@ -626,8 +631,10 @@ public final class ShardRouting implements Streamable, ToXContent {
         result = 31 * result + (relocatingNodeId != null ? relocatingNodeId.hashCode() : 0);
         result = 31 * result + (primary ? 1 : 0);
         result = 31 * result + (state != null ? state.hashCode() : 0);
+        result = 31 * result + (int) (version ^ (version >>> 32));
         result = 31 * result + (restoreSource != null ? restoreSource.hashCode() : 0);
         result = 31 * result + (allocationId != null ? allocationId.hashCode() : 0);
+        result = 31 * result + (unassignedInfo != null ? unassignedInfo.hashCode() : 0);
         return hashCode = result;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -293,4 +293,27 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
         builder.endObject();
         return builder;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        UnassignedInfo that = (UnassignedInfo) o;
+
+        if (timestamp != that.timestamp) return false;
+        if (reason != that.reason) return false;
+        if (message != null ? !message.equals(that.message) : that.message != null) return false;
+        return !(failure != null ? !failure.equals(that.failure) : that.failure != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = reason != null ? reason.hashCode() : 0;
+        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = 31 * result + (message != null ? message.hashCode() : 0);
+        result = 31 * result + (failure != null ? failure.hashCode() : 0);
+        return result;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RandomShardRoutingMutator.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RandomShardRoutingMutator.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing;
+
+import static org.elasticsearch.test.ESTestCase.randomAsciiOfLength;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomInt;
+
+/**
+ * Utility class the makes random modifications to ShardRouting
+ */
+public final class RandomShardRoutingMutator {
+    private RandomShardRoutingMutator() {
+
+    }
+
+    public static void randomChange(ShardRouting shardRouting, String[] nodes) {
+        switch (randomInt(3)) {
+            case 0:
+                if (shardRouting.unassigned() == false) {
+                    shardRouting.moveToUnassigned(new UnassignedInfo(randomReason(), randomAsciiOfLength(10)));
+                } else if (shardRouting.unassignedInfo() != null) {
+                    shardRouting.updateUnassignedInfo(new UnassignedInfo(randomReason(), randomAsciiOfLength(10)));
+                }
+                break;
+            case 1:
+                if (shardRouting.unassigned()) {
+                    shardRouting.initialize(randomFrom(nodes));
+                }
+                break;
+            case 2:
+                if (shardRouting.primary()) {
+                    shardRouting.moveFromPrimary();
+                } else {
+                    shardRouting.moveToPrimary();
+                }
+                break;
+            case 3:
+                if (shardRouting.initializing()) {
+                    shardRouting.moveToStarted();
+                }
+                break;
+        }
+    }
+
+
+    public static UnassignedInfo.Reason randomReason() {
+        switch (randomInt(9)) {
+            case 0:
+                return UnassignedInfo.Reason.INDEX_CREATED;
+            case 1:
+                return UnassignedInfo.Reason.CLUSTER_RECOVERED;
+            case 2:
+                return UnassignedInfo.Reason.INDEX_REOPENED;
+            case 3:
+                return UnassignedInfo.Reason.DANGLING_INDEX_IMPORTED;
+            case 4:
+                return UnassignedInfo.Reason.NEW_INDEX_RESTORED;
+            case 5:
+                return UnassignedInfo.Reason.EXISTING_INDEX_RESTORED;
+            case 6:
+                return UnassignedInfo.Reason.REPLICA_ADDED;
+            case 7:
+                return UnassignedInfo.Reason.ALLOCATION_FAILED;
+            case 8:
+                return UnassignedInfo.Reason.NODE_LEFT;
+            default:
+                return UnassignedInfo.Reason.REROUTE_CANCELLED;
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -67,7 +67,6 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -140,7 +139,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.XContentTestUtils.convertToMap;
-import static org.elasticsearch.test.XContentTestUtils.mapsEqualIgnoringArrayOrder;
+import static org.elasticsearch.test.XContentTestUtils.differenceBetweenMapsIgnoringArrayOrder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.*;
 
@@ -1072,7 +1071,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
                             // but we can compare serialization sizes - they should be the same
                             assertEquals("clusterstate size does not match", masterClusterStateSize, localClusterStateSize);
                             // Compare JSON serialization
-                            assertTrue("clusterstate JSON serialization does not match", mapsEqualIgnoringArrayOrder(masterStateMap, localStateMap));
+                            assertNull("clusterstate JSON serialization does not match", differenceBetweenMapsIgnoringArrayOrder(masterStateMap, localStateMap));
                         } catch (AssertionError error) {
                             logger.error("Cluster state from master:\n{}\nLocal cluster state:\n{}", masterClusterState.toString(), localClusterState.toString());
                             throw error;


### PR DESCRIPTION
The equalTo logic of ShardRouting doesn't take version and unassignedInfo into the account when compares shard routings.  Since cluster state diff relies on equal to detect the changes that needs to be sent to other cluster, this omission might lead to changes not being properly propagated to other nodes in the cluster.
