### PR TITLE
cmd /C needs to be quoted as a whole when starting integration tests

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -32,8 +32,10 @@
       <echoxml><exec script="${script.base}"><nested/></exec></echoxml>
       <exec executable="cmd" osfamily="winnt" dir="${temp.cwd}" failonerror="${failonerror}" spawn="@{spawn}" taskname="${script.base}">
         <arg value="/c"/>
+        <arg value="&quot;"/>
         <arg value="@{script}.bat"/>
         <nested/>
+        <arg value="&quot;"/>
       </exec>
 
       <exec executable="sh" osfamily="unix" dir="${temp.cwd}" failonerror="${failonerror}" spawn="@{spawn}" taskname="${script.base}">


### PR DESCRIPTION
To support spaces in both the command as well as its arguments `cmd /C` needs
be called like this:

```
cmd /C ""c:\a b\c.bat" "argument 1" "argument2""
```

Note the double quotes around the whole command line.

ant was running:

```
cmd /C "c:\a b\c.bat" "argument 1" "argument2"
```

which triggers `cmd /C`  to preprocess the command line to

```
cmd /C c:\a b\c.bat" "argument 1" "argument2
```

Which would make it appear as though ant was not properly quoting, which it was but just not according to `cmd /C`'s rules.

Closes #12848
