### PR TITLE
Plugin load order

### DIFF
--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -390,7 +390,7 @@ public class PluginsService extends AbstractComponent {
         }
     }
 
-    public static SortedSet<URL> getUniqueSortedUrls(Collection<URL> urls) {
+    static SortedSet<URL> getUniqueSortedUrls(Collection<URL> urls) {
         SortedSet<URL> result = new TreeSet<URL>(new Comparator<URL>() {
             @Override
             public int compare(URL a, URL b) {

--- a/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -390,15 +390,15 @@ public class PluginsService extends AbstractComponent {
         }
     }
 
-    public static SortedSet<URL> getUniqueUrls(Collection<URL> urls) {
-        SortedSet<URL> uniqueUrls = new TreeSet<URL>(new Comparator<URL>() {
+    public static SortedSet<URL> getUniqueSortedUrls(Collection<URL> urls) {
+        SortedSet<URL> result = new TreeSet<URL>(new Comparator<URL>() {
             @Override
             public int compare(URL a, URL b) {
                 return a.toString().compareTo(b.toString());
             }
         });
-        uniqueUrls.addAll(urls);
-        return uniqueUrls;
+        result.addAll(urls);
+        return result;
     }
 
     private ImmutableList<Tuple<PluginInfo,Plugin>> loadPluginsFromClasspath(Settings settings) {
@@ -406,15 +406,13 @@ public class PluginsService extends AbstractComponent {
 
         // Trying JVM plugins: looking for es-plugin.properties files
         try {
-            Enumeration<URL> pluginUrls = settings.getClassLoader().getResources(esPluginPropertiesFile);
-
             // use a set for uniqueness as some classloaders such as groovy's can return the same URL multiple times and
             // these plugins should only be loaded once. We also want to have a deterministic order for loading the URLs.
             // Plugins should load independent of the order. If they do not, at least load them in an order that does not
             // change based on the hash of the URL.
-            SortedSet<URL> uniqueUrls = getUniqueUrls(Collections.list(pluginUrls));
+            SortedSet<URL> uniqueSortedPluginUrls = getUniqueSortedUrls(Collections.list(settings.getClassLoader().getResources(esPluginPropertiesFile)));
 
-            for (URL pluginUrl : uniqueUrls) {
+            for (URL pluginUrl : uniqueSortedPluginUrls) {
                 logger.trace("loading plugin " + pluginUrl.toString());
                 Properties pluginProps = new Properties();
                 InputStream is = null;

--- a/src/test/java/org/elasticsearch/plugins/PluginServiceUnitTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginServiceUnitTests.java
@@ -34,7 +34,7 @@ public class PluginServiceUnitTests extends ElasticsearchTestCase {
     @Test
     public void testThatPluginUrlsAreUniqueAndSorted() throws MalformedURLException {
         List<URL> urls = Arrays.asList(new URL[]{ new URL("http://bar"), new URL("http://bbb"), new URL("http://bar") });
-        Object[] uniqueUrls = PluginsService.getUniqueUrls(urls).toArray();
+        Object[] uniqueUrls = PluginsService.getUniqueSortedUrls(urls).toArray();
         assertThat(uniqueUrls, is(new Object[]{ new URL("http://bar"), new URL("http://bbb") }));
     }
 }

--- a/src/test/java/org/elasticsearch/plugins/PluginServiceUnitTests.java
+++ b/src/test/java/org/elasticsearch/plugins/PluginServiceUnitTests.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+public class PluginServiceUnitTests extends ElasticsearchTestCase {
+
+    @Test
+    public void testThatPluginUrlsAreUniqueAndSorted() throws MalformedURLException {
+        List<URL> urls = Arrays.asList(new URL[]{ new URL("http://bar"), new URL("http://bbb"), new URL("http://bar") });
+        Object[] uniqueUrls = PluginsService.getUniqueUrls(urls).toArray();
+        assertThat(uniqueUrls, is(new Object[]{ new URL("http://bar"), new URL("http://bbb") }));
+    }
+}


### PR DESCRIPTION
Currently, plugins are loaded based on the hash of the plugin path. This can make (buggy) plugin pairs that seemingly work in one install break when run from somewhere else.

Plugins _should_ work regardless of the order they are loaded in. If they do not, then it's at least helpful to be able to reason about the order.
