### PR TITLE
Remove ES_CLEAN_BEFORE_TEST

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -473,10 +473,8 @@ and in another window:
 ----------------------------------------------------
 vagrant up centos-7 && vagrant ssh centos-7
 cd $RPM
-sudo ES_CLEAN_BEFORE_TEST=true bats $BATS/*rpm*.bats
+sudo bats $BATS/*rpm*.bats
 ----------------------------------------------------
-
-At this point `ES_CLEAN_BEFORE_TEST=true` is required or tests fail spuriously.
 
 If you wanted to retest all the release artifacts on a single VM you could:
 -------------------------------------------------
@@ -486,7 +484,7 @@ mvn -amd -pl distribution install -DskipTests
 mvn -Dtests.vagrant -pl qa/vagrant pre-integration-test
 vagrant up trusty && vagrant ssh trusty
 cd $TESTROOT
-sudo ES_CLEAN_BEFORE_TEST=true bats $BATS/*.bats
+sudo bats $BATS/*.bats
 -------------------------------------------------
 
 == Coverage analysis

--- a/qa/vagrant/pom.xml
+++ b/qa/vagrant/pom.xml
@@ -18,7 +18,7 @@
     <!-- The documentation for how to run this is in ../../Vagrantfile -->
     <properties>
       <testScripts>*.bats</testScripts>
-      <testCommand>sudo ES_CLEAN_BEFORE_TEST=true bats $BATS/${testScripts}</testCommand>
+      <testCommand>sudo bats $BATS/${testScripts}</testCommand>
 
       <allDebBoxes>precise, trusty, vivid, wheezy, jessie</allDebBoxes>
       <allRpmBoxes>centos-6, centos-7, fedora-22, oel-7</allRpmBoxes>

--- a/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
@@ -305,51 +305,41 @@ clean_before_test() {
                             "/usr/lib/tmpfiles.d/elasticsearch.conf" \
                             "/usr/lib/sysctl.d/elasticsearch.conf")
 
-    if [ "$ES_CLEAN_BEFORE_TEST" = "true" ]; then
-        # Kills all processes of user elasticsearch
-        if id elasticsearch > /dev/null 2>&1; then
-            pkill -u elasticsearch 2>/dev/null || true
-        fi
-
-        # Kills all running Elasticsearch processes
-        ps aux | grep -i "org.elasticsearch.bootstrap.Elasticsearch" | awk {'print $2'} | xargs kill -9 > /dev/null 2>&1 || true
-
-        # Removes RPM package
-        if is_rpm; then
-            rpm --quiet -e elasticsearch > /dev/null 2>&1 || true
-        fi
-
-        if [ -x "`which yum 2>/dev/null`" ]; then
-            yum remove -y elasticsearch > /dev/null 2>&1 || true
-        fi
-
-        # Removes DEB package
-        if is_dpkg; then
-            dpkg --purge elasticsearch > /dev/null 2>&1 || true
-        fi
-
-        if [ -x "`which apt-get 2>/dev/null`" ]; then
-            apt-get --quiet --yes purge elasticsearch > /dev/null 2>&1 || true
-        fi
-
-        # Removes user & group
-        userdel elasticsearch > /dev/null 2>&1 || true
-        groupdel elasticsearch > /dev/null 2>&1 || true
-
-
-        # Removes all files
-        for d in "${ELASTICSEARCH_TEST_FILES[@]}"; do
-            if [ -e "$d" ]; then
-                rm -rf "$d"
-            fi
-        done
+    # Kills all processes of user elasticsearch
+    if id elasticsearch > /dev/null 2>&1; then
+        pkill -u elasticsearch 2>/dev/null || true
     fi
 
-    # Checks that all files are deleted
+    # Kills all running Elasticsearch processes
+    ps aux | grep -i "org.elasticsearch.bootstrap.Elasticsearch" | awk {'print $2'} | xargs kill -9 > /dev/null 2>&1 || true
+
+    # Removes RPM package
+    if is_rpm; then
+        rpm --quiet -e elasticsearch > /dev/null 2>&1 || true
+    fi
+
+    if [ -x "`which yum 2>/dev/null`" ]; then
+        yum remove -y elasticsearch > /dev/null 2>&1 || true
+    fi
+
+    # Removes DEB package
+    if is_dpkg; then
+        dpkg --purge elasticsearch > /dev/null 2>&1 || true
+    fi
+
+    if [ -x "`which apt-get 2>/dev/null`" ]; then
+        apt-get --quiet --yes purge elasticsearch > /dev/null 2>&1 || true
+    fi
+
+    # Removes user & group
+    userdel elasticsearch > /dev/null 2>&1 || true
+    groupdel elasticsearch > /dev/null 2>&1 || true
+
+
+    # Removes all files
     for d in "${ELASTICSEARCH_TEST_FILES[@]}"; do
         if [ -e "$d" ]; then
-            echo "$d should not exist before running the tests" >&2
-            exit 1
+            rm -rf "$d"
         fi
     done
 }


### PR DESCRIPTION
In the bats test ES_CLEAN_BEFORE_TEST was used to clean the environment
before running the tests. Unfortunately the tests don't work unless you
specify it every time. This removes that option and always runs the clean.
