### PR TITLE
No need to find replica copy when index is created

### DIFF
--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -70,6 +70,10 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
                 if (shard.relocatingNodeId() != null) {
                     continue;
                 }
+                // if we are allocating a replica because of index creation, no need to go and find a copy, there isn't one...
+                if (shard.allocatedPostIndexCreate() == false) {
+                    continue;
+                }
 
                 AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> shardStores = fetchData(shard, allocation);
                 if (shardStores.hasData() == false) {
@@ -113,6 +117,11 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
         while (unassignedIterator.hasNext()) {
             ShardRouting shard = unassignedIterator.next();
             if (shard.primary()) {
+                continue;
+            }
+
+            // if we are allocating a replica because of index creation, no need to go and find a copy, there isn't one...
+            if (shard.allocatedPostIndexCreate() == false) {
                 continue;
             }
 


### PR DESCRIPTION
There is no need to try and go fetch replica copies for best allocation when the index is created
