### PR TITLE
[TEST] remove createExpectedQuery from BaseQueryTestCase

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -95,7 +95,8 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
      * Returns the query name for the query.
      */
     @SuppressWarnings("unchecked")
-    public QB queryName(String queryName) {
+    @Override
+    public final QB queryName(String queryName) {
         this.queryName = queryName;
         return (QB) this;
     }
@@ -103,6 +104,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
     /**
      * Sets the query name for the query.
      */
+    @Override
     public final String queryName() {
         return queryName;
     }
@@ -110,6 +112,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
     /**
      * Returns the boost for this query.
      */
+    @Override
     public final float boost() {
         return this.boost;
     }
@@ -119,7 +122,8 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
      * weightings) have their score multiplied by the boost provided.
      */
     @SuppressWarnings("unchecked")
-    public QB boost(float boost) {
+    @Override
+    public final QB boost(float boost) {
         this.boost = boost;
         return (QB) this;
     }

--- a/core/src/main/java/org/elasticsearch/index/query/EmptyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/EmptyQueryBuilder.java
@@ -81,4 +81,26 @@ public class EmptyQueryBuilder extends ToXContentToBytes implements QueryBuilder
     public EmptyQueryBuilder readFrom(StreamInput in) throws IOException {
         return EmptyQueryBuilder.PROTOTYPE;
     }
+
+    @Override
+    public EmptyQueryBuilder queryName(String queryName) {
+        //no-op
+        return this;
+    }
+
+    @Override
+    public String queryName() {
+        return null;
+    }
+
+    @Override
+    public float boost() {
+        return -1;
+    }
+
+    @Override
+    public EmptyQueryBuilder boost(float boost) {
+        //no-op
+        return this;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -120,16 +120,6 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
         this(name, (Object) value);
     }
 
-    /**
-     * Sets the boost for this query.  Documents matching this query will (in addition to the normal
-     * weightings) have their score multiplied by the boost provided.
-     */
-    @Override
-    public FuzzyQueryBuilder boost(float boost) {
-        this.boost = boost;
-        return this;
-    }
-
     public FuzzyQueryBuilder fuzziness(Fuzziness fuzziness) {
         this.fuzziness = fuzziness;
         return this;

--- a/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
@@ -42,6 +42,10 @@ public class LimitQueryBuilder extends AbstractQueryBuilder<LimitQueryBuilder> {
         this.limit = limit;
     }
 
+    public int limit() {
+        return limit;
+    }
+
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -56,4 +56,25 @@ public interface QueryBuilder<QB extends QueryBuilder> extends NamedWriteable<QB
      */
     //norelease once we move to serializing queries over the wire in Streamable format, this method shouldn't be needed anymore
     BytesReference buildAsBytes();
+
+    /**
+     * Sets the query name for the query.
+     */
+    QB queryName(String queryName);
+
+    /**
+     * Returns the query name for the query.
+     */
+    String queryName();
+
+    /**
+     * Returns the boost for this query.
+     */
+    float boost();
+
+    /**
+     * Sets the boost for this query.  Documents matching this query will (in addition to the normal
+     * weightings) have their score multiplied by the boost provided.
+     */
+    QB boost(float boost);
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -59,18 +59,6 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
     }
 
     @Override
-    public QueryFilterBuilder boost(float boost) {
-        //no-op: QueryFilterParser doesn't support boost, we should be consistent and ignore it here too.
-        return this;
-    }
-
-    @Override
-    public QueryFilterBuilder queryName(String queryName) {
-        //no-op: QueryFilterParser doesn't support _name, we should be consistent and ignore it here too.
-        return this;
-    }
-
-    @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field(NAME);
         queryBuilder.toXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -52,6 +52,7 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
         builder.startObject(NAME);
         builder.field(SpanMultiTermQueryParser.MATCH_NAME);
         multiTermQueryBuilder.toXContent(builder, params);
+        printBoostAndQueryName(builder);
         builder.endObject();
     }
 
