### PR TITLE
Rethrow exception during recovery finalization even if source is not broken

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -435,6 +435,7 @@ public class RecoverySourceHandler {
                                 exception.addSuppressed(remoteException);
                                 logger.warn("{} Remote file corruption during finalization on node {}, recovering {}. local checksum OK",
                                         corruptIndexException, shard.shardId(), request.targetNode());
+                                throw exception;
                             } else {
                                 throw remoteException;
                             }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -406,9 +406,13 @@ public class RecoveryTarget extends AbstractComponent {
                         logger.debug("Failed to clean lucene index", e);
                         ex.addSuppressed(e);
                     }
-                    throw new RecoveryFailedException(recoveryStatus.state(), "failed to clean after recovery", ex);
+                    RecoveryFailedException rfe = new RecoveryFailedException(recoveryStatus.state(), "failed to clean after recovery", ex);
+                    recoveryStatus.fail(rfe, true);
+                    throw rfe;
                 } catch (Exception ex) {
-                    throw new RecoveryFailedException(recoveryStatus.state(), "failed to clean after recovery", ex);
+                    RecoveryFailedException rfe = new RecoveryFailedException(recoveryStatus.state(), "failed to clean after recovery", ex);
+                    recoveryStatus.fail(rfe, true);
+                    throw rfe;
                 }
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
             }


### PR DESCRIPTION
Today we miss to throw / rethrow an recovery exception if it happens during
the finalization of phase 1 if the source files are not affected. Even worse
this can cause some dataloss if the reason for this exception is a failure of
deleting a corruption marker or similar pre-existing corruptions since we continue
with the recovery and mark the target shared as started which will in-turn open
an engine with an empty index.
