### PR TITLE
Add `path.shared_data`

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -126,6 +126,9 @@ final class Security {
         // read-write dirs
         addPath(policy, environment.tmpFile(), "read,readlink,write,delete");
         addPath(policy, environment.logsFile(), "read,readlink,write,delete");
+        if (environment.sharedDataFile() != null) {
+            addPath(policy, environment.sharedDataFile(), "read,readlink,write,delete");
+        }
         for (Path path : environment.dataFiles()) {
             addPath(policy, path, "read,readlink,write,delete");
         }

--- a/core/src/main/java/org/elasticsearch/env/Environment.java
+++ b/core/src/main/java/org/elasticsearch/env/Environment.java
@@ -57,6 +57,8 @@ public class Environment {
 
     private final Path pluginsFile;
 
+    private final Path sharedDataFile;
+
     /** location of bin/, used by plugin manager */
     private final Path binFile;
 
@@ -126,6 +128,11 @@ public class Environment {
             dataFiles = new Path[]{homeFile.resolve("data")};
             dataWithClusterFiles = new Path[]{homeFile.resolve("data").resolve(ClusterName.clusterNameFromSettings(settings).value())};
         }
+        if (settings.get("path.shared_data") != null) {
+            sharedDataFile = PathUtils.get(cleanPath(settings.get("path.shared_data")));
+        } else {
+            sharedDataFile = null;
+        }
         String[] repoPaths = settings.getAsArray("path.repo");
         if (repoPaths.length > 0) {
             repoFiles = new Path[repoPaths.length];
@@ -163,6 +170,13 @@ public class Environment {
      */
     public Path[] dataFiles() {
         return dataFiles;
+    }
+
+    /**
+     * The shared data location
+     */
+    public Path sharedDataFile() {
+        return sharedDataFile;
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/bootstrap/SecurityTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/SecurityTests.java
@@ -77,6 +77,7 @@ public class SecurityTests extends ESTestCase {
         settingsBuilder.put("path.scripts", esHome.resolve("scripts").toString());
         settingsBuilder.put("path.plugins", esHome.resolve("plugins").toString());
         settingsBuilder.putArray("path.data", esHome.resolve("data1").toString(), esHome.resolve("data2").toString());
+        settingsBuilder.put("path.shared_data", esHome.resolve("custom").toString());
         settingsBuilder.put("path.logs", esHome.resolve("logs").toString());
         settingsBuilder.put("pidfile", esHome.resolve("test.pid").toString());
         Settings settings = settingsBuilder.build();
@@ -122,6 +123,7 @@ public class SecurityTests extends ESTestCase {
         for (Path dataPath : environment.dataWithClusterFiles()) {
             assertExactPermissions(new FilePermission(dataPath.toString(), "read,readlink,write,delete"), permissions);
         }
+        assertExactPermissions(new FilePermission(environment.sharedDataFile().toString(), "read,readlink,write,delete"), permissions);
         // logs: r/w
         assertExactPermissions(new FilePermission(environment.logsFile().toString(), "read,readlink,write,delete"), permissions);
         // temp dir: r/w

--- a/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -300,7 +300,7 @@ public class NodeEnvironmentTests extends ESTestCase {
     @Test
     public void testCustomDataPaths() throws Exception {
         String[] dataPaths = tmpPaths();
-        NodeEnvironment env = newNodeEnvironment(dataPaths, Settings.EMPTY);
+        NodeEnvironment env = newNodeEnvironment(dataPaths, "/tmp", Settings.EMPTY);
 
         Settings s1 = Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).build();
         Settings s2 = Settings.builder().put(IndexMetaData.SETTING_DATA_PATH, "/tmp/foo").build();
@@ -323,7 +323,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                 env.indexPaths(i), equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/myindex")));
 
         env.close();
-        NodeEnvironment env2 = newNodeEnvironment(dataPaths,
+        NodeEnvironment env2 = newNodeEnvironment(dataPaths, "/tmp",
                 Settings.builder().put(NodeEnvironment.ADD_NODE_ID_TO_CUSTOM_PATH, false).build());
 
         assertThat(env2.availableShardPaths(sid), equalTo(env2.availableShardPaths(sid)));
@@ -377,6 +377,16 @@ public class NodeEnvironmentTests extends ESTestCase {
         Settings build = Settings.builder()
                 .put(settings)
                 .put("path.home", createTempDir().toAbsolutePath().toString())
+                .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
+                .putArray("path.data", dataPaths).build();
+        return new NodeEnvironment(build, new Environment(build));
+    }
+
+    public NodeEnvironment newNodeEnvironment(String[] dataPaths, String sharedDataPath, Settings settings) throws IOException {
+        Settings build = Settings.builder()
+                .put(settings)
+                .put("path.home", createTempDir().toAbsolutePath().toString())
+                .put("path.shared_data", sharedDataPath)
                 .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
                 .putArray("path.data", dataPaths).build();
         return new NodeEnvironment(build, new Environment(build));

--- a/core/src/test/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.Node;
@@ -118,16 +119,20 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
 
     private static Node newNode() {
         Node build = NodeBuilder.nodeBuilder().local(true).data(true).settings(Settings.builder()
-            .put(ClusterName.SETTING, InternalTestCluster.clusterName("single-node-cluster", randomLong()))
-            .put("path.home", createTempDir())
-            .put("node.name", nodeName())
-            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put("script.inline", "on")
-            .put("script.indexed", "on")
-            .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
-            .put("http.enabled", false)
-            .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // make sure we get what we set :)
+                .put(ClusterName.SETTING, InternalTestCluster.clusterName("single-node-cluster", randomLong()))
+                .put("path.home", createTempDir())
+                // TODO: use a consistent data path for custom paths
+                // This needs to tie into the ESIntegTestCase#indexSettings() method
+                .put("path.shared_data", createTempDir().getParent())
+                .put("node.name", nodeName())
+                .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("script.inline", "on")
+                .put("script.indexed", "on")
+                .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
+                .put("http.enabled", false)
+                .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // make sure we get what we set :)
         ).build();
         build.start();
         assertThat(DiscoveryNode.localNode(build.settings()), is(true));

--- a/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -301,6 +301,7 @@ public final class InternalTestCluster extends TestCluster {
                 builder.put("path.data", dataPath.toString());
             }
         }
+        builder.put("path.shared_data", baseDir.resolve("custom"));
         builder.put("path.home", baseDir);
         builder.put("path.repo", baseDir.resolve("repos"));
         builder.put("transport.tcp.port", BASE_PORT + "-" + (BASE_PORT + 100));

--- a/docs/reference/indices/shadow-replicas.asciidoc
+++ b/docs/reference/indices/shadow-replicas.asciidoc
@@ -14,26 +14,20 @@ settings, you need to enable using it in elasticsearch.yml:
 [source,yaml]
 --------------------------------------------------
 node.enable_custom_paths: true
+node.add_id_to_custom_path: false
 --------------------------------------------------
 
-You will also need to disable the default security manager that Elasticsearch
-runs with. You can do this by either passing
-`-Des.security.manager.enabled=false` with the parameters while starting
-Elasticsearch, or you can disable it in elasticsearch.yml:
+You will also need to indicate to the security manager where the custom indices
+will be, so that the correct permissions can be applied. You can do this by
+setting the `path.shared_data` setting in elasticsearch.yml:
 
 [source,yaml]
 --------------------------------------------------
-security.manager.enabled: false
+path.shared_data: /opt/data
 --------------------------------------------------
 
-[WARNING]
-========================
-Disabling the security manager means that the Elasticsearch process is not
-limited to the directories and files that it can read and write. However,
-because the `index.data_path` setting is set when creating the index, the
-security manager would prevent writing or reading from the index's location, so
-it must be disabled.
-========================
+This means that Elasticsearch can read and write to files in any subdirectory of
+the `path.shared_data` setting.
 
 You can then create an index with a custom data path, where each node will use
 this path for the data:
@@ -54,7 +48,7 @@ curl -XPUT 'localhost:9200/my_index' -d '
     "index" : {
         "number_of_shards" : 1,
         "number_of_replicas" : 4,
-        "data_path": "/var/data/my_index",
+        "data_path": "/opt/data/my_index",
         "shadow_replicas": true
     } 
 }'
@@ -62,7 +56,7 @@ curl -XPUT 'localhost:9200/my_index' -d '
 
 [WARNING]
 ========================
-In the above example, the "/var/data/my_index" path is a shared filesystem that
+In the above example, the "/opt/data/my_index" path is a shared filesystem that
 must be available on every node in the Elasticsearch cluster. You must also
 ensure that the Elasticsearch process has the correct permissions to read from
 and write to the directory used in the `index.data_path` setting.


### PR DESCRIPTION
This allows `path.shared_data` to be added to the security manager while
still allowing a custom `data_path` for indices using shadow replicas.

For example, configuring `path.shared_data: /tmp/foo`, then created an
index with:

```
POST /myindex
{
  "index": {
    "number_of_shards": 1,
    "number_of_replicas": 1,
    "data_path": "/tmp/foo/bar/baz",
    "shadow_replicas": true
  }
}
```

The index will then reside in `/tmp/foo/bar/baz`.

`path.shared_data` defaults to `${path.home}/data` if not specified.

Resolves #12714
Relates to #11065
