### PR TITLE
Copy headers from the MLT request before calling the multi-termvectors API

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -236,8 +236,8 @@ public class MoreLikeThisQueryParser implements QueryParser {
                 }
             }
             // fetching the items with multi-termvectors API
-            org.apache.lucene.index.Fields[] likeFields = fetchService.fetch(items);
             items.copyContextAndHeadersFrom(SearchContext.current());
+            org.apache.lucene.index.Fields[] likeFields = fetchService.fetch(items);
             mltQuery.setLikeText(likeFields);
 
             BooleanQuery boolQuery = new BooleanQuery();


### PR DESCRIPTION
Today, we call the fetch service with a MultiTermVectorsRequest and then after that copy the headers
and context to the MultiTermVectorsRequest. The fetch service executes the request so the headers
and context are not used when the request is executed. This changes the code to copy the headers
and context first, so the headers and information from the context are available when executing the
request.
