### PR TITLE
Fix setting timezone on default DateTime formatter

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
+++ b/core/src/main/java/org/elasticsearch/common/rounding/TimeZoneRounding.java
@@ -64,6 +64,9 @@ public abstract class TimeZoneRounding extends Rounding {
         }
 
         public Builder timeZone(DateTimeZone timeZone) {
+            if (timeZone == null) {
+                throw new IllegalArgumentException("Setting null as timezone is not supported");
+            }
             this.timeZone = timeZone;
             return this;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormat.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormat.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.aggregations.support.format;
 
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.joda.time.DateTimeZone;
 
 /**
  *
@@ -67,12 +68,12 @@ public class ValueFormat {
 
         public static final DateTime DEFAULT = new DateTime(DateFieldMapper.Defaults.DATE_TIME_FORMATTER.format(), ValueFormatter.DateTime.DEFAULT, ValueParser.DateMath.DEFAULT);
 
-        public static DateTime format(String format) {
-            return new DateTime(format, new ValueFormatter.DateTime(format), new ValueParser.DateMath(format));
+        public static DateTime format(String format, DateTimeZone timezone) {
+            return new DateTime(format, new ValueFormatter.DateTime(format, timezone), new ValueParser.DateMath(format));
         }
 
-        public static DateTime mapper(DateFieldMapper.DateFieldType fieldType) {
-            return new DateTime(fieldType.dateTimeFormatter().format(), ValueFormatter.DateTime.mapper(fieldType), ValueParser.DateMath.mapper(fieldType));
+        public static DateTime mapper(DateFieldMapper.DateFieldType fieldType, DateTimeZone timezone) {
+            return new DateTime(fieldType.dateTimeFormatter().format(), ValueFormatter.DateTime.mapper(fieldType, timezone), ValueParser.DateMath.mapper(fieldType));
         }
 
         public DateTime(String pattern, ValueFormatter formatter, ValueParser parser) {
@@ -81,7 +82,7 @@ public class ValueFormat {
 
         @Override
         public DateTime create(String pattern) {
-            return format(pattern);
+            return format(pattern, DateTimeZone.UTC);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormatter.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/format/ValueFormatter.java
@@ -33,7 +33,6 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
-import java.util.TimeZone;
 
 /**
  * A strategy for formatting time represented as millis long value to string
@@ -61,7 +60,6 @@ public interface ValueFormatter extends Streamable {
     String format(long value);
 
     /**
-     * The 
      * @param value double The double value to format.
      * @return      The formatted value as string
      */
@@ -104,8 +102,8 @@ public interface ValueFormatter extends Streamable {
         public static final ValueFormatter DEFAULT = new ValueFormatter.DateTime(DateFieldMapper.Defaults.DATE_TIME_FORMATTER);
         private DateTimeZone timeZone = DateTimeZone.UTC;
 
-        public static DateTime mapper(DateFieldMapper.DateFieldType fieldType) {
-            return new DateTime(fieldType.dateTimeFormatter());
+        public static DateTime mapper(DateFieldMapper.DateFieldType fieldType, DateTimeZone timezone) {
+            return new DateTime(fieldType.dateTimeFormatter(), timezone);
         }
 
         static final byte ID = 2;
@@ -122,13 +120,19 @@ public interface ValueFormatter extends Streamable {
             this.formatter = formatter;
         }
 
+        public DateTime(String format, DateTimeZone timezone) {
+            this.formatter = Joda.forPattern(format);
+            this.timeZone = timezone != null ? timezone : DateTimeZone.UTC;
+        }
+
+        public DateTime(FormatDateTimeFormatter formatter, DateTimeZone timezone) {
+            this.formatter = formatter;
+            this.timeZone = timezone != null ? timezone : DateTimeZone.UTC;
+        }
+
         @Override
         public String format(long time) {
             return formatter.printer().withZone(timeZone).print(time);
-        }
-
-        public void setTimeZone(DateTimeZone timeZone) {
-            this.timeZone = timeZone;
         }
 
         @Override
@@ -264,7 +268,7 @@ public interface ValueFormatter extends Streamable {
 
         }
     }
-    
+
     static class BooleanFormatter implements ValueFormatter {
 
         static final byte ID = 10;


### PR DESCRIPTION
This PR prevents setting timezone on ValueFormatter.DateTime. Instead
the timezone information needed when printing buckets key-as-string
information is provided at constrution time of the ValueFormatter, making
sure we don't overwrite any constants. This, however, made it necessary to
be able to access the timezone information when resolving the format
in ValueSourseParser, so the `time_zone` parameter is now parsed alongside
the `format` parameter in ValueSourceParser rather than in DateHistogramParser.

Closes #12531
