### PR TITLE
when parsed query is null, return null.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -191,6 +191,11 @@ public class CommonTermsQueryParser implements QueryParser {
         ExtendedCommonTermsQuery commonsQuery = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, maxTermFrequency, disableCoord, fieldType);
         commonsQuery.setBoost(boost);
         Query query = parseQueryString(commonsQuery, value.toString(), field, parseContext, analyzer, lowFreqMinimumShouldMatch, highFreqMinimumShouldMatch);
+
+        if (query == null){
+            return null;
+        }
+
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
         }


### PR DESCRIPTION
Quick fix [12683](https://github.com/elastic/elasticsearch/issues/12683)

Parser should return null right away.
