### PR TITLE
Fixed official api name in docs

### DIFF
--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -97,7 +97,7 @@ will not start.
 ==== Installed Plugins
 
 A list of the currently loaded plugins can be retrieved using the
-<<cluster-nodes-info,Node Info API>>.
+<<cluster-nodes-info,Nodes Info API>>.
 
 [float]
 ==== Removing plugins


### PR DESCRIPTION
I think that `Nodes Info API` is official api name.
I fixed it.
- https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html

Thank you so much.
