### PR TITLE
Build: Remove profile to create attached RPM

### DIFF
--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -339,31 +339,6 @@
 
     <profiles>
         <profile>
-            <id>release</id>
-            <activation>
-                <property>
-                    <name>package.rpm</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>rpm-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-rpm</id>
-                                <goals>
-                                    <goal>attached-rpm</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>sign-rpm</id>
             <activation>
                 <property>


### PR DESCRIPTION
This is no longer necessary, as the RPM is now built as
a primary artifact, so no need to deploy it as a secondary
artifact anymore.

Closes #12529

Docs for this at http://www.mojohaus.org/rpm-maven-plugin/usage.html
