### PR TITLE
[build] mvn install renames artifacts when copying

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -143,9 +143,9 @@
   <!-- TODO: doesn't belong here, but we will figure it out -->
   <target name="start-foreground" depends="stop-external-cluster">
       <delete dir="${integ.scratch}"/>
-      <unzip src="${project.build.directory}/releases/elasticsearch-${project.version}.zip" dest="${integ.scratch}"/>
+      <unzip src="${project.build.directory}/releases/${project.artifactId}-${project.version}.zip" dest="${integ.scratch}"/>
       <local name="home"/>
-      <property name="home" location="${integ.scratch}/elasticsearch-${elasticsearch.version}"/>
+      <property name="home" location="${integ.scratch}/${project.artifactId}-${elasticsearch.version}"/>
       <run-script script="${home}/bin/elasticsearch" spawn="false"
                   args="${integ.args} -Des.path.repo=${home}/repo">
         <nested>
@@ -185,7 +185,7 @@
   <target name="setup-workspace-zip" depends="stop-external-cluster" unless="${shouldskip}">
     <sequential>
       <delete dir="${integ.scratch}"/>
-      <unzip src="${project.build.directory}/releases/elasticsearch-${project.version}.zip" 
+      <unzip src="${project.build.directory}/releases/${project.artifactId}-${project.version}.zip" 
              dest="${integ.scratch}"/>
     </sequential>
   </target>
@@ -200,7 +200,7 @@
   <target name="setup-workspace-tar" depends="stop-external-cluster" unless="${shouldskip}">
     <sequential>
       <delete dir="${integ.scratch}"/>
-      <untar src="${project.build.directory}/releases/elasticsearch-${project.version}.tar.gz" 
+      <untar src="${project.build.directory}/releases/${project.artifactId}-${project.version}.tar.gz" 
              dest="${integ.scratch}"
              compression="gzip"/>
     </sequential>
@@ -217,7 +217,7 @@
       <delete dir="${integ.scratch}"/>
       <mkdir dir="${integ.scratch}/deb-extracted"/>
       <local name="debfile"/>
-      <property name="debfile" location="${project.build.directory}/releases/elasticsearch-${project.version}.deb"/>
+      <property name="debfile" location="${project.build.directory}/releases/${project.artifactId}-${project.version}.deb"/>
       <!-- print some basic package info -->
       <exec executable="dpkg-deb" failonerror="true" taskname="deb-info">
          <arg value="-I"/>
@@ -244,7 +244,7 @@
       <local name="rpm.file"/>
       <local name="rpm.database"/>
       <local name="rpm.extracted"/>
-      <property name="rpm.file" location="${project.build.directory}/releases/elasticsearch-${project.version}.rpm"/>
+      <property name="rpm.file" location="${project.build.directory}/releases/${project.artifactId}-${project.version}.rpm"/>
       <property name="rpm.database" location="${integ.scratch}/rpm-database"/>
       <property name="rpm.extracted" location="${integ.scratch}/rpm-extracted"/>
       <mkdir dir="${rpm.database}"/>

--- a/distribution/deb/pom.xml
+++ b/distribution/deb/pom.xml
@@ -9,8 +9,14 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-deb</artifactId>
+    <groupId>org.elasticsearch.distribution.deb</groupId>
+    <artifactId>elasticsearch</artifactId>
     <name>Elasticsearch DEB Distribution</name>
+    <!--
+        We should use deb packaging here because we don't want to publish any jar.
+        But if you do this, then maven lifecycle does not execute any test (nor compile any test)
+     -->
+    <!--packaging>deb</packaging-->
 
     <properties>
         <deb.sign>false</deb.sign>
@@ -19,8 +25,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.elasticsearch.distribution</groupId>
-            <artifactId>elasticsearch-fully-loaded</artifactId>
+            <groupId>org.elasticsearch.distribution.fully-loaded</groupId>
+            <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>
             <type>pom</type>
         </dependency>
@@ -90,7 +96,6 @@
                 <!-- some infos https://github.com/tcurdt/jdeb/blob/master/docs/maven.md -->
                 <artifactId>jdeb</artifactId>
                 <groupId>org.vafer</groupId>
