### PR TITLE
Bats testing: Remove useless systemctl check

### DIFF
--- a/distribution/src/main/packaging/scripts/postrm
+++ b/distribution/src/main/packaging/scripts/postrm
@@ -68,7 +68,7 @@ fi
 
 if [ "$REMOVE_SERVICE" = "true" ]; then
     if command -v systemctl >/dev/null; then
-        systemctl --no-reload disable elasticsearch.service > /dev/null 2>&1 || true
+        systemctl disable elasticsearch.service > /dev/null 2>&1 || true
     fi
 
     if command -v chkconfig >/dev/null; then

--- a/distribution/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/distribution/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -116,11 +116,6 @@ setup() {
     # The removal must disable the service
     # see prerm file
     if is_systemd; then
-        # Redhat based systemd distros usually returns exit code 1
-        # OpenSUSE13 returns 0
-        run systemctl status elasticsearch.service
-        [ "$status" -eq 1 ] || [ "$status" -eq 0 ]
-
         run systemctl is-enabled elasticsearch.service
         [ "$status" -eq 1 ]
     fi


### PR DESCRIPTION
Bats testing uncovered a useless systemctl check, that resulted in an
error, because the systemctl file was uninstalled, but we hoped to
check for an explicetely configured SystemExitCode.

In addition we did not reload the systemctl configuration when uninstalling
elasticsearch, which now is fixed as well.

Closes #12682
