### PR TITLE
Add build short hash to the download manager headers to identify staging builds

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
@@ -360,10 +360,11 @@ public class HttpDownloadHelper {
 
             if (connection instanceof HttpURLConnection) {
                 ((HttpURLConnection) connection).setInstanceFollowRedirects(false);
-                ((HttpURLConnection) connection).setUseCaches(true);
-                ((HttpURLConnection) connection).setConnectTimeout(5000);
+                connection.setUseCaches(true);
+                connection.setConnectTimeout(5000);
             }
             connection.setRequestProperty("ES-Version", Version.CURRENT.toString());
+            connection.setRequestProperty("ES-Build-Hash", Build.CURRENT.hashShort());
             connection.setRequestProperty("User-Agent", "elasticsearch-plugin-manager");
 
             // connect to the remote site (may take some time)


### PR DESCRIPTION
It might turn out to be useful to have the actual commit hash of the version we are
looking for if our download manager can just redirect to the right staging repository.
