### PR TITLE
Cancel replica recovery on another sync option copy found

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -95,7 +95,11 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
         /**
          * When a shard moves from started back to initializing, for example, during shadow replica
          */
-        REINITIALIZED;
+        REINITIALIZED,
+        /**
+         * A better replica location is identified and causes the existing replica allocation to be cancelled.
+         */
+        REALLOCATED_REPLICA;
     }
 
     private final Reason reason;

--- a/core/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -126,6 +126,7 @@ public class GatewayAllocator extends AbstractComponent {
         }); // sort for priority ordering
 
         changed |= primaryShardAllocator.allocateUnassigned(allocation);
+        changed |= replicaShardAllocator.processExistingRecoveries(allocation);
         changed |= replicaShardAllocator.allocateUnassigned(allocation);
         return changed;
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -60,7 +60,8 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
                 UnassignedInfo.Reason.ALLOCATION_FAILED,
                 UnassignedInfo.Reason.NODE_LEFT,
                 UnassignedInfo.Reason.REROUTE_CANCELLED,
-                UnassignedInfo.Reason.REINITIALIZED};
+                UnassignedInfo.Reason.REINITIALIZED,
+                UnassignedInfo.Reason.REALLOCATED_REPLICA};
         for (int i = 0; i < order.length; i++) {
             assertThat(order[i].ordinal(), equalTo(i));
         }


### PR DESCRIPTION
When a replica is initializing from the primary, and we find a better node that has full sync id match, it is better to cancel the existing replica allocation and allocate it to the new node with sync id match (eventually)
