### PR TITLE
simple query string: remove (not working) support for alternate formats

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -93,11 +93,6 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("spaghetti").field("*body")).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "5", "6");
-
-        // Have to bypass the builder here because the builder always uses "fields" instead of "field"
-        searchResponse = client().prepareSearch().setQuery("{\"simple_query_string\": {\"query\": \"spaghetti\", \"field\": \"_all\"}}").get();
-        assertHitCount(searchResponse, 2l);
-        assertSearchHits(searchResponse, "5", "6");
     }
 
     @Test


### PR DESCRIPTION
Removed attempt of parsing of `field` rather than `fields` and attempted support of the following syntax:

```
{
  "simple_query_string": {
    "body" : {
      "query": "foo bar"
    }
  }
}
```

Both these two syntaxes were undocumented, untested and not working.

Added test for case when `fields` is not specified, then the default field is queried.

Closes #12794
