### PR TITLE
Avoid extra reroutes of delayed shards in RoutingService

### DIFF
--- a/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -272,11 +272,15 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadOperati
             concreteIndices = clusterState.metaData().concreteIndices(request.indicesOptions(), request.indices());
         } catch (IndexMissingException e) {
             // one of the specified indices is not there - treat it as RED.
-            ClusterHealthResponse response = new ClusterHealthResponse(clusterName.value(), Strings.EMPTY_ARRAY, clusterState, numberOfPendingTasks, numberOfInFlightFetch, UnassignedInfo.getNumberOfDelayedUnassigned(settings, clusterState));
+            ClusterHealthResponse response = new ClusterHealthResponse(clusterName.value(),
+                    Strings.EMPTY_ARRAY, clusterState, numberOfPendingTasks, numberOfInFlightFetch,
+                    UnassignedInfo.getNumberOfDelayedUnassigned(System.currentTimeMillis(), settings, clusterState));
             response.status = ClusterHealthStatus.RED;
             return response;
         }
 
-        return new ClusterHealthResponse(clusterName.value(), concreteIndices, clusterState, numberOfPendingTasks, numberOfInFlightFetch, UnassignedInfo.getNumberOfDelayedUnassigned(settings, clusterState));
+        return new ClusterHealthResponse(clusterName.value(),
+                concreteIndices, clusterState, numberOfPendingTasks, numberOfInFlightFetch,
+                UnassignedInfo.getNumberOfDelayedUnassigned(System.currentTimeMillis(), settings, clusterState));
     }
 }

