### PR TITLE
[build] simplify ant script for plugins

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -93,21 +93,11 @@
         </nested>
       </run-script>
 
-      <!-- check that plugin was installed into correct place -->
-      <local name="longname"/>
-      <property name="longname" value="@{name}"/>
-      <local name="shortname"/>
-      <filter-property src="longname" dest="shortname">
-        <chain>
-          <replaceregex pattern="^elasticsearch-" replace=""/>
-        </chain>
-      </filter-property>
-
-      <fail message="did not find plugin installed as ${shortname}">
+      <fail message="did not find plugin installed as @{name}">
         <condition>
           <not>
             <resourceexists>
-              <file file="@{home}/plugins/${shortname}"/>
+              <file file="@{home}/plugins/@{name}"/>
             </resourceexists>
           </not>
         </condition>
@@ -203,8 +193,8 @@
   </macrodef>
 
   <!-- Takes a plugin zip file and return the plugin name. For instance
-       'elasticsearch-analysis-icu-2.0.0.zip' would return
-       'elasticsearch-analysis-icu'. -->
+       'analysis-icu-2.0.0.zip' would return
+       'analysis-icu'. -->
   <macrodef name="convert-plugin-name">
       <attribute name="file"/>
       <attribute name="outputproperty"/>
@@ -213,7 +203,6 @@
       <basename file="@{file}" property="file.base"/>
       <filter-property src="file.base" dest="@{outputproperty}">
         <chain>
-          <replaceregex pattern="^elasticsearch-" replace=""/>
           <replacestring from="-${elasticsearch.version}.zip" to=""/>
         </chain>
       </filter-property>

--- a/qa/vagrant/pom.xml
+++ b/qa/vagrant/pom.xml
@@ -94,7 +94,7 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.elasticsearch.plugin</groupId>
-                                    <artifactId>elasticsearch-jvm-example</artifactId>
+                                    <artifactId>jvm-example</artifactId>
                                     <version>${elasticsearch.version}</version>
                                     <type>zip</type>
                                 </artifactItem>

--- a/qa/vagrant/src/test/resources/packaging/scripts/25_tar_plugins.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/25_tar_plugins.bats
@@ -61,7 +61,7 @@ setup() {
     assert_file_exist "/tmp/elasticsearch/config/jvm-example/example.yaml"
     assert_file_exist "/tmp/elasticsearch/plugins/jvm-example"
     assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/jvm-example-"*".jar"
     echo "Running jvm-example's bin script...."
     /tmp/elasticsearch/bin/jvm-example/test | grep test
 
@@ -106,7 +106,7 @@ setup() {
     assert_file_exist "/tmp/elasticsearch/config/jvm-example/example.yaml"
     assert_file_exist "$TEMP_PLUGINS_DIR/jvm-example"
     assert_file_exist "$TEMP_PLUGINS_DIR/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "$TEMP_PLUGINS_DIR/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "$TEMP_PLUGINS_DIR/jvm-example/jvm-example-"*".jar"
 
     # Remove the plugin
     run /tmp/elasticsearch/bin/plugin remove jvm-example
@@ -156,7 +156,7 @@ setup() {
     assert_file_exist "$TEMP_CONFIG_DIR/jvm-example/example.yaml"
     assert_file_exist "/tmp/elasticsearch/plugins/jvm-example"
     assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/jvm-example-"*".jar"
 
     # Remove the plugin
     run /tmp/elasticsearch/bin/plugin remove jvm-example
@@ -210,7 +210,7 @@ setup() {
     assert_file_exist "$TEMP_CONFIG_DIR/jvm-example/example.yaml"
     assert_file_exist "/tmp/elasticsearch/plugins/jvm-example"
     assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/jvm-example-"*".jar"
 
     # Remove the plugin
     run /tmp/elasticsearch/bin/plugin remove jvm-example
@@ -254,7 +254,7 @@ setup() {
     assert_file_exist "$ES_DIR/config/jvm-example/example.yaml"
     assert_file_exist "$ES_DIR/plugins/jvm-example"
     assert_file_exist "$ES_DIR/plugins/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "$ES_DIR/plugins/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "$ES_DIR/plugins/jvm-example/jvm-example-"*".jar"
 
     # Remove the plugin
     run "$ES_DIR/bin/plugin" remove jvm-example
@@ -298,7 +298,7 @@ setup() {
     assert_file_exist "/tmp/elasticsearch/config/jvm-example/example.yaml"
     assert_file_exist "/tmp/elasticsearch/plugins/jvm-example"
     assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "/tmp/elasticsearch/plugins/jvm-example/jvm-example-"*".jar"
 
     # Remove the plugin
     run /tmp/elasticsearch/bin/plugin remove jvm-example

--- a/qa/vagrant/src/test/resources/packaging/scripts/50_plugins.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/50_plugins.bats
@@ -74,7 +74,7 @@ install_package() {
     assert_file_exist "/etc/elasticsearch/jvm-example/example.yaml"
     assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example"
     assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/jvm-example-"*".jar"
 
     # Remove the plugin
     run /usr/share/elasticsearch/bin/plugin remove jvm-example
@@ -121,7 +121,7 @@ install_package() {
     assert_file_exist "/etc/elasticsearch/jvm-example/example.yaml"
     assert_file_exist "$TEMP_PLUGINS_DIR/jvm-example"
     assert_file_exist "$TEMP_PLUGINS_DIR/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "$TEMP_PLUGINS_DIR/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "$TEMP_PLUGINS_DIR/jvm-example/jvm-example-"*".jar"
 
 
     # Remove the plugin
@@ -183,7 +183,7 @@ install_package() {
     assert_file_exist "$TEMP_CONFIG_DIR/jvm-example/example.yaml"
     assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example"
     assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/jvm-example-"*".jar"
 
     # Remove the plugin
     run /usr/share/elasticsearch/bin/plugin remove jvm-example
@@ -241,7 +241,7 @@ install_package() {
     assert_file_exist "$TEMP_CONFIG_DIR/jvm-example/example.yaml"
     assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example"
     assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/plugin-descriptor.properties"
-    assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/elasticsearch-jvm-example-"*".jar"
+    assert_file_exist "/usr/share/elasticsearch/plugins/jvm-example/jvm-example-"*".jar"
 
     # Remove the plugin
     run /usr/share/elasticsearch/bin/plugin remove jvm-example

--- a/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
@@ -27,7 +27,7 @@
 
 
 # Variables used by tests
-EXAMPLE_PLUGIN_ZIP=$(readlink -m elasticsearch-jvm-example-*.zip)
+EXAMPLE_PLUGIN_ZIP=$(readlink -m jvm-example-*.zip)
 
 # Checks if necessary commands are available to run the tests
 


### PR DESCRIPTION
Now we are using short names for artifactId (see #12879) so we don't need anymore to transform long names `elasticsearch-pluginname` to short names `pluginname` in ant script when we install a plugin.
