### PR TITLE
Fix Bootstrap to not call System.exit

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -222,7 +222,7 @@ public class Bootstrap {
         }
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Throwable {
         BootstrapCLIParser bootstrapCLIParser = new BootstrapCLIParser();
         CliTool.ExitStatus status = bootstrapCLIParser.execute(args);
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -24,7 +24,7 @@ package org.elasticsearch.bootstrap;
  */
 public class Elasticsearch extends Bootstrap {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         Bootstrap.main(args);
     }
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -24,7 +24,7 @@ package org.elasticsearch.bootstrap;
  */
 public class Elasticsearch extends Bootstrap {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Throwable {
         Bootstrap.main(args);
     }
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/ElasticsearchF.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ElasticsearchF.java
@@ -25,7 +25,7 @@ package org.elasticsearch.bootstrap;
  */
 public class ElasticsearchF {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         System.setProperty("es.foreground", "yes");
         Bootstrap.main(args);
     }

--- a/core/src/main/java/org/elasticsearch/bootstrap/ElasticsearchF.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ElasticsearchF.java
@@ -25,7 +25,7 @@ package org.elasticsearch.bootstrap;
  */
 public class ElasticsearchF {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Throwable {
         System.setProperty("es.foreground", "yes");
         Bootstrap.main(args);
     }


### PR DESCRIPTION
Its not going to work: its blocked by security policy
and will just add a confusing SecurityException to the mix, and
bogusly give an exit status of 0 when in fact something bad happened.

Finally, if ES can't startup, it is a serious problem, there is
no sense in hiding the reason why: deliver the full stack trace.
