### PR TITLE
Expose points_only option through geo_shape field mapper

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/XShapeCollection.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/XShapeCollection.java
@@ -36,8 +36,18 @@ import java.util.List;
  */
 public class XShapeCollection<S extends Shape> extends ShapeCollection<S> {
 
+  private boolean pointsOnly = false;
+
   public XShapeCollection(List<S> shapes, SpatialContext ctx) {
     super(shapes, ctx);
+  }
+
+  public boolean pointsOnly() {
+    return this.pointsOnly;
+  }
+
+  public void setPointsOnly(boolean pointsOnly) {
+    this.pointsOnly = pointsOnly;
   }
 
   @Override

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
@@ -51,7 +51,9 @@ public class MultiPointBuilder extends PointCollection<MultiPointBuilder> {
         for (Coordinate coord : points) {
             shapes.add(SPATIAL_CONTEXT.makePoint(coord.x, coord.y));
         }
-        return new XShapeCollection<>(shapes, SPATIAL_CONTEXT);
+        XShapeCollection multiPoints = new XShapeCollection<>(shapes, SPATIAL_CONTEXT);
+        multiPoints.setPointsOnly(true);
+        return multiPoints;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -27,7 +27,6 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.unit.DistanceUnit.Distance;

--- a/core/src/test/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/geo/GeoShapeFieldMapperTests.java
@@ -168,6 +168,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                     .field("tree", "quadtree")
                     .field("tree_levels", "6")
                     .field("distance_error_pct", "0.5")
+                    .field("points_only", true)
                 .endObject().endObject()
                 .endObject().endObject().string();
 
@@ -181,6 +182,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(strategy.getDistErrPct(), equalTo(0.5));
         assertThat(strategy.getGrid(), instanceOf(QuadPrefixTree.class));
         assertThat(strategy.getGrid().getMaxLevels(), equalTo(6));
+        assertThat(strategy.isPointsOnly(), equalTo(true));
     }
     
     @Test
@@ -308,7 +310,28 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             assertThat(strategy.getGrid().getMaxLevels(), equalTo(GeoUtils.quadTreeLevelsForPrecision(70d)+1)); 
         }
     }
-    
+
+    @Test
+    public void testPointsOnlyOption() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("tree", "geohash")
+                .field("points_only", true)
+                .endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
+
+        GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
+        PrefixTreeStrategy strategy = geoShapeFieldMapper.fieldType().defaultStrategy();
+
+        assertThat(strategy.getGrid(), instanceOf(GeohashPrefixTree.class));
+        assertThat(strategy.isPointsOnly(), equalTo(true));
+    }
+
     @Test
     public void testLevelDefaults() throws IOException {
         DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();

--- a/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
+++ b/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
@@ -63,6 +63,14 @@ public class RandomShapeGenerator {
         }
     }
 
+    public static ShapeBuilder createShape(Random r) throws InvalidShapeException {
+        return createShapeNear(r, null);
+    }
+
+    public static ShapeBuilder createShape(Random r, ShapeType st) {
+        return createShapeNear(r, null, st);
+    }
+
     public static ShapeBuilder createShapeNear(Random r, Point nearPoint) throws InvalidShapeException {
         return createShape(r, nearPoint, null, null);
     }
@@ -211,7 +219,8 @@ public class RandomShapeGenerator {
                     try {
                         pgb.build();
                     } catch (InvalidShapeException e) {
-                        return null;
+                        // jts bug rarely results in an invalid shape, if it does happen we try again instead of returning null
+                        return createShape(r, nearPoint, within, st, validate);
                     }
                 }
                 return pgb;

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -62,6 +62,16 @@ outer ring vertices in counterclockwise order with inner ring(s) vertices (holes
 in clockwise order. Setting this parameter in the geo_shape mapping explicitly
 sets vertex order for the coordinate list of a geo_shape field but can be
 overridden in each individual GeoJSON document.
+
+|`points_only` |Setting this option to `true` (defaults to `false`) configures
+the `geo_shape` field type for point shapes only (NOTE: Multi-Points are not
+yet supported). This optimizes index and search performance for the `geohash` and
+`quadtree` when it is known that only points will be indexed. At present geo_shape
+queries can not be executed on `geo_point` field types. This option bridges the gap
+by improving point performance on a `geo_shape` field so that `geo_shape` queries are
+optimal on a point only field.
+
+
 |=======================================================================
 
 [float]


### PR DESCRIPTION
This PR adds a `points_only` option (defaults to `false`) to the GeoShapeFieldMapper that exposes the pointsOnly optimization in lucene's RecursivePrefixTreeStrategy. This optimization short-circuits DFS traversal when it is known that the field contains points only. To enforce this option the `GeoShapeFieldMapper` has been updated to throw a MapperParsingException for any `Shape` that is not of type `Point` when the option is set to `true`.  Randomized testing is added and docs are updated. ShapeCollection has also been updated to eventually support MultiPoint. Limitations of S4j are currently the only blocker. 

closes #12856
