### PR TITLE
add integration tests for tar/deb/rpm packaging

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -206,10 +206,12 @@
       <mkdir dir="${integ.scratch}/deb-extracted"/>
       <local name="debfile"/>
       <property name="debfile" location="${project.build.directory}/releases/elasticsearch-${project.version}.deb"/>
+      <!-- print some basic package info -->
       <exec executable="dpkg-deb" failonerror="true" taskname="deb-info">
-         <arg value="-W"/>
+         <arg value="-I"/>
          <arg value="${debfile}"/> 
       </exec>
+      <!-- extract contents from .deb package -->
       <exec executable="dpkg-deb" failonerror="true">
          <arg value="-x"/> 
          <arg value="${debfile}"/> 
@@ -220,6 +222,46 @@
 
   <target name="start-external-cluster-deb" depends="setup-workspace-deb" unless="${shouldskip}">
     <startup-elasticsearch home="${integ.scratch}/deb-extracted/usr/share/elasticsearch/"/>
+  </target>
+
+  <!-- distribution tests: .rpm -->
+  <target name="setup-workspace-rpm" depends="stop-external-cluster" unless="${shouldskip}">
+    <sequential>
+      <delete dir="${integ.scratch}"/>
+      <!-- use full paths with paranoia, we will be doing relocations -->
+      <local name="rpm.file"/>
+      <local name="rpm.database"/>
+      <local name="rpm.extracted"/>
+      <property name="rpm.file" location="${project.build.directory}/releases/elasticsearch-${project.version}.rpm"/>
+      <property name="rpm.database" location="${integ.scratch}/rpm-database"/>
+      <property name="rpm.extracted" location="${integ.scratch}/rpm-extracted"/>
+      <mkdir dir="${rpm.database}"/>
+      <mkdir dir="${rpm.extracted}"/>
+      <!-- print some basic package info -->
+      <exec executable="rpm" failonerror="true" taskname="rpm-info">
+         <arg value="-q"/>
+         <arg value="-i"/>
+         <arg value="-p"/>
+         <arg value="${rpm.file}"/> 
+      </exec>
+      <!-- extract contents from .rpm package -->
+      <exec executable="rpm" failonerror="true" taskname="rpm">
+         <arg value="--dbpath"/>
+         <arg value="${rpm.database}"/>
+         <arg value="--badreloc"/>
+         <arg value="--relocate"/>
+         <arg value="/=${rpm.extracted}"/>
+         <arg value="--nodeps"/> 
+         <arg value="--noscripts"/> 
+         <arg value="--notriggers"/> 
+         <arg value="-i"/>
+         <arg value="${rpm.file}"/> 
+      </exec>
+    </sequential>
+  </target>
+
+  <target name="start-external-cluster-rpm" depends="setup-workspace-rpm" unless="${shouldskip}">
+    <startup-elasticsearch home="${integ.scratch}/rpm-extracted/usr/share/elasticsearch/"/>
   </target>
 
 </project>

--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -183,4 +183,19 @@
     <delete file="${integ.pidfile}"/>
   </target>
 
+  <!-- distribution tests: .tar.gz -->
+
+  <target name="setup-workspace-tar" depends="stop-external-cluster" unless="${shouldskip}">
+    <sequential>
+      <delete dir="${integ.scratch}"/>
+      <untar src="${project.build.directory}/releases/elasticsearch-${project.version}.tar.gz" 
+             dest="${integ.scratch}"
+             compression="gzip"/>
+    </sequential>
+  </target>
+
+  <target name="start-external-cluster-tar" depends="setup-workspace-tar" unless="${shouldskip}">
+    <startup-elasticsearch/>
+  </target>
+
 </project>

--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -198,4 +198,28 @@
     <startup-elasticsearch/>
   </target>
 
