### PR TITLE
Startup: Disable globbing in shell script

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -125,6 +125,7 @@ export HOSTNAME=`hostname -s`
 
 # manual parsing to find out, if process should be detached
 daemonized=`echo $* | grep -E -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`
+set -f
 if [ -z "$daemonized" ] ; then
     eval exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS "\"-Des.path.home=$ES_HOME\"" -cp "\"$ES_CLASSPATH\"" \
           org.elasticsearch.bootstrap.Elasticsearch start $*


### PR DESCRIPTION
In order to not accidentally expand wilcard arguments
like --http.cors.allow-origin '*' on startup, globbing
needs to be disabled before Elasticsearch is started.

Closes #12689
