### PR TITLE
Log network configuration at debug level

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/IfConfig.java
+++ b/core/src/main/java/org/elasticsearch/common/network/IfConfig.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.network;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.List;
+import java.util.Locale;
+
+/** 
+ * Simple class to log {@code ifconfig}-style output at DEBUG logging.
+ */
+final class IfConfig {
+
+    private static final ESLogger logger = Loggers.getLogger(IfConfig.class);    
+    private static final String INDENT = "        ";
+    
+    /** log interface configuration at debug level, if its enabled */
+    static void logIfNecessary() {
+        if (logger.isDebugEnabled()) {
+            try {
+                doLogging();
+            } catch (IOException | SecurityException e) {
+                logger.warn("unable to gather network information", e);
+            }
+        }
+    }
+    
+    /** perform actual logging: might throw exception if things go wrong */
+    private static void doLogging() throws IOException {
+        StringBuilder msg = new StringBuilder();
+        for (NetworkInterface nic : NetworkUtils.getInterfaces()) {
+            msg.append(System.lineSeparator());
+
+            // ordinary name
+            msg.append(nic.getName());
+            msg.append(System.lineSeparator());
+            
+            // display name (e.g. on windows)
+            if (!nic.getName().equals(nic.getDisplayName())) {
+                msg.append(INDENT);
+                msg.append(nic.getDisplayName());
+                msg.append(System.lineSeparator());
+            }
+            
+            // addresses: v4 first, then v6
+            List<InterfaceAddress> addresses = nic.getInterfaceAddresses();
+            for (InterfaceAddress address : addresses) {
+                if (address.getAddress() instanceof Inet6Address == false) {
+                    msg.append(INDENT);
+                    msg.append(formatAddress(address));
+                    msg.append(System.lineSeparator());
+                }
+            }
+            
+            for (InterfaceAddress address : addresses) {
+                if (address.getAddress() instanceof Inet6Address) {
+                    msg.append(INDENT);
+                    msg.append(formatAddress(address));
+                    msg.append(System.lineSeparator());
+                }
+            }
+            
+            // hardware address
+            byte hardware[] = nic.getHardwareAddress();
+            if (hardware != null) {
+                msg.append(INDENT);
+                msg.append("hardware ");
+                for (int i = 0; i < hardware.length; i++) {
+                    if (i > 0) {
+                        msg.append(":");
+                    }
+                    msg.append(String.format(Locale.ROOT, "%02X", hardware[i]));
+                }
+                msg.append(System.lineSeparator());
+            }
+             
+            // attributes
+            msg.append(INDENT);
+            msg.append(formatFlags(nic));
+            msg.append(System.lineSeparator());
+        }
+        logger.debug("configuration:" + System.lineSeparator() + "{}", msg.toString());
+    }
+    
+    /** format internet address: java's default doesn't include everything useful */
+    private static String formatAddress(InterfaceAddress interfaceAddress) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        
+        InetAddress address = interfaceAddress.getAddress();
+        if (address instanceof Inet6Address) {
+            sb.append("inet6 ");
+            sb.append(address.toString().substring(1));
+            sb.append(" prefixlen:");
+            sb.append(interfaceAddress.getNetworkPrefixLength());
+        } else {
+            sb.append("inet ");
+            sb.append(address.toString().substring(1));
+            int netmask = 0xFFFFFFFF << (32 - interfaceAddress.getNetworkPrefixLength());
+            sb.append(" netmask:" + InetAddress.getByAddress(new byte[] {
+                    (byte)(netmask >>> 24), 
+                    (byte)(netmask >>> 16 & 0xFF), 
+                    (byte)(netmask >>> 8 & 0xFF), 
+                    (byte)(netmask & 0xFF) 
+            }).toString().substring(1));
+            InetAddress broadcast = interfaceAddress.getBroadcast();
+            if (broadcast != null) {
+                sb.append(" broadcast:" + broadcast.toString().substring(1));
+            }
+        }
+        if (address.isLoopbackAddress()) {
+            sb.append(" scope:host");
+        } else if (address.isLinkLocalAddress()) {
+            sb.append(" scope:link");
+        } else if (address.isSiteLocalAddress()) {
+            sb.append(" scope:site");
+        }
+        return sb.toString();
+    }
+    
+    /** format network interface flags */
+    private static String formatFlags(NetworkInterface nic) throws SocketException {
+        StringBuilder flags = new StringBuilder();
+        if (nic.isUp()) {
+            flags.append("UP ");
+        }
+        if (nic.supportsMulticast()) {
+            flags.append("MULTICAST ");
+        }
+        if (nic.isLoopback()) {
+            flags.append("LOOPBACK ");
+        }
+        if (nic.isPointToPoint()) {
+            flags.append("POINTOPOINT ");
+        }
+        if (nic.isVirtual()) {
+            flags.append("VIRTUAL ");
+        }
+        flags.append("mtu:" + nic.getMTU());
+        flags.append(" index:" + nic.getIndex());
+        return flags.toString();
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -82,6 +82,7 @@ public class NetworkService extends AbstractComponent {
     @Inject
     public NetworkService(Settings settings) {
         super(settings);
+        IfConfig.logIfNecessary();
         InetSocketTransportAddress.setResolveAddress(settings.getAsBoolean("network.address.serialization.resolve", false));
     }
 


### PR DESCRIPTION
In 2.0, a lot of users are probably going to have to deal with this to get stuff to work, since we only bind to loopback by default, they are going to have to configure interfaces, deal with addresses, and so on.

I hate loggers :) but if things go wrong, it would be good to have an easy way to debug what java sees on the system, similar to running `ifconfig -a`:

```
2015-08-19 00:25:40,933][DEBUG][org.elasticsearch.common.network] configuration:

lo
        Software Loopback Interface 1
        inet 127.0.0.1 netmask:255.0.0.0 broadcast:127.255.255.255 scope:host
        inet6 0:0:0:0:0:0:0:1 prefixlen:128 scope:host
        UP MULTICAST LOOPBACK mtu:-1 index:1

eth0
        Microsoft Kernel Debug Network Adapter
        MULTICAST mtu:-1 index:2

eth1
        Intel(R) PRO/1000 MT Desktop Adapter
        inet 10.0.2.15 netmask:255.255.255.0 broadcast:10.0.2.255 scope:site
        inet6 fe80:0:0:0:e5ff:af5:8ad0:d2d1%eth1 prefixlen:64 scope:link
        hardware 08:00:27:65:7C:DF
        UP MULTICAST mtu:1500 index:3

net0
        Microsoft ISATAP Adapter
        inet6 fe80:0:0:0:0:5efe:a00:20f%net0 prefixlen:128 scope:link
        hardware 00:00:00:00:00:00:00:E0
        POINTOPOINT mtu:1280 index:4

net1
        Teredo Tunneling Pseudo-Interface
        inet6 2001:0:5ef5:79fd:1048:33e8:b7ac:c1f9 prefixlen:0
        inet6 fe80:0:0:0:1048:33e8:b7ac:c1f9%net1 prefixlen:32 scope:link
        hardware 00:00:00:00:00:00:00:E0
        UP POINTOPOINT mtu:1280 index:5
...
```
