### PR TITLE
Remove unused methods hitsExecutionNeeded and hitsExecute from FetchSubPhase

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -192,12 +192,6 @@ public class FetchPhase implements SearchPhase {
             }
         }
 
-        for (FetchSubPhase fetchSubPhase : fetchSubPhases) {
-            if (fetchSubPhase.hitsExecutionNeeded(context)) {
-                fetchSubPhase.hitsExecute(context, hits);
-            }
-        }
-
         context.fetchResult().hits(new InternalSearchHits(hits, context.queryResult().topDocs().totalHits, context.queryResult().topDocs().getMaxScore()));
     }
 

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -110,8 +110,4 @@ public interface FetchSubPhase {
      * Executes the hit level phase, with a reader and doc id (note, its a low level reader, and the matching doc).
      */
     void hitExecute(SearchContext context, HitContext hitContext);
-
-    boolean hitsExecutionNeeded(SearchContext context);
-
-    void hitsExecute(SearchContext context, InternalSearchHit[] hits);
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/explain/ExplainFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/explain/ExplainFetchSubPhase.java
@@ -42,15 +42,6 @@ public class ExplainFetchSubPhase implements FetchSubPhase {
     }
 
     @Override
-    public boolean hitsExecutionNeeded(SearchContext context) {
-        return false;
-    }
-
-    @Override
-    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
-    }
-
-    @Override
     public boolean hitExecutionNeeded(SearchContext context) {
         return context.explain();
     }

--- a/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/fielddata/FieldDataFieldsFetchSubPhase.java
@@ -56,15 +56,6 @@ public class FieldDataFieldsFetchSubPhase implements FetchSubPhase {
     }
 
     @Override
-    public boolean hitsExecutionNeeded(SearchContext context) {
-        return false;
-    }
-
-    @Override
-    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
-    }
-
-    @Override
     public boolean hitExecutionNeeded(SearchContext context) {
         return context.hasFieldDataFields();
     }

--- a/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsFetchSubPhase.java
@@ -111,15 +111,6 @@ public class InnerHitsFetchSubPhase implements FetchSubPhase {
         hitContext.hit().setInnerHits(results);
     }
 
-    @Override
-    public boolean hitsExecutionNeeded(SearchContext context) {
-        return false;
-    }
-
-    @Override
-    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
-    }
-
     // To get around cyclic dependency issue
     public void setFetchPhase(FetchPhase fetchPhase) {
         this.fetchPhase = fetchPhase;

--- a/core/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
@@ -47,15 +47,6 @@ public class MatchedQueriesFetchSubPhase implements FetchSubPhase {
     }
 
     @Override
-    public boolean hitsExecutionNeeded(SearchContext context) {
-        return false;
-    }
-
-    @Override
-    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
-    }
-
-    @Override
     public boolean hitExecutionNeeded(SearchContext context) {
         return !context.parsedQuery().namedFilters().isEmpty()
                 || (context.parsedPostFilter() !=null && !context.parsedPostFilter().namedFilters().isEmpty());

--- a/core/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsFetchSubPhase.java
@@ -56,15 +56,6 @@ public class ScriptFieldsFetchSubPhase implements FetchSubPhase {
     }
 
     @Override
-    public boolean hitsExecutionNeeded(SearchContext context) {
-        return false;
-    }
-
-    @Override
-    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
-    }
-
-    @Override
     public boolean hitExecutionNeeded(SearchContext context) {
         return context.hasScriptFields();
     }

--- a/core/src/main/java/org/elasticsearch/search/fetch/source/FetchSourceSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/source/FetchSourceSubPhase.java
@@ -51,15 +51,6 @@ public class FetchSourceSubPhase implements FetchSubPhase {
     }
 
     @Override
-    public boolean hitsExecutionNeeded(SearchContext context) {
-        return false;
-    }
-
-    @Override
-    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
-    }
-
-    @Override
     public boolean hitExecutionNeeded(SearchContext context) {
         return context.sourceRequested();
     }

--- a/core/src/main/java/org/elasticsearch/search/fetch/version/VersionFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/version/VersionFetchSubPhase.java
@@ -44,15 +44,6 @@ public class VersionFetchSubPhase implements FetchSubPhase {
     }
 
     @Override
-    public boolean hitsExecutionNeeded(SearchContext context) {
-        return false;
-    }
-
-    @Override
-    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
-    }
-
-    @Override
     public boolean hitExecutionNeeded(SearchContext context) {
         return context.version();
     }

--- a/core/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
@@ -60,15 +60,6 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
     }
 
     @Override
-    public boolean hitsExecutionNeeded(SearchContext context) {
-        return false;
-    }
-
-    @Override
-    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
-    }
-
-    @Override
     public boolean hitExecutionNeeded(SearchContext context) {
         return context.highlight() != null;
     }


### PR DESCRIPTION
The hits execution was never used by any sub fetch phase.
