### PR TITLE
Use AllocationID for shard size caching on master

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -19,23 +19,23 @@
 
 package org.elasticsearch.cluster;
 
-import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.cluster.routing.ShardRouting;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
  * ClusterInfo is an object representing a map of nodes to {@link DiskUsage}
- * and a map of shard ids to shard sizes, see
- * <code>InternalClusterInfoService.shardIdentifierFromRouting(String)</code>
- * for the key used in the shardSizes map
+ * and a map of shard ids to shard sizes keyed by the {@link AllocationId}
  */
 public class ClusterInfo {
-
+    public static final ClusterInfo EMPTY = new ClusterInfo(Collections.EMPTY_MAP, Collections.EMPTY_MAP);
     private final Map<String, DiskUsage> usages;
-    final Map<String, Long> shardSizes;
+    private final Map<AllocationId, Long> shardSizes;
 
-    public ClusterInfo(Map<String, DiskUsage> usages, Map<String, Long> shardSizes) {
+    public ClusterInfo(Map<String, DiskUsage> usages, Map<AllocationId, Long> shardSizes) {
         this.usages = usages;
         this.shardSizes = shardSizes;
     }
@@ -45,14 +45,14 @@ public class ClusterInfo {
     }
 
     public Long getShardSize(ShardRouting shardRouting) {
-        return shardSizes.get(shardIdentifierFromRouting(shardRouting));
+        return shardSizes.get(shardRouting.allocationId());
     }
 
-    /**
-     * Method that incorporates the ShardId for the shard into a string that
-     * includes a 'p' or 'r' depending on whether the shard is a primary.
-     */
-    static String shardIdentifierFromRouting(ShardRouting shardRouting) {
-        return shardRouting.shardId().toString() + "[" + (shardRouting.primary() ? "p" : "r") + "]";
+    final int getNumShardSizes() { // for testing
+        return shardSizes.size();
+    }
+
+    final Collection<Long> getShardSizeValues() { // for testing
+        return shardSizes.values();
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/EmptyClusterInfoService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/EmptyClusterInfoService.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster;
 
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 
@@ -31,11 +30,9 @@ public class EmptyClusterInfoService extends AbstractComponent implements Cluste
     private final static class Holder {
         private final static EmptyClusterInfoService instance = new EmptyClusterInfoService();
     }
-    private final ClusterInfo emptyClusterInfo;
 
     private EmptyClusterInfoService() {
         super(Settings.EMPTY);
-        emptyClusterInfo = new ClusterInfo(ImmutableMap.<String, DiskUsage>of(), ImmutableMap.<String, Long>of());
     }
 
     public static EmptyClusterInfoService getInstance() {
@@ -44,7 +41,7 @@ public class EmptyClusterInfoService extends AbstractComponent implements Cluste
 
     @Override
     public ClusterInfo getClusterInfo() {
-        return emptyClusterInfo;
+        return ClusterInfo.EMPTY;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
-import com.google.common.collect.ImmutableMap;
 
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
-import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -47,9 +42,7 @@ public class DiskThresholdDeciderUnitTests extends ESTestCase {
         ClusterInfoService cis = new ClusterInfoService() {
             @Override
             public ClusterInfo getClusterInfo() {
-                Map<String, DiskUsage> usages = new HashMap<>();
-                Map<String, Long> shardSizes = new HashMap<>();
-                return new ClusterInfo(ImmutableMap.copyOf(usages), ImmutableMap.copyOf(shardSizes));
+                return ClusterInfo.EMPTY;
             }
 
             @Override

--- a/core/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.state;
 
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
@@ -92,7 +91,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
                         .nodes(DiscoveryNodes.EMPTY_NODES)
                         .build()
         );
-        ClusterInfo clusterInfo = new ClusterInfo(ImmutableMap.<String, DiskUsage>of(), ImmutableMap.<String, Long>of());
+        ClusterInfo clusterInfo = ClusterInfo.EMPTY;
 
         RoutingAllocation routingAllocation = new RoutingAllocation(allocationDeciders, routingNodes, current.nodes(), clusterInfo);
         allocator.allocateUnassigned(routingAllocation);


### PR DESCRIPTION
Today we build a custom cache key that treats all replicas
equally for a shard. This might have problems if some replicas are
much bigger due to a pending merge etc. Now that we have an Allocaiton ID
we can utilize it as a cache key.
