### PR TITLE
Add randomized jitter to s3 client retries

### DIFF
--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -121,11 +121,6 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
             clientConfiguration.withProxyHost(proxyHost).setProxyPort(proxyPort);
         }
 
-        if (maxRetries != null) {
-            // If not explicitly set, default to 3 with exponential backoff policy
-            clientConfiguration.setMaxErrorRetry(maxRetries);
-        }
-
         // #155: we might have 3rd party users using older S3 API version
         String awsSigner = settings.get("cloud.aws.s3.signer", settings.get("cloud.aws.signer"));
         if (awsSigner != null) {

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/DefaultS3OutputStream.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/DefaultS3OutputStream.java
@@ -109,6 +109,11 @@ public class DefaultS3OutputStream extends S3OutputStream {
                     break;
                 } catch (AmazonClientException e) {
                     if (getBlobStore().shouldRetry(e) && retry < getNumberOfRetries()) {
+                        try {
+                            Thread.sleep(getBlobStore().getWaitInterval(retry));
+                        } catch (InterruptedException e1) {
+                            // do nothing
+                        }
                         is.reset();
                         retry++;
                     } else {
@@ -161,6 +166,11 @@ public class DefaultS3OutputStream extends S3OutputStream {
                 }
             } catch (AmazonClientException e) {
                 if (getBlobStore().shouldRetry(e) && retry < getNumberOfRetries()) {
+                    try {
+                        Thread.sleep(getBlobStore().getWaitInterval(retry));
+                    } catch (InterruptedException e1) {
+                        // do nothing.
+                    }
                     retry++;
                 } else {
                     throw e;
@@ -190,6 +200,13 @@ public class DefaultS3OutputStream extends S3OutputStream {
                     return;
                 } catch (AmazonClientException e) {
                     if (getBlobStore().shouldRetry(e) && retry < getNumberOfRetries()) {
+
+                        try {
+                            Thread.sleep(getBlobStore().getWaitInterval(retry));
+                        } catch (InterruptedException e1) {
+                           // do nothing.
+                        }
+
                         is.reset();
                         retry++;
                     } else {
@@ -226,6 +243,11 @@ public class DefaultS3OutputStream extends S3OutputStream {
                 return;
             } catch (AmazonClientException e) {
                 if (getBlobStore().shouldRetry(e) && retry < getNumberOfRetries()) {
+                    try {
+                        Thread.sleep(getBlobStore().getWaitInterval(retry));
+                    } catch (InterruptedException e1) {
+                        // do nothing.
+                    }
                     retry++;
                 } else {
                     abortMultipart();

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStore.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStore.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
 import java.util.ArrayList;
+import java.util.Random;
 
 /**
  *
@@ -44,6 +45,7 @@ import java.util.ArrayList;
 public class S3BlobStore extends AbstractComponent implements BlobStore {
 
     public static final ByteSizeValue MIN_BUFFER_SIZE = new ByteSizeValue(5, ByteSizeUnit.MB);
+    public static final int MAX_WAIT_INTERVAL = 2000;
 
     private final AmazonS3 client;
 
@@ -158,6 +160,10 @@ public class S3BlobStore extends AbstractComponent implements BlobStore {
             }
         }
         return e.isRetryable();
+    }
+
+    protected int getWaitInterval(int retry) {
+        return Math.min(new Random().nextInt((int) (Math.pow(2.0, retry)) * 100), MAX_WAIT_INTERVAL);
     }
 
     @Override


### PR DESCRIPTION
Add jitter in AWS S3 retry and delete setting max retry when initializing S3 client , [#11934](https://github.com/elastic/elasticsearch/issues/11934) and [#12434](https://github.com/elastic/elasticsearch/issues/12434)
