### PR TITLE
Add support for `disable_coord` param to `terms` query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -84,6 +84,8 @@ public class TermsQueryParser implements QueryParser {
         String lookupRouting = null;
         String minShouldMatch = null;
 
+        boolean disableCoord = false;
+
         XContentParser.Token token;
         List<Object> terms = Lists.newArrayList();
         String fieldName = null;
@@ -147,6 +149,8 @@ public class TermsQueryParser implements QueryParser {
                     minShouldMatch = parser.textOrNull();
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
+                } else if (("disable_coord").equals(currentFieldName) || ("disableCoord").equals(currentFieldName)) {
+                    disableCoord = parser.booleanValue();
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();
                 } else {
@@ -191,7 +195,7 @@ public class TermsQueryParser implements QueryParser {
                 query = new TermsQuery(fieldName, filterValues);
             }
         } else {
-            BooleanQuery bq = new BooleanQuery();
+            BooleanQuery bq = new BooleanQuery(disableCoord);
             for (Object term : terms) {
                 if (fieldType != null) {
                     bq.add(fieldType.termQuery(term, parseContext), Occur.SHOULD);

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1073,6 +1073,33 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
 
         assertThat(((TermQuery) clauses[1].getQuery()).getTerm(), equalTo(new Term("name.first", "test")));
         assertThat(clauses[1].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+
+        assertFalse("terms query disable_coord disabled by default", booleanQuery.isCoordDisabled());
+    }
+
+    @Test
+    public void testTermsQueryOptions() throws IOException {
+        IndexQueryParserService queryParser = queryParser();
+        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/terms-query-options.json");
+        Query parsedQuery = queryParser.parse(query).query();
+        assertThat(parsedQuery, instanceOf(BooleanQuery.class));
+        BooleanQuery booleanQuery = (BooleanQuery) parsedQuery;
+        BooleanClause[] clauses = booleanQuery.getClauses();
+
+        assertThat(clauses.length, equalTo(3));
+
+        assertThat(((TermQuery) clauses[0].getQuery()).getTerm(), equalTo(new Term("name.first", "shay")));
+        assertThat(clauses[0].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+
+        assertThat(((TermQuery) clauses[1].getQuery()).getTerm(), equalTo(new Term("name.first", "test")));
+        assertThat(clauses[1].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+
+        assertThat(((TermQuery) clauses[2].getQuery()).getTerm(), equalTo(new Term("name.first", "elasticsearch")));
+        assertThat(clauses[2].getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+
+        assertTrue("terms query disable_coord option mismatch", booleanQuery.isCoordDisabled());
+        assertThat(booleanQuery.getBoost(), equalTo(2.0f));
+        assertThat(booleanQuery.getMinimumNumberShouldMatch(), equalTo(2));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/terms-query-options.json
+++ b/core/src/test/java/org/elasticsearch/index/query/terms-query-options.json
@@ -1,0 +1,8 @@
+{
+    "terms":{
+        "name.first":["shay", "test", "elasticsearch"],
+        "disable_coord":true,
+        "boost":2.0,
+        "min_should_match":2
+    }
+}


### PR DESCRIPTION
Trivial change to enable `disable_coord` support for TermsQuery .

Added test case to verify support for options in  `TermsQuery` Parser.

Closes #12755
