### PR TITLE
Consolidate .gitignore entires for eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,13 +21,8 @@ backwards/
 ## files to ensure common coding style across Eclipse and IDEA.
 .project
 .classpath
-/.settings
 eclipse-build
-*/.project
-*/.classpath
-*/eclipse-build
-*/.settings
-plugins/*/.settings
+.settings
 
 ## netbeans ignores
 nb-configuration.xml


### PR DESCRIPTION
Rather than specify paths for the .gitignored files that Eclipse uses for
project management just ignore all files and directories that look like
those directories. That way we can add new subprojects and we won't need
add more .gitignore entries.
