### PR TITLE
Add explicit check that we have reached the end of the settings stream when parsing settings

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -250,4 +250,6 @@ public interface XContentParser extends Releasable {
      * @return last token's location or null if cannot be determined
      */
     XContentLocation getTokenLocation();
+
+    boolean isClosed();
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
@@ -248,4 +248,9 @@ public class JsonXContentParser extends AbstractXContentParser {
         }
         throw new IllegalStateException("No matching token for json_token [" + token + "]");
     }
+
+    @Override
+    public boolean isClosed() {
+        return parser.isClosed();
+    }
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -319,4 +319,7 @@ public abstract class AbstractXContentParser implements XContentParser {
         }
         return null;
     }
+
+    @Override
+    public abstract boolean isClosed();
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
@@ -20,11 +20,11 @@
 package org.elasticsearch.common.settings.loader;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -48,5 +48,19 @@ public class YamlSettingsLoaderTests extends ElasticsearchTestCase {
         assertThat(settings.getAsArray("test1.test3").length, equalTo(2));
         assertThat(settings.getAsArray("test1.test3")[0], equalTo("test3-1"));
         assertThat(settings.getAsArray("test1.test3")[1], equalTo("test3-2"));
+    }
+
+    @Test(expected = SettingsException.class)
+    public void testIndentation() {
+        settingsBuilder()
+                .loadFromClasspath("org/elasticsearch/common/settings/loader/indentation-settings.yml")
+                .build();
+    }
+
+    @Test(expected = SettingsException.class)
+    public void testIndentationWithExplicitDocumentStart() {
+        settingsBuilder()
+                .loadFromClasspath("org/elasticsearch/common/settings/loader/indentation-with-explicit-document-start-settings.yml")
+                .build();
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/indentation-settings.yml
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/indentation-settings.yml
@@ -1,0 +1,10 @@
+ test1:
+   value1: value1
+   test2:
+     value2: value2
+     value3: 2
+   test3:
+     - test3-1
+     - test3-2
+test4:
+  value4: value4

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/indentation-with-explicit-document-start-settings.yml
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/indentation-with-explicit-document-start-settings.yml
@@ -1,0 +1,11 @@
+ test1:
+   value1: value1
+   test2:
+     value2: value2
+     value3: 2
+   test3:
+     - test3-1
+     - test3-2
+---
+test4:
+  value4: value4


### PR DESCRIPTION
Settings are currently parsed by looping over the tokens until an END_OBJECT token is reached. However, this does not mean that the end of the settings stream was reached. This can occur, for example, when parsing a YAML settings file with inconsistent indentation. Currently in this case, some settings will be silently ignored. This commit forces a check that we have in fact reached the end of the settings stream.

Closes #12382
