### PR TITLE
Update percolate.asciidoc

### DIFF
--- a/docs/reference/search/percolate.asciidoc
+++ b/docs/reference/search/percolate.asciidoc
@@ -65,7 +65,7 @@ Match a document to the registered percolator queries:
 
 [source,js]
 --------------------------------------------------
-curl -XGET 'localhost:9200/my-index/my-type/_percolate' -d '{
+curl -XPOST 'localhost:9200/my-index/my-type/_percolate' -d '{
     "doc" : {
         "message" : "A new bonsai tree in the office"
     }


### PR DESCRIPTION
request type must be set 'POST' when querying with request body.
