### PR TITLE
Remove the `node.enable_custom_paths` setting

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -114,12 +114,8 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final Map<ShardId, InternalShardLock> shardLocks = new HashMap<>();
 
-    private final boolean customPathsEnabled;
-
     // Setting to automatically append node id to custom data paths
     public static final String ADD_NODE_ID_TO_CUSTOM_PATH = "node.add_id_to_custom_path";
-    // Setting to enable custom index.data_path setting for new indices
-    public static final String SETTING_CUSTOM_DATA_PATH_ENABLED = "node.enable_custom_paths";
 
     // If enabled, the [verbose] SegmentInfos.infoStream logging is sent to System.out:
     public static final String SETTING_ENABLE_LUCENE_SEGMENT_INFOS_TRACE = "node.enable_lucene_segment_infos_trace";
@@ -134,7 +130,6 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         super(settings);
 
         this.addNodeId = settings.getAsBoolean(ADD_NODE_ID_TO_CUSTOM_PATH, true);
-        this.customPathsEnabled = settings.getAsBoolean(SETTING_CUSTOM_DATA_PATH_ENABLED, false);
 
         if (!DiscoveryNode.nodeRequiresLocalStorage(settings)) {
             nodePaths = null;
@@ -775,11 +770,6 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         return settings;
     }
 
