### PR TITLE
Make fetch sub phases pluggable

### DIFF
--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -285,12 +285,12 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
-    public FetchSubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory) {
+    public <SubPhaseContext extends FetchSubPhaseContext> SubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory<SubPhaseContext> contextFactory) {
         String subPhaseName = contextFactory.getName();
         if (subPhaseContexts.get(subPhaseName) == null) {
             subPhaseContexts.put(subPhaseName, contextFactory.newContextInstance());
         }
-        return subPhaseContexts.get(subPhaseName);
+        return (SubPhaseContext) subPhaseContexts.get(subPhaseName);
     }
 
     // Unused:

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -396,16 +396,6 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
-    public boolean hasFieldDataFields() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public FieldDataFieldsContext fieldDataFields() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public boolean hasScriptFields() {
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -60,7 +60,6 @@ import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseContext;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -294,11 +294,6 @@ public class PercolateContext extends SearchContext {
         return subPhaseContexts.get(subPhaseName);
     }
 
-    @Override
-    public boolean hasFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory) {
-        return subPhaseContexts.get(contextFactory.getName()) != null;
-    }
-
     // Unused:
     @Override
     public void preProcess() {

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.aggregations.AggregationModule;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.dfs.DfsPhase;
 import org.elasticsearch.search.fetch.FetchPhase;
+import org.elasticsearch.search.fetch.FetchSubPhaseModule;
 import org.elasticsearch.search.fetch.explain.ExplainFetchSubPhase;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsFetchSubPhase;
@@ -63,7 +64,8 @@ public class SearchModule extends AbstractModule implements SpawnModules {
                 new HighlightModule(),
                 new SuggestModule(),
                 new FunctionScoreModule(),
-                new AggregationModule());
+                new AggregationModule(),
+                new FetchSubPhaseModule());
     }
 
     @Override
