### PR TITLE
Speed up the `function_score` query when scores are not needed.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/BoostScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/BoostScoreFunction.java
@@ -58,6 +58,11 @@ public class BoostScoreFunction extends ScoreFunction {
     }
 
     @Override
+    public boolean needsScores() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "boost[" + boost + "]";
     }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -91,6 +91,11 @@ public class FieldValueFactorFunction extends ScoreFunction {
         };
     }
 
+    @Override
+    public boolean needsScores() {
+        return false;
+    }
+
     /**
      * The Type class encapsulates the modification types that can be applied
      * to the score/value product.

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
@@ -81,4 +81,8 @@ public class RandomScoreFunction extends ScoreFunction {
         };
     }
 
+    @Override
+    public boolean needsScores() {
+        return false;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
@@ -39,4 +39,11 @@ public abstract class ScoreFunction {
     }
 
     public abstract LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) throws IOException;
+
+    /**
+     * Indicates if document scores are needed by this function.
+     * 
+     * @return {@code true} if scores are needed.
+     */
+    public abstract boolean needsScores();
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
@@ -127,6 +127,13 @@ public class ScriptScoreFunction extends ScoreFunction {
     }
 
     @Override
+    public boolean needsScores() {
+        // Scripts might use _score so we return true here
+        // TODO: Make scripts able to tell us whether they use scores
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "script" + sScript.toString();
     }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
@@ -71,6 +71,11 @@ public class WeightFactorFunction extends ScoreFunction {
         };
     }
 
+    @Override
+    public boolean needsScores() {
+        return false;
+    }
+
     public Explanation explainWeight() {
         return Explanation.match(getWeight(), "weight");
     }
@@ -98,6 +103,11 @@ public class WeightFactorFunction extends ScoreFunction {
                     return Explanation.match(1.0f, "constant score 1.0 - no function provided");
                 }
             };
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -290,6 +290,11 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         }
 
         @Override
+        public boolean needsScores() {
+            return false;
+        }
+
+        @Override
         protected NumericDoubleValues distance(LeafReaderContext context) {
             final MultiGeoPointValues geoPointValues = fieldData.load(context).getGeoPointValues();
             return mode.select(new MultiValueMode.UnsortedNumericDoubleValues() {
@@ -350,6 +355,11 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
             super(scale, decay, offset, func, mode);
             this.fieldData = fieldData;
             this.origin = origin;
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
This change improves the `function_score` query to not compute scores at all
when they are not needed, and to not compute scores on the underlying query
when the combine function is to replace the score with the scores of the
functions.
