### PR TITLE
[build] rpm module should be build on machine with /usr/bin/rpmbuild

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -33,9 +33,6 @@
         <project.licenses.dir>${project.basedir}/../licenses</project.licenses.dir>
         <project.licenses.check_target>${integ.scratch}</project.licenses.check_target>
 
-        <!-- rpmbuild location : default to /usr/bin/rpmbuild -->
-        <packaging.rpm.rpmbuild>/usr/bin/rpmbuild</packaging.rpm.rpmbuild>
-
         <!-- we expect packaging formats to have integration tests, but not unit tests -->
         <skip.unit.tests>true</skip.unit.tests>
     </properties>
@@ -172,6 +169,11 @@
     </modules>
 
     <profiles>
+        <!--
+            We include automatically RPM module when it's available in common locations.
+            If your rpmbuild is in another location (but in path), run maven with rpm profile:
+             mvn deploy -Prpm
+        -->
         <profile>
             <id>macos_brew</id>
             <activation>
@@ -190,7 +192,7 @@
             <activation>
                 <file>
                     <!-- Folks having /usr/bin/rpmbuild available will be able to build the rpm module -->
-                    <exists>${packaging.rpm.rpmbuild}</exists>
+                    <exists>/usr/bin/rpmbuild</exists>
                 </file>
             </activation>
             <modules>


### PR DESCRIPTION
We build the rpm module automatically if you have either:
- `/usr/bin/rpmbuild`
- `/usr/local/bin/rpmbuild`

available.

If your `rpmbuild` is in another location and available in your path, then run maven with `rpm` profile:

``` sh
mvn deploy -Prpm
```

Closes #12984.
