### PR TITLE
 Throw Exception for missing settings file

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1129,7 +1129,7 @@ public final class Settings implements ToXContent {
             }
             InputStream is = classLoader.getResourceAsStream(resourceName);
             if (is == null) {
-                return this;
+                throw new SettingsException("Failed to load settings from [" + resourceName + "]");
             }
 
             return loadFromStream(resourceName, is);

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
@@ -63,4 +63,17 @@ public class YamlSettingsLoaderTests extends ESTestCase {
                 .loadFromClasspath("org/elasticsearch/common/settings/loader/indentation-with-explicit-document-start-settings.yml")
                 .build();
     }
+
+    
+    @Test
+    public void testYamlSettingsNoFile() throws Exception {
+        String invalidResourceName = "org/elasticsearch/common/settings/loader/no-test-settings.yml";
+        try {
+            Settings defaultSettings = settingsBuilder().loadFromClasspath(invalidResourceName).build();
+            fail("For a not exiting file an exception should be thrown.");
+        } catch (Exception e) {
+            assertTrue(e instanceof SettingsException);
+            assertThat(e.getMessage(), equalTo("Failed to load settings from [" + invalidResourceName + "]"));
+        }
+    }
 }


### PR DESCRIPTION
An Exception will be thrown when the given YAML-file doesn't exist.

Applied changed to the current sources to get rid of merge problems

Closes #11510
