### PR TITLE
Move the `_size` mapper to a plugin.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -228,8 +228,6 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                         if (source.ttl > 0) {
                             value = docMapper.TTLFieldMapper().valueForSearch(source.timestamp + source.ttl);
                         }
-                    } else if (field.equals(SizeFieldMapper.NAME) && docMapper.rootMapper(SizeFieldMapper.class).fieldType().stored()) {
-                        value = source.source.length();
                     } else {
                         if (searchLookup == null) {
                             searchLookup = new SearchLookup(mapperService, null, new String[]{type});

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -48,7 +48,6 @@ import org.elasticsearch.index.mapper.internal.IdFieldMapper;
 import org.elasticsearch.index.mapper.internal.IndexFieldMapper;
 import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
 import org.elasticsearch.index.mapper.internal.RoutingFieldMapper;
-import org.elasticsearch.index.mapper.internal.SizeFieldMapper;
 import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
 import org.elasticsearch.index.mapper.internal.TTLFieldMapper;
 import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
@@ -106,7 +105,6 @@ public class DocumentMapper implements ToXContent {
             this.rootMappers.put(IdFieldMapper.class, new IdFieldMapper(indexSettings, mapperService.fullName(IdFieldMapper.NAME)));
             this.rootMappers.put(RoutingFieldMapper.class, new RoutingFieldMapper(indexSettings, mapperService.fullName(RoutingFieldMapper.NAME)));
             // add default mappers, order is important (for example analyzer should come before the rest to set context.analyzer)
-            this.rootMappers.put(SizeFieldMapper.class, new SizeFieldMapper(indexSettings, mapperService.fullName(SizeFieldMapper.NAME)));
             this.rootMappers.put(IndexFieldMapper.class, new IndexFieldMapper(indexSettings, mapperService.fullName(IndexFieldMapper.NAME)));
             this.rootMappers.put(SourceFieldMapper.class, new SourceFieldMapper(indexSettings));
             this.rootMappers.put(TypeFieldMapper.class, new TypeFieldMapper(indexSettings, mapperService.fullName(TypeFieldMapper.NAME)));
@@ -283,10 +281,6 @@ public class DocumentMapper implements ToXContent {
         return rootMapper(ParentFieldMapper.class);
     }
 
-    public SizeFieldMapper sizeFieldMapper() {
-        return rootMapper(SizeFieldMapper.class);
-    }
-
     public TimestampFieldMapper timestampFieldMapper() {
         return rootMapper(TimestampFieldMapper.class);
     }
@@ -297,10 +291,6 @@ public class DocumentMapper implements ToXContent {
 
     public IndexFieldMapper IndexFieldMapper() {
         return rootMapper(IndexFieldMapper.class);
-    }
-
-    public SizeFieldMapper SizeFieldMapper() {
-        return rootMapper(SizeFieldMapper.class);
     }
 
     public Query typeFilter() {

--- a/core/src/test/java/org/elasticsearch/get/GetActionIT.java
+++ b/core/src/test/java/org/elasticsearch/get/GetActionIT.java
@@ -1031,9 +1031,6 @@ public class GetActionIT extends ESIntegTestCase {
             "    \"doc\": {\n" +
             "      \"_timestamp\": {\n" +
             "        \"enabled\": true\n" +
-            "      },\n" +
-            "      \"_size\": {\n" +
-            "        \"enabled\": true\n" +
             "      }\n" +
             "    }\n" +
             "  }\n" +
@@ -1045,7 +1042,7 @@ public class GetActionIT extends ESIntegTestCase {
             "  \"text\": \"some text.\"\n" +
             "}\n";
         client().prepareIndex("test", "doc").setId("1").setSource(doc).setRouting("1").get();
-        String[] fieldsList = {"_timestamp", "_size", "_routing"};
+        String[] fieldsList = {"_timestamp", "_routing"};
         // before refresh - document is only in translog
         assertGetFieldsAlwaysWorks(indexOrAlias(), "doc", "1", fieldsList, "1");
         refresh();

--- a/core/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
@@ -44,8 +44,8 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
-import org.elasticsearch.index.mapper.internal.SizeFieldMapper;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -387,7 +387,7 @@ public class SimpleAllMapperTests extends ESSingleNodeTestCase {
         String mapping = "{";
         Map<String, String> rootTypes = new HashMap<>();
         //just pick some example from DocumentMapperParser.rootTypeParsers
-        rootTypes.put(SizeFieldMapper.NAME, "{\"enabled\" : true}");
+        rootTypes.put(TimestampFieldMapper.NAME, "{\"enabled\" : true}");
         rootTypes.put("include_in_all", "true");
         rootTypes.put("dynamic_date_formats", "[\"yyyy-MM-dd\", \"dd-MM-yyyy\"]");
         rootTypes.put("numeric_detection", "true");

--- a/core/src/test/java/org/elasticsearch/index/mapper/typelevels/ParseMappingTypeLevelTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/typelevels/ParseMappingTypeLevelTests.java
@@ -33,16 +33,16 @@ public class ParseMappingTypeLevelTests extends ESSingleNodeTestCase {
     @Test
     public void testTypeLevel() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("_size").field("enabled", true).endObject()
+                .startObject("_timestamp").field("enabled", true).endObject()
                 .endObject().endObject().string();
 
         DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
         DocumentMapper mapper = parser.parse("type", mapping);
         assertThat(mapper.type(), equalTo("type"));
-        assertThat(mapper.sizeFieldMapper().enabled(), equalTo(true));
+        assertThat(mapper.timestampFieldMapper().enabled(), equalTo(true));
 
         mapper = parser.parse(mapping);
         assertThat(mapper.type(), equalTo("type"));
-        assertThat(mapper.sizeFieldMapper().enabled(), equalTo(true));
+        assertThat(mapper.timestampFieldMapper().enabled(), equalTo(true));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/update/UpdateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/update/UpdateMappingTests.java
@@ -159,25 +159,6 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
     }
 
     @Test
-    public void testSizeParsing() throws IOException {
-        IndexService indexService = createIndex("test", Settings.settingsBuilder().build());
-        XContentBuilder indexMapping = XContentFactory.jsonBuilder();
-        boolean enabled = randomBoolean();
-        indexMapping.startObject()
-                .startObject("type")
-                .startObject("_size")
-                .field("enabled", enabled)
-                .endObject()
-                .endObject()
-                .endObject();
-        DocumentMapper documentMapper = indexService.mapperService().parse("type", new CompressedXContent(indexMapping.string()), true);
-        assertThat(documentMapper.sizeFieldMapper().enabled(), equalTo(enabled));
-        assertTrue(documentMapper.sizeFieldMapper().fieldType().stored());
-        documentMapper = indexService.mapperService().parse("type", new CompressedXContent(documentMapper.mappingSource().string()), true);
-        assertThat(documentMapper.sizeFieldMapper().enabled(), equalTo(enabled));
-    }
-
-    @Test
     public void testSizeTimestampIndexParsing() throws IOException {
         IndexService indexService = createIndex("test", Settings.settingsBuilder().build());
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/update/default_mapping_with_disabled_root_types.json");
@@ -192,7 +173,7 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
         createIndex("test1", Settings.settingsBuilder().build());
         createIndex("test2", Settings.settingsBuilder().build());
         XContentBuilder defaultMapping = XContentFactory.jsonBuilder().startObject()
-                .startObject(MapperService.DEFAULT_MAPPING).startObject("_size").field("enabled", true).endObject().endObject()
+                .startObject(MapperService.DEFAULT_MAPPING).startObject("_timestamp").field("enabled", true).endObject().endObject()
                 .endObject();
         client().admin().indices().preparePutMapping().setType(MapperService.DEFAULT_MAPPING).setSource(defaultMapping).get();
         XContentBuilder typeMapping = XContentFactory.jsonBuilder().startObject()
@@ -204,7 +185,7 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
         GetMappingsResponse response = client().admin().indices().prepareGetMappings("test2").get();
         assertNotNull(response.getMappings().get("test2").get("type").getSourceAsMap().get("_all"));
         assertFalse((Boolean) ((LinkedHashMap) response.getMappings().get("test2").get("type").getSourceAsMap().get("_all")).get("enabled"));
-        assertNotNull(response.getMappings().get("test2").get("type").getSourceAsMap().get("_size"));
-        assertTrue((Boolean)((LinkedHashMap)response.getMappings().get("test2").get("type").getSourceAsMap().get("_size")).get("enabled"));
+        assertNotNull(response.getMappings().get("test2").get("type").getSourceAsMap().get("_timestamp"));
+        assertTrue((Boolean)((LinkedHashMap)response.getMappings().get("test2").get("type").getSourceAsMap().get("_timestamp")).get("enabled"));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/update/default_mapping_with_disabled_root_types.json
+++ b/core/src/test/java/org/elasticsearch/index/mapper/update/default_mapping_with_disabled_root_types.json
@@ -1,1 +1,1 @@
-{"type":{"_size":{"enabled":false},"_timestamp":{"enabled":false}}}
+{"type":{"_timestamp":{"enabled":false}}}

--- a/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
@@ -507,37 +507,6 @@ public class PercolatorIT extends ESIntegTestCase {
     }
 
     @Test
-    public void percolateWithSizeField() throws Exception {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
-                .startObject("_size").field("enabled", true).endObject()
-                .startObject("properties").startObject("field1").field("type", "string").endObject().endObject()
-                .endObject().endObject().string();
-
-        assertAcked(prepareCreate("test").addMapping("type1", mapping));
-        ensureGreen();
-
-        logger.info("--> register a query");
-        client().prepareIndex("test", PercolatorService.TYPE_NAME, "kuku")
-                .setSource(jsonBuilder().startObject()
-                        .field("query", termQuery("field1", "value1"))
-                        .endObject())
-                .setRefresh(true)
-                .execute().actionGet();
-
-        logger.info("--> percolate a document");
-        PercolateResponse percolate = client().preparePercolate().setIndices("test").setDocumentType("type1")
-                .setSource(jsonBuilder().startObject()
-                        .startObject("doc")
-                        .field("field1", "value1")
-                        .endObject()
-                        .endObject())
-                .execute().actionGet();
-        assertMatchCount(percolate, 1l);
-        assertThat(percolate.getMatches(), arrayWithSize(1));
-        assertThat(convertFromTextArray(percolate.getMatches(), "test"), arrayContaining("kuku"));
-    }
-
-    @Test
     public void testPercolateStatistics() throws Exception {
         client().admin().indices().prepareCreate("test").execute().actionGet();
         ensureGreen();

--- a/core/src/test/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -76,9 +76,8 @@ public class SearchFieldsIT extends ESIntegTestCase {
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().execute().actionGet();
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
-                // _timestamp and _size are randomly enabled via templates but we don't want it here to test stored fields behaviour
+                // _timestamp is randomly enabled via templates but we don't want it here to test stored fields behaviour
                 .startObject("_timestamp").field("enabled", false).endObject()
-                .startObject("_size").field("enabled", false).endObject()
                 .startObject("properties")
                 .startObject("field1").field("type", "string").field("store", "yes").endObject()
                 .startObject("field2").field("type", "string").field("store", "no").endObject()

--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -102,7 +102,6 @@ import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Loading;
-import org.elasticsearch.index.mapper.internal.SizeFieldMapper;
 import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
 import org.elasticsearch.index.shard.MergePolicyConfig;
 import org.elasticsearch.index.translog.Translog;
@@ -356,11 +355,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
                     mappings.startObject(TimestampFieldMapper.NAME)
                             .field("enabled", randomBoolean());
                     mappings.endObject();
-                }
-                if (randomBoolean()) {
-                    mappings.startObject(SizeFieldMapper.NAME)
-                            .field("enabled", randomBoolean())
-                            .endObject();
                 }
                 mappings.startArray("dynamic_templates")
                         .startObject()

--- a/plugins/mapper-size/pom.xml
+++ b/plugins/mapper-size/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to Elasticsearch under one or more contributor
+license agreements. See the NOTICE file distributed with this work for additional
+information regarding copyright ownership. ElasticSearch licenses this file to you
+under the Apache License, Version 2.0 (the "License"); you may not use this
+file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.elasticsearch.plugin</groupId>
+        <artifactId>elasticsearch-plugin</artifactId>
+        <version>2.0.0-beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>elasticsearch-mapper-size</artifactId>
+    <name>Elasticsearch Mapper size plugin</name>
+    <description>The Mapper Size plugin allows document to record their uncompressed size at index time.</description>
+
+    <properties>
+        <elasticsearch.plugin.classname>org.elasticsearch.plugin.mapper.MapperSizePlugin</elasticsearch.plugin.classname>
+        <tests.rest.suite>mapper_size</tests.rest.suite>
+        <tests.rest.load_packaged>false</tests.rest.load_packaged>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/plugins/mapper-size/rest-api-spec/test/mapper_size/10_basic.yaml
+++ b/plugins/mapper-size/rest-api-spec/test/mapper_size/10_basic.yaml
@@ -1,0 +1,32 @@
+# Integration tests for Mapper Size components
+#
+
+---
+"Mapper Size":
+
+    - do:
+        indices.create:
+            index: test
+            body:
+                mappings:
+                    type1: { "_size": { "enabled": true } }
+
+    - do:
+        index:
+            index: test
+            type: type1
+            id: 1
+            body: { "foo": "bar" }
+
+    - do:
+        indices.refresh: {}
+
+    - do:
+        get:
+            index: test
+            type: type1
+            id: 1
+            fields: "_size"
+
+    - match: { _size: 13 }
+

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/RegisterSizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/RegisterSizeFieldMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.size;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.AbstractIndexComponent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.MapperService;
+
+public class RegisterSizeFieldMapper extends AbstractIndexComponent {
+
+    @Inject
+    public RegisterSizeFieldMapper(Index index, Settings indexSettings, MapperService mapperService) {
+        super(index, indexSettings);
+        mapperService.documentMapperParser().putRootTypeParser(SizeFieldMapper.NAME, new SizeFieldMapper.TypeParser());
+    }
+
+}

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.index.mapper.internal;
+package org.elasticsearch.index.mapper.size;
 
 import org.apache.lucene.document.Field;
 import org.elasticsearch.Version;
@@ -33,6 +33,7 @@ import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.core.IntegerFieldMapper;
+import org.elasticsearch.index.mapper.internal.EnabledAttributeMapper;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -86,7 +87,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(parserContext.mapperService().fullName(NAME));
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
@@ -106,11 +107,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
 
     private EnabledAttributeMapper enabledState;
 
-    public SizeFieldMapper(Settings indexSettings, MappedFieldType existing) {
-        this(Defaults.ENABLED_STATE, existing == null ? Defaults.SIZE_FIELD_TYPE.clone() : existing.clone(), indexSettings);
-    }
-
-    public SizeFieldMapper(EnabledAttributeMapper enabled, MappedFieldType fieldType, Settings indexSettings) {
+    private SizeFieldMapper(EnabledAttributeMapper enabled, MappedFieldType fieldType, Settings indexSettings) {
         super(NAME, fieldType, Defaults.SIZE_FIELD_TYPE, indexSettings);
         this.enabledState = enabled;
 

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/plugin/mapper/MapperSizeIndexModule.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/plugin/mapper/MapperSizeIndexModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.mapper;
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.index.mapper.size.RegisterSizeFieldMapper;
+
+public class MapperSizeIndexModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(RegisterSizeFieldMapper.class).asEagerSingleton();
+    }
+
+}

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/plugin/mapper/MapperSizePlugin.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/plugin/mapper/MapperSizePlugin.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.mapper;
+
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.plugins.AbstractPlugin;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class MapperSizePlugin extends AbstractPlugin {
+
+    @Override
+    public String name() {
+        return "mapper-size";
+    }
+
+    @Override
+    public String description() {
+        return "A mapper that allows document to record their uncompressed size";
+    }
+
+    @Override
+    public Collection<Class<? extends Module>> indexModules() {
+        return Collections.<Class<? extends Module>>singleton(MapperSizeIndexModule.class);
+    }
+
+}

--- a/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/MapperSizeRestIT.java
+++ b/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/MapperSizeRestIT.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.size;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.RestTestCandidate;
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+
+import java.io.IOException;
+
+public class MapperSizeRestIT extends ESRestTestCase {
+
+    public MapperSizeRestIT(@Name("yaml") RestTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
+        return createParameters(0, 1);
+    }
+}
+

--- a/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
+++ b/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
@@ -38,7 +38,9 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_size").field("enabled", true).endObject()
                 .endObject().endObject().string();
-        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+        parser.putRootTypeParser(SizeFieldMapper.NAME, new SizeFieldMapper.TypeParser());
+        DocumentMapper docMapper = parser.parse(mapping);
 
         BytesReference source = XContentFactory.jsonBuilder()
                 .startObject()
@@ -56,7 +58,10 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
                 .startObject("_size").field("enabled", true).field("store", "yes").endObject()
                 .endObject().endObject().string();
         Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
-        DocumentMapper docMapper = createIndex("test", indexSettings).mapperService().documentMapperParser().parse(mapping);
+
+        DocumentMapperParser parser = createIndex("test", indexSettings).mapperService().documentMapperParser();
+        parser.putRootTypeParser(SizeFieldMapper.NAME, new SizeFieldMapper.TypeParser());
+        DocumentMapper docMapper = parser.parse(mapping);
 
         BytesReference source = XContentFactory.jsonBuilder()
                 .startObject()
@@ -73,7 +78,9 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_size").field("enabled", false).endObject()
                 .endObject().endObject().string();
-        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+        parser.putRootTypeParser(SizeFieldMapper.NAME, new SizeFieldMapper.TypeParser());
+        DocumentMapper docMapper = parser.parse(mapping);
 
         BytesReference source = XContentFactory.jsonBuilder()
                 .startObject()
@@ -105,6 +112,7 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
                 .startObject("_size").field("enabled", true).endObject()
                 .endObject().endObject().string();
         DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+        parser.putRootTypeParser(SizeFieldMapper.NAME, new SizeFieldMapper.TypeParser());
         DocumentMapper enabledMapper = parser.parse(enabledMapping);
 
         String disabledMapping = XContentFactory.jsonBuilder().startObject().startObject("type")
@@ -113,6 +121,6 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
         DocumentMapper disabledMapper = parser.parse(disabledMapping);
 
         enabledMapper.merge(disabledMapper.mapping(), false, false);
-        assertThat(enabledMapper.SizeFieldMapper().enabled(), is(false));
+        assertThat(enabledMapper.rootMapper(SizeFieldMapper.class).enabled(), is(false));
     }
 }

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -430,9 +430,10 @@
         <module>cloud-gce</module>
         <module>cloud-azure</module>
         <module>cloud-aws</module>
-        <module>site-example</module>
+        <module>delete-by-query</module>
         <module>lang-python</module>
         <module>lang-javascript</module>
-        <module>delete-by-query</module>
+        <module>mapper-size</module>
+        <module>site-example</module>
     </modules>
 </project>

--- a/qa/smoke-test-plugins/pom.xml
+++ b/qa/smoke-test-plugins/pom.xml
@@ -127,7 +127,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-site-example</artifactId>
+                   <artifactId>elasticsearch-delete-by-query</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -151,11 +151,20 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-delete-by-query</artifactId>
+                   <artifactId>elasticsearch-mapper-size</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
                  </artifactItem>
+
+                 <artifactItem>
+                   <groupId>org.elasticsearch.plugin</groupId>
+                   <artifactId>elasticsearch-site-example</artifactId>
+                   <version>${elasticsearch.version}</version>
+                   <type>zip</type>
+                   <overWrite>true</overWrite>
+                 </artifactItem>
+
                </artifactItems>
              </configuration>
            </execution>


### PR DESCRIPTION
This is one of our esoteric metadata mappers so I think we should distribute
it in a plugin rather than in elasticsearch core.

This introduces one limitation: the value of the `_size` parameter is not
retrievable for documents that are only in the transaction log.
