### PR TITLE
Don't show access_key and filter_key in S3 repository settings

### DIFF
--- a/plugins/cloud-aws/rest-api-spec/test/cloud_aws/20_repository.yaml
+++ b/plugins/cloud-aws/rest-api-spec/test/cloud_aws/20_repository.yaml
@@ -1,0 +1,23 @@
+# Integration tests for Cloud AWS components
+#
+"S3 repository can be registereed":
+    - do:
+        snapshot.create_repository:
+          repository: test_repo_s3_1
+          verify: false
+          body:
+            type: s3
+            settings:
+              bucket: "my_bucket_name"
+              access_key: "AKVAIQBF2RECL7FJWGJQ"
+              secret_key: "vExyMThREXeRMm/b/LRzEB8jWwvzQeXgjqMX+6br"
+
+    # Get repositry
+    - do:
+        snapshot.get_repository:
+          repository: test_repo_s3_1
+
+    - is_true: test_repo_s3_1
+    - is_true: test_repo_s3_1.settings.bucket
+    - is_false: test_repo_s3_1.settings.access_key
+    - is_false: test_repo_s3_1.settings.secret_key

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -50,10 +50,14 @@ public class AwsEc2Service extends AbstractLifecycleComponent<AwsEc2Service> {
     @Inject
     public AwsEc2Service(Settings settings, SettingsFilter settingsFilter, NetworkService networkService, DiscoveryNodeService discoveryNodeService) {
         super(settings);
+        // Filter global settings
         settingsFilter.addFilter("cloud.key");
         settingsFilter.addFilter("cloud.account");
         settingsFilter.addFilter("cloud.aws.access_key");
         settingsFilter.addFilter("cloud.aws.secret_key");
+        // Filter repository-specific settings
+        settingsFilter.addFilter("access_key");
+        settingsFilter.addFilter("secret_key");
         // add specific ec2 name resolver
         networkService.addCustomNameResolver(new Ec2NameResolver(settings));
         discoveryNodeService.addCustomAttributeProvider(new Ec2CustomNodeAttributes(settings));

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -283,6 +283,9 @@
                     <include>api/indices.refresh.json</include>
                     <include>api/nodes.info.json</include>
                     <include>api/count.json</include>
+                    <!-- used in repository plugin REST tests -->
+                    <include>api/snapshot.create_repository.json</include>
+                    <include>api/snapshot.get_repository.json</include>
                 </includes>
             </testResource>
             <!-- shared test resources like log4j.properties -->


### PR DESCRIPTION
In #11265 we added an ability to filter out sensitive repository settings. This commit uses this change to filter out access_key and filter_key in S3 repository settings.

Closes elastic/elasticsearch-cloud-aws#184
