### PR TITLE
Proto: Separating QueryParseContext and QueryGenerationContext

### DIFF
--- a/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -19,6 +19,9 @@
 
 package org.apache.lucene.queryparser.classic;
 
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -39,11 +42,9 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.query.QueryGenerationContext;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.support.QueryParsers;
-
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -252,7 +253,7 @@ public class MapperQueryParser extends QueryParser {
                     Query query = null;
                     if (currentFieldType.useTermQueryWithQueryString()) {
                         try {
-                            query = currentFieldType.termQuery(queryText, parseContext);
+                            query = currentFieldType.termQuery(queryText, new QueryGenerationContext(parseContext));
                         } catch (RuntimeException e) {
                             if (settings.lenient()) {
                                 return null;

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.query.QueryGenerationException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.rest.RestStatus;
@@ -588,7 +589,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 ResourceNotFoundException.class,
                 IndexNotFoundException.class,
                 ShardNotFoundException.class,
-                NotSerializableExceptionWrapper.class
+                NotSerializableExceptionWrapper.class,
+                QueryGenerationException.class
         };
         Map<String, Constructor<? extends ElasticsearchException>> mapping = new HashMap<>(exceptions.length);
         for (Class<? extends ElasticsearchException> e : exceptions) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import com.google.common.base.Strings;
+
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
@@ -30,10 +31,10 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.fieldstats.FieldStats;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.BytesRefs;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.query.QueryGenerationContext;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 
@@ -186,6 +187,7 @@ public abstract class MappedFieldType extends FieldType {
         fieldDataType = new FieldDataType(typeName());
     }
 
+    @Override
     public abstract MappedFieldType clone();
 
     @Override
@@ -437,11 +439,11 @@ public abstract class MappedFieldType extends FieldType {
         return new Term(names().indexName(), indexedValueForSearch(value));
     }
 
-    public Query termQuery(Object value, @Nullable QueryParseContext context) {
+    public Query termQuery(Object value, @Nullable QueryGenerationContext generationContext) {
         return new TermQuery(createTerm(value));
     }
 
-    public Query termsQuery(List values, @Nullable QueryParseContext context) {
+    public Query termsQuery(List values, @Nullable QueryGenerationContext context) {
         BytesRef[] bytesRefs = new BytesRef[values.size()];
         for (int i = 0; i < bytesRefs.length; i++) {
             bytesRefs[i] = indexedValueForSearch(values.get(i));

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/AllFieldMapper.java
@@ -40,7 +40,7 @@ import org.elasticsearch.index.mapper.MergeMappingException;
 import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryGenerationContext;
 import org.elasticsearch.index.similarity.SimilarityLookupService;
 
 import java.io.IOException;
@@ -117,7 +117,7 @@ public class AllFieldMapper extends MetadataFieldMapper {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(parserContext.mapperService().fullName(NAME));
-            
+
             // parseField below will happily parse the doc_values setting, but it is then never passed to
             // the AllFieldMapper ctor in the builder since it is not valid. Here we validate
             // the doc values settings (old and new) are rejected
@@ -134,7 +134,7 @@ public class AllFieldMapper extends MetadataFieldMapper {
                     throw new MapperParsingException("Field [" + name + "] is always tokenized and cannot have doc values");
                 }
             }
-            
+
             parseField(builder, builder.name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
@@ -186,7 +186,7 @@ public class AllFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, QueryParseContext context) {
+        public Query termQuery(Object value, QueryGenerationContext context) {
             return queryStringTermQuery(createTerm(value));
         }
     }
@@ -294,7 +294,7 @@ public class AllFieldMapper extends MetadataFieldMapper {
         if (includeDefaults || fieldType().omitNorms() != Defaults.FIELD_TYPE.omitNorms()) {
             builder.field("omit_norms", fieldType().omitNorms());
         }
-        
+
         doXContentAnalyzers(builder, includeDefaults);
 
         if (fieldType().similarity() != null) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/IdFieldMapper.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper.internal;
 
 import com.google.common.collect.Iterables;
+
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
@@ -49,6 +50,7 @@ import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.Uid;
+import org.elasticsearch.index.query.QueryGenerationContext;
 import org.elasticsearch.index.query.QueryParseContext;
 
 import java.io.IOException;
@@ -60,7 +62,7 @@ import java.util.Map;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
 
 /**
- * 
+ *
  */
 public class IdFieldMapper extends MetadataFieldMapper {
 
@@ -167,7 +169,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, @Nullable QueryParseContext context) {
+        public Query termQuery(Object value, @Nullable QueryGenerationContext context) {
             if (indexOptions() != IndexOptions.NONE || context == null) {
                 return super.termQuery(value, context);
             }
@@ -176,7 +178,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query termsQuery(List values, @Nullable QueryParseContext context) {
+        public Query termsQuery(List values, @Nullable QueryGenerationContext context) {
             if (indexOptions() != IndexOptions.NONE || context == null) {
                 return super.termsQuery(values, context);
             }
@@ -236,7 +238,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
         super(NAME, fieldType, Defaults.FIELD_TYPE, indexSettings);
         this.path = path;
     }
-    
+
     private static MappedFieldType idFieldType(Settings indexSettings, MappedFieldType existing) {
         if (existing != null) {
             return existing.clone();

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/IndexFieldMapper.java
@@ -38,8 +38,7 @@ import org.elasticsearch.index.mapper.MergeMappingException;
 import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
-import org.elasticsearch.index.query.QueryParseContext;
-
+import org.elasticsearch.index.query.QueryGenerationContext;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -157,7 +156,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
          * indices
          */
         @Override
-        public Query termQuery(Object value, @Nullable QueryParseContext context) {
+        public Query termQuery(Object value, @Nullable QueryGenerationContext context) {
             if (context == null) {
                 return super.termQuery(value, context);
             }
@@ -167,11 +166,11 @@ public class IndexFieldMapper extends MetadataFieldMapper {
                 return Queries.newMatchNoDocsQuery();
             }
         }
-        
-        
+
+
 
         @Override
-        public Query termsQuery(List values, QueryParseContext context) {
+        public Query termsQuery(List values, QueryGenerationContext context) {
             if (context == null) {
                 return super.termsQuery(values, context);
             }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.mapper.internal;
 
 import com.google.common.base.Objects;
+
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.index.IndexOptions;
@@ -43,6 +44,7 @@ import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.Uid;
+import org.elasticsearch.index.query.QueryGenerationContext;
 import org.elasticsearch.index.query.QueryParseContext;
 
 import java.io.IOException;
@@ -189,12 +191,12 @@ public class ParentFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, @Nullable QueryParseContext context) {
+        public Query termQuery(Object value, @Nullable QueryGenerationContext context) {
             return termsQuery(Collections.singletonList(value), context);
         }
 
         @Override
-        public Query termsQuery(List values, @Nullable QueryParseContext context) {
+        public Query termsQuery(List values, @Nullable QueryGenerationContext context) {
             if (context == null) {
                 return super.termsQuery(values, context);
             }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -43,7 +43,7 @@ import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.Uid;
-import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryGenerationContext;
 
 import java.io.IOException;
 import java.util.List;
@@ -137,7 +137,7 @@ public class TypeFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public Query termQuery(Object value, @Nullable QueryParseContext context) {
+        public Query termQuery(Object value, @Nullable QueryGenerationContext context) {
             if (indexOptions() == IndexOptions.NONE) {
                 return new ConstantScoreQuery(new PrefixQuery(new Term(UidFieldMapper.NAME, Uid.typePrefixAsBytes(BytesRefs.toBytesRef(value)))));
             }

--- a/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -68,20 +68,20 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
     }
 
     @Override
-    public final Query toQuery(QueryParseContext parseContext) throws IOException {
-        Query query = doToQuery(parseContext);
+    public final Query toQuery(QueryGenerationContext generationContext) throws IOException {
+        Query query = doToQuery(generationContext);
         if (query != null) {
             query.setBoost(boost);
             if (queryName != null) {
-                parseContext.addNamedQuery(queryName, query);
+                generationContext.addNamedQuery(queryName, query);
             }
         }
         return query;
     }
 
     //norelease to be made abstract once all query builders override doToQuery providing their own specific implementation.
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        return parseContext.indexQueryParserService().queryParser(getName()).parse(parseContext);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        return generationContext.indexQueryParserService().queryParser(getName()).parse(generationContext.getParseContext());
     }
 
     @Override
@@ -215,17 +215,17 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
     /**
      * Helper method to convert collection of {@link QueryBuilder} instances to lucene
      * {@link Query} instances. {@link QueryBuilder} that return <tt>null</tt> calling
-     * their {@link QueryBuilder#toQuery(QueryParseContext)} method are not added to the
+     * their {@link QueryBuilder#toQuery(QueryGenerationContext)} method are not added to the
      * resulting collection.
      *
      * @throws IOException
      * @throws QueryParsingException
      */
-    protected static Collection<Query> toQueries(Collection<QueryBuilder> queryBuilders, QueryParseContext parseContext) throws QueryParsingException,
+    protected static Collection<Query> toQueries(Collection<QueryBuilder> queryBuilders, QueryGenerationContext generationContext) throws QueryParsingException,
             IOException {
         List<Query> queries = new ArrayList<>(queryBuilders.size());
         for (QueryBuilder queryBuilder : queryBuilders) {
-            Query query = queryBuilder.toQuery(parseContext);
+            Query query = queryBuilder.toQuery(generationContext);
             if (query != null) {
                 queries.add(query);
             }

--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryBuilder.java
@@ -84,7 +84,7 @@ public class AndQueryBuilder extends AbstractQueryBuilder<AndQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         if (filters.isEmpty()) {
             // no filters provided, this should be ignored upstream
             return null;
@@ -92,7 +92,7 @@ public class AndQueryBuilder extends AbstractQueryBuilder<AndQueryBuilder> {
 
         BooleanQuery query = new BooleanQuery();
         for (QueryBuilder f : filters) {
-            Query innerQuery = f.toQuery(parseContext);
+            Query innerQuery = f.toQuery(generationContext);
             // ignore queries that are null
             if (innerQuery != null) {
                 query.add(innerQuery, Occur.MUST);

--- a/core/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
@@ -27,13 +27,13 @@ import java.io.IOException;
  * Class used during the query parsers refactoring. Will be removed once we can parse search requests on the coordinating node.
  * All query parsers that have a refactored "fromXContent" method can be changed to extend this instead of {@link BaseQueryParserTemp}.
  * Keeps old {@link QueryParser#parse(QueryParseContext)} method as a stub delegating to
- * {@link QueryParser#fromXContent(QueryParseContext)} and {@link QueryBuilder#toQuery(QueryParseContext)}}
+ * {@link QueryParser#fromXContent(QueryParseContext)} and {@link QueryBuilder#toQuery(QueryGenerationContext)}}
  */
 //norelease needs to be removed once we parse search requests on the coordinating node, as the parse method is not needed anymore at that point.
 public abstract class BaseQueryParser implements QueryParser {
 
     @Override
     public final Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
-        return fromXContent(parseContext).toQuery(parseContext);
+        return fromXContent(parseContext).toQuery(new QueryGenerationContext(parseContext));
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -254,12 +254,12 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         BooleanQuery booleanQuery = new BooleanQuery(disableCoord);
-        addBooleanClauses(parseContext, booleanQuery, mustClauses, BooleanClause.Occur.MUST);
-        addBooleanClauses(parseContext, booleanQuery, mustNotClauses, BooleanClause.Occur.MUST_NOT);
-        addBooleanClauses(parseContext, booleanQuery, shouldClauses, BooleanClause.Occur.SHOULD);
-        addBooleanClauses(parseContext, booleanQuery, filterClauses, BooleanClause.Occur.FILTER);
+        addBooleanClauses(generationContext, booleanQuery, mustClauses, BooleanClause.Occur.MUST);
+        addBooleanClauses(generationContext, booleanQuery, mustNotClauses, BooleanClause.Occur.MUST_NOT);
+        addBooleanClauses(generationContext, booleanQuery, shouldClauses, BooleanClause.Occur.SHOULD);
+        addBooleanClauses(generationContext, booleanQuery, filterClauses, BooleanClause.Occur.FILTER);
 
         if (booleanQuery.clauses().isEmpty()) {
             return new MatchAllDocsQuery();
@@ -279,9 +279,9 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         return validationException;
     }
 
-    private static void addBooleanClauses(QueryParseContext parseContext, BooleanQuery booleanQuery, List<QueryBuilder> clauses, Occur occurs) throws IOException {
+    private static void addBooleanClauses(QueryGenerationContext generationContext, BooleanQuery booleanQuery, List<QueryBuilder> clauses, Occur occurs) throws IOException {
         for (QueryBuilder query : clauses) {
-            Query luceneQuery = query.toQuery(parseContext);
+            Query luceneQuery = query.toQuery(generationContext);
             if (luceneQuery != null) {
                 booleanQuery.add(new BooleanClause(luceneQuery, occurs));
             }

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -129,9 +129,9 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        Query positive = positiveQuery.toQuery(parseContext);
-        Query negative = negativeQuery.toQuery(parseContext);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        Query positive = positiveQuery.toQuery(generationContext);
+        Query negative = negativeQuery.toQuery(generationContext);
         // make upstream queries ignore this query by returning `null`
         // if either inner query builder returns null
         if (positive == null || negative == null) {

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  * CommonTermsQuery query is a query that executes high-frequency terms in a
  * optional sub-query to prevent slow queries due to "common" terms like
  * stopwords. This query basically builds 2 queries off the
- * {@link org.apache.lucene.queries.CommonTermsQuery#add(Term) added} terms 
+ * {@link org.apache.lucene.queries.CommonTermsQuery#add(Term) added} terms
  * where low-frequency terms are added to a required boolean clause
  * and high-frequency terms are added to an optional boolean clause. The
  * optional clause is only executed if the required "low-frequency' clause
@@ -154,7 +154,7 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
         this.cutoffFrequency = cutoffFrequency;
         return this;
     }
-    
+
     public float cutoffFrequency() {
         return this.cutoffFrequency;
     }
@@ -180,7 +180,7 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
         this.lowFreqMinimumShouldMatch = lowFreqMinimumShouldMatch;
         return this;
     }
-    
+
     public String lowFreqMinimumShouldMatch() {
         return this.lowFreqMinimumShouldMatch;
     }
@@ -228,9 +228,9 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         String field;
-        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        MappedFieldType fieldType = generationContext.fieldMapper(fieldName);
         if (fieldType != null) {
             field = fieldType.names().indexName();
         } else {
@@ -240,25 +240,25 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
         Analyzer analyzerObj;
         if (analyzer == null) {
             if (fieldType != null) {
-                analyzerObj = parseContext.getSearchAnalyzer(fieldType);
+                analyzerObj = generationContext.getSearchAnalyzer(fieldType);
             } else {
-                analyzerObj = parseContext.mapperService().searchAnalyzer();
+                analyzerObj = generationContext.mapperService().searchAnalyzer();
             }
         } else {
-            analyzerObj = parseContext.mapperService().analysisService().analyzer(analyzer);
+            analyzerObj = generationContext.mapperService().analysisService().analyzer(analyzer);
             if (analyzerObj == null) {
                 throw new IllegalArgumentException("no analyzer found for [" + analyzer + "]");
             }
         }
-        
+
         Occur highFreqOccur = highFreqOperator.toBooleanClauseOccur();
         Occur lowFreqOccur = lowFreqOperator.toBooleanClauseOccur();
 
         ExtendedCommonTermsQuery commonsQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, cutoffFrequency, disableCoord, fieldType);
         return parseQueryString(commonsQuery, text, field, analyzerObj, lowFreqMinimumShouldMatch, highFreqMinimumShouldMatch);
     }
-    
-    static Query parseQueryString(ExtendedCommonTermsQuery query, Object queryString, String field, Analyzer analyzer, 
+
+    static Query parseQueryString(ExtendedCommonTermsQuery query, Object queryString, String field, Analyzer analyzer,
                                          String lowFreqMinimumShouldMatch, String highFreqMinimumShouldMatch) throws IOException {
         // Logic similar to QueryParser#getFieldQuery
         int count = 0;

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryBuilder.java
@@ -72,13 +72,13 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        Query innerFilter = filterBuilder.toQuery(parseContext);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        Query innerFilter = filterBuilder.toQuery(generationContext);
         if (innerFilter == null ) {
             // return null so that parent queries (e.g. bool) also ignore this
             return null;
         }
-        return new ConstantScoreQuery(filterBuilder.toQuery(parseContext));
+        return new ConstantScoreQuery(filterBuilder.toQuery(generationContext));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryBuilder.java
@@ -96,9 +96,9 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         // return null if there are no queries at all
-        Collection<Query> luceneQueries = toQueries(queries, parseContext);
+        Collection<Query> luceneQueries = toQueries(queries, generationContext);
         if (luceneQueries.isEmpty()) {
             return null;
         }

--- a/core/src/main/java/org/elasticsearch/index/query/EmptyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/EmptyQueryBuilder.java
@@ -62,7 +62,7 @@ public class EmptyQueryBuilder extends ToXContentToBytes implements QueryBuilder
     }
 
     @Override
-    public Query toQuery(QueryParseContext parseContext) throws IOException {
+    public Query toQuery(QueryGenerationContext generationContext) throws IOException {
         // empty
         return null;
     }

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -63,8 +63,8 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        return newFilter(parseContext, name);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        return newFilter(generationContext, name);
     }
 
     @Override
@@ -74,19 +74,23 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     public static Query newFilter(QueryParseContext parseContext, String fieldPattern) {
-        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)parseContext.mapperService().fullName(FieldNamesFieldMapper.NAME);
+        return newFilter(new QueryGenerationContext(parseContext), fieldPattern);
+    }
+
+    public static Query newFilter(QueryGenerationContext context, String fieldPattern) {
+        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)context.mapperService().fullName(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType == null) {
             // can only happen when no types exist, so no docs exist either
             return Queries.newMatchNoDocsQuery();
         }
 
-        ObjectMapper objectMapper = parseContext.getObjectMapper(fieldPattern);
+        ObjectMapper objectMapper = context.getObjectMapper(fieldPattern);
         if (objectMapper != null) {
             // automatic make the object mapper pattern
             fieldPattern = fieldPattern + ".*";
         }
 
-        Collection<String> fields = parseContext.simpleMatchToIndexNames(fieldPattern);
+        Collection<String> fields = context.simpleMatchToIndexNames(fieldPattern);
         if (fields.isEmpty()) {
             // no fields exists, so we should not match anything
             return Queries.newMatchNoDocsQuery();
@@ -94,7 +98,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
 
         BooleanQuery boolFilter = new BooleanQuery();
         for (String field : fields) {
-            MappedFieldType fieldType = parseContext.fieldMapper(field);
+            MappedFieldType fieldType = context.fieldMapper(field);
             Query filter = null;
             if (fieldNamesFieldType.isEnabled()) {
                 final String f;
@@ -103,11 +107,11 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
                 } else {
                     f = field;
                 }
-                filter = fieldNamesFieldType.termQuery(f, parseContext);
+                filter = fieldNamesFieldType.termQuery(f, null);
             }
             // if _field_names are not indexed, we need to go the slow way
             if (filter == null && fieldType != null) {
-                filter = fieldType.rangeQuery(null, null, true, true, parseContext);
+                filter = fieldType.rangeQuery(null, null, true, true, null);
             }
             if (filter == null) {
                 filter = new TermRangeQuery(field, null, null, true, true);

--- a/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FQueryFilterBuilder.java
@@ -73,9 +73,9 @@ public class FQueryFilterBuilder extends AbstractQueryBuilder<FQueryFilterBuilde
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         // inner query builder can potentially be `null`, in that case we ignore it
-        Query innerQuery = this.queryBuilder.toQuery(parseContext);
+        Query innerQuery = this.queryBuilder.toQuery(generationContext);
         if (innerQuery == null) {
             return null;
         }

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -82,13 +82,13 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
     }
 
     @Override
-    protected SpanQuery doToQuery(QueryParseContext parseContext) throws IOException {
+    protected SpanQuery doToQuery(QueryGenerationContext generationContext) throws IOException {
         String fieldInQuery = fieldName;
-        MappedFieldType fieldType = parseContext.fieldMapper(fieldName);
+        MappedFieldType fieldType = generationContext.fieldMapper(fieldName);
         if (fieldType != null) {
             fieldInQuery = fieldType.names().indexName();
         }
-        Query innerQuery = queryBuilder.toQuery(parseContext);
+        Query innerQuery = queryBuilder.toQuery(generationContext);
         assert innerQuery instanceof SpanQuery;
         return new FieldMaskingSpanQuery((SpanQuery)innerQuery, fieldInQuery);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FilteredQueryBuilder.java
@@ -95,9 +95,9 @@ public class FilteredQueryBuilder extends AbstractQueryBuilder<FilteredQueryBuil
     }
 
     @Override
-    public Query doToQuery(QueryParseContext parseContext) throws QueryParsingException, IOException {
-        Query query = queryBuilder.toQuery(parseContext);
-        Query filter = filterBuilder.toQuery(parseContext);
+    public Query doToQuery(QueryGenerationContext generationContext) throws QueryParsingException, IOException {
+        Query query = queryBuilder.toQuery(generationContext);
+        Query filter = filterBuilder.toQuery(generationContext);
 
         if (query == null) {
             // Most likely this query was generated from the JSON query DSL - it parsed to an EmptyQueryBuilder so we ignore

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryParser.java
@@ -157,7 +157,7 @@ public class GeoShapeQueryParser extends BaseQueryParserTemp {
             // this strategy doesn't support disjoint anymore: but it did before, including creating lucene fieldcache (!)
             // in this case, execute disjoint as exists && !intersects
             BooleanQuery bool = new BooleanQuery();
-            Query exists = ExistsQueryBuilder.newFilter(parseContext, fieldName);
+            Query exists = ExistsQueryBuilder.newFilter(new QueryGenerationContext(parseContext), fieldName);
             Filter intersects = strategy.makeFilter(getArgs(shape, ShapeRelation.INTERSECTS));
             bool.add(exists, BooleanClause.Occur.MUST);
             bool.add(intersects, BooleanClause.Occur.MUST_NOT);

--- a/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -76,10 +76,10 @@ public class GeohashCellQuery {
         }
 
         if (geohashes == null || geohashes.size() == 0) {
-            return geoHashMapper.termQuery(geohash, context);
+            return geoHashMapper.termQuery(geohash, new QueryGenerationContext(context));
         } else {
             geohashes.add(geohash);
-            return geoHashMapper.termsQuery(geohashes, context);
+            return geoHashMapper.termsQuery(geohashes, new QueryGenerationContext(context));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -124,16 +124,16 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         Query query;
         if (this.ids.isEmpty()) {
              query = Queries.newMatchNoDocsQuery();
         } else {
             Collection<String> typesForQuery;
             if (types == null || types.length == 0) {
-                typesForQuery = parseContext.queryTypes();
+                typesForQuery = generationContext.queryTypes();
             } else if (types.length == 1 && MetaData.ALL.equals(types[0])) {
-                typesForQuery = parseContext.mapperService().types();
+                typesForQuery = generationContext.mapperService().types();
             } else {
                 typesForQuery = Sets.newHashSet(types);
             }

--- a/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/LimitQueryBuilder.java
@@ -51,7 +51,7 @@ public class LimitQueryBuilder extends AbstractQueryBuilder<LimitQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         // this filter is deprecated and parses to a filter that matches everything
         return Queries.newMatchAllQuery();
     }

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -44,7 +44,7 @@ public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         return Queries.newMatchAllQuery();
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryParser.java
@@ -68,7 +68,7 @@ public class MatchQueryParser extends BaseQueryParserTemp {
 
         Object value = null;
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
-        MatchQuery matchQuery = new MatchQuery(parseContext);
+        MatchQuery matchQuery = new MatchQuery(new QueryGenerationContext(parseContext));
         String minimumShouldMatch = null;
         String queryName = null;
 

--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -137,7 +137,7 @@ public class MissingQueryParser extends BaseQueryParserTemp {
                     } else {
                         f = field;
                     }
-                    filter = fieldNamesFieldType.termQuery(f, parseContext);
+                    filter = fieldNamesFieldType.termQuery(f, new QueryGenerationContext(parseContext));
                 }
                 // if _field_names are not indexed, we need to go the slow way
                 if (filter == null && fieldType != null) {

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -57,7 +57,7 @@ public class MultiMatchQueryParser extends BaseQueryParserTemp {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         Float tieBreaker = null;
         MultiMatchQueryBuilder.Type type = null;
-        MultiMatchQuery multiMatchQuery = new MultiMatchQuery(parseContext);
+        MultiMatchQuery multiMatchQuery = new MultiMatchQuery(new QueryGenerationContext(parseContext));
         String minimumShouldMatch = null;
         Map<String, Float> fieldNameWithBoosts = Maps.newHashMap();
         String queryName = null;

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
@@ -64,8 +64,8 @@ public class NotQueryBuilder extends AbstractQueryBuilder<NotQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        Query luceneQuery = filter.toQuery(parseContext);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        Query luceneQuery = filter.toQuery(generationContext);
         if (luceneQuery == null) {
             return null;
         }

--- a/core/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/OrQueryBuilder.java
@@ -81,7 +81,7 @@ public class OrQueryBuilder extends AbstractQueryBuilder<OrQueryBuilder> {
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         if (filters.isEmpty()) {
             // no filters provided, this should be ignored upstream
             return null;
@@ -89,7 +89,7 @@ public class OrQueryBuilder extends AbstractQueryBuilder<OrQueryBuilder> {
 
         BooleanQuery query = new BooleanQuery();
         for (QueryBuilder f : filters) {
-            Query innerQuery = f.toQuery(parseContext);
+            Query innerQuery = f.toQuery(generationContext);
             // ignore queries that are null
             if (innerQuery != null) {
                 query.add(innerQuery, Occur.SHOULD);

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import java.io.IOException;
 
 public interface QueryBuilder<QB extends QueryBuilder> extends NamedWriteable<QB>, ToXContent {
-    
+
     /**
      * Validate the query.
      * @return a {@link QueryValidationException} containing error messages, {@code null} if query is valid.
@@ -42,12 +42,12 @@ public interface QueryBuilder<QB extends QueryBuilder> extends NamedWriteable<QB
      * Returns <tt>null</tt> if this query should be ignored in the context of
      * parent queries.
      *
-     * @param parseContext additional information needed to construct the queries
+     * @param generationContext additional information needed to construct the queries
      * @return the {@link Query} or <tt>null</tt> if this query should be ignored upstream
      * @throws QueryParsingException
      * @throws IOException
      */
-    Query toQuery(QueryParseContext parseContext) throws IOException;
+    Query toQuery(QueryGenerationContext generationContext) throws IOException;
 
     /**
      * Returns a {@link org.elasticsearch.common.bytes.BytesReference}

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -81,9 +81,9 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         // inner query builder can potentially be `null`, in that case we ignore it
-        Query innerQuery = this.queryBuilder.toQuery(parseContext);
+        Query innerQuery = this.queryBuilder.toQuery(generationContext);
         if (innerQuery == null) {
             return null;
         }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryGenerationContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryGenerationContext.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.analysis.AnalysisService;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.object.ObjectMapper;
+
+import java.util.Collection;
+
+/**
+ * Wrapper around a {@link QueryParseContext} that can be later on fleshed out to only
+ * include methods and state that we need in the query generation phase
+ */
+public class QueryGenerationContext {
+
+    private final QueryParseContext parseContext;
+
+    public QueryGenerationContext(QueryParseContext parseContext) {
+        this.parseContext = parseContext;
+    }
+
+    public void addNamedQuery(String queryName, Query query) {
+        this.parseContext.addNamedQuery(queryName, query);
+    }
+
+    /**
+     * @return
+     */
+    //norelease temporary way of still accessing the wrapped parse context
+    public QueryParseContext getParseContext() {
+        return this.parseContext;
+    }
+
+    public IndexQueryParserService indexQueryParserService() {
+        return this.parseContext.indexQueryParserService();
+    }
+
+    public MapperService mapperService() {
+        return this.parseContext.mapperService();
+    }
+
+    public Analyzer getSearchAnalyzer(MappedFieldType fieldType) {
+        return this.parseContext.getSearchAnalyzer(fieldType);
+    }
+
+    public Collection<String> queryTypes() {
+        return this.parseContext.queryTypes();
+    }
+
+    public MappedFieldType fieldMapper(String fieldName) {
+        return this.parseContext.fieldMapper(fieldName);
+    }
+
+    public String defaultField() {
+        return this.parseContext.defaultField();
+    }
+
+    public AnalysisService analysisService() {
+        return this.parseContext.analysisService();
+    }
+
+    public ObjectMapper getObjectMapper(String fieldPattern) {
+        return this.parseContext.getObjectMapper(fieldPattern);
+    }
+
+    public Collection<String> simpleMatchToIndexNames(String fieldPattern) {
+        return this.parseContext.simpleMatchToIndexNames(fieldPattern);
+    }
+
+    public void setAllowUnmappedFields(boolean flag) {
+        this.parseContext.setAllowUnmappedFields(flag);
+    }
+
+    public Index index() {
+        return this.parseContext.index();
+    }
+
+    public ImmutableMap<String, Query> copyNamedQueries() {
+        return this.parseContext.copyNamedQueries();
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/query/QueryGenerationException.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryGenerationException.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class QueryGenerationException extends ElasticsearchException {
+
+    public QueryGenerationException(QueryGenerationContext context, String msg, Object... args) {
+        this(context, msg, null, args);
+    }
+
+    public QueryGenerationException(QueryGenerationContext context, String msg, Throwable cause, Object... args) {
+        super(msg, cause, args);
+        setIndex(context.index());
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    public QueryGenerationException(StreamInput in) throws IOException{
+        super(in);
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -265,7 +265,7 @@ public class QueryParseContext {
         QueryBuilder builder = parseInnerQueryBuilder();
         Query result = null;
         if (builder != null) {
-            result = builder.toQuery(this);
+            result = builder.toQuery(new QueryGenerationContext(this));
         }
         return result;
     }
@@ -279,7 +279,7 @@ public class QueryParseContext {
         QueryBuilder builder = parseInnerFilterToQueryBuilder();
         Query result = null;
         if (builder != null) {
-            result = builder.toQuery(this);
+            result = builder.toQuery(new QueryGenerationContext(this));
         }
         return result;
     }
@@ -321,7 +321,7 @@ public class QueryParseContext {
     @Deprecated
     public Query parseInnerFilter(String queryName) throws IOException, QueryParsingException {
         QueryBuilder builder = parseInnerFilterToQueryBuilder(queryName);
-        return (builder != null) ? builder.toQuery(this) : null;
+        return (builder != null) ? builder.toQuery(new QueryGenerationContext(this)) : null;
     }
 
     public Collection<String> simpleMatchToIndexNames(String pattern) {

--- a/core/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryWrappingQueryBuilder.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * QueryBuilder implementation that  holds a lucene query, which can be returned by {@link QueryBuilder#toQuery(QueryParseContext)}.
+ * QueryBuilder implementation that  holds a lucene query, which can be returned by {@link QueryBuilder#toQuery(QueryGenerationContext)}.
  * Doesn't support conversion to {@link org.elasticsearch.common.xcontent.XContent} via {@link #doXContent(XContentBuilder, Params)}.
  */
 //norelease to be removed once all queries support separate fromXContent and toQuery methods. Make AbstractQueryBuilder#toQuery final as well then.
@@ -47,7 +47,7 @@ public class QueryWrappingQueryBuilder extends AbstractQueryBuilder<QueryWrappin
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         return query;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -243,9 +243,9 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         Query query = null;
-        MappedFieldType mapper = parseContext.fieldMapper(this.fieldName);
+        MappedFieldType mapper = generationContext.fieldMapper(this.fieldName);
         if (mapper != null) {
             if (mapper instanceof DateFieldMapper.DateFieldType) {
                 DateMathParser forcedDateParser = null;
@@ -256,18 +256,18 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
                 if (this.timeZone != null) {
                     dateTimeZone = DateTimeZone.forID(this.timeZone);
                 }
-                query = ((DateFieldMapper.DateFieldType) mapper).rangeQuery(from, to, includeLower, includeUpper, dateTimeZone, forcedDateParser, parseContext);
+                query = ((DateFieldMapper.DateFieldType) mapper).rangeQuery(from, to, includeLower, includeUpper, dateTimeZone, forcedDateParser, null);
             } else  {
                 if (timeZone != null) {
-                    throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non date field ["
+                    throw new QueryGenerationException(generationContext, "[range] time_zone can not be applied to non date field ["
                             + fieldName + "]");
                 }
                 //LUCENE 4 UPGRADE Mapper#rangeQuery should use bytesref as well?
-                query = mapper.rangeQuery(from, to, includeLower, includeUpper, parseContext);
+                query = mapper.rangeQuery(from, to, includeLower, includeUpper, null);
             }
         } else {
             if (timeZone != null) {
-                throw new QueryParsingException(parseContext, "[range] time_zone can not be applied to non unmapped field ["
+                throw new QueryGenerationException(generationContext, "[range] time_zone can not be applied to non unmapped field ["
                         + fieldName + "]");
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -260,21 +260,21 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         // Use the default field (_all) if no fields specified
         if (fieldsAndWeights.isEmpty()) {
-            String field = parseContext.defaultField();
+            String field = generationContext.defaultField();
             fieldsAndWeights.put(field, 1.0F);
         }
 
         // Use standard analyzer by default if none specified
         Analyzer luceneAnalyzer;
         if (analyzer == null) {
-            luceneAnalyzer = parseContext.mapperService().searchAnalyzer();
+            luceneAnalyzer = generationContext.mapperService().searchAnalyzer();
         } else {
-            luceneAnalyzer = parseContext.analysisService().analyzer(analyzer);
+            luceneAnalyzer = generationContext.analysisService().analyzer(analyzer);
             if (luceneAnalyzer == null) {
-                throw new QueryParsingException(parseContext, "[" + SimpleQueryStringBuilder.NAME + "] analyzer [" + analyzer
+                throw new QueryGenerationException(generationContext, "[" + SimpleQueryStringBuilder.NAME + "] analyzer [" + analyzer
                         + "] not found");
             }
 

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -82,10 +82,10 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        Query innerBig = big.toQuery(parseContext);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        Query innerBig = big.toQuery(generationContext);
         assert innerBig instanceof SpanQuery;
-        Query innerLittle = little.toQuery(parseContext);
+        Query innerLittle = little.toQuery(generationContext);
         assert innerLittle instanceof SpanQuery;
         return new SpanContainingQuery((SpanQuery) innerBig, (SpanQuery) innerLittle);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -88,8 +88,8 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        Query innerSpanQuery = matchBuilder.toQuery(parseContext);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        Query innerSpanQuery = matchBuilder.toQuery(generationContext);
         assert innerSpanQuery instanceof SpanQuery;
         return new SpanFirstQuery((SpanQuery) innerSpanQuery, end);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -62,8 +62,8 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        Query subQuery = multiTermQueryBuilder.toQuery(parseContext);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        Query subQuery = multiTermQueryBuilder.toQuery(generationContext);
         if (subQuery instanceof MultiTermQuery == false) {
             throw new UnsupportedOperationException("unsupported inner query, should be " + MultiTermQuery.class.getName() +" but was "
                     + subQuery.getClass().getName());

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryBuilder.java
@@ -137,10 +137,10 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         SpanQuery[] spanQueries = new SpanQuery[clauses.size()];
         for (int i = 0; i < clauses.size(); i++) {
-            Query query = clauses.get(i).toQuery(parseContext);
+            Query query = clauses.get(i).toQuery(generationContext);
             assert query instanceof SpanQuery;
             spanQueries[i] = (SpanQuery) query;
         }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -136,11 +136,11 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
 
-        Query includeQuery = this.include.toQuery(parseContext);
+        Query includeQuery = this.include.toQuery(generationContext);
         assert includeQuery instanceof SpanQuery;
-        Query excludeQuery = this.exclude.toQuery(parseContext);
+        Query excludeQuery = this.exclude.toQuery(generationContext);
         assert excludeQuery instanceof SpanQuery;
 
         SpanNotQuery query = new SpanNotQuery((SpanQuery) includeQuery, (SpanQuery) excludeQuery, pre, post);

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -68,7 +68,7 @@ public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuil
     }
 
     @Override
-    public SpanQuery doToQuery(QueryParseContext context) throws IOException {
+    public SpanQuery doToQuery(QueryGenerationContext context) throws IOException {
         BytesRef valueBytes = null;
         String fieldName = this.fieldName;
         MappedFieldType mapper = context.fieldMapper(fieldName);

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -87,10 +87,10 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
     }
 
     @Override
-    protected Query doToQuery(QueryParseContext parseContext) throws IOException {
-        Query innerBig = big.toQuery(parseContext);
+    protected Query doToQuery(QueryGenerationContext generationContext) throws IOException {
+        Query innerBig = big.toQuery(generationContext);
         assert innerBig instanceof SpanQuery;
-        Query innerLittle = little.toQuery(parseContext);
+        Query innerLittle = little.toQuery(generationContext);
         assert innerLittle instanceof SpanQuery;
         return new SpanWithinQuery((SpanQuery) innerBig, (SpanQuery) innerLittle);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -71,11 +71,11 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
     }
 
     @Override
-    public Query doToQuery(QueryParseContext parseContext) throws IOException {
+    public Query doToQuery(QueryGenerationContext generationContext) throws IOException {
         Query query = null;
-        MappedFieldType mapper = parseContext.fieldMapper(this.fieldName);
+        MappedFieldType mapper = generationContext.fieldMapper(this.fieldName);
         if (mapper != null) {
-            query = mapper.termQuery(this.value, parseContext);
+            query = mapper.termQuery(this.value, generationContext);
         }
         if (query == null) {
             query = new TermQuery(new Term(this.fieldName, BytesRefs.toBytesRef(this.value)));

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -181,7 +181,7 @@ public class TermsQueryParser extends BaseQueryParserTemp {
         Query query;
         if (parseContext.isFilter()) {
             if (fieldType != null) {
-                query = fieldType.termsQuery(terms, parseContext);
+                query = fieldType.termsQuery(terms, new QueryGenerationContext(parseContext));
             } else {
                 BytesRef[] filterValues = new BytesRef[terms.size()];
                 for (int i = 0; i < filterValues.length; i++) {
@@ -193,7 +193,7 @@ public class TermsQueryParser extends BaseQueryParserTemp {
             BooleanQuery bq = new BooleanQuery();
             for (Object term : terms) {
                 if (fieldType != null) {
-                    bq.add(fieldType.termQuery(term, parseContext), Occur.SHOULD);
+                    bq.add(fieldType.termQuery(term, new QueryGenerationContext(parseContext)), Occur.SHOULD);
                 } else {
                     bq.add(new TermQuery(new Term(fieldName, BytesRefs.toBytesRef(term))), Occur.SHOULD);
                 }

--- a/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -29,10 +29,9 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryGenerationContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,10 +47,10 @@ public class MultiMatchQuery extends MatchQuery {
         this.groupTieBreaker = tieBreaker;
     }
 
-    public MultiMatchQuery(QueryParseContext parseContext) {
-        super(parseContext);
+    public MultiMatchQuery(QueryGenerationContext context) {
+        super(context);
     }
-    
+
     private Query parseAndApply(Type type, String fieldName, Object value, String minimumShouldMatch, Float boostValue) throws IOException {
         Query query = parse(type, fieldName, value);
         if (query instanceof BooleanQuery) {
@@ -163,7 +162,7 @@ public class MultiMatchQuery extends MatchQuery {
             List<Tuple<String, Float>> missing = new ArrayList<>();
             for (Map.Entry<String, Float> entry : fieldNames.entrySet()) {
                 String name = entry.getKey();
-                MappedFieldType fieldType = parseContext.fieldMapper(name);
+                MappedFieldType fieldType = context.fieldMapper(name);
                 if (fieldType != null) {
                     Analyzer actualAnalyzer = getAnalyzer(fieldType);
                     name = fieldType.names().indexName();

--- a/core/src/test/java/org/elasticsearch/index/query/AndQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AndQueryBuilderTest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 public class AndQueryBuilderTest extends BaseQueryTestCase<AndQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(AndQueryBuilder queryBuilder, QueryParseContext context) throws QueryParsingException, IOException {
+    protected Query doCreateExpectedQuery(AndQueryBuilder queryBuilder, QueryGenerationContext context) throws QueryParsingException, IOException {
         if (queryBuilder.filters().isEmpty()) {
             return null;
         }
@@ -68,7 +68,7 @@ public class AndQueryBuilderTest extends BaseQueryTestCase<AndQueryBuilder> {
     @Test
     public void testNoInnerQueries() throws QueryParsingException, IOException {
         AndQueryBuilder andQuery = new AndQueryBuilder();
-        assertNull(andQuery.toQuery(createContext()));
+        assertNull(andQuery.toQuery(createGenerationContext()));
     }
 
     @Test(expected=QueryParsingException.class)

--- a/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BaseQueryTestCase.java
@@ -240,7 +240,7 @@ public abstract class BaseQueryTestCase<QB extends AbstractQueryBuilder<QB>> ext
     @Test
     public void testToQuery() throws IOException {
         QB testQuery = createTestQueryBuilder();
-        QueryParseContext context = createContext();
+        QueryGenerationContext context = new QueryGenerationContext(createContext());
         context.setAllowUnmappedFields(true);
 
         Query expectedQuery = createExpectedQuery(testQuery, context);
@@ -256,7 +256,7 @@ public abstract class BaseQueryTestCase<QB extends AbstractQueryBuilder<QB>> ext
         }
     }
 
-    protected final Query createExpectedQuery(QB queryBuilder, QueryParseContext context) throws IOException {
+    protected final Query createExpectedQuery(QB queryBuilder, QueryGenerationContext context) throws IOException {
         Query expectedQuery = doCreateExpectedQuery(queryBuilder, context);
         if (expectedQuery != null) {
             expectedQuery.setBoost(queryBuilder.boost());
@@ -266,15 +266,15 @@ public abstract class BaseQueryTestCase<QB extends AbstractQueryBuilder<QB>> ext
 
     /**
      * Creates the expected lucene query given the current {@link QueryBuilder} and {@link QueryParseContext}.
-     * The returned query will be compared with the result of {@link QueryBuilder#toQuery(QueryParseContext)} to test its behaviour.
+     * The returned query will be compared with the result of {@link QueryBuilder#toQuery(QueryGenerationContext)} to test its behaviour.
      */
-    protected abstract Query doCreateExpectedQuery(QB queryBuilder, QueryParseContext context) throws IOException;
+    protected abstract Query doCreateExpectedQuery(QB queryBuilder, QueryGenerationContext context) throws IOException;
 
     /**
-     * Run after default equality comparison between lucene expected query and result of {@link QueryBuilder#toQuery(QueryParseContext)}.
+     * Run after default equality comparison between lucene expected query and result of {@link QueryBuilder#toQuery(QueryGenerationContext)}.
      * Can contain additional assertions that are query specific. Default implementation verifies that names queries are properly handled.
      */
-    protected final void assertLuceneQuery(QB queryBuilder, Query query, QueryParseContext context) {
+    protected final void assertLuceneQuery(QB queryBuilder, Query query, QueryGenerationContext context) {
         if (queryBuilder.queryName() != null) {
             Query namedQuery = context.copyNamedQueries().get(queryBuilder.queryName());
             assertThat(namedQuery, equalTo(query));
@@ -304,6 +304,13 @@ public abstract class BaseQueryTestCase<QB extends AbstractQueryBuilder<QB>> ext
      */
     protected static QueryParseContext createContext() {
         return new QueryParseContext(index, queryParserService);
+    }
+
+    /**
+     * @return a new {@link QueryGenerationContext} based on the base test index and queryParserService
+     */
+    protected static QueryGenerationContext createGenerationContext() {
+        return new QueryGenerationContext(new QueryParseContext(index, queryParserService));
     }
 
     protected static void assertQueryHeader(XContentParser parser, String expectedParserName) throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BaseTermQueryTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>>
     }
 
     @Override
-    protected Query doCreateExpectedQuery(QB queryBuilder, QueryParseContext context) {
+    protected Query doCreateExpectedQuery(QB queryBuilder, QueryGenerationContext context) {
         BytesRef value = null;
         if (getCurrentTypes().length > 0) {
             if (queryBuilder.fieldName().equals(BOOLEAN_FIELD_NAME) || queryBuilder.fieldName().equals(INT_FIELD_NAME) || queryBuilder.fieldName().equals(DOUBLE_FIELD_NAME)) {

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTest.java
@@ -66,7 +66,7 @@ public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
     }
 
     @Override
-    protected Query doCreateExpectedQuery(BoolQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(BoolQueryBuilder queryBuilder, QueryGenerationContext context) throws IOException {
         if (!queryBuilder.hasClauses()) {
             return new MatchAllDocsQuery();
         }
@@ -84,10 +84,10 @@ public class BoolQueryBuilderTest extends BaseQueryTestCase<BoolQueryBuilder> {
         return queryBuilder.adjustPureNegative() ? fixNegativeQueryIfNeeded(boolQuery) : boolQuery;
     }
 
-    private static void addBooleanClauses(QueryParseContext parseContext, BooleanQuery booleanQuery, List<QueryBuilder> clauses, Occur occurs)
+    private static void addBooleanClauses(QueryGenerationContext context, BooleanQuery booleanQuery, List<QueryBuilder> clauses, Occur occurs)
             throws IOException {
         for (QueryBuilder query : clauses) {
-            Query innerQuery = query.toQuery(parseContext);
+            Query innerQuery = query.toQuery(context);
             if (innerQuery != null) {
                 booleanQuery.add(new BooleanClause(innerQuery, occurs));
             }

--- a/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTest.java
@@ -35,7 +35,7 @@ public class BoostingQueryBuilderTest extends BaseQueryTestCase<BoostingQueryBui
     }
 
     @Override
-    protected Query doCreateExpectedQuery(BoostingQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(BoostingQueryBuilder queryBuilder, QueryGenerationContext context) throws IOException {
         Query positive = queryBuilder.positive().toQuery(context);
         Query negative = queryBuilder.negative().toQuery(context);
         if (positive == null || negative == null) {

--- a/core/src/test/java/org/elasticsearch/index/query/CommonTermsQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/CommonTermsQueryBuilderTest.java
@@ -35,7 +35,7 @@ public class CommonTermsQueryBuilderTest extends BaseQueryTestCase<CommonTermsQu
     @Override
     protected CommonTermsQueryBuilder doCreateTestQueryBuilder() {
         CommonTermsQueryBuilder query;
-        
+
         // mapped or unmapped field
         String text = randomAsciiOfLengthBetween(1, 10);
         if (randomBoolean()) {
@@ -43,7 +43,7 @@ public class CommonTermsQueryBuilderTest extends BaseQueryTestCase<CommonTermsQu
         } else {
             query = new CommonTermsQueryBuilder(randomAsciiOfLengthBetween(1, 10), text);
         }
-        
+
         if (randomBoolean()) {
             query.cutoffFrequency((float) randomIntBetween(1, 10));
         }
@@ -51,7 +51,7 @@ public class CommonTermsQueryBuilderTest extends BaseQueryTestCase<CommonTermsQu
         if (randomBoolean()) {
             query.lowFreqOperator(randomFrom(Operator.values()));
         }
-            
+
         // number of low frequency terms that must match
         if (randomBoolean()) {
             query.lowFreqMinimumShouldMatch("" + randomIntBetween(1, 5));
@@ -65,11 +65,11 @@ public class CommonTermsQueryBuilderTest extends BaseQueryTestCase<CommonTermsQu
         if (randomBoolean()) {
             query.highFreqMinimumShouldMatch("" + randomIntBetween(1, 5));
         }
-        
+
         if (randomBoolean()) {
             query.analyzer(randomFrom("simple", "keyword", "whitespace"));
         }
-        
+
         if (randomBoolean()) {
             query.disableCoord(randomBoolean());
         }
@@ -77,7 +77,7 @@ public class CommonTermsQueryBuilderTest extends BaseQueryTestCase<CommonTermsQu
     }
 
     @Override
-    protected Query doCreateExpectedQuery(CommonTermsQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(CommonTermsQueryBuilder queryBuilder, QueryGenerationContext context) throws IOException {
         String fieldName = queryBuilder.fieldName();
         Analyzer analyzer = context.mapperService().searchAnalyzer();
 
@@ -92,13 +92,13 @@ public class CommonTermsQueryBuilderTest extends BaseQueryTestCase<CommonTermsQu
         if (queryBuilder.analyzer() != null) {
             analyzer = context.analysisService().analyzer(queryBuilder.analyzer());
         }
-        
+
         Occur highFreqOccur = queryBuilder.highFreqOperator().toBooleanClauseOccur();
         Occur lowFreqOccur = queryBuilder.lowFreqOperator().toBooleanClauseOccur();
 
-        ExtendedCommonTermsQuery expectedQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, queryBuilder.cutoffFrequency(), 
+        ExtendedCommonTermsQuery expectedQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, queryBuilder.cutoffFrequency(),
                 queryBuilder.disableCoord(), fieldType);
-        CommonTermsQueryBuilder.parseQueryString(expectedQuery, queryBuilder.text(), fieldName, analyzer, 
+        CommonTermsQueryBuilder.parseQueryString(expectedQuery, queryBuilder.text(), fieldName, analyzer,
                 queryBuilder.lowFreqMinimumShouldMatch(), queryBuilder.highFreqMinimumShouldMatch());
         return expectedQuery;
     }
@@ -118,7 +118,7 @@ public class CommonTermsQueryBuilderTest extends BaseQueryTestCase<CommonTermsQu
     @Test
     public void testNoTermsFromQueryString() throws IOException {
         CommonTermsQueryBuilder builder = new CommonTermsQueryBuilder(STRING_FIELD_NAME, "");
-        QueryParseContext context = createContext();
+        QueryGenerationContext context = createGenerationContext();
         context.setAllowUnmappedFields(true);
         assertNull(builder.toQuery(context));
     }

--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 public class ConstantScoreQueryBuilderTest extends BaseQueryTestCase<ConstantScoreQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(ConstantScoreQueryBuilder testBuilder, QueryParseContext context) throws QueryParsingException, IOException {
+    protected Query doCreateExpectedQuery(ConstantScoreQueryBuilder testBuilder, QueryGenerationContext context) throws QueryParsingException, IOException {
         Query innerQuery = testBuilder.query().toQuery(context);
         if (innerQuery != null) {
             return new ConstantScoreQuery(innerQuery);

--- a/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTest.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 public class DisMaxQueryBuilderTest extends BaseQueryTestCase<DisMaxQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(DisMaxQueryBuilder testBuilder, QueryParseContext context) throws QueryParsingException, IOException {
+    protected Query doCreateExpectedQuery(DisMaxQueryBuilder testBuilder, QueryGenerationContext context) throws QueryParsingException, IOException {
         Collection<Query> queries = AbstractQueryBuilder.toQueries(testBuilder.queries(), context);
         if (queries.isEmpty()) {
             return null;
@@ -63,7 +63,7 @@ public class DisMaxQueryBuilderTest extends BaseQueryTestCase<DisMaxQueryBuilder
     @Test
     public void testNoInnerQueries() throws QueryParsingException, IOException {
         DisMaxQueryBuilder disMaxBuilder = new DisMaxQueryBuilder();
-        assertNull(disMaxBuilder.toQuery(createContext()));
+        assertNull(disMaxBuilder.toQuery(createGenerationContext()));
         assertNull(disMaxBuilder.validate());
     }
 
@@ -84,7 +84,7 @@ public class DisMaxQueryBuilderTest extends BaseQueryTestCase<DisMaxQueryBuilder
                 .queryParser(queryId).fromXContent(context);
 
         DisMaxQueryBuilder disMaxBuilder = new DisMaxQueryBuilder().add(innerQueryBuilder);
-        assertNull(disMaxBuilder.toQuery(context));
+        assertNull(disMaxBuilder.toQuery(new QueryGenerationContext(context)));
     }
 
     @Test(expected=NullPointerException.class)

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTest.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 
 public class ExistsQueryBuilderTest extends BaseQueryTestCase<ExistsQueryBuilder> {
 
-    private static Collection<String> getFieldNamePattern(String fieldName, QueryParseContext context) {
+    private static Collection<String> getFieldNamePattern(String fieldName, QueryGenerationContext context) {
         if (getCurrentTypes().length > 0 && fieldName.equals(BaseQueryTestCase.OBJECT_FIELD_NAME)) {
             // "object" field has two inner fields (age, price), so if query hits that field, we
             // extend field name with wildcard to match both nested fields. This is similar to what
@@ -41,7 +41,7 @@ public class ExistsQueryBuilderTest extends BaseQueryTestCase<ExistsQueryBuilder
     }
 
     @Override
-    protected Query doCreateExpectedQuery(ExistsQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(ExistsQueryBuilder queryBuilder, QueryGenerationContext context) throws IOException {
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType)context.mapperService().fullName(FieldNamesFieldMapper.NAME);
         Collection<String> fields = getFieldNamePattern(queryBuilder.name(), context);
 
@@ -52,13 +52,13 @@ public class ExistsQueryBuilderTest extends BaseQueryTestCase<ExistsQueryBuilder
         BooleanQuery boolFilter = new BooleanQuery();
         for (String field : fields) {
             if (fieldNamesFieldType.isEnabled()) {
-                boolFilter.add(fieldNamesFieldType.termQuery(field, context), BooleanClause.Occur.SHOULD);
+                boolFilter.add(fieldNamesFieldType.termQuery(field, null), BooleanClause.Occur.SHOULD);
             } else {
                 MappedFieldType fieldType = context.fieldMapper(field);
                 if (fieldType == null) {
                     boolFilter.add(new TermRangeQuery(field, null, null, true, true), BooleanClause.Occur.SHOULD);
                 } else {
-                    boolFilter.add(fieldType.rangeQuery(null, null, true, true, context), BooleanClause.Occur.SHOULD);
+                    boolFilter.add(fieldType.rangeQuery(null, null, true, true, null), BooleanClause.Occur.SHOULD);
                 }
             }
         }

--- a/core/src/test/java/org/elasticsearch/index/query/FQueryFilterBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FQueryFilterBuilderTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class FQueryFilterBuilderTest extends BaseQueryTestCase<FQueryFilterBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(FQueryFilterBuilder queryBuilder, QueryParseContext context) throws QueryParsingException, IOException {
+    protected Query doCreateExpectedQuery(FQueryFilterBuilder queryBuilder, QueryGenerationContext context) throws QueryParsingException, IOException {
         Query query = queryBuilder.innerQuery().toQuery(context);
         if (query != null) {
             return new ConstantScoreQuery(query);
@@ -54,7 +54,7 @@ public class FQueryFilterBuilderTest extends BaseQueryTestCase<FQueryFilterBuild
     @Test
     public void testNoInnerQuery() throws QueryParsingException, IOException {
         FQueryFilterBuilder queryFilterQuery = new FQueryFilterBuilder(EmptyQueryBuilder.PROTOTYPE);
-        assertNull(queryFilterQuery.toQuery(createContext()));
+        assertNull(queryFilterQuery.toQuery(createGenerationContext()));
     }
 
     /**
@@ -73,7 +73,7 @@ public class FQueryFilterBuilderTest extends BaseQueryTestCase<FQueryFilterBuild
 
         // check that when wrapping this filter, toQuery() returns null
         FQueryFilterBuilder queryFilterQuery = new FQueryFilterBuilder(innerQuery);
-        assertNull(queryFilterQuery.toQuery(createContext()));
+        assertNull(queryFilterQuery.toQuery(createGenerationContext()));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 public class FieldMaskingSpanQueryBuilderTest extends BaseQueryTestCase<FieldMaskingSpanQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(FieldMaskingSpanQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(FieldMaskingSpanQueryBuilder testQueryBuilder, QueryGenerationContext context) throws IOException {
         String fieldInQuery = testQueryBuilder.fieldName();
         MappedFieldType fieldType = context.fieldMapper(fieldInQuery);
         if (fieldType != null) {

--- a/core/src/test/java/org/elasticsearch/index/query/FilteredQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FilteredQueryBuilderTest.java
@@ -39,7 +39,7 @@ public class FilteredQueryBuilderTest extends BaseQueryTestCase<FilteredQueryBui
     }
 
     @Override
-    protected Query doCreateExpectedQuery(FilteredQueryBuilder qb, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(FilteredQueryBuilder qb, QueryGenerationContext context) throws IOException {
         Query query = qb.query().toQuery(context);
         Query filter = qb.filter().toQuery(context);
 

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTest.java
@@ -51,7 +51,7 @@ public class IdsQueryBuilderTest extends BaseQueryTestCase<IdsQueryBuilder> {
     }
 
     @Override
-    protected Query doCreateExpectedQuery(IdsQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(IdsQueryBuilder queryBuilder, QueryGenerationContext context) throws IOException {
         Query expectedQuery;
         if (queryBuilder.ids().size() == 0) {
             expectedQuery = Queries.newMatchNoDocsQuery();

--- a/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTest.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 public class LimitQueryBuilderTest extends BaseQueryTestCase<LimitQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(LimitQueryBuilder queryBuilder, QueryParseContext context) {
+    protected Query doCreateExpectedQuery(LimitQueryBuilder queryBuilder, QueryGenerationContext context) {
         // this filter is deprecated and parses to a filter that matches everything
         return Queries.newMatchAllQuery();
     }

--- a/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTest.java
@@ -25,7 +25,7 @@ import org.apache.lucene.search.Query;
 public class MatchAllQueryBuilderTest extends BaseQueryTestCase<MatchAllQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(MatchAllQueryBuilder queryBuilder, QueryParseContext context) {
+    protected Query doCreateExpectedQuery(MatchAllQueryBuilder queryBuilder, QueryGenerationContext context) {
         return new MatchAllDocsQuery();
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 public class NotQueryBuilderTest extends BaseQueryTestCase<NotQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(NotQueryBuilder queryBuilder, QueryParseContext context) throws QueryParsingException, IOException {
+    protected Query doCreateExpectedQuery(NotQueryBuilder queryBuilder, QueryGenerationContext context) throws QueryParsingException, IOException {
         if (queryBuilder.filter().toQuery(context) == null) {
             return null;
         }

--- a/core/src/test/java/org/elasticsearch/index/query/OrQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/OrQueryBuilderTest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 public class OrQueryBuilderTest extends BaseQueryTestCase<OrQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(OrQueryBuilder queryBuilder, QueryParseContext context) throws QueryParsingException, IOException {
+    protected Query doCreateExpectedQuery(OrQueryBuilder queryBuilder, QueryGenerationContext context) throws QueryParsingException, IOException {
         if (queryBuilder.filters().isEmpty()) {
             return null;
         }
@@ -69,7 +69,7 @@ public class OrQueryBuilderTest extends BaseQueryTestCase<OrQueryBuilder> {
     @Test
     public void testNoInnerQueries() throws QueryParsingException, IOException {
         OrQueryBuilder orQuery = new OrQueryBuilder();
-        assertNull(orQuery.toQuery(createContext()));
+        assertNull(orQuery.toQuery(createGenerationContext()));
     }
 
     @Test(expected=QueryParsingException.class)

--- a/core/src/test/java/org/elasticsearch/index/query/QueryFilterBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryFilterBuilderTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public class QueryFilterBuilderTest extends BaseQueryTestCase<QueryFilterBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(QueryFilterBuilder queryBuilder, QueryParseContext context) throws QueryParsingException, IOException {
+    protected Query doCreateExpectedQuery(QueryFilterBuilder queryBuilder, QueryGenerationContext context) throws QueryParsingException, IOException {
         Query query = queryBuilder.innerQuery().toQuery(context);
         return query != null ? new ConstantScoreQuery(query) : query;
     }

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTest.java
@@ -93,7 +93,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
     }
 
     @Override
-    protected Query doCreateExpectedQuery(RangeQueryBuilder queryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(RangeQueryBuilder queryBuilder, QueryGenerationContext context) throws IOException {
         Query expectedQuery;
         String fieldName = queryBuilder.fieldName();
         if (getCurrentTypes().length == 0 || (fieldName.equals(DATE_FIELD_NAME) == false && fieldName.equals(INT_FIELD_NAME) == false)) {
@@ -111,7 +111,7 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
             }
             MappedFieldType mapper = context.fieldMapper(queryBuilder.fieldName());
             expectedQuery = ((DateFieldMapper.DateFieldType) mapper).rangeQuery(BytesRefs.toBytesRef(queryBuilder.from()), BytesRefs.toBytesRef(queryBuilder.to()),
-                    queryBuilder.includeLower(), queryBuilder.includeUpper(), dateTimeZone, forcedDateParser, context);
+                    queryBuilder.includeLower(), queryBuilder.includeUpper(), dateTimeZone, forcedDateParser, null);
         } else if (queryBuilder.fieldName().equals(INT_FIELD_NAME)) {
             expectedQuery = NumericRangeQuery.newIntRange(INT_FIELD_NAME, (Integer) queryBuilder.from(), (Integer) queryBuilder.to(),
                     queryBuilder.includeLower(), queryBuilder.includeUpper());
@@ -145,20 +145,20 @@ public class RangeQueryBuilderTest extends BaseQueryTestCase<RangeQueryBuilder> 
     /**
      * Specifying a timezone together with a numeric range query should throw an exception.
      */
-    @Test(expected=QueryParsingException.class)
+    @Test(expected=QueryGenerationException.class)
     public void testToQueryNonDateWithTimezone() throws QueryParsingException, IOException {
         RangeQueryBuilder query = new RangeQueryBuilder(INT_FIELD_NAME);
         query.from(1).to(10).timeZone("UTC");
-        query.toQuery(createContext());
+        query.toQuery(createGenerationContext());
     }
 
     /**
      * Specifying a timezone together with an unmapped field should throw an exception.
      */
-    @Test(expected=QueryParsingException.class)
+    @Test(expected=QueryGenerationException.class)
     public void testToQueryUnmappedWithTimezone() throws QueryParsingException, IOException {
         RangeQueryBuilder query = new RangeQueryBuilder("bogus_field");
         query.from(1).to(10).timeZone("UTC");
-        query.toQuery(createContext());
+        query.toQuery(createGenerationContext());
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTest.java
@@ -152,15 +152,15 @@ public class SimpleQueryStringBuilderTest extends BaseQueryTestCase<SimpleQueryS
     @Test
     public void testDefaultOperatorHandling() throws IOException {
         SimpleQueryStringBuilder qb = new SimpleQueryStringBuilder("The quick brown fox.");
-        BooleanQuery boolQuery = (BooleanQuery) qb.toQuery(createContext());
+        BooleanQuery boolQuery = (BooleanQuery) qb.toQuery(createGenerationContext());
         assertThat(shouldClauses(boolQuery), is(4));
 
         qb.defaultOperator(Operator.AND);
-        boolQuery = (BooleanQuery) qb.toQuery(createContext());
+        boolQuery = (BooleanQuery) qb.toQuery(createGenerationContext());
         assertThat(shouldClauses(boolQuery), is(0));
 
         qb.defaultOperator(Operator.OR);
-        boolQuery = (BooleanQuery) qb.toQuery(createContext());
+        boolQuery = (BooleanQuery) qb.toQuery(createGenerationContext());
         assertThat(shouldClauses(boolQuery), is(4));
     }
 
@@ -183,7 +183,7 @@ public class SimpleQueryStringBuilderTest extends BaseQueryTestCase<SimpleQueryS
         qb.analyzer(null);
         qb.minimumShouldMatch(null);
         qb.queryName(null);
-        assertEquals(qb.toQuery(createContext()), createExpectedQuery(qb, createContext()));
+        assertEquals(qb.toQuery(createGenerationContext()), createExpectedQuery(qb, createGenerationContext()));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -231,7 +231,7 @@ public class SimpleQueryStringBuilderTest extends BaseQueryTestCase<SimpleQueryS
     }
 
     @Override
-    protected Query doCreateExpectedQuery(SimpleQueryStringBuilder queryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(SimpleQueryStringBuilder queryBuilder, QueryGenerationContext context) throws IOException {
         Map<String, Float> fields = new TreeMap<>();
         // Use the default field (_all) if no fields specified
         if (queryBuilder.fields().isEmpty()) {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public class SpanContainingQueryBuilderTest extends BaseQueryTestCase<SpanContainingQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(SpanContainingQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(SpanContainingQueryBuilder testQueryBuilder, QueryGenerationContext context) throws IOException {
         SpanQuery big = (SpanQuery) testQueryBuilder.big().toQuery(context);
         SpanQuery little = (SpanQuery) testQueryBuilder.little().toQuery(context);
         return new SpanContainingQuery(big, little);

--- a/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public class SpanFirstQueryBuilderTest extends BaseQueryTestCase<SpanFirstQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(SpanFirstQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(SpanFirstQueryBuilder testQueryBuilder, QueryGenerationContext context) throws IOException {
         SpanQuery innerQuery = (SpanQuery) testQueryBuilder.matchBuilder().toQuery(context);
         return new SpanFirstQuery(innerQuery, testQueryBuilder.end());
     }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public class SpanMultiTermQueryBuilderTest extends BaseQueryTestCase<SpanMultiTermQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(SpanMultiTermQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(SpanMultiTermQueryBuilder testQueryBuilder, QueryGenerationContext context) throws IOException {
         Query multiTermQuery = testQueryBuilder.multiTermQueryBuilder().toQuery(context);
         return new SpanMultiTermQueryWrapper<>((MultiTermQuery) multiTermQuery);
     }
@@ -72,7 +72,7 @@ public class SpanMultiTermQueryBuilderTest extends BaseQueryTestCase<SpanMultiTe
         if (getCurrentTypes().length > 0 && parseContext.fieldMapper(DATE_FIELD_NAME) != null) {
             try {
                 RangeQueryBuilder query = new RangeQueryBuilder(DATE_FIELD_NAME);
-                new SpanMultiTermQueryBuilder(query).toQuery(createContext());
+                new SpanMultiTermQueryBuilder(query).toQuery(createGenerationContext());
                 fail("Exception expected, range query on date fields should not generate a lucene " + MultiTermQuery.class.getName());
             } catch (UnsupportedOperationException e) {
                 assert(e.getMessage().contains("unsupported inner query, should be " + MultiTermQuery.class.getName()));

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class SpanNearQueryBuilderTest extends BaseQueryTestCase<SpanNearQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(SpanNearQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(SpanNearQueryBuilder testQueryBuilder, QueryGenerationContext context) throws IOException {
         List<SpanQueryBuilder> clauses = testQueryBuilder.clauses();
         SpanQuery[] spanQueries = new SpanQuery[clauses.size()];
         for (int i = 0; i < clauses.size(); i++) {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class SpanNotQueryBuilderTest extends BaseQueryTestCase<SpanNotQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(SpanNotQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(SpanNotQueryBuilder testQueryBuilder, QueryGenerationContext context) throws IOException {
         SpanQuery include = (SpanQuery) testQueryBuilder.include().toQuery(context);
         SpanQuery exclude = (SpanQuery) testQueryBuilder.exclude().toQuery(context);
         return new SpanNotQuery(include, exclude, testQueryBuilder.pre(), testQueryBuilder.post());

--- a/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public class SpanWithinQueryBuilderTest extends BaseQueryTestCase<SpanWithinQueryBuilder> {
 
     @Override
-    protected Query doCreateExpectedQuery(SpanWithinQueryBuilder testQueryBuilder, QueryParseContext context) throws IOException {
+    protected Query doCreateExpectedQuery(SpanWithinQueryBuilder testQueryBuilder, QueryGenerationContext context) throws IOException {
         SpanQuery big = (SpanQuery) testQueryBuilder.big().toQuery(context);
         SpanQuery little = (SpanQuery) testQueryBuilder.little().toQuery(context);
         return new SpanWithinQuery(big, little);


### PR DESCRIPTION
The parse() method we are currently splitting into a query parsing part (fromXContent()) and a lucene query generating part (toQuery()) in the feature refactoring branch (#10217) takes `QueryParseContext` as an argument. At some point we need to excute these two steps in different phases on the coordinating node and the shards. This protoype PR tries to anticipate this by introducing a new QueryGenerationContext object as the argument of the query-generating methods (toQuery() and all dependent methods). As a first stept this new context simply wraps the old context object and delegated all calls made to it to the inner object. In subsequent steps we can then try to separate the different behaviour needed in the two context objects. 

PR goes against query refactoring branch.