--- a/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -167,12 +167,12 @@ public class UnassignedInfo implements ToXContent {
     /**
      * The time in millisecond until this unassigned shard can be reassigned.
      */
-    public long getDelayAllocationExpirationIn(Settings settings, Settings indexSettings) {
+    public long getDelayAllocationExpirationIn(long unassignedShardsAllocatedTimestamp, Settings settings, Settings indexSettings) {
         long delayTimeout = getAllocationDelayTimeoutSetting(settings, indexSettings);
         if (delayTimeout == 0) {
             return 0;
         }
-        long delta = System.currentTimeMillis() - timestamp;
+        long delta = unassignedShardsAllocatedTimestamp - timestamp;
         // account for time drift, treat it as no timeout
         if (delta < 0) {
             return 0;
@@ -184,12 +184,12 @@ public class UnassignedInfo implements ToXContent {
     /**
      * Returns the number of shards that are unassigned and currently being delayed.
      */
-    public static int getNumberOfDelayedUnassigned(Settings settings, ClusterState state) {
+    public static int getNumberOfDelayedUnassigned(long unassignedShardsAllocatedTimestamp, Settings settings, ClusterState state) {
         int count = 0;
         for (ShardRouting shard : state.routingTable().shardsWithState(ShardRoutingState.UNASSIGNED)) {
             if (shard.primary() == false) {
                 IndexMetaData indexMetaData = state.metaData().index(shard.getIndex());
-                long delay = shard.unassignedInfo().getDelayAllocationExpirationIn(settings, indexMetaData.getSettings());
+                long delay = shard.unassignedInfo().getDelayAllocationExpirationIn(unassignedShardsAllocatedTimestamp, settings, indexMetaData.getSettings());
                 if (delay > 0) {
                     count++;
                 }
@@ -219,12 +219,12 @@ public class UnassignedInfo implements ToXContent {
     /**
      * Finds the next (closest) delay expiration of an unassigned shard. Returns 0 if there are none.
      */
-    public static long findNextDelayedAllocationIn(Settings settings, ClusterState state) {
+    public static long findNextDelayedAllocationIn(long unassignedShardsAllocatedTimestamp, Settings settings, ClusterState state) {
         long nextDelay = Long.MAX_VALUE;
         for (ShardRouting shard : state.routingTable().shardsWithState(ShardRoutingState.UNASSIGNED)) {
             if (shard.primary() == false) {
                 IndexMetaData indexMetaData = state.metaData().index(shard.getIndex());
-                long nextShardDelay = shard.unassignedInfo().getDelayAllocationExpirationIn(settings, indexMetaData.getSettings());
+                long nextShardDelay = shard.unassignedInfo().getDelayAllocationExpirationIn(unassignedShardsAllocatedTimestamp, settings, indexMetaData.getSettings());
                 if (nextShardDelay > 0 && nextShardDelay < nextDelay) {
                     nextDelay = nextShardDelay;
                 }

--- a/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
+++ b/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteTests.java
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.cluster.allocation;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingService;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.RerouteExplanation;
@@ -33,15 +35,19 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.DisableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
 import java.io.File;
@@ -160,6 +166,45 @@ public class ClusterRerouteTests extends ElasticsearchIntegrationTest {
                 .put("gateway.type", "local")
                 .build();
         rerouteWithAllocateLocalGateway(commonSettings);
+    }
+
+    /**
+     * Test that we don't miss any reroutes when concurrent_recoveries
+     * is set very low and there are a large number of unassigned shards.
+     */
+    @Test
+    @LuceneTestCase.Slow
+    public void testDelayWithALargeAmountOfShards() throws Exception {
+        Settings commonSettings = settingsBuilder()
+                .put("gateway.type", "local")
+                .put(ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_CONCURRENT_RECOVERIES, 1)
+                .build();
+        logger.info("--> starting 4 nodes");
+        String node_1 = internalCluster().startNode(commonSettings);
+        internalCluster().startNode(commonSettings);
+        internalCluster().startNode(commonSettings);
+        internalCluster().startNode(commonSettings);
+
+        assertThat(cluster().size(), equalTo(4));
+        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth().setWaitForNodes("4").execute().actionGet();
+        assertThat(healthResponse.isTimedOut(), equalTo(false));
+
+        logger.info("--> create indices");
+        for (int i = 0; i < 25; i++) {
+            client().admin().indices().prepareCreate("test" + i)
+                    .setSettings(settingsBuilder()
+                            .put("index.number_of_shards", 5).put("index.number_of_replicas", 1)
+                            .put("index.unassigned.node_left.delayed_timeout", randomIntBetween(250, 1000) + "ms"))
+                    .execute().actionGet();
+        }
+
+        ensureGreen(TimeValue.timeValueMinutes(1));
+
+        logger.info("--> stopping node1");
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(node_1));
+
+        // This might run slowly on older hardware
+        ensureGreen(TimeValue.timeValueMinutes(2));
     }
 
     private void rerouteWithAllocateLocalGateway(Settings commonSettings) throws Exception {

--- a/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -269,7 +269,7 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
         assertBusy(new Runnable() {
             @Override
             public void run() {
-                long delay = unassignedInfo.getDelayAllocationExpirationIn(ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), ImmutableSettings.EMPTY);
+                long delay = unassignedInfo.getDelayAllocationExpirationIn(System.currentTimeMillis(), ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), ImmutableSettings.EMPTY);
                 assertThat(delay, greaterThan(0l));
                 assertThat(delay, lessThan(TimeValue.timeValueHours(10).millis()));
             }
@@ -286,7 +286,7 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
         UnassignedInfo unassignedInfo = new UnassignedInfo(RandomPicks.randomFrom(getRandom(), reasons), null);
         long delay = unassignedInfo.getAllocationDelayTimeoutSetting(ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), ImmutableSettings.EMPTY);
         assertThat(delay, equalTo(0l));
-        delay = unassignedInfo.getDelayAllocationExpirationIn(ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), ImmutableSettings.EMPTY);
+        delay = unassignedInfo.getDelayAllocationExpirationIn(System.currentTimeMillis(), ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), ImmutableSettings.EMPTY);
         assertThat(delay, equalTo(0l));
     }
 
@@ -302,7 +302,7 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
                 .routingTable(RoutingTable.builder().addAsNew(metaData.index("test1")).addAsNew(metaData.index("test2"))).build();
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().put(newNode("node1")).put(newNode("node2"))).build();
         clusterState = ClusterState.builder(clusterState).routingResult(allocation.reroute(clusterState)).build();
-        assertThat(UnassignedInfo.getNumberOfDelayedUnassigned(ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState), equalTo(0));
+        assertThat(UnassignedInfo.getNumberOfDelayedUnassigned(System.currentTimeMillis(), ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState), equalTo(0));
         // starting primaries
         clusterState = ClusterState.builder(clusterState).routingResult(allocation.applyStartedShards(clusterState, clusterState.routingNodes().shardsWithState(INITIALIZING))).build();
         // starting replicas
@@ -311,7 +311,7 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
         // remove node2 and reroute
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
         clusterState = ClusterState.builder(clusterState).routingResult(allocation.reroute(clusterState)).build();
-        assertThat(clusterState.prettyPrint(), UnassignedInfo.getNumberOfDelayedUnassigned(ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState), equalTo(2));
+        assertThat(clusterState.prettyPrint(), UnassignedInfo.getNumberOfDelayedUnassigned(System.currentTimeMillis(), ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState), equalTo(2));
     }
 
     @Test
@@ -326,7 +326,7 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
                 .routingTable(RoutingTable.builder().addAsNew(metaData.index("test1")).addAsNew(metaData.index("test2"))).build();
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder().put(newNode("node1")).put(newNode("node2"))).build();
         clusterState = ClusterState.builder(clusterState).routingResult(allocation.reroute(clusterState)).build();
-        assertThat(UnassignedInfo.getNumberOfDelayedUnassigned(ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState), equalTo(0));
+        assertThat(UnassignedInfo.getNumberOfDelayedUnassigned(System.currentTimeMillis(), ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState), equalTo(0));
         // starting primaries
         clusterState = ClusterState.builder(clusterState).routingResult(allocation.applyStartedShards(clusterState, clusterState.routingNodes().shardsWithState(INITIALIZING))).build();
         // starting replicas
@@ -339,7 +339,7 @@ public class UnassignedInfoTests extends ElasticsearchAllocationTestCase {
         long nextDelaySetting = UnassignedInfo.findSmallestDelayedAllocationSetting(ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState);
         assertThat(nextDelaySetting, equalTo(TimeValue.timeValueHours(10).millis()));
 
-        long nextDelay = UnassignedInfo.findNextDelayedAllocationIn(ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState);
+        long nextDelay = UnassignedInfo.findNextDelayedAllocationIn(System.currentTimeMillis(), ImmutableSettings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, "10h").build(), clusterState);
         assertThat(nextDelay, greaterThan(TimeValue.timeValueHours(9).millis()));
         assertThat(nextDelay, lessThanOrEqualTo(TimeValue.timeValueHours(10).millis()));
     }


### PR DESCRIPTION
In order to avoid extra reroutes, `RoutingService` should avoid
scheduling a reroute of any shards where the delay is negative. To make
sure that we don't encounter a race condition between the
GatewayAllocator thinking a shard is delayed and RoutingService thinking
it is not, the GatewayAllocator will update the RoutingService with the
last time it checked in order to use a consistent "view" of the delay.

Resolves #12456
Relates to #12515 and #12456

This is a PR against 1.7 and will be forward-ported
