### PR TITLE
Plugin script: Fix ES_HOME with spaces

### DIFF
--- a/distribution/src/main/resources/bin/plugin
+++ b/distribution/src/main/resources/bin/plugin
@@ -23,7 +23,7 @@ ES_HOME=`cd "$ES_HOME"; pwd`
 
 # Sets the default values for elasticsearch variables used in this script
 if [ -z "$CONF_DIR" ]; then
-  CONF_DIR="${packaging.plugin.default.config.dir}"
+  CONF_DIR="$ES_HOME/config"
 
   if [ -z "$CONF_FILE" ]; then
     CONF_FILE="$CONF_DIR/elasticsearch.yml"
@@ -31,12 +31,12 @@ if [ -z "$CONF_DIR" ]; then
 fi
 
 if [ -z "$CONF_FILE" ]; then
-  CONF_FILE="${packaging.plugin.default.config.file}"
+  CONF_FILE="$ES_HOME/config/elasticsearch.yml"
 fi
 
 # The default env file is defined at building/packaging time.
-# For a ${packaging.type} package, the value is "${packaging.env.file}".
-ES_ENV_FILE="${packaging.env.file}"
+# For a tar.gz package, the value is "".
+ES_ENV_FILE=""
 
 # If an include is specified with the ES_INCLUDE environment variable, use it
 if [ -n "$ES_INCLUDE" ]; then
@@ -88,7 +88,7 @@ if [ -e "$CONF_DIR" ]; then
     *-Des.default.path.conf=*|*-Des.path.conf=*)
     ;;
     *)
-      properties="$properties -Des.default.path.conf=$CONF_DIR"
+      properties="$properties -Des.default.path.conf=\"$CONF_DIR\""
     ;;
   esac
 fi
@@ -98,11 +98,11 @@ if [ -e "$CONF_FILE" ]; then
     *-Des.default.config=*|*-Des.config=*)
     ;;
     *)
-      properties="$properties -Des.default.config=$CONF_FILE"
+      properties="$properties -Des.default.config=\"$CONF_FILE\""
     ;;
   esac
 fi
 
 export HOSTNAME=`hostname -s`
 
-exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" $properties -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManagerCliParser $args
+eval "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home=\""$ES_HOME"\" $properties -cp \""$ES_HOME/lib/*"\" org.elasticsearch.plugins.PluginManager $args


### PR DESCRIPTION
When ES_HOME has spaces we get funky "cannot find main class <part of a
directory>" errors. This makes them stop by escaping directories and using
eval instead of exec.

Closes #12504
