### PR TITLE
Updating default position_offset_gap to 10.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/analysis/CustomAnalyzerProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/CustomAnalyzerProvider.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.settings.IndexSettings;
 
 import java.util.List;
@@ -77,7 +78,7 @@ public class CustomAnalyzerProvider extends AbstractIndexAnalyzerProvider<Custom
             tokenFilters.add(tokenFilter);
         }
 
-        int positionOffsetGap = analyzerSettings.getAsInt("position_offset_gap", 0);
+        int positionOffsetGap = analyzerSettings.getAsInt("position_offset_gap", StringFieldMapper.Defaults.POSITION_OFFSET_GAP);
         int offsetGap = analyzerSettings.getAsInt("offset_gap", -1);
 
         this.customAnalyzer = new CustomAnalyzer(tokenizer,

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -70,7 +70,12 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
 
         protected String nullValue = Defaults.NULL_VALUE;
 
-        protected int positionOffsetGap = Defaults.POSITION_OFFSET_GAP;
+        /**
+         * The offset gap between different values of the same field. -1 means
+         * use the default from the analyzer which in turn defaults to
+         * StringFieldMapp.Defaults.POSITION_OFFSET_GAP.
+         */
+        protected int positionOffsetGap = -1;
 
         protected int ignoreAbove = Defaults.IGNORE_ABOVE;
 
@@ -102,10 +107,20 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
 
         @Override
         public StringFieldMapper build(BuilderContext context) {
-            if (positionOffsetGap > 0) {
-                fieldType.setIndexAnalyzer(new NamedAnalyzer(fieldType.indexAnalyzer(), positionOffsetGap));
-                fieldType.setSearchAnalyzer(new NamedAnalyzer(fieldType.searchAnalyzer(), positionOffsetGap));
-                fieldType.setSearchQuoteAnalyzer(new NamedAnalyzer(fieldType.searchQuoteAnalyzer(), positionOffsetGap));
+            // Let the mapping override the position_offset_gap in the analyzer if it is different.
+            if (positionOffsetGap != -1) {
+                if (fieldType.indexAnalyzer() != null &&
+                        positionOffsetGap != fieldType.indexAnalyzer().getOffsetGap(fieldType.indexAnalyzer().name())) {
+                    fieldType.setIndexAnalyzer(new NamedAnalyzer(fieldType.indexAnalyzer(), positionOffsetGap));                
+                }
+                if (fieldType.searchAnalyzer() != null &&
+                        positionOffsetGap != fieldType.searchAnalyzer().getOffsetGap(fieldType.searchAnalyzer().name())) {
+                    fieldType.setSearchAnalyzer(new NamedAnalyzer(fieldType.searchAnalyzer(), positionOffsetGap));                
+                }
+                if (fieldType.searchQuoteAnalyzer() != null &&
+                        positionOffsetGap != fieldType.searchQuoteAnalyzer().getOffsetGap(fieldType.searchQuoteAnalyzer().name())) {
+                    fieldType.setSearchQuoteAnalyzer(new NamedAnalyzer(fieldType.searchQuoteAnalyzer(), positionOffsetGap));                
+                }
             }
             // if the field is not analyzed, then by default, we should omit norms and have docs only
             // index options, as probably what the user really wants

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -62,7 +62,7 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
 
         // NOTE, when adding defaults here, make sure you add them in the builder
         public static final String NULL_VALUE = null;
-        public static final int POSITION_OFFSET_GAP = 0;
+        public static final int POSITION_OFFSET_GAP = 10;
         public static final int IGNORE_ABOVE = -1;
     }
 

--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -150,7 +150,7 @@ limit to `32766 / 3 = 10922` since UTF-8 characters may occupy at most 3
 bytes.
 
 |`position_offset_gap` |Position increment gap between field instances
-with the same field name. Defaults to 0.
+with the same field name. Defaults to 10.
 |=======================================================================
 
 The `string` type also support custom indexing parameters associated


### PR DESCRIPTION
Addresses #7268.

This commit includes the suggestion to update the default in CustomAnalyzerProvider as well. It looks like the position_offset_gap setting was added there first and then the default was added subsequently in StringFieldMapper (#1812 and #1813), so there might have just been an oversight in sharing the default between them.
