### PR TITLE
Add shadow indicator when using shadow replicas

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -420,7 +420,10 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                             .put(indexMetaData, false)
                             .build();
 
-                    logger.info("[{}] creating index, cause [{}], templates {}, shards [{}]/[{}], mappings {}", request.index(), request.cause(), templateNames, indexMetaData.numberOfShards(), indexMetaData.numberOfReplicas(), mappings.keySet());
+                    String maybeShadowIndicator = IndexMetaData.isIndexUsingShadowReplicas(indexMetaData.settings()) ? "s" : "";
+                    logger.info("[{}] creating index, cause [{}], templates {}, shards [{}]/[{}{}], mappings {}",
+                            request.index(), request.cause(), templateNames, indexMetaData.numberOfShards(),
+                            indexMetaData.numberOfReplicas(), maybeShadowIndicator, mappings.keySet());
 
                     ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
                     if (!request.blocks().isEmpty()) {


### PR DESCRIPTION
Very simple PR that changes:

```
[2015-07-22 09:42:44,088][INFO ][org.elasticsearch.cluster.metadata] [node_t0] [test] creating index, cause [api], templates [], shards [1]/[1], mappings [doc]
```

Into:

```
[2015-07-22 09:42:44,088][INFO ][org.elasticsearch.cluster.metadata] [node_t0] [test] creating index, cause [api], templates [], shards [1]/[1s], mappings [doc]
```

When shadow replicas are used.
