### PR TITLE
_all: Stop NPE querying _all when it doesn't exist

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.payloads.AveragePayloadFunction;
@@ -124,13 +125,20 @@ public final class AllTermQuery extends PayloadTermQuery {
 
     @Override
     public Query rewrite(IndexReader reader) throws IOException {
+        boolean fieldExists = false;
         boolean hasPayloads = false;
         for (LeafReaderContext context : reader.leaves()) {
             final Terms terms = context.reader().terms(term.field());
-            if (terms.hasPayloads()) {
-                hasPayloads = true;
-                break;
+            if (terms != null) {
+                fieldExists = true;
+                if (terms.hasPayloads()) {
+                    hasPayloads = true;
+                    break;
+                }
             }
+        }
+        if (fieldExists == false) {
+            return new MatchNoDocsQuery();
         }
         if (hasPayloads == false) {
             TermQuery rewritten = new TermQuery(term);

--- a/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -138,7 +138,9 @@ public final class AllTermQuery extends PayloadTermQuery {
             }
         }
         if (fieldExists == false) {
-            return new MatchNoDocsQuery();
+            Query rewritten = new MatchNoDocsQuery();
+            rewritten.setBoost(getBoost());
+            return rewritten;
         }
         if (hasPayloads == false) {
             TermQuery rewritten = new TermQuery(term);

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -1868,6 +1868,24 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void testAllFieldEmptyMapping() throws Exception {
+        client().prepareIndex("myindex", "mytype").setId("1").setSource("{}").setRefresh(true).get();
+        SearchResponse response = client().prepareSearch("myindex").setQuery(matchQuery("_all", "foo")).get();
+        assertNoFailures(response);
+    }
+
+    @Test
+    public void testAllDisabledButQueried() throws Exception {
+        createIndex("myindex");
+        assertAcked(client().admin().indices().preparePutMapping("myindex").setType("mytype").setSource(
+                jsonBuilder().startObject().startObject("mytype").startObject("_all").field("enabled", false)));
+        client().prepareIndex("myindex", "mytype").setId("1").setSource("bar", "foo").setRefresh(true).get();
+        SearchResponse response = client().prepareSearch("myindex").setQuery(matchQuery("_all", "foo")).get();
+        assertNoFailures(response);
+        assertHitCount(response, 0);
+    }
+
+    @Test
     public void testIndicesQuery() throws Exception {
         createIndex("index1", "index2", "index3");
 


### PR DESCRIPTION
This can happen in two ways:
1. The _all field is disabled.
2. There are documents in the index, the _all field is enabled, but there are
no fields in any of the documents.

In both of these cases we now rewrite the query to a MatchNoDocsQuery which
should be safe because there isn't anything to match.

Closes #12439
