### PR TITLE
Add integration test phase for elasticsearch core/

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -261,7 +261,7 @@ The REST tests are run automatically when executing the maven test command. To r
 REST tests use the following command:
 
 ---------------------------------------------------------------------------
-mvn test -Dtests.filter="@Rest"
+mvn verify -Dtests.filter="@Rest"
 ---------------------------------------------------------------------------
 
 `ElasticsearchRestTests` is the executable test class that runs all the

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,11 +16,6 @@
     <name>Elasticsearch Core</name>
     <description>Elasticsearch - Open Source, Distributed, RESTful Search Engine</description>
 
-
-    <properties>
-        <skip.integ.tests>true</skip.integ.tests>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/core/src/test/java/org/elasticsearch/test/rest/Rest0IT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Rest0IT.java
@@ -26,13 +26,13 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
 
-/** Rest API tests subset 7 */
-public class Rest7Tests extends ElasticsearchRestTestCase {
-    public Rest7Tests(@Name("yaml") RestTestCandidate testCandidate) {
+/** Rest API tests subset 0 */
+public class Rest0IT extends ElasticsearchRestTestCase {
+    public Rest0IT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
-        return createParameters(7, 8);
+        return createParameters(0, 8);
     }
 }

--- a/core/src/test/java/org/elasticsearch/test/rest/Rest1IT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Rest1IT.java
@@ -27,8 +27,8 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 import java.io.IOException;
 
 /** Rest API tests subset 1 */
-public class Rest1Tests extends ElasticsearchRestTestCase {
-    public Rest1Tests(@Name("yaml") RestTestCandidate testCandidate) {
+public class Rest1IT extends ElasticsearchRestTestCase {
+    public Rest1IT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
     @ParametersFactory

--- a/core/src/test/java/org/elasticsearch/test/rest/Rest2IT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Rest2IT.java
@@ -27,8 +27,8 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 import java.io.IOException;
 
 /** Rest API tests subset 2 */
-public class Rest2Tests extends ElasticsearchRestTestCase {
-    public Rest2Tests(@Name("yaml") RestTestCandidate testCandidate) {
+public class Rest2IT extends ElasticsearchRestTestCase {
+    public Rest2IT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
     @ParametersFactory

--- a/core/src/test/java/org/elasticsearch/test/rest/Rest3IT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Rest3IT.java
@@ -26,13 +26,13 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
 
-/** Rest API tests subset 5 */
-public class Rest5Tests extends ElasticsearchRestTestCase {
-    public Rest5Tests(@Name("yaml") RestTestCandidate testCandidate) {
+/** Rest API tests subset 3 */
+public class Rest3IT extends ElasticsearchRestTestCase {
+    public Rest3IT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
-        return createParameters(5, 8);
+        return createParameters(3, 8);
     }
 }

--- a/core/src/test/java/org/elasticsearch/test/rest/Rest4IT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Rest4IT.java
@@ -26,13 +26,13 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
 
-/** Rest API tests subset 6 */
-public class Rest6Tests extends ElasticsearchRestTestCase {
-    public Rest6Tests(@Name("yaml") RestTestCandidate testCandidate) {
+/** Rest API tests subset 4 */
+public class Rest4IT extends ElasticsearchRestTestCase {
+    public Rest4IT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
-        return createParameters(6, 8);
+        return createParameters(4, 8);
     }
 }

--- a/core/src/test/java/org/elasticsearch/test/rest/Rest5IT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Rest5IT.java
@@ -26,13 +26,13 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
 
-/** Rest API tests subset 0 */
-public class Rest0Tests extends ElasticsearchRestTestCase {
-    public Rest0Tests(@Name("yaml") RestTestCandidate testCandidate) {
+/** Rest API tests subset 5 */
+public class Rest5IT extends ElasticsearchRestTestCase {
+    public Rest5IT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
-        return createParameters(0, 8);
+        return createParameters(5, 8);
     }
 }

--- a/core/src/test/java/org/elasticsearch/test/rest/Rest6IT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Rest6IT.java
@@ -26,13 +26,13 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
 
-/** Rest API tests subset 4 */
-public class Rest4Tests extends ElasticsearchRestTestCase {
-    public Rest4Tests(@Name("yaml") RestTestCandidate testCandidate) {
+/** Rest API tests subset 6 */
+public class Rest6IT extends ElasticsearchRestTestCase {
+    public Rest6IT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
-        return createParameters(4, 8);
+        return createParameters(6, 8);
     }
 }

--- a/core/src/test/java/org/elasticsearch/test/rest/Rest7IT.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Rest7IT.java
@@ -26,13 +26,13 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
 
-/** Rest API tests subset 3 */
-public class Rest3Tests extends ElasticsearchRestTestCase {
-    public Rest3Tests(@Name("yaml") RestTestCandidate testCandidate) {
+/** Rest API tests subset 7 */
+public class Rest7IT extends ElasticsearchRestTestCase {
+    public Rest7IT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);
     }
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws IOException, RestTestParseException {
-        return createParameters(3, 8);
+        return createParameters(7, 8);
     }
 }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -132,6 +132,23 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>com.carrotsearch.randomizedtesting</groupId>
+                    <artifactId>junit4-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>integ-tests</id>
+                            <configuration>
+                                <!-- currently only 1 cpu works, because integ tests don't make "unique" test directories? -->
+                                <parallelism>1</parallelism>
+                                <systemProperties>
+                                    <!-- use external cluster -->
+                                    <tests.cluster>127.0.0.1:9300</tests.cluster>
+                                </systemProperties>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -400,6 +400,23 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>com.carrotsearch.randomizedtesting</groupId>
+                    <artifactId>junit4-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>integ-tests</id>
+                            <configuration>
+                                <!-- currently only 1 cpu works, because integ tests don't make "unique" test directories? -->
+                                <parallelism>1</parallelism>
+                                <systemProperties>
+                                    <!-- use external cluster -->
+                                    <tests.cluster>127.0.0.1:9300</tests.cluster>
+                                </systemProperties>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -733,16 +733,12 @@
                                         summaryFile="${project.build.directory}/failsafe-reports/failsafe-summary.xml"
                                         dir="${project.build.directory}/failsafe-reports"/>
                                 </listeners>
-                                <!-- currently only 1 cpu works, because integ tests don't make "unique" test directories? -->
-                                <parallelism>1</parallelism>
                                 <includes>
                                     <include>**/*IT.class</include>
                                 </includes>
                                 <systemProperties>
                                     <!-- integ tests are typically slow! -->
                                     <tests.slow>true</tests.slow>
-                                    <!-- use external cluster -->
-                                    <tests.cluster>127.0.0.1:9300</tests.cluster>
                                     <!-- let framework know we are running integ tests, for correct 'reproduce with' line -->
                                     <tests.verify.phase>true</tests.verify.phase>
                                 </systemProperties>


### PR DESCRIPTION
Today for elasticsearch/core, `mvn test` runs a mix of unit and integration tests, and `mvn verify` doesnt really do anything additional.

Instead we currently have a lot of complicated stuff like `@Slow`, `@Integration`, and -D's to run them with to try to make it easier to run a subset of the tests, but I think this causes build failures because its too easy to forget to run tests.slow, etc before pushing. This stuff is really just workarounds for not setting things up properly.

So I think we should just move integration tests to the integration test phase. I think we should do it proper and remove those annotations like `@Slow` and `@Integration` and make our integration tests just ITs: no maven magic or magical test filtering, that gets confusing. It allows people to iterate quicker since unit testing phase will get fast once we move them all over.

And the build gets a lot simpler to prevent build failures: run `mvn verify` before pushing. I did just the rest tests here as a start.

Core integration tests run with parallel jvms and everything else so it is not a slowdown, just a separation.
