### PR TITLE
Allow plugins to add custom stats to Node Stats

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -77,6 +77,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
     @Nullable
     private ScriptStats scriptStats;
 
+    @Nullable
+    private PluginsStat pluginsStat;
+
     NodeStats() {
     }
 
@@ -84,7 +87,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
                      @Nullable OsStats os, @Nullable ProcessStats process, @Nullable JvmStats jvm, @Nullable ThreadPoolStats threadPool,
                      @Nullable FsInfo fs, @Nullable TransportStats transport, @Nullable HttpStats http,
                      @Nullable AllCircuitBreakerStats breaker,
-                     @Nullable ScriptStats scriptStats) {
+                     @Nullable ScriptStats scriptStats, @Nullable PluginsStat pluginsStat) {
         super(node);
         this.timestamp = timestamp;
         this.indices = indices;
@@ -97,6 +100,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         this.http = http;
         this.breaker = breaker;
         this.scriptStats = scriptStats;
+        this.pluginsStat = pluginsStat;
     }
 
     public long getTimestamp() {
@@ -176,6 +180,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         return this.scriptStats;
     }
 
+    @Nullable
+    public PluginsStat getPluginsStat() {
+        return pluginsStat;
+    }
+
     public static NodeStats readNodeStats(StreamInput in) throws IOException {
         NodeStats nodeInfo = new NodeStats();
         nodeInfo.readFrom(in);
@@ -212,7 +221,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         }
         breaker = AllCircuitBreakerStats.readOptionalAllCircuitBreakerStats(in);
         scriptStats = in.readOptionalStreamable(new ScriptStats());
-
+        pluginsStat = in.readOptionalStreamable(new PluginsStat());
     }
 
     @Override
@@ -269,6 +278,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         }
         out.writeOptionalStreamable(breaker);
         out.writeOptionalStreamable(scriptStats);
+        out.writeOptionalStreamable(pluginsStat);
     }
 
     @Override
@@ -318,6 +328,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContent {
         }
         if (getScriptStats() != null) {
             getScriptStats().toXContent(builder, params);
+        }
+        if (getPluginsStat() != null) {
+            getPluginsStat().toXContent(builder, params);
         }
 
         return builder;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.node.stats;
 
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -42,6 +43,8 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     private boolean http;
     private boolean breaker;
     private boolean script;
+    private boolean plugins;
+    private String[] custom;
 
     protected NodesStatsRequest() {
     }
@@ -69,6 +72,8 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         this.http = true;
         this.breaker = true;
         this.script = true;
+        this.plugins = true;
+        this.custom = Strings.EMPTY_ARRAY;
         return this;
     }
 
@@ -87,6 +92,8 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         this.http = false;
         this.breaker = false;
         this.script = false;
+        this.plugins = false;
+        this.custom = null;
         return this;
     }
 
@@ -252,6 +259,24 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         return this;
     }
 
+    public boolean plugins() {
+        return plugins || (custom != null && custom.length > 0);
+    }
+
+    public NodesStatsRequest plugins(boolean plugins) {
+        this.plugins = plugins;
+        return this;
+    }
+
+    public String[] custom() {
+        return custom;
+    }
+
+    public NodesStatsRequest custom(String... customs) {
+        this.custom = customs;
+        return this;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -266,6 +291,9 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         http = in.readBoolean();
         breaker = in.readBoolean();
         script = in.readBoolean();
+        plugins = in.readBoolean();
+        custom = in.readStringArray();
+
     }
 
     @Override
@@ -282,6 +310,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         out.writeBoolean(http);
         out.writeBoolean(breaker);
         out.writeBoolean(script);
+        out.writeBoolean(plugins);
+        out.writeStringArrayNullable(custom);
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
@@ -67,6 +67,16 @@ public class NodesStatsRequestBuilder extends NodesOperationRequestBuilder<Nodes
         return this;
     }
 
