### PR TITLE
Forbid @Slow

### DIFF
--- a/dev-tools/src/main/resources/forbidden/test-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/test-signatures.txt
@@ -19,3 +19,4 @@ com.carrotsearch.randomizedtesting.annotations.Seed @ Don't commit hardcoded see
 com.carrotsearch.randomizedtesting.annotations.Repeat @ Don't commit hardcoded repeats
 
 org.apache.lucene.codecs.Codec#setDefault(org.apache.lucene.codecs.Codec) @ Use the SuppressCodecs("*") annotation instead
+org.apache.lucene.util.LuceneTestCase$Slow @ Don't write slow tests

--- a/plugins/cloud-aws/src/test/java/org/elasticsearch/cloud/aws/blobstore/S3OutputStreamTest.java
+++ b/plugins/cloud-aws/src/test/java/org/elasticsearch/cloud/aws/blobstore/S3OutputStreamTest.java
@@ -77,7 +77,7 @@ public class S3OutputStreamTest extends ElasticsearchTestCase {
 
     }
 
-    @Test @Slow
+    @Test
     public void testWriteExactlyNTimesMoreDataThanBufferSize() throws IOException {
         int n = randomIntBetween(2, 3);
         int length = n * BUFFER_SIZE;


### PR DESCRIPTION
Now that all uses of @Slow are gone, we can forbid this annotations use
so tests are not confusing. Follow up to #12617.
