### PR TITLE
Query DSL: don't cache type filter in DocumentMapper

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -168,8 +168,6 @@ public class DocumentMapper implements ToXContent {
 
     private boolean hasNestedObjects = false;
 
-    private final Query typeFilter;
-
     private final ReleasableLock mappingWriteLock;
     private final ReentrantReadWriteLock mappingLock;
 
@@ -190,7 +188,6 @@ public class DocumentMapper implements ToXContent {
                 meta);
         this.documentParser = new DocumentParser(indexSettings, docMapperParser, this, new ReleasableLock(mappingLock.readLock()));
 
-        this.typeFilter = typeMapper().fieldType().termQuery(type, null);
         this.mappingWriteLock = new ReleasableLock(mappingLock.writeLock());
         this.mappingLock = mappingLock;
 
@@ -307,7 +304,7 @@ public class DocumentMapper implements ToXContent {
     }
 
     public Query typeFilter() {
-        return this.typeFilter;
+        return typeMapper().fieldType().termQuery(type, null);
     }
 
     public boolean hasNestedObjects() {


### PR DESCRIPTION
If we cache the type filter and we e.g. set its boost which is now settable on all queries, the boost will change for all subsequent queries. We should rather create a new query every time.

This PR is against the query-refactoring branch.
