### PR TITLE
Elasticsearch bootstrap help shouldn't mention plugins

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/elasticsearch.help
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/elasticsearch.help
@@ -8,7 +8,7 @@ SYNOPSIS
 
 DESCRIPTION
 
-    Start elasticsearch and manage plugins
+    Start an elasticsearch node
 
 COMMANDS
 


### PR DESCRIPTION
We have a dedicated entry point for that.
