### PR TITLE
Use explict flag if index should be created on engine creation

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -135,7 +135,7 @@ public final class EngineConfig {
 
     private static final String DEFAULT_CODEC_NAME = "default";
     private TranslogConfig translogConfig;
-
+    private boolean create = false;
 
     /**
      * Creates a new {@link org.elasticsearch.index.engine.EngineConfig}
@@ -432,5 +432,21 @@ public final class EngineConfig {
      */
     public TranslogConfig getTranslogConfig() {
         return translogConfig;
+    }
+
+    /**
+     * Iff set to <code>true</code> the engine will create a new lucene index when opening the engine.
+     * Otherwise the lucene index writer is opened in append mode. The default is <code>false</code>
+     */
+    public void setCreate(boolean create) {
+        this.create = create;
+    }
+
+    /**
+     * Iff <code>true</code> the engine should create a new lucene index when opening the engine.
+     * Otherwise the lucene index writer should be opened in append mode. The default is <code>false</code>
+     */
+    public boolean isCreate() {
+        return create;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -118,14 +118,11 @@ public class InternalEngine extends Engine {
             for (int i = 0; i < dirtyLocks.length; i++) {
                 dirtyLocks[i] = new Object();
             }
-
             throttle = new IndexThrottle();
             this.searcherFactory = new SearchFactory(logger, isClosed, engineConfig);
             final Translog.TranslogGeneration translogGeneration;
             try {
-                // TODO: would be better if ES could tell us "from above" whether this shard was already here, instead of using Lucene's API
-                // (which relies on IO ops, directory listing, and has had scary bugs in the past):
-                boolean create = !Lucene.indexExists(store.directory());
+                final boolean create = engineConfig.isCreate();
                 writer = createWriter(create);
                 indexWriter = writer;
                 translog = openTranslog(engineConfig, writer, create || skipInitialTranslogRecovery || engineConfig.forceNewTranslog());

--- a/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
@@ -104,6 +104,7 @@ public final class ShadowIndexShard extends IndexShard {
     protected Engine newEngine(boolean skipInitialTranslogRecovery, EngineConfig config) {
         assert this.shardRouting.primary() == false;
         assert skipInitialTranslogRecovery : "can not recover from gateway";
+        config.setCreate(false); // hardcoded - we always expect an index to be present
         return engineFactory.newReadOnlyEngine(config);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/StoreRecoveryService.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/StoreRecoveryService.java
@@ -246,7 +246,7 @@ public class StoreRecoveryService extends AbstractIndexShardComponent implements
                 recoveryState.getTranslog().totalOperations(0);
                 recoveryState.getTranslog().totalOperationsOnStart(0);
             }
-            typesToUpdate = indexShard.performTranslogRecovery();
+            typesToUpdate = indexShard.performTranslogRecovery(indexShouldExists);
 
             indexShard.finalizeRecovery();
             String indexName = indexShard.shardId().index().name();
@@ -318,7 +318,7 @@ public class StoreRecoveryService extends AbstractIndexShardComponent implements
                 snapshotShardId = new ShardId(restoreSource.index(), shardId.id());
             }
             indexShardRepository.restore(restoreSource.snapshotId(), restoreSource.version(), shardId, snapshotShardId, recoveryState);
-            indexShard.skipTranslogRecovery(true);
+            indexShard.skipTranslogRecovery();
             indexShard.finalizeRecovery();
             indexShard.postRecovery("restore done");
             restoreService.indexShardRestoreCompleted(restoreSource.snapshotId(), shardId);

--- a/core/src/main/java/org/elasticsearch/index/shard/TranslogRecoveryPerformer.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/TranslogRecoveryPerformer.java
@@ -204,7 +204,7 @@ public class TranslogRecoveryPerformer {
             query = queryParserService.parseQuery(source).query();
         } catch (QueryParsingException ex) {
             // for BWC we try to parse directly the query since pre 1.0.0.Beta2 we didn't require a top level query field
-            if ( queryParserService.getIndexCreatedVersion().onOrBefore(Version.V_1_0_0_Beta2)) {
+            if (queryParserService.getIndexCreatedVersion().onOrBefore(Version.V_1_0_0_Beta2)) {
                 try {
                     XContentParser parser = XContentHelper.createParser(source);
                     ParsedQuery parse = queryParserService.parse(parser);

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -274,7 +274,7 @@ public class RecoveryTarget extends AbstractComponent {
             try (RecoveriesCollection.StatusRef statusRef = onGoingRecoveries.getStatusSafe(request.recoveryId(), request.shardId())) {
                 final RecoveryStatus recoveryStatus = statusRef.status();
                 recoveryStatus.state().getTranslog().totalOperations(request.totalTranslogOps());
-                recoveryStatus.indexShard().skipTranslogRecovery(false);
+                recoveryStatus.indexShard().skipTranslogRecovery();
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }

--- a/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MockDirectoryWrapper;
 import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Nullable;
@@ -226,6 +227,11 @@ public class ShadowEngineTests extends ESTestCase {
             public void onFailedEngine(ShardId shardId, String reason, @Nullable Throwable t) {
                 // we don't need to notify anybody in this test
         }}, null, IndexSearcher.getDefaultQueryCache(), IndexSearcher.getDefaultQueryCachingPolicy(), new IndexSearcherWrappingService(), translogConfig);
+        try {
+            config.setCreate(Lucene.indexExists(store.directory()) == false);
+        } catch (IOException e) {
+            throw new ElasticsearchException("can't find index?", e);
+        }
         return config;
     }
 


### PR DESCRIPTION
Today we try to detect if there is an index existing in the directory
and if not we create one. This can be tricky and errof prone since we
rely on the filesystem without taking the context into account when the
engine gets created. We know in all situations if the index should be created
so we can just use this infromation and rely on the lucene index writer to barf
if we hit a situations where we can't append to an index while we should.
