### PR TITLE
Refactor - shard variable dependency from processFirstPhaseResults as shard is no more needed

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -180,7 +180,7 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
 
         void onFirstPhaseResult(int shardIndex, ShardRouting shard, FirstResult result, ShardIterator shardIt) {
             result.shardTarget(new SearchShardTarget(shard.currentNodeId(), shard.index(), shard.id()));
-            processFirstPhaseResult(shardIndex, shard, result);
+            processFirstPhaseResult(shardIndex, result);
             // we need to increment successful ops first before we compare the exit condition otherwise if we
             // are fast we could concurrently update totalOps but then preempt one of the threads which can
             // cause the successor to read a wrong value from successfulOps if second phase is very fast ie. count etc.
@@ -358,7 +358,7 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
 
         protected abstract void sendExecuteFirstPhase(DiscoveryNode node, ShardSearchTransportRequest request, ActionListener<FirstResult> listener);
 
-        protected final void processFirstPhaseResult(int shardIndex, ShardRouting shard, FirstResult result) {
+        protected final void processFirstPhaseResult(int shardIndex, FirstResult result) {
             firstResults.set(shardIndex, result);
 
             if (logger.isTraceEnabled()) {


### PR DESCRIPTION
this is a small commit to remove the
shard variable dependency from processFirstPhaseResults as shard is no more
needed here . it only deals with the results obtained from the synchronous search on each shard.
It is [here](https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java#L361)
