### PR TITLE
[TEST] Add tests for searching missing _all field

### DIFF
--- a/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
+++ b/src/test/java/org/elasticsearch/search/query/SearchQueryTests.java
@@ -1831,6 +1831,24 @@ public class SearchQueryTests extends ElasticsearchIntegrationTest {
     }
 
     @Test
+    public void testAllFieldEmptyMapping() throws Exception {
+        client().prepareIndex("myindex", "mytype").setId("1").setSource("{}").setRefresh(true).get();
+        SearchResponse response = client().prepareSearch("myindex").setQuery(matchQuery("_all", "foo")).get();
+        assertNoFailures(response);
+    }
+
+    @Test
+    public void testAllDisabledButQueried() throws Exception {
+        createIndex("myindex");
+        assertAcked(client().admin().indices().preparePutMapping("myindex").setType("mytype").setSource(
+                jsonBuilder().startObject().startObject("mytype").startObject("_all").field("enabled", false)));
+        client().prepareIndex("myindex", "mytype").setId("1").setSource("bar", "foo").setRefresh(true).get();
+        SearchResponse response = client().prepareSearch("myindex").setQuery(matchQuery("_all", "foo")).get();
+        assertNoFailures(response);
+        assertHitCount(response, 0);
+    }
+
+    @Test
     public void testIndicesQuery() throws Exception {
         createIndex("index1", "index2", "index3");
         ensureGreen();


### PR DESCRIPTION
In 2.x searching the _all field spat out NullPointerException. It never
has in 1.x but we never had a test for it. This adds that test.

Closes #12439
