### PR TITLE
Query refactoring: SpanWithinQueryBuilder and Parser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -324,9 +324,12 @@ public abstract class QueryBuilders {
         return new SpanOrQueryBuilder();
     }
 
-    /** Creates a new {@code span_within} builder. */
-    public static SpanWithinQueryBuilder spanWithinQuery() {
-        return new SpanWithinQueryBuilder();
+    /** Creates a new {@code span_within} builder.
+    * @param big the big clause, it must enclose {@code little} for a match.
+    * @param little the little clause, it must be contained within {@code big} for a match.
+    */
+    public static SpanWithinQueryBuilder spanWithinQuery(SpanQueryBuilder big, SpanQueryBuilder little) {
+        return new SpanWithinQueryBuilder(big, little);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1347,9 +1347,7 @@ public class SimpleIndexQueryParserTests extends ElasticsearchSingleNodeTest {
         IndexQueryParserService queryParser = queryParser();
         Query expectedQuery = new SpanWithinQuery(new SpanTermQuery(new Term("age", longToPrefixCoded(34, 0))),
                                                   new SpanTermQuery(new Term("age", longToPrefixCoded(35, 0))));
-        Query actualQuery = queryParser.parse(spanWithinQuery()
-                                              .big(spanTermQuery("age", 34))
-                                              .little(spanTermQuery("age", 35)))
+        Query actualQuery = queryParser.parse(spanWithinQuery(spanTermQuery("age", 34), spanTermQuery("age", 35)))
                                               .query();
         assertEquals(expectedQuery, actualQuery);
     }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.apache.lucene.search.spans.SpanWithinQuery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class SpanWithinQueryBuilderTest extends BaseQueryTestCase<SpanWithinQueryBuilder> {
+
+    @Override
+    protected Query doCreateExpectedQuery(SpanWithinQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+        SpanQuery big = (SpanQuery) testQueryBuilder.big().toQuery(context);
+        SpanQuery little = (SpanQuery) testQueryBuilder.little().toQuery(context);
+        return new SpanWithinQuery(big, little);
+    }
+
+    @Override
+    protected SpanWithinQueryBuilder doCreateTestQueryBuilder() {
+        SpanTermQueryBuilder bigQuery = new SpanTermQueryBuilderTest().createTestQueryBuilder();
+        // we need same field name and value type as bigQuery for little query
+        String fieldName = bigQuery.fieldName();
+        Object littleValue;
+        switch (fieldName) {
+            case BOOLEAN_FIELD_NAME: littleValue = randomBoolean(); break;
+            case INT_FIELD_NAME: littleValue = randomInt(); break;
+            case DOUBLE_FIELD_NAME: littleValue = randomDouble(); break;
+            case STRING_FIELD_NAME: littleValue = randomAsciiOfLengthBetween(1, 10); break;
+            default : littleValue = randomAsciiOfLengthBetween(1, 10);
+        }
+        SpanTermQueryBuilder littleQuery = new SpanTermQueryBuilder(fieldName, littleValue);
+        return new SpanWithinQueryBuilder(bigQuery, littleQuery);
+    }
+
+    @Test
+    public void testValidate() {
+        int totalExpectedErrors = 0;
+        SpanQueryBuilder bigSpanQueryBuilder;
+        if (randomBoolean()) {
+            bigSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            totalExpectedErrors++;
+        } else {
+            bigSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
+        }
+        SpanQueryBuilder littleSpanQueryBuilder;
+        if (randomBoolean()) {
+            littleSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            totalExpectedErrors++;
+        } else {
+            littleSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
+        }
+        SpanWithinQueryBuilder queryBuilder = new SpanWithinQueryBuilder(bigSpanQueryBuilder, littleSpanQueryBuilder);
+        assertValidate(queryBuilder, totalExpectedErrors);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testNullBig() {
+        new SpanWithinQueryBuilder(null, new SpanTermQueryBuilder("name", "value"));
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testNullLittle() {
+        new SpanWithinQueryBuilder(new SpanTermQueryBuilder("name", "value"), null);
+    }
+}

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -27,6 +27,13 @@ Updated the static factory methods in QueryBuilders accordingly.
 Removed setter for mandatory include/exclude span query clause, needs to be set in constructor now.
 Updated the static factory methods in QueryBuilders and tests accordingly.
 
+==== SpanWithinQueryBuilder
+
+Removed setters for mandatory big/little inner span queries. Both arguments now have
+to be supplied at construction time already and have to be non-null. Updated
+static factory methods in QueryBuilders accordingly.
+>>>>>>> Query refactoring: SpanWithinQueryBuilder and Parser
+
 ==== QueryFilterBuilder
 
 Removed the setter `queryName(String queryName)` since this field is not supported


### PR DESCRIPTION
Moving the query building functionality from the parser to the builders
new toQuery() method analogous to other recent query refactorings.

Relates to #10217
