### PR TITLE
Upgrade HDRHistogram to version 2.1.6.

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksTests.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import com.google.common.collect.Lists;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.script.Script;
@@ -51,7 +50,6 @@ import static org.hamcrest.Matchers.sameInstance;
 /**
  *
  */
-@AwaitsFix(bugUrl = "single test methods fail with occassional seeds (see HDRPercentilesTests.testScript_ExplicitSingleValued_WithParams for example) but only if run as a whole test class not if run as a single test method")
 public class HDRPercentileRanksTests extends AbstractNumericTests {
 
     private static double[] randomPercents(long minValue, long maxValue) {
@@ -372,7 +370,6 @@ public class HDRPercentileRanksTests extends AbstractNumericTests {
 
     @Override
     @Test
-    @AwaitsFix(bugUrl="Fails with seed: B75FCDC119D90BBE, Colin to fix")
     public void testScript_SingleValued_WithParams() throws Exception {
         int sigDigits = randomSignificantDigits();
         Map<String, Object> params = new HashMap<>();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesTests.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import com.google.common.collect.Lists;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.script.Script;
@@ -52,7 +51,6 @@ import static org.hamcrest.Matchers.sameInstance;
 /**
  *
  */
-@AwaitsFix(bugUrl = "single test methods fail with occassional seeds (see testScript_ExplicitSingleValued_WithParams for example) but only if run as a whole test class not if run as a single test method")
 public class HDRPercentilesTests extends AbstractNumericTests {
 
     private static double[] randomPercentiles() {
@@ -379,7 +377,6 @@ public class HDRPercentilesTests extends AbstractNumericTests {
 
     @Override
     @Test
-    @AwaitsFix(bugUrl = "fails with -Dtests.seed=5BFFA768633A0A59 but only if run as a whole test class not if run as a single test method")
     public void testScript_ExplicitSingleValued_WithParams() throws Exception {
         Map<String, Object> params = new HashMap<>();
         params.put("dec", 1);

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
             <dependency>
                 <groupId>org.hdrhistogram</groupId>
                 <artifactId>HdrHistogram</artifactId>
-                <version>2.1.5</version>
+                <version>2.1.6</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This release fixes https://github.com/HdrHistogram/HdrHistogram/pull/68 which
we have been hitting in our CI tests, for instance:
http://build-us-00.elastic.co/job/es_core_master_metal/10567/
