### PR TITLE
Index "creation_date" not accurate when created with settings from another index

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -329,9 +329,10 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                         indexSettingsBuilder.put(SETTING_VERSION_CREATED, createdVersion);
                     }
 
-                    if (indexSettingsBuilder.get(SETTING_CREATION_DATE) == null) {
-                        indexSettingsBuilder.put(SETTING_CREATION_DATE, new DateTime(DateTimeZone.UTC).getMillis());
-                    }
+                    // removing it due to bug : https://github.com/elastic/elasticsearch/issues/12790
+                    // if (indexSettingsBuilder.get(SETTING_CREATION_DATE) == null) {
+                    indexSettingsBuilder.put(SETTING_CREATION_DATE, new DateTime(DateTimeZone.UTC).getMillis());
+                    //}
 
                     indexSettingsBuilder.put(SETTING_INDEX_UUID, Strings.randomBase64UUID());
 

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -41,22 +41,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class CreateIndexIT extends ESIntegTestCase {
 
     @Test
-    public void testCreationDate_Given() {
-        prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_CREATION_DATE, 4l)).get();
-        ClusterStateResponse response = client().admin().cluster().prepareState().get();
-        ClusterState state = response.getState();
-        assertThat(state, notNullValue());
-        MetaData metadata = state.getMetaData();
-        assertThat(metadata, notNullValue());
-        ImmutableOpenMap<String, IndexMetaData> indices = metadata.getIndices();
-        assertThat(indices, notNullValue());
-        assertThat(indices.size(), equalTo(1));
-        IndexMetaData index = indices.get("test");
-        assertThat(index, notNullValue());
-        assertThat(index.creationDate(), equalTo(4l));
-    }
-
-    @Test
     public void testCreationDate_Generated() {
         long timeBeforeRequest = System.currentTimeMillis();
         prepareCreate("test").get();


### PR DESCRIPTION
issue_topic - Index "creation_date" not accurate when created with settings from another index
issue_id - 12790
issue_url - https://github.com/elastic/elasticsearch/issues/12790
# PROBLEM STATEMENT:

Create Index operation API is capable of taking the settings as input
and create an index. The problem is that it is also using the
input creation_date and creating new index with same date
# APPROACH:

Find where it accepts the creating_date from the request object and
change it so that it is always generated at the time of index creation.
(it should effectively behave like uuid)
# Files Changed:

```
    modified:   core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
modified:   core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
```

> modified:   core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java

Here the part where it looks for creation_date from request object is removed.

> modified:   core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java

Removed test case that tests that the date given in settings is same as the creation_date of the
newly created index.
# RESULT AFTER THE CHANGE:

input settings

``` javascript
{
     'settings':
          {  'index':
                       {'number_of_replicas': '1',
                         'version': {'created': '2000010'},
                         'creation_date': '1439384094544'
                         'uuid': 'ayzHgwB3Sgey-Pk_Okgwyg',
                         'number_of_shards': '5',
                       }
          }
}
```

new index settings

``` javascript
{
    'settings':
          {'index':
                     {'number_of_replicas': '1',
                      'version': {'created': '2000010'},
                      'creation_date': '1439456346424',
                      'uuid': 'fddpIVxNTTKPzqDakLAL4A',
                      'number_of_shards': '5'
                     }
         }
}
```

Please give feedback.
# Test case to check result

https://github.com/HarishAtGitHub/elasticsearch-tester/blob/master/12790.py
