### PR TITLE
rpm and deb create scripts directory

### DIFF
--- a/distribution/deb/pom.xml
+++ b/distribution/deb/pom.xml
@@ -139,6 +139,12 @@
                                         <group>root</group>
                                     </mapper>
                                 </data>
+                                <data>
+                                    <type>template</type>
+                                    <paths>
+                                        <path>${packaging.elasticsearch.conf.dir}/scripts</path>
+                                    </paths>
+                                </data>
                                 <!-- Add environment vars file -->
                                 <data>
                                     <src>${project.build.directory}/generated-packaging/deb/env/elasticsearch</src>

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -144,6 +144,10 @@
                                 </source>
                             </sources>
                         </mapping>
+                        <mapping>
+                            <directory>${packaging.elasticsearch.conf.dir}/scripts</directory>
+                            <configuration>noreplace</configuration>
+                        </mapping>
                         <!-- Add environment vars file -->
                         <mapping>
                             <directory>/etc/sysconfig/</directory>


### PR DESCRIPTION
Elasticsearch will create this if it doesn't exist if it cant but because
it doesn't own /etc/elasticsearch when installed by rpm and deb it can't
create /etc/elasticsearch/scripts.

Closes #12702
