### PR TITLE
Propagate Headers and Context through to ScriptService

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/template/TransportRenderSearchTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/template/TransportRenderSearchTemplateAction.java
@@ -55,7 +55,7 @@ public class TransportRenderSearchTemplateAction extends HandledTransportAction<
 
             @Override
             protected void doRun() throws Exception {
-                ExecutableScript executable = scriptService.executable(request.template(), ScriptContext.Standard.SEARCH);
+                ExecutableScript executable = scriptService.executable(request.template(), ScriptContext.Standard.SEARCH, request);
                 BytesReference processedTemplate = (BytesReference) executable.run();
                 RenderSearchTemplateResponse response = new RenderSearchTemplateResponse();
                 response.source(processedTemplate);

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -146,7 +146,7 @@ public class TransportPercolateAction extends TransportBroadcastAction<Percolate
             PercolateResponse.Match[] matches = request.onlyCount() ? null : PercolateResponse.EMPTY;
             return new PercolateResponse(shardsResponses.length(), successfulShards, failedShards, shardFailures, tookInMillis, matches);
         } else {
-            PercolatorService.ReduceResult result = percolatorService.reduce(percolatorTypeId, shardResults);
+            PercolatorService.ReduceResult result = percolatorService.reduce(percolatorTypeId, shardResults, request);
             long tookInMillis =  Math.max(1, System.currentTimeMillis() - request.startTime);
             return new PercolateResponse(
                     shardsResponses.length(), successfulShards, failedShards, shardFailures,

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchCountAction.java
@@ -75,7 +75,8 @@ public class TransportSearchCountAction extends TransportSearchTypeAction {
         @Override
         protected void moveToSecondPhase() throws Exception {
             // no need to sort, since we know we have no hits back
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(SearchPhaseController.EMPTY_DOCS, firstResults, (AtomicArray<? extends FetchSearchResultProvider>) AtomicArray.empty());
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(SearchPhaseController.EMPTY_DOCS, firstResults,
+                    (AtomicArray<? extends FetchSearchResultProvider>) AtomicArray.empty(), request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryAndFetchAction.java
@@ -134,7 +134,8 @@ public class TransportSearchDfsQueryAndFetchAction extends TransportSearchTypeAc
                 @Override
                 public void doRun() throws IOException {
                     sortedShardList = searchPhaseController.sortDocs(true, queryFetchResults);
-                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults, queryFetchResults);
+                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults,
+                            queryFetchResults, request);
                     String scrollId = null;
                     if (request.scroll() != null) {
                         scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchDfsQueryThenFetchAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search.type;
 
 import com.carrotsearch.hppc.IntArrayList;
+
 import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
@@ -39,8 +40,8 @@ import org.elasticsearch.search.action.SearchServiceTransportAction;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.search.dfs.AggregatedDfs;
 import org.elasticsearch.search.dfs.DfsSearchResult;
-import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.fetch.FetchSearchResult;
+import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchRequest;
@@ -210,7 +211,8 @@ public class TransportSearchDfsQueryThenFetchAction extends TransportSearchTypeA
             threadPool.executor(ThreadPool.Names.SEARCH).execute(new ActionRunnable<SearchResponse>(listener) {
                 @Override
                 public void doRun() throws IOException {
-                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults);
+                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults,
+                            fetchResults, request);
                     String scrollId = null;
                     if (request.scroll() != null) {
                         scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryAndFetchAction.java
@@ -81,7 +81,8 @@ public class TransportSearchQueryAndFetchAction extends TransportSearchTypeActio
                 public void doRun() throws IOException {
                     boolean useScroll = request.scroll() != null;
                     sortedShardList = searchPhaseController.sortDocs(useScroll, firstResults);
-                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults, firstResults);
+                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults,
+                            firstResults, request);
                     String scrollId = null;
                     if (request.scroll() != null) {
                         scrollId = buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchQueryThenFetchAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search.type;
 
 import com.carrotsearch.hppc.IntArrayList;
+
 import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
@@ -145,7 +146,8 @@ public class TransportSearchQueryThenFetchAction extends TransportSearchTypeActi
             threadPool.executor(ThreadPool.Names.SEARCH).execute(new ActionRunnable<SearchResponse>(listener) {
                 @Override
                 public void doRun() throws IOException {
-                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults, fetchResults);
+                    final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, firstResults,
+                            fetchResults, request);
                     String scrollId = null;
                     if (request.scroll() != null) {
                         scrollId = TransportSearchHelper.buildScrollId(request.searchType(), firstResults, null);

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScanAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search.type;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -73,7 +74,8 @@ public class TransportSearchScanAction extends TransportSearchTypeAction {
 
         @Override
         protected void moveToSecondPhase() throws Exception {
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(SearchPhaseController.EMPTY_DOCS, firstResults, (AtomicArray<? extends FetchSearchResultProvider>) AtomicArray.empty());
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(SearchPhaseController.EMPTY_DOCS, firstResults,
+                    (AtomicArray<? extends FetchSearchResultProvider>) AtomicArray.empty(), request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = buildScrollId(request.searchType(), firstResults, ImmutableMap.of("total_hits", Long.toString(internalResponse.hits().totalHits())));

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryAndFetchAction.java
@@ -21,7 +21,11 @@ package org.elasticsearch.action.search.type;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.search.*;
+import org.elasticsearch.action.search.ReduceSearchPhaseException;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -188,7 +192,8 @@ public class TransportSearchScrollQueryAndFetchAction extends AbstractComponent 
 
         private void innerFinishHim() throws Exception {
             ScoreDoc[] sortedShardList = searchPhaseController.sortDocs(true, queryFetchResults);
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults, queryFetchResults);
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryFetchResults,
+                    queryFetchResults, request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = request.scrollId();

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryThenFetchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollQueryThenFetchAction.java
@@ -20,9 +20,14 @@
 package org.elasticsearch.action.search.type;
 
 import com.carrotsearch.hppc.IntArrayList;
+
 import org.apache.lucene.search.ScoreDoc;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.search.*;
+import org.elasticsearch.action.search.ReduceSearchPhaseException;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -239,7 +244,7 @@ public class TransportSearchScrollQueryThenFetchAction extends AbstractComponent
         }
 
         private void innerFinishHim() {
-            InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults);
+            InternalSearchResponse internalResponse = searchPhaseController.merge(sortedShardList, queryResults, fetchResults, request);
             String scrollId = null;
             if (request.scroll() != null) {
                 scrollId = request.scrollId();

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollScanAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchScrollScanAction.java
@@ -212,7 +212,8 @@ public class TransportSearchScrollScanAction extends AbstractComponent {
                     docs.add(scoreDoc);
                 }
             }
-            final InternalSearchResponse internalResponse = searchPhaseController.merge(docs.toArray(new ScoreDoc[0]), queryFetchResults, queryFetchResults);
+            final InternalSearchResponse internalResponse = searchPhaseController.merge(docs.toArray(new ScoreDoc[0]), queryFetchResults,
+                    queryFetchResults, request);
             ((InternalSearchHits) internalResponse.hits()).totalHits = Long.parseLong(this.scrollId.getAttributes().get("total_hits"));
 
 

--- a/core/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/core/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -143,7 +143,7 @@ public class TransportSuggestAction extends TransportBroadcastAction<SuggestRequ
                     throw new IllegalArgumentException("suggest content missing");
                 }
                 final SuggestionSearchContext context = suggestPhase.parseElement().parseInternal(parser, indexService.mapperService(),
-                        indexService.queryParserService(), request.shardId().getIndex(), request.shardId().id());
+                        indexService.queryParserService(), request.shardId().getIndex(), request.shardId().id(), request);
                 final Suggest result = suggestPhase.execute(context, searcher.searcher());
                 return new ShardSuggestResponse(request.shardId(), result);
             }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -246,7 +246,7 @@ public class UpdateHelper extends AbstractComponent {
     private Map<String, Object> executeScript(UpdateRequest request, Map<String, Object> ctx) {
         try {
             if (scriptService != null) {
-                ExecutableScript script = scriptService.executable(request.script, ScriptContext.Standard.UPDATE);
+                ExecutableScript script = scriptService.executable(request.script, ScriptContext.Standard.UPDATE, request);
                 script.setNextVar("ctx", ctx);
                 script.run();
                 // we need to unwrap the ctx...

--- a/core/src/main/java/org/elasticsearch/common/DelegatingHasContextAndHeaders.java
+++ b/core/src/main/java/org/elasticsearch/common/DelegatingHasContextAndHeaders.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common;
+
+import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
+
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+
+import java.util.Set;
+
+public class DelegatingHasContextAndHeaders implements HasContextAndHeaders {
+
+    private HasContextAndHeaders delegate;
+
+    public DelegatingHasContextAndHeaders(HasContextAndHeaders delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public <V> void putHeader(String key, V value) {
+        delegate.putHeader(key, value);
+    }
+
+    @Override
+    public void copyContextAndHeadersFrom(HasContextAndHeaders other) {
+        delegate.copyContextAndHeadersFrom(other);
+    }
+
+    @Override
+    public <V> V getHeader(String key) {
+        return delegate.getHeader(key);
+    }
+
+    @Override
+    public boolean hasHeader(String key) {
+        return delegate.hasHeader(key);
+    }
+
+    @Override
+    public <V> V putInContext(Object key, Object value) {
+        return delegate.putInContext(key, value);
+    }
+
+    @Override
+    public Set<String> getHeaders() {
+        return delegate.getHeaders();
+    }
+
+    @Override
+    public void copyHeadersFrom(HasHeaders from) {
+        delegate.copyHeadersFrom(from);
+    }
+
+    @Override
+    public void putAllInContext(ObjectObjectAssociativeContainer<Object, Object> map) {
+        delegate.putAllInContext(map);
+    }
+
+    @Override
+    public <V> V getFromContext(Object key) {
+        return delegate.getFromContext(key);
+    }
+
+    @Override
+    public <V> V getFromContext(Object key, V defaultValue) {
+        return delegate.getFromContext(key, defaultValue);
+    }
+
+    @Override
+    public boolean hasInContext(Object key) {
+        return delegate.hasInContext(key);
+    }
+
+    @Override
+    public int contextSize() {
+        return delegate.contextSize();
+    }
+
+    @Override
+    public boolean isContextEmpty() {
+        return delegate.isContextEmpty();
+    }
+
+    @Override
+    public ImmutableOpenMap<Object, Object> getContext() {
+        return delegate.getContext();
+    }
+
+    @Override
+    public void copyContextFrom(HasContext other) {
+        delegate.copyContextFrom(other);
+    }
+
+
+}

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -23,6 +23,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -199,7 +200,7 @@ public class DocumentMapper implements ToXContent {
         List<FieldMapper> newFieldMappers = new ArrayList<>();
         for (MetadataFieldMapper metadataMapper : this.mapping.metadataMappers) {
             if (metadataMapper instanceof FieldMapper) {
-                newFieldMappers.add((FieldMapper) metadataMapper);
+                newFieldMappers.add(metadataMapper);
             }
         }
         MapperUtils.collect(this.mapping.root, newObjectMappers, newFieldMappers);
@@ -452,7 +453,7 @@ public class DocumentMapper implements ToXContent {
         public Map<String, Object> transformSourceAsMap(Map<String, Object> sourceAsMap) {
             try {
                 // We use the ctx variable and the _source name to be consistent with the update api.
-                ExecutableScript executable = scriptService.executable(script, ScriptContext.Standard.MAPPING);
+                ExecutableScript executable = scriptService.executable(script, ScriptContext.Standard.MAPPING, null);
                 Map<String, Object> ctx = new HashMap<>(1);
                 ctx.put("_source", sourceAsMap);
                 executable.setNextVar("ctx", ctx);

--- a/core/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TemplateQueryParser.java
@@ -29,6 +29,7 @@ import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.Template;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class TemplateQueryParser implements QueryParser {
      * Parses the template query replacing template parameters with provided
      * values. Handles both submitting the template as part of the request as
      * well as referencing only the template name.
-     * 
+     *
      * @param parseContext
      *            parse context containing the templated query.
      */
@@ -77,7 +78,7 @@ public class TemplateQueryParser implements QueryParser {
     public Query parse(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
         Template template = parse(parser, parseContext.parseFieldMatcher());
-        ExecutableScript executable = this.scriptService.executable(template, ScriptContext.Standard.SEARCH);
+        ExecutableScript executable = this.scriptService.executable(template, ScriptContext.Standard.SEARCH, SearchContext.current());
 
         BytesReference querySource = (BytesReference) executable.run();
 

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -32,7 +32,10 @@ import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.percolate.PercolateShardRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.*;
+import org.elasticsearch.common.HasContext;
+import org.elasticsearch.common.HasContextAndHeaders;
+import org.elasticsearch.common.HasHeaders;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.text.StringText;
@@ -75,7 +78,11 @@ import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -121,7 +128,7 @@ public class PercolateContext extends SearchContext {
     public PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, IndexShard indexShard,
                             IndexService indexService, PageCacheRecycler pageCacheRecycler,
                             BigArrays bigArrays, ScriptService scriptService, Query aliasFilter, ParseFieldMatcher parseFieldMatcher) {
-        super(parseFieldMatcher);
+        super(parseFieldMatcher, request);
         this.indexShard = indexShard;
         this.indexService = indexService;
         this.fieldDataService = indexService.fieldData();

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.percolator;
 
 import com.carrotsearch.hppc.IntObjectHashMap;
+
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.index.memory.ExtendedMemoryIndex;
@@ -40,6 +41,7 @@ import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -63,9 +65,11 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.DocumentMapperForType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
@@ -73,7 +77,10 @@ import org.elasticsearch.index.percolator.stats.ShardPercolateService;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.percolator.QueryCollector.*;
+import org.elasticsearch.percolator.QueryCollector.Count;
+import org.elasticsearch.percolator.QueryCollector.Match;
+import org.elasticsearch.percolator.QueryCollector.MatchAndScore;
+import org.elasticsearch.percolator.QueryCollector.MatchAndSort;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.SearchShardTarget;
@@ -95,7 +102,9 @@ import java.util.Map;
 
 import static org.elasticsearch.common.util.CollectionUtils.eagerTransform;
 import static org.elasticsearch.index.mapper.SourceToParse.source;
-import static org.elasticsearch.percolator.QueryCollector.*;
+import static org.elasticsearch.percolator.QueryCollector.count;
+import static org.elasticsearch.percolator.QueryCollector.match;
+import static org.elasticsearch.percolator.QueryCollector.matchAndScore;
 
 public class PercolatorService extends AbstractComponent {
 
@@ -162,9 +171,9 @@ public class PercolatorService extends AbstractComponent {
     }
 
 
-    public ReduceResult reduce(byte percolatorTypeId, List<PercolateShardResponse> shardResults) {
+    public ReduceResult reduce(byte percolatorTypeId, List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext) {
         PercolatorType percolatorType = percolatorTypes.get(percolatorTypeId);
-        return percolatorType.reduce(shardResults);
+        return percolatorType.reduce(shardResults, headersContext);
     }
 
     public PercolateShardResponse percolate(PercolateShardRequest request) {
@@ -423,7 +432,7 @@ public class PercolatorService extends AbstractComponent {
         // 0x00 is reserved for empty type.
         byte id();
 
-        ReduceResult reduce(List<PercolateShardResponse> shardResults);
+        ReduceResult reduce(List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext);
 
         PercolateShardResponse doPercolate(PercolateShardRequest request, PercolateContext context, boolean isNested);
 
@@ -437,14 +446,14 @@ public class PercolatorService extends AbstractComponent {
         }
 
         @Override
-        public ReduceResult reduce(List<PercolateShardResponse> shardResults) {
+        public ReduceResult reduce(List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext) {
             long finalCount = 0;
             for (PercolateShardResponse shardResponse : shardResults) {
                 finalCount += shardResponse.count();
             }
 
             assert !shardResults.isEmpty();
-            InternalAggregations reducedAggregations = reduceAggregations(shardResults);
+            InternalAggregations reducedAggregations = reduceAggregations(shardResults, headersContext);
             return new ReduceResult(finalCount, reducedAggregations);
         }
 
@@ -481,8 +490,8 @@ public class PercolatorService extends AbstractComponent {
         }
 
         @Override
-        public ReduceResult reduce(List<PercolateShardResponse> shardResults) {
-            return countPercolator.reduce(shardResults);
+        public ReduceResult reduce(List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext) {
+            return countPercolator.reduce(shardResults, headersContext);
         }
 
         @Override
@@ -511,7 +520,7 @@ public class PercolatorService extends AbstractComponent {
         }
 
         @Override
-        public ReduceResult reduce(List<PercolateShardResponse> shardResults) {
+        public ReduceResult reduce(List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext) {
             long foundMatches = 0;
             int numMatches = 0;
             for (PercolateShardResponse response : shardResults) {
@@ -537,7 +546,7 @@ public class PercolatorService extends AbstractComponent {
             }
 
             assert !shardResults.isEmpty();
-            InternalAggregations reducedAggregations = reduceAggregations(shardResults);
+            InternalAggregations reducedAggregations = reduceAggregations(shardResults, headersContext);
             return new ReduceResult(foundMatches, finalMatches.toArray(new PercolateResponse.Match[finalMatches.size()]), reducedAggregations);
         }
 
@@ -589,8 +598,8 @@ public class PercolatorService extends AbstractComponent {
         }
 
         @Override
-        public ReduceResult reduce(List<PercolateShardResponse> shardResults) {
-            return matchPercolator.reduce(shardResults);
+        public ReduceResult reduce(List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext) {
+            return matchPercolator.reduce(shardResults, headersContext);
         }
 
         @Override
@@ -622,8 +631,8 @@ public class PercolatorService extends AbstractComponent {
         }
 
         @Override
-        public ReduceResult reduce(List<PercolateShardResponse> shardResults) {
-            return matchPercolator.reduce(shardResults);
+        public ReduceResult reduce(List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext) {
+            return matchPercolator.reduce(shardResults, headersContext);
         }
 
         @Override
@@ -656,7 +665,7 @@ public class PercolatorService extends AbstractComponent {
         }
 
         @Override
-        public ReduceResult reduce(List<PercolateShardResponse> shardResults) {
+        public ReduceResult reduce(List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext) {
             long foundMatches = 0;
             int nonEmptyResponses = 0;
             int firstNonEmptyIndex = 0;
@@ -735,7 +744,7 @@ public class PercolatorService extends AbstractComponent {
             }
 
             assert !shardResults.isEmpty();
-            InternalAggregations reducedAggregations = reduceAggregations(shardResults);
+            InternalAggregations reducedAggregations = reduceAggregations(shardResults, headersContext);
             return new ReduceResult(foundMatches, finalMatches.toArray(new PercolateResponse.Match[finalMatches.size()]), reducedAggregations);
         }
 
@@ -843,7 +852,7 @@ public class PercolatorService extends AbstractComponent {
         }
     }
 
-    private InternalAggregations reduceAggregations(List<PercolateShardResponse> shardResults) {
+    private InternalAggregations reduceAggregations(List<PercolateShardResponse> shardResults, HasContextAndHeaders headersContext) {
         if (shardResults.get(0).aggregations() == null) {
             return null;
         }
@@ -852,14 +861,15 @@ public class PercolatorService extends AbstractComponent {
         for (PercolateShardResponse shardResult : shardResults) {
             aggregationsList.add(shardResult.aggregations());
         }
-        InternalAggregations aggregations = InternalAggregations.reduce(aggregationsList, new ReduceContext(bigArrays, scriptService));
+        InternalAggregations aggregations = InternalAggregations.reduce(aggregationsList, new ReduceContext(bigArrays, scriptService,
+                headersContext));
         if (aggregations != null) {
             List<SiblingPipelineAggregator> pipelineAggregators = shardResults.get(0).pipelineAggregators();
             if (pipelineAggregators != null) {
                 List<InternalAggregation> newAggs = new ArrayList<>(eagerTransform(aggregations.asList(), PipelineAggregator.AGGREGATION_TRANFORM_FUNCTION));
                 for (SiblingPipelineAggregator pipelineAggregator : pipelineAggregators) {
-                    InternalAggregation newAgg = pipelineAggregator.doReduce(new InternalAggregations(newAggs), new ReduceContext(bigArrays,
-                            scriptService));
+                    InternalAggregation newAgg = pipelineAggregator.doReduce(new InternalAggregations(newAggs), new ReduceContext(
+                            bigArrays, scriptService, headersContext));
                     newAggs.add(newAgg);
                 }
                 aggregations = new InternalAggregations(newAggs);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.search.aggregations;
 
+import org.elasticsearch.common.DelegatingHasContextAndHeaders;
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -90,12 +92,13 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, St
         }
     }
 
-    public static class ReduceContext {
+    public static class ReduceContext extends DelegatingHasContextAndHeaders {
 
         private final BigArrays bigArrays;
         private ScriptService scriptService;
 
-        public ReduceContext(BigArrays bigArrays, ScriptService scriptService) {
+        public ReduceContext(BigArrays bigArrays, ScriptService scriptService, HasContextAndHeaders headersContext) {
+            super(headersContext);
             this.bigArrays = bigArrays;
             this.scriptService = scriptService;
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
@@ -60,11 +60,11 @@ public class SignificantTermsParametersParser extends AbstractTermsParametersPar
 
     @Override
     public void parseSpecial(String aggregationName, XContentParser parser, SearchContext context, XContentParser.Token token, String currentFieldName) throws IOException {
-        
+
         if (token == XContentParser.Token.START_OBJECT) {
             SignificanceHeuristicParser significanceHeuristicParser = significanceHeuristicParserMapper.get(currentFieldName);
             if (significanceHeuristicParser != null) {
-                significanceHeuristic = significanceHeuristicParser.parse(parser, context.parseFieldMatcher());
+                significanceHeuristic = significanceHeuristicParser.parse(parser, context.parseFieldMatcher(), context);
             } else if (context.parseFieldMatcher().match(currentFieldName, BACKGROUND_FILTER)) {
                 filter = context.queryParserService().parseInnerFilter(parser).query();
             } else {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/GND.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/GND.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 
@@ -115,7 +116,8 @@ public class GND extends NXYSignificanceHeuristic {
         }
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher, SearchContext context)
+                throws IOException, QueryParsingException {
             String givenName = parser.currentName();
             boolean backgroundIsSuperset = true;
             XContentParser.Token token = parser.nextToken();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/JLHScore.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/JLHScore.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 
@@ -108,7 +109,8 @@ public class JLHScore extends SignificanceHeuristic {
     public static class JLHScoreParser implements SignificanceHeuristicParser {
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher, SearchContext context)
+                throws IOException, QueryParsingException {
             // move to the closing bracket
             if (!parser.nextToken().equals(XContentParser.Token.END_OBJECT)) {
                 throw new ElasticsearchParseException("failed to parse [jhl] significance heuristic. expected an empty object, but found [{}] instead", parser.currentToken());

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/NXYSignificanceHeuristic.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/NXYSignificanceHeuristic.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 
@@ -138,7 +139,8 @@ public abstract class NXYSignificanceHeuristic extends SignificanceHeuristic {
     public static abstract class NXYParser implements SignificanceHeuristicParser {
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher, SearchContext context)
+                throws IOException, QueryParsingException {
             String givenName = parser.currentName();
             boolean includeNegatives = false;
             boolean backgroundIsSuperset = true;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/PercentageScore.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/PercentageScore.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 
@@ -57,7 +58,7 @@ public class PercentageScore extends SignificanceHeuristic {
 
     /**
      * Indicates the significance of a term in a sample by determining what percentage
-     * of all occurrences of a term are found in the sample. 
+     * of all occurrences of a term are found in the sample.
      */
     @Override
     public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
@@ -65,7 +66,7 @@ public class PercentageScore extends SignificanceHeuristic {
         if (supersetFreq == 0) {
             // avoid a divide by zero issue
             return 0;
-        }        
+        }
         return (double) subsetFreq / (double) supersetFreq;
    }
 
@@ -77,7 +78,8 @@ public class PercentageScore extends SignificanceHeuristic {
     public static class PercentageScoreParser implements SignificanceHeuristicParser {
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher, SearchContext context)
+                throws IOException, QueryParsingException {
             // move to the closing bracket
             if (!parser.nextToken().equals(XContentParser.Token.END_OBJECT)) {
                 throw new ElasticsearchParseException("failed to parse [percentage] significance heuristic. expected an empty object, but got [{}] instead", parser.currentToken());

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -24,17 +24,21 @@ package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParsingException;
-import org.elasticsearch.script.*;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.script.Script.ScriptField;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptParameterParser;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Map;
@@ -81,8 +85,9 @@ public class ScriptHeuristic extends SignificanceHeuristic {
 
     }
 
+    @Override
     public void initialize(InternalAggregation.ReduceContext context) {
-        searchScript = context.scriptService().executable(script, ScriptContext.Standard.AGGS);
+        searchScript = context.scriptService().executable(script, ScriptContext.Standard.AGGS, context);
         searchScript.setNextVar("_subset_freq", subsetDfHolder);
         searchScript.setNextVar("_subset_size", subsetSizeHolder);
         searchScript.setNextVar("_superset_freq", supersetDfHolder);
@@ -129,7 +134,8 @@ public class ScriptHeuristic extends SignificanceHeuristic {
         }
 
         @Override
-        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException {
+        public SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher, SearchContext context)
+                throws IOException, QueryParsingException {
             String heuristicName = parser.currentName();
             Script script = null;
             XContentParser.Token token;
@@ -169,7 +175,7 @@ public class ScriptHeuristic extends SignificanceHeuristic {
             }
             ExecutableScript searchScript;
             try {
-                searchScript = scriptService.executable(script, ScriptContext.Standard.AGGS);
+                searchScript = scriptService.executable(script, ScriptContext.Standard.AGGS, context);
             } catch (Exception e) {
                 throw new ElasticsearchParseException("failed to parse [{}] significance heuristic. the script [{}] could not be loaded", e, script, heuristicName);
             }
@@ -204,21 +210,23 @@ public class ScriptHeuristic extends SignificanceHeuristic {
 
     public final class LongAccessor extends Number {
         public long value;
+        @Override
         public int intValue() {
             return (int)value;
         }
+        @Override
         public long longValue() {
             return value;
         }
 
         @Override
         public float floatValue() {
-            return (float)value;
+            return value;
         }
 
         @Override
         public double doubleValue() {
-            return (double)value;
+            return value;
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificanceHeuristicParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/SignificanceHeuristicParser.java
@@ -23,12 +23,14 @@ package org.elasticsearch.search.aggregations.bucket.significant.heuristics;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 
 public interface SignificanceHeuristicParser {
 
-    SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher) throws IOException, QueryParsingException;
+    SignificanceHeuristic parse(XContentParser parser, ParseFieldMatcher parseFieldMatcher, SearchContext context) throws IOException,
+            QueryParsingException;
 
     String[] getNames();
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
@@ -91,7 +91,7 @@ public class InternalScriptedMetric extends InternalMetricsAggregation implement
                 vars.putAll(firstAggregation.reduceScript.getParams());
             }
             CompiledScript compiledScript = reduceContext.scriptService().compile(firstAggregation.reduceScript,
-                    ScriptContext.Standard.AGGS);
+                    ScriptContext.Standard.AGGS, reduceContext);
             ExecutableScript script = reduceContext.scriptService().executable(compiledScript, vars);
             aggregation = script.run();
         } else {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -58,11 +58,11 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
         this.params = params;
         ScriptService scriptService = context.searchContext().scriptService();
         if (initScript != null) {
-            scriptService.executable(initScript, ScriptContext.Standard.AGGS).run();
+            scriptService.executable(initScript, ScriptContext.Standard.AGGS, context.searchContext()).run();
         }
         this.mapScript = scriptService.search(context.searchContext().lookup(), mapScript, ScriptContext.Standard.AGGS);
         if (combineScript != null) {
-            this.combineScript = scriptService.executable(combineScript, ScriptContext.Standard.AGGS);
+            this.combineScript = scriptService.executable(combineScript, ScriptContext.Standard.AGGS, context.searchContext());
         } else {
             this.combineScript = null;
         }
@@ -159,7 +159,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
                 return null;
             }
         }
-        
+
         @SuppressWarnings({ "unchecked" })
         private static <T> T deepCopyParams(T original, SearchContext context) {
             T clone;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketscript/BucketScriptPipelineAggregator.java
@@ -104,7 +104,7 @@ public class BucketScriptPipelineAggregator extends PipelineAggregator {
         InternalMultiBucketAggregation<InternalMultiBucketAggregation, InternalMultiBucketAggregation.InternalBucket> originalAgg = (InternalMultiBucketAggregation<InternalMultiBucketAggregation, InternalMultiBucketAggregation.InternalBucket>) aggregation;
         List<? extends Bucket> buckets = originalAgg.getBuckets();
 
-        CompiledScript compiledScript = reduceContext.scriptService().compile(script, ScriptContext.Standard.AGGS);
+        CompiledScript compiledScript = reduceContext.scriptService().compile(script, ScriptContext.Standard.AGGS, reduceContext);
         List newBuckets = new ArrayList<>();
         for (Bucket bucket : buckets) {
             Map<String, Object> vars = new HashMap<>();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/having/BucketSelectorPipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/having/BucketSelectorPipelineAggregator.java
@@ -98,7 +98,7 @@ public class BucketSelectorPipelineAggregator extends PipelineAggregator {
         InternalMultiBucketAggregation<InternalMultiBucketAggregation, InternalMultiBucketAggregation.InternalBucket> originalAgg = (InternalMultiBucketAggregation<InternalMultiBucketAggregation, InternalMultiBucketAggregation.InternalBucket>) aggregation;
         List<? extends Bucket> buckets = originalAgg.getBuckets();
 
-        CompiledScript compiledScript = reduceContext.scriptService().compile(script, ScriptContext.Standard.AGGS);
+        CompiledScript compiledScript = reduceContext.scriptService().compile(script, ScriptContext.Standard.AGGS, reduceContext);
         List newBuckets = new ArrayList<>();
         for (Bucket bucket : buckets) {
             Map<String, Object> vars = new HashMap<>();

--- a/core/src/main/java/org/elasticsearch/search/controller/SearchPhaseController.java
+++ b/core/src/main/java/org/elasticsearch/search/controller/SearchPhaseController.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.TermStatistics;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.collect.HppcMaps;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -296,7 +297,8 @@ public class SearchPhaseController extends AbstractComponent {
         }
     }
 
-    public InternalSearchResponse merge(ScoreDoc[] sortedDocs, AtomicArray<? extends QuerySearchResultProvider> queryResultsArr, AtomicArray<? extends FetchSearchResultProvider> fetchResultsArr) {
+    public InternalSearchResponse merge(ScoreDoc[] sortedDocs, AtomicArray<? extends QuerySearchResultProvider> queryResultsArr,
+            AtomicArray<? extends FetchSearchResultProvider> fetchResultsArr, HasContextAndHeaders headersContext) {
 
         List<? extends AtomicArray.Entry<? extends QuerySearchResultProvider>> queryResults = queryResultsArr.asList();
         List<? extends AtomicArray.Entry<? extends FetchSearchResultProvider>> fetchResults = fetchResultsArr.asList();
@@ -404,7 +406,7 @@ public class SearchPhaseController extends AbstractComponent {
                 for (AtomicArray.Entry<? extends QuerySearchResultProvider> entry : queryResults) {
                     aggregationsList.add((InternalAggregations) entry.value.queryResult().aggregations());
                 }
-                aggregations = InternalAggregations.reduce(aggregationsList, new ReduceContext(bigArrays, scriptService));
+                aggregations = InternalAggregations.reduce(aggregationsList, new ReduceContext(bigArrays, scriptService, headersContext));
             }
         }
 
@@ -413,8 +415,8 @@ public class SearchPhaseController extends AbstractComponent {
             if (pipelineAggregators != null) {
                 List<InternalAggregation> newAggs = new ArrayList<>(eagerTransform(aggregations.asList(), PipelineAggregator.AGGREGATION_TRANFORM_FUNCTION));
                 for (SiblingPipelineAggregator pipelineAggregator : pipelineAggregators) {
-                    InternalAggregation newAgg = pipelineAggregator.doReduce(new InternalAggregations(newAggs), new ReduceContext(bigArrays,
-                            scriptService));
+                    InternalAggregation newAgg = pipelineAggregator.doReduce(new InternalAggregations(newAggs), new ReduceContext(
+                            bigArrays, scriptService, headersContext));
                     newAggs.add(newAgg);
                 }
                 aggregations = new InternalAggregations(newAggs);

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.internal;
 
-import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
@@ -30,12 +29,8 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.HasContext;
-import org.elasticsearch.common.HasContextAndHeaders;
-import org.elasticsearch.common.HasHeaders;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.lucene.search.function.BoostScoreFunction;
@@ -78,7 +73,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  *
@@ -146,7 +140,7 @@ public class DefaultSearchContext extends SearchContext {
                                 BigArrays bigArrays, Counter timeEstimateCounter, ParseFieldMatcher parseFieldMatcher,
                                 TimeValue timeout
     ) {
-        super(parseFieldMatcher);
+        super(parseFieldMatcher, request);
         this.id = id;
         this.request = request;
         this.searchType = request.searchType();
@@ -722,81 +716,6 @@ public class DefaultSearchContext extends SearchContext {
     @Override
     public InnerHitsContext innerHits() {
         return innerHitsContext;
-    }
-
-    @Override
-    public <V> V putInContext(Object key, Object value) {
-        return request.putInContext(key, value);
-    }
-
-    @Override
-    public void putAllInContext(ObjectObjectAssociativeContainer<Object, Object> map) {
-        request.putAllInContext(map);
-    }
-
-    @Override
-    public <V> V getFromContext(Object key) {
-        return request.getFromContext(key);
-    }
-
-    @Override
-    public <V> V getFromContext(Object key, V defaultValue) {
-        return request.getFromContext(key, defaultValue);
-    }
-
-    @Override
-    public boolean hasInContext(Object key) {
-        return request.hasInContext(key);
-    }
-
-    @Override
-    public int contextSize() {
-        return request.contextSize();
-    }
-
-    @Override
-    public boolean isContextEmpty() {
-        return request.isContextEmpty();
-    }
-
-    @Override
-    public ImmutableOpenMap<Object, Object> getContext() {
-        return request.getContext();
-    }
-
-    @Override
-    public void copyContextFrom(HasContext other) {
-        request.copyContextFrom(other);
-    }
-
-    @Override
-    public <V> void putHeader(String key, V value) {
-        request.putHeader(key, value);
-    }
-
-    @Override
-    public <V> V getHeader(String key) {
-        return request.getHeader(key);
-    }
-
-    @Override
-    public boolean hasHeader(String key) {
-        return request.hasHeader(key);
-    }
-
-    @Override
-    public Set<String> getHeaders() {
-        return request.getHeaders();
-    }
-
-    @Override
-    public void copyHeadersFrom(HasHeaders from) {
-        request.copyHeadersFrom(from);
-    }
-
-    @Override
-    public void copyContextAndHeadersFrom(HasContextAndHeaders other) {
-        request.copyContextAndHeadersFrom(other);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -19,16 +19,13 @@
 
 package org.elasticsearch.search.internal;
 
-import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
-
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
-import org.elasticsearch.common.*;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
@@ -59,7 +56,6 @@ import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public abstract class FilteredSearchContext extends SearchContext {
 
@@ -67,7 +63,7 @@ public abstract class FilteredSearchContext extends SearchContext {
 
     public FilteredSearchContext(SearchContext in) {
         //inner_hits in percolator ends up with null inner search context
-        super(in == null ? ParseFieldMatcher.EMPTY : in.parseFieldMatcher());
+        super(in == null ? ParseFieldMatcher.EMPTY : in.parseFieldMatcher(), in);
         this.in = in;
     }
 
@@ -524,81 +520,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public Counter timeEstimateCounter() {
         return in.timeEstimateCounter();
-    }
-
-    @Override
-    public <V> V putInContext(Object key, Object value) {
-        return in.putInContext(key, value);
-    }
-
-    @Override
-    public void putAllInContext(ObjectObjectAssociativeContainer<Object, Object> map) {
-        in.putAllInContext(map);
-    }
-
-    @Override
-    public <V> V getFromContext(Object key) {
-        return in.getFromContext(key);
-    }
-
-    @Override
-    public <V> V getFromContext(Object key, V defaultValue) {
-        return in.getFromContext(key, defaultValue);
-    }
-
-    @Override
-    public boolean hasInContext(Object key) {
-        return in.hasInContext(key);
-    }
-
-    @Override
-    public int contextSize() {
-        return in.contextSize();
-    }
-
-    @Override
-    public boolean isContextEmpty() {
-        return in.isContextEmpty();
-    }
-
-    @Override
-    public ImmutableOpenMap<Object, Object> getContext() {
-        return in.getContext();
-    }
-
-    @Override
-    public void copyContextFrom(HasContext other) {
-        in.copyContextFrom(other);
-    }
-
-    @Override
-    public <V> void putHeader(String key, V value) {
-        in.putHeader(key, value);
-    }
-
-    @Override
-    public <V> V getHeader(String key) {
-        return in.getHeader(key);
-    }
-
-    @Override
-    public boolean hasHeader(String key) {
-        return in.hasHeader(key);
-    }
-
-    @Override
-    public Set<String> getHeaders() {
-        return in.getHeaders();
-    }
-
-    @Override
-    public void copyHeadersFrom(HasHeaders from) {
-        in.copyHeadersFrom(from);
-    }
-
-    @Override
-    public void copyContextAndHeadersFrom(HasContextAndHeaders other) {
-        in.copyContextAndHeadersFrom(other);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -21,12 +21,14 @@ package org.elasticsearch.search.internal;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.DelegatingHasContextAndHeaders;
 import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseFieldMatcher;
@@ -67,7 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public abstract class SearchContext implements Releasable, HasContextAndHeaders {
+public abstract class SearchContext extends DelegatingHasContextAndHeaders implements Releasable {
 
     private static ThreadLocal<SearchContext> current = new ThreadLocal<>();
     public final static int DEFAULT_TERMINATE_AFTER = 0;
@@ -91,7 +93,8 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     protected final ParseFieldMatcher parseFieldMatcher;
 
-    protected SearchContext(ParseFieldMatcher parseFieldMatcher) {
+    protected SearchContext(ParseFieldMatcher parseFieldMatcher, HasContextAndHeaders contextHeaders) {
+        super(contextHeaders);
         this.parseFieldMatcher = parseFieldMatcher;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestContextParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestContextParser.java
@@ -18,13 +18,15 @@
  */
 package org.elasticsearch.search.suggest;
 
-import java.io.IOException;
-
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 
+import java.io.IOException;
+
 public interface SuggestContextParser {
-    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException;
+    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService,
+            IndexQueryParserService queryParserService, HasContextAndHeaders headersContext) throws IOException;
 
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestParseElement.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.suggest;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
@@ -45,11 +46,13 @@ public final class SuggestParseElement implements SearchParseElement {
 
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
-        SuggestionSearchContext suggestionSearchContext = parseInternal(parser, context.mapperService(), context.queryParserService(), context.shardTarget().index(), context.shardTarget().shardId());
+        SuggestionSearchContext suggestionSearchContext = parseInternal(parser, context.mapperService(), context.queryParserService(),
+                context.shardTarget().index(), context.shardTarget().shardId(), context);
         context.suggest(suggestionSearchContext);
     }
 
-    public SuggestionSearchContext parseInternal(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService, String index, int shardId) throws IOException {
+    public SuggestionSearchContext parseInternal(XContentParser parser, MapperService mapperService,
+            IndexQueryParserService queryParserService, String index, int shardId, HasContextAndHeaders headersContext) throws IOException {
         SuggestionSearchContext suggestionSearchContext = new SuggestionSearchContext();
 
         BytesRef globalText = null;
@@ -88,7 +91,7 @@ public final class SuggestParseElement implements SearchParseElement {
                             throw new IllegalArgumentException("Suggester[" + fieldName + "] not supported");
                         }
                         final SuggestContextParser contextParser = suggesters.get(fieldName).getContextParser();
-                        suggestionContext = contextParser.parse(parser, mapperService, queryParserService);
+                        suggestionContext = contextParser.parse(parser, mapperService, queryParserService, headersContext);
                     }
                 }
                 if (suggestionContext != null) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestParser.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.suggest.completion;
 
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -49,13 +50,14 @@ public class CompletionSuggestParser implements SuggestContextParser {
     }
 
     @Override
-    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException {
+    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService,
+            IndexQueryParserService queryParserService, HasContextAndHeaders headersContext) throws IOException {
         XContentParser.Token token;
         String fieldName = null;
         CompletionSuggestionContext suggestion = new CompletionSuggestionContext(completionSuggester);
-        
+
         XContentParser contextParser = null;
-        
+
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 fieldName = parser.currentName();
@@ -90,7 +92,7 @@ public class CompletionSuggestParser implements SuggestContextParser {
                     // Copy the current structure. We will parse, once the mapping is provided
                     XContentBuilder builder = XContentFactory.contentBuilder(parser.contentType());
                     builder.copyCurrentStructure(parser);
-                    BytesReference bytes = builder.bytes();               
+                    BytesReference bytes = builder.bytes();
                     contextParser = parser.contentType().xContent().createParser(bytes);
                 } else {
                     throw new IllegalArgumentException("suggester [completion] doesn't support field [" + fieldName + "]");
@@ -99,7 +101,7 @@ public class CompletionSuggestParser implements SuggestContextParser {
                 throw new IllegalArgumentException("suggester[completion]  doesn't support field [" + fieldName + "]");
             }
         }
-        
+
         suggestion.fieldType((CompletionFieldMapper.CompletionFieldType) mapperService.smartNameFieldType(suggestion.getField()));
 
         CompletionFieldMapper.CompletionFieldType fieldType = suggestion.fieldType();

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -22,6 +22,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
@@ -48,12 +49,13 @@ public final class PhraseSuggestParser implements SuggestContextParser {
     }
 
     @Override
-    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException {
+    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService,
+            IndexQueryParserService queryParserService, HasContextAndHeaders headersContext) throws IOException {
         PhraseSuggestionContext suggestion = new PhraseSuggestionContext(suggester);
         suggestion.setQueryParserService(queryParserService);
         XContentParser.Token token;
         String fieldName = null;
-        boolean gramSizeSet = false; 
+        boolean gramSizeSet = false;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 fieldName = parser.currentName();
@@ -140,7 +142,8 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                                 throw new IllegalArgumentException("suggester[phrase][collate] query already set, doesn't support additional [" + fieldName + "]");
                             }
                             Template template = Template.parse(parser, queryParserService.parseFieldMatcher());
-                            CompiledScript compiledScript = suggester.scriptService().compile(template, ScriptContext.Standard.SEARCH);
+                            CompiledScript compiledScript = suggester.scriptService().compile(template, ScriptContext.Standard.SEARCH,
+                                    headersContext);
                             suggestion.setCollateQueryScript(compiledScript);
                         } else if ("params".equals(fieldName)) {
                             suggestion.setCollateScriptParams(parser.map());
@@ -162,7 +165,7 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                 throw new IllegalArgumentException("suggester[phrase] doesn't support field [" + fieldName + "]");
             }
         }
-        
+
         if (suggestion.getField() == null) {
             throw new IllegalArgumentException("The required field option is missing");
         }
@@ -178,11 +181,11 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                 suggestion.setAnalyzer(fieldType.searchAnalyzer());
             }
         }
-        
+
         if (suggestion.model() == null) {
             suggestion.setModel(StupidBackoffScorer.FACTORY);
         }
-        
+
         if (!gramSizeSet || suggestion.generators().isEmpty()) {
             final ShingleTokenFilterFactory.Factory shingleFilterFactory = SuggestUtils.getShingleFilterFactory(suggestion.getAnalyzer());
             if (!gramSizeSet) {
@@ -204,9 +207,9 @@ public final class PhraseSuggestParser implements SuggestContextParser {
                 suggestion.addGenerator(generator);
             }
         }
-        
-        
-        
+
+
+
         return suggestion;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestParser.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.suggest.term;
 
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
@@ -38,7 +39,8 @@ public final class TermSuggestParser implements SuggestContextParser {
     }
 
     @Override
-    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException {
+    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService,
+            IndexQueryParserService queryParserService, HasContextAndHeaders headersContext) throws IOException {
         XContentParser.Token token;
         String fieldName = null;
         TermSuggestionContext suggestion = new TermSuggestionContext(suggester);

--- a/core/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TemplateQueryParserTest.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.AbstractModule;

--- a/core/src/test/java/org/elasticsearch/script/NativeScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/NativeScriptTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.script;
 
 import com.google.common.collect.ImmutableSet;
+import org.elasticsearch.common.ContextAndHeaderHolder;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -47,6 +48,7 @@ public class NativeScriptTests extends ESTestCase {
 
     @Test
     public void testNativeScript() throws InterruptedException {
+        ContextAndHeaderHolder contextAndHeaders = new ContextAndHeaderHolder();
         Settings settings = Settings.settingsBuilder()
                 .put("name", "testNativeScript")
                 .put("path.home", createTempDir())
@@ -62,13 +64,14 @@ public class NativeScriptTests extends ESTestCase {
         ScriptService scriptService = injector.getInstance(ScriptService.class);
 
         ExecutableScript executable = scriptService.executable(new Script("my", ScriptType.INLINE, NativeScriptEngineService.NAME, null),
-                ScriptContext.Standard.SEARCH);
+                ScriptContext.Standard.SEARCH, contextAndHeaders);
         assertThat(executable.run().toString(), equalTo("test"));
         terminate(injector.getInstance(ThreadPool.class));
     }
 
     @Test
     public void testFineGrainedSettingsDontAffectNativeScripts() throws IOException {
+        ContextAndHeaderHolder contextAndHeaders = new ContextAndHeaderHolder();
         Settings.Builder builder = Settings.settingsBuilder();
         if (randomBoolean()) {
             ScriptType scriptType = randomFrom(ScriptType.values());
@@ -87,8 +90,8 @@ public class NativeScriptTests extends ESTestCase {
         ScriptService scriptService = new ScriptService(settings, environment, scriptEngineServices, resourceWatcherService, scriptContextRegistry);
 
         for (ScriptContext scriptContext : scriptContextRegistry.scriptContexts()) {
-            assertThat(scriptService.compile(new Script("my", ScriptType.INLINE, NativeScriptEngineService.NAME, null), scriptContext),
-                    notNullValue());
+            assertThat(scriptService.compile(new Script("my", ScriptType.INLINE, NativeScriptEngineService.NAME, null), scriptContext,
+                    contextAndHeaders), notNullValue());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggester.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggester.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.suggest;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.util.CharsRefBuilder;
+import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
@@ -59,7 +60,8 @@ public class CustomSuggester extends Suggester<CustomSuggester.CustomSuggestions
     public SuggestContextParser getContextParser() {
         return new SuggestContextParser() {
             @Override
-            public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException {
+            public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService,
+                    IndexQueryParserService queryParserService, HasContextAndHeaders headersContext) throws IOException {
                 Map<String, Object> options = parser.map();
                 CustomSuggestionsContext suggestionContext = new CustomSuggestionsContext(CustomSuggester.this, options);
                 suggestionContext.setField((String) options.get("field"));

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -94,7 +94,7 @@ public class TestSearchContext extends SearchContext {
     private final Map<String, FetchSubPhaseContext> subPhaseContexts = new HashMap<>();
 
     public TestSearchContext(ThreadPool threadPool,PageCacheRecycler pageCacheRecycler, BigArrays bigArrays, IndexService indexService) {
-        super(ParseFieldMatcher.STRICT);
+        super(ParseFieldMatcher.STRICT, null);
         this.pageCacheRecycler = pageCacheRecycler;
         this.bigArrays = bigArrays.withCircuitBreaking();
         this.indexService = indexService;
@@ -105,7 +105,7 @@ public class TestSearchContext extends SearchContext {
     }
 
     public TestSearchContext() {
-        super(ParseFieldMatcher.STRICT);
+        super(ParseFieldMatcher.STRICT, null);
         this.pageCacheRecycler = null;
         this.bigArrays = null;
         this.indexService = null;

--- a/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
+++ b/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
@@ -27,13 +27,16 @@ import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptRequest;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
 import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
@@ -44,6 +47,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.GeoShapeQueryBuilder;
@@ -52,9 +56,16 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermsLookupQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.Template;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregatorBuilders;
+import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
@@ -64,6 +75,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -77,11 +89,14 @@ import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.node.Node.HTTP_ENABLED;
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.search.suggest.SuggestBuilders.phraseSuggestion;
 import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSuggestionSize;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasStatus;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -274,6 +289,59 @@ public class ContextAndHeaderTransportIT extends ESIntegTestCase {
     }
 
     @Test
+    public void testThatIndexedScriptGetRequestInTemplateQueryContainsContextAndHeaders() throws Exception {
+        PutIndexedScriptResponse scriptResponse = transportClient()
+                .preparePutIndexedScript(
+                        MustacheScriptEngineService.NAME,
+                        "my_script",
+                        jsonBuilder().startObject().field("script", "{ \"query\": { \"match\": { \"name\": \"Star Wars\" }}}").endObject()
+                                .string()).get();
+        assertThat(scriptResponse.isCreated(), is(true));
+
+        transportClient().prepareIndex(queryIndex, "type", "1")
+                .setSource(jsonBuilder().startObject().field("name", "Star Wars - The new republic").endObject()).get();
+        transportClient().admin().indices().prepareRefresh(queryIndex).get();
+
+        SearchResponse searchResponse = transportClient()
+                .prepareSearch(queryIndex)
+                .setQuery(
+                        QueryBuilders.templateQuery(new Template("my_script", ScriptType.INDEXED,
+                                MustacheScriptEngineService.NAME, null, null))).get();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 1);
+
+        assertGetRequestsContainHeaders(".scripts");
+        assertRequestsContainHeader(PutIndexedScriptRequest.class);
+    }
+
+    @Test
+    public void testThatIndexedScriptGetRequestInReducePhaseContainsContextAndHeaders() throws Exception {
+        PutIndexedScriptResponse scriptResponse = transportClient().preparePutIndexedScript(GroovyScriptEngineService.NAME, "my_script",
+                jsonBuilder().startObject().field("script", "_value0 * 10").endObject().string()).get();
+        assertThat(scriptResponse.isCreated(), is(true));
+
+        transportClient().prepareIndex(queryIndex, "type", "1")
+                .setSource(jsonBuilder().startObject().field("s_field", "foo").field("l_field", 10).endObject()).get();
+        transportClient().admin().indices().prepareRefresh(queryIndex).get();
+
+        SearchResponse searchResponse = transportClient()
+                .prepareSearch(queryIndex)
+                .addAggregation(
+                        AggregationBuilders
+                                .terms("terms")
+                                .field("s_field")
+                                .subAggregation(AggregationBuilders.max("max").field("l_field"))
+                                .subAggregation(
+                                        PipelineAggregatorBuilders.bucketScript("scripted").setBucketsPaths("max").script(
+                                                new Script("my_script", ScriptType.INDEXED, GroovyScriptEngineService.NAME, null)))).get();
+        assertNoFailures(searchResponse);
+        assertHitCount(searchResponse, 1);
+
+        assertGetRequestsContainHeaders(".scripts");
+        assertRequestsContainHeader(PutIndexedScriptRequest.class);
+    }
+
+    @Test
     public void testThatSearchTemplatesWithIndexedTemplatesGetRequestContainsContextAndHeaders() throws Exception {
         PutIndexedScriptResponse scriptResponse = transportClient().preparePutIndexedScript(MustacheScriptEngineService.NAME, "the_template",
                 jsonBuilder().startObject().startObject("template").startObject("query").startObject("match")
@@ -301,6 +369,98 @@ public class ContextAndHeaderTransportIT extends ESIntegTestCase {
         assertGetRequestsContainHeaders(".scripts");
         assertRequestsContainHeader(PutIndexedScriptRequest.class);
     }
+
+    @Test
+    public void testThatIndexedScriptGetRequestInPhraseSuggestContainsContextAndHeaders() throws Exception {
+        CreateIndexRequestBuilder builder = transportClient().admin().indices().prepareCreate("test").setSettings(settingsBuilder()
+                .put(indexSettings())
+                .put(SETTING_NUMBER_OF_SHARDS, 1) // A single shard will help to keep the tests repeatable.
+                .put("index.analysis.analyzer.text.tokenizer", "standard")
+                .putArray("index.analysis.analyzer.text.filter", "lowercase", "my_shingle")
+                .put("index.analysis.filter.my_shingle.type", "shingle")
+                .put("index.analysis.filter.my_shingle.output_unigrams", true)
+                .put("index.analysis.filter.my_shingle.min_shingle_size", 2)
+                .put("index.analysis.filter.my_shingle.max_shingle_size", 3));
+
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("type1")
+                .startObject("properties")
+                .startObject("title")
+                .field("type", "string")
+                .field("analyzer", "text")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        assertAcked(builder.addMapping("type1", mapping));
+        ensureGreen();
+
+        List<String> titles = new ArrayList<>();
+
+        titles.add("United States House of Representatives Elections in Washington 2006");
+        titles.add("United States House of Representatives Elections in Washington 2005");
+        titles.add("State");
+        titles.add("Houses of Parliament");
+        titles.add("Representative Government");
+        titles.add("Election");
+
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+        for (String title: titles) {
+            transportClient().prepareIndex("test", "type1").setSource("title", title).get();
+        }
+        transportClient().admin().indices().prepareRefresh("test").get();
+
+        String filterStringAsFilter = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("match_phrase")
+                .field("title", "{{suggestion}}")
+                .endObject()
+                .endObject()
+                .endObject()
+                .string();
+
+        PutIndexedScriptResponse scriptResponse = transportClient()
+                .preparePutIndexedScript(
+                        MustacheScriptEngineService.NAME,
+                        "my_script",
+                jsonBuilder().startObject().field("script", filterStringAsFilter).endObject()
+                                .string()).get();
+        assertThat(scriptResponse.isCreated(), is(true));
+
+        PhraseSuggestionBuilder suggest = phraseSuggestion("title")
+                .field("title")
+                .addCandidateGenerator(PhraseSuggestionBuilder.candidateGenerator("title")
+                        .suggestMode("always")
+                        .maxTermFreq(.99f)
+                        .size(10)
+                        .maxInspections(200)
+                )
+                .confidence(0f)
+                .maxErrors(2f)
+                .shardSize(30000)
+                .size(10);
+
+        PhraseSuggestionBuilder filteredFilterSuggest = suggest.collateQuery(new Template("my_script", ScriptType.INDEXED,
+                MustacheScriptEngineService.NAME, null, null));
+
+        SearchRequestBuilder searchRequestBuilder = transportClient().prepareSearch("test").setSize(0);
+        String suggestText = "united states house of representatives elections in washington 2006";
+        if (suggestText != null) {
+            searchRequestBuilder.setSuggestText(suggestText);
+        }
+        searchRequestBuilder.addSuggestion(filteredFilterSuggest);
+        SearchResponse actionGet = searchRequestBuilder.execute().actionGet();
+        assertThat(Arrays.toString(actionGet.getShardFailures()), actionGet.getFailedShards(), equalTo(0));
+        Suggest searchSuggest = actionGet.getSuggest();
+
+        assertSuggestionSize(searchSuggest, 0, 2, "title");
+
+        assertGetRequestsContainHeaders(".scripts");
+        assertRequestsContainHeader(PutIndexedScriptRequest.class);
+    }
+
 
     @Test
     public void testThatRelevantHttpHeadersBecomeRequestHeaders() throws Exception {


### PR DESCRIPTION
At the moment if an index script is used in a request, the spawned request to get the indexed script from the `.scripts` index does not get the headers and context copied to it from the original request. This change makes the calls to the `ScriptService` pass in a `HasContextAndHeaders` object that can provide the headers and context. For the `search()` method the context and headers are retrieved from `SearchContext.current()`.

Closes #12891
