### PR TITLE
improve integration tests output when ES cannot be started.

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -12,9 +12,12 @@
   <!-- if this exists, ES is running (maybe) -->
   <available property="integ.pidfile.exists" file="${integ.pidfile}"/>
 
+  <!-- name of our cluster, maybe needs changing -->
+  <property name="integ.cluster.name" value="prepare_release"/>
+
   <!-- arguments passed to elasticsearch when running -->
   <property name="integ.args"
-            value="-Des.node.name=smoke_tester -Des.cluster.name=prepare_release
+            value="-Des.node.name=smoke_tester -Des.cluster.name=${integ.cluster.name}
                    -Des.discovery.zen.ping.multicast.enabled=false -Des.script.inline=on
                    -Des.http.port=${integ.http.port} -Des.transport.tcp.port=${integ.transport.port}
                    -Des.script.indexed=on -Des.pidfile=${integ.pidfile} -Des.repositories.url.allowed_urls=http://snapshot.test*"/>
@@ -120,11 +123,23 @@
     <sequential>
       <echo>Starting up external cluster...</echo>
       <run-script script="@{home}/bin/elasticsearch" spawn="true"
-                  args="@{args} -Des.path.repo=@{home}/repo" />
+                  args="@{args} -Des.path.repo=@{home}/repo"/>
 
-      <waitfor maxwait="3" maxwaitunit="minute" checkevery="500">
+      <local name="failed.to.start"/>
+      <waitfor maxwait="30" maxwaitunit="second"
+               checkevery="500" checkeveryunit="millisecond"
+               timeoutproperty="failed.to.start">
         <http url="http://127.0.0.1:${integ.http.port}"/>
       </waitfor>
+
+      <!-- best effort, print console log. useful if it fails especially -->
+      <local name="log.contents"/>
+      <loadfile srcFile="@{home}/logs/${integ.cluster.name}.log"
+                property="log.contents"
+                failonerror="false"/>
+      <echo message="${log.contents}"/>
+
+      <fail message="ES instance did not start" if="failed.to.start"/>
 
       <local name="integ.pid"/>
       <extract-pid property="integ.pid"/>


### PR DESCRIPTION
This can happen for a number of reasons, including bugs.
Today you will get a super crappy failure, telling you a .pid file
was not found... you can go look in target/integ-tests/elasticsearch-xxx/logs
and examine the log file, but thats kinda a pain and not easy if its a jenkins
server.

Instead we can fail like this:

```
start-external-cluster-with-plugin:
     [echo] Installing plugin elasticsearch-example-jvm-plugin...
    [mkdir] Created dir: /home/rmuir/workspace/elasticsearch/plugins/jvm-example/target/integ-tests/temp
     [exec] -> Installing elasticsearch-example-jvm-plugin...
     [exec] Plugins directory [/home/rmuir/workspace/elasticsearch/plugins/jvm-example/target/integ-tests/elasticsearch-2.0.0-SNAPSHOT/plugins] does not exist. Creating...
     [exec] Trying file:/home/rmuir/workspace/elasticsearch/plugins/jvm-example/target/releases/elasticsearch-example-jvm-plugin-2.0.0-SNAPSHOT.zip ...
     [exec] Downloading ...........DONE
     [exec] PluginInfo{name='example-jvm-plugin', description='Demonstrates all the pluggable Java entry points in Elasticsearch', site=false, jvm=true, classname=org.elasticsearch.plugin.example.ExampleJvmPlugin, isolated=true, version='2.0.0-SNAPSHOT'}
     [exec] Installed example-jvm-plugin into /home/rmuir/workspace/elasticsearch/plugins/jvm-example/target/integ-tests/elasticsearch-2.0.0-SNAPSHOT/plugins/example-jvm-plugin
     [echo] Starting up external cluster...
     [echo] [2015-08-04 22:02:55,130][INFO ][org.elasticsearch.node   ] [smoke_tester] version[2.0.0-SNAPSHOT], pid[4321], build[e2a47d8/2015-08-05T00:50:08Z]
     [echo] [2015-08-04 22:02:55,130][INFO ][org.elasticsearch.node   ] [smoke_tester] initializing ...
     [echo] [2015-08-04 22:02:55,259][INFO ][org.elasticsearch.plugins] [smoke_tester] loaded [uber-plugin], sites []
     [echo] [2015-08-04 22:02:55,260][ERROR][org.elasticsearch.bootstrap] Exception
     [echo] java.lang.NullPointerException
     [echo]     at org.elasticsearch.common.settings.Settings$Builder.put(Settings.java:1051)
     [echo]     at org.elasticsearch.plugins.PluginsService.updatedSettings(PluginsService.java:208)
     [echo]     at org.elasticsearch.node.Node.<init>(Node.java:148)
     [echo]     at org.elasticsearch.node.NodeBuilder.build(NodeBuilder.java:157)
     [echo]     at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:177)
     [echo]     at org.elasticsearch.bootstrap.Bootstrap.main(Bootstrap.java:272)
     [echo]     at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:28)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 25.178 s
[INFO] Finished at: 2015-08-04T22:03:14-05:00
[INFO] Final Memory: 32M/515M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (integ-setup) on project elasticsearch-example-jvm-plugin: An Ant BuildException has occured: The following error occurred while executing this line:
[ERROR] /home/rmuir/workspace/elasticsearch/plugins/jvm-example/target/dev-tools/ant/integration-tests.xml:176: The following error occurred while executing this line:
[ERROR] /home/rmuir/workspace/elasticsearch/plugins/jvm-example/target/dev-tools/ant/integration-tests.xml:142: ES instance did not start
```
