### PR TITLE
Don't cache percolator query on loading percolators

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/core/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.percolator;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
@@ -260,7 +261,9 @@ public class PercolatorQueriesRegistry extends AbstractIndexShardComponent imple
             try (Engine.Searcher searcher = shard.engine().acquireSearcher("percolator_load_queries")) {
                 Query query = new TermQuery(new Term(TypeFieldMapper.NAME, PercolatorService.TYPE_NAME));
                 QueriesLoaderCollector queryCollector = new QueriesLoaderCollector(PercolatorQueriesRegistry.this, logger, mapperService, indexFieldDataService);
-                searcher.searcher().search(query, queryCollector);
+                IndexSearcher indexSearcher = new IndexSearcher(searcher.reader());
+                indexSearcher.setQueryCache(null);
+                indexSearcher.search(query, queryCollector);
                 Map<BytesRef, Query> queries = queryCollector.queries();
                 for (Map.Entry<BytesRef, Query> entry : queries.entrySet()) {
                     Query previousQuery = percolateQueries.put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
No need to load catch this query since it's cheap and not reused.
If we cache it, it can cause assertions to be tripped since this
method is executed during postRecovery phase and might still run while
nodes are shutdown in tests.

here are related test failures:

http://build-us-00.elastic.co/job/elasticsearch-20-oracle-jdk6/11
http://build-us-00.elastic.co/job/elasticsearch-20-suse/5/
