### PR TITLE
Accumulate validation errors when validating index templates

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionRequestValidationException.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionRequestValidationException.java
@@ -19,45 +19,7 @@
 
 package org.elasticsearch.action;
 
-import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.ValidationException;
 
-
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- *
- */
-public class ActionRequestValidationException extends IllegalArgumentException {
-
-    private final List<String> validationErrors = new ArrayList<>();
-
-    public ActionRequestValidationException() {
-        super("validation failed");
-    }
-
-    public void addValidationError(String error) {
-        validationErrors.add(error);
-    }
-
-    public void addValidationErrors(Iterable<String> errors) {
-        for (String error : errors) {
-            validationErrors.add(error);
-        }
-    }
-
-    public List<String> validationErrors() {
-        return validationErrors;
-    }
-
-    @Override
-    public String getMessage() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Validation Failed: ");
-        int index = 0;
-        for (String error : validationErrors) {
-            sb.append(++index).append(": ").append(error).append(";");
-        }
-        return sb.toString();
-    }
+public class ActionRequestValidationException extends ValidationException {
 }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -29,12 +29,12 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.TimeoutClusterStateUpdateTask;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.indices.IndexCreationException;
 import org.elasticsearch.indices.IndexTemplateAlreadyExistsException;
 import org.elasticsearch.indices.IndexTemplateMissingException;
 import org.elasticsearch.indices.InvalidIndexTemplateException;
@@ -179,41 +179,44 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
     }
 
     private void validate(PutRequest request) {
+        List<String> validationErrors = Lists.newArrayList();
         if (request.name.contains(" ")) {
-            throw new InvalidIndexTemplateException(request.name, "name must not contain a space");
+            validationErrors.add("name must not contain a space");
         }
         if (request.name.contains(",")) {
-            throw new InvalidIndexTemplateException(request.name, "name must not contain a ','");
+            validationErrors.add("name must not contain a ','");
         }
         if (request.name.contains("#")) {
-            throw new InvalidIndexTemplateException(request.name, "name must not contain a '#'");
+            validationErrors.add("name must not contain a '#'");
         }
         if (request.name.startsWith("_")) {
-            throw new InvalidIndexTemplateException(request.name, "name must not start with '_'");
+            validationErrors.add("name must not start with '_'");
         }
         if (!request.name.toLowerCase(Locale.ROOT).equals(request.name)) {
-            throw new InvalidIndexTemplateException(request.name, "name must be lower cased");
+            validationErrors.add("name must be lower cased");
         }
         if (request.template.contains(" ")) {
-            throw new InvalidIndexTemplateException(request.name, "template must not contain a space");
+            validationErrors.add("template must not contain a space");
         }
         if (request.template.contains(",")) {
-            throw new InvalidIndexTemplateException(request.name, "template must not contain a ','");
+            validationErrors.add("template must not contain a ','");
         }
         if (request.template.contains("#")) {
-            throw new InvalidIndexTemplateException(request.name, "template must not contain a '#'");
+            validationErrors.add("template must not contain a '#'");
         }
         if (request.template.startsWith("_")) {
-            throw new InvalidIndexTemplateException(request.name, "template must not start with '_'");
+            validationErrors.add("template must not start with '_'");
         }
         if (!Strings.validFileNameExcludingAstrix(request.template)) {
-            throw new InvalidIndexTemplateException(request.name, "template must not container the following characters " + Strings.INVALID_FILENAME_CHARS);
+            validationErrors.add("template must not container the following characters " + Strings.INVALID_FILENAME_CHARS);
         }
 
-        try {
-            metaDataCreateIndexService.validateIndexSettings(request.name, request.settings);
-        } catch (IndexCreationException exception) {
-            throw new InvalidIndexTemplateException(request.name, exception.getDetailedMessage());
+        List<String> indexSettingsValidation = metaDataCreateIndexService.getIndexSettingsValidationErrors(request.settings);
+        validationErrors.addAll(indexSettingsValidation);
+        if (!validationErrors.isEmpty()) {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationErrors(validationErrors);
+            throw new InvalidIndexTemplateException(request.name, validationException.getMessage());
         }
 
         for (Alias alias : request.aliases) {
@@ -271,7 +274,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
             this.mappings.putAll(mappings);
             return this;
         }
-        
+
         public PutRequest aliases(Set<Alias> aliases) {
             this.aliases.addAll(aliases);
             return this;

--- a/core/src/main/java/org/elasticsearch/common/ValidationException.java
+++ b/core/src/main/java/org/elasticsearch/common/ValidationException.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Encapsulates an accumulation of validation errors
+ */
+public class ValidationException extends IllegalArgumentException {
+    private final List<String> validationErrors = new ArrayList<>();
+
+    public ValidationException() {
+        super("validation failed");
+    }
+
+    /**
+     * Add a new validation error to the accumulating validation errors
+     * @param error the error to add
+     */
+    public void addValidationError(String error) {
+        validationErrors.add(error);
+    }
+
+    /**
+     * Add a sequence of validation errors to the accumulating validation errors
+     * @param errors the errors to add
+     */
+    public void addValidationErrors(Iterable<String> errors) {
+        for (String error : errors) {
+            validationErrors.add(error);
+        }
+    }
+
+    /**
+     * Returns the validation errors accumulated
+     * @return
+     */
+    public List<String> validationErrors() {
+        return validationErrors;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Validation Failed: ");
+        int index = 0;
+        for (String error : validationErrors) {
+            sb.append(++index).append(": ").append(error).append(";");
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
This commit changes the behavior when validating index templates to
accumulate all validation errors before reporting failure to the user.
This addresses a usability issue when creating index templates.

Closes #12900
