### PR TITLE
Skip hidden files

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -312,6 +312,10 @@ public class PluginsService extends AbstractComponent {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(pluginsDirectory)) {
             for (Path plugin : stream) {
                 try {
+                    if (Files.isHidden(plugin)) {
+                        logger.trace("--- skip hidden plugin file[{}]", plugin.toAbsolutePath());
+                        continue;
+                    }
                     logger.trace("--- adding plugin [{}]", plugin.toAbsolutePath());
                     PluginInfo info = PluginInfo.readFromProperties(plugin);
                     List<URL> urls = new ArrayList<>();


### PR DESCRIPTION
Quick fix, skip hidden files when loading plugins. [https://github.com/elastic/elasticsearch/issues/12433]
