### PR TITLE
Fix upgrade RPM script

### DIFF
--- a/src/packaging/common/scripts/postrm
+++ b/src/packaging/common/scripts/postrm
@@ -8,8 +8,8 @@ ${packaging.scripts.header}
 #       $1=purge     : indicates an upgrade
 #
 #   On RedHat,
-#       $1=1         : indicates an new install
-#       $1=2         : indicates an upgrade
+#       $1=0         : indicates a removal
+#       $1=1         : indicates an upgrade
 
 
 
@@ -39,7 +39,7 @@ case "$1" in
         REMOVE_SERVICE=true
         REMOVE_USER_AND_GROUP=true
     ;;
-    2)
+    1)
         # If $1=1 this is an upgrade
         IS_UPGRADE=true
     ;;


### PR DESCRIPTION
This is a partial backport of #12298. This fixes an
issue that rpms could not be upgraded, because of a bad
number check in the postrm script, which exits with a
failure.

Reminds us, we also need to test upgrading of RPMS in CI.

Closes #12606
