### PR TITLE
Remove duplicate code in AndQueryParser

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
@@ -73,12 +73,6 @@ public class AndQueryParser extends BaseQueryParser<AndQueryBuilder> {
                             QueryBuilder filter = parseContext.parseInnerFilterToQueryBuilder();
                             queries.add(filter);
                         }
-                    } else {
-                        queriesFound = true;
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            QueryBuilder filter = parseContext.parseInnerFilterToQueryBuilder();
-                            queries.add(filter);
-                        }
                     }
                 } else if (token.isValue()) {
                     if ("_name".equals(currentFieldName)) {


### PR DESCRIPTION
When parsing inner array of filters, AndQueryParser seems to check for correct "filters" field name but then does the same kind of operation in the `else` branch of the stament. This PR removes the leniency of allowing array with fieldname other than `filters`. Top level array with nested queries is still allowed.

This PR is against the feature refactoring branch.
