### PR TITLE
Plugin script: Fix ES_HOME with spaces

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -88,7 +88,7 @@ if [ -e "$CONF_DIR" ]; then
     *-Des.default.path.conf=*|*-Des.path.conf=*)
     ;;
     *)
-      properties="$properties -Des.default.path.conf=$CONF_DIR"
+      properties="$properties -Des.default.path.conf=\"$CONF_DIR\""
     ;;
   esac
 fi
@@ -98,11 +98,11 @@ if [ -e "$CONF_FILE" ]; then
     *-Des.default.config=*|*-Des.config=*)
     ;;
     *)
-      properties="$properties -Des.default.config=$CONF_FILE"
+      properties="$properties -Des.default.config=\"$CONF_FILE\""
     ;;
   esac
 fi
 
 export HOSTNAME=`hostname -s`
 
-exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="$ES_HOME" $properties -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginManager $args
+eval "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home=\""$ES_HOME"\" $properties -cp \""$ES_HOME/lib/*"\" org.elasticsearch.plugins.PluginManager $args

--- a/bin/plugin
+++ b/bin/plugin
@@ -69,15 +69,15 @@ fi
 while [ $# -gt 0 ]; do
   case $1 in
     -D*=*)
-      properties="$properties $1"
+      properties="$properties \"$1\""
       ;;
     -D*)
       var=$1
       shift
-      properties="$properties $var=$1"
+      properties="$properties \"$var\"=\"$1\""
       ;;
     *)
-      args="$args $1"
+      args="$args \"$1\""
   esac
   shift
 done

--- a/src/test/resources/packaging/scripts/25_tar_plugins.bats
+++ b/src/test/resources/packaging/scripts/25_tar_plugins.bats
@@ -33,6 +33,7 @@
 load packaging_test_utils
 
 setup() {
+
     # Cleans everything for every test execution
     clean_before_test
 
@@ -341,4 +342,101 @@ setup() {
     # Delete the custom plugins directory
     run rm -rf "$TEMP_CONFIG_DIR"
     [ "$status" -eq 0 ]
+}
+
+@test "[TAR] install shield plugin to elasticsearch directory with a space" {
+    export ES_DIR="/tmp/elastic search"
+
+    # Install the archive
+    install_archive
+
+    # Checks that the archive is correctly installed
+    verify_archive_installation
+
+    # Move the Elasticsearch installation to a directory with a space in it
+    rm -rf "$ES_DIR"
+    mv /tmp/elasticsearch "$ES_DIR"
+
+    # Checks that plugin archive is available
+    [ -e "$SHIELD_ZIP" ]
+
+    # Install Shield
+    run "$ES_DIR/bin/plugin" -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP"
+    [ "$status" -eq 0 ]
+
+    # Checks that Shield is correctly installed
+    assert_file_exist "$ES_DIR/bin/shield"
+    assert_file_exist "$ES_DIR/bin/shield/esusers"
+    assert_file_exist "$ES_DIR/bin/shield/syskeygen"
+    assert_file_exist "$ES_DIR/config/shield"
+    assert_file_exist "$ES_DIR/config/shield/role_mapping.yml"
+    assert_file_exist "$ES_DIR/config/shield/roles.yml"
+    assert_file_exist "$ES_DIR/config/shield/users"
+    assert_file_exist "$ES_DIR/config/shield/users_roles"
+    assert_file_exist "$ES_DIR/plugins/shield"
+
+    # Remove the plugin
+    run "$ES_DIR/bin/plugin" -r elasticsearch/shield/latest
+    [ "$status" -eq 0 ]
+
+    # Checks that the plugin is correctly removed
+    assert_file_not_exist "$ES_DIR/bin/shield"
+    assert_file_exist "$ES_DIR/config/shield"
+    assert_file_exist "$ES_DIR/config/shield/role_mapping.yml"
+    assert_file_exist "$ES_DIR/config/shield/roles.yml"
+    assert_file_exist "$ES_DIR/config/shield/users"
+    assert_file_exist "$ES_DIR/config/shield/users_roles"
+    assert_file_not_exist "$ES_DIR/plugins/shield"
+
+    #Cleanup our temporary Elasticsearch installation
+    rm -rf "$ES_DIR"
+}
+
+@test "[TAR] install shield plugin from a directory with a space" {
+    export SHIELD_ZIP_WITH_SPACE="/tmp/plugins with space/shield.zip"
+
+    # Install the archive
+    install_archive
+
+    # Checks that the archive is correctly installed
+    verify_archive_installation
+
+    # Checks that plugin archive is available
+    [ -e "$SHIELD_ZIP" ]
+
+    # Copy the shield plugin to a directory with a space in it
+    rm -f "$SHIELD_ZIP_WITH_SPACE"
+    mkdir -p "$(dirname "$SHIELD_ZIP_WITH_SPACE")"
+    cp $SHIELD_ZIP "$SHIELD_ZIP_WITH_SPACE"
+
+    # Install Shield
+    run /tmp/elasticsearch/bin/plugin -i elasticsearch/shield/latest -u "file://$SHIELD_ZIP_WITH_SPACE"
+    [ "$status" -eq 0 ]
+
+    # Checks that Shield is correctly installed
+    assert_file_exist "/tmp/elasticsearch/bin/shield"
+    assert_file_exist "/tmp/elasticsearch/bin/shield/esusers"
+    assert_file_exist "/tmp/elasticsearch/bin/shield/syskeygen"
+    assert_file_exist "/tmp/elasticsearch/config/shield"
+    assert_file_exist "/tmp/elasticsearch/config/shield/role_mapping.yml"
+    assert_file_exist "/tmp/elasticsearch/config/shield/roles.yml"
+    assert_file_exist "/tmp/elasticsearch/config/shield/users"
+    assert_file_exist "/tmp/elasticsearch/config/shield/users_roles"
+    assert_file_exist "/tmp/elasticsearch/plugins/shield"
+
+    # Remove the plugin
+    run /tmp/elasticsearch/bin/plugin -r elasticsearch/shield/latest
+    [ "$status" -eq 0 ]
+
+    # Checks that the plugin is correctly removed
+    assert_file_not_exist "/tmp/elasticsearch/bin/shield"
+    assert_file_exist "/tmp/elasticsearch/config/shield"
+    assert_file_exist "/tmp/elasticsearch/config/shield/role_mapping.yml"
+    assert_file_exist "/tmp/elasticsearch/config/shield/roles.yml"
+    assert_file_exist "/tmp/elasticsearch/config/shield/users"
+    assert_file_exist "/tmp/elasticsearch/config/shield/users_roles"
+    assert_file_not_exist "/tmp/elasticsearch/plugins/shield"
+
+    #Cleanup our plugin directory with a space
+    rm -rf "$SHIELD_ZIP_WITH_SPACE"
 }


### PR DESCRIPTION
When ES_HOME has spaces we get funky "cannot find main class directory>"
errors. This makes them stop by escaping directories and using eval instead
of exec.

Closes #12504
