### PR TITLE
Optimize sorted scroll when sorting by `_doc`.

### DIFF
--- a/core/src/main/java/org/apache/lucene/queries/MinDocQuery.java
+++ b/core/src/main/java/org/apache/lucene/queries/MinDocQuery.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.queries;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+
+import java.io.IOException;
+
+/** A {@link Query} that only matches documents that are greater than or equal
+ *  to a configured doc ID. */
+public final class MinDocQuery extends Query {
+
+    private final int minDoc;
+
+    /** Sole constructor. */
+    public MinDocQuery(int minDoc) {
+        this.minDoc = minDoc;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * super.hashCode() + minDoc;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (super.equals(obj) == false) {
+            return false;
+        }
+        MinDocQuery that = (MinDocQuery) obj;
+        return minDoc == that.minDoc;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
+        return new ConstantScoreWeight(this) {
+            @Override
+            public Scorer scorer(LeafReaderContext context, final Bits acceptDocs) throws IOException {
+                final int maxDoc = context.reader().maxDoc();
+                if (context.docBase + maxDoc <= minDoc) {
+                    return null;
+                }
+                final int segmentMinDoc = Math.max(0, minDoc - context.docBase);
+                final DocIdSetIterator disi = new DocIdSetIterator() {
+
+                    int doc = -1;
+
+                    @Override
+                    public int docID() {
+                        return doc;
+                    }
+
+                    @Override
+                    public int nextDoc() throws IOException {
+                        return advance(doc + 1);
+                    }
+
+                    @Override
+                    public int advance(int target) throws IOException {
+                        assert target > doc;
+                        if (doc == -1) {
+                            // skip directly to minDoc
+                            doc = Math.max(target, segmentMinDoc);
+                        } else {
+                            doc = target;
+                        }
+                        while (doc < maxDoc) {
+                            if (acceptDocs == null || acceptDocs.get(doc)) {
+                                break;
+                            }
+                            doc += 1;
+                        }
+                        if (doc >= maxDoc) {
+                            doc = NO_MORE_DOCS;
+                        }
+                        return doc;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return maxDoc - segmentMinDoc;
+                    }
+
+                };
+                return new ConstantScoreScorer(this, score(), disi);
+            }
+        };
+    }
+
+    @Override
+    public String toString(String field) {
+        return "MinDocQuery(minDoc=" + minDoc  + ")";
+    }
+}

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -27,7 +27,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Counter;
@@ -53,7 +52,6 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
@@ -68,6 +66,7 @@ import org.elasticsearch.search.highlight.SearchContextHighlight;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.InternalSearchHitField;
+import org.elasticsearch.search.internal.ScrollContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.lookup.LeafSearchLookup;
@@ -348,12 +347,12 @@ public class PercolateContext extends SearchContext {
     }
 
     @Override
