### PR TITLE
Enhancement/terms lookup fixes

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/TermsLookupQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsLookupQueryBuilder.java
@@ -34,7 +34,6 @@ public class TermsLookupQueryBuilder extends QueryBuilder {
     private String lookupId;
     private String lookupRouting;
     private String lookupPath;
-    private Boolean lookupCache;
 
     private String queryName;
 
@@ -87,11 +86,6 @@ public class TermsLookupQueryBuilder extends QueryBuilder {
         return this;
     }
 
-    public TermsLookupQueryBuilder lookupCache(boolean lookupCache) {
-        this.lookupCache = lookupCache;
-        return this;
-    }
-
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(TermsQueryParser.NAME);
@@ -104,9 +98,6 @@ public class TermsLookupQueryBuilder extends QueryBuilder {
         builder.field("id", lookupId);
         if (lookupRouting != null) {
             builder.field("routing", lookupRouting);
-        }
-        if (lookupCache != null) {
-            builder.field("cache", lookupCache);
         }
         builder.field("path", lookupPath);
         builder.endObject();

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -32,6 +32,10 @@ public class TermsQueryBuilder extends QueryBuilder implements BoostableQueryBui
 
     private final Object values;
 
+    private String minimumShouldMatch;
+
+    private Boolean disableCoord;
+
     private String queryName;
 
     private String execution;
@@ -126,6 +130,26 @@ public class TermsQueryBuilder extends QueryBuilder implements BoostableQueryBui
     }
 
     /**
+     * Sets the minimum number of matches across the provided terms. Defaults to <tt>1</tt>.
+     * @deprecated use [bool] query instead
+     */
+    @Deprecated
+    public TermsQueryBuilder minimumShouldMatch(String minimumShouldMatch) {
+        this.minimumShouldMatch = minimumShouldMatch;
+        return this;
+    }
+
+    /**
+     * Disables <tt>Similarity#coord(int,int)</tt> in scoring. Defaults to <tt>false</tt>.
+     * @deprecated use [bool] query instead
+     */
+    @Deprecated
+    public TermsQueryBuilder disableCoord(boolean disableCoord) {
+        this.disableCoord = disableCoord;
+        return this;
+    }
+
+    /**
      * Sets the filter name for the filter that can be used when searching for matched_filters per hit.
      */
     public TermsQueryBuilder queryName(String queryName) {
@@ -146,6 +170,14 @@ public class TermsQueryBuilder extends QueryBuilder implements BoostableQueryBui
 
         if (execution != null) {
             builder.field("execution", execution);
+        }
+
+        if (minimumShouldMatch != null) {
+            builder.field("minimum_should_match", minimumShouldMatch);
+        }
+
+        if (disableCoord != null) {
+            builder.field("disable_coord", disableCoord);
         }
 
         if (boost != -1) {

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -51,6 +51,7 @@ public class TermsQueryParser implements QueryParser {
 
     public static final String NAME = "terms";
     private static final ParseField MIN_SHOULD_MATCH_FIELD = new ParseField("min_match", "min_should_match").withAllDeprecated("Use [bool] query instead");
+    private static final ParseField DISABLE_COORD_FIELD = new ParseField("disable_coord").withAllDeprecated("Use [bool] query instead");
     private Client client;
 
     @Deprecated
@@ -149,7 +150,7 @@ public class TermsQueryParser implements QueryParser {
                     minShouldMatch = parser.textOrNull();
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
-                } else if (("disable_coord").equals(currentFieldName) || ("disableCoord").equals(currentFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, DISABLE_COORD_FIELD)) {
                     disableCoord = parser.booleanValue();
                 } else if ("_name".equals(currentFieldName)) {
                     queryName = parser.text();


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/12042#issuecomment-131024096 .
- Java api: remove support for lookup cache in TermsLookupBuilder: TermsQueryParser doesn't support the cache field anymore, so if it gets set through java api, the subsequent parsing of that query will throw error
- Java api: restore support for minimumShouldMatch and disableCoord in TermsQueryBuilder: TermsQueryParser still parses those values although deprecated. These need to be present in the java api as well to get ready for the query refactoring, where the builders are the intermediate query format that we parse our json queries into. Whatever the parser supports need to be supported by the builder as well.
