### PR TITLE
Add script compilation stats

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -33,6 +33,7 @@ import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.monitor.process.ProcessStats;
+import org.elasticsearch.script.ScriptStats;
 import org.elasticsearch.threadpool.ThreadPoolStats;
 import org.elasticsearch.transport.TransportStats;
 
@@ -73,13 +74,17 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
     @Nullable
     private AllCircuitBreakerStats breaker;
 
+    @Nullable
+    private ScriptStats scriptStats;
+
     NodeStats() {
     }
 
     public NodeStats(DiscoveryNode node, long timestamp, @Nullable NodeIndicesStats indices,
                      @Nullable OsStats os, @Nullable ProcessStats process, @Nullable JvmStats jvm, @Nullable ThreadPoolStats threadPool,
                      @Nullable FsInfo fs, @Nullable TransportStats transport, @Nullable HttpStats http,
-                     @Nullable AllCircuitBreakerStats breaker) {
+                     @Nullable AllCircuitBreakerStats breaker,
+                     @Nullable ScriptStats scriptStats) {
         super(node);
         this.timestamp = timestamp;
         this.indices = indices;
@@ -91,6 +96,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         this.transport = transport;
         this.http = http;
         this.breaker = breaker;
+        this.scriptStats = scriptStats;
     }
 
     public long getTimestamp() {
@@ -165,6 +171,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         return this.breaker;
     }
 
+    @Nullable
+    public ScriptStats getScriptStats() {
+        return this.scriptStats;
+    }
+
     public static NodeStats readNodeStats(StreamInput in) throws IOException {
         NodeStats nodeInfo = new NodeStats();
         nodeInfo.readFrom(in);
@@ -200,6 +211,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
             http = HttpStats.readHttpStats(in);
         }
         breaker = AllCircuitBreakerStats.readOptionalAllCircuitBreakerStats(in);
+        scriptStats = in.readOptionalStreamable(new ScriptStats());
 
     }
 
@@ -256,6 +268,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
             http.writeTo(out);
         }
         out.writeOptionalStreamable(breaker);
+        out.writeOptionalStreamable(scriptStats);
     }
 
     @Override
@@ -302,6 +315,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         }
         if (getBreaker() != null) {
             getBreaker().toXContent(builder, params);
+        }
+        if (getScriptStats() != null) {
+            getScriptStats().toXContent(builder, params);
         }
 
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -41,6 +41,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     private boolean transport;
     private boolean http;
     private boolean breaker;
+    private boolean script;
 
     protected NodesStatsRequest() {
     }
@@ -67,6 +68,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         this.transport = true;
         this.http = true;
         this.breaker = true;
+        this.script = true;
         return this;
     }
 
@@ -84,6 +86,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         this.transport = false;
         this.http = false;
         this.breaker = false;
+        this.script = false;
         return this;
     }
 
@@ -240,6 +243,15 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         return this;
     }
 
+    public boolean script() {
+        return script;
+    }
+
+    public NodesStatsRequest script(boolean script) {
+        this.script = script;
+        return this;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -253,6 +265,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         transport = in.readBoolean();
         http = in.readBoolean();
         breaker = in.readBoolean();
+        script = in.readBoolean();
     }
 
     @Override
@@ -268,6 +281,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         out.writeBoolean(transport);
         out.writeBoolean(http);
         out.writeBoolean(breaker);
+        out.writeBoolean(script);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
@@ -62,6 +62,11 @@ public class NodesStatsRequestBuilder extends NodesOperationRequestBuilder<Nodes
         return this;
     }
 
