### PR TITLE
Do not track named queries that are null

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -182,7 +182,9 @@ public class QueryParseContext {
     }
 
     public void addNamedQuery(String name, Query query) {
-        namedQueries.put(name, query);
+        if (query != null) {
+            namedQueries.put(name, query);
+        }
     }
 
     public ImmutableMap<String, Query> copyNamedQueries() {

--- a/core/src/test/java/org/elasticsearch/index/query/CommonTermsQueryParserTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/CommonTermsQueryParserTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class CommonTermsQueryParserTest extends ESSingleNodeTestCase {
+    @Test
+    public void testWhenParsedQueryIsNullNoNullPointerExceptionIsThrown() throws IOException {
+        final String index = "test-index";
+        final String type = "test-type";
+        client()
+                .admin()
+                .indices()
+                .prepareCreate(index)
+                .addMapping(type, "name", "type=string,analyzer=stop")
+                .execute()
+                .actionGet();
+        ensureGreen();
+
+        CommonTermsQueryBuilder commonTermsQueryBuilder =
+                new CommonTermsQueryBuilder("name", "the").queryName("query-name");
+
+        // the named query parses to null; we are testing this does not cause a NullPointerException
+        SearchResponse response =
+                client().prepareSearch(index).setTypes(type).setQuery(commonTermsQueryBuilder).execute().actionGet();
+
+        assertNotNull(response);
+        assertEquals(response.getHits().hits().length, 0);
+    }
+}


### PR DESCRIPTION
Adding a named query that is null can lead to a `NullPointerException`
when copying the named queries. This is due to an implementation detail
in [`QueryParseContent.copyNamedQueries`](https://github.com/elastic/elasticsearch/blob/d0abffc9acb9afddc83ae99ae17848b813fd918f/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java#L188). In particular, this method uses
[`com.google.common.collect.ImmutableMap.copyOf`](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/collect/ImmutableMap.html#copyOf%28java.util.Map%29). A documented requirement
of [`ImmutableMap`](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/collect/ImmutableMap.html) is that none of the entries have a null key nor null
value. Therefore, we should not add such queries to the [`namedQueries`](https://github.com/elastic/elasticsearch/blob/d0abffc9acb9afddc83ae99ae17848b813fd918f/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java#L86)
map. This will not change any behavior since [`Map.get`](http://docs.oracle.com/javase/7/docs/api/java/util/Map.html#get%28java.lang.Object%29) returns null if no
entry with the given key exists anyway.

Closes #12683
