### PR TITLE
Add more permissions for bouncycastle

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -121,4 +121,6 @@ grant {
   
   // needed to allow installation of bouncycastle crypto provider
   permission java.security.SecurityPermission "putProviderProperty.BC";
+  permission java.security.SecurityPermission "insertProvider.BC";
+  permission org.bouncycastle.jce.ProviderConfigurationPermission "BC", "ecImplicitlyCA, threadLocalEcImplicitlyCA";
 };


### PR DESCRIPTION
As explained in [bouncy castle doc](http://www.bouncycastle.org/wiki/display/JA1/Using+the+Bouncy+Castle+Provider's+ImplicitlyCA+Facility), we need to have:

```
grant {
   permission java.security.SecurityPermission "putProviderProperty.BC";
   permission java.security.SecurityPermission "insertProvider.BC";
   permission org.bouncycastle.jce.ProviderConfigurationPermission "BC", "ecImplicitlyCA, threadLocalEcImplicitlyCA";
};
```

Mapper attachment plugin needs them to run properly.
