### PR TITLE
Default date formats to use underscores via PUT

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/DateFieldMapper.java
@@ -72,8 +72,8 @@ public class DateFieldMapper extends NumberFieldMapper {
     public static final String CONTENT_TYPE = "date";
 
     public static class Defaults extends NumberFieldMapper.Defaults {
-        public static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("strictDateOptionalTime||epoch_millis", Locale.ROOT);
-        public static final FormatDateTimeFormatter DATE_TIME_FORMATTER_BEFORE_2_0 = Joda.forPattern("dateOptionalTime", Locale.ROOT);
+        public static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("strict_date_optional_time||epoch_millis", Locale.ROOT);
+        public static final FormatDateTimeFormatter DATE_TIME_FORMATTER_BEFORE_2_0 = Joda.forPattern("date_optional_time", Locale.ROOT);
         public static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
         public static final DateFieldType FIELD_TYPE = new DateFieldType();
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -495,7 +495,7 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         Version randomVersion = VersionUtils.randomVersionBetween(getRandom(), Version.V_0_90_0, Version.V_1_6_1);
         IndexService index = createIndex("test", settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, randomVersion).build());
         client().admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
-        assertDateFormat("epoch_millis||dateOptionalTime");
+        assertDateFormat("epoch_millis||date_optional_time");
         DocumentMapper defaultMapper = index.mapperService().documentMapper("type");
 
         defaultMapper.parse("test", "type", "1", XContentFactory.jsonBuilder()
@@ -543,13 +543,13 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
 
     public void testThatUpgradingAnOlderIndexToStrictDateWorks() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("date_field").field("type", "date").field("format", "dateOptionalTime").endObject().endObject()
+                .startObject("properties").startObject("date_field").field("type", "date").field("format", "date_optional_time").endObject().endObject()
                 .endObject().endObject().string();
 
         Version randomVersion = VersionUtils.randomVersionBetween(getRandom(), Version.V_0_90_0, Version.V_1_6_1);
         createIndex("test", settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, randomVersion).build());
         client().admin().indices().preparePutMapping("test").setType("type").setSource(mapping).get();
-        assertDateFormat("epoch_millis||dateOptionalTime");
+        assertDateFormat("epoch_millis||date_optional_time");
 
         // index doc
         client().prepareIndex("test", "type", "1").setSource(XContentFactory.jsonBuilder()
@@ -561,12 +561,12 @@ public class SimpleDateMappingTests extends ElasticsearchSingleNodeTest {
         String newMapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("date_field")
                 .field("type", "date")
-                .field("format", "strictDateOptionalTime||epoch_millis")
+                .field("format", "strict_date_optional_time||epoch_millis")
                 .endObject().endObject().endObject().endObject().string();
         PutMappingResponse putMappingResponse = client().admin().indices().preparePutMapping("test").setType("type").setSource(newMapping).get();
         assertThat(putMappingResponse.isAcknowledged(), is(true));
 
-        assertDateFormat("strictDateOptionalTime||epoch_millis");
+        assertDateFormat("strict_date_optional_time||epoch_millis");
     }
 
     private void assertDateFormat(String expectedFormat) throws IOException {


### PR DESCRIPTION
A PUT will default to `strictDateOptionalTime` or `dateOptionalTime` before 2.0, this PR changes the default format to `strict_date_optional_time` or `date_optional_time` respectively. Existing tests modified to test new format.

cc @clintongormley 

Closes #12429
