### PR TITLE
Fix ShardUtils#getElasticsearchDirectoryReader()

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/ShardUtils.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardUtils.java
@@ -78,7 +78,11 @@ public final class ShardUtils {
             if (reader instanceof ElasticsearchDirectoryReader) {
                 return (ElasticsearchDirectoryReader) reader;
             } else {
-                return null; // lucene needs a getDelegate method on FilteredDirectoryReader - not a big deal here
+                // We need to use FilterDirectoryReader#getDelegate and not FilterDirectoryReader#unwrap, because
+                // If there are multiple levels of filtered leaf readers then with the unwrap() method it immediately
+                // returns the most inner leaf reader and thus skipping of over any other filtered leaf reader that
+                // may be instance of ElasticsearchLeafReader. This can cause us to miss the shardId.
+                return getElasticsearchDirectoryReader(((FilterDirectoryReader) reader).getDelegate());
             }
         }
         return null;


### PR DESCRIPTION
fix ShardUtils#getElasticsearchDirectoryReader(...) to use FilterDirectoryReader#getDelegate()
