### PR TITLE
Fix variable substitution for OS's using systemd 

### DIFF
--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -19,12 +19,12 @@ User=${packaging.elasticsearch.user}
 Group=${packaging.elasticsearch.group}
 
 ExecStart=${packaging.elasticsearch.bin.dir}/elasticsearch \
-                                                -Des.pidfile=$PID_DIR/elasticsearch.pid \
-                                                -Des.default.path.home=$ES_HOME \
-                                                -Des.default.path.logs=$LOG_DIR \
-                                                -Des.default.path.data=$DATA_DIR \
-                                                -Des.default.config=$CONF_FILE \
-                                                -Des.default.path.conf=$CONF_DIR
+                                                -Des.pidfile=${PID_DIR}/elasticsearch.pid \
+                                                -Des.default.path.home=${ES_HOME} \
+                                                -Des.default.path.logs=${LOG_DIR} \
+                                                -Des.default.path.data=${DATA_DIR} \
+                                                -Des.default.config=${CONF_FILE} \
+                                                -Des.default.path.conf=${CONF_DIR}
 
 # Connects standard output to /dev/null
 StandardOutput=null


### PR DESCRIPTION
Systemd looks to be a bit less tolerant about $VAR than bash is. Replace
$VAR with ${VAR} in places in the systemd configuration file to get the
substitutions working.