-                <version>1.4</version>
                 <configuration>
                     <!-- By default it should generates target/${artifactId}_${version}.deb but we get elasticsearch_2.0.0~SNAPSHOT_all.deb -->
                     <deb>${project.build.directory}/releases/elasticsearch-${project.version}.deb</deb>
@@ -253,6 +258,7 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>

--- a/distribution/fully-loaded/pom.xml
+++ b/distribution/fully-loaded/pom.xml
@@ -9,7 +9,8 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-fully-loaded</artifactId>
+    <groupId>org.elasticsearch.distribution.fully-loaded</groupId>
+    <artifactId>elasticsearch</artifactId>
     <name>Elasticsearch with all optional dependencies</name>
     <packaging>pom</packaging>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -71,7 +71,6 @@
     </dependencies>
 
     <build>
-        <finalName>elasticsearch-${project.version}</finalName>
         <plugins>
             <!-- We copy libs for deb and rpm -->
             <plugin>
@@ -155,6 +154,14 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <!-- distribution modules don't provide any jar. No need to upload empty jars to maven central -->
+                        <skipIfEmpty>true</skipIfEmpty>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.carrotsearch.randomizedtesting</groupId>

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -9,14 +9,15 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-rpm</artifactId>
+    <groupId>org.elasticsearch.distribution.rpm</groupId>
+    <artifactId>elasticsearch</artifactId>
     <name>Elasticsearch RPM Distribution</name>
     <packaging>rpm</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.elasticsearch.distribution</groupId>
-            <artifactId>elasticsearch-fully-loaded</artifactId>
+            <groupId>org.elasticsearch.distribution.fully-loaded</groupId>
+            <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>
             <type>pom</type>
         </dependency>
@@ -301,7 +302,6 @@
                                     <type>${project.packaging}</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/releases/</outputDirectory>
-                                    <destFileName>elasticsearch-${project.version}.rpm</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/distribution/shaded/pom.xml
+++ b/distribution/shaded/pom.xml
@@ -9,7 +9,8 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-shaded</artifactId>
+    <groupId>org.elasticsearch.distribution.shaded</groupId>
+    <artifactId>elasticsearch</artifactId>
     <name>Elasticsearch Shaded Distribution</name>
 
     <dependencies>
@@ -21,13 +22,13 @@
     </dependencies>
 
     <build>
-        <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <!-- see docs, incremental builds dont play well with shading otherwise -->
                 <configuration>
+                    <skipIfEmpty>false</skipIfEmpty>
                     <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>

--- a/distribution/src/main/assemblies/common-bin.xml
+++ b/distribution/src/main/assemblies/common-bin.xml
@@ -4,10 +4,11 @@
             <outputDirectory>/lib</outputDirectory>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>false</useTransitiveFiltering>
+            <useProjectArtifact>false</useProjectArtifact>
             <excludes>
               <!-- don't include our POMs etc that we use internally -->
               <!-- otherwise, don't filter here. mark deps properly instead -->
-              <exclude>org.elasticsearch.distribution:*</exclude>
+              <exclude>*:pom</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/distribution/tar/pom.xml
+++ b/distribution/tar/pom.xml
@@ -9,13 +9,19 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-tar</artifactId>
+    <groupId>org.elasticsearch.distribution.tar</groupId>
+    <artifactId>elasticsearch</artifactId>
     <name>Elasticsearch TAR Distribution</name>
+    <!--
+        We should use pom packaging here because we don't want to publish any jar.
+        But if you do this, then maven lifecycle does not execute any test (nor compile any test)
+     -->
+    <!--packaging>pom</packaging-->
 
     <dependencies>
         <dependency>
-            <groupId>org.elasticsearch.distribution</groupId>
-            <artifactId>elasticsearch-fully-loaded</artifactId>
+            <groupId>org.elasticsearch.distribution.fully-loaded</groupId>
+            <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>
             <type>pom</type>
         </dependency>

--- a/distribution/zip/pom.xml
+++ b/distribution/zip/pom.xml
@@ -9,13 +9,19 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-zip</artifactId>
+    <groupId>org.elasticsearch.distribution.zip</groupId>
+    <artifactId>elasticsearch</artifactId>
     <name>Elasticsearch ZIP Distribution</name>
