### PR TITLE
Configure Maven -source target as Java 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,6 +466,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                      <source>1.7</source>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -567,6 +570,7 @@
                         <compilerArgs>
                             <arg>-XDignore.symbol.file</arg>
                         </compilerArgs>
+                        <source>1.7</source>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
We require Java 1.7 as a minimum anyway, so this doesn't cause any breakage.