-    /** return true if custom paths are allowed for indices */
-    public boolean isCustomPathsEnabled() {
-        return customPathsEnabled;
-    }
-
     /**
      * @param indexSettings settings for an index
      * @return true if the index has a custom data path
@@ -800,7 +790,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         String customDataDir = indexSettings.get(IndexMetaData.SETTING_DATA_PATH);
         if (customDataDir != null) {
             // This assert is because this should be caught by MetaDataCreateIndexService
-            assert customPathsEnabled;
+            assert sharedDataPath != null;
             if (addNodeId) {
                 return sharedDataPath.resolve(customDataDir).resolve(Integer.toString(this.localNodeId));
             } else {

--- a/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -368,7 +368,6 @@ public class NodeEnvironmentTests extends ESTestCase {
         Settings build = Settings.builder()
                 .put(settings)
                 .put("path.home", createTempDir().toAbsolutePath().toString())
-                .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
                 .putArray("path.data", tmpPaths()).build();
         return new NodeEnvironment(build, new Environment(build));
     }
@@ -377,7 +376,6 @@ public class NodeEnvironmentTests extends ESTestCase {
         Settings build = Settings.builder()
                 .put(settings)
                 .put("path.home", createTempDir().toAbsolutePath().toString())
-                .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
                 .putArray("path.data", dataPaths).build();
         return new NodeEnvironment(build, new Environment(build));
     }
@@ -387,7 +385,6 @@ public class NodeEnvironmentTests extends ESTestCase {
                 .put(settings)
                 .put("path.home", createTempDir().toAbsolutePath().toString())
                 .put("path.shared_data", sharedDataPath)
-                .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
                 .putArray("path.data", dataPaths).build();
         return new NodeEnvironment(build, new Environment(build));
     }

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
@@ -75,7 +75,6 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
     private Settings nodeSettings(String dataPath) {
         return Settings.builder()
                 .put("node.add_id_to_custom_path", false)
-                .put("node.enable_custom_paths", true)
                 .put("path.shared_data", dataPath)
                 .put("index.store.fs.fs_lock", randomFrom("native", "simple"))
                 .build();
@@ -417,7 +416,6 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
         Path dataPath = createTempDir();
         Settings nodeSettings = Settings.builder()
                 .put("node.add_id_to_custom_path", false)
-                .put("node.enable_custom_paths", true)
                 .put("plugin.types", MockTransportService.Plugin.class.getName())
                 .put("path.shared_data", dataPath)
                 .build();

--- a/core/src/test/java/org/elasticsearch/indices/IndicesCustomDataPathIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesCustomDataPathIT.java
@@ -54,7 +54,6 @@ public class IndicesCustomDataPathIT extends ESIntegTestCase {
     private Settings nodeSettings(String dataPath) {
         return Settings.builder()
                 .put("node.add_id_to_custom_path", false)
-                .put("node.enable_custom_paths", true)
                 .put("path.shared_data", dataPath)
                 .put("index.store.fs.fs_lock", randomFrom("native", "simple"))
                 .build();

--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1615,7 +1615,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 // from failing on nodes without enough disk space
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, "1b")
                 .put(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "1b")
-                .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
                 .put("script.indexed", "on")
                 .put("script.inline", "on")
                         // wait short time for other active shards before actually deleting, default 30s not needed in tests

--- a/core/src/test/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -125,7 +125,6 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
                 // This needs to tie into the ESIntegTestCase#indexSettings() method
                 .put("path.shared_data", createTempDir().getParent())
                 .put("node.name", nodeName())
-                .put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true)
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put("script.inline", "on")

--- a/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -309,7 +309,6 @@ public final class InternalTestCluster extends TestCluster {
         builder.put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true);
         builder.put("node.mode", NODE_MODE);
         builder.put("http.pipelining", enableHttpPipelining);
-        builder.put(NodeEnvironment.SETTING_CUSTOM_DATA_PATH_ENABLED, true);
         if (Strings.hasLength(System.getProperty("es.logger.level"))) {
             builder.put("logger.level", System.getProperty("es.logger.level"));
         }

--- a/docs/reference/indices/shadow-replicas.asciidoc
+++ b/docs/reference/indices/shadow-replicas.asciidoc
@@ -9,11 +9,12 @@ as how Elasticsearch should replay operations on all the replica shards of an
 index.
 
 In order to fully utilize the `index.data_path` and `index.shadow_replicas`
-settings, you need to enable using it in elasticsearch.yml:
+settings, you need to allow Elasticsearch to use the same data directory for
+multiple instances by setting `node.add_id_to_custom_path` to false in
+elasticsearch.yml:
 
 [source,yaml]
 --------------------------------------------------
-node.enable_custom_paths: true
 node.add_id_to_custom_path: false
 --------------------------------------------------
 
@@ -117,8 +118,3 @@ These are non-dynamic settings that need to be configured in `elasticsearch.yml`
     of "/tmp/foo" is used, the first locally-running node will use "/tmp/foo/0",
     the second will use "/tmp/foo/1", the third "/tmp/foo/2", etc. Defaults to
     `true`.
-
-`node.enable_custom_paths`::
-    Boolean value that must be set to `true` in order to use the
-    `index.data_path` setting. Defaults to `false`.
-

--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -48,7 +48,6 @@ The shard stores information is grouped by indices and shard ids.
                     "name": "node_t0",
                     "transport_address": "local[1]",
                     "attributes": {
-                        "enable_custom_paths": "true",
                         "mode": "local"
                     }
                 },

--- a/docs/reference/migration/migrate_2_0.asciidoc
+++ b/docs/reference/migration/migrate_2_0.asciidoc
@@ -852,3 +852,36 @@ parsed at alias creation time and the parsed form was kept around in memory.
 
 The `prefer_local` has been removed from the _analyze api. The _analyze api is a light operation and the caller shouldn't
 be concerned about whether it executes on the node that receives the request or another node.
+
+=== Shadow replicas
+
+The `node.enable_custom_paths` setting has been removed and replaced by the
+`path.shared_data` setting to allow shadow replicas with custom paths to work
+with the security manager. For example, if your previous configuration had:
+
+```
+node.enable_custom_paths: true
+```
+
+And you created an index using shadow replicas with `index.data_path` set to
+`/opt/data/my_index` with the following:
+
+[source,js]
+--------------------------------------------------
+curl -XPUT 'localhost:9200/my_index' -d '
+{
+    "index" : {
+        "number_of_shards" : 1,
+        "number_of_replicas" : 4,
+        "data_path": "/opt/data/my_index",
+        "shadow_replicas": true
+    }
+}'
+--------------------------------------------------
+
+For 2.0, you will need to set `path.shared_data` to a parent directory of the
+index's data_path, so:
+
+```
+path.shared_data: /opt/data
+```


### PR DESCRIPTION
This setting is useless now that we have the `path.shared_data` setting.

Resolves #12776