+  <!-- distribution tests: .deb -->
+
+  <target name="setup-workspace-deb" depends="stop-external-cluster" unless="${shouldskip}">
+    <sequential>
+      <delete dir="${integ.scratch}"/>
+      <mkdir dir="${integ.scratch}/deb-extracted"/>
+      <local name="debfile"/>
+      <property name="debfile" location="${project.build.directory}/releases/elasticsearch-${project.version}.deb"/>
+      <exec executable="dpkg-deb" failonerror="true" taskname="deb-info">
+         <arg value="-W"/>
+         <arg value="${debfile}"/> 
+      </exec>
+      <exec executable="dpkg-deb" failonerror="true">
+         <arg value="-x"/> 
+         <arg value="${debfile}"/> 
+         <arg value="${integ.scratch}/deb-extracted"/> 
+      </exec>
+    </sequential>
+  </target>
+
+  <target name="start-external-cluster-deb" depends="setup-workspace-deb" unless="${shouldskip}">
+    <startup-elasticsearch home="${integ.scratch}/deb-extracted/usr/share/elasticsearch/"/>
+  </target>
+
 </project>

--- a/distribution/deb/pom.xml
+++ b/distribution/deb/pom.xml
@@ -10,11 +10,9 @@
     </parent>
 
     <artifactId>elasticsearch-deb</artifactId>
-    <packaging>deb</packaging>
     <name>Elasticsearch DEB Distribution</name>
 
     <properties>
-        <skip.integ.tests>true</skip.integ.tests>
         <deb.sign>false</deb.sign>
         <deb.sign.method>dpkg-sig</deb.sign.method>
     </properties>
@@ -273,8 +271,49 @@
                             </target>
                         </configuration>
                     </execution>
+                    <!-- start up external cluster -->
+                    <execution>
+                        <id>integ-setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.integ.tests}</skip>
+                            <target>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster-deb"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- shut down external cluster -->
+                    <execution>
+                        <id>integ-teardown</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.integ.tests}</skip>
+                            <target>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="stop-external-cluster"/>
+                            </target>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+       <!-- we run integration test with real dpkg utils, you must have them -->
+       <profile>
+           <id>has_dpkg</id>
+           <activation>
+              <file><missing>/usr/bin/dpkg-deb</missing></file>
+           </activation>
+           <properties>
+               <skip.integ.tests>true</skip.integ.tests>
+           </properties>
+       </profile>
+    </profiles>
 </project>

--- a/distribution/deb/src/test/java/org/elasticsearch/test/rest/RestIT.java
+++ b/distribution/deb/src/test/java/org/elasticsearch/test/rest/RestIT.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+
+import java.io.IOException;
+
+/** Rest integration test. runs against external cluster in 'mvn verify' */
+public class RestIT extends ElasticsearchRestTestCase {
+    public RestIT(RestTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+    // we run them all sequentially: start simple!
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
+        return createParameters(0, 1);
+    }
+}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -90,6 +90,30 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-test-framework</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -15,7 +15,6 @@
     <name>Elasticsearch Distribution</name>
 
     <properties>
-        <skipTests>true</skipTests>
         <!-- Properties used for building RPM & DEB packages (see common/packaging.properties) -->
         <packaging.elasticsearch.home.dir>/usr/share/elasticsearch</packaging.elasticsearch.home.dir>
         <packaging.elasticsearch.bin.dir>/usr/share/elasticsearch/bin</packaging.elasticsearch.bin.dir>
@@ -32,6 +31,9 @@
 
         <!-- rpmbuild location : default to /usr/bin/rpmbuild -->
         <packaging.rpm.rpmbuild>/usr/bin/rpmbuild</packaging.rpm.rpmbuild>
+
+        <!-- we expect packaging formats to have integration tests, but not unit tests -->
+        <skip.unit.tests>true</skip.unit.tests>
     </properties>
 
     <dependencies>

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -14,7 +14,6 @@
     <packaging>rpm</packaging>
 
     <properties>
-        <skip.integ.tests>true</skip.integ.tests>
     </properties>
 
     <build>
@@ -329,6 +328,34 @@
                                     <arg value="${basedir}/../licenses"/>
                                     <arg value="${basedir}/target/releases/${project.build.finalName}.rpm"/>
                                 </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- start up external cluster -->
+                    <execution>
+                        <id>integ-setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.integ.tests}</skip>
+                            <target>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster-rpm"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- shut down external cluster -->
+                    <execution>
+                        <id>integ-teardown</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.integ.tests}</skip>
+                            <target>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="stop-external-cluster"/>
                             </target>
                         </configuration>
                     </execution>

