### PR TITLE
Add support for bulk delete operation in snapshot repository

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -48,9 +49,16 @@ public interface BlobContainer {
     /**
      * Deletes a blob with giving name.
      *
-     * If blob exist but cannot be deleted an exception has to be thrown.
+     * If a blob exists but cannot be deleted an exception has to be thrown.
      */
     void deleteBlob(String blobName) throws IOException;
+
+    /**
+     * Deletes blobs with giving names.
+     *
+     * If a blob exists but cannot be deleted an exception has to be thrown.
+     */
+    void deleteBlobs(Collection<String> blobNames) throws IOException;
 
     /**
      * Deletes all blobs in the container that match the specified prefix.

--- a/core/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -48,6 +49,13 @@ public abstract class AbstractBlobContainer implements BlobContainer {
         Map<String, BlobMetaData> blobs = listBlobsByPrefix(blobNamePrefix);
         for (BlobMetaData blob : blobs.values()) {
             deleteBlob(blob.name());
+        }
+    }
+
+    @Override
+    public void deleteBlobs(Collection<String> blobNames) throws IOException {
+        for(String blob: blobNames) {
+            deleteBlob(blob);
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -61,6 +62,11 @@ public class BlobContainerWrapper implements BlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         delegate.deleteBlob(blobName);
+    }
+
+    @Override
+    public void deleteBlobs(Collection<String> blobNames) throws IOException {
+        delegate.deleteBlobs(blobNames);
     }
 
     @Override


### PR DESCRIPTION
Currently when we delete files belonging to deleted snapshots we issue one delete command to underlying snapshot store at a time. Some repositories can benefit from bulk deletes of multiple files.

Closes #12533
