### PR TITLE
Fix rpm -e removing /etc/elasticsearch

### DIFF
--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -142,6 +142,15 @@
                         </mapping>
                         <!-- Add configuration files -->
                         <mapping>
+                            <!-- Explicitly add conf.dir to the file list so
+                                 that it is removed when the package is removed.
+                                 This is required because the scripts
+                                 subdirectory is created outside of the mapping
+                                 that creates the conf.dir.-->
+                            <directory>${packaging.elasticsearch.conf.dir}</directory>
+                            <configuration>noreplace</configuration>
+                        </mapping>
+                        <mapping>
                             <directory>${packaging.elasticsearch.conf.dir}/</directory>
                             <configuration>noreplace</configuration>
                             <sources>


### PR DESCRIPTION
When we fixed rpm creating the /etc/elasticsearch/scripts directory we
broke removing the rpm - it lef the /etc/elasticsearch directory behind.
This fixes that.