--- a/distribution/rpm/src/test/java/org/elasticsearch/test/rest/RestIT.java
+++ b/distribution/rpm/src/test/java/org/elasticsearch/test/rest/RestIT.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+
+import java.io.IOException;
+
+/** Rest integration test. runs against external cluster in 'mvn verify' */
+public class RestIT extends ElasticsearchRestTestCase {
+    public RestIT(RestTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+    // we run them all sequentially: start simple!
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
+        return createParameters(0, 1);
+    }
+}

--- a/distribution/tar/pom.xml
+++ b/distribution/tar/pom.xml
@@ -13,7 +13,7 @@
     <name>Elasticsearch TAR Distribution</name>
 
     <properties>
-        <skip.integ.tests>true</skip.integ.tests>
+        <skip.integ.tests>false</skip.integ.tests>
     </properties>
 
     <build>
@@ -65,6 +65,33 @@
                                     <arg value="${basedir}/../licenses"/>
                                     <arg value="${basedir}/target/releases/${project.build.finalName}.tar.gz"/>
                                 </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- integration tests -->
+                    <!-- start up external cluster -->
+                    <execution>
+                        <id>integ-setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster-tar"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- shut down external cluster -->
+                    <execution>
+                        <id>integ-teardown</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="stop-external-cluster"/>
                             </target>
                         </configuration>
                     </execution>

--- a/distribution/tar/pom.xml
+++ b/distribution/tar/pom.xml
@@ -13,7 +13,6 @@
     <name>Elasticsearch TAR Distribution</name>
 
     <properties>
-        <skip.integ.tests>false</skip.integ.tests>
     </properties>
 
     <build>
@@ -77,6 +76,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.integ.tests}</skip>
                             <target>
                                 <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster-tar"/>
                             </target>
@@ -90,6 +90,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.integ.tests}</skip>
                             <target>
                                 <ant antfile="${elasticsearch.integ.antfile}" target="stop-external-cluster"/>
                             </target>

--- a/distribution/tar/src/test/java/org/elasticsearch/test/rest/RestIT.java
+++ b/distribution/tar/src/test/java/org/elasticsearch/test/rest/RestIT.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+
+import java.io.IOException;
+
+/** Rest integration test. runs against external cluster in 'mvn verify' */
+public class RestIT extends ElasticsearchRestTestCase {
+    public RestIT(RestTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+    // we run them all sequentially: start simple!
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
+        return createParameters(0, 1);
+    }
+}

--- a/distribution/zip/pom.xml
+++ b/distribution/zip/pom.xml
@@ -90,6 +90,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.integ.tests}</skip>
                             <target>
                                 <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster"/>
                             </target>
@@ -103,6 +104,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.integ.tests}</skip>
                             <target>
                                 <ant antfile="${elasticsearch.integ.antfile}" target="stop-external-cluster"/>
                             </target>

--- a/distribution/zip/pom.xml
+++ b/distribution/zip/pom.xml
@@ -16,35 +16,6 @@
         <skip.integ.tests>false</skip.integ.tests>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.carrotsearch.randomizedtesting</groupId>
-            <artifactId>randomizedtesting-runner</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-test-framework</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
     <build>
         <filters>
             <filter>${project.basedir}/../src/main/packaging/packaging.properties</filter>

--- a/pom.xml
+++ b/pom.xml
@@ -1332,7 +1332,7 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
             <activation>
                 <activeByDefault>false</activeByDefault>
                 <file>
-                    <missing>${basedir}/src</missing>
+                    <missing>${basedir}/src/test/java</missing>
                 </file>
             </activation>
             <properties>


### PR DESCRIPTION
There are no automated tests for these packages. But we can do various types of verification, at the minimum extract the contents of the package with `dpkg-deb` or `rpm` or `tar`, start elasticsearch, and run integration tests.

These tests are not perfect, they are not installing the stuff on a virtual machine. But they are better than no tests like this, and simple to understand.

There are more cleanups to do here after, but this is really missing.
