### PR TITLE
[allocation] change watermark low and high defaults

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -50,15 +50,15 @@ import java.util.Set;
  * <code>cluster.routing.allocation.disk.watermark.low</code> is the low disk
  * watermark. New shards will not allocated to a node with usage higher than this,
  * although this watermark may be passed by allocating a shard. It defaults to
- * 0.85 (85.0%).
+ * 1gb.
  *
  * <code>cluster.routing.allocation.disk.watermark.high</code> is the high disk
  * watermark. If a node has usage higher than this, shards are not allowed to
  * remain on the node. In addition, if allocating a shard to a node causes the
  * node to pass this watermark, it will not be allowed. It defaults to
- * 0.90 (90.0%).
+ * 500mb.
  *
- * Both watermark settings are expressed in terms of used disk percentage, or
+ * Both watermark settings are expressed in terms of used disk percentage (like 90%), or
  * exact byte values for free space (like "500mb")
  *
  * <code>cluster.routing.allocation.disk.threshold_enabled</code> is used to
@@ -233,8 +233,8 @@ public class DiskThresholdDecider extends AllocationDecider {
     @Inject
     public DiskThresholdDecider(Settings settings, NodeSettingsService nodeSettingsService, ClusterInfoService infoService, Client client) {
         super(settings);
-        String lowWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, "85%");
-        String highWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "90%");
+        String lowWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, "1gb");
+        String highWatermark = settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK, "500mb");
 
         if (!validWatermarkSetting(lowWatermark, CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK)) {
             throw new ElasticsearchParseException("unable to parse low watermark [{}]", lowWatermark);

--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -15,16 +15,16 @@ file or updated dynamically on a live cluster with the
 
 `cluster.routing.allocation.disk.watermark.low`::
 
-    Controls the low watermark for disk usage. It defaults to 85%, meaning ES will
-    not allocate new shards to nodes once they have more than 85% disk used. It
-    can also be set to an absolute byte value (like 500mb) to prevent ES from
+    Controls the low watermark for disk usage. It defaults to 1gb, meaning ES will
+    not allocate new shards to nodes once they have more than 1gb disk used. It
+    can also be set to an relative byte value (like 85%) to prevent ES from
     allocating shards if less than the configured amount of space is available.
 
 `cluster.routing.allocation.disk.watermark.high`::
 
-    Controls the high watermark. It defaults to 90%, meaning ES will attempt to
-    relocate shards to another node if the node disk usage rises above 90%. It can
-    also be set to an absolute byte value (similar to the low watermark) to
+    Controls the high watermark. It defaults to 500mb, meaning ES will attempt to
+    relocate shards to another node if the node disk usage rises above 500mb. It can
+    also be set to an relative byte value (like 90%) to
     relocate shards once less than the configured amount of space is available on
     the node.
 


### PR DESCRIPTION
 As for now, we have the current defaults:
- `cluster.routing.allocation.disk.watermark.low:85%`
- `cluster.routing.allocation.disk.watermark.high:90%`

But, even if you have plenty of free space on you 1Tb disk, you could end up not allocating any replica if you have less than 15gb free disk space.

This change propose to set:
- `cluster.routing.allocation.disk.watermark.low:1gb`
- `cluster.routing.allocation.disk.watermark.high:500mb`

as the new defaults.

Related to https://github.com/elastic/elasticsearch/pull/12853#issuecomment-130614764
Closes #12852.
