### PR TITLE
Remove unused java opts/es java opts from plugin manager call

### DIFF
--- a/distribution/src/main/resources/bin/plugin
+++ b/distribution/src/main/resources/bin/plugin
@@ -108,4 +108,4 @@ fi
 HOSTNAME=`hostname | cut -d. -f1`
 export HOSTNAME
 
-eval "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginManagerCliParser $args
+eval "$JAVA" -client -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginManagerCliParser $args

--- a/distribution/src/main/resources/bin/plugin.bat
+++ b/distribution/src/main/resources/bin/plugin.bat
@@ -11,7 +11,7 @@ TITLE Elasticsearch Plugin Manager ${project.version}
 
 SET HOSTNAME=%COMPUTERNAME%
 
-"%JAVA_HOME%\bin\java" %JAVA_OPTS% %ES_JAVA_OPTS% -Xmx64m -Xms16m -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*;" "org.elasticsearch.plugins.PluginManagerCliParser" %*
+"%JAVA_HOME%\bin\java" -client -Des.path.home="%ES_HOME%" -cp "%ES_HOME%/lib/*;" "org.elasticsearch.plugins.PluginManagerCliParser" %*
 goto finally
 
 


### PR DESCRIPTION
When calling the plugin manager on java 7 with additional JAVA_OPTS
that change heap configuration compared to what is set at the plugin
manager shell script. This resulted in errors.

This commit removes the JAVA_OPTS and ES_JAVA_OPTS from the plugin
manager call to prevent those settings.

Closes #12479
