### PR TITLE
Cryptic error message when mis-spelling a field in geo-distance aggregation

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -99,15 +99,13 @@ public class GeoDistanceParser implements Aggregator.Parser {
                 } else if ("distance_type".equals(currentFieldName) || "distanceType".equals(currentFieldName)) {
                     distanceType = GeoDistance.fromString(parser.text());
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
-                            + currentFieldName + "].", parser.getTokenLocation());
+                    throw new SearchParseException(context, getSearchParseExceptionMessage(currentFieldName, aggregationName), parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
-                            + currentFieldName + "].", parser.getTokenLocation());
+                    throw new SearchParseException(context, getSearchParseExceptionMessage(currentFieldName, aggregationName), parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("ranges".equals(currentFieldName)) {
@@ -141,11 +139,11 @@ public class GeoDistanceParser implements Aggregator.Parser {
                         ranges.add(new RangeAggregator.Range(key(key, from, to), from, fromAsStr, to, toAsStr));
                     }
                 } else  {
-                    throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
-                            + currentFieldName + "].", parser.getTokenLocation());
+                    throw new SearchParseException(context, getSearchParseExceptionMessage(currentFieldName, aggregationName),
+                            parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "].",
+                throw new SearchParseException(context, getSearchParseExceptionMessage(currentFieldName, aggregationName),
                         parser.getTokenLocation());
             }
         }
@@ -162,6 +160,13 @@ public class GeoDistanceParser implements Aggregator.Parser {
         }
 
         return new GeoDistanceFactory(aggregationName, vsParser.config(), InternalGeoDistance.FACTORY, origin, unit, distanceType, ranges, keyed);
+    }
+
+    private static String getSearchParseExceptionMessage(String currentFieldName, String aggregationName) {
+        return "Failed when parsing field with name '" +  currentFieldName +
+                "' found inside aggregation with name '" + aggregationName + "'." + " Few Possible Causes for the error:" +
+                "1)Misspelling the field name.  2)Giving a field name which is not recognized by Geo Distance Aggregator." +
+                "3)Assigning the field to a value with unallowed object type. ";
     }
 
     private static class GeoDistanceFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -163,10 +163,8 @@ public class GeoDistanceParser implements Aggregator.Parser {
     }
 
     private static String getSearchParseExceptionMessage(String currentFieldName, String aggregationName) {
-        return "Failed when parsing field with name '" +  currentFieldName +
-                "' found inside aggregation with name '" + aggregationName + "'." + " Few Possible Causes for the error:" +
-                "1)Misspelling the field name.  2)Giving a field name which is not recognized by Geo Distance Aggregator." +
-                "3)Assigning the field to a value with unallowed object type. ";
+        return "Failed when parsing field: '" +  currentFieldName +
+                "' found inside aggregation: '" + aggregationName + "'.";
     }
 
     private static class GeoDistanceFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java
@@ -99,13 +99,13 @@ public class GeoDistanceParser implements Aggregator.Parser {
                 } else if ("distance_type".equals(currentFieldName) || "distanceType".equals(currentFieldName)) {
                     distanceType = GeoDistance.fromString(parser.text());
                 } else {
-                    throw new SearchParseException(context, getSearchParseExceptionMessage(currentFieldName, aggregationName), parser.getTokenLocation());
+                    throw new SearchParseException(context, getSearchParseExceptionMessage(token, currentFieldName, aggregationName), parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("keyed".equals(currentFieldName)) {
                     keyed = parser.booleanValue();
                 } else {
-                    throw new SearchParseException(context, getSearchParseExceptionMessage(currentFieldName, aggregationName), parser.getTokenLocation());
+                    throw new SearchParseException(context, getSearchParseExceptionMessage(token, currentFieldName, aggregationName), parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if ("ranges".equals(currentFieldName)) {
@@ -139,11 +139,11 @@ public class GeoDistanceParser implements Aggregator.Parser {
                         ranges.add(new RangeAggregator.Range(key(key, from, to), from, fromAsStr, to, toAsStr));
                     }
                 } else  {
-                    throw new SearchParseException(context, getSearchParseExceptionMessage(currentFieldName, aggregationName),
+                    throw new SearchParseException(context, getSearchParseExceptionMessage(token, currentFieldName, aggregationName),
                             parser.getTokenLocation());
                 }
             } else {
-                throw new SearchParseException(context, getSearchParseExceptionMessage(currentFieldName, aggregationName),
+                throw new SearchParseException(context, getSearchParseExceptionMessage(token, currentFieldName, aggregationName),
                         parser.getTokenLocation());
             }
         }
@@ -162,9 +162,9 @@ public class GeoDistanceParser implements Aggregator.Parser {
         return new GeoDistanceFactory(aggregationName, vsParser.config(), InternalGeoDistance.FACTORY, origin, unit, distanceType, ranges, keyed);
     }
 
-    private static String getSearchParseExceptionMessage(String currentFieldName, String aggregationName) {
-        return "Failed when parsing field: '" +  currentFieldName +
-                "' found inside aggregation: '" + aggregationName + "'.";
+    private static String getSearchParseExceptionMessage(XContentParser.Token token, String currentFieldName, String aggregationName) {
+        return "Unexpected token " + token + " found when parsing field: '" +  currentFieldName +
+                "' inside aggregation: '" + aggregationName + "'.";
     }
 
     private static class GeoDistanceFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {


### PR DESCRIPTION
issue-id - 12391
issue-url - https://github.com/elastic/elasticsearch/issues/12391
# Problem statement:

when sometimes the fields in the Geo distance aggregator query is misspelt., it
results in throwing out an error message. But is is highly crytic
# Approach:

The error messages at present in GeoDistanceParser which is responsible
for parsing the fields within an aggregator of type geo_distance has error message like this

``` java

throw new SearchParseException(context, "Unexpected token " + token + " in [" + aggregationName + "]."

```

in the above it relies on "token" variable which holds the Parser util's representation of what
1) close bracket is
2) open bracket is
3) array start bracket is
4) field is
5) field value is

and so on ....

as it is a variable that is used by the util for its own understanding, it is highly cryptic.
So it is not advicable to use this.
Instead directly point to "fieldname" whose parsing resulted in error (here it is in variable "currentFieldName")
and to aggregator name so that people can use it to find in which aggregator the field lies (in varible "aggregationName")

so remove token and use aggregationName and currentFieldName to narrow down on the location of error.
# Results:

new message

---

   Failed when parsing field with name 'orgin' found inside aggregation with name 'per_ring'. Few Possible Causes for the error:1)Misspelling the field name.  2)Giving a field name which is not recognized by Geo Distance Aggregator.3)Assigning the field to a value with unallowed object type.

old message

---

   Unexpected token START_OBJECT in [per_ring].
# Files Changed:

modified:   core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceParser.java

here made the error message more readable.
The same error message is applicable at a number of places so made it into a function.
# TODO for FUTURE :

The same type of problem exists in most of the parsers that we have in elasticsearch.
so make this fix common one to all and make the message to be constructed at one common place
