### PR TITLE
Added an `optimize_bbox` option for `geo_polygon` queries.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -36,6 +36,8 @@ public class GeoPolygonQueryBuilder extends QueryBuilder {
 
     private final List<GeoPoint> shell = Lists.newArrayList();
 
+    private String optimizeBbox;
+
     private String queryName;
 
     public GeoPolygonQueryBuilder(String name) {
@@ -61,7 +63,12 @@ public class GeoPolygonQueryBuilder extends QueryBuilder {
         shell.add(point);
         return this;
     }
-    
+
+    public GeoPolygonQueryBuilder optimizeBbox(String optimizeBbox) {
+        this.optimizeBbox = optimizeBbox;
+        return this;
+    }
+
     /**
      * Sets the filter name for the filter that can be used when searching for matched_filters per hit.
      */
@@ -82,6 +89,9 @@ public class GeoPolygonQueryBuilder extends QueryBuilder {
         builder.endArray();
         builder.endObject();
 
+        if (optimizeBbox != null) {
+            builder.field("optimize_bbox", optimizeBbox);
+        }
         if (queryName != null) {
             builder.field("_name", queryName);
         }

--- a/core/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonQuery.java
@@ -19,15 +19,23 @@
 
 package org.elasticsearch.index.search.geo;
 
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.commons.lang3.Validate;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.RandomAccessWeight;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper.GeoPointFieldType;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -38,12 +46,29 @@ import java.util.Arrays;
 public class GeoPolygonQuery extends Query {
 
     private final GeoPoint[] points;
-
     private final IndexGeoPointFieldData indexFieldData;
+    private final Query boundingBoxQuery;
 
-    public GeoPolygonQuery(IndexGeoPointFieldData indexFieldData, GeoPoint...points) {
+    public GeoPolygonQuery(GeoPoint[] points, GeoPointFieldType fieldType,
+            IndexGeoPointFieldData indexFieldData, String optimizeBbox) {
         this.points = points;
         this.indexFieldData = indexFieldData;
+        this.boundingBoxQuery = getBoundingBoxQuery(fieldType, indexFieldData, optimizeBbox);
+    }
+
+    private Query getBoundingBoxQuery(GeoPointFieldType fieldType, IndexGeoPointFieldData indexFieldData, String optimizeBbox) {
+        if (optimizeBbox != null && !"none".equals(optimizeBbox)) {
+            BoundingBox boundingBox = determineBoundingBox(points);
+            if ("memory".equals(optimizeBbox)) {
+                return new InMemoryGeoBoundingBoxQuery(boundingBox.topLeft(), boundingBox.bottomRight(), indexFieldData);
+            } else if ("indexed".equals(optimizeBbox)) {
+                return IndexedGeoBoundingBoxQuery.create(boundingBox.topLeft(), boundingBox.bottomRight(), fieldType);
+            } else {
+                throw new IllegalArgumentException("type [" + optimizeBbox + "] for bounding box optimization not supported");
+            }
+        } else {
+            return null;
+        }
     }
 
     public GeoPoint[] points() {
@@ -56,50 +81,62 @@ public class GeoPolygonQuery extends Query {
 
     @Override
     public Weight createWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
-        return new RandomAccessWeight(this) {
+        final Weight boundingBoxWeight = boundingBoxQuery != null ?
+                searcher.createNormalizedWeight(boundingBoxQuery, false) :
+                null;
+
+        return new ConstantScoreWeight(this) {
             @Override
-            protected Bits getMatchingDocs(LeafReaderContext context) throws IOException {
-                final int maxDoc = context.reader().maxDoc();
+            public Scorer scorer(LeafReaderContext context, final Bits acceptDocs) throws IOException {
+                DocIdSetIterator approximation = boundingBoxWeight != null ?
+                        boundingBoxWeight.scorer(context, null) :
+                        DocIdSetIterator.all(context.reader().maxDoc());
+
+                if (approximation == null) {
+                    // If the approximation is empty, no documents can match.
+                    return null;
+                }
+
                 final MultiGeoPointValues values = indexFieldData.load(context).getGeoPointValues();
-                return new Bits() {
-
-                    private boolean pointInPolygon(GeoPoint[] points, double lat, double lon) {
-                        boolean inPoly = false;
-
-                        for (int i = 1; i < points.length; i++) {
-                            if (points[i].lon() < lon && points[i-1].lon() >= lon
-                                    || points[i-1].lon() < lon && points[i].lon() >= lon) {
-                                if (points[i].lat() + (lon - points[i].lon()) /
-                                        (points[i-1].lon() - points[i].lon()) * (points[i-1].lat() - points[i].lat()) < lat) {
-                                    inPoly = !inPoly;
-                                }
-                            }
-                        }
-                        return inPoly;
-                    }
-
+                final TwoPhaseIterator twoPhaseIterator = new TwoPhaseIterator(approximation) {
                     @Override
-                    public boolean get(int doc) {
+                    public boolean matches() throws IOException {
+                        final int doc = approximation.docID();
+                        if (acceptDocs != null && acceptDocs.get(doc) == false) {
+                            return false;
+                        }
+
                         values.setDocument(doc);
-                        final int length = values.count();
-                        for (int i = 0; i < length; i++) {
+                        for (int i = 0; i < values.count(); i++) {
                             GeoPoint point = values.valueAt(i);
-                            if (pointInPolygon(points, point.lat(), point.lon())) {
+                            if (containedInPolygon(point.getLat(), point.getLon())) {
                                 return true;
                             }
                         }
                         return false;
                     }
-
-                    @Override
-                    public int length() {
-                        return maxDoc;
-                    }
-
                 };
+                return new ConstantScoreScorer(this, score(), twoPhaseIterator);
             }
         };
     }
+
+    @VisibleForTesting
+    protected boolean containedInPolygon(double lat, double lon) {
+        boolean inPoly = false;
+
+        for (int i = 1; i < points.length; i++) {
+            if (points[i].lon() < lon && points[i-1].lon() >= lon
+                    || points[i-1].lon() < lon && points[i].lon() >= lon) {
+                if (points[i].lat() + (lon - points[i].lon()) /
+                        (points[i-1].lon() - points[i].lon()) * (points[i-1].lat() - points[i].lat()) < lat) {
+                    inPoly = !inPoly;
+                }
+            }
+        }
+        return inPoly;
+    }
+
 
     @Override
     public String toString(String field) {
@@ -125,5 +162,42 @@ public class GeoPolygonQuery extends Query {
         h = 31 * h + indexFieldData.getFieldNames().indexName().hashCode();
         h = 31 * h + Arrays.hashCode(points);
         return h;
+    }
+
+    public BoundingBox determineBoundingBox(GeoPoint[] points) {
+        Validate.isTrue(points.length > 0);
+        double maxLat = points[0].lat();
+        double minLat = points[0].lat();
+        double maxLon = points[0].lon();
+        double minLon = points[0].lon();
+
+        for (int i = 1; i < points.length; i++) {
+            maxLat = Math.max(maxLat, points[i].lat());
+            minLat = Math.min(minLat, points[i].lat());
+            maxLon = Math.max(maxLon, points[i].lon());
+            minLon = Math.min(minLon, points[i].lon());
+        }
+
+        GeoPoint topLeft = new GeoPoint(maxLat, minLon);
+        GeoPoint bottomRight = new GeoPoint(minLat, maxLon);
+        return new BoundingBox(topLeft, bottomRight);
+    }
+
+    private static class BoundingBox {
+        private final GeoPoint topLeft;
+        private final GeoPoint bottomRight;
+
+        public BoundingBox(GeoPoint topLeft, GeoPoint bottomRight) {
+            this.topLeft = topLeft;
+            this.bottomRight = bottomRight;
+        }
+
+        public GeoPoint topLeft() {
+            return topLeft;
+        }
+
+        public GeoPoint bottomRight() {
+            return bottomRight;
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoPolygonTests.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoPolygonTests.java
@@ -19,73 +19,105 @@
 
 package org.elasticsearch.search.geo;
 
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.Engine.Searcher;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper.GeoPointFieldType;
+import org.elasticsearch.index.search.geo.GeoPolygonQuery;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.geoPolygonQuery;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
-@ElasticsearchIntegrationTest.SuiteScopeTest
-public class GeoPolygonTests extends ElasticsearchIntegrationTest {
+public class GeoPolygonTests extends ElasticsearchSingleNodeTest {
 
-    @Override
-    protected void setupSuiteScopeCluster() throws Exception {
+    @Before
+    protected void setup() throws Exception {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("location").field("type", "geo_point").field("lat_lon", true)
-                .startObject("fielddata").field("format", randomNumericFieldDataFormat()).endObject().endObject().endObject()
+                .startObject("fielddata").field("format", "doc_values").endObject().endObject().endObject()
                 .endObject().endObject();
-        assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
+        createIndex("test", Settings.EMPTY, "type1", xContentBuilder);
         ensureGreen();
 
-        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
-                .field("name", "New York")
-                .startObject("location").field("lat", 40.714).field("lon", -74.006).endObject()
-                .endObject()), 
+        BulkRequestBuilder bulkRequest = client().prepareBulk().setRefresh(true);
+
+        bulkRequest.add(client().prepareIndex("test", "type1", "1")
+                .setSource(jsonBuilder()
+                    .startObject()
+                        .field("name", "New York")
+                        .startObject("location").field("lat", 40.714).field("lon", -74.006).endObject()
+                    .endObject()));
         // to NY: 5.286 km
-        client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject()
-                .field("name", "Times Square")
-                .startObject("location").field("lat", 40.759).field("lon", -73.984).endObject()
-                .endObject()),
+        bulkRequest.add(client().prepareIndex("test", "type1", "2")
+                .setSource(jsonBuilder()
+                    .startObject()
+                        .field("name", "Times Square")
+                        .startObject("location").field("lat", 40.759).field("lon", -73.984).endObject()
+                    .endObject()));
         // to NY: 0.4621 km
-        client().prepareIndex("test", "type1", "3").setSource(jsonBuilder().startObject()
-                .field("name", "Tribeca")
-                .startObject("location").field("lat", 40.718).field("lon", -74.008).endObject()
-                .endObject()),
+        bulkRequest.add(client().prepareIndex("test", "type1", "3")
+                .setSource(jsonBuilder()
+                    .startObject()
+                        .field("name", "Tribeca")
+                        .startObject("location").field("lat", 40.718).field("lon", -74.008).endObject()
+                    .endObject()));
         // to NY: 1.055 km
-        client().prepareIndex("test", "type1", "4").setSource(jsonBuilder().startObject()
-                .field("name", "Wall Street")
-                .startObject("location").field("lat", 40.705).field("lon", -74.009).endObject()
-                .endObject()),
+        bulkRequest.add(client().prepareIndex("test", "type1", "4")
+                .setSource(jsonBuilder()
+                    .startObject()
+                        .field("name", "Wall Street")
+                        .startObject("location").field("lat", 40.705).field("lon", -74.009).endObject()
+                    .endObject()));
         // to NY: 1.258 km
-        client().prepareIndex("test", "type1", "5").setSource(jsonBuilder().startObject()
-                .field("name", "Soho")
-                .startObject("location").field("lat", 40.725).field("lon", -74).endObject()
-                .endObject()),
+        bulkRequest.add(client().prepareIndex("test", "type1", "5")
+                .setSource(jsonBuilder()
+                    .startObject()
+                        .field("name", "Soho")
+                        .startObject("location").field("lat", 40.725).field("lon", -74).endObject()
+                    .endObject()));
         // to NY: 2.029 km
-        client().prepareIndex("test", "type1", "6").setSource(jsonBuilder().startObject()
-                .field("name", "Greenwich Village")
-                .startObject("location").field("lat", 40.731).field("lon", -73.996).endObject()
-                .endObject()),
+        bulkRequest.add(client().prepareIndex("test", "type1", "6")
+                .setSource(jsonBuilder()
+                    .startObject()
+                        .field("name", "Greenwich Village")
+                        .startObject("location").field("lat", 40.731).field("lon", -73.996).endObject()
+                    .endObject()));
         // to NY: 8.572 km
-        client().prepareIndex("test", "type1", "7").setSource(jsonBuilder().startObject()
-                .field("name", "Brooklyn")
-                .startObject("location").field("lat", 40.65).field("lon", -73.95).endObject()
-                .endObject()));
-        ensureSearchable("test");
+        bulkRequest.add(client().prepareIndex("test", "type1", "7")
+                .setSource(jsonBuilder()
+                    .startObject()
+                        .field("name", "Brooklyn")
+                        .startObject("location").field("lat", 40.65).field("lon", -73.95).endObject()
+                    .endObject()));
+
+        bulkRequest.get();
     }
 
     @Test
     public void simplePolygonTest() throws Exception {
-
         SearchResponse searchResponse = client().prepareSearch("test") // from NY
                 .setQuery(boolQuery().must(geoPolygonQuery("location")
                         .addPoint(40.7, -74.0)
@@ -116,4 +148,91 @@ public class GeoPolygonTests extends ElasticsearchIntegrationTest {
             assertThat(hit.id(), anyOf(equalTo("1"), equalTo("3"), equalTo("4"), equalTo("5")));
         }
     }
+
+    @Test
+    public void testBoundingBoxOptimization() throws Exception {
+        // Check that the bounding box doesn't affect what the polygon filter returns (and so
+        // is truly just an optimization).
+        long numHits = -1;
+        for (String bboxType : Arrays.asList("none", "memory", "indexed")) {
+            SearchResponse searchResponse = client().prepareSearch("test") // from NY
+                    .setQuery(geoPolygonQuery("location")
+                            .optimizeBbox(bboxType)
+                            .addPoint(40.7, -74.0)
+                            .addPoint(40.7, -74.1)
+                            .addPoint(40.75, -74.2)
+                            .addPoint(40.8, -74.1)
+                            .addPoint(40.75, -74.05)
+                            .addPoint(40.8, -74.0)
+                            .addPoint(40.7, -74.0))
+                    .execute().actionGet();
+
+            assertSearchResponse(searchResponse);
+            logger.info("{} -> {} hits", bboxType, searchResponse.getHits().totalHits());
+            if (numHits < 0) {
+                numHits = searchResponse.getHits().getTotalHits();
+            } else {
+                assertThat(searchResponse.getHits().getTotalHits(), equalTo(numHits));
+            }
+        }
+    }
+
+    @Test
+    public void testBoundingBoxAppliedFirst() throws Exception {
+        final GeoPoint[] points = new GeoPoint[]{
+                new GeoPoint(40.7, -74.0),
+                new GeoPoint(40.7, -74.1),
+                new GeoPoint(40.75, -74.2),
+                new GeoPoint(40.8, -74.1),
+                new GeoPoint(40.75, -74.05),
+                new GeoPoint(40.8, -74.0),
+                new GeoPoint(40.7, -74.0)};
+
+        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
+        IndexService indexService = indicesService.indexService("test");
+
+        @SuppressWarnings("null")
+        GeoPointFieldType fieldType = (GeoPointFieldType) indexService.mapperService().smartNameFieldType("location");
+        IndexGeoPointFieldData indexFieldData = indexService.fieldData().getForField(fieldType);
+
+        Map<String, Integer> expectedNumChecks = ImmutableMap.of(
+                "none", 7,
+                "memory", 4,
+                "indexed", 4);
+
+        for (String bboxType : expectedNumChecks.keySet()) {
+            CountingGeoPolygonQuery query = new CountingGeoPolygonQuery(
+                    points, fieldType, indexFieldData, bboxType);
+
+            for (int shardId : indexService.shardIds()) {
+                @SuppressWarnings("null")
+                Searcher searcher = indexService.shard(shardId).acquireSearcher("test");
+                searcher.searcher().search(query, 1000 /* an arbitrary large number */);
+                searcher.close();
+            }
+
+            assertThat(query.getNumChecks(), equalTo(expectedNumChecks.get(bboxType)));
+        }
+    }
+
+    private static class CountingGeoPolygonQuery extends GeoPolygonQuery {
+        private final AtomicInteger numChecks;
+
+        public CountingGeoPolygonQuery(GeoPoint[] points, GeoPointFieldType fieldType,
+                IndexGeoPointFieldData indexFieldData, String optimizeBbox) {
+            super(points, fieldType, indexFieldData, optimizeBbox);
+            numChecks = new AtomicInteger(0);
+        }
+
+        @Override
+        protected boolean containedInPolygon(double lat, double lon) {
+            numChecks.incrementAndGet();
+            return super.containedInPolygon(lat, lon);
+        }
+
+        public int getNumChecks() {
+            return numChecks.get();
+        }
+    }
 }
+


### PR DESCRIPTION
This setting is analogous to the one for geo_distance queries, and defaults to "memory". Note
that the optimization will need to be updated when addressing #5968.

Closes #10356.