@@ -100,17 +101,5 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
     @Override
     public String getName() {
         return NAME;
-    }
-
-    @Override
-    public SpanMultiTermQueryBuilder boost(float boost) {
-        //no-op: SpanMultiTermQueryParser doesn't support boost, we should be consistent and ignore it here too.
-        return this;
-    }
-
-    @Override
-    public SpanMultiTermQueryBuilder queryName(String queryName) {
-        //no-op: SpanMultiTermQueryParser doesn't support _name, we should be consistent and ignore it here too.
-        return this;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentParser.Token;
 
 import java.io.IOException;
 
@@ -44,24 +43,40 @@ public class SpanMultiTermQueryParser extends BaseQueryParser {
     @Override
     public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
-
-        Token token = parser.nextToken();
-        if (!MATCH_NAME.equals(parser.currentName()) || token != XContentParser.Token.FIELD_NAME) {
-            throw new QueryParsingException(parseContext, "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause");
+        String currentFieldName = null;
+        MultiTermQueryBuilder subQuery = null;
+        String queryName = null;
+        float boost = AbstractQueryBuilder.DEFAULT_BOOST;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if (MATCH_NAME.equals(currentFieldName)) {
+                    QueryBuilder innerQuery = parseContext.parseInnerQueryBuilder();
+                    if (innerQuery instanceof MultiTermQueryBuilder == false) {
+                        throw new QueryParsingException(parseContext, "[span_multi] [" + MATCH_NAME + "] must be of type multi term query");
+                    }
+                    subQuery = (MultiTermQueryBuilder) innerQuery;
+                } else {
+                    throw new QueryParsingException(parseContext, "[span_multi] query does not support [" + currentFieldName + "]");
+                }
+            } else if (token.isValue()) {
+                if ("_name".equals(currentFieldName)) {
+                    queryName = parser.text();
+                } else if ("boost".equals(currentFieldName)) {
+                    boost = parser.floatValue();
+                } else {
+                    throw new QueryParsingException(parseContext, "[span_multi] query does not support [" + currentFieldName + "]");
+                }
+            }
         }
 
-        token = parser.nextToken();
-        if (token != XContentParser.Token.START_OBJECT) {
-            throw new QueryParsingException(parseContext, "spanMultiTerm must have [" + MATCH_NAME + "] multi term query clause");
+        if (subQuery == null) {
+            throw new QueryParsingException(parseContext, "[span_multi] must have [" + MATCH_NAME + "] multi term query clause");
         }
 
-        QueryBuilder subQuery = parseContext.parseInnerQueryBuilder();
-        if (subQuery instanceof MultiTermQueryBuilder == false) {
-            throw new QueryParsingException(parseContext, "spanMultiTerm [" + MATCH_NAME + "] must be of type multi term query");
-        }
-
-        parser.nextToken();
-        return new SpanMultiTermQueryBuilder((MultiTermQueryBuilder) subQuery);
+        return new SpanMultiTermQueryBuilder(subQuery).queryName(queryName).boost(boost);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
@@ -19,11 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.lucene.BytesRefs;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -79,15 +74,14 @@ public abstract class BaseTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>>
 
     @Test
     public void testValidate() throws QueryParsingException {
-        
-        QB queryBuilder = createQueryBuilder("all", "good");
+        QB queryBuilder = createQueryBuilder(randomAsciiOfLengthBetween(1, 30), randomAsciiOfLengthBetween(1, 30));
         assertNull(queryBuilder.validate());
 
-        queryBuilder = createQueryBuilder(null, "Term");
+        queryBuilder = createQueryBuilder(null, randomAsciiOfLengthBetween(1, 30));
         assertNotNull(queryBuilder.validate());
         assertThat(queryBuilder.validate().validationErrors().size(), is(1));
 
-        queryBuilder = createQueryBuilder("", "Term");
+        queryBuilder = createQueryBuilder("", randomAsciiOfLengthBetween(1, 30));
         assertNotNull(queryBuilder.validate());
         assertThat(queryBuilder.validate().validationErrors().size(), is(1));
 
@@ -95,21 +89,4 @@ public abstract class BaseTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>>
         assertNotNull(queryBuilder.validate());
         assertThat(queryBuilder.validate().validationErrors().size(), is(2));
     }
-
-    @Override
-    protected Query doCreateExpectedQuery(QB queryBuilder, QueryParseContext context) {
-        BytesRef value = null;
-        if (getCurrentTypes().length > 0) {
-            if (queryBuilder.fieldName().equals(BOOLEAN_FIELD_NAME) || queryBuilder.fieldName().equals(INT_FIELD_NAME) || queryBuilder.fieldName().equals(DOUBLE_FIELD_NAME)) {
-                MappedFieldType mapper = context.fieldMapper(queryBuilder.fieldName());
-                value = mapper.indexedValueForSearch(queryBuilder.value);
-            }
-        }
-        if (value == null) {
-            value = BytesRefs.toBytesRef(queryBuilder.value);
-        }
-        return createLuceneTermQuery(new Term(queryBuilder.fieldName(), value));
-    }
-
-    protected abstract Query createLuceneTermQuery(Term term);
 }

--- a/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTest.java
@@ -25,6 +25,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
+
 public class BoostingQueryBuilderTest extends BaseQueryTestCase<BoostingQueryBuilder> {
 
     @Override
@@ -35,13 +38,14 @@ public class BoostingQueryBuilderTest extends BaseQueryTestCase<BoostingQueryBui
     }
 
     @Override
-    protected Query doCreateExpectedQuery(BoostingQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+    protected void doAssertLuceneQuery(BoostingQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
         Query positive = queryBuilder.positive().toQuery(context);
         Query negative = queryBuilder.negative().toQuery(context);
         if (positive == null || negative == null) {
-            return null;
+            assertThat(query, nullValue());
+        } else {
+            assertThat(query, instanceOf(BoostingQuery.class));
         }
-        return new BoostingQuery(positive, negative, queryBuilder.negativeBoost());
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTest.java
@@ -27,16 +27,11 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-public class ConstantScoreQueryBuilderTest extends BaseQueryTestCase<ConstantScoreQueryBuilder> {
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
 
-    @Override
-    protected Query doCreateExpectedQuery(ConstantScoreQueryBuilder testBuilder, QueryParseContext context) throws QueryParsingException, IOException {
-        Query innerQuery = testBuilder.query().toQuery(context);
-        if (innerQuery != null) {
-            return new ConstantScoreQuery(innerQuery);
-        }
-        return null;
-    }
+public class ConstantScoreQueryBuilderTest extends BaseQueryTestCase<ConstantScoreQueryBuilder> {
 
     /**
      * @return a {@link ConstantScoreQueryBuilder} with random boost between 0.1f and 2.0f
@@ -44,6 +39,18 @@ public class ConstantScoreQueryBuilderTest extends BaseQueryTestCase<ConstantSco
     @Override
     protected ConstantScoreQueryBuilder doCreateTestQueryBuilder() {
         return new ConstantScoreQueryBuilder(RandomQueryBuilder.createQuery(random()));
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(ConstantScoreQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        Query innerQuery = queryBuilder.query().toQuery(context);
+        if (innerQuery == null) {
+            assertThat(query, nullValue());
+        } else {
+            assertThat(query, instanceOf(ConstantScoreQuery.class));
+            ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
+            assertThat(constantScoreQuery.getQuery(), equalTo(innerQuery));
+        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/FQueryFilterBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FQueryFilterBuilderTest.java
@@ -27,17 +27,12 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
+
 @SuppressWarnings("deprecation")
 public class FQueryFilterBuilderTest extends BaseQueryTestCase<FQueryFilterBuilder> {
-
-    @Override
-    protected Query doCreateExpectedQuery(FQueryFilterBuilder queryBuilder, QueryParseContext context) throws QueryParsingException, IOException {
-        Query query = queryBuilder.innerQuery().toQuery(context);
-        if (query != null) {
-            return new ConstantScoreQuery(query);
-        }
-        return null;
-    }
 
     /**
      * @return a FQueryFilterBuilder with random inner query
@@ -46,6 +41,18 @@ public class FQueryFilterBuilderTest extends BaseQueryTestCase<FQueryFilterBuild
     protected FQueryFilterBuilder doCreateTestQueryBuilder() {
         QueryBuilder innerQuery = RandomQueryBuilder.createQuery(random());
         return new FQueryFilterBuilder(innerQuery);
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(FQueryFilterBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        Query innerQuery = queryBuilder.innerQuery().toQuery(context);
+        if (innerQuery == null) {
+            assertThat(query, nullValue());
+        } else {
+            assertThat(query, instanceOf(ConstantScoreQuery.class));
+            ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
+            assertThat(constantScoreQuery.getQuery(), equalTo(innerQuery));
+        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
@@ -19,16 +19,14 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.lucene.search.Queries;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class LimitQueryBuilderTest extends BaseQueryTestCase<LimitQueryBuilder> {
-
-    @Override
-    protected Query doCreateExpectedQuery(LimitQueryBuilder queryBuilder, QueryParseContext context) {
-        // this filter is deprecated and parses to a filter that matches everything
-        return Queries.newMatchAllQuery();
-    }
 
     /**
      * @return a LimitQueryBuilder with random limit between 0 and 20
@@ -36,5 +34,10 @@ public class LimitQueryBuilderTest extends BaseQueryTestCase<LimitQueryBuilder> 
     @Override
     protected LimitQueryBuilder doCreateTestQueryBuilder() {
         return new LimitQueryBuilder(randomIntBetween(0, 20));
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(LimitQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(MatchAllDocsQuery.class));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -22,16 +22,19 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 
-public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
+import java.io.IOException;
 
-    @Override
-    protected Query doCreateExpectedQuery(MatchAllQueryBuilder queryBuilder, QueryParseContext context) {
-        return new MatchAllDocsQuery();
-    }
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
     @Override
     protected MatchAllQueryBuilder doCreateTestQueryBuilder() {
         return new MatchAllQueryBuilder();
     }
 
+    @Override
+    protected void doAssertLuceneQuery(MatchAllQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(MatchAllDocsQuery.class));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/MissingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MissingQueryBuilderTest.java
@@ -19,15 +19,10 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.*;
-import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
-import org.elasticsearch.index.mapper.object.ObjectMapper;
+import org.apache.lucene.search.Query;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collection;
 
 import static org.hamcrest.Matchers.is;
 
@@ -35,7 +30,7 @@ public class MissingQueryBuilderTest extends BaseQueryTestCase<MissingQueryBuild
 
     @Override
     protected MissingQueryBuilder doCreateTestQueryBuilder() {
-        MissingQueryBuilder query  = new MissingQueryBuilder(getRandomFieldName());
+        MissingQueryBuilder query  = new MissingQueryBuilder(randomBoolean() ? randomFrom(mappedFieldNames) : randomAsciiOfLengthBetween(1, 10));
         if (randomBoolean()) {
             query.nullValue(randomBoolean());
         }
@@ -49,115 +44,9 @@ public class MissingQueryBuilderTest extends BaseQueryTestCase<MissingQueryBuild
         return query;
     }
 
-    private String getRandomFieldName() {
-        if (randomBoolean()) {
-            return randomAsciiOfLengthBetween(1, 10);
-        }
-        switch (randomIntBetween(0, 3)) {
-            case 0:
-                return BOOLEAN_FIELD_NAME;
-            case 1:
-                return STRING_FIELD_NAME;
-            case 2:
-                return INT_FIELD_NAME;
-            case 3:
-                return DOUBLE_FIELD_NAME;
-            default:
-                throw new UnsupportedOperationException();
-        }
-    }
-
     @Override
-    protected Query doCreateExpectedQuery(MissingQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
-        final boolean existence = queryBuilder.existence();
-        final boolean nullValue = queryBuilder.nullValue();
-        String fieldPattern = queryBuilder.fieldPattern();
-
-        if (!existence && !nullValue) {
-            throw new QueryParsingException(context, "missing must have either existence, or null_value, or both set to true");
-        }
-
-        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context.mapperService().fullName(FieldNamesFieldMapper.NAME);
-        if (fieldNamesFieldType == null) {
-            // can only happen when no types exist, so no docs exist either
-            return Queries.newMatchNoDocsQuery();
-        }
-
-        ObjectMapper objectMapper = context.getObjectMapper(fieldPattern);
-        if (objectMapper != null) {
-            // automatic make the object mapper pattern
-            fieldPattern = fieldPattern + ".*";
-        }
-
-        Collection<String> fields = context.simpleMatchToIndexNames(fieldPattern);
-        if (fields.isEmpty()) {
-            if (existence) {
-                // if we ask for existence of fields, and we found none, then we should match on all
-                return Queries.newMatchAllQuery();
-            }
-            return null;
-        }
-
-        Query existenceFilter = null;
-        Query nullFilter = null;
-
-        if (existence) {
-            BooleanQuery boolFilter = new BooleanQuery();
-            for (String field : fields) {
-                MappedFieldType fieldType = context.fieldMapper(field);
-                Query filter = null;
-                if (fieldNamesFieldType.isEnabled()) {
-                    final String f;
-                    if (fieldType != null) {
-                        f = fieldType.names().indexName();
-                    } else {
-                        f = field;
-                    }
-                    filter = fieldNamesFieldType.termQuery(f, context);
-                }
-                // if _field_names are not indexed, we need to go the slow way
-                if (filter == null && fieldType != null) {
-                    filter = fieldType.rangeQuery(null, null, true, true);
-                }
-                if (filter == null) {
-                    filter = new TermRangeQuery(field, null, null, true, true);
-                }
-                boolFilter.add(filter, BooleanClause.Occur.SHOULD);
-            }
-
-            existenceFilter = boolFilter;
-            existenceFilter = Queries.not(existenceFilter);;
-        }
-
-        if (nullValue) {
-            for (String field : fields) {
-                MappedFieldType fieldType = context.fieldMapper(field);
-                if (fieldType != null) {
-                    nullFilter = fieldType.nullValueQuery();
-                }
-            }
-        }
-
-        Query filter;
-        if (nullFilter != null) {
-            if (existenceFilter != null) {
-                BooleanQuery combined = new BooleanQuery();
-                combined.add(existenceFilter, BooleanClause.Occur.SHOULD);
-                combined.add(nullFilter, BooleanClause.Occur.SHOULD);
-                // cache the not filter as well, so it will be faster
-                filter = combined;
-            } else {
-                filter = nullFilter;
-            }
-        } else {
-            filter = existenceFilter;
-        }
-
-        if (filter == null) {
-            return null;
-        }
-
-        return new ConstantScoreQuery(filter);
+    protected void doAssertLuceneQuery(MissingQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        //too many mapping dependent cases to test, we don't want to end up duplication the toQuery method
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTest.java
@@ -19,20 +19,15 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
-import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.common.lucene.BytesRefs;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.support.QueryParsers;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class RegexpQueryBuilderTest extends BaseQueryTestCase<RegexpQueryBuilder> {
@@ -62,25 +57,8 @@ public class RegexpQueryBuilderTest extends BaseQueryTestCase<RegexpQueryBuilder
     }
 
     @Override
-    protected Query doCreateExpectedQuery(RegexpQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
-        //norelease fix to be removed to avoid NPE on unmapped fields
-        context.parseFieldMatcher(randomBoolean() ? ParseFieldMatcher.EMPTY : ParseFieldMatcher.STRICT);
-        MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(context.parseFieldMatcher(), queryBuilder.rewrite(), null);
-
-        Query query = null;
-        MappedFieldType fieldType = context.fieldMapper(queryBuilder.fieldName());
-        if (fieldType != null) {
-            query = fieldType.regexpQuery(queryBuilder.value(), queryBuilder.flags(), queryBuilder.maxDeterminizedStates(), method, context);
-        }
-        if (query == null) {
-            RegexpQuery regexpQuery = new RegexpQuery(new Term(queryBuilder.fieldName(), BytesRefs.toBytesRef(queryBuilder.value())), 
-                    queryBuilder.flags(), queryBuilder.maxDeterminizedStates());
-            if (method != null) {
-                regexpQuery.setRewriteMethod(method);
-            }
-            query = regexpQuery;
-        }
-        return query;
+    protected void doAssertLuceneQuery(RegexpQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(RegexpQuery.class));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class ScriptQueryBuilderTest extends BaseQueryTestCase<ScriptQueryBuilder> {
@@ -47,8 +48,8 @@ public class ScriptQueryBuilderTest extends BaseQueryTestCase<ScriptQueryBuilder
     }
 
     @Override
-    protected Query doCreateExpectedQuery(ScriptQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
-        return new ScriptQueryBuilder.ScriptQuery(queryBuilder.script(), context.scriptService(), context.lookup());
+    protected void doAssertLuceneQuery(ScriptQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(ScriptQueryBuilder.ScriptQuery.class));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
@@ -21,24 +21,23 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanContainingQuery;
-import org.apache.lucene.search.spans.SpanQuery;
 import org.junit.Test;
 
 import java.io.IOException;
 
-public class SpanContainingQueryBuilderTest extends BaseQueryTestCase<SpanContainingQueryBuilder> {
+import static org.hamcrest.CoreMatchers.instanceOf;
 
-    @Override
-    protected Query doCreateExpectedQuery(SpanContainingQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
-        SpanQuery big = (SpanQuery) testQueryBuilder.big().toQuery(context);
-        SpanQuery little = (SpanQuery) testQueryBuilder.little().toQuery(context);
-        return new SpanContainingQuery(big, little);
-    }
+public class SpanContainingQueryBuilderTest extends BaseQueryTestCase<SpanContainingQueryBuilder> {
 
     @Override
     protected SpanContainingQueryBuilder doCreateTestQueryBuilder() {
         SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(2);
         return new SpanContainingQueryBuilder(spanTermQueries[0], spanTermQueries[1]);
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(SpanContainingQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(SpanContainingQuery.class));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTest.java
@@ -25,24 +25,25 @@ import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.io.IOException;
 
 import static org.elasticsearch.index.query.QueryBuilders.spanTermQuery;
+import static org.hamcrest.CoreMatchers.*;
 
 public class SpanFirstQueryBuilderTest extends BaseQueryTestCase<SpanFirstQueryBuilder> {
-
-    @Override
-    protected Query doCreateExpectedQuery(SpanFirstQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
-        SpanQuery innerQuery = (SpanQuery) testQueryBuilder.matchBuilder().toQuery(context);
-        return new SpanFirstQuery(innerQuery, testQueryBuilder.end());
-    }
 
     @Override
     protected SpanFirstQueryBuilder doCreateTestQueryBuilder() {
         SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(1);
         return new SpanFirstQueryBuilder(spanTermQueries[0], randomIntBetween(0, 1000));
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(SpanFirstQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(SpanFirstQuery.class));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTest.java
@@ -26,18 +26,24 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-public class SpanMultiTermQueryBuilderTest extends BaseQueryTestCase<SpanMultiTermQueryBuilder> {
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
-    @Override
-    protected Query doCreateExpectedQuery(SpanMultiTermQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
-        Query multiTermQuery = testQueryBuilder.multiTermQueryBuilder().toQuery(context);
-        return new SpanMultiTermQueryWrapper<>((MultiTermQuery) multiTermQuery);
-    }
+public class SpanMultiTermQueryBuilderTest extends BaseQueryTestCase<SpanMultiTermQueryBuilder> {
 
     @Override
     protected SpanMultiTermQueryBuilder doCreateTestQueryBuilder() {
         MultiTermQueryBuilder multiTermQueryBuilder = RandomQueryBuilder.createMultiTermQuery(random());
         return new SpanMultiTermQueryBuilder(multiTermQueryBuilder);
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(SpanMultiTermQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(SpanMultiTermQueryWrapper.class));
+        SpanMultiTermQueryWrapper spanMultiTermQueryWrapper = (SpanMultiTermQueryWrapper) query;
+        Query multiTermQuery = queryBuilder.multiTermQueryBuilder().toQuery(context);
+        assertThat(multiTermQuery, instanceOf(MultiTermQuery.class));
+        assertThat(spanMultiTermQueryWrapper.getWrappedQuery(), equalTo(new SpanMultiTermQueryWrapper<>((MultiTermQuery)multiTermQuery).getWrappedQuery()));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanNotQuery;
-import org.apache.lucene.search.spans.SpanQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -33,15 +32,9 @@ import static org.elasticsearch.index.query.QueryBuilders.spanNearQuery;
 import static org.elasticsearch.index.query.QueryBuilders.spanTermQuery;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class SpanNotQueryBuilderTest extends BaseQueryTestCase<SpanNotQueryBuilder> {
-
-    @Override
-    protected Query doCreateExpectedQuery(SpanNotQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
-        SpanQuery include = (SpanQuery) testQueryBuilder.include().toQuery(context);
-        SpanQuery exclude = (SpanQuery) testQueryBuilder.exclude().toQuery(context);
-        return new SpanNotQuery(include, exclude, testQueryBuilder.pre(), testQueryBuilder.post());
-    }
 
     @Override
     protected SpanNotQueryBuilder doCreateTestQueryBuilder() {
@@ -59,6 +52,14 @@ public class SpanNotQueryBuilderTest extends BaseQueryTestCase<SpanNotQueryBuild
             }
         }
         return queryBuilder;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(SpanNotQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(SpanNotQuery.class));
+        SpanNotQuery spanNotQuery = (SpanNotQuery) query;
+        assertThat(spanNotQuery.getExclude(), equalTo(queryBuilder.exclude().toQuery(context)));
+        assertThat(spanNotQuery.getInclude(), equalTo(queryBuilder.include().toQuery(context)));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTest.java
@@ -25,21 +25,12 @@ import org.apache.lucene.search.spans.SpanQuery;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Iterator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class SpanOrQueryBuilderTest extends BaseQueryTestCase<SpanOrQueryBuilder> {
-
-    @Override
-    protected Query doCreateExpectedQuery(SpanOrQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
-        List<SpanQueryBuilder> clauses = testQueryBuilder.clauses();
-        SpanQuery[] spanQueries = new SpanQuery[clauses.size()];
-        for (int i = 0; i < clauses.size(); i++) {
-            Query query = clauses.get(i).toQuery(context);
-            assert query instanceof SpanQuery;
-            spanQueries[i] = (SpanQuery) query;
-        }
-        return new SpanOrQuery(spanQueries);
-    }
 
     @Override
     protected SpanOrQueryBuilder doCreateTestQueryBuilder() {
@@ -49,6 +40,17 @@ public class SpanOrQueryBuilderTest extends BaseQueryTestCase<SpanOrQueryBuilder
             queryBuilder.clause(clause);
         }
         return queryBuilder;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(SpanOrQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(SpanOrQuery.class));
+        SpanOrQuery spanOrQuery = (SpanOrQuery) query;
+        assertThat(spanOrQuery.getClauses().length, equalTo(queryBuilder.clauses().size()));
+        Iterator<SpanQueryBuilder> spanQueryBuilderIterator = queryBuilder.clauses().iterator();
+        for (SpanQuery spanQuery : spanOrQuery.getClauses()) {
+            assertThat(spanQuery, equalTo(spanQueryBuilderIterator.next().toQuery(context)));
+        }
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
@@ -20,25 +20,24 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanWithinQuery;
 import org.junit.Test;
 
 import java.io.IOException;
 
-public class SpanWithinQueryBuilderTest extends BaseQueryTestCase<SpanWithinQueryBuilder> {
+import static org.hamcrest.CoreMatchers.instanceOf;
 
-    @Override
-    protected Query doCreateExpectedQuery(SpanWithinQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
-        SpanQuery big = (SpanQuery) testQueryBuilder.big().toQuery(context);
-        SpanQuery little = (SpanQuery) testQueryBuilder.little().toQuery(context);
-        return new SpanWithinQuery(big, little);
-    }
+public class SpanWithinQueryBuilderTest extends BaseQueryTestCase<SpanWithinQueryBuilder> {
 
     @Override
     protected SpanWithinQueryBuilder doCreateTestQueryBuilder() {
         SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTest().createSpanTermQueryBuilders(2);
         return new SpanWithinQueryBuilder(spanTermQueries[0], spanTermQueries[1]);
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(SpanWithinQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(SpanWithinQuery.class));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTest.java
@@ -19,18 +19,13 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.support.QueryParsers;
 import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class WildcardQueryBuilderTest extends BaseQueryTestCase<WildcardQueryBuilder> {
@@ -53,26 +48,8 @@ public class WildcardQueryBuilderTest extends BaseQueryTestCase<WildcardQueryBui
     }
 
     @Override
-    protected Query doCreateExpectedQuery(WildcardQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
-        String indexFieldName;
-        BytesRef valueBytes;
-
-        MappedFieldType fieldType = context.fieldMapper(queryBuilder.fieldName());
-        if (fieldType != null) {
-            indexFieldName = fieldType.names().indexName();
-            valueBytes = fieldType.indexedValueForSearch(queryBuilder.value());
-        } else {
-            indexFieldName = queryBuilder.fieldName();
-            valueBytes = new BytesRef(queryBuilder.value());
-        }
-
-        WildcardQuery expectedQuery = new WildcardQuery(new Term(indexFieldName, valueBytes));
-
-        //norelease fix to be removed to avoid NPE on unmapped fields
-        context.parseFieldMatcher(randomBoolean() ? ParseFieldMatcher.EMPTY : ParseFieldMatcher.STRICT);
-        MultiTermQuery.RewriteMethod rewriteMethod = QueryParsers.parseRewriteMethod(context.parseFieldMatcher(), queryBuilder.rewrite(), null);
-        QueryParsers.setRewriteMethod(expectedQuery, rewriteMethod);
-        return expectedQuery;
+    protected void doAssertLuceneQuery(WildcardQueryBuilder queryBuilder, Query query, QueryParseContext context) throws IOException {
+        assertThat(query, instanceOf(WildcardQuery.class));
     }
 
     @Test


### PR DESCRIPTION
We currently test the toQuery method by comparing its return value with the output of createExpectedQuery. This seemed at first like a good deep test for the lucene generated queries, but ends up causing a lot of code duplication between tests and prod code, which smells like this test is not that useful after all.

This commit removes the requirement for createExpectedQuery, we test a bit less the lucene generated queries, but we do still have a testToQuery method in BaseQueryTestCase. This test acts as smoke test to verify that there are no issues with our toQuery method implementation for each query: it verifies that two equal queries should result in the same lucene query. It also verifies that changing the boost value of a query affects the result of the toQuery.

Part of the previous createExpectedQuery can be moved to assertLuceneQuery using normal assertions, we do it when it makes sense only though.

This commit also adds support for boost and queryName to SpanMultiTermQueryParser and SpanMultiTermQueryBuilder, plus it removes no-op setters for queryName and boost from QueryFilterBuilder. Instead we simply declare in our test infra that query filter doesn't support boost and queryName and we disable tests aroudn these fields in that specific case. Boost and queryName support is also moved down to the QueryBuilder interface.
