### PR TITLE
add type safety for QueryParser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
@@ -27,8 +27,12 @@ import java.util.ArrayList;
 
 import static com.google.common.collect.Lists.newArrayList;
 
+/**
+ * Parser for and query
+ * @deprecated use bool query instead
+ */
 @Deprecated
-public class AndQueryParser extends BaseQueryParser {
+public class AndQueryParser extends BaseQueryParser<AndQueryBuilder> {
 
     @Inject
     public AndQueryParser() {
@@ -40,7 +44,7 @@ public class AndQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public AndQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         final ArrayList<QueryBuilder> queries = newArrayList();

--- a/core/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BaseQueryParser.java
@@ -27,10 +27,10 @@ import java.io.IOException;
  * Class used during the query parsers refactoring. Will be removed once we can parse search requests on the coordinating node.
  * All query parsers that have a refactored "fromXContent" method can be changed to extend this instead of {@link BaseQueryParserTemp}.
  * Keeps old {@link QueryParser#parse(QueryShardContext)} method as a stub delegating to
- * {@link QueryParser#fromXContent(QueryShardContext)} and {@link QueryBuilder#toQuery(QueryShardContext)}}
+ * {@link QueryParser#fromXContent(QueryParseContext)} and {@link QueryBuilder#toQuery(QueryShardContext)}}
  */
 //norelease needs to be removed once we parse search requests on the coordinating node, as the parse method is not needed anymore at that point.
-public abstract class BaseQueryParser implements QueryParser {
+public abstract class BaseQueryParser<QB extends QueryBuilder<QB>> implements QueryParser<QB> {
 
     @Override
     public final Query parse(QueryShardContext context) throws IOException, QueryParsingException {

--- a/core/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoolQueryParser.java
@@ -30,9 +30,9 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 
 /**
- * Parser for the {@link BoolQueryBuilder}
+ * Parser for bool query
  */
-public class BoolQueryParser extends BaseQueryParser {
+public class BoolQueryParser extends BaseQueryParser<BoolQueryBuilder> {
 
     @Inject
     public BoolQueryParser(Settings settings) {
@@ -45,7 +45,7 @@ public class BoolQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public BoolQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         boolean disableCoord = BoolQueryBuilder.DISABLE_COORD_DEFAULT;

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for boosting query
  */
-public class BoostingQueryParser extends BaseQueryParser {
+public class BoostingQueryParser extends BaseQueryParser<BoostingQueryBuilder> {
 
     @Inject
     public BoostingQueryParser() {
@@ -39,7 +39,7 @@ public class BoostingQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public BoostingQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         QueryBuilder positiveQuery = null;

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for common terms query
  */
-public class CommonTermsQueryParser extends BaseQueryParser {
+public class CommonTermsQueryParser extends BaseQueryParser<CommonTermsQueryBuilder> {
 
     @Inject
     public CommonTermsQueryParser() {
@@ -39,7 +39,7 @@ public class CommonTermsQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public CommonTermsQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {

--- a/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ConstantScoreQueryParser.java
@@ -27,9 +27,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for constant_score query
  */
-public class ConstantScoreQueryParser extends BaseQueryParser {
+public class ConstantScoreQueryParser extends BaseQueryParser<ConstantScoreQueryBuilder> {
 
     private static final ParseField INNER_QUERY_FIELD = new ParseField("filter", "query");
 
@@ -43,7 +43,7 @@ public class ConstantScoreQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public ConstantScoreQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         QueryBuilder query = null;

--- a/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/DisMaxQueryParser.java
@@ -29,9 +29,9 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 
 /**
- *
+ * Parser for dis_max query
  */
-public class DisMaxQueryParser extends BaseQueryParser {
+public class DisMaxQueryParser extends BaseQueryParser<DisMaxQueryBuilder> {
 
     @Inject
     public DisMaxQueryParser() {
@@ -43,7 +43,7 @@ public class DisMaxQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public DisMaxQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for exists query
  */
-public class ExistsQueryParser extends BaseQueryParser {
+public class ExistsQueryParser extends BaseQueryParser<ExistsQueryBuilder> {
 
     @Inject
     public ExistsQueryParser() {
@@ -39,7 +39,7 @@ public class ExistsQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public ExistsQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         String fieldPattern = null;

--- a/core/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -27,9 +27,11 @@ import java.io.IOException;
 /**
  * The "fquery" filter is the same as the {@link QueryFilterParser} except that it allows also to
  * associate a name with the query filter.
+ * @deprecated Useless now that queries and filters are merged: pass the
+ *             query as a filter directly.
  */
 @Deprecated
-public class FQueryFilterParser extends BaseQueryParser {
+public class FQueryFilterParser extends BaseQueryParser<FQueryFilterBuilder> {
 
     @Inject
     public FQueryFilterParser() {
@@ -41,7 +43,7 @@ public class FQueryFilterParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public FQueryFilterBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         QueryBuilder wrappedQuery = null;

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for field_masking_span query
  */
-public class FieldMaskingSpanQueryParser extends BaseQueryParser {
+public class FieldMaskingSpanQueryParser extends BaseQueryParser<FieldMaskingSpanQueryBuilder> {
 
     @Inject
     public FieldMaskingSpanQueryParser() {
@@ -39,7 +39,7 @@ public class FieldMaskingSpanQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public FieldMaskingSpanQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;

--- a/core/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -25,11 +25,11 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
+ * Parser for filtered query.
  * @deprecated Use {@link BoolQueryParser} instead.
  */
-
 @Deprecated
-public class FilteredQueryParser extends BaseQueryParser {
+public class FilteredQueryParser extends BaseQueryParser<FilteredQueryBuilder> {
 
     @Inject
     public FilteredQueryParser() {
@@ -41,7 +41,7 @@ public class FilteredQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public FilteredQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         QueryBuilder query = null;

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryParser.java
@@ -28,9 +28,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Parser for the IdsQuery.
+ * Parser for ids query
  */
-public class IdsQueryParser extends BaseQueryParser {
+public class IdsQueryParser extends BaseQueryParser<IdsQueryBuilder> {
 
     @Inject
     public IdsQueryParser() {
@@ -45,7 +45,7 @@ public class IdsQueryParser extends BaseQueryParser {
      * @return a QueryBuilder representation of the query passed in as XContent in the parse context
      */
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
+    public IdsQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
         List<String> ids = new ArrayList<>();
         List<String> types = new ArrayList<>();

--- a/core/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
@@ -24,8 +24,12 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
+/**
+ * Parser for limit query
+ * @deprecated use terminate_after feature instead
+ */
 @Deprecated
-public class LimitQueryParser extends BaseQueryParser {
+public class LimitQueryParser extends BaseQueryParser<LimitQueryBuilder> {
 
     @Inject
     public LimitQueryParser() {
@@ -37,7 +41,7 @@ public class LimitQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public LimitQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         int limit = -1;

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryParser.java
@@ -26,9 +26,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- * Parser code for MatchAllQuery
+ * Parser for match_all query
  */
-public class MatchAllQueryParser extends BaseQueryParser {
+public class MatchAllQueryParser extends BaseQueryParser<MatchAllQueryBuilder> {
 
     @Inject
     public MatchAllQueryParser() {

--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for missing query
  */
-public class MissingQueryParser extends BaseQueryParser {
+public class MissingQueryParser extends BaseQueryParser<MissingQueryBuilder> {
 
     @Inject
     public MissingQueryParser() {
@@ -39,7 +39,7 @@ public class MissingQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public MissingQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         String fieldPattern = null;

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
@@ -26,9 +26,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for not query
  */
-public class NotQueryParser extends BaseQueryParser {
+public class NotQueryParser extends BaseQueryParser<NotQueryBuilder> {
 
     private static final ParseField QUERY_FIELD = new ParseField("filter", "query");
 
@@ -42,7 +42,7 @@ public class NotQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public NotQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         QueryBuilder query = null;

--- a/core/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
@@ -27,8 +27,12 @@ import java.util.ArrayList;
 
 import static com.google.common.collect.Lists.newArrayList;
 
+/**
+ * Parser for or query
+ * @deprecated use bool query instead
+ */
 @Deprecated
-public class OrQueryParser extends BaseQueryParser {
+public class OrQueryParser extends BaseQueryParser<OrQueryBuilder> {
 
     @Inject
     public OrQueryParser() {
@@ -40,7 +44,7 @@ public class OrQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public OrQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         final ArrayList<QueryBuilder> queries = newArrayList();

--- a/core/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PrefixQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for prefix query
  */
-public class PrefixQueryParser extends BaseQueryParser {
+public class PrefixQueryParser extends BaseQueryParser<PrefixQueryBuilder> {
 
     @Inject
     public PrefixQueryParser() {
@@ -39,7 +39,7 @@ public class PrefixQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public PrefixQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         String fieldName = parser.currentName();

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
@@ -23,8 +23,12 @@ import org.elasticsearch.common.inject.Inject;
 
 import java.io.IOException;
 
+/**
+ * Parser for query filter
+ * @deprecated use any query instead directly, possible since queries and filters are merged.
+ */
 @Deprecated
-public class QueryFilterParser extends BaseQueryParser {
+public class QueryFilterParser extends BaseQueryParser<QueryFilterBuilder> {
 
     @Inject
     public QueryFilterParser() {
@@ -36,7 +40,7 @@ public class QueryFilterParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public QueryFilterBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         return new QueryFilterBuilder(parseContext.parseInnerQueryBuilder());
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParser.java
@@ -25,9 +25,10 @@ import org.elasticsearch.common.Nullable;
 import java.io.IOException;
 
 /**
- *
+ * Defines a query parser that is able to read and parse a query object in {@link org.elasticsearch.common.xcontent.XContent}
+ * format and create an internal object representing the query, implementing {@link QueryBuilder}, which can be streamed to other nodes.
  */
-public interface QueryParser {
+public interface QueryParser<QB extends QueryBuilder<QB>> {
 
     /**
      * The names this query parser is registered under.
@@ -58,10 +59,10 @@ public interface QueryParser {
      * @throws IOException
      * @throws QueryParsingException
      */
-    QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException;
+    QB fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException;
 
     /**
      * @return an empty {@link QueryBuilder} instance for this parser that can be used for deserialization
      */
-    QueryBuilder<? extends QueryBuilder> getBuilderPrototype();
+    QB getBuilderPrototype();
 }

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -26,9 +26,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for range query
  */
-public class RangeQueryParser extends BaseQueryParser {
+public class RangeQueryParser extends BaseQueryParser<RangeQueryBuilder> {
 
     private static final ParseField FIELDDATA_FIELD = new ParseField("fielddata").withAllDeprecated("[no replacement]");
 

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryParser.java
@@ -24,9 +24,10 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
-public class RegexpQueryParser extends BaseQueryParser {
-
-    public static final int DEFAULT_FLAGS_VALUE = RegexpFlag.ALL.value();
+/**
+ * Parser for regexp query
+ */
+public class RegexpQueryParser extends BaseQueryParser<RegexpQueryBuilder> {
 
     @Inject
     public RegexpQueryParser() {
@@ -38,7 +39,7 @@ public class RegexpQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public RegexpQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         String fieldName = parser.currentName();

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
@@ -32,9 +32,9 @@ import java.util.Map;
 import static com.google.common.collect.Maps.newHashMap;
 
 /**
- *
+ * Parser for script query
  */
-public class ScriptQueryParser extends BaseQueryParser {
+public class ScriptQueryParser extends BaseQueryParser<ScriptQueryBuilder> {
 
     @Inject
     public ScriptQueryParser() {
@@ -46,7 +46,7 @@ public class ScriptQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public ScriptQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
         ScriptParameterParser scriptParameterParser = new ScriptParameterParser();
         

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -59,7 +59,7 @@ import java.util.Map;
  * {@code fields} - fields to search, defaults to _all if not set, allows
  * boosting a field with ^n
  */
-public class SimpleQueryStringParser extends BaseQueryParser {
+public class SimpleQueryStringParser extends BaseQueryParser<SimpleQueryStringBuilder> {
 
     @Inject
     public SimpleQueryStringParser() {

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.spans.SpanContainingQuery;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -27,9 +26,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- * Parser for {@link SpanContainingQuery}
+ * Parser for span_containing query
  */
-public class SpanContainingQueryParser extends BaseQueryParser {
+public class SpanContainingQueryParser extends BaseQueryParser<SpanContainingQueryBuilder> {
 
     @Inject
     public SpanContainingQueryParser() {
@@ -41,7 +40,7 @@ public class SpanContainingQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public SpanContainingQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String queryName = null;

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryParser.java
@@ -26,9 +26,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for span_first query
  */
-public class SpanFirstQueryParser extends BaseQueryParser {
+public class SpanFirstQueryParser extends BaseQueryParser<SpanFirstQueryBuilder> {
 
     @Inject
     public SpanFirstQueryParser() {
@@ -40,7 +40,7 @@ public class SpanFirstQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public SpanFirstQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for span_multi query
  */
-public class SpanMultiTermQueryParser extends BaseQueryParser {
+public class SpanMultiTermQueryParser extends BaseQueryParser<SpanMultiTermQueryBuilder> {
 
     public static final String MATCH_NAME = "match";
 
@@ -41,7 +41,7 @@ public class SpanMultiTermQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public SpanMultiTermQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
         String currentFieldName = null;
         MultiTermQueryBuilder subQuery = null;

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -29,9 +29,9 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 
 /**
- *
+ * Parser for span_near query
  */
-public class SpanNearQueryParser extends BaseQueryParser {
+public class SpanNearQueryParser extends BaseQueryParser<SpanNearQueryBuilder> {
 
     @Inject
     public SpanNearQueryParser() {
@@ -43,7 +43,7 @@ public class SpanNearQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public SpanNearQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
@@ -77,7 +77,7 @@ public class SpanNearQueryParser extends BaseQueryParser {
                 } else if ("collect_payloads".equals(currentFieldName) || "collectPayloads".equals(currentFieldName)) {
                     collectPayloads = parser.booleanValue();
                 } else if ("slop".equals(currentFieldName)) {
-                    slop = Integer.valueOf(parser.intValue());
+                    slop = parser.intValue();
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
                 } else if ("_name".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryParser.java
@@ -26,9 +26,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for span_not query
  */
-public class SpanNotQueryParser extends BaseQueryParser {
+public class SpanNotQueryParser extends BaseQueryParser<SpanNotQueryBuilder> {
 
     @Inject
     public SpanNotQueryParser() {
@@ -40,7 +40,7 @@ public class SpanNotQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public SpanNotQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -27,7 +27,10 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 
-public class SpanOrQueryParser extends BaseQueryParser {
+/**
+ * Parser for span_or query
+ */
+public class SpanOrQueryParser extends BaseQueryParser<SpanOrQueryBuilder> {
 
     @Override
     public String[] names() {
@@ -35,7 +38,7 @@ public class SpanOrQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public SpanOrQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryParser.java
@@ -26,10 +26,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- * Parses the json representation of a spantermquery into the Elasticsearch internal
- * query builder representation.
+ * Parser for span_term query
  */
-public class SpanTermQueryParser extends BaseQueryParser {
+public class SpanTermQueryParser extends BaseQueryParser<SpanTermQueryBuilder> {
 
     @Inject
     public SpanTermQueryParser() {
@@ -41,7 +40,7 @@ public class SpanTermQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public SpanTermQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         XContentParser.Token token = parser.currentToken();

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.spans.SpanWithinQuery;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -27,9 +26,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- * Parser for {@link SpanWithinQuery}
+ * Parser for span_within query
  */
-public class SpanWithinQueryParser extends BaseQueryParser {
+public class SpanWithinQueryParser extends BaseQueryParser<SpanWithinQueryBuilder> {
 
     @Inject
     public SpanWithinQueryParser() {
@@ -41,7 +40,7 @@ public class SpanWithinQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public SpanWithinQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- * Parser for the TermQuery.
+ * Parser for the term query
  */
-public class TermQueryParser extends BaseQueryParser {
+public class TermQueryParser extends BaseQueryParser<TermQueryBuilder> {
 
     @Inject
     public TermQueryParser() {
@@ -39,7 +39,7 @@ public class TermQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public TermQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         String queryName = null;

--- a/core/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
@@ -25,7 +25,10 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
-public class TypeQueryParser extends BaseQueryParser {
+/**
+ * Parser for type query
+ */
+public class TypeQueryParser extends BaseQueryParser<TypeQueryBuilder> {
 
     @Inject
     public TypeQueryParser() {
@@ -37,7 +40,7 @@ public class TypeQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public TypeQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
         BytesRef type = null;
 

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryParser.java
@@ -25,9 +25,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- *
+ * Parser for wildcard query
  */
-public class WildcardQueryParser extends BaseQueryParser {
+public class WildcardQueryParser extends BaseQueryParser<WildcardQueryBuilder> {
 
     @Inject
     public WildcardQueryParser() {
@@ -39,7 +39,7 @@ public class WildcardQueryParser extends BaseQueryParser {
     }
 
     @Override
-    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
+    public WildcardQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         XContentParser.Token token = parser.nextToken();

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryParser.java
@@ -45,7 +45,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
- *
+ * Parser for function_score query
  */
 public class FunctionScoreQueryParser implements QueryParser {
 

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -11,7 +11,8 @@ Plugins implementing custom queries need to implement the `fromXContent(QueryPar
 into an intermediate query representation that can be streamed between the nodes in binary format, effectively the
 query object used in the java api. Also, the query parser needs to implement the `getBuilderPrototype` method that
 returns a prototype of the streamable query, which allows to deserialize an incoming query by calling
-`readFrom(StreamInput)` against it, which will create a new object, see usages of `Writeable`.
+`readFrom(StreamInput)` against it, which will create a new object, see usages of `Writeable`. The `QueryParser`
+also needs to declare the generic type of the query that it supports and it's able to parse.
 The query object can then transform itself into a lucene query through the new `toQuery(QueryShardContext)` method,
 which returns a lucene query to be executed on the data node. The query implementation also needs to implement the
 `validate` method that allows to validate the content of the query, no matter whether it came in through the java api


### PR DESCRIPTION
QueryParser now explicitly declares the type of `QueryBuilder` that it creates. Properly applied to already refactored queries, not applicable to queries that are not refactored yet as their fromXContent returns QueryWrappingQueryBuilder but the return type of getBuilderPrototype is different.
