### PR TITLE
Don't use port 9200/9300 for integration tests

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -16,6 +16,7 @@
   <property name="integ.args"
             value="-Des.node.name=smoke_tester -Des.cluster.name=prepare_release
                    -Des.discovery.zen.ping.multicast.enabled=false -Des.script.inline=on
+                   -Des.http.port=${integ.http.port} -Des.transport.tcp.port=${integ.transport.port}
                    -Des.script.indexed=on -Des.pidfile=${integ.pidfile} -Des.repositories.url.allowed_urls=http://snapshot.test*"/>
 
   <!-- runs an OS script -->
@@ -122,7 +123,7 @@
                   args="@{args} -Des.path.repo=@{home}/repo" />
 
       <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
-        <http url="http://127.0.0.1:9200"/>
+        <http url="http://127.0.0.1:${integ.http.port}"/>
       </waitfor>
 
       <local name="integ.pid"/>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -167,7 +167,7 @@
                                 <parallelism>1</parallelism>
                                 <systemProperties>
                                     <!-- use external cluster -->
-                                    <tests.cluster>127.0.0.1:9300</tests.cluster>
+                                    <tests.cluster>127.0.0.1:${integ.transport.port}</tests.cluster>
                                 </systemProperties>
                             </configuration>
                         </execution>

--- a/distribution/zip/pom.xml
+++ b/distribution/zip/pom.xml
@@ -60,7 +60,11 @@
                         </goals>
                         <configuration>
                             <target if="${run}">
-                                <ant antfile="${elasticsearch.integ.antfile}" target="start-foreground"/>
+                                <!-- use conventional port numbers -->
+                                <ant antfile="${elasticsearch.integ.antfile}" target="start-foreground">
+                                    <property name="integ.http.port" value="9200"/>
+                                    <property name="integ.transport.port" value="9300"/>
+                                </ant>
                             </target>
                         </configuration>
                     </execution>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -411,7 +411,7 @@
                                 <parallelism>1</parallelism>
                                 <systemProperties>
                                     <!-- use external cluster -->
-                                    <tests.cluster>127.0.0.1:9300</tests.cluster>
+                                    <tests.cluster>127.0.0.1:${integ.transport.port}</tests.cluster>
                                 </systemProperties>
                             </configuration>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,8 @@
         <integ.scratch>${project.build.directory}/integ-tests</integ.scratch>
         <integ.deps>${project.build.directory}/integ-deps</integ.deps>
         <integ.temp>${integ.scratch}/temp</integ.temp>
+        <integ.http.port>9400</integ.http.port>
+        <integ.transport.port>9500</integ.transport.port>
         <no.commit.pattern>\bno(n|)commit\b</no.commit.pattern>
     </properties>
 


### PR DESCRIPTION
This just causes confusion if a dev is running ES locally already.

This fix is just a simple practical fix, we can look at more complicated stuff like http://www.mojohaus.org/build-helper-maven-plugin/reserve-network-port-mojo.html later, but we may want to refactor to ranges anyway to run distribution tests in parallel, etc.
