### PR TITLE
Internal: prevent NPE from being thrown in ParseField when providing a null field name as an argument

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -81,6 +81,9 @@ public class ParseField {
     }
 
     boolean match(String currentFieldName, EnumSet<Flag> flags) {
+        if (currentFieldName == null) {
+            return false;
+        }
         if (allReplacedWith == null && (currentFieldName.equals(camelCaseName) || currentFieldName.equals(underscoreName))) {
             return true;
         }


### PR DESCRIPTION
Internal: prevent NPE from being thrown in ParseField when providing a null field name as an argument
