### PR TITLE
Remove lenient store type parsing

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
+++ b/core/src/main/java/org/elasticsearch/index/store/FsDirectoryService.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -101,7 +102,7 @@ public class FsDirectoryService extends DirectoryService implements StoreRateLim
 
 
     protected Directory newFSDirectory(Path location, LockFactory lockFactory) throws IOException {
-        final String storeType = indexSettings.get(IndexStoreModule.STORE_TYPE, IndexStoreModule.Type.DEFAULT.name());
+        final String storeType = indexSettings.get(IndexStoreModule.STORE_TYPE, IndexStoreModule.Type.DEFAULT.getSettingsKey());
         if (IndexStoreModule.Type.FS.match(storeType) || IndexStoreModule.Type.DEFAULT.match(storeType)) {
             final FSDirectory open = FSDirectory.open(location, lockFactory); // use lucene defaults
             if (open instanceof MMapDirectory && Constants.WINDOWS == false) {

--- a/core/src/main/java/org/elasticsearch/index/store/IndexStoreModule.java
+++ b/core/src/main/java/org/elasticsearch/index/store/IndexStoreModule.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableList;
 import org.elasticsearch.common.inject.*;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.Locale;
+
 /**
  *
  */
@@ -33,32 +35,20 @@ public class IndexStoreModule extends AbstractModule implements SpawnModules {
     private final Settings settings;
 
     public enum Type {
-        NIOFS {
-            @Override
-            public boolean match(String setting) {
-                return super.match(setting) || "nio_fs".equalsIgnoreCase(setting);
-            }
-        },
-        MMAPFS {
-            @Override
-            public boolean match(String setting) {
-                return super.match(setting) || "mmap_fs".equalsIgnoreCase(setting);
-            }
-        },
-
-        SIMPLEFS {
-            @Override
-            public boolean match(String setting) {
-                return super.match(setting) || "simple_fs".equalsIgnoreCase(setting);
-            }
-        },
+        NIOFS,
+        MMAPFS,
+        SIMPLEFS,
         FS,
-        DEFAULT,;
+        DEFAULT;
+
+        public String getSettingsKey() {
+            return this.name().toLowerCase(Locale.ROOT);
+        }
         /**
          * Returns true iff this settings matches the type.
          */
         public boolean match(String setting) {
-            return this.name().equalsIgnoreCase(setting);
+            return getSettingsKey().equals(setting);
         }
     }
 
@@ -68,7 +58,7 @@ public class IndexStoreModule extends AbstractModule implements SpawnModules {
 
     @Override
     public Iterable<? extends Module> spawnModules() {
-        final String storeType = settings.get(STORE_TYPE, Type.DEFAULT.name());
+        final String storeType = settings.get(STORE_TYPE, Type.DEFAULT.getSettingsKey());
         for (Type type : Type.values()) {
             if (type.match(storeType)) {
                 return ImmutableList.of(new DefaultStoreModule());

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeServiceTest.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeServiceTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster.metadata;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.store.IndexStoreModule;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+public class MetaDataIndexUpgradeServiceTest extends ESTestCase {
+
+    public void testUpgradeStoreSettings() {
+        final String type = RandomPicks.randomFrom(random(), Arrays.asList("nio_fs", "mmap_fs", "simple_fs", "default", "fs"));
+        MetaDataIndexUpgradeService metaDataIndexUpgradeService = new MetaDataIndexUpgradeService(Settings.EMPTY, null);
+        Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexStoreModule.STORE_TYPE, randomBoolean() ? type : type.toUpperCase(Locale.ROOT))
+                .build();
+        IndexMetaData test = IndexMetaData.builder("test")
+                .settings(indexSettings)
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build();
+        IndexMetaData indexMetaData = metaDataIndexUpgradeService.upgradeSettings(test);
+        assertEquals(type.replace("_", ""), indexMetaData.getSettings().get(IndexStoreModule.STORE_TYPE));
+    }
+
+    public void testNoStoreSetting() {
+        Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .build();
+        IndexMetaData test = IndexMetaData.builder("test")
+                .settings(indexSettings)
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build();
+        MetaDataIndexUpgradeService metaDataIndexUpgradeService = new MetaDataIndexUpgradeService(Settings.EMPTY, null);
+        IndexMetaData indexMetaData = metaDataIndexUpgradeService.upgradeSettings(test);
+        assertSame(indexMetaData, test);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/store/IndexStoreBWCTest.java
+++ b/core/src/test/java/org/elasticsearch/index/store/IndexStoreBWCTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.store;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import org.apache.lucene.store.*;
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ */
+public class IndexStoreBWCTest extends ESSingleNodeTestCase {
+
+
+    public void testOldCoreTypesFail() {
+        try {
+            createIndex("test", Settings.builder().put(IndexStoreModule.STORE_TYPE, "nio_fs").build());
+            fail();
+        } catch (Exception ex) {
+        }
+        try {
+            createIndex("test", Settings.builder().put(IndexStoreModule.STORE_TYPE, "mmap_fs").build());
+            fail();
+        } catch (Exception ex) {
+        }
+        try {
+            createIndex("test", Settings.builder().put(IndexStoreModule.STORE_TYPE, "simple_fs").build());
+            fail();
+        } catch (Exception ex) {
+        }
+    }
+
+    public void testUpgradeCoreTypes() throws IOException {
+        String type = RandomPicks.randomFrom(random(), Arrays.asList("nio", "mmap", "simple"));
+        createIndex("test", Settings.builder()
+                .put(IndexStoreModule.STORE_TYPE, type+"fs")
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_7_0)
+                .build());
+
+        client().admin().indices().prepareClose("test").get();
+        client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder()
+                .put(IndexStoreModule.STORE_TYPE, type + "_fs").build()).get();
+        GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
+        String actualType = getSettingsResponse.getSetting("test", IndexStoreModule.STORE_TYPE);
+        assertEquals(type + "_fs", actualType);
+
+        // now reopen and upgrade
+        client().admin().indices().prepareOpen("test").get();
+
+        getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
+        actualType = getSettingsResponse.getSetting("test", IndexStoreModule.STORE_TYPE);
+        assertEquals(type+"fs", actualType);
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Locale;
 
 /**
  */
@@ -37,7 +38,7 @@ public class IndexStoreTests extends ESTestCase {
         final Path tempDir = createTempDir();
         final IndexStoreModule.Type[] values = IndexStoreModule.Type.values();
         final IndexStoreModule.Type type = RandomPicks.randomFrom(random(), values);
-        Settings settings = Settings.settingsBuilder().put(IndexStoreModule.STORE_TYPE, type.name()).build();
+        Settings settings = Settings.settingsBuilder().put(IndexStoreModule.STORE_TYPE, type.name().toLowerCase(Locale.ROOT)).build();
         FsDirectoryService service = new FsDirectoryService(settings, null, new ShardPath(tempDir, tempDir, "foo", new ShardId("foo", 0)));
         try (final Directory directory = service.newFSDirectory(tempDir, NoLockFactory.INSTANCE)) {
             switch (type) {
@@ -80,6 +81,4 @@ public class IndexStoreTests extends ESTestCase {
             }
         }
     }
-
-
 }

--- a/core/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
+++ b/core/src/test/java/org/elasticsearch/test/store/MockFSDirectoryService.java
@@ -210,7 +210,7 @@ public class MockFSDirectoryService extends FsDirectoryService {
     private FsDirectoryService randomDirectorService(IndexStore indexStore, ShardPath path) {
         Settings.Builder builder = Settings.settingsBuilder();
         builder.put(indexSettings);
-        builder.put(IndexStoreModule.STORE_TYPE, RandomPicks.randomFrom(random, IndexStoreModule.Type.values()));
+        builder.put(IndexStoreModule.STORE_TYPE, RandomPicks.randomFrom(random, IndexStoreModule.Type.values()).getSettingsKey());
         return new FsDirectoryService(builder.build(), indexStore, path);
     }
 


### PR DESCRIPTION
Today we accept store types like `nio_fs`, `nioFs`, `niofs` etc.
this commit removes the leniency and only accepts plain values without underscore.
Yet, this commit also has a BWC layer that upgrades existing indices to the new version.
Affected enums are:
- `nio_fs`
- `mmap_fs`
- `simple_fs`
