### PR TITLE
Query DSL: Remove duplicate code in AndQueryParser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
@@ -80,14 +80,6 @@ public class AndQueryParser implements QueryParser {
                                 queries.add(filter);
                             }
                         }
-                    } else {
-                        queriesFound = true;
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            Query filter = parseContext.parseInnerFilter();
-                            if (filter != null) {
-                                queries.add(filter);
-                            }
-                        }
                     }
                 } else if (token.isValue()) {
                     if ("_name".equals(currentFieldName)) {


### PR DESCRIPTION
When parsing inner array of filters, AndQueryParser seems to
check for correct "filters" field name but then does the same
kind of operation in the `else` branch of the stament. This
seems like it can be removed.
