### PR TITLE
Only resolve host if explicitly allowed.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
@@ -94,7 +94,11 @@ public final class InetSocketTransportAddress implements TransportAddress {
 
     @Override
     public String getHost() {
-        return address.getHostName();
+        if (resolveAddress) {
+            return address.getHostName();
+        } else {
+            return getAddress();
+        }
     }
 
     @Override


### PR DESCRIPTION
We have some settings that prevent host name resolution which should
be repected by InetSocketTransportAddress#getHost() to only resolve if
allowed or desired.
