### PR TITLE
Query Refactoring: Move null-checks to validate

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -233,7 +233,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
         return queries;
     }
 
-    protected static QueryValidationException validateInnerQueries(List<QueryBuilder> queryBuilders, QueryValidationException initialValidationException) {
+    protected QueryValidationException validateInnerQueries(List<QueryBuilder> queryBuilders, QueryValidationException initialValidationException) {
         QueryValidationException validationException = initialValidationException;
         for (QueryBuilder queryBuilder : queryBuilders) {
             validationException = validateInnerQuery(queryBuilder, validationException);
@@ -241,13 +241,15 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
         return validationException;
     }
 
-    protected static QueryValidationException validateInnerQuery(QueryBuilder queryBuilder, QueryValidationException initialValidationException) {
+    protected QueryValidationException validateInnerQuery(QueryBuilder queryBuilder, QueryValidationException initialValidationException) {
         QueryValidationException validationException = initialValidationException;
         if (queryBuilder != null) {
             QueryValidationException queryValidationException = queryBuilder.validate();
             if (queryValidationException != null) {
                 validationException = QueryValidationException.addValidationErrors(queryValidationException.validationErrors(), validationException);
             }
+        } else {
+            validationException = addValidationError("inner query cannot be null", validationException);
         }
         return validationException;
     }

--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
@@ -51,7 +51,7 @@ public class AndQueryBuilder extends AbstractQueryBuilder<AndQueryBuilder> {
      */
     public AndQueryBuilder(QueryBuilder... filters) {
         for (QueryBuilder filter : filters) {
-            this.filters.add(Objects.requireNonNull(filter));
+            this.filters.add(filter);
         }
     }
 
@@ -60,7 +60,7 @@ public class AndQueryBuilder extends AbstractQueryBuilder<AndQueryBuilder> {
      * @param filterBuilder nested filter, no <tt>null</tt> value allowed
      */
     public AndQueryBuilder add(QueryBuilder filterBuilder) {
-        filters.add(Objects.requireNonNull(filterBuilder));
+        filters.add(filterBuilder);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -68,7 +68,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
      * contribute to scoring. No <tt>null</tt> value allowed.
      */
     public BoolQueryBuilder must(QueryBuilder queryBuilder) {
-        mustClauses.add(Objects.requireNonNull(queryBuilder));
+        mustClauses.add(queryBuilder);
         return this;
     }
 
@@ -84,7 +84,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
      * not contribute to scoring. No <tt>null</tt> value allowed.
      */
     public BoolQueryBuilder filter(QueryBuilder queryBuilder) {
-        filterClauses.add(Objects.requireNonNull(queryBuilder));
+        filterClauses.add(queryBuilder);
         return this;
     }
 
@@ -100,7 +100,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
      * No <tt>null</tt> value allowed.
      */
     public BoolQueryBuilder mustNot(QueryBuilder queryBuilder) {
-        mustNotClauses.add(Objects.requireNonNull(queryBuilder));
+        mustNotClauses.add(queryBuilder);
         return this;
     }
 
@@ -119,7 +119,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
      * @see #minimumNumberShouldMatch(int)
      */
     public BoolQueryBuilder should(QueryBuilder queryBuilder) {
-        shouldClauses.add(Objects.requireNonNull(queryBuilder));
+        shouldClauses.add(queryBuilder);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -50,15 +50,7 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
 
     private float negativeBoost = -1;
 
-    static final BoostingQueryBuilder PROTOTYPE = new BoostingQueryBuilder();
-
-    /**
-     * this constructor only used for prototype
-     */
-    private BoostingQueryBuilder() {
-        this.positiveQuery = null;
-        this.negativeQuery = null;
-    }
+    static final BoostingQueryBuilder PROTOTYPE = new BoostingQueryBuilder(null, null);
 
     /**
      * Create a new {@link BoostingQueryBuilder}
@@ -67,8 +59,8 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
      * @param negativeQuery the negative query for this boosting query.
      */
     public BoostingQueryBuilder(QueryBuilder positiveQuery, QueryBuilder negativeQuery) {
-        this.positiveQuery = Objects.requireNonNull(positiveQuery);
-        this.negativeQuery = Objects.requireNonNull(negativeQuery);
+        this.positiveQuery = positiveQuery;
+        this.negativeQuery = negativeQuery;
     }
 
     /**
@@ -118,8 +110,16 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
         if (negativeBoost < 0) {
             validationException = addValidationError("query requires negativeBoost to be set to positive value", validationException);
         }
-        validationException = validateInnerQuery(negativeQuery, validationException);
-        validationException = validateInnerQuery(positiveQuery, validationException);
+        if (negativeQuery == null) {
+            validationException = addValidationError("inner clause [negative] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(negativeQuery, validationException);
+        }
+        if (positiveQuery == null) {
+            validationException = addValidationError("inner clause [positive] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(positiveQuery, validationException);
+        }
         return validationException;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -38,12 +38,7 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
 
     private final QueryBuilder filterBuilder;
 
-    static final ConstantScoreQueryBuilder PROTOTYPE = new ConstantScoreQueryBuilder();
-
-    // only used for prototype
-    private ConstantScoreQueryBuilder() {
-        this.filterBuilder = null;
-    }
+    static final ConstantScoreQueryBuilder PROTOTYPE = new ConstantScoreQueryBuilder(null);
 
     /**
      * A query that wraps another query and simply returns a constant score equal to the
@@ -52,7 +47,7 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
      * @param filterBuilder The query to wrap in a constant score query
      */
     public ConstantScoreQueryBuilder(QueryBuilder filterBuilder) {
-        this.filterBuilder = Objects.requireNonNull(filterBuilder);
+        this.filterBuilder = filterBuilder;
     }
 
     /**
@@ -83,7 +78,13 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
 
     @Override
     public QueryValidationException validate() {
-        return validateInnerQuery(filterBuilder, null);
+        QueryValidationException validationException = null;
+        if (filterBuilder == null) {
+            validationException = addValidationError("inner clause [filter] cannot be null.", validationException);
+        } else {
+            validateInnerQuery(filterBuilder, validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -52,7 +52,7 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
      * Add a sub-query to this disjunction.
      */
     public DisMaxQueryBuilder add(QueryBuilder queryBuilder) {
-        queries.add(Objects.requireNonNull(queryBuilder));
+        queries.add(queryBuilder);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
@@ -39,7 +39,7 @@ public class FQueryFilterBuilder extends AbstractQueryBuilder<FQueryFilterBuilde
 
     public static final String NAME = "fquery";
 
-    static final FQueryFilterBuilder PROTOTYPE = new FQueryFilterBuilder();
+    static final FQueryFilterBuilder PROTOTYPE = new FQueryFilterBuilder(null);
 
     private final QueryBuilder queryBuilder;
 
@@ -49,11 +49,7 @@ public class FQueryFilterBuilder extends AbstractQueryBuilder<FQueryFilterBuilde
      * @param queryBuilder The query to wrap as a filter
      */
     public FQueryFilterBuilder(QueryBuilder queryBuilder) {
-        this.queryBuilder = Objects.requireNonNull(queryBuilder);
-    }
-
-    private FQueryFilterBuilder() {
-        this.queryBuilder = null;
+        this.queryBuilder = queryBuilder;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -38,13 +38,7 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
 
     private final String fieldName;
 
-    static final FieldMaskingSpanQueryBuilder PROTOTYPE = new FieldMaskingSpanQueryBuilder();
-
-    // only used for prototype
-    private FieldMaskingSpanQueryBuilder() {
-        this.queryBuilder = null;
-        this.fieldName = null;
-    }
+    static final FieldMaskingSpanQueryBuilder PROTOTYPE = new FieldMaskingSpanQueryBuilder(null, null);
 
     /**
      * Constructs a new {@link FieldMaskingSpanQueryBuilder} given an inner {@link SpanQueryBuilder} for
@@ -53,8 +47,8 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
      * @param fieldName the field name
      */
     public FieldMaskingSpanQueryBuilder(SpanQueryBuilder queryBuilder, String fieldName) {
-        this.queryBuilder = Objects.requireNonNull(queryBuilder);
-        this.fieldName = Objects.requireNonNull(fieldName);
+        this.queryBuilder = queryBuilder;
+        this.fieldName = fieldName;
     }
 
     /**
@@ -95,11 +89,16 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
 
     @Override
     public QueryValidationException validate() {
-        QueryValidationException validationExceptions = validateInnerQuery(queryBuilder, null);
-        if (fieldName == null || fieldName.isEmpty()) {
-            validationExceptions = addValidationError("field name is null or empty", validationExceptions);
+        QueryValidationException validationException = null;
+        if (queryBuilder == null) {
+            validationException = addValidationError("inner clause [query] cannot be null.", validationException);
+        } else {
+            validationException = validateInnerQuery(queryBuilder, validationException);
         }
-        return validationExceptions;
+        if (fieldName == null || fieldName.isEmpty()) {
+            validationException = addValidationError("field name is null or empty", validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
@@ -37,14 +37,10 @@ public class NotQueryBuilder extends AbstractQueryBuilder<NotQueryBuilder> {
 
     private final QueryBuilder filter;
 
-    static final NotQueryBuilder PROTOTYPE = new NotQueryBuilder();
+    static final NotQueryBuilder PROTOTYPE = new NotQueryBuilder(null);
 
     public NotQueryBuilder(QueryBuilder filter) {
-        this.filter = Objects.requireNonNull(filter);
-    }
-
-    private NotQueryBuilder() {
-        this.filter = null;
+        this.filter = filter;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
@@ -48,7 +48,7 @@ public class OrQueryBuilder extends AbstractQueryBuilder<OrQueryBuilder> {
 
     public OrQueryBuilder(QueryBuilder... filters) {
         for (QueryBuilder filter : filters) {
-            this.filters.add(Objects.requireNonNull(filter));
+            this.filters.add(filter);
         }
     }
 
@@ -57,7 +57,7 @@ public class OrQueryBuilder extends AbstractQueryBuilder<OrQueryBuilder> {
      * No <tt>null</tt> value allowed.
      */
     public OrQueryBuilder add(QueryBuilder filterBuilder) {
-        filters.add(Objects.requireNonNull(filterBuilder));
+        filters.add(filterBuilder);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -40,7 +40,7 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
 
     private final QueryBuilder queryBuilder;
 
-    static final QueryFilterBuilder PROTOTYPE = new QueryFilterBuilder();
+    static final QueryFilterBuilder PROTOTYPE = new QueryFilterBuilder(null);
 
     /**
      * A filter that simply wraps a query.
@@ -48,11 +48,7 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
      * @param queryBuilder The query to wrap as a filter
      */
     public QueryFilterBuilder(QueryBuilder queryBuilder) {
-        this.queryBuilder = Objects.requireNonNull(queryBuilder);
-    }
-
-    private QueryFilterBuilder() {
-        this.queryBuilder = null;
+        this.queryBuilder = queryBuilder;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -54,20 +54,13 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
 
     private boolean collectPayloads = DEFAULT_COLLECT_PAYLOADS;
 
-    static final SpanNearQueryBuilder PROTOTYPE = new SpanNearQueryBuilder();
+    static final SpanNearQueryBuilder PROTOTYPE = new SpanNearQueryBuilder(0);
 
     /**
      * @param slop controls the maximum number of intervening unmatched positions permitted
      */
     public SpanNearQueryBuilder(int slop) {
         this.slop = slop;
-    }
-
-    /**
-     * only used for prototype
-     */
-    private SpanNearQueryBuilder() {
-        this.slop = 0;
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/AndQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AndQueryBuilderTest.java
@@ -81,16 +81,6 @@ public class AndQueryBuilderTest extends BaseQueryTestCase<AndQueryBuilder> {
         context.indexQueryParserService().queryParser(AndQueryBuilder.PROTOTYPE.getName()).fromXContent(context);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testNullConstructor() {
-        new AndQueryBuilder(EmptyQueryBuilder.PROTOTYPE, null);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testAddNull() {
-        new AndQueryBuilder(EmptyQueryBuilder.PROTOTYPE).add(null);
-    }
-
     @Test
     public void testValidate() {
         AndQueryBuilder andQuery = new AndQueryBuilder();
@@ -98,7 +88,11 @@ public class AndQueryBuilderTest extends BaseQueryTestCase<AndQueryBuilder> {
         int totalExpectedErrors = 0;
         for (int i = 0; i < iters; i++) {
             if (randomBoolean()) {
-                andQuery.add(RandomQueryBuilder.createInvalidQuery(random()));
+                if (randomBoolean()) {
+                    andQuery.add(RandomQueryBuilder.createInvalidQuery(random()));
+                } else {
+                    andQuery.add(null);
+                }
                 totalExpectedErrors++;
             } else {
                 andQuery.add(RandomQueryBuilder.createQuery(random()));

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
@@ -101,7 +101,11 @@ public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
         int totalExpectedErrors = 0;
         for (int i = 0; i < iters; i++) {
             if (randomBoolean()) {
-                booleanQuery.must(RandomQueryBuilder.createInvalidQuery(random()));
+                if (randomBoolean()) {
+                    booleanQuery.must(RandomQueryBuilder.createInvalidQuery(random()));
+                } else {
+                    booleanQuery.must(null);
+                }
                 totalExpectedErrors++;
             } else {
                 booleanQuery.must(RandomQueryBuilder.createQuery(random()));
@@ -110,48 +114,42 @@ public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
         iters = randomIntBetween(0, 3);
         for (int i = 0; i < iters; i++) {
             if (randomBoolean()) {
-                booleanQuery.should(RandomQueryBuilder.createInvalidQuery(random()));
+                if (randomBoolean()) {
+                    booleanQuery.should(RandomQueryBuilder.createInvalidQuery(random()));
+                } else {
+                    booleanQuery.should(null);
+                }
                 totalExpectedErrors++;
             } else {
                 booleanQuery.should(RandomQueryBuilder.createQuery(random()));
             }
         }
+        iters = randomIntBetween(0, 3);
         for (int i = 0; i < iters; i++) {
             if (randomBoolean()) {
-                booleanQuery.mustNot(RandomQueryBuilder.createInvalidQuery(random()));
+                if (randomBoolean()) {
+                    booleanQuery.mustNot(RandomQueryBuilder.createInvalidQuery(random()));
+                } else {
+                    booleanQuery.mustNot(null);
+                }
                 totalExpectedErrors++;
             } else {
                 booleanQuery.mustNot(RandomQueryBuilder.createQuery(random()));
             }
         }
+        iters = randomIntBetween(0, 3);
         for (int i = 0; i < iters; i++) {
             if (randomBoolean()) {
-                booleanQuery.filter(RandomQueryBuilder.createInvalidQuery(random()));
+                if (randomBoolean()) {
+                    booleanQuery.filter(RandomQueryBuilder.createInvalidQuery(random()));
+                } else {
+                    booleanQuery.filter(null);
+                }
                 totalExpectedErrors++;
             } else {
                 booleanQuery.filter(RandomQueryBuilder.createQuery(random()));
             }
         }
         assertValidate(booleanQuery, totalExpectedErrors);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testAddNullMust() {
-        new BoolQueryBuilder().must(null);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testAddNullMustNot() {
-        new BoolQueryBuilder().mustNot(null);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testAddNullShould() {
-        new BoolQueryBuilder().should(null);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testAddNullFilter() {
-        new BoolQueryBuilder().filter(null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTest.java
@@ -47,16 +47,20 @@ public class BoostingQueryBuilderTest extends BaseQueryTestCase<BoostingQueryBui
     @Test
     public void testValidate() {
         int totalExpectedErrors = 0;
-        QueryBuilder positive;
-        QueryBuilder negative;
+        QueryBuilder positive = null;
+        QueryBuilder negative = null;
         if (frequently()) {
-            negative = RandomQueryBuilder.createInvalidQuery(random());
+            if (randomBoolean()) {
+                negative = RandomQueryBuilder.createInvalidQuery(random());
+            }
             totalExpectedErrors++;
         } else {
             negative = RandomQueryBuilder.createQuery(random());
         }
         if (frequently()) {
-            positive = RandomQueryBuilder.createInvalidQuery(random());
+            if (randomBoolean()) {
+                positive = RandomQueryBuilder.createInvalidQuery(random());
+            }
             totalExpectedErrors++;
         } else {
             positive = RandomQueryBuilder.createQuery(random());
@@ -69,14 +73,5 @@ public class BoostingQueryBuilderTest extends BaseQueryTestCase<BoostingQueryBui
             totalExpectedErrors++;
         }
         assertValidate(boostingQuery, totalExpectedErrors);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullConstructorArgument() {
-        if (randomBoolean()) {
-            new BoostingQueryBuilder(null, RandomQueryBuilder.createQuery(random()));
-        } else {
-            new BoostingQueryBuilder(RandomQueryBuilder.createQuery(random()), null);
-        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTest.java
@@ -62,20 +62,17 @@ public class ConstantScoreQueryBuilderTest extends BaseQueryTestCase<ConstantSco
 
     @Test
     public void testValidate() {
-        QueryBuilder innerQuery;
+        QueryBuilder innerQuery = null;
         int totalExpectedErrors = 0;
         if (randomBoolean()) {
-            innerQuery = RandomQueryBuilder.createInvalidQuery(random());
+            if (randomBoolean()) {
+                innerQuery = RandomQueryBuilder.createInvalidQuery(random());
+            }
             totalExpectedErrors++;
         } else {
             innerQuery = RandomQueryBuilder.createQuery(random());
         }
         ConstantScoreQueryBuilder constantScoreQuery = new ConstantScoreQueryBuilder(innerQuery);
         assertValidate(constantScoreQuery, totalExpectedErrors);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullConstructor() {
-        new ConstantScoreQueryBuilder(null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTest.java
@@ -87,11 +87,6 @@ public class DisMaxQueryBuilderTest extends BaseQueryTestCase<DisMaxQueryBuilder
         assertNull(disMaxBuilder.toQuery(context));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testAddNull() {
-        new DisMaxQueryBuilder().add(null);
-    }
-
     @Test
     public void testValidate() {
         DisMaxQueryBuilder disMaxQuery = new DisMaxQueryBuilder();
@@ -99,7 +94,11 @@ public class DisMaxQueryBuilderTest extends BaseQueryTestCase<DisMaxQueryBuilder
         int totalExpectedErrors = 0;
         for (int i = 0; i < iters; i++) {
             if (randomBoolean()) {
-                disMaxQuery.add(RandomQueryBuilder.createInvalidQuery(random()));
+                if (randomBoolean()) {
+                    disMaxQuery.add(RandomQueryBuilder.createInvalidQuery(random()));
+                } else {
+                    disMaxQuery.add(null);
+                }
                 totalExpectedErrors++;
             } else {
                 disMaxQuery.add(RandomQueryBuilder.createQuery(random()));

--- a/core/src/test/java/org/elasticsearch/index/query/FQueryFilterBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FQueryFilterBuilderTest.java
@@ -78,20 +78,17 @@ public class FQueryFilterBuilderTest extends BaseQueryTestCase<FQueryFilterBuild
 
     @Test
     public void testValidate() {
-        QueryBuilder innerQuery;
+        QueryBuilder innerQuery = null;
         int totalExpectedErrors = 0;
         if (randomBoolean()) {
-            innerQuery = RandomQueryBuilder.createInvalidQuery(random());
+            if (randomBoolean()) {
+                innerQuery = RandomQueryBuilder.createInvalidQuery(random());
+            }
             totalExpectedErrors++;
         } else {
             innerQuery = RandomQueryBuilder.createQuery(random());
         }
         FQueryFilterBuilder fQueryFilter = new FQueryFilterBuilder(innerQuery);
         assertValidate(fQueryFilter, totalExpectedErrors);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullConstructo() {
-        new FQueryFilterBuilder(null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTest.java
@@ -55,32 +55,26 @@ public class FieldMaskingSpanQueryBuilderTest extends BaseQueryTestCase<FieldMas
 
     @Test
     public void testValidate() {
-        String fieldName;
-        SpanQueryBuilder spanQueryBuilder;
+        String fieldName = null;
+        SpanQueryBuilder spanQueryBuilder = null;
         int totalExpectedErrors = 0;
         if (randomBoolean()) {
             fieldName = "fieldName";
         } else {
-            fieldName = "";
+            if (randomBoolean()) {
+                fieldName = "";
+            }
             totalExpectedErrors++;
         }
         if (randomBoolean()) {
-            spanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            if (randomBoolean()) {
+                spanQueryBuilder = new SpanTermQueryBuilder("", "test");
+            }
             totalExpectedErrors++;
         } else {
             spanQueryBuilder = new SpanTermQueryBuilder("name", "value");
         }
         FieldMaskingSpanQueryBuilder queryBuilder = new FieldMaskingSpanQueryBuilder(spanQueryBuilder, fieldName);
         assertValidate(queryBuilder, totalExpectedErrors);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullFieldName() {
-        new FieldMaskingSpanQueryBuilder(new SpanTermQueryBuilder("name", "value"), null);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullInnerQuery() {
-            new FieldMaskingSpanQueryBuilder(null, "");
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTest.java
@@ -45,11 +45,6 @@ public class NotQueryBuilderTest extends BaseQueryTestCase<NotQueryBuilder> {
         return new NotQueryBuilder(RandomQueryBuilder.createQuery(random()));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testNotQueryBuilderNull() {
-        new NotQueryBuilder(null);
-    }
-
     /**
      * @throws IOException
      */
@@ -65,10 +60,12 @@ public class NotQueryBuilderTest extends BaseQueryTestCase<NotQueryBuilder> {
 
     @Test
     public void testValidate() {
-        QueryBuilder innerQuery;
+        QueryBuilder innerQuery = null;
         int totalExpectedErrors = 0;
         if (randomBoolean()) {
-            innerQuery = RandomQueryBuilder.createInvalidQuery(random());
+            if (randomBoolean()) {
+                innerQuery = RandomQueryBuilder.createInvalidQuery(random());
+            }
             totalExpectedErrors++;
         } else {
             innerQuery = RandomQueryBuilder.createQuery(random());

--- a/core/src/test/java/org/elasticsearch/index/query/OrQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/OrQueryBuilderTest.java
@@ -89,22 +89,16 @@ public class OrQueryBuilderTest extends BaseQueryTestCase<OrQueryBuilder> {
         int totalExpectedErrors = 0;
         for (int i = 0; i < iters; i++) {
             if (randomBoolean()) {
-                orQuery.add(RandomQueryBuilder.createInvalidQuery(random()));
+                if (randomBoolean()) {
+                    orQuery.add(RandomQueryBuilder.createInvalidQuery(random()));
+                } else {
+                    orQuery.add(null);
+                }
                 totalExpectedErrors++;
             } else {
                 orQuery.add(RandomQueryBuilder.createQuery(random()));
             }
         }
         assertValidate(orQuery, totalExpectedErrors);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testNullConstructor() {
-        new OrQueryBuilder(EmptyQueryBuilder.PROTOTYPE, null);
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void testAddNull() {
-        new OrQueryBuilder().add(null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/QueryFilterBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryFilterBuilderTest.java
@@ -43,17 +43,14 @@ public class QueryFilterBuilderTest extends BaseQueryTestCase<QueryFilterBuilder
         return new QueryFilterBuilder(innerQuery);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testQueryFilterBuilderNull() {
-        new QueryFilterBuilder(null);
-    }
-
     @Test
     public void testValidate() {
-        QueryBuilder innerQuery;
+        QueryBuilder innerQuery = null;
         int totalExpectedErrors = 0;
         if (randomBoolean()) {
-            innerQuery = RandomQueryBuilder.createInvalidQuery(random());
+            if (randomBoolean()) {
+                innerQuery = RandomQueryBuilder.createInvalidQuery(random());
+            }
             totalExpectedErrors++;
         } else {
             innerQuery = RandomQueryBuilder.createQuery(random());


### PR DESCRIPTION
Following up to #12427, this PR does same changes, moving null-checks from construtors
and setters in query builder to the validate() method.

PR against query-refactoring branch
