### PR TITLE
Fixed section name and api name in docs

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -114,7 +114,7 @@ If both `doc` and `script` is specified, then `doc` is ignored. Best is
 to put your field pairs of the partial document in the script itself.
 
 [float]
-=== `detect_noop`
+=== Detecting noop
 
 By default if `doc` is specified then the document is always updated even
 if the merging process doesn't cause any changes.  Specifying `detect_noop`
@@ -247,12 +247,10 @@ return the full updated source.
 
 `version` & `version_type`::
 
-The Update API uses the Elasticsearch's versioning support internally to make
+The update API uses the Elasticsearch's versioning support internally to make
 sure the document doesn't change during the update. You can use the `version`
 parameter to specify that the document should only be updated if it's version
 matches the one specified. By setting version type to `force` you can force
 the new version of the document after update (use with care! with `force`
 there is no guarantee the document didn't change).Version types `external` &
 `external_gte` are not supported.
-
-


### PR DESCRIPTION
I fixed section name, like image bellow.
- https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html

![es-docs](https://cloud.githubusercontent.com/assets/1573290/9323841/b06d50fa-45bf-11e5-99c1-8594c9691626.png)

Thank you so much.
