### PR TITLE
Release: Update build release script to reflect latest changes

### DIFF
--- a/dev-tools/build_repositories.sh
+++ b/dev-tools/build_repositories.sh
@@ -158,8 +158,8 @@ mkdir -p $centosdir
 echo "RPM: Syncing repository for version $version into $centosdir"
 $s3cmd sync s3://$S3_BUCKET_SYNC_FROM/elasticsearch/$version/centos/ $centosdir
 
-rpm=target/rpm/elasticsearch/RPMS/noarch/elasticsearch*.rpm
-echo "RPM: Copying $rpm into $centosdor"
+rpm=distribution/rpm/target/releases/signed/elasticsearch*.rpm
+echo "RPM: Copying signed $rpm into $centosdir"
 cp $rpm $centosdir
 
 echo "RPM: Running createrepo in $centosdir"
@@ -176,7 +176,7 @@ $s3cmd sync -P $centosdir/ s3://$S3_BUCKET_SYNC_TO/elasticsearch/$version/centos
 ## DEB
 ###################
 
-deb=target/releases/elasticsearch*.deb
+deb=distribution/deb/target/releases/elasticsearch*.deb
 
 echo "DEB: Creating repository directory structure"
 

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <skip.integ.tests>true</skip.integ.tests>
+        <rpm.outputDirectory>${project.build.directory}/releases/</rpm.outputDirectory>
+    </properties>
+
     <build>
 
         <filters>
@@ -301,7 +306,7 @@
                                     <version>${project.version}</version>
                                     <type>${project.packaging}</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/releases/</outputDirectory>
+                                    <outputDirectory>${rpm.outputDirectory}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>


### PR DESCRIPTION
As the script now deploys to S3 and several things in master have
changed, this script needs to reflect the latest changes
- An unsigned RPM is built by default, so that users of older
  RPM based distros can download and use that RPM by default
- In addition a signed RPM is built, that is used for the repositories
- Paths for the new distributions have been fixed
- The check for the number of jars has been removed, as this is done
  as part of the license checking in `mvn verify`
- Checksum generation has been removed, as this is done as part of the
  mvn build
- Publishing artifacts of S3 has been removed
- Repostitory creation script has been updated