+    public NodesStatsRequestBuilder setPlugins(boolean plugins) {
+        request.plugins(plugins);
+        return this;
+    }
+
+    public NodesStatsRequestBuilder setCustom(String... customs) {
+        request.custom(customs);
+        return this;
+    }
+
     /**
      * Should the node indices stats be returned.
      */

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/PluginsStat.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/PluginsStat.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.stats;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.plugins.PluginStat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PluginsStat implements Streamable, ToXContent {
+
+    private List<PluginStat> stats;
+
+    public PluginsStat() {
+        stats = new ArrayList<>();
+    }
+
+    public PluginsStat(int size) {
+        stats = new ArrayList<>(size);
+    }
+
+    public List<PluginStat> getStats() {
+        return stats;
+    }
+
+    public void add(PluginStat stat) {
+        stats.add(stat);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            stats.add(PluginStat.readFromStream(in));
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInt(stats.size());
+        for (PluginStat stat : getStats()) {
+            stat.writeTo(out);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        for (PluginStat pluginStat : getStats()) {
+            builder.field(pluginStat.getCategory(), pluginStat, params);
+        }
+        return builder;
+    }
+
+    public static PluginsStat readPluginsStat(StreamInput in) throws IOException {
+        PluginsStat pluginsStat = new PluginsStat();
+        pluginsStat.readFrom(in);
+        return pluginsStat;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -80,7 +80,7 @@ public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRe
     protected NodeStats nodeOperation(NodeStatsRequest nodeStatsRequest) {
         NodesStatsRequest request = nodeStatsRequest.request;
         return nodeService.stats(request.indices(), request.os(), request.process(), request.jvm(), request.threadPool(), request.network(),
-                request.fs(), request.transport(), request.http(), request.breaker(), request.script());
+                request.fs(), request.transport(), request.http(), request.breaker(), request.script(), request.plugins(), request.custom());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -100,7 +100,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     @Override
     protected ClusterStatsNodeResponse nodeOperation(ClusterStatsNodeRequest nodeRequest) {
         NodeInfo nodeInfo = nodeService.info(false, true, false, true, false, false, true, false, true);
-        NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE, false, true, true, false, false, true, false, false, false, false);
+        NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE, false, true, true, false, false, true, false, false, false, false, false);
         List<ShardStats> shardsStats = new ArrayList<>();
         for (IndexService indexService : indicesService) {
             for (IndexShard indexShard : indexService) {

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -300,6 +300,9 @@ public class XContentHelper {
 
     public static void copyCurrentStructure(XContentGenerator generator, XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();
+        if (token == null) {
+            token = parser.nextToken();
+        }
 
         // Let's handle field-name separately first
         if (token == XContentParser.Token.FIELD_NAME) {

--- a/core/src/main/java/org/elasticsearch/node/service/NodeService.java
+++ b/core/src/main/java/org/elasticsearch/node/service/NodeService.java
@@ -145,13 +145,14 @@ public class NodeService extends AbstractComponent {
                 transportService.stats(),
                 httpServer == null ? null : httpServer.stats(),
                 circuitBreakerService.stats(),
-                scriptService.stats()
+                scriptService.stats(),
+                pluginService == null ? null : pluginService.stats()
         );
     }
 
     public NodeStats stats(CommonStatsFlags indices, boolean os, boolean process, boolean jvm, boolean threadPool, boolean network,
                            boolean fs, boolean transport, boolean http, boolean circuitBreaker,
-                           boolean script) {
+                           boolean script, boolean plugins, String... custom) {
         // for indices stats we want to include previous allocated shards stats as well (it will
         // only be applied to the sensible ones to use, like refresh/merge/flush/indexing stats)
         return new NodeStats(discovery.localNode(), System.currentTimeMillis(),
@@ -164,7 +165,8 @@ public class NodeService extends AbstractComponent {
                 transport ? transportService.stats() : null,
                 http ? (httpServer == null ? null : httpServer.stats()) : null,
                 circuitBreaker ? circuitBreakerService.stats() : null,
-                script ? scriptService.stats() : null
+                script ? scriptService.stats() : null,
+                plugins ? (pluginService == null ? null : pluginService.stats(custom)) : null
         );
     }
 }

--- a/core/src/main/java/org/elasticsearch/plugins/PluginStat.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginStat.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PluginStat implements Streamable, ToXContent {
+
+    private String category;
+    private CompressedXContent data;
+
+    public PluginStat() {
+    }
+
+    public PluginStat(String category, CompressedXContent data) {
+        this.category = category;
+        this.data = data;
+    }
+
+    public PluginStat(String category, BytesReference data) throws IOException {
+        this(category, new CompressedXContent(data));
+    }
+
+    public PluginStat(String category, ToXContent xcontent, XContentType type, ToXContent.Params params) throws IOException {
+        this(category, new CompressedXContent(xcontent, type, params));
+    }
+
+    public Map<String, Object> getStatsAsMap() throws IOException {
+        Tuple<XContentType, Map<String, Object>> statAsMap = XContentHelper.convertToMap(data.compressedReference(), true);
+
+        Map<String, Object> statsAsMap = new HashMap<>();
+        statsAsMap.put(category, statAsMap.v2());
+        return statsAsMap;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        category = in.readOptionalString();
+        data = CompressedXContent.readCompressedString(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(category);
+        data.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        try (XContentParser parser = XContentHelper.createParser(data.compressedReference())) {
+            XContentHelper.copyCurrentStructure(builder.generator(), parser);
+        }
+        return builder;
+    }
+
+    public static PluginStat readFromStream(StreamInput in) throws IOException {
+        PluginStat pluginStat = new PluginStat();
+        pluginStat.readFrom(in);
+        return pluginStat;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/plugins/PluginStatsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginStatsService.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import java.util.Collection;
+
+/**
+ * Plugin stats service can be implemented by plugins in order to provide custom statistics
+ */
+public interface PluginStatsService {
+
+    /**
+     * Returns custom statistics about the plugin
+     */
+    Collection<PluginStat> stats();
+}

--- a/core/src/test/java/org/elasticsearch/action/admin/node/NodeStatsPluginIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/node/NodeStatsPluginIT.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.node;
+
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.admin.cluster.node.stats.PluginsStat;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.plugins.PluginStat;
+import org.elasticsearch.plugins.PluginStatsService;
+import org.elasticsearch.plugins.PluginsModule;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.common.xcontent.XContentFactory.smileBuilder;
+import static org.hamcrest.Matchers.equalTo;
+
+@ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 0, numClientNodes = 0)
+public class NodeStatsPluginIT extends ESIntegTestCase {
+
+    @Test
+    public void testPluginStats() throws Exception {
+        logger.debug("--> starting first node with no custom stats");
+        String node1 = internalCluster().startNode();
+
+        logger.debug("--> checking that plugins stats are empty");
+        NodesStatsResponse response = client().admin().cluster().prepareNodesStats().setPlugins(true).get();
+        assertNodesCount(response.getNodes(), 1);
+        for (NodeStats node : response.getNodes()) {
+            assertNull(node.getPluginsStat());
+        }
+
+        logger.debug("--> starting second node with custom stats");
+        String node2 = internalCluster().startNode(Settings.builder().put("plugin.types", FirstPlugin.class.getName()));
+        response = client().admin().cluster().prepareNodesStats().setPlugins(true).get();
+        assertNodesCount(response.getNodes(), 2);
+
+        logger.debug("--> checking that plugins stats now contain the 'foo' stat with expected values");
+        assertPluginStat(response.getNodes(), "foo", "foo_1", 123, "foo_2", 1437580442979L);
+
+        logger.debug("--> starting third node with custom stats");
+        String node3 = internalCluster().startNode(Settings.builder().put("plugin.types", SecondPlugin.class.getName()));
+        response = client().admin().cluster().prepareNodesStats().setPlugins(true).get();
+        assertNodesCount(response.getNodes(), 3);
+
+        logger.debug("--> checking that plugins stats now containall custom stats with expected values");
+        assertPluginStat(response.getNodes(), "foo", "foo_1", 123, "foo_2", 1437580442979L);
+        assertPluginStat(response.getNodes(), "bar", "bar_1", 1437580443456L);
+        assertPluginStat(response.getNodes(), "baz", "baz_1", true, "baz_2", "value");
+        assertPluginStat(response.getNodes(), "qux", "id", "qux_1", "count", 456);
+
+        logger.debug("--> checking that plugins stats are not returned when plugins parameter is set to false");
+        response = client().admin().cluster().prepareNodesStats().setPlugins(false).get();
+        assertNotPluginStat(response.getNodes(), "foo");
+        assertNotPluginStat(response.getNodes(), "bar");
+        assertNotPluginStat(response.getNodes(), "baz");
+        assertNotPluginStat(response.getNodes(), "qux");
+
+        logger.debug("--> checking that only node2 stats are returned");
+        response = client().admin().cluster().prepareNodesStats(node2).all().get();
+        assertPluginStat(response.getNodes(), "foo", "foo_1", 123, "foo_2", 1437580442979L);
+        assertNotPluginStat(response.getNodes(), "bar");
+        assertNotPluginStat(response.getNodes(), "baz");
+        assertNotPluginStat(response.getNodes(), "qux");
+
+        logger.debug("--> checking that only node3 stats are returned, whichever node is requested");
+        for (String nodeId : Arrays.asList(node1, node2, node3)) {
+            response = client(nodeId).admin().cluster().prepareNodesStats(node3).all().get();
+            assertNotPluginStat(response.getNodes(), "foo");
+            assertPluginStat(response.getNodes(), "bar", "bar_1", 1437580443456L);
+            assertPluginStat(response.getNodes(), "baz", "baz_1", true, "baz_2", "value");
+            assertPluginStat(response.getNodes(), "qux", "id", "qux_1", "count", 456);
+        }
+
+        logger.debug("--> checking that only 'bar' stats is returned");
+        response = client().admin().cluster().prepareNodesStats().setPlugins(false).setCustom("bar", "none").get();
+        assertNotPluginStat(response.getNodes(), "foo");
+        assertPluginStat(response.getNodes(), "bar", "bar_1", 1437580443456L);
+        assertNotPluginStat(response.getNodes(), "baz");
+        assertNotPluginStat(response.getNodes(), "qux");
+
+        logger.debug("--> checking that only 'ba*' stats are returned");
+        response = client().admin().cluster().prepareNodesStats().setPlugins(false).setCustom("ba*").get();
+        assertNotPluginStat(response.getNodes(), "foo");
+        assertPluginStat(response.getNodes(), "bar", "bar_1", 1437580443456L);
+        assertPluginStat(response.getNodes(), "baz", "baz_1", true, "baz_2", "value");
+        assertNotPluginStat(response.getNodes(), "qux");
+
+        logger.debug("--> checking that 'bar' stats can't be returned when only node 1 & 2 are requested");
+        response = client().admin().cluster().prepareNodesStats(node1, node2).setCustom("bar", "none").get();
+        assertNotPluginStat(response.getNodes(), "foo");
+        assertNotPluginStat(response.getNodes(), "bar");
+        assertNotPluginStat(response.getNodes(), "baz");
+        assertNotPluginStat(response.getNodes(), "qux");
+    }
+
+    private void assertNodesCount(NodeStats[] nodes, int count) {
+        assertNotNull(nodes);
+        assertThat(nodes.length, equalTo(count));
+    }
+
+    private void assertPluginStat(NodeStats[] nodes, String category, Object... values) {
+        assertTrue("plugin stat should exist", containsPluginStat(nodes, category, values));
+    }
+
+    private void assertNotPluginStat(NodeStats[] nodes, String category, Object... values) {
+        assertFalse("plugin stat should not exist", containsPluginStat(nodes, category, values));
+    }
+
+    private boolean containsPluginStat(NodeStats[] nodes, String category, Object... values) {
+        try {
+            for (NodeStats node : nodes) {
+                PluginsStat stats = node.getPluginsStat();
+                if (stats != null) {
+                    for (PluginStat stat : stats.getStats()) {
+                        Map<String, Object> statsAsMap = stat.getStatsAsMap();
+                        if (statsAsMap.containsKey(category)) {
+                            if (!CollectionUtils.isEmpty(values)) {
+                                // Builds a map with the expected values
+                                Map<String, Object> expected = new HashMap<>();
+                                for (int i = 0; i < values.length; i++) {
+                                    expected.put((String) values[i], values[++i]);
+                                }
+
+                                // Compare the plugin stat with the expected map values
+                                Map<String, Object> data = (Map<String, Object>) statsAsMap.get(category);
+                                assertThat(data, Matchers.equalTo(expected));
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            // Ok
+        }
+        return false;
+    }
+
+    public static class FirstPlugin extends AbstractPlugin {
+        @Override
+        public String name() {
+            return "first-plugin";
+        }
+
+        @Override
+        public String description() {
+            return "A plugin that provides 1 custom statistic";
+        }
+
+        public void onModule(PluginsModule pluginsModule) {
+            pluginsModule.registerStatsService(FirstStatsService.class);
+        }
+    }
+
+    public static class FirstStatsService implements PluginStatsService {
+        @Override
+        public Collection<PluginStat> stats() {
+            List<PluginStat> stats = new ArrayList<>();
+            try {
+                PluginStat stat = new PluginStat("foo", jsonBuilder()
+                                                            .startObject()
+                                                                .field("foo_1", 123)
+                                                                .field("foo_2", 1437580442979L)
+                                                            .endObject()
+                                                        .bytes());
+                stats.add(stat);
+            } catch (IOException e) {
+                // We don't care
+            }
+            return stats;
+        }
+    }
+
+    public static class SecondPlugin extends AbstractPlugin {
+
+        public SecondPlugin() {
+        }
+
+        @Override
+        public String name() {
+            return "second-plugin";
+        }
+
+        @Override
+        public String description() {
+            return "Another plugin that provides custom stats";
+        }
+
+        public void onModule(PluginsModule pluginsModule) {
+            pluginsModule.registerStatsService(SecondStatsService.class);
+        }
+    }
+
+    public static class SecondStatsService implements PluginStatsService {
+        @Override
+        public Collection<PluginStat> stats() {
+            List<PluginStat> stats = new ArrayList<>();
+            try {
+                PluginStat stat1 = new PluginStat("bar", smileBuilder()
+                                                            .startObject()
+                                                                .field("bar_1", 1437580443456L)
+                                                            .endObject()
+                                                         .bytes());
+
+                PluginStat stat2 = new PluginStat("baz", jsonBuilder()
+                                                            .startObject()
+                                                                .field("baz_1", true)
+                                                                .field("baz_2", "value")
+                                                            .endObject()
+                                                        .bytes());
+
+                PluginStat stat3 = new PluginStat("qux", new CustomStat("qux_1", 456), randomFrom(XContentType.values()), ToXContent.EMPTY_PARAMS);
+
+                stats.add(stat1);
+                stats.add(stat2);
+                stats.add(stat3);
+            } catch (IOException e) {
+                // We don't care
+            }
+            return stats;
+        }
+    }
+
+    public static class CustomStat implements ToXContent {
+
+        private String id;
+        private int count;
+
+        public CustomStat(String id, int count) {
+            this.id = id;
+            this.count = count;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field("id", id);
+            builder.field("count", count);
+            return builder;
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -180,7 +180,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
                 null, null, null, null, null,
                 fsInfo,
                 null, null, null,
-                null);
+                null, null);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/plugins/PluginStatTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginStatTests.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+
+public class PluginStatTests extends ESTestCase {
+/*
+    @Test
+    public void testStringSerialization() throws IOException {
+        PluginStat serialized = PluginStat.stringStat(randomAsciiOfLength(10), randomAsciiOfLengthBetween(10, 30));
+        assertNotNull(serialized);
+
+        PluginStat deserialized = deserialize(serialize(serialized));
+        assertNotNull(deserialized);
+
+        assertThat(deserialized.getType(), equalTo(serialized.getType()));
+        assertThat(deserialized.getName(), equalTo(serialized.getName()));
+        assertThat(deserialized.getValue(), equalTo(serialized.getValue()));
+    }
+
+    @Test
+    public void testStringToXContent() throws IOException {
+        PluginStat stat = PluginStat.stringStat("hello", "world");
+
+        BytesReference result = build(XContentType.JSON, stat);
+        assertThat(result.toUtf8(), is("{\"hello\":\"world\"}"));
+    }
+
+    @Test
+    public void testLongSerialization() throws IOException {
+        PluginStat serialized = PluginStat.longStat(randomAsciiOfLength(10), randomLong());
+        assertNotNull(serialized);
+
+        PluginStat deserialized = deserialize(serialize(serialized));
+        assertNotNull(deserialized);
+
+        assertThat(deserialized.getType(), equalTo(serialized.getType()));
+        assertThat(deserialized.getName(), equalTo(serialized.getName()));
+        assertThat(deserialized.getValue(), equalTo(serialized.getValue()));
+    }
+
+    @Test
+    public void testLongToXContent() throws IOException {
+        PluginStat stat = PluginStat.longStat("total_count", 123456L);
+
+        BytesReference result = build(XContentType.JSON, stat);
+        assertThat(result.toUtf8(), is("{\"total_count\":123456}"));
+    }
+
+    @Test
+    public void testObjectSerialization() throws IOException {
+        PluginStat inner;
+        if (randomBoolean()) {
+            inner = PluginStat.longStat(randomAsciiOfLength(10), randomLong());
+        } else {
+            inner = PluginStat.stringStat(randomAsciiOfLength(10), randomAsciiOfLengthBetween(10, 30));
+        }
+
+        PluginStat serialized = PluginStat.innerStat(randomAsciiOfLength(10), inner);
+        assertNotNull(serialized);
+
+        PluginStat deserialized = deserialize(serialize(serialized));
+        assertNotNull(deserialized);
+
+        assertThat(deserialized.getType(), equalTo(serialized.getType()));
+        assertThat(deserialized.getName(), equalTo(serialized.getName()));
+        assertThat(deserialized.getValue(), equalTo(serialized.getValue()));
+    }
+
+    @Test
+    public void testObjectToXContent() throws IOException {
+        PluginStat stat = PluginStat.innerStat("my_plugin",
+                                PluginStat.innerStat("remote",
+                                        PluginStat.stringStat("origin", "git@github.com:my/plugin.git")
+                                )
+        );
+
+        BytesReference result = build(XContentType.JSON, stat);
+        assertThat(result.toUtf8(), is("{\"my_plugin\":{\"remote\":{\"origin\":\"git@github.com:my/plugin.git\"}}}"));
+    }
+
+    private BytesReference serialize(PluginStat stat) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            PluginStat.writePluginStat(output, stat);
+            return output.bytes();
+        }
+    }
+
+    private PluginStat deserialize(BytesReference in) throws IOException {
+        try (StreamInput input = StreamInput.wrap(in)) {
+            return PluginStat.readPluginStat(input);
+        }
+    }
+
+    private BytesReference build(XContentType xContentType, PluginStat stat) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            try (XContentBuilder builder = new XContentBuilder(xContentType.xContent(), output)) {
+                builder.startObject();
+                stat.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                builder.endObject();
+            }
+            return output.bytes();
+        }
+    }
+    */
+}
+

--- a/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1871,7 +1871,7 @@ public final class InternalTestCluster extends TestCluster {
                 }
 
                 NodeService nodeService = getInstanceFromNode(NodeService.class, nodeAndClient.node);
-                NodeStats stats = nodeService.stats(CommonStatsFlags.ALL, false, false, false, false, false, false, false, false, false, false);
+                NodeStats stats = nodeService.stats(CommonStatsFlags.ALL, false, false, false, false, false, false, false, false, false, false, false);
                 assertThat("Fielddata size must be 0 on node: " + stats.getNode(), stats.getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0l));
                 assertThat("Query cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0l));
                 assertThat("FixedBitSet cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getSegments().getBitsetMemoryInBytes(), equalTo(0l));


### PR DESCRIPTION
Work in progress pull request for #12526.

This pull request allows plugins to add their own custom stats to the Node Stats. Plugins can use the `PluginsModule.registerStatsService()` to register a new `PluginStatsService`: 

``` java
public static class MyPlugin extends AbstractPlugin {
        ...
        public void onModule(PluginsModule pluginsModule) {
            pluginsModule.registerStatsService(MyCustomStatsService.class);
        }
}
```

A PluginStatsService provides a set of plugin stat objects which are basically a key/category associated to a XContent. This XContent is useful because it can be easily streamed between nodes (even if the master node does not have the plugin installed) and it allows to build complex stats objects on plugin side. 

Here is a simple example of how a plugin can implement a PluginStatsService:

``` java
public static class MyCustomStatsService implements PluginStatsService {
        @Override
        public Collection<PluginStat> stats() {
            List<PluginStat> stats = new ArrayList<>();
            try {
                PluginStat stat = new PluginStat("foo", jsonBuilder()
                                                            .startObject()
                                                                .field("version", "1.0.3")
                                                                .field("foo_2", 1437580442979L)
                                                            .endObject()
                                                        .bytes());
                stats.add(stat);
            } catch (IOException e) {
                // We don't care
            }
            return stats;
        }
    }
```

Internally, the NodeService calls the PluginService.stats() method which iterates over all registered PluginStatsService and compute their stats. Note: plugins stats services are passed to the plugin service instance using Guice providers.

A plugin can return multiple stats with multiple categories, and the category name is used as namespace in the Node Stats response.

The REST API can accept a `plugins` flag to retrieve all custom plugins stats:

```
GET /_nodes/stats/plugins?pretty
{
  "cluster_name" : "elasticsearch",
  "nodes" : {
    "4_YaEiKeS-2_JLNLbdYBbA" : {
      "timestamp" : 1439371328976,
      "name" : "Tri-Man",
      "transport_address" : "inet[/127.0.0.1:9300]",
      "host" : "portable",
      "ip" : [ "inet[/127.0.0.1:9300]", "NONE" ],
      "foo" : {
        "version" : "1.0.3",
        "properties" : {
          "chunk_batch" : 123
        }
      },
      "session" : {
        "uptime" : 1439371328977,
        "uids" : [ 1, 5, 9, 7, 3 ]
      }
    }
  }
}
```

One can also use a custom flag to retrieve a given plugin stats. Here it retrieves the stat `session` that it provides by a plugin installed on node Tri-man only:

```
GET  /_nodes/stats/session?pretty
{
  "cluster_name" : "elasticsearch",
  "nodes" : {
    "4_YaEiKeS-2_JLNLbdYBbA" : {
      "timestamp" : 1439371356029,
      "name" : "Tri-Man",
      "transport_address" : "inet[/127.0.0.1:9300]",
      "host" : "portable",
      "ip" : [ "inet[/127.0.0.1:9300]", "NONE" ],
      "session" : {
        "uptime" : 1439371356029,
        "uids" : [ 1, 5, 9, 7, 3 ]
      }
    },
    "2JupIqE8QpChAHdtT-f2lQ" : {
      "timestamp" : 1439371356028,
      "name" : "Widget",
      "transport_address" : "inet[/127.0.0.1:9301]",
      "host" : "portable",
      "ip" : [ "inet[/127.0.0.1:9301]", "NONE" ]
    }
  }
}
```

Response filtering also works, which is cool:

```
GET 'localhost:9200/_nodes/stats?pretty&filter_path=**.azure.**.c*'
{
  "nodes" : {
    "4_YaEiKeS-2_JLNLbdYBbA" : {
      "azure" : {
        "properties" : {
          "chunk_batch" : 123
        }
      }
    }
  }
}
```

There are some questions left:
- how plugin stats are shown and computed in Cluster Stats
- what to do in case of categery/namespace conflicts (2 different plugins returning a `foo` stat)
- maybe propagate request params to the plugin stats services

I personally like how it currently works but I'd be glad to have some feedback.
