### PR TITLE
Fix reproduction line to include project filters

### DIFF
--- a/core/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/core/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -78,9 +78,13 @@ public class ReproduceInfoPrinter extends RunListener {
 
         final StringBuilder b = new StringBuilder();
         if (inVerifyPhase()) {
-            b.append("REPRODUCE WITH: mvn verify -Pdev -Dskip.unit.tests");
+            b.append("REPRODUCE WITH: mvn verify -Pdev -Dskip.unit.tests" );
         } else {
             b.append("REPRODUCE WITH: mvn test -Pdev");
+        }
+        String project = System.getProperty("tests.project");
+        if (project != null) {
+            b.append(" -pl " + project);
         }
         MavenMessageBuilder mavenMessageBuilder = new MavenMessageBuilder(b);
         mavenMessageBuilder.appendAllOpts(failure.getDescription());

--- a/pom.xml
+++ b/pom.xml
@@ -623,6 +623,7 @@
                             <tests.appendseed>${tests.appendseed}</tests.appendseed>
                             <tests.cluster>${tests.cluster}</tests.cluster>
                             <tests.iters>${tests.iters}</tests.iters>
+                            <tests.project>${project.groupId}:${project.artifactId}</tests.project>
                             <tests.maxfailures>${tests.maxfailures}</tests.maxfailures>
                             <tests.failfast>${tests.failfast}</tests.failfast>
                             <tests.class>${tests.class}</tests.class>


### PR DESCRIPTION
Today on a failure the reproduce line printed out by the test framework
will build all projects and might fail if the test class is not present.
This commit adds a reactor filter to the reproduction line to ensure
unrelated projects are skipped.

Closes #12838
