### PR TITLE
PluginManager: Do not try other URLs if specific URL was passed

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -153,7 +153,7 @@ public class PluginManager {
             }
         }
 
-        if (!downloaded) {
+        if (!downloaded && url == null) {
             // We try all possible locations
             for (URL url : pluginHandle.urls()) {
                 terminal.println("Trying %s ...", url.toExternalForm());

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerIT.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerIT.java
@@ -536,6 +536,9 @@ public class PluginManagerIT extends ESIntegTestCase {
             // IO_ERROR because there is no real file delivered...
             assertStatus(String.format(Locale.ROOT, "install foo --url https://user:pass@localhost:%s/foo.zip --verbose --timeout 1s", port), ExitStatus.IO_ERROR);
 
+            // ensure that we did not try any other data source like download.elastic.co, in case we specified our own local URL
+            assertThat(terminal.getTerminalOutput(), not(hasItem(containsString("download.elastic.co"))));
+
             assertThat(requests, hasSize(1));
             String msg = String.format(Locale.ROOT, "Request header did not contain Authorization header, terminal output was: %s", terminal.getTerminalOutput());
             assertThat(msg, requests.get(0).headers().contains("Authorization"), is(true));


### PR DESCRIPTION
If an URL specified with --url on the command line cannot be reached,
the plugin manager tries URLs at download.elastic.co automatically.

This can lead to download wrong plugins and also exposes potentially
the name of an internal plugin to the download service.

This fix ensures, that the plugin manager simply aborts, if the specified
URL cannot be downloaded.

This was uncovered by CI tests, that returned a strange error code, instead of returning a regular failure due to running into timeout when trying to reach elastic.co even though it should not have.