@@ -73,14 +75,6 @@ public class SearchModule extends AbstractModule implements SpawnModules {
         bind(SearchPhaseController.class).asEagerSingleton();
 
         bind(FetchPhase.class).asEagerSingleton();
-        bind(ExplainFetchSubPhase.class).asEagerSingleton();
-        bind(FieldDataFieldsFetchSubPhase.class).asEagerSingleton();
-        bind(ScriptFieldsFetchSubPhase.class).asEagerSingleton();
-        bind(FetchSourceSubPhase.class).asEagerSingleton();
-        bind(VersionFetchSubPhase.class).asEagerSingleton();
-        bind(MatchedQueriesFetchSubPhase.class).asEagerSingleton();
-        bind(HighlightPhase.class).asEagerSingleton();
-        bind(InnerHitsFetchSubPhase.class).asEagerSingleton();
 
         bind(SearchServiceTransportAction.class).asEagerSingleton();
         bind(MoreLikeThisFetchService.class).asEagerSingleton();

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -86,13 +86,8 @@ public class FetchPhase implements SearchPhase {
     @Inject
     public FetchPhase(Set<FetchSubPhase> fetchSubPhases, InnerHitsFetchSubPhase innerHitsFetchSubPhase) {
         innerHitsFetchSubPhase.setFetchPhase(this);
-        this.fetchSubPhases = new FetchSubPhase[fetchSubPhases.size() + 1];
-        int counter = 0;
-        for (FetchSubPhase phase : fetchSubPhases) {
-            this.fetchSubPhases[counter] = phase;
-            counter++;
-        }
-        this.fetchSubPhases[counter] = innerHitsFetchSubPhase;
+        this.fetchSubPhases = fetchSubPhases.toArray(new FetchSubPhase[fetchSubPhases.size() + 1]);
+        this.fetchSubPhases[fetchSubPhases.size()] = innerHitsFetchSubPhase;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -45,6 +45,7 @@ import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchParseElement;
@@ -83,13 +84,15 @@ public class FetchPhase implements SearchPhase {
     private final FetchSubPhase[] fetchSubPhases;
 
     @Inject
-    public FetchPhase(HighlightPhase highlightPhase, ScriptFieldsFetchSubPhase scriptFieldsPhase,
-                      MatchedQueriesFetchSubPhase matchedQueriesPhase, ExplainFetchSubPhase explainPhase, VersionFetchSubPhase versionPhase,
-                      FetchSourceSubPhase fetchSourceSubPhase, FieldDataFieldsFetchSubPhase fieldDataFieldsFetchSubPhase, 
-                      InnerHitsFetchSubPhase innerHitsFetchSubPhase) {
+    public FetchPhase(Set<FetchSubPhase> fetchSubPhases, InnerHitsFetchSubPhase innerHitsFetchSubPhase) {
         innerHitsFetchSubPhase.setFetchPhase(this);
-        this.fetchSubPhases = new FetchSubPhase[]{scriptFieldsPhase, matchedQueriesPhase, explainPhase, highlightPhase,
-                fetchSourceSubPhase, versionPhase, fieldDataFieldsFetchSubPhase, innerHitsFetchSubPhase};
+        this.fetchSubPhases = new FetchSubPhase[fetchSubPhases.size() + 1];
+        int counter = 0;
+        for (FetchSubPhase phase : fetchSubPhases) {
+            this.fetchSubPhases[counter] = phase;
+            counter++;
+        }
+        this.fetchSubPhases[counter] = innerHitsFetchSubPhase;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -114,4 +114,11 @@ public interface FetchSubPhase {
     boolean hitsExecutionNeeded(SearchContext context);
 
     void hitsExecute(SearchContext context, InternalSearchHit[] hits);
+
+    public interface ContextFactory {
+
+        public String getName();
+
+        public FetchSubPhaseContext newContextInstance();
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -121,7 +121,7 @@ public interface FetchSubPhase {
      * Fetch phases that use the plugin mechanism must provide a ContextFactory to the SearchContext that creates the fetch phase context and also associates them with a name.
      * See {@link SearchContext#getFetchSubPhaseContext(FetchSubPhase.ContextFactory)}
      */
-    public interface ContextFactory {
+    public interface ContextFactory<SubPhaseContext extends FetchSubPhaseContext> {
 
         /**
          * The name of the context.
@@ -131,6 +131,6 @@ public interface FetchSubPhase {
         /**
          * Creates a new instance of a FetchSubPhaseContext that holds all information a FetchSubPhase needs to execute on hits.
          */
-        public FetchSubPhaseContext newContextInstance();
+        public SubPhaseContext newContextInstance();
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -115,10 +115,22 @@ public interface FetchSubPhase {
 
     void hitsExecute(SearchContext context, InternalSearchHit[] hits);
 
+    /**
+     * This interface is in the fetch phase plugin mechanism.
+     * Whenever a new search is executed we create a new {@link SearchContext} that holds individual contexts for each {@link org.elasticsearch.search.fetch.FetchSubPhase}.
+     * Fetch phases that use the plugin mechanism must provide a ContextFactory to the SearchContext that creates the fetch phase context and also associates them with a name.
+     * See {@link SearchContext#getFetchSubPhaseContext(FetchSubPhase.ContextFactory)}
+     */
     public interface ContextFactory {
 
+        /**
+         * The name of the context.
+         */
         public String getName();
 
+        /**
+         * Creates a new instance of a FetchSubPhaseContext that holds all information a FetchSubPhase needs to execute on hits.
+         */
         public FetchSubPhaseContext newContextInstance();
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseContext.java
@@ -19,14 +19,26 @@
 
 package org.elasticsearch.search.fetch;
 
+/**
+ * This class stores  if or if not a FetchSubPhase is supposed to execute.
+ * It be extended by FetchSubPhases to hold information the phase needs to execute on hits.
+ * See {@link org.elasticsearch.search.fetch.FetchSubPhase.ContextFactory} and also {@link org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext} for an example.
+ */
 public class FetchSubPhaseContext {
 
+    // This is to store if the FetchSubPhase should be executed at all.
     private boolean hitExecutionNeeded = false;
 
+    /**
+     * Set if this phase should be executed at all.
+     */
     void setHitExecutionNeeded(boolean hitExecutionNeeded) {
         this.hitExecutionNeeded = hitExecutionNeeded;
     }
 
+    /**
+     * Returns if this phase be executed at all.
+     */
     public boolean hitExecutionNeeded() {
         return hitExecutionNeeded;
     }

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseContext.java
@@ -20,8 +20,9 @@
 package org.elasticsearch.search.fetch;
 
 /**
- * This class stores  if or if not a FetchSubPhase is supposed to execute.
- * It be extended by FetchSubPhases to hold information the phase needs to execute on hits.
+ * All configuration and context needed by the FetchSubPhase to execute on hits.
+ * The only required information in this base class is whether or not the sub phase needs to be run at all.
+ * It can be extended by FetchSubPhases to hold information the phase needs to execute on hits.
  * See {@link org.elasticsearch.search.fetch.FetchSubPhase.ContextFactory} and also {@link org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext} for an example.
  */
 public class FetchSubPhaseContext {

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseContext.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch;
+
+public interface FetchSubPhaseContext {
+
+}

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseModule.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseModule.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.fetch;
+
+import com.google.common.collect.Lists;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.multibindings.Multibinder;
+import org.elasticsearch.search.fetch.explain.ExplainFetchSubPhase;
+import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsFetchSubPhase;
+import org.elasticsearch.search.fetch.innerhits.InnerHitsFetchSubPhase;
+import org.elasticsearch.search.fetch.matchedqueries.MatchedQueriesFetchSubPhase;
+import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
+import org.elasticsearch.search.fetch.source.FetchSourceSubPhase;
+import org.elasticsearch.search.fetch.version.VersionFetchSubPhase;
+import org.elasticsearch.search.highlight.HighlightPhase;
+
+import java.util.List;
+
+/**
+ *
+ */
+public class FetchSubPhaseModule extends AbstractModule {
+
+    private List<Class<? extends FetchSubPhase>> fetchSubPhases = Lists.newArrayList();
+
+    public FetchSubPhaseModule() {
+        registerFetchSubPhase(ExplainFetchSubPhase.class);
+        registerFetchSubPhase(FieldDataFieldsFetchSubPhase.class);
+        registerFetchSubPhase(ScriptFieldsFetchSubPhase.class);
+        registerFetchSubPhase(FetchSourceSubPhase.class);
+        registerFetchSubPhase(VersionFetchSubPhase.class);
+        registerFetchSubPhase(MatchedQueriesFetchSubPhase.class);
+        registerFetchSubPhase(HighlightPhase.class);
+    }
+
+    public void registerFetchSubPhase(Class<? extends FetchSubPhase> subPhase) {
+        fetchSubPhases.add(subPhase);
+    }
+
+    @Override
+    protected void configure() {
+        Multibinder<FetchSubPhase> parserMapBinder = Multibinder.newSetBinder(binder(), FetchSubPhase.class);
+        for (Class<? extends FetchSubPhase> clazz : fetchSubPhases) {
+            parserMapBinder.addBinding().to(clazz);
+        }
+        bind(InnerHitsFetchSubPhase.class).asEagerSingleton();
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseModule.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseModule.java
@@ -33,7 +33,17 @@ import org.elasticsearch.search.highlight.HighlightPhase;
 import java.util.List;
 
 /**
- *
+ * Module for registering fetch sub phases. Fetch phases are executed when the document is finally
+ * retrieved from the shard. To implement a new fetch phase one needs to implement the following classes and interfaces
+ * <p/>
+ * <ul>
+ * <li>  {@link FetchSubPhaseParseElement} </li>
+ * <li>  {@link FetchSubPhase} </li>
+ * <li>  {@link FetchSubPhaseContext} </li>
+ * </ul>
+ * <p/>
+ * The FetchSubPhase must then be registered with this module with {@link FetchSubPhaseModule#registerFetchSubPhase(Class<? extends FetchSubPhase>)}.
+ * See {@link FieldDataFieldsFetchSubPhase} for an example.
  */
 public class FetchSubPhaseModule extends AbstractModule {
 

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseParseElement.java
@@ -33,13 +33,13 @@ public abstract class FetchSubPhaseParseElement<SubPhaseContext extends FetchSub
         SubPhaseContext fetchSubPhaseContext = context.getFetchSubPhaseContext(getContextFactory());
         // this is to make sure that the SubFetchPhase knows it should execute
         fetchSubPhaseContext.setHitExecutionNeeded(true);
-        innerParse(parser, fetchSubPhaseContext);
+        innerParse(parser, fetchSubPhaseContext, context);
     }
 
     /**
      * Implement the actual parsing here.
      */
-    protected abstract void innerParse(XContentParser parser, SubPhaseContext fetchSubPhaseContext) throws Exception;
+    protected abstract void innerParse(XContentParser parser, SubPhaseContext fetchSubPhaseContext, SearchContext searchContext) throws Exception;
 
     /**
      * Return the ContextFactory for this FetchSubPhase.

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseParseElement.java
@@ -23,16 +23,26 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.internal.SearchContext;
 
+/**
+ * A parse element for a {@link org.elasticsearch.search.fetch.FetchSubPhase} that is used when parsing a search request.
+ */
 public abstract class FetchSubPhaseParseElement implements SearchParseElement {
 
     @Override
-    public void parse(XContentParser parser, SearchContext context) throws Exception {
+    final public void parse(XContentParser parser, SearchContext context) throws Exception {
         FetchSubPhaseContext fetchSubPhaseContext = context.getFetchSubPhaseContext(getContextFactory());
+        // this is to make sure that the SubFetchPhase knows it should execute
         fetchSubPhaseContext.setHitExecutionNeeded(true);
         innerParse(parser, fetchSubPhaseContext);
     }
 
+    /**
+     * Implement the actual parsing here.
+     */
     protected abstract void innerParse(XContentParser parser, FetchSubPhaseContext fetchSubPhaseContext) throws Exception;
 
+    /**
+     * Return the ContextFactory for this FetchSubPhase.
+     */
     protected abstract FetchSubPhase.ContextFactory getContextFactory();
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseParseElement.java
@@ -26,11 +26,11 @@ import org.elasticsearch.search.internal.SearchContext;
 /**
  * A parse element for a {@link org.elasticsearch.search.fetch.FetchSubPhase} that is used when parsing a search request.
  */
-public abstract class FetchSubPhaseParseElement implements SearchParseElement {
+public abstract class FetchSubPhaseParseElement<SubPhaseContext extends FetchSubPhaseContext> implements SearchParseElement {
 
     @Override
     final public void parse(XContentParser parser, SearchContext context) throws Exception {
-        FetchSubPhaseContext fetchSubPhaseContext = context.getFetchSubPhaseContext(getContextFactory());
+        SubPhaseContext fetchSubPhaseContext = context.getFetchSubPhaseContext(getContextFactory());
         // this is to make sure that the SubFetchPhase knows it should execute
         fetchSubPhaseContext.setHitExecutionNeeded(true);
         innerParse(parser, fetchSubPhaseContext);
@@ -39,10 +39,10 @@ public abstract class FetchSubPhaseParseElement implements SearchParseElement {
     /**
      * Implement the actual parsing here.
      */
-    protected abstract void innerParse(XContentParser parser, FetchSubPhaseContext fetchSubPhaseContext) throws Exception;
+    protected abstract void innerParse(XContentParser parser, SubPhaseContext fetchSubPhaseContext) throws Exception;
 
     /**
      * Return the ContextFactory for this FetchSubPhase.
      */
-    protected abstract FetchSubPhase.ContextFactory getContextFactory();
+    protected abstract FetchSubPhase.ContextFactory<SubPhaseContext> getContextFactory();
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseParseElement.java
@@ -19,16 +19,20 @@
 
 package org.elasticsearch.search.fetch;
 
-public class FetchSubPhaseContext {
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.internal.SearchContext;
 
-    private boolean hitExecutionNeeded = false;
+public abstract class FetchSubPhaseParseElement implements SearchParseElement {
 
-    void setHitExecutionNeeded(boolean hitExecutionNeeded) {
-        this.hitExecutionNeeded = hitExecutionNeeded;
+    @Override
+    public void parse(XContentParser parser, SearchContext context) throws Exception {
+        FetchSubPhaseContext fetchSubPhaseContext = context.getFetchSubPhaseContext(getContextFactory());
+        fetchSubPhaseContext.setHitExecutionNeeded(true);
+        innerParse(parser, fetchSubPhaseContext);
     }
 
-    public boolean hitExecutionNeeded() {
-        return hitExecutionNeeded;
-    }
+    protected abstract void innerParse(XContentParser parser, FetchSubPhaseContext fetchSubPhaseContext) throws Exception;
 
+    protected abstract FetchSubPhase.ContextFactory getContextFactory();
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsContext.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * All the required context to pull a field from the field data cache.
  */
-public class FieldDataFieldsContext implements FetchSubPhaseContext{
+public class FieldDataFieldsContext extends FetchSubPhaseContext {
 
     public static class FieldDataField {
         private final String name;

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsContext.java
@@ -19,13 +19,14 @@
 package org.elasticsearch.search.fetch.fielddata;
 
 import com.google.common.collect.Lists;
+import org.elasticsearch.search.fetch.FetchSubPhaseContext;
 
 import java.util.List;
 
 /**
  * All the required context to pull a field from the field data cache.
  */
-public class FieldDataFieldsContext {
+public class FieldDataFieldsContext implements FetchSubPhaseContext{
 
     public static class FieldDataField {
         private final String name;

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
@@ -45,7 +45,7 @@ import java.util.Map;
 public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
 
     public static final String[] NAMES = {"fielddata_fields", "fielddataFields"};
-    public static final ContextFactory CONTEXT_FACTORY = new ContextFactory() {
+    public static final ContextFactory<FieldDataFieldsContext> CONTEXT_FACTORY = new ContextFactory<FieldDataFieldsContext>() {
 
         @Override
         public String getName() {
@@ -53,7 +53,7 @@ public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
         }
 
         @Override
-        public FetchSubPhaseContext newContextInstance() {
+        public FieldDataFieldsContext newContextInstance() {
             return new FieldDataFieldsContext();
         }
     };
@@ -86,7 +86,7 @@ public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
 
     @Override
     public void hitExecute(SearchContext context, HitContext hitContext) {
-        for (FieldDataFieldsContext.FieldDataField field : ((FieldDataFieldsContext)context.getFetchSubPhaseContext(CONTEXT_FACTORY)).fields()) {
+        for (FieldDataFieldsContext.FieldDataField field : context.getFetchSubPhaseContext(CONTEXT_FACTORY).fields()) {
             if (hitContext.hit().fieldsOrNull() == null) {
                 hitContext.hit().fields(new HashMap<String, SearchHitField>(2));
             }

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.FetchSubPhaseContext;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.InternalSearchHitField;
 import org.elasticsearch.search.internal.SearchContext;
@@ -42,6 +43,20 @@ import java.util.Map;
  * Specifying {@code "fielddata_fields": ["field1", "field2"]}
  */
 public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
+
+    public static final String[] NAMES = {"fielddata_fields", "fielddataFields"};
+    public static final ContextFactory CONTEXT_FACTORY = new ContextFactory() {
+
+        @Override
+        public String getName() {
+            return NAMES[0];
+        }
+
+        @Override
+        public FetchSubPhaseContext newContextInstance() {
+            return new FieldDataFieldsContext();
+        }
+    };
 
     @Inject
     public FieldDataFieldsFetchSubPhase() {
@@ -66,12 +81,12 @@ public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
 
     @Override
     public boolean hitExecutionNeeded(SearchContext context) {
-        return context.hasFieldDataFields();
+        return context.hasFetchSubPhaseContext(CONTEXT_FACTORY);
     }
 
     @Override
     public void hitExecute(SearchContext context, HitContext hitContext) {
-        for (FieldDataFieldsContext.FieldDataField field : context.fieldDataFields().fields()) {
+        for (FieldDataFieldsContext.FieldDataField field : ((FieldDataFieldsContext)context.getFetchSubPhaseContext(CONTEXT_FACTORY)).fields()) {
             if (hitContext.hit().fieldsOrNull() == null) {
                 hitContext.hit().fields(new HashMap<String, SearchHitField>(2));
             }

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
@@ -81,7 +81,7 @@ public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
 
     @Override
     public boolean hitExecutionNeeded(SearchContext context) {
-        return context.hasFetchSubPhaseContext(CONTEXT_FACTORY);
+        return context.getFetchSubPhaseContext(CONTEXT_FACTORY).hitExecutionNeeded();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
@@ -39,7 +39,7 @@ import org.elasticsearch.search.internal.SearchContext;
 public class FieldDataFieldsParseElement extends FetchSubPhaseParseElement<FieldDataFieldsContext> {
 
     @Override
-    protected void innerParse(XContentParser parser, FieldDataFieldsContext fieldDataFieldsContext) throws Exception {
+    protected void innerParse(XContentParser parser, FieldDataFieldsContext fieldDataFieldsContext, SearchContext searchContext) throws Exception {
         XContentParser.Token token = parser.currentToken();
         if (token == XContentParser.Token.START_ARRAY) {
             while (parser.nextToken() != XContentParser.Token.END_ARRAY) {

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
@@ -20,12 +20,15 @@ package org.elasticsearch.search.fetch.fielddata;
 
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.FetchSubPhaseContext;
+import org.elasticsearch.search.fetch.FetchSubPhaseParseElement;
 import org.elasticsearch.search.internal.SearchContext;
 
 /**
  * Parses field name values from the {@code fielddata_fields} parameter in a
  * search request.
- *
+ * <p/>
  * <pre>
  * {
  *   "query": {...},
@@ -33,10 +36,11 @@ import org.elasticsearch.search.internal.SearchContext;
  * }
  * </pre>
  */
-public class FieldDataFieldsParseElement implements SearchParseElement {
+public class FieldDataFieldsParseElement extends FetchSubPhaseParseElement {
+
     @Override
-    public void parse(XContentParser parser, SearchContext context) throws Exception {
-        FieldDataFieldsContext fieldDataFieldsContext = (FieldDataFieldsContext)context.getFetchSubPhaseContext(FieldDataFieldsFetchSubPhase.CONTEXT_FACTORY);
+    protected void innerParse(XContentParser parser, FetchSubPhaseContext fetchSubPhaseContext) throws Exception {
+        FieldDataFieldsContext fieldDataFieldsContext = (FieldDataFieldsContext) fetchSubPhaseContext;
         XContentParser.Token token = parser.currentToken();
         if (token == XContentParser.Token.START_ARRAY) {
             while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
@@ -46,8 +50,13 @@ public class FieldDataFieldsParseElement implements SearchParseElement {
         } else if (token == XContentParser.Token.VALUE_STRING) {
             String fieldName = parser.text();
             fieldDataFieldsContext.add(new FieldDataFieldsContext.FieldDataField(fieldName));
-        }  else {
+        } else {
             throw new IllegalStateException("Expected either a VALUE_STRING or an START_ARRAY but got " + token);
         }
+    }
+
+    @Override
+    protected FetchSubPhase.ContextFactory getContextFactory() {
+        return FieldDataFieldsFetchSubPhase.CONTEXT_FACTORY;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
@@ -36,11 +36,10 @@ import org.elasticsearch.search.internal.SearchContext;
  * }
  * </pre>
  */
-public class FieldDataFieldsParseElement extends FetchSubPhaseParseElement {
+public class FieldDataFieldsParseElement extends FetchSubPhaseParseElement<FieldDataFieldsContext> {
 
     @Override
-    protected void innerParse(XContentParser parser, FetchSubPhaseContext fetchSubPhaseContext) throws Exception {
-        FieldDataFieldsContext fieldDataFieldsContext = (FieldDataFieldsContext) fetchSubPhaseContext;
+    protected void innerParse(XContentParser parser, FieldDataFieldsContext fieldDataFieldsContext) throws Exception {
         XContentParser.Token token = parser.currentToken();
         if (token == XContentParser.Token.START_ARRAY) {
             while (parser.nextToken() != XContentParser.Token.END_ARRAY) {

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsParseElement.java
@@ -36,15 +36,16 @@ import org.elasticsearch.search.internal.SearchContext;
 public class FieldDataFieldsParseElement implements SearchParseElement {
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
+        FieldDataFieldsContext fieldDataFieldsContext = (FieldDataFieldsContext)context.getFetchSubPhaseContext(FieldDataFieldsFetchSubPhase.CONTEXT_FACTORY);
         XContentParser.Token token = parser.currentToken();
         if (token == XContentParser.Token.START_ARRAY) {
             while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                 String fieldName = parser.text();
-                context.fieldDataFields().add(new FieldDataFieldsContext.FieldDataField(fieldName));
+                fieldDataFieldsContext.add(new FieldDataFieldsContext.FieldDataField(fieldName));
             }
         } else if (token == XContentParser.Token.VALUE_STRING) {
             String fieldName = parser.text();
-            context.fieldDataFields().add(new FieldDataFieldsContext.FieldDataField(fieldName));
+            fieldDataFieldsContext.add(new FieldDataFieldsContext.FieldDataField(fieldName));
         }  else {
             throw new IllegalStateException("Expected either a VALUE_STRING or an START_ARRAY but got " + token);
         }

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -129,10 +129,10 @@ public class DefaultSearchContext extends SearchContext {
     private final Map<String, FetchSubPhaseContext> subPhaseContexts = new HashMap<>();
 
     public DefaultSearchContext(long id, ShardSearchRequest request, SearchShardTarget shardTarget,
-                         Engine.Searcher engineSearcher, IndexService indexService, IndexShard indexShard,
-                         ScriptService scriptService, PageCacheRecycler pageCacheRecycler,
-                         BigArrays bigArrays, Counter timeEstimateCounter, ParseFieldMatcher parseFieldMatcher,
-                         TimeValue timeout
+                                Engine.Searcher engineSearcher, IndexService indexService, IndexShard indexShard,
+                                ScriptService scriptService, PageCacheRecycler pageCacheRecycler,
+                                BigArrays bigArrays, Counter timeEstimateCounter, ParseFieldMatcher parseFieldMatcher,
+                                TimeValue timeout
     ) {
         super(parseFieldMatcher);
         this.id = id;
@@ -305,13 +305,14 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public FetchSubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory) {
+    public <SubPhaseContext extends FetchSubPhaseContext> SubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory<SubPhaseContext> contextFactory) {
         String subPhaseName = contextFactory.getName();
         if (subPhaseContexts.get(subPhaseName) == null) {
             subPhaseContexts.put(subPhaseName, contextFactory.newContextInstance());
         }
-        return subPhaseContexts.get(subPhaseName);
+        return (SubPhaseContext) subPhaseContexts.get(subPhaseName);
     }
+
 
     @Override
     public SearchContextHighlight highlight() {

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -55,7 +55,6 @@ import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseContext;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -101,7 +100,6 @@ public class DefaultSearchContext extends SearchContext {
     private boolean explain;
     private boolean version = false; // by default, we don't return versions
     private List<String> fieldNames;
-    private FieldDataFieldsContext fieldDataFields;
     private ScriptFieldsContext scriptFields;
     private FetchSourceContext fetchSourceContext;
     private int from = -1;

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -352,19 +352,6 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean hasFieldDataFields() {
-        return fieldDataFields != null;
-    }
-
-    @Override
-    public FieldDataFieldsContext fieldDataFields() {
-        if (fieldDataFields == null) {
-            fieldDataFields = new FieldDataFieldsContext();
-        }
-        return this.fieldDataFields;
-    }
-
-    @Override
     public boolean hasScriptFields() {
         return scriptFields != null;
     }

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -728,11 +728,6 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean hasFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory) {
-        return subPhaseContexts.get(contextFactory.getName()) != null;
-    }
-
-    @Override
     public void innerHits(InnerHitsContext innerHitsContext) {
         this.innerHitsContext = innerHitsContext;
     }

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -212,16 +212,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean hasFieldDataFields() {
-        return in.hasFieldDataFields();
-    }
-
-    @Override
-    public FieldDataFieldsContext fieldDataFields() {
-        return in.fieldDataFields();
-    }
-
-    @Override
     public boolean hasScriptFields() {
         return in.hasScriptFields();
     }

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -45,6 +45,8 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.FetchSubPhaseContext;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
@@ -627,5 +629,15 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public void copyContextAndHeadersFrom(HasContextAndHeaders other) {
         in.copyContextAndHeadersFrom(other);
+    }
+
+    @Override
+    public FetchSubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory subPhase) {
+        return in.getFetchSubPhaseContext(subPhase);
+    }
+
+    @Override
+    public boolean hasFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory) {
+        return in.hasFetchSubPhaseContext(contextFactory);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -625,9 +625,4 @@ public abstract class FilteredSearchContext extends SearchContext {
     public FetchSubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory subPhase) {
         return in.getFetchSubPhaseContext(subPhase);
     }
-
-    @Override
-    public boolean hasFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory) {
-        return in.hasFetchSubPhaseContext(contextFactory);
-    }
 }

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -47,7 +47,6 @@ import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseContext;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -621,7 +621,7 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public FetchSubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory subPhase) {
-        return in.getFetchSubPhaseContext(subPhase);
+    public <SubPhaseContext extends FetchSubPhaseContext> SubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory<SubPhaseContext> contextFactory) {
+        return in.getFetchSubPhaseContext(contextFactory);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -186,10 +186,6 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     public abstract void addRescore(RescoreSearchContext rescore);
 
-    public abstract boolean hasFieldDataFields();
-
-    public abstract FieldDataFieldsContext fieldDataFields();
-
     public abstract boolean hasScriptFields();
 
     public abstract ScriptFieldsContext scriptFields();

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -50,6 +50,8 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.FetchSubPhaseContext;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
@@ -162,6 +164,8 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
     public abstract SearchContextAggregations aggregations();
 
     public abstract SearchContext aggregations(SearchContextAggregations aggregations);
+
+    public abstract FetchSubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory);
 
     public abstract SearchContextHighlight highlight();
 
@@ -359,6 +363,8 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
     public abstract ObjectMapper getObjectMapper(String name);
 
     public abstract Counter timeEstimateCounter();
+
+    public abstract boolean hasFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory);
 
     /**
      * The life time of an object that is used during search execution.

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -164,7 +164,7 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     public abstract SearchContext aggregations(SearchContextAggregations aggregations);
 
-    public abstract FetchSubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory);
+    public abstract  <SubPhaseContext extends FetchSubPhaseContext> SubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory<SubPhaseContext> contextFactory);
 
     public abstract SearchContextHighlight highlight();
 

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -360,8 +360,6 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     public abstract Counter timeEstimateCounter();
 
-    public abstract boolean hasFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory);
-
     /**
      * The life time of an object that is used during search execution.
      */

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -52,7 +52,6 @@ import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseContext;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;

--- a/core/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.fetch.FetchSearchResult;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
@@ -62,7 +61,6 @@ public class SubSearchContext extends FilteredSearchContext {
     private int docsIdsToLoadSize;
 
     private List<String> fieldNames;
-    private FieldDataFieldsContext fieldDataFields;
     private ScriptFieldsContext scriptFields;
     private FetchSourceContext fetchSourceContext;
     private SearchContextHighlight highlight;

--- a/core/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
@@ -133,19 +133,6 @@ public class SubSearchContext extends FilteredSearchContext {
     }
 
     @Override
-    public boolean hasFieldDataFields() {
-        return fieldDataFields != null;
-    }
-
-    @Override
-    public FieldDataFieldsContext fieldDataFields() {
-        if (fieldDataFields == null) {
-            fieldDataFields = new FieldDataFieldsContext();
-        }
-        return this.fieldDataFields;
-    }
-
-    @Override
     public boolean hasScriptFields() {
         return scriptFields != null;
     }

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
@@ -186,7 +186,7 @@ public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
     public static class TermVectorsFetchParseElement extends FetchSubPhaseParseElement<TermVectorsFetchContext> {
 
         @Override
-        protected void innerParse(XContentParser parser, TermVectorsFetchContext termVectorsFetchContext) throws Exception {
+        protected void innerParse(XContentParser parser, TermVectorsFetchContext termVectorsFetchContext, SearchContext searchContext) throws Exception {
             XContentParser.Token token = parser.currentToken();
             if (token == XContentParser.Token.VALUE_STRING) {
                 String fieldName = parser.text();

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
@@ -183,12 +183,11 @@ public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    public static class TermVectorsFetchParseElement extends FetchSubPhaseParseElement {
+    public static class TermVectorsFetchParseElement extends FetchSubPhaseParseElement<TermVectorsFetchContext> {
 
         @Override
-        protected void innerParse(XContentParser parser, FetchSubPhaseContext fetchSubPhaseContext) throws Exception {
+        protected void innerParse(XContentParser parser, TermVectorsFetchContext termVectorsFetchContext) throws Exception {
             XContentParser.Token token = parser.currentToken();
-            TermVectorsFetchContext termVectorsFetchContext = (TermVectorsFetchContext) fetchSubPhaseContext;
             if (token == XContentParser.Token.VALUE_STRING) {
                 String fieldName = parser.text();
                 termVectorsFetchContext.setField(fieldName);

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
@@ -137,9 +137,7 @@ public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
 
         @Override
         public Map<String, ? extends SearchParseElement> parseElements() {
-            ImmutableMap.Builder<String, SearchParseElement> parseElements = ImmutableMap.builder();
-            parseElements.put("term_vectors_fetch", new TermVectorsFetchParseElement());
-            return parseElements.build();
+            return ImmutableMap.of("term_vectors_fetch", new TermVectorsFetchParseElement());
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
@@ -117,7 +117,7 @@ public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
 
     public static class TermVectorsFetchSubPhase implements FetchSubPhase {
 
-        public static final ContextFactory CONTEXT_FACTORY = new ContextFactory() {
+        public static final ContextFactory<TermVectorsFetchContext> CONTEXT_FACTORY = new ContextFactory<TermVectorsFetchContext>() {
 
             @Override
             public String getName() {
@@ -125,7 +125,7 @@ public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
             }
 
             @Override
-            public FetchSubPhaseContext newContextInstance() {
+            public TermVectorsFetchContext newContextInstance() {
                 return new TermVectorsFetchContext();
             }
         };
@@ -158,7 +158,7 @@ public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
 
         @Override
         public void hitExecute(SearchContext context, HitContext hitContext) {
-            String field = ((TermVectorsFetchContext) context.getFetchSubPhaseContext(CONTEXT_FACTORY)).getField();
+            String field = context.getFetchSubPhaseContext(CONTEXT_FACTORY).getField();
 
             if (hitContext.hit().fieldsOrNull() == null) {
                 hitContext.hit().fields(new HashMap<String, SearchHitField>());

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
@@ -153,7 +153,7 @@ public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
 
         @Override
         public boolean hitExecutionNeeded(SearchContext context) {
-            return context.hasFetchSubPhaseContext(CONTEXT_FACTORY);
+            return context.getFetchSubPhaseContext(CONTEXT_FACTORY).hitExecutionNeeded();
         }
 
         @Override
@@ -183,21 +183,27 @@ public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
         }
     }
 
-    public static class TermVectorsFetchParseElement implements SearchParseElement {
+    public static class TermVectorsFetchParseElement extends FetchSubPhaseParseElement {
 
         @Override
-        public void parse(XContentParser parser, SearchContext context) throws Exception {
+        protected void innerParse(XContentParser parser, FetchSubPhaseContext fetchSubPhaseContext) throws Exception {
             XContentParser.Token token = parser.currentToken();
+            TermVectorsFetchContext termVectorsFetchContext = (TermVectorsFetchContext) fetchSubPhaseContext;
             if (token == XContentParser.Token.VALUE_STRING) {
                 String fieldName = parser.text();
-                ((TermVectorsFetchContext) context.getFetchSubPhaseContext(TermVectorsFetchSubPhase.CONTEXT_FACTORY)).setField(fieldName);
+                termVectorsFetchContext.setField(fieldName);
             } else {
                 throw new IllegalStateException("Expected a VALUE_STRING but got " + token);
             }
         }
+
+        @Override
+        protected FetchSubPhase.ContextFactory getContextFactory() {
+            return TermVectorsFetchSubPhase.CONTEXT_FACTORY;
+        }
     }
 
-    public static class TermVectorsFetchContext implements FetchSubPhaseContext {
+    public static class TermVectorsFetchContext extends FetchSubPhaseContext {
 
         private String field = null;
 

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginTests.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.termvectors.TermVectorsRequest;
+import org.elasticsearch.action.termvectors.TermVectorsResponse;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.search.SearchHitField;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.search.internal.InternalSearchHitField;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.client.Requests.indexRequest;
+import static org.elasticsearch.common.settings.Settings.settingsBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ *
+ */
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class FetchSubPhasePluginTests extends ElasticsearchIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return settingsBuilder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put("plugin.types", FetchTermVectorsPlugin.class.getName())
+                .build();
+    }
+
+    @Test
+    public void testPlugin() throws Exception {
+        client().admin()
+                .indices()
+                .prepareCreate("test")
+                .addMapping(
+                        "type1",
+                        jsonBuilder()
+                                .startObject().startObject("type1")
+                                .startObject("properties")
+                                .startObject("test")
+                                .field("type", "string").field("term_vector", "yes")
+                                .endObject()
+                                .endObject()
+                                .endObject().endObject()).execute().actionGet();
+        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
+
+        client().index(
+                indexRequest("test").type("type1").id("1")
+                        .source(jsonBuilder().startObject().field("test", "I am sam i am").endObject())).actionGet();
+
+        client().admin().indices().prepareRefresh().execute().actionGet();
+
+        String searchSource = jsonBuilder().startObject()
+                .field("term_vectors_fetch", "test")
+                .endObject().string();
+        SearchResponse response = client().prepareSearch().setSource(searchSource).get();
+        assertSearchResponse(response);
+        assertThat(((Map<String, Integer>) response.getHits().getAt(0).field("term_vectors_fetch").getValues().get(0)).get("i"), equalTo(2));
+        assertThat(((Map<String, Integer>) response.getHits().getAt(0).field("term_vectors_fetch").getValues().get(0)).get("am"), equalTo(2));
+        assertThat(((Map<String, Integer>) response.getHits().getAt(0).field("term_vectors_fetch").getValues().get(0)).get("sam"), equalTo(1));
+    }
+
+    public static class FetchTermVectorsPlugin extends AbstractPlugin {
+
+        @Override
+        public String name() {
+            return "fetch-term-vectors";
+        }
+
+        @Override
+        public String description() {
+            return "fetch plugin to test if the plugin mechanism works";
+        }
+
+        public void onModule(FetchSubPhaseModule fetchSubPhaseModule) {
+            fetchSubPhaseModule.registerFetchSubPhase(TermVectorsFetchSubPhase.class);
+        }
+    }
+
+    public static class TermVectorsFetchSubPhase implements FetchSubPhase {
+
+        public static final ContextFactory CONTEXT_FACTORY = new ContextFactory() {
+
+            @Override
+            public String getName() {
+                return NAMES[0];
+            }
+
+            @Override
+            public FetchSubPhaseContext newContextInstance() {
+                return new TermVectorsFetchContext();
+            }
+        };
+
+        public TermVectorsFetchSubPhase() {
+        }
+
+        public static final String[] NAMES = {"term_vectors_fetch"};
+
+        @Override
+        public Map<String, ? extends SearchParseElement> parseElements() {
+            ImmutableMap.Builder<String, SearchParseElement> parseElements = ImmutableMap.builder();
+            parseElements.put("term_vectors_fetch", new TermVectorsFetchParseElement());
+            return parseElements.build();
+        }
+
+        @Override
+        public boolean hitsExecutionNeeded(SearchContext context) {
+            return false;
+        }
+
+        @Override
+        public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
+        }
+
+        @Override
+        public boolean hitExecutionNeeded(SearchContext context) {
+            return context.hasFetchSubPhaseContext(CONTEXT_FACTORY);
+        }
+
+        @Override
+        public void hitExecute(SearchContext context, HitContext hitContext) {
+            String field = ((TermVectorsFetchContext) context.getFetchSubPhaseContext(CONTEXT_FACTORY)).getField();
+
+            if (hitContext.hit().fieldsOrNull() == null) {
+                hitContext.hit().fields(new HashMap<String, SearchHitField>());
+            }
+            SearchHitField hitField = hitContext.hit().fields().get(NAMES[0]);
+            if (hitField == null) {
+                hitField = new InternalSearchHitField(NAMES[0], new ArrayList<>(1));
+                hitContext.hit().fields().put(NAMES[0], hitField);
+            }
+            TermVectorsResponse termVector = context.indexShard().termVectorsService().getTermVectors(new TermVectorsRequest(context.indexShard().indexService().index().getName(), hitContext.hit().type(), hitContext.hit().id()), context.indexShard().indexService().index().getName());
+            try {
+                Map<String, Integer> tv = new HashMap<>();
+                TermsEnum terms = termVector.getFields().terms(field).iterator();
+                BytesRef term;
+                while ((term = terms.next()) != null) {
+                    tv.put(term.utf8ToString(), terms.postings(null, null, PostingsEnum.ALL).freq());
+                }
+                hitField.values().add(tv);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static class TermVectorsFetchParseElement implements SearchParseElement {
+
+        @Override
+        public void parse(XContentParser parser, SearchContext context) throws Exception {
+            XContentParser.Token token = parser.currentToken();
+            if (token == XContentParser.Token.VALUE_STRING) {
+                String fieldName = parser.text();
+                ((TermVectorsFetchContext) context.getFetchSubPhaseContext(TermVectorsFetchSubPhase.CONTEXT_FACTORY)).setField(fieldName);
+            } else {
+                throw new IllegalStateException("Expected a VALUE_STRING but got " + token);
+            }
+        }
+    }
+
+    public static class TermVectorsFetchContext implements FetchSubPhaseContext {
+
+        private String field = null;
+
+        public TermVectorsFetchContext() {
+        }
+
+        public void setField(String field) {
+            this.field = field;
+        }
+
+        public String getField() {
+            return field;
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -204,12 +204,12 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public FetchSubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory) {
+    public <SubPhaseContext extends FetchSubPhaseContext> SubPhaseContext getFetchSubPhaseContext(FetchSubPhase.ContextFactory<SubPhaseContext> contextFactory) {
         String subPhaseName = contextFactory.getName();
         if (subPhaseContexts.get(subPhaseName) == null) {
             subPhaseContexts.put(subPhaseName, contextFactory.newContextInstance());
         }
-        return subPhaseContexts.get(subPhaseName);
+        return (SubPhaseContext) subPhaseContexts.get(subPhaseName);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -246,16 +246,6 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean hasFieldDataFields() {
-        return false;
-    }
-
-    @Override
-    public FieldDataFieldsContext fieldDataFields() {
-        return null;
-    }
-
-    @Override
     public boolean hasScriptFields() {
         return false;
     }

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -214,11 +214,6 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public boolean hasFetchSubPhaseContext(FetchSubPhase.ContextFactory contextFactory) {
-        return subPhaseContexts.get(contextFactory.getName()) != null;
-    }
-
-    @Override
     public SearchContextHighlight highlight() {
         return null;
     }

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -50,7 +50,6 @@ import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseContext;
-import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsContext;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;


### PR DESCRIPTION
This is wip, only opening this pull request so that it is easier to discuss.
I made the fetch sub phases pluggable to see if this adds too much complexity. With this change new or existing fetch sub phases such as fielddata fields or script fields can be plugged in.
As a proof of concept I changed fielddata fields to use the plugin mechanism and added an example for 
a plugged in fetch phase in the test.
While this adds a little more guice stuff, it also removes the need for implementing methods like `hasFieldDataFields()` and `fieldDataFields()` in every subclass of SearchContext. 
In addition we could easily add features like  #10729 and also move features like fielddatafields from core to a plugin immediately. Overall my feeling is that it would be a win to make sub phases pluggable.

It is work in progress because converting inner hits to use the plugin mechanism will be a little more 
tricky. Also not all fetch phases are structured the same so converting all sub phases might need more work as well.
