### PR TITLE
Tests: Move qa's convert-plugin-name macrodef to dev-tools.

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -187,6 +187,24 @@
     </sequential>
   </macrodef>
 
+  <!-- Takes a plugin zip file and return the plugin name. For instance
+       'elasticsearch-analysis-icu-2.0.0.zip' would return
+       'elasticsearch-analysis-icu'. -->
+  <macrodef name="convert-plugin-name">
+      <attribute name="file"/>
+      <attribute name="outputproperty"/>
+    <sequential>
+      <local name="file.base"/>
+      <basename file="@{file}" property="file.base"/>
+      <filter-property src="file.base" dest="@{outputproperty}">
+        <chain>
+          <replaceregex pattern="^elasticsearch-" replace=""/>
+          <replacestring from="-${elasticsearch.version}.zip" to=""/>
+        </chain>
+      </filter-property>
+    </sequential>
+  </macrodef>
+
   <!-- unzip the elasticsearch zip -->
   <target name="setup-workspace" depends="stop-external-cluster">
     <sequential>

--- a/qa/smoke-test-plugins/integration-tests.xml
+++ b/qa/smoke-test-plugins/integration-tests.xml
@@ -4,21 +4,6 @@
 
   <import file="${elasticsearch.integ.antfile.default}"/>
 
-  <macrodef name="convert-plugin-name">
-      <attribute name="file"/>
-      <attribute name="outputproperty"/>
-    <sequential>
-      <local name="file.base"/>
-      <basename file="@{file}" property="file.base"/>
-      <filter-property src="file.base" dest="@{outputproperty}">
-        <chain>
-          <replaceregex pattern="^elasticsearch-" replace=""/>
-          <replacestring from="-${elasticsearch.version}.zip" to=""/>
-        </chain>
-      </filter-property>
-    </sequential>
-  </macrodef>
-
   <target name="start-external-cluster-with-plugins" depends="setup-workspace" unless="${shouldskip}">
     <fail message="Expected ${expected.plugin.count} dependencies, are plugins missing from this pom.xml?">
       <condition>


### PR DESCRIPTION
This would allow to use it for plugins which are in different repositories.