+    public NodesStatsRequestBuilder setScript(boolean script) {
+        request.script(script);
+        return this;
+    }
+
     /**
      * Should the node indices stats be returned.
      */

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -80,7 +80,7 @@ public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRe
     protected NodeStats nodeOperation(NodeStatsRequest nodeStatsRequest) {
         NodesStatsRequest request = nodeStatsRequest.request;
         return nodeService.stats(request.indices(), request.os(), request.process(), request.jvm(), request.threadPool(), request.network(),
-                request.fs(), request.transport(), request.http(), request.breaker());
+                request.fs(), request.transport(), request.http(), request.breaker(), request.script());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -100,7 +100,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     @Override
     protected ClusterStatsNodeResponse nodeOperation(ClusterStatsNodeRequest nodeRequest) {
         NodeInfo nodeInfo = nodeService.info(false, true, false, true, false, false, true, false, true);
-        NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE, false, true, true, false, false, true, false, false, false);
+        NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE, false, true, true, false, false, true, false, false, false, false);
         List<ShardStats> shardsStats = new ArrayList<>();
         for (IndexService indexService : indicesService) {
             for (IndexShard indexShard : indexService) {

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
@@ -76,6 +76,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
             nodesStatsRequest.indices(metrics.contains("indices"));
             nodesStatsRequest.process(metrics.contains("process"));
             nodesStatsRequest.breaker(metrics.contains("breaker"));
+            nodesStatsRequest.script(metrics.contains("script"));
 
             // check for index specific metrics
             if (metrics.contains("indices")) {

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -57,6 +57,7 @@ import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
+import org.elasticsearch.script.ScriptStats;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 import java.util.Locale;
@@ -92,7 +93,7 @@ public class RestNodesAction extends AbstractCatAction {
                     @Override
                     public void processResponse(final NodesInfoResponse nodesInfoResponse) {
                         NodesStatsRequest nodesStatsRequest = new NodesStatsRequest();
-                        nodesStatsRequest.clear().jvm(true).os(true).fs(true).indices(true).process(true);
+                        nodesStatsRequest.clear().jvm(true).os(true).fs(true).indices(true).process(true).script(true);
                         client.admin().cluster().nodesStats(nodesStatsRequest, new RestResponseListener<NodesStatsResponse>(channel) {
                             @Override
                             public RestResponse buildResponse(NodesStatsResponse nodesStatsResponse) throws Exception {
@@ -182,6 +183,9 @@ public class RestNodesAction extends AbstractCatAction {
 
         table.addCell("refresh.total", "alias:rto,refreshTotal;default:false;text-align:right;desc:total refreshes");
         table.addCell("refresh.time", "alias:rti,refreshTime;default:false;text-align:right;desc:time spent in refreshes");
+
+        table.addCell("script.compilations", "alias:scrcc,scriptCompilations;default:false;text-align:right;desc:script compilations");
+        table.addCell("script.cache_evictions", "alias:scrce,scriptCacheEvictions;default:false;text-align:right;desc:script cache evictions");
 
         table.addCell("search.fetch_current", "alias:sfc,searchFetchCurrent;default:false;text-align:right;desc:current fetch phase ops");
         table.addCell("search.fetch_time", "alias:sfti,searchFetchTime;default:false;text-align:right;desc:time spent in fetch phase");
@@ -316,6 +320,10 @@ public class RestNodesAction extends AbstractCatAction {
             RefreshStats refreshStats = indicesStats == null ? null : indicesStats.getRefresh();
             table.addCell(refreshStats == null ? null : refreshStats.getTotal());
             table.addCell(refreshStats == null ? null : refreshStats.getTotalTime());
+
+            ScriptStats scriptStats = stats == null ? null : stats.getScriptStats();
+            table.addCell(scriptStats == null ? null : scriptStats.getCompilations());
+            table.addCell(scriptStats == null ? null : scriptStats.getCacheEvictions());
 
             SearchStats searchStats = indicesStats == null ? null : indicesStats.getSearch();
             table.addCell(searchStats == null ? null : searchStats.getTotal().getFetchCurrent());

--- a/core/src/main/java/org/elasticsearch/script/ScriptMetrics.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptMetrics.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.common.metrics.CounterMetric;
+
+public class ScriptMetrics {
+    final CounterMetric compilationsMetric = new CounterMetric();
+    final CounterMetric cacheEvictionsMetric = new CounterMetric();
+
+    public ScriptStats stats() {
+        return new ScriptStats(compilationsMetric.count(), cacheEvictionsMetric.count());
+    }
+
+    public void onCompilation() {
+        compilationsMetric.inc();
+    }
+
+    public void onCacheEviction() {
+        cacheEvictionsMetric.inc();
+    }
+}

--- a/core/src/main/java/org/elasticsearch/script/ScriptStats.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptStats.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+
+public class ScriptStats implements Streamable, ToXContent {
+    private long compilations;
+    private long cacheEvictions;
+
+    public ScriptStats() {
+    }
+
+    public ScriptStats(long compilations, long cacheEvictions) {
+        this.compilations = compilations;
+        this.cacheEvictions = cacheEvictions;
+    }
+
+    public void add(ScriptStats stats) {
+        this.compilations += stats.compilations;
+        this.cacheEvictions += stats.cacheEvictions;
+    }
+
+    public long getCompilations() {
+        return compilations;
+    }
+
+    public long getCacheEvictions() {
+        return cacheEvictions;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        compilations = in.readVLong();
+        cacheEvictions = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(compilations);
+        out.writeVLong(cacheEvictions);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.SCRIPT_STATS);
+        builder.field(Fields.COMPILATIONS, getCompilations());
+        builder.field(Fields.CACHE_EVICTIONS, getCacheEvictions());
+        builder.endObject();
+        return builder;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString SCRIPT_STATS = new XContentBuilderString("script");
+        static final XContentBuilderString COMPILATIONS = new XContentBuilderString("compilations");
+        static final XContentBuilderString CACHE_EVICTIONS = new XContentBuilderString("cache_evictions");
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -179,7 +179,8 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
                 System.currentTimeMillis(),
                 null, null, null, null, null,
                 fsInfo,
-                null, null, null);
+                null, null, null,
+                null);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -387,6 +387,73 @@ public class ScriptServiceTests extends ESTestCase {
         }
     }
 
+    @Test
+    public void testCompileCountedInCompilationStats() throws IOException {
+        buildScriptService(Settings.EMPTY);
+        scriptService.compile(new Script("1+1", ScriptType.INLINE, "test", null), randomFrom(scriptContexts));
+        assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    @Test
+    public void testExecutableCountedInCompilationStats() throws IOException {
+        buildScriptService(Settings.EMPTY);
+        scriptService.executable(new Script("1+1", ScriptType.INLINE, "test", null), randomFrom(scriptContexts));
+        assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    @Test
+    public void testSearchCountedInCompilationStats() throws IOException {
+        buildScriptService(Settings.EMPTY);
+        scriptService.search(null, new Script("1+1", ScriptType.INLINE, "test", null), randomFrom(scriptContexts));
+        assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    @Test
+    public void testMultipleCompilationsCountedInCompilationStats() throws IOException {
+        buildScriptService(Settings.EMPTY);
+        int numberOfCompilations = randomIntBetween(1, 1024);
+        for (int i = 0; i < numberOfCompilations; i++) {
+            scriptService.compile(new Script(String.format("%d+%d", i, i), ScriptType.INLINE, "test", null), randomFrom(scriptContexts));
+        }
+        assertEquals(numberOfCompilations, scriptService.stats().getCompilations());
+    }
+
+    @Test
+    public void testCompilationStatsOnCacheHit() throws IOException {
+        Settings.Builder builder = Settings.builder();
+        builder.put(ScriptService.SCRIPT_CACHE_SIZE_SETTING, 1);
+        buildScriptService(builder.build());
+        scriptService.executable(new Script("1+1", ScriptType.INLINE, "test", null), randomFrom(scriptContexts));
+        scriptService.executable(new Script("1+1", ScriptType.INLINE, "test", null), randomFrom(scriptContexts));
+        assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    @Test
+    public void testFileScriptCountedInCompilationStats() throws IOException {
+        buildScriptService(Settings.EMPTY);
+        createFileScripts("test");
+        scriptService.compile(new Script("file_script", ScriptType.FILE, "test", null), randomFrom(scriptContexts));
+        assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    @Test
+    public void testIndexedScriptCountedInCompilationStats() throws IOException {
+        buildScriptService(Settings.EMPTY);
+        scriptService.compile(new Script("script", ScriptType.INDEXED, "test", null), randomFrom(scriptContexts));
+        assertEquals(1L, scriptService.stats().getCompilations());
+    }
+
+    @Test
+    public void testCacheEvictionCountedInCacheEvictionsStats() throws IOException {
+        Settings.Builder builder = Settings.builder();
+        builder.put(ScriptService.SCRIPT_CACHE_SIZE_SETTING, 1);
+        buildScriptService(builder.build());
+        scriptService.executable(new Script("1+1", ScriptType.INLINE, "test", null), randomFrom(scriptContexts));
+        scriptService.executable(new Script("2+2", ScriptType.INLINE, "test", null), randomFrom(scriptContexts));
+        assertEquals(2L, scriptService.stats().getCompilations());
+        assertEquals(1L, scriptService.stats().getCacheEvictions());
+    }
+
     private void createFileScripts(String... langs) throws IOException {
         for (String lang : langs) {
             Path scriptPath = scriptsFilePath.resolve("file_script." + lang);

--- a/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1855,7 +1855,7 @@ public final class InternalTestCluster extends TestCluster {
                 }
 
                 NodeService nodeService = getInstanceFromNode(NodeService.class, nodeAndClient.node);
-                NodeStats stats = nodeService.stats(CommonStatsFlags.ALL, false, false, false, false, false, false, false, false, false);
+                NodeStats stats = nodeService.stats(CommonStatsFlags.ALL, false, false, false, false, false, false, false, false, false, false);
                 assertThat("Fielddata size must be 0 on node: " + stats.getNode(), stats.getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0l));
                 assertThat("Query cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0l));
                 assertThat("FixedBitSet cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getSegments().getBitsetMemoryInBytes(), equalTo(0l));

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -168,6 +168,8 @@ percolating |0s
 |`percolate.total` |`pto`, `percolateTotal` |No |Total percolations |0
 |`refresh.total` |`rto`, `refreshTotal` |No |Number of refreshes |16
 |`refresh.time` |`rti`, `refreshTime` |No |Time spent in refreshes |91ms
+|`script.compilations` |`scrcc`, `scriptCompilations` |No |Total script compilations |17
+|`script.cache_evictions` |`scrce`, `scriptCacheEvictions` |No |Total compiled scripts evicted from cache |6
 |`search.fetch_current` |`sfc`, `searchFetchCurrent` |No |Current fetch
 phase operations |0
 |`search.fetch_time` |`sfti`, `searchFetchTime` |No |Time spent in fetch


### PR DESCRIPTION
This commit adds basic support to track the number of times scripts are
compiled and compiled scripts are evicted from the script cache. These
statistics are tracked at the node level.

Closes #12673
