### PR TITLE
Fix documentation: scrolls are not closed automatically.

### DIFF
--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -176,9 +176,11 @@ curl -XGET localhost:9200/_nodes/stats/indices/search?pretty
 
 ==== Clear scroll API
 
-Search contexts are removed automatically either when all results have been
-retrieved or when the `scroll` timeout has been exceeded.  However, you can
-clear a search context manually with the `clear-scroll` API:
+Search context are automatically removed when the `scroll` timeout has been
+exceeded. However keeping scrolls open has a cost, as discussed in the
+<<scroll-search-context,previous section>> so scrolls should be explicitly
+cleared as soon as the scroll is not being used anymore using the
+`clear-scroll` API:
 
 [source,js]
 ---------------------------------------


### PR DESCRIPTION
The documentation states that scrolls are automatically closed when all
documents are consumed, but this is not the case. I first tried to fix
the code to close scrolls automatically but this made REST tests fail
because clearing a scroll that is already closed returned a 4xx error
instead of a 2xx code, so this has probably been this way for a very long
time.
