### PR TITLE
Docs: Mention in migration doc that order to dynamic arguments is important

### DIFF
--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -827,6 +827,19 @@ infrastructure for the pluginmanager and the elasticsearch start up
 script, the `-v` parameter now stands for `--verbose`, where as `-V` or
 `--version` can be used to show the Elasticsearch version and exit.
 
+=== `/bin/elasticsearch` dynamic parameters must come after static ones
+
+If you are setting configuration options like cluster name or node name via
+the commandline, you have to ensure, that the static options like pid file
+path or daemonizing always come first, like this
+
+```
+/bin/elasticsearch -d -p /tmp/foo.pid --http.cors.enabled=true --http.cors.allow-origin='*'
+
+```
+
+For a list of those static parameters, run `/bin/elasticsearch -h`
+
 === Aliases
 
 Fields used in alias filters no longer have to exist in the mapping upon alias creation time. Alias filters are now

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -59,13 +59,13 @@ There are added features when using the `elasticsearch` shell script.
 The first, which was explained earlier, is the ability to easily run the
 process either in the foreground or the background.
 
-Another feature is the ability to pass `-X` and `-D` or getopt long style
+Another feature is the ability to pass `-D` or getopt long style
 configuration parameters directly to the script. When set, all override
 anything set using either `JAVA_OPTS` or `ES_JAVA_OPTS`. For example:
 
 [source,sh]
 --------------------------------------------------
-$ bin/elasticsearch -Xmx2g -Xms2g -Des.index.store.type=memory --node.name=my-node
+$ bin/elasticsearch -Des.index.refresh_interval=5s --node.name=my-node
 --------------------------------------------------
 *************************************************************************
 

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -319,9 +319,8 @@ YAML or JSON):
 --------------------------------------------------
 $ curl -XPUT http://localhost:9200/kimchy/ -d \
 '
-index :
-    store:
-        type: memory
+index:
+    refresh_interval: 5s
 '
 --------------------------------------------------
 
@@ -331,8 +330,7 @@ within the `elasticsearch.yml` file, the following can be set:
 [source,yaml]
 --------------------------------------------------
 index :
-    store:
-        type: memory
+    refresh_interval: 5s
 --------------------------------------------------
 
 This means that every index that gets created on the specific node
@@ -343,7 +341,7 @@ above can also be set as a "collapsed" setting, for example:
 
 [source,sh]
 --------------------------------------------------
-$ elasticsearch -Des.index.store.type=memory
+$ elasticsearch -Des.index.refresh_interval=5s
 --------------------------------------------------
 
 All of the index level configuration can be found within each


### PR DESCRIPTION
Due to the limited abilities of parsing of dynamic (not configured) arguments
like `http.cors.enabled`, that dont map to a command line argument but will
become configuration, we need to mention explicitely, that those dynamic arguments
must come last.

Also fixed some mentions of a memory index setting, that does not exist anymore.

Closes #12758
