### PR TITLE
Apply additional plugin settings only if settings are not explicit

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -787,43 +787,6 @@ public final class Settings implements ToXContent {
         }
 
         /**
-         * Removes the specified value from the given key.
-         * Returns true if the value was found and removed, false otherwise.
-         */
-        public boolean removeArrayElement(String key, String value) {
-            // TODO: this is too crazy, we should just have a multimap...
-            String oldValue = get(key);
-            if (oldValue != null) {
-                // single valued case
-                boolean match = oldValue.equals(value);
-                if (match) {
-                    remove(key);
-                }
-                return match;
-            }
-
-            // multi valued
-            int i = 0;
-            while (true) {
-                String toCheck = map.get(key + '.' + i++);
-                if (toCheck == null) {
-                    return false;
-                } else if (toCheck.equals(value)) {
-                    break;
-                }
-            }
-            // found the value, shift values after it back one index
-            int j = i + 1;
-            while (true) {
-                String toMove = map.get(key + '.' + j++);
-                if (toMove == null) {
-                    return true;
-                }
-                put(key + '.' + i++, toMove);
-            }
-        }
-
-        /**
          * Returns a setting value based on the setting key.
          */
         public String get(String key) {

--- a/core/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -99,7 +99,8 @@ public interface Plugin {
     void processModule(Module module);
 
     /**
-     * Additional node settings loaded by the plugin
+     * Additional node settings loaded by the plugin. Note that settings that are explicit in the nodes settings can't be
+     * overwritten with the additional settings. These settings added if they don't exist.
      */
     Settings additionalSettings();
 }

--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -202,12 +202,11 @@ public class PluginsService extends AbstractComponent {
     }
 
     public Settings updatedSettings() {
-        Settings.Builder builder = Settings.settingsBuilder()
-                .put(this.settings);
+        final Settings.Builder builder = Settings.settingsBuilder();
         for (Tuple<PluginInfo, Plugin> plugin : plugins) {
             builder.put(plugin.v2().additionalSettings());
         }
-        return builder.build();
+        return builder.put(this.settings).build();
     }
 
     public Collection<Class<? extends Module>> modules() {

--- a/core/src/test/java/org/elasticsearch/test/ESBackcompatTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESBackcompatTestCase.java
@@ -251,9 +251,9 @@ public abstract class ESBackcompatTestCase extends ESIntegTestCase {
 
     protected Settings commonNodeSettings(int nodeOrdinal) {
         Settings.Builder builder = Settings.builder().put(requiredSettings());
-        builder.removeArrayElement("plugin.types", MockTransportService.Plugin.class.getName());
-        builder.removeArrayElement("plugin.types", AssertingLocalTransport.class.getName());
         builder.put(TransportModule.TRANSPORT_TYPE_KEY, "netty"); // run same transport  / disco as external
+        builder.put("node.mode", "network");
+
         if (compatibilityVersion().before(Version.V_1_3_2)) {
             // if we test against nodes before 1.3.2 we disable all the compression due to a known bug
             // see #7210

--- a/core/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/transport/netty/NettyTransportMultiPortIntegrationIT.java
@@ -56,14 +56,10 @@ public class NettyTransportMultiPortIntegrationIT extends ESIntegTestCase {
                 .put("network.host", "127.0.0.1")
                 .put(TransportModule.TRANSPORT_TYPE_KEY, "netty")
                 .put("node.mode", "network")
-                .put("node.local", false) // ensure randomization doesn't set local mode, since this has higher precedence
                 .put("transport.profiles.client1.port", randomPortRange)
                 .put("transport.profiles.client1.publish_host", "127.0.0.7")
                 .put("transport.profiles.client1.publish_port", "4321")
                 .put("transport.profiles.client1.reuse_address", true);
-        // more things that might have been randomized to remove to ensure a real network stack
-        builder.removeArrayElement("plugin.types", MockTransportService.Plugin.class.getName());
-        builder.removeArrayElement("plugin.types", AssertingLocalTransport.Plugin.class.getName());
         return builder.build();
     }
 


### PR DESCRIPTION
We have a way to allow a plugin to specify additional settings. These
settings should only be applied if they are not already existing in the
node settings.
