### PR TITLE
Validate checksums for plugins if available

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
@@ -34,6 +34,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
@@ -148,7 +149,7 @@ public class HttpDownloadHelper {
                 }
                 return true;
             }
-        } catch (FileNotFoundException e) {
+        } catch (FileNotFoundException | NoSuchFileException e) {
             // checksum file doesn't exist
             return false;
         } catch (IOException e) {

--- a/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
@@ -90,6 +90,8 @@ public class HttpDownloadHelper {
     public interface Checksummer {
         /** Return the hex string for the given byte array */
         String checksum(byte[] filebytes);
+        /** Human-readable name for the checksum format */
+        String name();
     }
 
     /** Checksummer for SHA1 */
@@ -98,6 +100,11 @@ public class HttpDownloadHelper {
         public String checksum(byte[] filebytes) {
             return Hashing.sha1().hashBytes(filebytes).toString();
         }
+
+        @Override
+        public String name() {
+            return "SHA1";
+        }
     };
 
     /** Checksummer for MD5 */
@@ -105,6 +112,11 @@ public class HttpDownloadHelper {
         @Override
         public String checksum(byte[] filebytes) {
             return Hashing.md5().hashBytes(filebytes).toString();
+        }
+
+        @Override
+        public String name() {
+            return "MD5";
         }
     };
 
@@ -125,14 +137,14 @@ public class HttpDownloadHelper {
                 byte[] fileBytes = Files.readAllBytes(originalFile);
                 List<String> checksumLines = Files.readAllLines(checksumFile);
                 if (checksumLines.size() != 1) {
-                    throw new ElasticsearchCorruptionException("invalid format for checksum file, expected 1 line, got: " +
-                            checksumLines.size());
+                    throw new ElasticsearchCorruptionException("invalid format for checksum file (" +
+                            hashFunc.name() + "), expected 1 line, got: " + checksumLines.size());
                 }
                 String checksumHex = checksumLines.get(0);
                 String fileHex = hashFunc.checksum(fileBytes);
                 if (fileHex.equals(checksumHex) == false) {
-                    throw new ElasticsearchCorruptionException("incorrect hash, file hash: [" +
-                            fileHex + "], expected: [" + checksumHex + "]");
+                    throw new ElasticsearchCorruptionException("incorrect hash (" + hashFunc.name() +
+                            "), file hash: [" + fileHex + "], expected: [" + checksumHex + "]");
                 }
                 return true;
             }

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -24,11 +24,13 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.Build;
+import org.elasticsearch.ElasticsearchCorruptionException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.JarHell;
 import org.elasticsearch.common.cli.Terminal;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.http.client.HttpDownloadHelper;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.unit.TimeValue;
@@ -125,6 +127,7 @@ public class PluginManager {
 
         HttpDownloadHelper downloadHelper = new HttpDownloadHelper();
         boolean downloaded = false;
+        boolean verified = false;
         HttpDownloadHelper.DownloadProgress progress;
         if (outputMode == OutputMode.SILENT) {
             progress = new HttpDownloadHelper.NullProgress();
@@ -145,7 +148,14 @@ public class PluginManager {
             try {
                 downloadHelper.download(pluginUrl, pluginFile, progress, this.timeout);
                 downloaded = true;
-            } catch (ElasticsearchTimeoutException e) {
+                terminal.println("Verifying %s checksums if available ...", pluginUrl.toExternalForm());
+                Tuple<URL, Path> sha1Info = pluginHandle.newChecksumUrlAndFile(environment, pluginUrl, "sha1");
+                verified = downloadHelper.downloadAndVerifyChecksum(sha1Info.v1(), pluginFile,
+                        sha1Info.v2(), progress, this.timeout, HttpDownloadHelper.SHA1_CHECKSUM);
+                Tuple<URL, Path> md5Info = pluginHandle.newChecksumUrlAndFile(environment, pluginUrl, "md5");
+                verified = verified || downloadHelper.downloadAndVerifyChecksum(md5Info.v1(), pluginFile,
+                        md5Info.v2(), progress, this.timeout, HttpDownloadHelper.MD5_CHECKSUM);
+            } catch (ElasticsearchTimeoutException | ElasticsearchCorruptionException e) {
                 throw e;
             } catch (Exception e) {
                 // ignore
@@ -164,8 +174,15 @@ public class PluginManager {
                 try {
                     downloadHelper.download(url, pluginFile, progress, this.timeout);
                     downloaded = true;
+                    terminal.println("Verifying %s checksums if available ...", url.toExternalForm());
+                    Tuple<URL, Path> sha1Info = pluginHandle.newChecksumUrlAndFile(environment, url, "sha1");
+                    verified = downloadHelper.downloadAndVerifyChecksum(sha1Info.v1(), pluginFile,
+                            sha1Info.v2(), progress, this.timeout, HttpDownloadHelper.SHA1_CHECKSUM);
+                    Tuple<URL, Path> md5Info = pluginHandle.newChecksumUrlAndFile(environment, url, "md5");
+                    verified = verified || downloadHelper.downloadAndVerifyChecksum(md5Info.v1(), pluginFile,
+                            md5Info.v2(), progress, this.timeout, HttpDownloadHelper.MD5_CHECKSUM);
                     break;
-                } catch (ElasticsearchTimeoutException e) {
+                } catch (ElasticsearchTimeoutException | ElasticsearchCorruptionException e) {
                     throw e;
                 } catch (Exception e) {
                     terminal.println(VERBOSE, "Failed: %s", ExceptionsHelper.detailedMessage(e));
@@ -177,6 +194,10 @@ public class PluginManager {
             // try to cleanup what we downloaded
             IOUtils.deleteFilesIgnoringExceptions(pluginFile);
             throw new IOException("failed to download out of all possible locations..., use --verbose to get detailed information");
+        }
+
+        if (verified == false) {
+            terminal.println("NOTE: Unable to verify checksum for downloaded plugin (unable to find .sha1 or .md5 file to verify)");
         }
         return pluginFile;
     }
@@ -467,6 +488,11 @@ public class PluginManager {
 
         Path newDistroFile(Environment env) throws IOException {
             return Files.createTempFile(env.tmpFile(), name, ".zip");
+        }
+
+        Tuple<URL, Path> newChecksumUrlAndFile(Environment env, URL originalUrl, String suffix) throws IOException {
+            URL newUrl = new URL(originalUrl.toString() + "." + suffix);
+            return new Tuple<>(newUrl, Files.createTempFile(env.tmpFile(), name, ".zip." + suffix));
         }
 
         Path extractedDir(Environment env) {

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.plugins;
 import com.google.common.io.Files;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.http.client.HttpDownloadHelper;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
@@ -30,6 +31,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Locale;
@@ -128,5 +130,14 @@ public class PluginManagerUnitTests extends ESTestCase {
         assertThat(handle.urls(), hasSize(1));
         URL expected = new URL("https", "github.com", "/" + user + "/" + pluginName + "/" + "archive/master.zip");
         assertThat(handle.urls().get(0), is(expected));
+    }
+
+    @Test
+    public void testDownloadHelperChecksums() throws Exception {
+        // Sanity check to make sure the checksum functions never change how they checksum things
+        assertEquals("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+                HttpDownloadHelper.SHA1_CHECKSUM.checksum("foo".getBytes(Charset.forName("UTF-8"))));
+        assertEquals("acbd18db4cc2f85cedef654fccc4a4d8",
+                HttpDownloadHelper.MD5_CHECKSUM.checksum("foo".getBytes(Charset.forName("UTF-8"))));
     }
 }


### PR DESCRIPTION
When a plugin is downloaded, this change additionally tries to download
`${pluginurl}.sha1` and verify the SHA1 checksum for the file. If no
.sha1 file is found, it tries `${pluginurl}.md5`.

Note that if neither checksum file is found, a notice is printed but the
plugin can still be installed. If the checksum check fails, the plugin
install is aborted.

Example output if no checksums are available:

```
bin/plugin install elasticsearch/elasticsearch-analysis-icu/2.6.0-SNAPSHOT
-> Installing elasticsearch/elasticsearch-analysis-icu/2.6.0-SNAPSHOT...
Trying http://download.elastic.co/elasticsearch/elasticsearch-analysis-icu/elasticsearch-analysis-icu-2.6.0-SNAPSHOT.zip ...
Trying http://search.maven.org/remotecontent?filepath=elasticsearch/elasticsearch-analysis-icu/2.6.0-SNAPSHOT/elasticsearch-analysis-icu-2.6.0-SNAPSHOT.zip ...
Trying https://oss.sonatype.org/service/local/repositories/releases/content/elasticsearch/elasticsearch-analysis-icu/2.6.0-SNAPSHOT/elasticsearch-analysis-icu-2.6.0-SNAPSHOT.zip ...
Trying https://github.com/elasticsearch/elasticsearch-analysis-icu/archive/2.6.0-SNAPSHOT.zip ...
Trying https://github.com/elasticsearch/elasticsearch-analysis-icu/archive/master.zip ...
Downloading .....................................DONE
Verifying https://github.com/elasticsearch/elasticsearch-analysis-icu/archive/master.zip checksums if available ...
NOTE: Unable to verify checksum for downloaded plugin (unable to find .sha1 or .md5 file to verify)
```

Example output if checksums are available:

```
bin/plugin install elasticsearch/elasticsearch-analysis-icu/2.6.0-SNAPSHOT
-> Installing elasticsearch/elasticsearch-analysis-icu/2.6.0-SNAPSHOT...
Trying http://download.elastic.co/elasticsearch/elasticsearch-analysis-icu/elasticsearch-analysis-icu-2.6.0-SNAPSHOT.zip ...
Trying http://search.maven.org/remotecontent?filepath=elasticsearch/elasticsearch-analysis-icu/2.6.0-SNAPSHOT/elasticsearch-analysis-icu-2.6.0-SNAPSHOT.zip ...
Trying https://oss.sonatype.org/service/local/repositories/releases/content/elasticsearch/elasticsearch-analysis-icu/2.6.0-SNAPSHOT/elasticsearch-analysis-icu-2.6.0-SNAPSHOT.zip ...
Trying https://github.com/elasticsearch/elasticsearch-analysis-icu/archive/2.6.0-SNAPSHOT.zip ...
Trying https://github.com/elasticsearch/elasticsearch-analysis-icu/archive/master.zip ...
Downloading .....................................DONE
Verifying https://github.com/elasticsearch/elasticsearch-analysis-icu/archive/master.zip checksums if available ...
Downloading .DONE
```

Example output if checksums fail:

```
bin/plugin install elasticsearch/elasticsearch-analysis-kuromoji/2.5.0 -url http://localhost:8000/elasticsearch-analysis-kuromoji-2.5.0.zip
-> Installing elasticsearch/elasticsearch-analysis-kuromoji/2.5.0...
Trying http://localhost:8000/elasticsearch-analysis-kuromoji-2.5.0.zip ...
Downloading .............................................DONE
Verifying http://localhost:8000/elasticsearch-analysis-kuromoji-2.5.0.zip checksums if available ...
Downloading .DONE
ERROR: incorrect hash, file hash: [dbdc9c2cd32782054497a21fbdcae3ca1ff23c80], expected: [dbdc9c2cd32782054497a21fbdcae3ca1ff23c80-bad]
```

Resolves #12750
