### PR TITLE
Copy the classloader from the original settings when checking for prompts

### DIFF
--- a/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
+++ b/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
@@ -180,7 +180,7 @@ public class InternalSettingsPreparer {
 
     static Settings replacePromptPlaceholders(Settings settings, Terminal terminal) {
         UnmodifiableIterator<Map.Entry<String, String>> iter = settings.getAsMap().entrySet().iterator();
-        Settings.Builder builder = Settings.builder();
+        Settings.Builder builder = Settings.builder().classLoader(settings.getClassLoaderIfSet());
 
         while (iter.hasNext()) {
             Map.Entry<String, String> entry = iter.next();

--- a/core/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
+++ b/core/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
@@ -29,6 +29,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -219,5 +221,20 @@ public class InternalSettingsPreparerTests extends ElasticsearchTestCase {
         assertThat(counter.intValue(), is(1));
         assertThat(settings.get("name"), is("prompted name 0"));
         assertThat(settings.get("node.name"), is("prompted name 0"));
+    }
+
+    @Test
+    public void testPreserveSettingsClassloader() {
+        final ClassLoader classLoader = URLClassLoader.newInstance(new URL[0]);
+        Settings settings = settingsBuilder()
+                .put("foo", "bar")
+                .put("path.home", createTempDir())
+                .classLoader(classLoader)
+                .build();
+
+        Tuple<Settings, Environment> tuple = InternalSettingsPreparer.prepareSettings(settings, randomBoolean());
+
+        Settings preparedSettings = tuple.v1();
+        assertThat(preparedSettings.getClassLoaderIfSet(), is(classLoader));
     }
 }


### PR DESCRIPTION
Today, when a user provides settings and specifies a classloader to be used, the classloader gets
dropped when we copy the settings to check for prompt entries. This change copies the classloader
when replacing the prompt placeholders and adds a test to ensure the InternalSettingsPreparer
always retains the classloader.

Closes #12340
