### PR TITLE
Release: remove aws-maven plugin/add docs

### DIFF
--- a/dev-tools/build_repositories.sh
+++ b/dev-tools/build_repositories.sh
@@ -158,7 +158,7 @@ mkdir -p $centosdir
 echo "RPM: Syncing repository for version $version into $centosdir"
 $s3cmd sync s3://$S3_BUCKET_SYNC_FROM/elasticsearch/$version/centos/ $centosdir
 
-rpm=distribution/rpm/target/releases/signed/elasticsearch*.rpm
+rpm=distribution/rpm/target/releases/elasticsearch*.rpm
 echo "RPM: Copying signed $rpm into $centosdir"
 cp $rpm $centosdir
 

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -35,13 +35,6 @@
         </configuration>
       </plugin>
     </plugins>
-    <extensions>
-      <extension>
-        <groupId>org.springframework.build</groupId>
-        <artifactId>aws-maven</artifactId>
-        <version>5.0.0.RELEASE</version>
-      </extension>
-    </extensions>
   </build>
   <profiles>
     <profile>
@@ -70,13 +63,6 @@
           </plugin>
         </plugins>
       </build>
-      <distributionManagement>
-        <repository>
-          <id>aws-release</id>
-          <name>AWS Release Repository</name>
-          <url>${elasticsearch.s3.repository}</url>
-        </repository>
-      </distributionManagement>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1262,13 +1262,6 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                 </plugin>
             </plugins>
         </pluginManagement>
-        <extensions>
-            <extension>
-                <groupId>org.springframework.build</groupId>
-                <artifactId>aws-maven</artifactId>
-                <version>5.0.0.RELEASE</version>
-            </extension>
-        </extensions>
     </build>
     <profiles>
         <profile>
@@ -1316,13 +1309,6 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                     </plugin>
                 </plugins>
             </build>
-            <distributionManagement>
-                <repository>
-                    <id>aws-release</id>
-                    <name>AWS Release Repository</name>
-                    <url>${elasticsearch.s3.repository}</url>
-                </repository>
-            </distributionManagement>
         </profile>
         <!-- license profile, to generate third party license file -->
         <profile>

--- a/rest-api-spec/pom.xml
+++ b/rest-api-spec/pom.xml
@@ -35,13 +35,6 @@
         </configuration>
       </plugin>
     </plugins>
-    <extensions>
-      <extension>
-        <groupId>org.springframework.build</groupId>
-        <artifactId>aws-maven</artifactId>
-        <version>5.0.0.RELEASE</version>
-      </extension>
-    </extensions>
   </build>
   <profiles>
     <profile>
@@ -70,13 +63,6 @@
           </plugin>
         </plugins>
       </build>
-      <distributionManagement>
-        <repository>
-          <id>aws-release</id>
-          <name>AWS Release Repository</name>
-          <url>${elasticsearch.s3.repository}</url>
-        </repository>
-      </distributionManagement>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
In order to have consistent deploys across several repositories,
we should deploy to sonatype first, then mirror those contents,
and then upload to s3.

This means, the aws wagon is not needed anymore.
