### PR TITLE
[maven] rename artifactIds from `elasticsearch-something` to `something`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,8 +12,7 @@
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch</artifactId>
 
-    <packaging>jar</packaging>
-    <name>Elasticsearch Core</name>
+    <name>Elasticsearch: Core</name>
     <description>Elasticsearch - Open Source, Distributed, RESTful Search Engine</description>
 
     <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch-parent</artifactId>
+        <artifactId>parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -163,7 +163,7 @@ public class PluginManager {
                 terminal.println("Failed: %s", ExceptionsHelper.detailedMessage(e));
             }
         } else {
-            if (PluginHandle.isOfficialPlugin(pluginHandle.repo, pluginHandle.user, pluginHandle.version)) {
+            if (PluginHandle.isOfficialPlugin(pluginHandle.name, pluginHandle.user, pluginHandle.version)) {
                 checkForOfficialPlugins(pluginHandle.name);
             }
         }
@@ -438,16 +438,14 @@ public class PluginManager {
      */
     static class PluginHandle {
 
-        final String name;
         final String version;
         final String user;
-        final String repo;
+        final String name;
 
-        PluginHandle(String name, String version, String user, String repo) {
-            this.name = name;
+        PluginHandle(String name, String version, String user) {
             this.version = version;
             this.user = user;
-            this.repo = repo;
+            this.name = name;
         }
 
         List<URL> urls() {
@@ -457,24 +455,24 @@ public class PluginManager {
                 if (user == null) {
                     // TODO Update to https
                     if (!Strings.isNullOrEmpty(System.getProperty(PROPERTY_SUPPORT_STAGING_URLS))) {
-                        addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip", version, Build.CURRENT.hashShort(), repo, version, repo, version));
+                        addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip", version, Build.CURRENT.hashShort(), name, version, name, version));
                     }
-                    addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/%s/%s/%s-%s.zip", repo, version, repo, version));
+                    addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/%s/%s/%s-%s.zip", name, version, name, version));
                 } else {
                     // Elasticsearch old download service
                     // TODO Update to https
-                    addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/%1$s/%2$s/%2$s-%3$s.zip", user, repo, version));
+                    addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/%1$s/%2$s/%2$s-%3$s.zip", user, name, version));
                     // Maven central repository
-                    addUrl(urls, String.format(Locale.ROOT, "http://search.maven.org/remotecontent?filepath=%1$s/%2$s/%3$s/%2$s-%3$s.zip", user.replace('.', '/'), repo, version));
+                    addUrl(urls, String.format(Locale.ROOT, "http://search.maven.org/remotecontent?filepath=%1$s/%2$s/%3$s/%2$s-%3$s.zip", user.replace('.', '/'), name, version));
                     // Sonatype repository
-                    addUrl(urls, String.format(Locale.ROOT, "https://oss.sonatype.org/service/local/repositories/releases/content/%1$s/%2$s/%3$s/%2$s-%3$s.zip", user.replace('.', '/'), repo, version));
+                    addUrl(urls, String.format(Locale.ROOT, "https://oss.sonatype.org/service/local/repositories/releases/content/%1$s/%2$s/%3$s/%2$s-%3$s.zip", user.replace('.', '/'), name, version));
                     // Github repository
-                    addUrl(urls, String.format(Locale.ROOT, "https://github.com/%1$s/%2$s/archive/%3$s.zip", user, repo, version));
+                    addUrl(urls, String.format(Locale.ROOT, "https://github.com/%1$s/%2$s/archive/%3$s.zip", user, name, version));
                 }
             }
             if (user != null) {
                 // Github repository for master branch (assume site)
-                addUrl(urls, String.format(Locale.ROOT, "https://github.com/%1$s/%2$s/archive/master.zip", user, repo));
+                addUrl(urls, String.format(Locale.ROOT, "https://github.com/%1$s/%2$s/archive/master.zip", user, name));
             }
             return urls;
         }
@@ -527,10 +525,10 @@ public class PluginManager {
             }
 
             if (isOfficialPlugin(repo, user, version)) {
-                return new PluginHandle(repo, Version.CURRENT.number(), null, repo);
+                return new PluginHandle(repo, Version.CURRENT.number(), null);
             }
 
-            return new PluginHandle(repo, version, user, repo);
+            return new PluginHandle(repo, version, user);
         }
 
         static boolean isOfficialPlugin(String repo, String user, String version) {

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -75,19 +75,19 @@ public class PluginManager {
 
     static final ImmutableSet<String> OFFICIAL_PLUGINS = ImmutableSet.<String>builder()
             .add(
-                    "elasticsearch-analysis-icu",
-                    "elasticsearch-analysis-kuromoji",
-                    "elasticsearch-analysis-phonetic",
-                    "elasticsearch-analysis-smartcn",
-                    "elasticsearch-analysis-stempel",
-                    "elasticsearch-cloud-aws",
-                    "elasticsearch-cloud-azure",
-                    "elasticsearch-cloud-gce",
-                    "elasticsearch-delete-by-query",
-                    "elasticsearch-lang-javascript",
-                    "elasticsearch-lang-python",
-                    "elasticsearch-mapper-murmur3",
-                    "elasticsearch-mapper-size"
+                    "analysis-icu",
+                    "analysis-kuromoji",
+                    "analysis-phonetic",
+                    "analysis-smartcn",
+                    "analysis-stempel",
+                    "cloud-aws",
+                    "cloud-azure",
+                    "cloud-gce",
+                    "delete-by-query",
+                    "lang-javascript",
+                    "lang-python",
+                    "mapper-murmur3",
+                    "mapper-size"
             ).build();
 
     private final Environment environment;
@@ -457,9 +457,9 @@ public class PluginManager {
                 if (user == null) {
                     // TODO Update to https
                     if (!Strings.isNullOrEmpty(System.getProperty(PROPERTY_SUPPORT_STAGING_URLS))) {
-                        addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/staging/elasticsearch-%s-%s/org/elasticsearch/plugin/elasticsearch-%s/%s/elasticsearch-%s-%s.zip", version, Build.CURRENT.hashShort(), repo, version, repo, version));
+                        addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip", version, Build.CURRENT.hashShort(), repo, version, repo, version));
                     }
-                    addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/elasticsearch-%s/%s/elasticsearch-%s-%s.zip", repo, version, repo, version));
+                    addUrl(urls, String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/%s/%s/%s-%s.zip", repo, version, repo, version));
                 } else {
                     // Elasticsearch old download service
                     // TODO Update to https
@@ -526,20 +526,11 @@ public class PluginManager {
                 }
             }
 
-            String endname = repo;
-            if (repo.startsWith("elasticsearch-")) {
-                // remove elasticsearch- prefix
-                endname = repo.substring("elasticsearch-".length());
-            } else if (repo.startsWith("es-")) {
-                // remove es- prefix
-                endname = repo.substring("es-".length());
-            }
-
             if (isOfficialPlugin(repo, user, version)) {
-                return new PluginHandle(endname, Version.CURRENT.number(), null, repo);
+                return new PluginHandle(repo, Version.CURRENT.number(), null, repo);
             }
 
-            return new PluginHandle(endname, version, user, repo);
+            return new PluginHandle(repo, version, user, repo);
         }
 
         static boolean isOfficialPlugin(String repo, String user, String version) {

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -453,7 +453,7 @@ public class PluginManager {
         List<URL> urls() {
             List<URL> urls = new ArrayList<>();
             if (version != null) {
-                // Elasticsearch new download service uses groupId org.elasticsearch.plugins from 2.0.0
+                // Elasticsearch new download service uses groupId org.elasticsearch.plugin from 2.0.0
                 if (user == null) {
                     // TODO Update to https
                     if (!Strings.isNullOrEmpty(System.getProperty(PROPERTY_SUPPORT_STAGING_URLS))) {

--- a/core/src/main/resources/org/elasticsearch/plugins/plugin-install.help
+++ b/core/src/main/resources/org/elasticsearch/plugins/plugin-install.help
@@ -22,7 +22,7 @@ DESCRIPTION
 
 EXAMPLES
 
-    plugin install elasticsearch-analysis-kuromoji
+    plugin install analysis-kuromoji
 
     plugin install elasticsearch/shield/latest
 
@@ -32,24 +32,24 @@ OFFICIAL PLUGINS
 
     The following plugins are officially supported and can be installed by just referring to their name
 
-    - elasticsearch-analysis-icu
-    - elasticsearch-analysis-kuromoji
-    - elasticsearch-analysis-phonetic
-    - elasticsearch-analysis-smartcn
-    - elasticsearch-analysis-stempel
-    - elasticsearch-cloud-aws
-    - elasticsearch-cloud-azure
-    - elasticsearch-cloud-gce
-    - elasticsearch-delete-by-query
-    - elasticsearch-lang-javascript
-    - elasticsearch-lang-python
-    - elasticsearch-mapper-murmur3
-    - elasticsearch-mapper-size
+    - analysis-icu
+    - analysis-kuromoji
+    - analysis-phonetic
+    - analysis-smartcn
+    - analysis-stempel
+    - cloud-aws
+    - cloud-azure
+    - cloud-gce
+    - delete-by-query
+    - lang-javascript
+    - lang-python
+    - mapper-murmur3
+    - mapper-size
 
 
 OPTIONS
 
-    -u,--url                     URL to retrive the plugin from
+    -u,--url                     URL to retrieve the plugin from
 
     -t,--timeout                 Timeout until the plugin download is abort
 

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerIT.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerIT.java
@@ -52,9 +52,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.BufferedWriter;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
@@ -539,18 +537,19 @@ public class PluginManagerIT extends ESIntegTestCase {
 
     @Test
     public void testOfficialPluginName_ThrowsException() throws IOException {
-        PluginManager.checkForOfficialPlugins("elasticsearch-analysis-icu");
-        PluginManager.checkForOfficialPlugins("elasticsearch-analysis-kuromoji");
-        PluginManager.checkForOfficialPlugins("elasticsearch-analysis-phonetic");
-        PluginManager.checkForOfficialPlugins("elasticsearch-analysis-smartcn");
-        PluginManager.checkForOfficialPlugins("elasticsearch-analysis-stempel");
-        PluginManager.checkForOfficialPlugins("elasticsearch-cloud-aws");
-        PluginManager.checkForOfficialPlugins("elasticsearch-cloud-azure");
-        PluginManager.checkForOfficialPlugins("elasticsearch-cloud-gce");
-        PluginManager.checkForOfficialPlugins("elasticsearch-delete-by-query");
-        PluginManager.checkForOfficialPlugins("elasticsearch-lang-javascript");
-        PluginManager.checkForOfficialPlugins("elasticsearch-lang-python");
-        PluginManager.checkForOfficialPlugins("elasticsearch-mapper-murmur3");
+        PluginManager.checkForOfficialPlugins("analysis-icu");
+        PluginManager.checkForOfficialPlugins("analysis-kuromoji");
+        PluginManager.checkForOfficialPlugins("analysis-phonetic");
+        PluginManager.checkForOfficialPlugins("analysis-smartcn");
+        PluginManager.checkForOfficialPlugins("analysis-stempel");
+        PluginManager.checkForOfficialPlugins("cloud-aws");
+        PluginManager.checkForOfficialPlugins("cloud-azure");
+        PluginManager.checkForOfficialPlugins("cloud-gce");
+        PluginManager.checkForOfficialPlugins("delete-by-query");
+        PluginManager.checkForOfficialPlugins("lang-javascript");
+        PluginManager.checkForOfficialPlugins("lang-python");
+        PluginManager.checkForOfficialPlugins("mapper-murmur3");
+        PluginManager.checkForOfficialPlugins("mapper-size");
 
         try {
             PluginManager.checkForOfficialPlugins("elasticsearch-mapper-attachment");

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -62,7 +62,7 @@ public class PluginManagerUnitTests extends ESTestCase {
                 .build();
         Environment environment = new Environment(settings);
 
-        PluginManager.PluginHandle pluginHandle = new PluginManager.PluginHandle(pluginName, "version", "user", "repo");
+        PluginManager.PluginHandle pluginHandle = new PluginManager.PluginHandle(pluginName, "version", "user");
         String configDirPath = Files.simplifyPath(pluginHandle.configDir(environment).normalize().toString());
         String expectedDirPath = Files.simplifyPath(genericConfigFolder.resolve(pluginName).normalize().toString());
 

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -82,12 +82,12 @@ public class PluginManagerUnitTests extends ESTestCase {
         Iterator<URL> iterator = handle.urls().iterator();
 
         if (supportStagingUrls) {
-            String expectedStagingURL = String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/staging/elasticsearch-%s-%s/org/elasticsearch/plugin/elasticsearch-%s/%s/elasticsearch-%s-%s.zip",
+            String expectedStagingURL = String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip",
                     Version.CURRENT.number(), Build.CURRENT.hashShort(), pluginName, Version.CURRENT.number(), pluginName, Version.CURRENT.number());
             assertThat(iterator.next().toExternalForm(), is(expectedStagingURL));
         }
 
-        URL expected = new URL("http", "download.elastic.co", "/elasticsearch/release/org/elasticsearch/plugin/elasticsearch-" + pluginName + "/" + Version.CURRENT.number() + "/elasticsearch-" +
+        URL expected = new URL("http", "download.elastic.co", "/elasticsearch/release/org/elasticsearch/plugin/" + pluginName + "/" + Version.CURRENT.number() + "/" +
                 pluginName + "-" + Version.CURRENT.number() + ".zip");
         assertThat(iterator.next().toExternalForm(), is(expected.toExternalForm()));
 
@@ -95,10 +95,10 @@ public class PluginManagerUnitTests extends ESTestCase {
     }
 
     @Test
-    public void testTrimmingElasticsearchFromOfficialPluginName() throws IOException {
-        String randomPluginName = randomFrom(PluginManager.OFFICIAL_PLUGINS.asList()).replaceFirst("elasticsearch-", "");
+    public void testOfficialPluginName() throws IOException {
+        String randomPluginName = randomFrom(PluginManager.OFFICIAL_PLUGINS.asList());
         PluginManager.PluginHandle handle = PluginManager.PluginHandle.parse(randomPluginName);
-        assertThat(handle.name, is(randomPluginName.replaceAll("^elasticsearch-", "")));
+        assertThat(handle.name, is(randomPluginName));
 
         boolean supportStagingUrls = randomBoolean();
         if (supportStagingUrls) {
@@ -108,12 +108,12 @@ public class PluginManagerUnitTests extends ESTestCase {
         Iterator<URL> iterator = handle.urls().iterator();
 
         if (supportStagingUrls) {
-            String expectedStagingUrl = String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/staging/elasticsearch-%s-%s/org/elasticsearch/plugin/elasticsearch-%s/%s/elasticsearch-%s-%s.zip",
+            String expectedStagingUrl = String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip",
                     Version.CURRENT.number(), Build.CURRENT.hashShort(), randomPluginName, Version.CURRENT.number(), randomPluginName, Version.CURRENT.number());
             assertThat(iterator.next().toExternalForm(), is(expectedStagingUrl));
         }
 
-        String releaseUrl = String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/elasticsearch-%s/%s/elasticsearch-%s-%s.zip",
+        String releaseUrl = String.format(Locale.ROOT, "http://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/%s/%s/%s-%s.zip",
                 randomPluginName, Version.CURRENT.number(), randomPluginName, Version.CURRENT.number());
         assertThat(iterator.next().toExternalForm(), is(releaseUrl));
 
@@ -121,12 +121,11 @@ public class PluginManagerUnitTests extends ESTestCase {
     }
 
     @Test
-    public void testTrimmingElasticsearchFromGithubPluginName() throws IOException {
+    public void testGithubPluginName() throws IOException {
         String user = randomAsciiOfLength(6);
-        String randomName = randomAsciiOfLength(10);
-        String pluginName = randomFrom("elasticsearch-", "es-") + randomName;
+        String pluginName = randomAsciiOfLength(10);
         PluginManager.PluginHandle handle = PluginManager.PluginHandle.parse(user + "/" + pluginName);
-        assertThat(handle.name, is(randomName));
+        assertThat(handle.name, is(pluginName));
         assertThat(handle.urls(), hasSize(1));
         assertThat(handle.urls().get(0).toExternalForm(), is(new URL("https", "github.com", "/" + user + "/" + pluginName + "/" + "archive/master.zip").toExternalForm()));
     }

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-dev-tools</artifactId>
   <version>2.1.0-SNAPSHOT</version>
-  <name>Elasticsearch Build Resources</name>
+  <name>Build Tools and Resources</name>
   <description>Tools to assist in building and developing in the Elasticsearch project</description>
   <parent>
       <groupId>org.sonatype.oss</groupId>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -1,7 +1,7 @@
 <project>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.elasticsearch</groupId>
-  <artifactId>elasticsearch-dev-tools</artifactId>
+  <artifactId>dev-tools</artifactId>
   <version>2.1.0-SNAPSHOT</version>
   <name>Build Tools and Resources</name>
   <description>Tools to assist in building and developing in the Elasticsearch project</description>

--- a/dev-tools/src/main/resources/license-check/check_license_and_sha.pl
+++ b/dev-tools/src/main/resources/license-check/check_license_and_sha.pl
@@ -30,6 +30,7 @@ $Source      = File::Spec->rel2abs($Source);
 
 say "LICENSE DIR: $License_Dir";
 say "SOURCE: $Source";
+say "IGNORE: $Ignore";
 
 die "License dir is not a directory: $License_Dir\n" . usage()
     unless -d $License_Dir;

--- a/distribution/deb/pom.xml
+++ b/distribution/deb/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.elasticsearch.distribution</groupId>
-        <artifactId>elasticsearch-distribution</artifactId>
+        <artifactId>distributions</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.elasticsearch.distribution.deb</groupId>
     <artifactId>elasticsearch</artifactId>
-    <name>Elasticsearch DEB Distribution</name>
+    <name>Distribution: Deb</name>
     <!--
         We should use deb packaging here because we don't want to publish any jar.
         But if you do this, then maven lifecycle does not execute any test (nor compile any test)

--- a/distribution/fully-loaded/pom.xml
+++ b/distribution/fully-loaded/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.elasticsearch.distribution</groupId>
-        <artifactId>elasticsearch-distribution</artifactId>
+        <artifactId>distributions</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.elasticsearch.distribution.fully-loaded</groupId>
     <artifactId>elasticsearch</artifactId>
-    <name>Elasticsearch with all optional dependencies</name>
+    <name>Distribution: with all optional dependencies</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <groupId>org.elasticsearch.distribution</groupId>
-    <artifactId>elasticsearch-distribution</artifactId>
+    <artifactId>distributions</artifactId>
     <packaging>pom</packaging>
-    <name>Elasticsearch Distribution</name>
+    <name>Distribution: Parent POM</name>
 
     <properties>
         <!-- Properties used for building RPM & DEB packages (see common/packaging.properties) -->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch-parent</artifactId>
+        <artifactId>parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.elasticsearch.distribution</groupId>
-        <artifactId>elasticsearch-distribution</artifactId>
+        <artifactId>distributions</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.elasticsearch.distribution.rpm</groupId>
     <artifactId>elasticsearch</artifactId>
-    <name>Elasticsearch RPM Distribution</name>
+    <name>Distribution: RPM</name>
     <packaging>rpm</packaging>
     <description>The RPM distribution of Elasticsearch</description>
 

--- a/distribution/shaded/pom.xml
+++ b/distribution/shaded/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.elasticsearch.distribution</groupId>
-        <artifactId>elasticsearch-distribution</artifactId>
+        <artifactId>distributions</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.elasticsearch.distribution.shaded</groupId>
     <artifactId>elasticsearch</artifactId>
-    <name>Elasticsearch Shaded Distribution</name>
+    <name>Distribution: Shaded JAR</name>
 
     <dependencies>
         <dependency>

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -47,7 +47,7 @@
 # hasn't been done, we assume that this is not a packaged version and the
 # user has forgotten to run Maven to create a package.
 IS_PACKAGED_VERSION='${project.parent.artifactId}'
-if [ "$IS_PACKAGED_VERSION" != "elasticsearch-distribution" ]; then
+if [ "$IS_PACKAGED_VERSION" != "distributions" ]; then
     cat >&2 << EOF
 Error: You must build the project with Maven or download a pre-built package
 before you can run Elasticsearch. See 'Building from Source' in README.textile

--- a/distribution/tar/pom.xml
+++ b/distribution/tar/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.elasticsearch.distribution</groupId>
-        <artifactId>elasticsearch-distribution</artifactId>
+        <artifactId>distributions</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.elasticsearch.distribution.tar</groupId>
     <artifactId>elasticsearch</artifactId>
-    <name>Elasticsearch TAR Distribution</name>
+    <name>Distribution: TAR</name>
     <!--
         We should use pom packaging here because we don't want to publish any jar.
         But if you do this, then maven lifecycle does not execute any test (nor compile any test)

--- a/distribution/zip/pom.xml
+++ b/distribution/zip/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.elasticsearch.distribution</groupId>
-        <artifactId>elasticsearch-distribution</artifactId>
+        <artifactId>distributions</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.elasticsearch.distribution.zip</groupId>
     <artifactId>elasticsearch</artifactId>
-    <name>Elasticsearch ZIP Distribution</name>
+    <name>Distribution: ZIP</name>
     <!--
         We should use pom packaging here because we don't want to publish any jar.
         But if you do this, then maven lifecycle does not execute any test (nor compile any test)

--- a/migrate.sh
+++ b/migrate.sh
@@ -68,7 +68,7 @@ function migratePlugin() {
 	mkdir -p plugins/$1
 	git mv -k * plugins/$1 > /dev/null 2>/dev/null       
 	git rm .gitignore > /dev/null 2>/dev/null
-	# echo "### change $1 groupId to org.elasticsearch.plugins"
+	# echo "### change $1 groupId to org.elasticsearch.plugin"
 	# Change the groupId to avoid conflicts with existing 2.0.0 versions.
 	replaceLine "    <groupId>org.elasticsearch<\/groupId>" "    <groupId>org.elasticsearch.plugin<\/groupId>" "plugins/$1/pom.xml"
 

--- a/plugins/analysis-icu/pom.xml
+++ b/plugins/analysis-icu/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-analysis-icu</artifactId>
-    <name>Elasticsearch ICU Analysis plugin</name>
+    <artifactId>analysis-icu</artifactId>
+    <name>Plugin: Analysis: ICU</name>
     <description>The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.</description>
 
     <properties>

--- a/plugins/analysis-kuromoji/pom.xml
+++ b/plugins/analysis-kuromoji/pom.xml
@@ -6,13 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-analysis-kuromoji</artifactId>
-    <packaging>jar</packaging>
-    <name>Elasticsearch Japanese (kuromoji) Analysis plugin</name>
+    <artifactId>analysis-kuromoji</artifactId>
+    <name>Plugin: Analysis: Japanese (kuromoji)</name>
     <description>The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.</description>
 
     <properties>

--- a/plugins/analysis-phonetic/pom.xml
+++ b/plugins/analysis-phonetic/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-analysis-phonetic</artifactId>
-    <name>Elasticsearch Phonetic Analysis plugin</name>
+    <artifactId>analysis-phonetic</artifactId>
+    <name>Plugin: Analysis: Phonetic</name>
     <description>The Phonetic Analysis plugin integrates phonetic token filter analysis with elasticsearch.</description>
 
     <properties>

--- a/plugins/analysis-smartcn/pom.xml
+++ b/plugins/analysis-smartcn/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-analysis-smartcn</artifactId>
-    <name>Elasticsearch Smart Chinese Analysis plugin</name>
+    <artifactId>analysis-smartcn</artifactId>
+    <name>Plugin: Analysis: Smart Chinese (smartcn)</name>
     <description>Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch.</description>
 
     <properties>

--- a/plugins/analysis-stempel/pom.xml
+++ b/plugins/analysis-stempel/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-analysis-stempel</artifactId>
-    <name>Elasticsearch Stempel (Polish) Analysis plugin</name>
+    <artifactId>analysis-stempel</artifactId>
+    <name>Plugin: Analysis: Polish (stempel)</name>
     <description>The Stempel (Polish) Analysis plugin integrates Lucene stempel (polish) analysis module into elasticsearch.</description>
 
     <properties>

--- a/plugins/cloud-aws/pom.xml
+++ b/plugins/cloud-aws/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-cloud-aws</artifactId>
-    <name>Elasticsearch AWS cloud plugin</name>
+    <artifactId>cloud-aws</artifactId>
+    <name>Plugin: Cloud: AWS</name>
     <description>The Amazon Web Service (AWS) Cloud plugin allows to use AWS API for the unicast discovery mechanism and add S3 repositories.</description>
 
     <properties>

--- a/plugins/cloud-azure/pom.xml
+++ b/plugins/cloud-azure/pom.xml
@@ -17,12 +17,12 @@ governing permissions and limitations under the License. -->
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-cloud-azure</artifactId>
-    <name>Elasticsearch Azure cloud plugin</name>
+    <artifactId>cloud-azure</artifactId>
+    <name>Plugin: Cloud: Azure</name>
     <description>The Azure Cloud plugin allows to use Azure API for the unicast discovery mechanism and add Azure storage repositories.</description>
 
     <properties>

--- a/plugins/cloud-gce/pom.xml
+++ b/plugins/cloud-gce/pom.xml
@@ -17,12 +17,12 @@ governing permissions and limitations under the License. -->
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-cloud-gce</artifactId>
-    <name>Elasticsearch Google Compute Engine cloud plugin</name>
+    <artifactId>cloud-gce</artifactId>
+    <name>Plugin: Cloud: Google Compute Engine</name>
     <description>The Google Compute Engine (GCE) Cloud plugin allows to use GCE API for the unicast discovery mechanism.</description>
 
     <properties>

--- a/plugins/delete-by-query/pom.xml
+++ b/plugins/delete-by-query/pom.xml
@@ -17,12 +17,12 @@ governing permissions and limitations under the License. -->
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-delete-by-query</artifactId>
-    <name>Elasticsearch Delete By Query plugin</name>
+    <artifactId>delete-by-query</artifactId>
+    <name>Plugin: Delete By Query</name>
     <description>The Delete By Query plugin allows to delete documents in Elasticsearch with a single query.</description>
 
     <properties>

--- a/plugins/jvm-example/pom.xml
+++ b/plugins/jvm-example/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-jvm-example</artifactId>
-    <name>Elasticsearch example JVM plugin</name>
+    <artifactId>jvm-example</artifactId>
+    <name>Plugin: JVM example</name>
     <description>Demonstrates all the pluggable Java entry points in Elasticsearch</description>
 
     <properties>

--- a/plugins/lang-javascript/pom.xml
+++ b/plugins/lang-javascript/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-lang-javascript</artifactId>
-    <name>Elasticsearch JavaScript language plugin</name>
+    <artifactId>lang-javascript</artifactId>
+    <name>Plugin: Language: JavaScript</name>
     <description>The JavaScript language plugin allows to have javascript as the language of scripts to execute.</description>
 
     <properties>

--- a/plugins/lang-python/pom.xml
+++ b/plugins/lang-python/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-lang-python</artifactId>
-    <name>Elasticsearch Python language plugin</name>
+    <artifactId>lang-python</artifactId>
+    <name>Plugin: Language: Python</name>
     <description>The Python language plugin allows to have python as the language of scripts to execute.</description>
 
     <properties>

--- a/plugins/mapper-murmur3/pom.xml
+++ b/plugins/mapper-murmur3/pom.xml
@@ -17,12 +17,12 @@ governing permissions and limitations under the License. -->
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-mapper-murmur3</artifactId>
-    <name>Elasticsearch Mapper Murmur3 plugin</name>
+    <artifactId>mapper-murmur3</artifactId>
+    <name>Plugin: Mapper: Murmur3</name>
     <description>The Mapper Murmur3 plugin allows to compute hashes of a field's values at index-time and to store them in the index.</description>
 
     <properties>

--- a/plugins/mapper-size/pom.xml
+++ b/plugins/mapper-size/pom.xml
@@ -17,12 +17,12 @@ governing permissions and limitations under the License. -->
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-mapper-size</artifactId>
-    <name>Elasticsearch Mapper size plugin</name>
+    <artifactId>mapper-size</artifactId>
+    <name>Plugin: Mapper: Size</name>
     <description>The Mapper Size plugin allows document to record their uncompressed size at index time.</description>
 
     <properties>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -15,7 +15,7 @@
 
     <parent>
         <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch-parent</artifactId>
+        <artifactId>parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -6,10 +6,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.elasticsearch.plugin</groupId>
-    <artifactId>elasticsearch-plugin</artifactId>
+    <artifactId>plugins</artifactId>
     <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Elasticsearch Plugin POM</name>
+    <name>Plugin: Parent POM</name>
     <inceptionYear>2009</inceptionYear>
     <description>A parent project for Elasticsearch plugins</description>
 

--- a/plugins/site-example/pom.xml
+++ b/plugins/site-example/pom.xml
@@ -6,12 +6,12 @@
 
     <parent>
         <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>elasticsearch-plugin</artifactId>
+        <artifactId>plugins</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>elasticsearch-site-example</artifactId>
-    <name>Elasticsearch Example site plugin</name>
+    <artifactId>site-example</artifactId>
+    <name>Plugin: Example site</name>
     <description>Demonstrates how to serve resources via elasticsearch.</description>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Elasticsearch Parent POM</name>
-    <description>Elasticsearch Parent POM</description>
+    <description>Parent POM</description>
     <inceptionYear>2009</inceptionYear>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -1216,6 +1216,7 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                                         <arg value="--check"/>
                                         <arg value="${project.licenses.dir}"/>
                                         <arg value="${project.licenses.check_target}"/>
+                                        <arg value="${project.build.finalName}"/>
                                     </exec>
                                 </target>
                             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <dependencies>
             <dependency>
                 <groupId>org.elasticsearch</groupId>
-                <artifactId>elasticsearch-dev-tools</artifactId>
+                <artifactId>dev-tools</artifactId>
                 <version>${elasticsearch.version}</version>
             </dependency>
 
@@ -797,8 +797,8 @@
                     <version>1.5</version>
                     <configuration>
                         <resourceBundles>
-                            <resourceBundle>org.elasticsearch:elasticsearch-dev-tools:${elasticsearch.version}</resourceBundle>
-                            <resourceBundle>org.elasticsearch:elasticsearch-rest-api-spec:${elasticsearch.version}</resourceBundle>
+                            <resourceBundle>org.elasticsearch:dev-tools:${elasticsearch.version}</resourceBundle>
+                            <resourceBundle>org.elasticsearch:rest-api-spec:${elasticsearch.version}</resourceBundle>
                         </resourceBundles>
                         <outputDirectory>${elasticsearch.tools.directory}</outputDirectory>
                         <!-- don't include dev-tools in artifacts -->

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>elasticsearch-parent</artifactId>
     <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Elasticsearch Parent POM</name>
+    <name>Elasticsearch: Parent POM</name>
     <description>Parent POM</description>
     <inceptionYear>2009</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.elasticsearch</groupId>
-    <artifactId>elasticsearch-parent</artifactId>
+    <artifactId>parent</artifactId>
     <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Elasticsearch: Parent POM</name>
@@ -27,9 +27,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:elasticsearch/elasticsearch-parent.git</connection>
-        <developerConnection>scm:git:git@github.com:elasticsearch/elasticsearch-parent.git</developerConnection>
-        <url>http://github.com/elasticsearch/elasticsearch-parent</url>
+        <connection>scm:git:git@github.com:elastic/elasticsearch.git</connection>
+        <developerConnection>scm:git:git@github.com:elastic/elasticsearch.git</developerConnection>
+        <url>http://github.com/elastic/elasticsearch</url>
     </scm>
 
     <properties>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -14,7 +14,7 @@
 
     <parent>
         <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch-parent</artifactId>
+        <artifactId>parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 

--- a/qa/smoke-test-plugins/pom.xml
+++ b/qa/smoke-test-plugins/pom.xml
@@ -335,7 +335,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-mapper-murmur3</artifactId>
+                   <artifactId>mapper-murmur3</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>

--- a/qa/smoke-test-plugins/pom.xml
+++ b/qa/smoke-test-plugins/pom.xml
@@ -247,7 +247,7 @@
                  <!-- plugins -->
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-analysis-kuromoji</artifactId>
+                   <artifactId>analysis-kuromoji</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -255,7 +255,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-analysis-smartcn</artifactId>
+                   <artifactId>analysis-smartcn</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -263,7 +263,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-analysis-stempel</artifactId>
+                   <artifactId>analysis-stempel</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -271,7 +271,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-analysis-phonetic</artifactId>
+                   <artifactId>analysis-phonetic</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -279,7 +279,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-analysis-icu</artifactId>
+                   <artifactId>analysis-icu</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -287,7 +287,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-cloud-gce</artifactId>
+                   <artifactId>cloud-gce</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -295,7 +295,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-cloud-azure</artifactId>
+                   <artifactId>cloud-azure</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -303,7 +303,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-cloud-aws</artifactId>
+                   <artifactId>cloud-aws</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -311,7 +311,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-delete-by-query</artifactId>
+                   <artifactId>delete-by-query</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -319,7 +319,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-lang-python</artifactId>
+                   <artifactId>lang-python</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -327,7 +327,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-lang-javascript</artifactId>
+                   <artifactId>lang-javascript</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -343,7 +343,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-mapper-size</artifactId>
+                   <artifactId>mapper-size</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -351,7 +351,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-site-example</artifactId>
+                   <artifactId>site-example</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>
@@ -359,7 +359,7 @@
 
                  <artifactItem>
                    <groupId>org.elasticsearch.plugin</groupId>
-                   <artifactId>elasticsearch-jvm-example</artifactId>
+                   <artifactId>jvm-example</artifactId>
                    <version>${elasticsearch.version}</version>
                    <type>zip</type>
                    <overWrite>true</overWrite>

--- a/rest-api-spec/pom.xml
+++ b/rest-api-spec/pom.xml
@@ -1,7 +1,7 @@
 <project>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.elasticsearch</groupId>
-  <artifactId>elasticsearch-rest-api-spec</artifactId>
+  <artifactId>rest-api-spec</artifactId>
   <version>2.1.0-SNAPSHOT</version>
   <name>Rest API Specification</name>
   <description>REST API Specification and tests for use with the Elasticsearch REST Test framework</description>

--- a/rest-api-spec/pom.xml
+++ b/rest-api-spec/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-rest-api-spec</artifactId>
   <version>2.1.0-SNAPSHOT</version>
-  <name>Elasticsearch Rest API Spec</name>
+  <name>Rest API Specification</name>
   <description>REST API Specification and tests for use with the Elasticsearch REST Test framework</description>
   <parent>
       <groupId>org.sonatype.oss</groupId>


### PR DESCRIPTION
In plugins, we are using non consistent naming. We use `elasticsearch-cloud-aws` as the artifactId, which generates a jar file called `elasticsearch-cloud-aws-VERSION.jar`.

But when you want to install the plugin, you will end up with a shorter name for the plugin `cloud-aws`.

```
bin/plugin install cloud-aws
```

This commit changes that and use consistent names for `artifactId`, so `finalName`.

Also changed the plugin maven names to respect the `QA`naming we have as I found it fine. 
Same for Distribution modules.
Same for parent, dev-tools and rest-spec.

Now, it gives:

```
[INFO] Reactor Summary:
[INFO] 
[INFO] Build Tools and Resources .......................... SUCCESS [  0.133 s]
[INFO] Rest API Specification ............................. SUCCESS [  0.003 s]
[INFO] Elasticsearch: Parent POM .......................... SUCCESS [  0.104 s]
[INFO] Elasticsearch: Core ................................ SUCCESS [  0.008 s]
[INFO] Distribution: Parent POM ........................... SUCCESS [  0.004 s]
[INFO] Distribution: with all optional dependencies ....... SUCCESS [  0.005 s]
[INFO] Distribution: Shaded ............................... SUCCESS [  0.006 s]
[INFO] Distribution: TAR .................................. SUCCESS [  0.006 s]
[INFO] Distribution: ZIP .................................. SUCCESS [  0.007 s]
[INFO] Distribution: Debian ............................... SUCCESS [  0.048 s]
[INFO] Distribution: RPM .................................. SUCCESS [  0.090 s]
[INFO] Plugin: Parent POM ................................. SUCCESS [  0.010 s]
[INFO] Plugin: Analysis: Japanese (kuromoji) .............. SUCCESS [  0.011 s]
[INFO] Plugin: Analysis: Smart Chinese (smartcn) .......... SUCCESS [  0.011 s]
[INFO] Plugin: Analysis: Polish (stempel) ................. SUCCESS [  0.012 s]
[INFO] Plugin: Analysis: Phonetic ......................... SUCCESS [  0.010 s]
[INFO] Plugin: Analysis: ICU .............................. SUCCESS [  0.010 s]
[INFO] Plugin: Cloud: Google Compute Engine ............... SUCCESS [  0.012 s]
[INFO] Plugin: Cloud: Azure ............................... SUCCESS [  0.012 s]
[INFO] Plugin: Cloud: AWS ................................. SUCCESS [  0.009 s]
[INFO] Plugin: Delete By Query ............................ SUCCESS [  0.023 s]
[INFO] Plugin: Language: Python ........................... SUCCESS [  0.011 s]
[INFO] Plugin: Language: JavaScript ....................... SUCCESS [  0.011 s]
[INFO] Plugin: Mapper: Size ............................... SUCCESS [  0.009 s]
[INFO] Plugin: JVM example ................................ SUCCESS [  0.020 s]
[INFO] Plugin: Example site ............................... SUCCESS [  0.010 s]
[INFO] QA: Parent POM ..................................... SUCCESS [  0.004 s]
[INFO] QA: Smoke Test Plugins ............................. SUCCESS [  0.009 s]
[INFO] QA: Smoke Test Shaded Jar .......................... SUCCESS [  0.017 s]
[INFO] QA: Smoke Test Multi-Node IT ....................... SUCCESS [  0.031 s]
```

Related to https://github.com/elastic/elasticsearch/pull/12775/files#r37074563

Also added a message when running license checker (cc @clintongormley).
