### PR TITLE
Adapt IndicesClusterStateService to use allocation ids

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/AllocationId.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/AllocationId.java
@@ -83,10 +83,10 @@ public class AllocationId implements ToXContent {
 
     /**
      * Creates a new allocation id representing a cancelled relocation.
-     *
+     * <p/>
      * Note that this is expected to be called on the allocation id
      * of the *source* shard
-     * */
+     */
     public static AllocationId cancelRelocation(AllocationId allocationId) {
         assert allocationId.getRelocationId() != null;
         return new AllocationId(allocationId.getId(), null);
@@ -94,7 +94,7 @@ public class AllocationId implements ToXContent {
 
     /**
      * Creates a new allocation id finalizing a relocation.
-     *
+     * <p/>
      * Note that this is expected to be called on the allocation id
      * of the *target* shard and thus it only needs to clear the relocating id.
      */
@@ -120,9 +120,16 @@ public class AllocationId implements ToXContent {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
         AllocationId that = (AllocationId) o;
-        if (!id.equals(that.id)) return false;
+        if (!id.equals(that.id)) {
+            return false;
+        }
         return !(relocationId != null ? !relocationId.equals(that.relocationId) : that.relocationId != null);
 
     }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -88,7 +88,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
     void add(ShardRouting shard) {
         // TODO use Set with ShardIds for faster lookup.
         for (ShardRouting shardRouting : shards) {
-            if (shardRouting.shardId().equals(shard.shardId())) {
+            if (shardRouting.isSameShard(shard)) {
                 throw new IllegalStateException("Trying to add a shard [" + shard.shardId().index().name() + "][" + shard.shardId().id() + "] to a node [" + nodeId + "] where it already exists");
             }
         }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -420,7 +420,7 @@ public final class ShardRouting implements Streamable, ToXContent {
     void relocate(String relocatingNodeId) {
         ensureNotFrozen();
         version++;
-        assert state == ShardRoutingState.STARTED : "current shard has to be started inorder to relocated " + this;
+        assert state == ShardRoutingState.STARTED : "current shard has to be started in order to be relocated " + this;
         state = ShardRoutingState.RELOCATING;
         this.relocatingNodeId = relocatingNodeId;
         this.allocationId = AllocationId.newRelocation(allocationId);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -420,7 +420,7 @@ public final class ShardRouting implements Streamable, ToXContent {
     void relocate(String relocatingNodeId) {
         ensureNotFrozen();
         version++;
-        assert state == ShardRoutingState.STARTED : this;
+        assert state == ShardRoutingState.STARTED : "current shard has to be started inorder to relocated " + this;
         state = ShardRoutingState.RELOCATING;
         this.relocatingNodeId = relocatingNodeId;
         this.allocationId = AllocationId.newRelocation(allocationId);
@@ -467,7 +467,7 @@ public final class ShardRouting implements Streamable, ToXContent {
         restoreSource = null;
         unassignedInfo = null; // we keep the unassigned data until the shard is started
         if (allocationId.getRelocationId() != null) {
-            // target relocation
+            // relocation target
             allocationId = AllocationId.finishRelocation(allocationId);
         }
         state = ShardRoutingState.STARTED;
@@ -498,6 +498,106 @@ public final class ShardRouting implements Streamable, ToXContent {
         primary = false;
     }
 
+    /** returns true if this routing has the same shardId as another */
+    public boolean isSameShard(ShardRouting other) {
+        return index.equals(other.index) && shardId == other.shardId;
+    }
+
+    /**
+     * returns true if this routing has the same allocation ID as another.
+     * <p/>
+     * Note: if both shard routing has a null as their {@link #allocationId()}, this method returns false as the routing describe
+     * no allocation at all..
+     **/
+    public boolean isSameAllocation(ShardRouting other) {
+        boolean b = this.allocationId != null && other.allocationId != null && this.allocationId.getId().equals(other.allocationId.getId());
+        assert b == false || this.currentNodeId.equals(other.currentNodeId) : "ShardRoutings have the same allocation id but not the same node. This [" + this + "], other [" + other + "]";
+        return b;
+    }
+
+    /** returns true if the routing is the relocation target of the given routing */
+    public boolean isRelocationTargetOf(ShardRouting other) {
+        boolean b = this.allocationId != null && other.allocationId != null && this.state == ShardRoutingState.INITIALIZING &&
+                this.allocationId.getId().equals(other.allocationId.getRelocationId());
+
+        assert b == false || other.state == ShardRoutingState.RELOCATING :
+                "ShardRouting is a relocation target but the source shard state isn't relocating. This [" + this + "], other [" + other + "]";
+
+
+        assert b == false || other.allocationId.getId().equals(this.allocationId.getRelocationId()) :
+                "ShardRouting is a relocation target but the source id isn't equal to source's allocationId.getRelocationId. This [" + this + "], other [" + other + "]";
+
+        assert b == false || other.currentNodeId().equals(this.relocatingNodeId) :
+                "ShardRouting is a relocation target but source current node id isn't equal to target relocating node. This [" + this + "], other [" + other + "]";
+
+        assert b == false || this.currentNodeId().equals(other.relocatingNodeId) :
+                "ShardRouting is a relocation target but current node id isn't equal to source relocating node. This [" + this + "], other [" + other + "]";
+
+        assert b == false || isSameShard(other) :
+                "ShardRouting is a relocation target but both routings are not of the same shard. This [" + this + "], other [" + other + "]";
+
+        assert b == false || this.primary == other.primary :
+                "ShardRouting is a relocation target but primary flag is different. This [" + this + "], target [" + other + "]";
+
+        return b;
+    }
+
+    /** returns true if the routing is the relocation source for the given routing */
+    public boolean isRelocationSourceOf(ShardRouting other) {
+        boolean b = this.allocationId != null && other.allocationId != null && other.state == ShardRoutingState.INITIALIZING &&
+                other.allocationId.getId().equals(this.allocationId.getRelocationId());
+
+        assert b == false || this.state == ShardRoutingState.RELOCATING :
+                "ShardRouting is a relocation source but shard state isn't relocating. This [" + this + "], other [" + other + "]";
+
+
+        assert b == false || this.allocationId.getId().equals(other.allocationId.getRelocationId()) :
+                "ShardRouting is a relocation source but the allocation id isn't equal to other.allocationId.getRelocationId. This [" + this + "], other [" + other + "]";
+
+        assert b == false || this.currentNodeId().equals(other.relocatingNodeId) :
+                "ShardRouting is a relocation source but current node isn't equal to other's relocating node. This [" + this + "], other [" + other + "]";
+
+        assert b == false || other.currentNodeId().equals(this.relocatingNodeId) :
+                "ShardRouting is a relocation source but relocating node isn't equal to other's current node. This [" + this + "], other [" + other + "]";
+
+        assert b == false || isSameShard(other) :
+                "ShardRouting is a relocation source but both routings are not of the same shard. This [" + this + "], target [" + other + "]";
+
+        assert b == false || this.primary == other.primary :
+                "ShardRouting is a relocation source but primary flag is different. This [" + this + "], target [" + other + "]";
+
+        return b;
+    }
+
+    /** returns true if the current routing is identical to the other routing in all but meta fields, i.e., version and unassigned info */
+    public boolean equalsIgnoringMetaData(ShardRouting other) {
+        if (primary != other.primary) {
+            return false;
+        }
+        if (shardId != other.shardId) {
+            return false;
+        }
+        if (currentNodeId != null ? !currentNodeId.equals(other.currentNodeId) : other.currentNodeId != null) {
+            return false;
+        }
+        if (index != null ? !index.equals(other.index) : other.index != null) {
+            return false;
+        }
+        if (relocatingNodeId != null ? !relocatingNodeId.equals(other.relocatingNodeId) : other.relocatingNodeId != null) {
+            return false;
+        }
+        if (allocationId != null ? !allocationId.equals(other.allocationId) : other.allocationId != null) {
+            return false;
+        }
+        if (state != other.state) {
+            return false;
+        }
+        if (restoreSource != null ? !restoreSource.equals(other.restoreSource) : other.restoreSource != null) {
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -508,32 +608,8 @@ public final class ShardRouting implements Streamable, ToXContent {
             return false;
         }
         ShardRouting that = (ShardRouting) o;
-
-        if (primary != that.primary) {
-            return false;
-        }
-        if (shardId != that.shardId) {
-            return false;
-        }
-        if (currentNodeId != null ? !currentNodeId.equals(that.currentNodeId) : that.currentNodeId != null) {
-            return false;
-        }
-        if (index != null ? !index.equals(that.index) : that.index != null) {
-            return false;
-        }
-        if (relocatingNodeId != null ? !relocatingNodeId.equals(that.relocatingNodeId) : that.relocatingNodeId != null) {
-            return false;
-        }
-        if (allocationId != null ? !allocationId.equals(that.allocationId) : that.allocationId != null) {
-            return false;
-        }
-        if (state != that.state) {
-            return false;
-        }
-        if (restoreSource != null ? !restoreSource.equals(that.restoreSource) : that.restoreSource != null) {
-            return false;
-        }
-        return true;
+        // TODO: add version + unassigned info check. see #12387
+        return equalsIgnoringMetaData(that);
     }
 
     private long hashVersion = version - 1;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
@@ -177,7 +177,7 @@ public class CancelAllocationCommand implements AllocationCommand {
                     RoutingNode relocatingFromNode = allocation.routingNodes().node(shardRouting.relocatingNodeId());
                     if (relocatingFromNode != null) {
                         for (ShardRouting fromShardRouting : relocatingFromNode) {
-                            if (fromShardRouting.shardId().equals(shardRouting.shardId()) && fromShardRouting.state() == RELOCATING) {
+                            if (fromShardRouting.isSameShard(shardRouting) && fromShardRouting.state() == RELOCATING) {
                                 allocation.routingNodes().cancelRelocation(fromShardRouting);
                                 break;
                             }
@@ -201,7 +201,7 @@ public class CancelAllocationCommand implements AllocationCommand {
                     if (initializingNode != null) {
                         while (initializingNode.hasNext()) {
                             ShardRouting initializingShardRouting = initializingNode.next();
-                            if (initializingShardRouting.shardId().equals(shardRouting.shardId()) && initializingShardRouting.initializing()) {
+                            if (initializingShardRouting.isRelocationTargetOf(shardRouting)) {
                                 initializingNode.remove();
                             }
                         }

--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -507,7 +507,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                 // for example: a shard that recovers from one node and now needs to recover to another node,
                 //              or a replica allocated and then allocating a primary because the primary failed on another node
                 boolean shardHasBeenRemoved = false;
-                if (currentRoutingEntry.initializing() && shardRouting.initializing() && !currentRoutingEntry.equals(shardRouting)) {
+                if (currentRoutingEntry.isSameAllocation(shardRouting) == false) {
                     logger.debug("[{}][{}] removing shard (different instance of it allocated on this node, current [{}], global [{}])", shardRouting.index(), shardRouting.id(), currentRoutingEntry, shardRouting);
                     // closing the shard will also cancel any ongoing recovery.
                     indexService.removeShard(shardRouting.id(), "removing shard (different instance of it allocated on this node)");
@@ -526,22 +526,20 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                         // closing the shard will also cancel any ongoing recovery.
                         indexService.removeShard(shardRouting.id(), "removing shard (recovery source node changed)");
                         shardHasBeenRemoved = true;
-
                     }
                 }
-                if (shardHasBeenRemoved == false && (shardRouting.equals(indexShard.routingEntry()) == false || shardRouting.version() > indexShard.routingEntry().version())) {
-                    if (shardRouting.primary() && indexShard.routingEntry().primary() == false && shardRouting.initializing() && indexShard.allowsPrimaryPromotion() == false) {
-                        logger.debug("{} reinitialize shard on primary promotion", indexShard.shardId());
-                        indexService.removeShard(shardId, "promoted to primary");
-                    } else {
-                        // if we happen to remove the shardRouting by id above we don't need to jump in here!
-                        indexShard.updateRoutingEntry(shardRouting, event.state().blocks().disableStatePersistence() == false);
-                    }
+
+                if (shardHasBeenRemoved == false) {
+                    // shadow replicas do not support primary promotion. The master would reinitialize the shard, giving it a new allocation, meaning we should be there.
+                    // nocommit: double check check this
+                    assert (shardRouting.primary() && currentRoutingEntry.primary() == false) == false || indexShard.allowsPrimaryPromotion() :
+                            "shard for doesn't support primary promotion but master promoted it with changing allocation. New routing " + shardRouting + ", current routing " + currentRoutingEntry;
+                    indexShard.updateRoutingEntry(shardRouting, event.state().blocks().disableStatePersistence() == false);
                 }
             }
 
             if (shardRouting.initializing()) {
-                applyInitializingShard(event.state(),indexMetaData, shardRouting);
+                applyInitializingShard(event.state(), indexMetaData, shardRouting);
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.routing;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -19,10 +19,12 @@
 
 package org.elasticsearch.cluster.routing;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ElasticsearchTestCase;
@@ -48,6 +50,177 @@ public class ShardRoutingTests extends ElasticsearchTestCase {
         }
     }
 
+    public void testIsSameAllocation() {
+        ShardRouting unassignedShard0 = TestShardRouting.newShardRouting("test", 0, null, false, ShardRoutingState.UNASSIGNED, 1);
+        ShardRouting unassignedShard1 = TestShardRouting.newShardRouting("test", 1, null, false, ShardRoutingState.UNASSIGNED, 1);
+        ShardRouting initializingShard0 = TestShardRouting.newShardRouting("test", 0, "1", randomBoolean(), ShardRoutingState.INITIALIZING, 1);
+        ShardRouting initializingShard1 = TestShardRouting.newShardRouting("test", 1, "1", randomBoolean(), ShardRoutingState.INITIALIZING, 1);
+        ShardRouting startedShard0 = new ShardRouting(initializingShard0);
+        startedShard0.moveToStarted();
+        ShardRouting startedShard1 = new ShardRouting(initializingShard1);
+        startedShard1.moveToStarted();
+
+        // test identity
+        assertTrue(initializingShard0.isSameAllocation(initializingShard0));
+
+        // test same allocation different state
+        assertTrue(initializingShard0.isSameAllocation(startedShard0));
+
+        // test unassigned is false even to itself
+        assertFalse(unassignedShard0.isSameAllocation(unassignedShard0));
+
+        // test different shards/nodes/state
+        assertFalse(unassignedShard0.isSameAllocation(unassignedShard1));
+        assertFalse(unassignedShard0.isSameAllocation(initializingShard0));
+        assertFalse(unassignedShard0.isSameAllocation(initializingShard1));
+        assertFalse(unassignedShard0.isSameAllocation(startedShard1));
+    }
+
+    public void testIsSameShard() {
+        ShardRouting index1Shard0a = randomShardRouting("index1", 0);
+        ShardRouting index1Shard0b = randomShardRouting("index1", 0);
+        ShardRouting index1Shard1 = randomShardRouting("index1", 1);
+        ShardRouting index2Shard0 = randomShardRouting("index2", 0);
+        ShardRouting index2Shard1 = randomShardRouting("index2", 1);
+
+        assertTrue(index1Shard0a.isSameShard(index1Shard0a));
+        assertTrue(index1Shard0a.isSameShard(index1Shard0b));
+        assertFalse(index1Shard0a.isSameShard(index1Shard1));
+        assertFalse(index1Shard0a.isSameShard(index2Shard0));
+        assertFalse(index1Shard0a.isSameShard(index2Shard1));
+    }
+
+    private ShardRouting randomShardRouting(String index, int shard) {
+        ShardRoutingState state = randomFrom(ShardRoutingState.values());
+        return TestShardRouting.newShardRouting(index, shard, state == ShardRoutingState.UNASSIGNED ? null : "1", state != ShardRoutingState.UNASSIGNED && randomBoolean(), state, randomInt(5));
+    }
+
+    public void testIsSourceTargetRelocation() {
+        ShardRouting unassignedShard0 = TestShardRouting.newShardRouting("test", 0, null, false, ShardRoutingState.UNASSIGNED, 1);
+        ShardRouting initializingShard0 = TestShardRouting.newShardRouting("test", 0, "node1", randomBoolean(), ShardRoutingState.INITIALIZING, 1);
+        ShardRouting initializingShard1 = TestShardRouting.newShardRouting("test", 1, "node1", randomBoolean(), ShardRoutingState.INITIALIZING, 1);
+        ShardRouting startedShard0 = new ShardRouting(initializingShard0);
+        startedShard0.moveToStarted();
+        ShardRouting startedShard1 = new ShardRouting(initializingShard1);
+        startedShard1.moveToStarted();
+        ShardRouting sourceShard0a = new ShardRouting(startedShard0);
+        sourceShard0a.relocate("node2");
+        ShardRouting targetShard0a = sourceShard0a.buildTargetRelocatingShard();
+        ShardRouting sourceShard0b = new ShardRouting(startedShard0);
+        sourceShard0b.relocate("node2");
+        ShardRouting sourceShard1 = new ShardRouting(startedShard1);
+        sourceShard1.relocate("node2");
+
+        // test true scenarios
+        assertTrue(targetShard0a.isRelocationTargetOf(sourceShard0a));
+        assertTrue(sourceShard0a.isRelocationSourceOf(targetShard0a));
+
+        // test two shards are not mixed
+        assertFalse(targetShard0a.isRelocationTargetOf(sourceShard1));
+        assertFalse(sourceShard1.isRelocationSourceOf(targetShard0a));
+
+        // test two allocations are not mixed
+        assertFalse(targetShard0a.isRelocationTargetOf(sourceShard0b));
+        assertFalse(sourceShard0b.isRelocationSourceOf(targetShard0a));
+
+        // test different shard states
+        assertFalse(targetShard0a.isRelocationTargetOf(unassignedShard0));
+        assertFalse(sourceShard0a.isRelocationTargetOf(unassignedShard0));
+        assertFalse(unassignedShard0.isRelocationSourceOf(targetShard0a));
+        assertFalse(unassignedShard0.isRelocationSourceOf(sourceShard0a));
+
+        assertFalse(targetShard0a.isRelocationTargetOf(initializingShard0));
+        assertFalse(sourceShard0a.isRelocationTargetOf(initializingShard0));
+        assertFalse(initializingShard0.isRelocationSourceOf(targetShard0a));
+        assertFalse(initializingShard0.isRelocationSourceOf(sourceShard0a));
+
+        assertFalse(targetShard0a.isRelocationTargetOf(startedShard0));
+        assertFalse(sourceShard0a.isRelocationTargetOf(startedShard0));
+        assertFalse(startedShard0.isRelocationSourceOf(targetShard0a));
+        assertFalse(startedShard0.isRelocationSourceOf(sourceShard0a));
+    }
+
+    public void testEqualsIgnoringVersion() {
+        ShardRouting routing = randomShardRouting("test", 0);
+
+        ShardRouting otherRouting = new ShardRouting(routing);
+
+        assertTrue("expected equality\nthis  " + routing + ",\nother " + otherRouting, routing.equalsIgnoringMetaData(otherRouting));
+        otherRouting = new ShardRouting(routing, 1);
+        assertTrue("expected equality\nthis  " + routing + ",\nother " + otherRouting, routing.equalsIgnoringMetaData(otherRouting));
+
+
+        otherRouting = new ShardRouting(routing);
+        Integer[] changeIds = new Integer[]{0, 1, 2, 3, 4, 5, 6};
+        for (int changeId : randomSubsetOf(randomIntBetween(1, changeIds.length), changeIds)) {
+            switch (changeId) {
+                case 0:
+                    // change index
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index() + "a", otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                            otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
+                    break;
+                case 1:
+                    // change shard id
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id() + 1, otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                            otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
+                    break;
+                case 2:
+                    // change current node
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId() == null ? "1" : otherRouting.currentNodeId() + "_1", otherRouting.relocatingNodeId(),
+                            otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
+                    break;
+                case 3:
+                    // change relocating node
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(),
+                            otherRouting.relocatingNodeId() == null ? "1" : otherRouting.relocatingNodeId() + "_1",
+                            otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
+                    break;
+                case 4:
+                    // change restore source
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                            otherRouting.restoreSource() == null ? new RestoreSource(new SnapshotId("test", "s1"), Version.CURRENT, "test") :
+                                    new RestoreSource(otherRouting.restoreSource().snapshotId(), Version.CURRENT, otherRouting.index() + "_1"),
+                            otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
+                    break;
+                case 5:
+                    // change primary flag
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                            otherRouting.restoreSource(), otherRouting.primary() == false, otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
+                    break;
+                case 6:
+                    // change state
+                    ShardRoutingState newState;
+                    do {
+                        newState = randomFrom(ShardRoutingState.values());
+                    } while (newState == otherRouting.state());
+
+                    UnassignedInfo unassignedInfo = otherRouting.unassignedInfo();
+                    if (unassignedInfo == null && (newState == ShardRoutingState.UNASSIGNED || newState == ShardRoutingState.INITIALIZING)) {
+                        unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test");
+                    }
+
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                            otherRouting.restoreSource(), otherRouting.primary(), newState, otherRouting.version(), unassignedInfo);
+                    break;
+            }
+
+            if (randomBoolean()) {
+                // change version
+                otherRouting = new ShardRouting(otherRouting, otherRouting.version() + 1);
+            }
+
+            if (randomBoolean()) {
+                // change unassigned info
+                otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                        otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(),
+                        otherRouting.unassignedInfo() == null ? new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test") :
+                                new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, otherRouting.unassignedInfo().getMessage() + "_1"));
+            }
+
+            logger.debug("comparing\nthis  {} to\nother {}", routing, otherRouting);
+            assertFalse("expected non-equality\nthis  " + routing + ",\nother " + otherRouting, routing.equalsIgnoringMetaData(otherRouting));
+        }
+    }
 
     public void testFrozenOnRoutingTable() {
         MetaData metaData = MetaData.builder()

--- a/core/src/test/java/org/elasticsearch/cluster/routing/TestShardRouting.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/TestShardRouting.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.cluster.routing;
 
+import org.elasticsearch.test.ElasticsearchTestCase;
+
 /**
  * A helper that allows to create shard routing instances within tests, while not requiring to expose
  * different simplified constructors on the ShardRouting itself.
@@ -26,19 +28,19 @@ package org.elasticsearch.cluster.routing;
 public class TestShardRouting {
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, boolean primary, ShardRoutingState state, long version) {
-        return new ShardRouting(index, shardId, currentNodeId, null, null, primary, state, version, null, buildAllocationId(state), true);
+        return new ShardRouting(index, shardId, currentNodeId, null, null, primary, state, version, buildUnassignedInfo(state), buildAllocationId(state), true);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, long version) {
-        return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, null, primary, state, version, null, buildAllocationId(state), true);
+        return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, null, primary, state, version, buildUnassignedInfo(state), buildAllocationId(state), true);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, AllocationId allocationId, long version) {
-        return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, null, primary, state, version, null, allocationId, true);
+        return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, null, primary, state, version, buildUnassignedInfo(state), allocationId, true);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, RestoreSource restoreSource, boolean primary, ShardRoutingState state, long version) {
-        return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, restoreSource, primary, state, version, null, buildAllocationId(state), true);
+        return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, restoreSource, primary, state, version, buildUnassignedInfo(state), buildAllocationId(state), true);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId,
@@ -57,6 +59,19 @@ public class TestShardRouting {
             case RELOCATING:
                 AllocationId allocationId = AllocationId.newInitializing();
                 return AllocationId.newRelocation(allocationId);
+            default:
+                throw new IllegalStateException("illegal state");
+        }
+    }
+
+    private static UnassignedInfo buildUnassignedInfo(ShardRoutingState state) {
+        switch (state) {
+            case UNASSIGNED:
+            case INITIALIZING:
+                return new UnassignedInfo(ElasticsearchTestCase.randomFrom(UnassignedInfo.Reason.values()), "auto generated for test");
+            case STARTED:
+            case RELOCATING:
+                return null;
             default:
                 throw new IllegalStateException("illegal state");
         }

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -205,7 +205,7 @@ public class IndexShardTests extends ElasticsearchSingleNodeTest {
         ShardStateMetaData shardStateMetaData = load(logger, env.availableShardPaths(shard.shardId));
         assertEquals(shardStateMetaData, getShardStateMetadata(shard));
 
-        routing = TestShardRouting.newShardRouting(shard.shardId.index().getName(), shard.shardId.id(), routing.currentNodeId(), null, null, routing.primary(), ShardRoutingState.INITIALIZING, shard.shardRouting.version() + 1);
+        routing = TestShardRouting.newShardRouting(shard.shardId.index().getName(), shard.shardId.id(), routing.currentNodeId(), null, routing.primary(), ShardRoutingState.INITIALIZING, shard.shardRouting.allocationId(), shard.shardRouting.version() + 1);
         shard.updateRoutingEntry(routing, true);
         shard.deleteShardState();
 


### PR DESCRIPTION
#12242 introduced a unique id for an assignment of shard to a node. We should use these id's to drive the decisions made by IndicesClusterStateService when processing the new cluster state sent by the master. If the local shard has a different allocation id than the new cluster state, the shard will be removed and a new one will be created. This fixes a couple of subtle bugs,  most notably a node previously got confused if an incoming cluster state had a newly allocated shard in the initializing state and the local copy was started (which can happen if cluster state updates are bulk processed). In that case, the node have previously re-used the local copy instead of initializing a new one.

 Also, as set of utility methods was introduced on ShardRouting to do various types of matching with other shard routings, giving control about what exactly should be matched (same shard id, same allocation id, all but version and shard info etc.). This is useful here, but also prepares the grounds for the change needed in #12387 (making ShardRouting.equals be strict and perform exact equality).
