### PR TITLE
Adds a setting to disable source output in slowlog

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -172,7 +172,9 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     public static final String SETTING_LEGACY_ROUTING_USE_TYPE = "index.legacy.routing.use_type";
     public static final String SETTING_DATA_PATH = "index.data_path";
     public static final String SETTING_SHARED_FS_ALLOW_RECOVERY_ON_ANY_NODE = "index.shared_filesystem.recover_on_any_node";
+    public static final String SETTING_SLOW_LOGGING_SOURCE ="index.slow_logging.source";
     public static final String INDEX_UUID_NA_VALUE = "_na_";
+
 
     // hard-coded hash function as of 2.0
     // older indices will read which hash function to use in their index settings
@@ -202,6 +204,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     private final org.apache.lucene.util.Version minimumCompatibleLuceneVersion;
     private final HashFunction routingHashFunction;
     private final boolean useTypeForRouting;
+    private final boolean indexSlowLoggingSource;
 
     private IndexMetaData(String index, long version, State state, Settings settings, ImmutableOpenMap<String, MappingMetaData> mappings, ImmutableOpenMap<String, AliasMetaData> aliases, ImmutableOpenMap<String, Custom> customs) {
         Preconditions.checkArgument(settings.getAsInt(SETTING_NUMBER_OF_SHARDS, null) != null, "must specify numberOfShards for index [" + index + "]");
@@ -256,6 +259,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             }
         }
         useTypeForRouting = settings.getAsBoolean(SETTING_LEGACY_ROUTING_USE_TYPE, false);
+        indexSlowLoggingSource = settings.getAsBoolean(SETTING_SLOW_LOGGING_SOURCE, true);
     }
 
     public String index() {
@@ -386,6 +390,14 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
 
     public int getTotalNumberOfShards() {
         return totalNumberOfShards();
+    }
+
+    public boolean slowLoggingSource() {
+        return indexSlowLoggingSource;
+    }
+
+    public boolean getSlowLoggingSource() {
+        return slowLoggingSource();
     }
 
     public Settings settings() {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -172,7 +172,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     public static final String SETTING_LEGACY_ROUTING_USE_TYPE = "index.legacy.routing.use_type";
     public static final String SETTING_DATA_PATH = "index.data_path";
     public static final String SETTING_SHARED_FS_ALLOW_RECOVERY_ON_ANY_NODE = "index.shared_filesystem.recover_on_any_node";
-    public static final String SETTING_SLOW_LOGGING_SOURCE ="index.slow_logging.source";
+    public static final String SETTING_SLOW_LOGGING_SOURCE = "index.slow_logging.source";
     public static final String INDEX_UUID_NA_VALUE = "_na_";
 
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -204,7 +204,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     private final org.apache.lucene.util.Version minimumCompatibleLuceneVersion;
     private final HashFunction routingHashFunction;
     private final boolean useTypeForRouting;
-    private final boolean indexSlowLoggingSource;
+    private final boolean logSourceInIndexSlowLog;
 
     private IndexMetaData(String index, long version, State state, Settings settings, ImmutableOpenMap<String, MappingMetaData> mappings, ImmutableOpenMap<String, AliasMetaData> aliases, ImmutableOpenMap<String, Custom> customs) {
         Preconditions.checkArgument(settings.getAsInt(SETTING_NUMBER_OF_SHARDS, null) != null, "must specify numberOfShards for index [" + index + "]");
@@ -259,7 +259,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             }
         }
         useTypeForRouting = settings.getAsBoolean(SETTING_LEGACY_ROUTING_USE_TYPE, false);
-        indexSlowLoggingSource = settings.getAsBoolean(SETTING_SLOW_LOGGING_SOURCE, true);
+        logSourceInIndexSlowLog = settings.getAsBoolean(SETTING_SLOW_LOGGING_SOURCE, true);
     }
 
     public String index() {
@@ -392,12 +392,12 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         return totalNumberOfShards();
     }
 
-    public boolean slowLoggingSource() {
-        return indexSlowLoggingSource;
+    public boolean logSourceInIndexSlowLog() {
+        return logSourceInIndexSlowLog;
     }
 
-    public boolean getSlowLoggingSource() {
-        return slowLoggingSource();
+    public boolean getLogSourceInIndexSlowLog() {
+        return logSourceInIndexSlowLog;
     }
 
     public Settings settings() {

--- a/core/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
+++ b/core/src/main/java/org/elasticsearch/index/settings/IndexDynamicSettingsModule.java
@@ -30,7 +30,6 @@ import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocatio
 import org.elasticsearch.cluster.settings.DynamicSettings;
 import org.elasticsearch.cluster.settings.Validator;
 import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.gateway.GatewayAllocator;
 import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.indexing.IndexingSlowLog;
 import org.elasticsearch.index.search.stats.SearchSlowLog;
@@ -73,6 +72,7 @@ public class IndexDynamicSettingsModule extends AbstractModule {
         indexDynamicSettings.addDynamicSetting(IndexMetaData.SETTING_BLOCKS_METADATA);
         indexDynamicSettings.addDynamicSetting(IndexMetaData.SETTING_SHARED_FS_ALLOW_RECOVERY_ON_ANY_NODE);
         indexDynamicSettings.addDynamicSetting(IndexMetaData.SETTING_PRIORITY, Validator.NON_NEGATIVE_INTEGER);
+        indexDynamicSettings.addDynamicSetting(IndexMetaData.SETTING_SLOW_LOGGING_SOURCE, Validator.BOOLEAN);
         indexDynamicSettings.addDynamicSetting(IndicesTTLService.INDEX_TTL_DISABLE_PURGE);
         indexDynamicSettings.addDynamicSetting(IndexShard.INDEX_REFRESH_INTERVAL, Validator.TIME);
         indexDynamicSettings.addDynamicSetting(PrimaryShardAllocator.INDEX_RECOVERY_INITIAL_SHARDS);


### PR DESCRIPTION
When logging large documents via slowlog, setting `index.slow_logging.source`
to `false` prevents the source from being displayed.

Closes #4485 

I don't see any tests for slowlog, so I used these steps to manually test:

```
curl -XPUT 'http://localhost:9200/bar'

# don't log source
curl -XPUT 'localhost:9200/bar/_settings' -d '
{
    "index" : {
        "slow_logging.source" : false
    }
}'

# bump the index threshold to 0s
curl -XPUT 'http://localhost:9200/bar/_settings' -d '
{
    "index.search.slowlog.threshold.query.warn" : "10s", 
    "index.search.slowlog.threshold.fetch.debug": "500ms", 
    "index.indexing.slowlog.threshold.index.info": "0ms" 
}'



curl -XPUT 'http://localhost:9200/bar/tweet/2' -d '
{
    "user": "kimchy",
    "postDate": "2009-11-15T13:12:00",
    "message": "Trying out Elasticsearch, so far so good?"
}'


curl -XPUT 'localhost:9200/bar/_settings' -d '
{
    "index" : {
        "slow_logging.source" : true
    }
}'


curl -XPUT 'http://localhost:9200/bar/tweet/3' -d '
{
    "user": "kimchy",
    "postDate": "2009-11-15T13:12:00",
    "message": "Foo bar baz"
}'

```
