### PR TITLE
Makes sure all POMs contain a description

### DIFF
--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -4,6 +4,7 @@
   <artifactId>elasticsearch-dev-tools</artifactId>
   <version>2.0.0-beta1-SNAPSHOT</version>
   <name>Elasticsearch Build Resources</name>
+  <description>Tools to assist in building and developing in the Elasticsearch project</description>
   <parent>
       <groupId>org.sonatype.oss</groupId>
       <artifactId>oss-parent</artifactId>

--- a/distribution/deb/pom.xml
+++ b/distribution/deb/pom.xml
@@ -17,6 +17,7 @@
         But if you do this, then maven lifecycle does not execute any test (nor compile any test)
      -->
     <!--packaging>deb</packaging-->
+    <description>The Debian distribution of Elasticsearch</description>
 
     <properties>
         <deb.sign>false</deb.sign>

--- a/distribution/deb/src/main/packaging/scripts/control
+++ b/distribution/deb/src/main/packaging/scripts/control
@@ -6,33 +6,4 @@ Depends: libc6, adduser
 Section: web
 Priority: optional
 Homepage: https://www.elastic.co/
-Description: Open Source, Distributed, RESTful Search Engine
- Elasticsearch is a distributed RESTful search engine built for the cloud.
- .
- Features include:
- .
- + Distributed and Highly Available Search Engine.
-   - Each index is fully sharded with a configurable number of shards.
-   - Each shard can have one or more replicas.
-   - Read / Search operations performed on either one of the replica shard.
- + Multi Tenant with Multi Types.
-   - Support for more than one index.
-   - Support for more than one type per index.
-   - Index level configuration (number of shards, index storage, ...).
- + Various set of APIs
-   - HTTP RESTful API
-   - Native Java API.
-   - All APIs perform automatic node operation rerouting.
- + Document oriented
-   - No need for upfront schema definition.
-   - Schema can be defined per type for customization of the indexing process.
- + Reliable, Asynchronous Write Behind for long term persistency.
- + (Near) Real Time Search.
- + Built on top of Lucene
-   - Each shard is a fully functional Lucene index
-   - All the power of Lucene easily exposed through simple
-     configuration/plugins.
- + Per operation consistency
-   - Single document level operations are atomic, consistent, isolated and
-     durable.
- + Open Source under the Apache License, version 2 ("ALv2").
+Description: Elasticsearch is a distributed RESTful search engine built for the cloud. Reference documentation can be found at https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html and the 'Elasticsearch: The Definitive Guide' book can be found at https://www.elastic.co/guide/en/elasticsearch/guide/current/index.html

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -13,6 +13,7 @@
     <artifactId>elasticsearch</artifactId>
     <name>Elasticsearch RPM Distribution</name>
     <packaging>rpm</packaging>
+    <description>The RPM distribution of Elasticsearch</description>
 
     <dependencies>
         <dependency>
@@ -122,6 +123,7 @@
                     <defaultUsername>root</defaultUsername>
                     <defaultGroupname>root</defaultGroupname>
                     <icon>${project.basedir}/src/main/resources/logo/elastic.gif</icon>
+                    <description>Elasticsearch is a distributed RESTful search engine built for the cloud. Reference documentation can be found at https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html and the 'Elasticsearch: The Definitive Guide' book can be found at https://www.elastic.co/guide/en/elasticsearch/guide/current/index.html</description>
                     <mappings>
                         <!-- Add bin directory -->
                         <mapping>

--- a/distribution/tar/pom.xml
+++ b/distribution/tar/pom.xml
@@ -17,6 +17,7 @@
         But if you do this, then maven lifecycle does not execute any test (nor compile any test)
      -->
     <!--packaging>pom</packaging-->
+    <description>The TAR distribution of Elasticsearch</description>
 
     <dependencies>
         <dependency>

--- a/distribution/zip/pom.xml
+++ b/distribution/zip/pom.xml
@@ -17,6 +17,7 @@
         But if you do this, then maven lifecycle does not execute any test (nor compile any test)
      -->
     <!--packaging>pom</packaging-->
+    <description>The ZIP distribution of Elasticsearch</description>
 
     <dependencies>
         <dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -11,6 +11,7 @@
     <packaging>pom</packaging>
     <name>Elasticsearch Plugin POM</name>
     <inceptionYear>2009</inceptionYear>
+    <description>A parent project for Elasticsearch plugins</description>
 
     <parent>
         <groupId>org.elasticsearch</groupId>

--- a/rest-api-spec/pom.xml
+++ b/rest-api-spec/pom.xml
@@ -4,6 +4,7 @@
   <artifactId>elasticsearch-rest-api-spec</artifactId>
   <version>2.0.0-beta1-SNAPSHOT</version>
   <name>Elasticsearch Rest API Spec</name>
+  <description>REST API Specification and tests for use with the Elasticsearch REST Test framework</description>
   <parent>
       <groupId>org.sonatype.oss</groupId>
       <artifactId>oss-parent</artifactId>


### PR DESCRIPTION
Also adds an explicit description the RPM package so it doesn't inherit the description from the POM.

Closes #12550
