### PR TITLE
Escape CLI parameters when starting elasticsearch

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -127,10 +127,10 @@ export HOSTNAME=`hostname -s`
 daemonized=`echo $* | grep -E -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`
 if [ -z "$daemonized" ] ; then
     eval exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS "\"-Des.path.home=$ES_HOME\"" -cp "\"$ES_CLASSPATH\"" \
-          org.elasticsearch.bootstrap.Elasticsearch start $*
+          org.elasticsearch.bootstrap.Elasticsearch start \"$@\"
 else
     eval exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS "\"-Des.path.home=$ES_HOME\"" -cp "\"$ES_CLASSPATH\"" \
-          org.elasticsearch.bootstrap.Elasticsearch start $* <&- &
+          org.elasticsearch.bootstrap.Elasticsearch start \"$@\" <&- &
 fi
 
 exit $?


### PR DESCRIPTION
I'm not sure if I should do this. 

Closes #12677 