+    <!--
+        We should use pom packaging here because we don't want to publish any jar.
+        But if you do this, then maven lifecycle does not execute any test (nor compile any test)
+     -->
+    <!--packaging>pom</packaging-->
 
     <dependencies>
         <dependency>
-            <groupId>org.elasticsearch.distribution</groupId>
-            <artifactId>elasticsearch-fully-loaded</artifactId>
+            <groupId>org.elasticsearch.distribution.fully-loaded</groupId>
+            <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>
             <type>pom</type>
         </dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -385,16 +385,14 @@
                                 <skip>${skip.integ.tests}</skip>
                                 <artifactItems>
                                     <artifactItem>
-                                        <groupId>org.elasticsearch.distribution</groupId>
-                                        <artifactId>elasticsearch-zip</artifactId>
+                                        <groupId>org.elasticsearch.distribution.zip</groupId>
+                                        <artifactId>elasticsearch</artifactId>
                                         <version>${elasticsearch.version}</version>
                                         <type>zip</type>
                                         <overWrite>true</overWrite>
-                                        <!-- these packaging builds sneakily rename their artifacts to look nothing
-                                             like their artifact id, so we must duplicate that rename here -->
-                                        <destFileName>elasticsearch-${elasticsearch.version}.zip</destFileName>
                                     </artifactItem>
                                 </artifactItems>
+                                <useBaseVersion>true</useBaseVersion>
                                 <outputDirectory>${integ.deps}</outputDirectory>
                             </configuration>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -905,7 +905,7 @@
                     <!-- some infos https://github.com/tcurdt/jdeb/blob/master/docs/maven.md -->
                     <groupId>org.vafer</groupId>
                     <artifactId>jdeb</artifactId>
-                    <version>1.3</version>
+                    <version>1.4</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
This PR:
- renames all distribution artifacts to `elasticsearch` so maven plugins will pick up the correct finalName without needing any hack.
- changes the groupId for every single distribution module as we can't have more than one module using the same groupId:artifactId
- does not attach anymore empty jar files for tar/zip/... modules as they don't contain any `src/main/java` stuff.

When you build it, you end up with:

```
$ tree ~/.m2/repository/org/elasticsearch/distribution
distribution
├── deb
│   └── elasticsearch
│       ├── 2.0.0-beta1-SNAPSHOT
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.deb
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.deb.md5
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.deb.sha1
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.md5
│       │   └── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.sha1
├── elasticsearch-distribution
│   ├── 2.0.0-beta1-SNAPSHOT
│   │   ├── elasticsearch-distribution-2.0.0-beta1-SNAPSHOT.pom
│   │   ├── elasticsearch-distribution-2.0.0-beta1-SNAPSHOT.pom.md5
│   │   └── elasticsearch-distribution-2.0.0-beta1-SNAPSHOT.pom.sha1
├── fully-loaded
│   └── elasticsearch
│       ├── 2.0.0-beta1-SNAPSHOT
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.md5
│       │   └── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.sha1
├── rpm
│   └── elasticsearch
│       ├── 2.0.0-beta1-SNAPSHOT
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.md5
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.sha1
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.rpm
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.rpm.md5
│       │   └── elasticsearch-2.0.0-beta1-SNAPSHOT.rpm.sha1
├── shaded
│   └── elasticsearch
│       ├── 2.0.0-beta1-SNAPSHOT
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.jar
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.jar.md5
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.jar.sha1
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.md5
│       │   └── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.sha1
├── tar
│   └── elasticsearch
│       ├── 2.0.0-beta1-SNAPSHOT
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.md5
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.sha1
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.tar.gz
│       │   ├── elasticsearch-2.0.0-beta1-SNAPSHOT.tar.gz.md5
│       │   └── elasticsearch-2.0.0-beta1-SNAPSHOT.tar.gz.sha1
└── zip
    └── elasticsearch
        └── 2.0.0-beta1-SNAPSHOT
            ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom
            ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.md5
            ├── elasticsearch-2.0.0-beta1-SNAPSHOT.pom.sha1
            ├── elasticsearch-2.0.0-beta1-SNAPSHOT.zip
            ├── elasticsearch-2.0.0-beta1-SNAPSHOT.zip.md5
            ├── elasticsearch-2.0.0-beta1-SNAPSHOT.zip.sha1
```

Closes #12536
