### PR TITLE
Prevents users from building a BulkProcessor with a null client

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -146,7 +146,7 @@ public class BulkProcessor implements Closeable {
 
     public static Builder builder(Client client, Listener listener) {
         if (client == null) {
-            throw new Exception("The client you specified while building a BulkProcessor is null");
+            throw new NullPointerException("The client you specified while building a BulkProcessor is null");
         }
         
         return new Builder(client, listener);

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -145,6 +145,10 @@ public class BulkProcessor implements Closeable {
     }
 
     public static Builder builder(Client client, Listener listener) {
+        if (client == null) {
+            throw new Exception("The client you specified while building a BulkProcessor is null");
+        }
+        
         return new Builder(client, listener);
     }
 


### PR DESCRIPTION
I suggest updating the BulkProcessor so that it prevents users from building a BulkProcessor with a null client.  If the client is null, then the class should throw an exception with a message that describes the cause of the exception.  Earlier today, when I passed a null client to the builder() method, later received an exception, and attempted to get the exception's message in my afterBulk() listener (e.g. e.getMessage()), the message was null.  It took me a while to pinpoint the cause of the problem.
