### PR TITLE
Moving null-checks from constructors to validate()

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -37,23 +37,15 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
     public static final String NAME = "span_containing";
     private final SpanQueryBuilder big;
     private final SpanQueryBuilder little;
-    static final SpanContainingQueryBuilder PROTOTYPE = new SpanContainingQueryBuilder();
+    static final SpanContainingQueryBuilder PROTOTYPE = new SpanContainingQueryBuilder(null, null);
 
     /**
      * @param big the big clause, it must enclose {@code little} for a match.
      * @param little the little clause, it must be contained within {@code big} for a match.
      */
     public SpanContainingQueryBuilder(SpanQueryBuilder big, SpanQueryBuilder little) {
-        this.little = Objects.requireNonNull(little);
-        this.big = Objects.requireNonNull(big);
-    }
-
-    /**
-     * only used for prototype
-     */
-    private SpanContainingQueryBuilder() {
-        this.little = null;
-        this.big = null;
+        this.little = little;
+        this.big = big;
     }
 
     /**
@@ -92,9 +84,18 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
 
     @Override
     public QueryValidationException validate() {
-        QueryValidationException validationExceptions = validateInnerQuery(big, null);
-        validationExceptions = validateInnerQuery(little, validationExceptions);
-        return validationExceptions;
+        QueryValidationException validationException = null;
+        if (big == null) {
+            validationException = addValidationError("inner clause [big] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(big, validationException);
+        }
+        if (little == null) {
+            validationException = addValidationError("inner clause [little] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(little, validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -37,7 +37,7 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
 
     private final int end;
 
-    static final SpanFirstQueryBuilder SPAN_FIRST_QUERY_BUILDER = new SpanFirstQueryBuilder();
+    static final SpanFirstQueryBuilder SPAN_FIRST_QUERY_BUILDER = new SpanFirstQueryBuilder(null, -1);
 
     /**
      * Query that matches spans queries defined in <code>matchBuilder</code>
@@ -47,20 +47,8 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
      * @throws IllegalArgumentException for negative <code>end</code> positions
      */
     public SpanFirstQueryBuilder(SpanQueryBuilder matchBuilder, int end) {
-        this.matchBuilder = Objects.requireNonNull(matchBuilder);
-        if (end >= 0) {
-            this.end = end;
-        } else {
-            throw new IllegalArgumentException("end parameter needs to be positive");
-        }
-    }
-
-    /**
-     * only used for prototype
-     */
-    private SpanFirstQueryBuilder() {
-        this.matchBuilder = null;
-        this.end = -1;
+        this.matchBuilder = matchBuilder;
+        this.end = end;
     }
 
     /**
@@ -96,7 +84,16 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
 
     @Override
     public QueryValidationException validate() {
-        return validateInnerQuery(matchBuilder, null);
+        QueryValidationException validationException = null;
+        if (matchBuilder == null) {
+            validationException = addValidationError("inner clause [match] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(matchBuilder, validationException);
+        }
+        if (end < 0) {
+            validationException = addValidationError("parameter [end] needs to be positive.", validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -46,7 +46,7 @@ public class SpanFirstQueryParser extends BaseQueryParser {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
 
         SpanQueryBuilder match = null;
-        int end = -1;
+        Integer end = null;
         String queryName = null;
 
         String currentFieldName = null;
@@ -79,7 +79,7 @@ public class SpanFirstQueryParser extends BaseQueryParser {
         if (match == null) {
             throw new QueryParsingException(parseContext, "spanFirst must have [match] span query clause");
         }
-        if (end == -1) {
+        if (end == null) {
             throw new QueryParsingException(parseContext, "spanFirst must have [end] set for it");
         }
         SpanFirstQueryBuilder queryBuilder = new SpanFirstQueryBuilder(match, end);

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+
 import java.io.IOException;
 import java.util.Objects;
 
@@ -35,17 +36,10 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
 
     public static final String NAME = "span_multi";
     private final MultiTermQueryBuilder multiTermQueryBuilder;
-    static final SpanMultiTermQueryBuilder PROTOTYPE = new SpanMultiTermQueryBuilder();
+    static final SpanMultiTermQueryBuilder PROTOTYPE = new SpanMultiTermQueryBuilder(null);
 
     public SpanMultiTermQueryBuilder(MultiTermQueryBuilder multiTermQueryBuilder) {
-        this.multiTermQueryBuilder = Objects.requireNonNull(multiTermQueryBuilder);
-    }
-
-    /**
-     * only used for prototype
-     */
-    private SpanMultiTermQueryBuilder() {
-        this.multiTermQueryBuilder = null;
+        this.multiTermQueryBuilder = multiTermQueryBuilder;
     }
 
     public MultiTermQueryBuilder multiTermQueryBuilder() {
@@ -73,7 +67,13 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
 
     @Override
     public QueryValidationException validate() {
-        return validateInnerQuery(multiTermQueryBuilder, null);
+        QueryValidationException validationException = null;
+        if (multiTermQueryBuilder == null) {
+            validationException = addValidationError("inner clause ["+ SpanMultiTermQueryParser.MATCH_NAME +"] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(multiTermQueryBuilder, validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -78,7 +78,7 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
     }
 
     public SpanNearQueryBuilder clause(SpanQueryBuilder clause) {
-        clauses.add(Objects.requireNonNull(clause));
+        clauses.add(clause);
         return this;
     }
 
@@ -149,14 +149,18 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
 
     @Override
     public QueryValidationException validate() {
-        QueryValidationException validationExceptions = null;
+        QueryValidationException validationException = null;
         if (clauses.isEmpty()) {
-            validationExceptions =  addValidationError("query must include [clauses]", validationExceptions);
+            validationException =  addValidationError("query must include [clauses]", validationException);
         }
         for (SpanQueryBuilder innerClause : clauses) {
-            validationExceptions = validateInnerQuery(innerClause, validationExceptions);
+            if (innerClause == null) {
+                validationException =  addValidationError("[clauses] contains null element", validationException);
+            } else {
+                validationException = validateInnerQuery(innerClause, validationException);
+            }
         }
-        return validationExceptions;
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -46,7 +46,7 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
 
     private int post = DEFAULT_POST;
 
-    static final SpanNotQueryBuilder PROTOTYPE = new SpanNotQueryBuilder();
+    static final SpanNotQueryBuilder PROTOTYPE = new SpanNotQueryBuilder(null, null);
 
     /**
      * Construct a span query matching spans from <code>include</code> which
@@ -55,14 +55,8 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
      * @param exclude the span query whose matches must not overlap
      */
     public SpanNotQueryBuilder(SpanQueryBuilder include, SpanQueryBuilder exclude) {
-        this.include = Objects.requireNonNull(include);
-        this.exclude = Objects.requireNonNull(exclude);
-    }
-
-    // only used for prototype
-    private SpanNotQueryBuilder() {
-           this.include = null;
-           this.exclude = null;
+        this.include = include;
+        this.exclude = exclude;
     }
 
     /**
@@ -149,9 +143,18 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
 
     @Override
     public QueryValidationException validate() {
-        QueryValidationException validationExceptions = validateInnerQuery(include, null);
-        validationExceptions = validateInnerQuery(exclude, validationExceptions);
-        return validationExceptions;
+        QueryValidationException validationException = null;
+        if (include == null) {
+            validationException = addValidationError("inner clause [include] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(include, validationException);
+        }
+        if (exclude == null) {
+            validationException = addValidationError("inner clause [exclude] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(exclude, validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -43,7 +43,7 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
     static final SpanOrQueryBuilder PROTOTYPE = new SpanOrQueryBuilder();
 
     public SpanOrQueryBuilder clause(SpanQueryBuilder clause) {
-        clauses.add(Objects.requireNonNull(clause));
+        clauses.add(clause);
         return this;
     }
 
@@ -79,14 +79,18 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
 
     @Override
     public QueryValidationException validate() {
-        QueryValidationException validationExceptions = null;
+        QueryValidationException validationException = null;
         if (clauses.isEmpty()) {
-            validationExceptions =  addValidationError("query must include [clauses]", validationExceptions);
+            validationException =  addValidationError("query must include [clauses]", validationException);
         }
         for (SpanQueryBuilder innerClause : clauses) {
-            validationExceptions = validateInnerQuery(innerClause, validationExceptions);
+            if (innerClause == null) {
+                validationException =  addValidationError("[clauses] contains null element", validationException);
+            } else {
+                validationException = validateInnerQuery(innerClause, validationException);
+            }
         }
-        return validationExceptions;
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -37,7 +37,7 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
     public static final String NAME = "span_within";
     private final SpanQueryBuilder big;
     private final SpanQueryBuilder little;
-    static final SpanWithinQueryBuilder PROTOTYPE = new SpanWithinQueryBuilder();
+    static final SpanWithinQueryBuilder PROTOTYPE = new SpanWithinQueryBuilder(null, null);
 
     /**
      * Query that returns spans from <code>little</code> that are contained in a spans from <code>big</code>.
@@ -45,16 +45,8 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
      * @param little the little clause, it must be contained within {@code big} for a match.
      */
     public SpanWithinQueryBuilder(SpanQueryBuilder big, SpanQueryBuilder little) {
-        this.little = Objects.requireNonNull(little);
-        this.big = Objects.requireNonNull(big);
-    }
-
-    /**
-     * for prototype only
-     */
-    private SpanWithinQueryBuilder() {
-        this.little = null;
-        this.big = null;
+        this.little = little;
+        this.big = big;
     }
 
     /**
@@ -97,9 +89,18 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
 
     @Override
     public QueryValidationException validate() {
-        QueryValidationException validationExceptions = validateInnerQuery(big, null);
-        validationExceptions = validateInnerQuery(little, validationExceptions);
-        return validationExceptions;
+        QueryValidationException validationException = null;
+        if (big == null) {
+            validationException = addValidationError("inner clause [big] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(big, validationException);
+        }
+        if (little == null) {
+            validationException = addValidationError("inner clause [little] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(little, validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
@@ -46,29 +46,27 @@ public class SpanContainingQueryBuilderTest extends BaseQueryTestCase<SpanContai
         int totalExpectedErrors = 0;
         SpanQueryBuilder bigSpanQueryBuilder;
         if (randomBoolean()) {
-            bigSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            if (randomBoolean()) {
+                bigSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            } else {
+                bigSpanQueryBuilder = null;
+            }
             totalExpectedErrors++;
         } else {
             bigSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
         }
         SpanQueryBuilder littleSpanQueryBuilder;
         if (randomBoolean()) {
-            littleSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            if (randomBoolean()) {
+                littleSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            } else {
+                littleSpanQueryBuilder = null;
+            }
             totalExpectedErrors++;
         } else {
             littleSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
         }
         SpanContainingQueryBuilder queryBuilder = new SpanContainingQueryBuilder(bigSpanQueryBuilder, littleSpanQueryBuilder);
         assertValidate(queryBuilder, totalExpectedErrors);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullBig() {
-        new SpanContainingQueryBuilder(null, new SpanTermQueryBuilder("name", "value"));
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullLittle() {
-        new SpanContainingQueryBuilder(new SpanTermQueryBuilder("name", "value"), null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTest.java
@@ -45,22 +45,21 @@ public class SpanFirstQueryBuilderTest extends BaseQueryTestCase<SpanFirstQueryB
         int totalExpectedErrors = 0;
         SpanQueryBuilder innerSpanQueryBuilder;
         if (randomBoolean()) {
-            innerSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            if (randomBoolean()) {
+                innerSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            } else {
+                innerSpanQueryBuilder = null;
+            }
             totalExpectedErrors++;
         } else {
             innerSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
         }
-        SpanFirstQueryBuilder queryBuilder = new SpanFirstQueryBuilder(innerSpanQueryBuilder, 10);
+        int end = 10;
+        if (randomBoolean()) {
+            end = -1;
+            totalExpectedErrors++;
+        }
+        SpanFirstQueryBuilder queryBuilder = new SpanFirstQueryBuilder(innerSpanQueryBuilder, end);
         assertValidate(queryBuilder, totalExpectedErrors);
-    }
-
-    @Test(expected=IllegalArgumentException.class)
-    public void testEndValueNegative() {
-        new SpanFirstQueryBuilder(new SpanTermQueryBuilder("name", "value"), -1);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testInnerQueryNull() {
-        new SpanFirstQueryBuilder(null, 1);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTest.java
@@ -45,18 +45,17 @@ public class SpanMultiTermQueryBuilderTest extends BaseQueryTestCase<SpanMultiTe
         int totalExpectedErrors = 0;
         MultiTermQueryBuilder multiTermQueryBuilder;
         if (randomBoolean()) {
-            multiTermQueryBuilder = new RangeQueryBuilder("");
+            if (randomBoolean()) {
+                multiTermQueryBuilder = new RangeQueryBuilder("");
+            } else {
+                multiTermQueryBuilder = null;
+            }
             totalExpectedErrors++;
         } else {
             multiTermQueryBuilder = new RangeQueryBuilder("field");
         }
         SpanMultiTermQueryBuilder queryBuilder = new SpanMultiTermQueryBuilder(multiTermQueryBuilder);
         assertValidate(queryBuilder, totalExpectedErrors);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testInnerQueryNull() {
-        new SpanMultiTermQueryBuilder(null);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTest.java
@@ -63,7 +63,11 @@ public class SpanNearQueryBuilderTest extends BaseQueryTestCase<SpanNearQueryBui
         int clauses = randomIntBetween(1, 10);
         for (int i = 0; i < clauses; i++) {
             if (randomBoolean()) {
-                queryBuilder.clause(new SpanTermQueryBuilder("", "test"));
+                if (randomBoolean()) {
+                    queryBuilder.clause(new SpanTermQueryBuilder("", "test"));
+                } else {
+                    queryBuilder.clause(null);
+                }
                 totalExpectedErrors++;
             } else {
                 queryBuilder.clause(new SpanTermQueryBuilder("name", "value"));

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTest.java
@@ -66,14 +66,22 @@ public class SpanNotQueryBuilderTest extends BaseQueryTestCase<SpanNotQueryBuild
         int totalExpectedErrors = 0;
         SpanQueryBuilder include;
         if (randomBoolean()) {
-            include = new SpanTermQueryBuilder("", "test");
+            if (randomBoolean()) {
+                include = new SpanTermQueryBuilder("", "test");
+            } else {
+                include = null;
+            }
             totalExpectedErrors++;
         } else {
             include = new SpanTermQueryBuilder("name", "value");
         }
         SpanQueryBuilder exclude;
         if (randomBoolean()) {
-            exclude = new SpanTermQueryBuilder("", "test");
+            if (randomBoolean()) {
+                exclude = new SpanTermQueryBuilder("", "test");
+            } else {
+                exclude = null;
+            }
             totalExpectedErrors++;
         } else {
             exclude = new SpanTermQueryBuilder("name", "value");
@@ -205,15 +213,5 @@ public class SpanNotQueryBuilderTest extends BaseQueryTestCase<SpanNotQueryBuild
         } catch (QueryParsingException e) {
             assertThat("QueryParsingException should have been caught", e.getDetailedMessage(), containsString("spanNot can either use [dist] or [pre] & [post] (or none)"));
         }
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullInclude() {
-        new SpanNotQueryBuilder(null, new SpanTermQueryBuilder("name", "value"));
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullExclude() {
-        new SpanNotQueryBuilder(new SpanTermQueryBuilder("name", "value"), null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
@@ -60,7 +60,11 @@ public class SpanOrQueryBuilderTest extends BaseQueryTestCase<SpanOrQueryBuilder
         int clauses = randomIntBetween(1, 10);
         for (int i = 0; i < clauses; i++) {
             if (randomBoolean()) {
-                queryBuilder.clause(new SpanTermQueryBuilder("", "test"));
+                if (randomBoolean()) {
+                    queryBuilder.clause(new SpanTermQueryBuilder("", "test"));
+                } else {
+                    queryBuilder.clause(null);
+                }
                 totalExpectedErrors++;
             } else {
                 queryBuilder.clause(new SpanTermQueryBuilder("name", "value"));

--- a/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
@@ -46,29 +46,27 @@ public class SpanWithinQueryBuilderTest extends BaseQueryTestCase<SpanWithinQuer
         int totalExpectedErrors = 0;
         SpanQueryBuilder bigSpanQueryBuilder;
         if (randomBoolean()) {
-            bigSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            if (randomBoolean()) {
+                bigSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            } else {
+                bigSpanQueryBuilder = null;
+            }
             totalExpectedErrors++;
         } else {
             bigSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
         }
         SpanQueryBuilder littleSpanQueryBuilder;
         if (randomBoolean()) {
-            littleSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            if (randomBoolean()) {
+                littleSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            } else {
+                littleSpanQueryBuilder = null;
+            }
             totalExpectedErrors++;
         } else {
             littleSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
         }
         SpanWithinQueryBuilder queryBuilder = new SpanWithinQueryBuilder(bigSpanQueryBuilder, littleSpanQueryBuilder);
         assertValidate(queryBuilder, totalExpectedErrors);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullBig() {
-        new SpanWithinQueryBuilder(null, new SpanTermQueryBuilder("name", "value"));
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullLittle() {
-        new SpanWithinQueryBuilder(new SpanTermQueryBuilder("name", "value"), null);
     }
 }


### PR DESCRIPTION
After joint discussion we decided to move the validation of inner queries etc... not being null to the validate() method only and rely on it being called rather than fail in constructors already. This PR moves those null-checks for already refactored span queries.

PR: query refactoring branch
