### PR TITLE
allow specifying additional arguments in startup-elasticsearch macrodef

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -155,6 +155,7 @@
       <attribute name="es.transport.tcp.port" default="${integ.transport.port}"/>
       <attribute name="es.pidfile" default="${integ.pidfile}"/>
       <attribute name="jvm.args" default="${tests.jvm.argline}"/>
+      <element name="additional-args" optional="true"/>
     <sequential>
       <!-- run bin/elasticsearch with args -->
       <echo>Starting up external cluster...</echo>
@@ -176,6 +177,7 @@
           <arg value="-Des.script.inline=on"/>
           <arg value="-Des.script.indexed=on"/>
           <arg value="-Des.repositories.url.allowed_urls=http://snapshot.test*"/>
+          <additional-args/>
         </nested>
       </run-script>
 


### PR DESCRIPTION
Previously we had additional.args as a argument to the startup-elasticsearch macrodef and this was
being used to set some additional elasticsearch settings. This adds the ability to specify additional
arguments back using a element called additional-args.
