### PR TITLE
Use preferIPv6Addresses for sort order, not preferIPv4Stack

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -51,12 +51,12 @@ public abstract class NetworkUtils {
      * @deprecated transition mechanism only
      */
     @Deprecated
-    static final boolean PREFER_V4 = Boolean.parseBoolean(System.getProperty("java.net.preferIPv4Stack", "true")); 
+    static final boolean PREFER_V6 = Boolean.parseBoolean(System.getProperty("java.net.preferIPv6Addresses", "false"));
     
     /** Sorts an address by preference. This way code like publishing can just pick the first one */
-    static int sortKey(InetAddress address, boolean prefer_v4) {
+    static int sortKey(InetAddress address, boolean prefer_v6) {
         int key = address.getAddress().length;
-        if (prefer_v4 == false) {
+        if (prefer_v6) {
             key = -key;
         }
         
@@ -88,7 +88,7 @@ public abstract class NetworkUtils {
         Collections.sort(list, new Comparator<InetAddress>() {
             @Override
             public int compare(InetAddress left, InetAddress right) {
-                int cmp = Integer.compare(sortKey(left, PREFER_V4), sortKey(right, PREFER_V4));
+                int cmp = Integer.compare(sortKey(left, PREFER_V6), sortKey(right, PREFER_V6));
                 if (cmp == 0) {
                     cmp = new BytesRef(left.getAddress()).compareTo(new BytesRef(right.getAddress()));
                 }

--- a/core/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
@@ -34,8 +34,8 @@ public class NetworkUtilsTests extends ESTestCase {
     public void testSortKey() throws Exception {
         InetAddress localhostv4 = InetAddress.getByName("127.0.0.1");
         InetAddress localhostv6 = InetAddress.getByName("::1");
-        assertTrue(NetworkUtils.sortKey(localhostv4, true) < NetworkUtils.sortKey(localhostv6, true));
-        assertTrue(NetworkUtils.sortKey(localhostv6, false) < NetworkUtils.sortKey(localhostv4, false));
+        assertTrue(NetworkUtils.sortKey(localhostv4, false) < NetworkUtils.sortKey(localhostv6, false));
+        assertTrue(NetworkUtils.sortKey(localhostv6, true) < NetworkUtils.sortKey(localhostv4, true));
     }
     
     /**


### PR DESCRIPTION
java.net.preferIPv6Addresses is a better choice. preferIPv4Stack is a nuclear option
and you just won't even bind to any IPv6 addresses. This reduces confusion.
