### PR TITLE
Adding build hash and build timestamp to the plugin-descriptor.properties

### DIFF
--- a/dev-tools/src/main/resources/plugin-metadata/plugin-descriptor.properties
+++ b/dev-tools/src/main/resources/plugin-metadata/plugin-descriptor.properties
@@ -57,11 +57,17 @@ jvm=${elasticsearch.plugin.jvm}
 # 'classname': the name of the class to load, fully-qualified.
 classname=${elasticsearch.plugin.classname}
 #
-# 'java.version' version of java the code is built against
+# 'java.version': version of java the code is built against
 java.version=${maven.compiler.target}
 #
-# 'elasticsearch.version' version of elasticsearch compiled against
+# 'elasticsearch.version': version of elasticsearch compiled against
 elasticsearch.version=${elasticsearch.version}
+#
+# 'hash': the commit hash relative to the code for systems that support it (e.g., git)
+hash=${buildNumber}
+#
+# 'timestamp': the build time of the plugin
+timestamp=${timestamp}
 #
 ### deprecated elements for jvm plugins :
 #


### PR DESCRIPTION
Adds something along the lines of this to each plugin:

``` properties
# 'hash': the commit hash relative to the code for systems that support it (e.g., git)
hash=f2f95ea115aa3fa2020d034ae4e10d2ef8837d62
#
# 'timestamp': the build time of the plugin
timestamp=1440012506349
```

Closes #13002
