### PR TITLE
Ignore EngineClosedException on IndexShard#sync

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -211,12 +211,7 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
         }
 
         if (indexShard.getTranslogDurability() == Translog.Durabilty.REQUEST && location != null) {
-            try {
-                indexShard.sync(location);
-            } catch (EngineClosedException e) {
-                // ignore, the engine is already closed and we do not want the
-                // operation to be retried, because it has been modified
-            }
+            indexShard.sync(location);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1403,9 +1403,11 @@ public class IndexShard extends AbstractIndexShardComponent {
      * Syncs the given location with the underlying storage unless already synced.
      */
     public void sync(Translog.Location location) {
-        final Engine engine = engine();
         try {
+            final Engine engine = engine();
             engine.getTranslog().ensureSynced(location);
+        } catch (EngineClosedException ex) {
+            // that's fine since we already synced everything on engine close - this also is conform with the methods documentation
         } catch (IOException ex) { // if this fails we are in deep shit - fail the request
             logger.debug("failed to sync translog", ex);
             throw new ElasticsearchException("failed to sync translog", ex);


### PR DESCRIPTION
This method syncs the translog unless it's already synced. If the engine
is alreayd closed we are guaranteed to be synced already such that we can just
ignore this exception.

Closes #12603