-    public Scroll scroll() {
+    public ScrollContext scrollContext() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public SearchContext scroll(Scroll scroll) {
+    public SearchContext scrollContext(ScrollContext scroll) {
         throw new UnsupportedOperationException();
     }
 
@@ -618,16 +617,6 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public void keepAlive(long keepAlive) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void lastEmittedDoc(ScoreDoc doc) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ScoreDoc lastEmittedDoc() {
         throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/DefaultSearchContext.java
@@ -49,7 +49,6 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
@@ -98,7 +97,7 @@ public class DefaultSearchContext extends SearchContext {
     // terminate after count
     private int terminateAfter = DEFAULT_TERMINATE_AFTER;
     private List<String> groupStats;
-    private Scroll scroll;
+    private ScrollContext scrollContext;
     private boolean explain;
     private boolean version = false; // by default, we don't return versions
     private List<String> fieldNames;
@@ -290,13 +289,13 @@ public class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public Scroll scroll() {
-        return this.scroll;
+    public ScrollContext scrollContext() {
+        return this.scrollContext;
     }
 
     @Override
-    public SearchContext scroll(Scroll scroll) {
-        this.scroll = scroll;
+    public SearchContext scrollContext(ScrollContext scrollContext) {
+        this.scrollContext = scrollContext;
         return this;
     }
 
@@ -650,16 +649,6 @@ public class DefaultSearchContext extends SearchContext {
     @Override
     public void keepAlive(long keepAlive) {
         this.keepAlive = keepAlive;
-    }
-
-    @Override
-    public void lastEmittedDoc(ScoreDoc doc) {
-        this.lastEmittedDoc = doc;
-    }
-
-    @Override
-    public ScoreDoc lastEmittedDoc() {
-        return lastEmittedDoc;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -23,7 +23,6 @@ import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
@@ -42,7 +41,6 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
@@ -154,13 +152,13 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public Scroll scroll() {
-        return in.scroll();
+    public ScrollContext scrollContext() {
+        return in.scrollContext();
     }
 
     @Override
-    public SearchContext scroll(Scroll scroll) {
-        return in.scroll(scroll);
+    public SearchContext scrollContext(ScrollContext scroll) {
+        return in.scrollContext(scroll);
     }
 
     @Override
@@ -481,16 +479,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public void keepAlive(long keepAlive) {
         in.keepAlive(keepAlive);
-    }
-
-    @Override
-    public void lastEmittedDoc(ScoreDoc doc) {
-        in.lastEmittedDoc(doc);
-    }
-
-    @Override
-    public ScoreDoc lastEmittedDoc() {
-        return in.lastEmittedDoc();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/ScrollContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ScrollContext.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.internal;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.elasticsearch.search.Scroll;
+
+/** Wrapper around information that needs to stay around when scrolling. */
+public class ScrollContext {
+
+    public int totalHits = -1;
+    public float maxScore;
+    public ScoreDoc lastEmittedDoc;
+    public Scroll scroll;
+
+}

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -24,7 +24,6 @@ import com.google.common.collect.MultimapBuilder;
 
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
@@ -159,9 +158,9 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
 
     protected abstract long nowInMillisImpl();
 
-    public abstract Scroll scroll();
+    public abstract ScrollContext scrollContext();
 
-    public abstract SearchContext scroll(Scroll scroll);
+    public abstract SearchContext scrollContext(ScrollContext scroll);
 
     public abstract SearchContextAggregations aggregations();
 
@@ -302,10 +301,6 @@ public abstract class SearchContext implements Releasable, HasContextAndHeaders 
     public abstract long keepAlive();
 
     public abstract void keepAlive(long keepAlive);
-
-    public abstract void lastEmittedDoc(ScoreDoc doc);
-
-    public abstract ScoreDoc lastEmittedDoc();
 
     public abstract SearchLookup lookup();
 

--- a/core/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
@@ -21,13 +21,10 @@ package org.elasticsearch.search.internal;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.lucene.search.Filter;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
@@ -101,7 +98,7 @@ public class SubSearchContext extends FilteredSearchContext {
     }
 
     @Override
-    public SearchContext scroll(Scroll scroll) {
+    public SearchContext scrollContext(ScrollContext scrollContext) {
         throw new UnsupportedOperationException("Not supported");
     }
 
@@ -301,11 +298,6 @@ public class SubSearchContext extends FilteredSearchContext {
 
     @Override
     public void keepAlive(long keepAlive) {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public void lastEmittedDoc(ScoreDoc doc) {
         throw new UnsupportedOperationException("Not supported");
     }
 

--- a/core/src/main/java/org/elasticsearch/search/scan/ScanContext.java
+++ b/core/src/main/java/org/elasticsearch/search/scan/ScanContext.java
@@ -20,18 +20,13 @@
 package org.elasticsearch.search.scan;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.queries.MinDocQuery;
 import org.apache.lucene.search.CollectionTerminatedException;
-import org.apache.lucene.search.ConstantScoreScorer;
-import org.apache.lucene.search.ConstantScoreWeight;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -118,93 +113,4 @@ public class ScanContext {
         }
     }
 
-    /**
-     * A filtering query that matches all doc IDs that are not deleted and
-     * greater than or equal to the configured doc ID.
-     */
-    // pkg-private for testing
-    static class MinDocQuery extends Query {
-
-        private final int minDoc;
-
-        MinDocQuery(int minDoc) {
-            this.minDoc = minDoc;
-        }
-
-        @Override
-        public int hashCode() {
-            return 31 * super.hashCode() + minDoc;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (super.equals(obj) == false) {
-                return false;
-            }
-            MinDocQuery that = (MinDocQuery) obj;
-            return minDoc == that.minDoc;
-        }
-
-        @Override
-        public Weight createWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
-            return new ConstantScoreWeight(this) {
-                @Override
-                public Scorer scorer(LeafReaderContext context, final Bits acceptDocs) throws IOException {
-                    final int maxDoc = context.reader().maxDoc();
-                    if (context.docBase + maxDoc <= minDoc) {
-                        return null;
-                    }
-                    final int segmentMinDoc = Math.max(0, minDoc - context.docBase);
-                    final DocIdSetIterator disi = new DocIdSetIterator() {
-
-                        int doc = -1;
-
-                        @Override
-                        public int docID() {
-                            return doc;
-                        }
-
-                        @Override
-                        public int nextDoc() throws IOException {
-                            return advance(doc + 1);
-                        }
-
-                        @Override
-                        public int advance(int target) throws IOException {
-                            assert target > doc;
-                            if (doc == -1) {
-                                // skip directly to minDoc
-                                doc = Math.max(target, segmentMinDoc);
-                            } else {
-                                doc = target;
-                            }
-                            while (doc < maxDoc) {
-                                if (acceptDocs == null || acceptDocs.get(doc)) {
-                                    break;
-                                }
-                                doc += 1;
-                            }
-                            if (doc >= maxDoc) {
-                                doc = NO_MORE_DOCS;
-                            }
-                            return doc;
-                        }
-
-                        @Override
-                        public long cost() {
-                            return maxDoc - minDoc;
-                        }
-
-                    };
-                    return new ConstantScoreScorer(this, score(), disi);
-                }
-            };
-        }
-
-        @Override
-        public String toString(String field) {
-            return "MinDocQuery(minDoc=" + minDoc  + ")";
-        }
-
-    }
 }

--- a/core/src/test/java/org/apache/lucene/queries/MinDocQueryTests.java
+++ b/core/src/test/java/org/apache/lucene/queries/MinDocQueryTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.queries;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryUtils;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class MinDocQueryTests extends ESTestCase {
+
+    public void testBasics() {
+        MinDocQuery query1 = new MinDocQuery(42);
+        MinDocQuery query2 = new MinDocQuery(42);
+        MinDocQuery query3 = new MinDocQuery(43);
+        QueryUtils.check(query1);
+        QueryUtils.checkEqual(query1, query2);
+        QueryUtils.checkUnequal(query1, query3);
+    }
+
+    public void testRandom() throws IOException {
+        final int numDocs = randomIntBetween(10, 200);
+        final Document doc = new Document();
+        final Directory dir = newDirectory();
+        final RandomIndexWriter w = new RandomIndexWriter(getRandom(), dir);
+        for (int i = 0; i < numDocs; ++i) {
+            w.addDocument(doc);
+        }
+        final IndexReader reader = w.getReader();
+        final IndexSearcher searcher = newSearcher(reader);
+        for (int i = 0; i <= numDocs; ++i) {
+            assertEquals(numDocs - i, searcher.count(new MinDocQuery(i)));
+        }
+        w.close();
+        reader.close();
+        dir.close();
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/scan/ScanContextTests.java
+++ b/core/src/test/java/org/elasticsearch/search/scan/ScanContextTests.java
@@ -27,13 +27,11 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryUtils;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
-import org.elasticsearch.search.scan.ScanContext.MinDocQuery;
 import org.elasticsearch.search.scan.ScanContext.ScanCollector;
 import org.elasticsearch.test.ESTestCase;
 
@@ -43,33 +41,6 @@ import java.util.Arrays;
 import java.util.List;
 
 public class ScanContextTests extends ESTestCase {
-
-    public void testMinDocQueryBasics() {
-        MinDocQuery query1 = new MinDocQuery(42);
-        MinDocQuery query2 = new MinDocQuery(42);
-        MinDocQuery query3 = new MinDocQuery(43);
-        QueryUtils.check(query1);
-        QueryUtils.checkEqual(query1, query2);
-        QueryUtils.checkUnequal(query1, query3);
-    }
-
-    public void testMinDocQueryRandom() throws IOException {
-        final int numDocs = randomIntBetween(10, 200);
-        final Document doc = new Document();
-        final Directory dir = newDirectory();
-        final RandomIndexWriter w = new RandomIndexWriter(getRandom(), dir);
-        for (int i = 0; i < numDocs; ++i) {
-            w.addDocument(doc);
-        }
-        final IndexReader reader = w.getReader();
-        final IndexSearcher searcher = newSearcher(reader);
-        for (int i = 0; i <= numDocs; ++i) {
-            assertEquals(numDocs - i, searcher.count(new MinDocQuery(i)));
-        }
-        w.close();
-        reader.close();
-        dir.close();
-    }
 
     private static TopDocs execute(IndexSearcher searcher, ScanContext ctx, Query query, int pageSize, boolean trackScores) throws IOException {
         query = ctx.wrapQuery(query);

--- a/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
+++ b/core/src/test/java/org/elasticsearch/test/TestSearchContext.java
@@ -19,7 +19,11 @@
 package org.elasticsearch.test;
 
 import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
-import org.apache.lucene.search.*;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
@@ -41,7 +45,6 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.dfs.DfsSearchResult;
@@ -53,6 +56,7 @@ import org.elasticsearch.search.fetch.script.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.SearchContextHighlight;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
+import org.elasticsearch.search.internal.ScrollContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -62,7 +66,11 @@ import org.elasticsearch.search.scan.ScanContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class TestSearchContext extends SearchContext {
 
@@ -185,13 +193,13 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public Scroll scroll() {
+    public ScrollContext scrollContext() {
         return null;
     }
 
     @Override
-    public SearchContext scroll(Scroll scroll) {
-        return null;
+    public SearchContext scrollContext(ScrollContext scrollContext) {
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -514,15 +522,6 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public void keepAlive(long keepAlive) {
-    }
-
-    @Override
-    public void lastEmittedDoc(ScoreDoc doc) {
-    }
-
-    @Override
-    public ScoreDoc lastEmittedDoc() {
-        return null;
     }
 
     @Override


### PR DESCRIPTION
This change means that we will be able to remove the `SCAN` search type in 3.0
and recommend users to use sorted scrolls instead.
