### PR TITLE
Test that shaded jar contains only shaded classes

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -286,4 +286,26 @@
     </java>
   </target>
 
+  <target name="check-shaded-jar-packages">
+    <!-- we unzip the jar, vs zipfileset, zipfileset toString is useless -->
+    <delete dir="${integ.temp}/unzipped"/>
+    <mkdir dir="${integ.temp}/unzipped"/>
+    <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar"
+           dest="${integ.temp}/unzipped"/>
+    <local name="unshaded.classes"/>
+    <fileset id="unshaded.classes"
+             dir="${integ.temp}/unzipped"
+             includes="**/*.class"
+             excludes="org/elasticsearch/**,org/apache/lucene/**"/>
+    <fail message="shaded jar contains packages outside of org.elasticsearch: ${toString:unshaded.classes}">
+       <condition>
+         <not>
+           <resourcecount count="0">
+             <fileset refid="unshaded.classes"/>
+           </resourcecount>
+         </not>
+       </condition>
+    </fail>
+  </target>
+
 </project>

--- a/distribution/shaded/pom.xml
+++ b/distribution/shaded/pom.xml
@@ -51,6 +51,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${elasticsearch.integ.antfile}" target="check-for-jar-hell"/>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="check-shaded-jar-packages"/>
                             </target>
                         </configuration>
                     </execution>
@@ -74,24 +75,10 @@
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <dependencyReducedPomLocation>${build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                     <artifactSet>
-                        <includes>
-                            <include>org.elasticsearch:elasticsearch</include>
-                            <include>com.google.guava:guava</include>
-                            <include>com.carrotsearch:hppc</include>
-                            <include>com.fasterxml.jackson.core:jackson-core</include>
-                            <include>com.fasterxml.jackson.dataformat:jackson-dataformat-smile</include>
-                            <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
-                            <include>com.fasterxml.jackson.dataformat:jackson-dataformat-cbor</include>
-                            <include>joda-time:joda-time</include>
-                            <include>org.joda:joda-convert</include>
-                            <include>io.netty:netty</include>
-                            <include>com.ning:compress-lzf</include>
-                            <include>com.github.spullara.mustache.java:compiler</include>
-                            <include>com.tdunning:t-digest</include>
-                            <include>org.apache.commons:commons-lang3</include>
-                            <include>commons-cli:commons-cli</include>
-                            <include>com.twitter:jsr166e</include>
-                        </includes>
+                        <excludes>
+                            <exclude>org.apache.lucene:*</exclude>
+                            <exclude>com.spatial4j:*</exclude>
+                        </excludes>
                     </artifactSet>
                     <transformers>
                         <!-- copy over MANIFEST.MF from unshaded jar, but mark jar as shaded too -->
@@ -107,8 +94,20 @@
                             <shadedPattern>org.elasticsearch.common</shadedPattern>
                         </relocation>
                         <relocation>
+                            <pattern>com.google.thirdparty</pattern>
+                            <shadedPattern>org.elasticsearch.common.thirdparty</shadedPattern>
+                        </relocation>
+                        <relocation>
                             <pattern>com.carrotsearch.hppc</pattern>
                             <shadedPattern>org.elasticsearch.common.hppc</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.HdrHistogram</pattern>
+                            <shadedPattern>org.elasticsearch.common.HdrHistogram</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.yaml</pattern>
+                            <shadedPattern>org.elasticsearch.common.yaml</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>com.twitter.jsr166e</pattern>
@@ -121,6 +120,10 @@
                         <relocation>
                             <pattern>org.joda.time</pattern>
                             <shadedPattern>org.elasticsearch.common.joda.time</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.joda.convert</pattern>
+                            <shadedPattern>org.elasticsearch.common.joda.convert</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>org.jboss.netty</pattern>


### PR DESCRIPTION
Fail the build if classes are missing relocation definitions. This allows us to also safely change this from an inclusion list to an exclusion list. When a jar is added, it will automatically be added to the shaded jar by default (unless you exclude it), and the build will fail until you relocate packages.

Will look like this (e.g. for hdrhistogram jar):

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (check-for-jar-hell) on project elasticsearch-shaded: An Ant BuildException has occured: The following error occurred while executing this line:
[ERROR] /home/rmuir/workspace/elasticsearch/distribution/shaded/target/dev-tools/ant/integration-tests.xml:299: shaded jar contains packages outside of org.elasticsearch: org/HdrHistogram/AbstractHistogram$1.class;org/HdrHistogram/AbstractHistogram$AllValues.class
```
