### PR TITLE
Improve java version comparison and explicitly enforce a version format

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.common.Strings;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class JavaVersion implements Comparable<JavaVersion> {
+    private final List<Integer> version;
+
+    public List<Integer> getVersion() {
+        return Collections.unmodifiableList(version);
+    }
+
+    private JavaVersion(List<Integer> version) {
+        this.version = version;
+    }
+
+    public static JavaVersion parse(String value) {
+        if (value == null) {
+            throw new NullPointerException("value");
+        }
+        if ("".equals(value)) {
+            throw new IllegalArgumentException("value");
+        }
+
+        List<Integer> version = new ArrayList<>();
+        String[] components = value.split("\\.");
+        for (String component : components) {
+            version.add(Integer.valueOf(component));
+        }
+
+        return new JavaVersion(version);
+    }
+
+    public static boolean isValid(String value) {
+        if (!value.matches("^0*[0-9]+(\\.[0-9]+)*$")) {
+            return false;
+        }
+        return true;
+    }
+
+    private final static JavaVersion CURRENT = parse(System.getProperty("java.specification.version"));
+
+    public static JavaVersion current() {
+        return CURRENT;
+    }
+
+    @Override
+    public int compareTo(JavaVersion o) {
+        int len = Math.max(version.size(), o.version.size());
+        for (int i = 0; i < len; i++) {
+            int d = (i < version.size() ? version.get(i) : 0);
+            int s = (i < o.version.size() ? o.version.get(i) : 0);
+            if (s < d)
+                return 1;
+            if (s > d)
+                return -1;
+        }
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.collectionToDelimitedString(version, ".");
+    }
+}

--- a/core/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -120,6 +120,7 @@ public class PluginInfo implements Streamable, ToXContent {
             if (javaVersionString == null) {
                 throw new IllegalArgumentException("Property [java.version] is missing for jvm plugin [" + name + "]");
             }
+            JarHell.checkVersionFormat(javaVersionString);
             JarHell.checkJavaVersion(name, javaVersionString);
             isolated = Boolean.parseBoolean(props.getProperty("isolated", "true"));
             classname = props.getProperty("classname");

--- a/core/src/test/java/org/elasticsearch/bootstrap/JavaVersionTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/JavaVersionTests.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class JavaVersionTests extends ESTestCase {
+    @Test
+    public void testParse() {
+        JavaVersion javaVersion = JavaVersion.parse("1.7.0");
+        List<Integer> version = javaVersion.getVersion();
+        assertThat(3, is(version.size()));
+        assertThat(1, is(version.get(0)));
+        assertThat(7, is(version.get(1)));
+        assertThat(0, is(version.get(2)));
+    }
+
+    @Test
+    public void testToString() {
+        JavaVersion javaVersion = JavaVersion.parse("1.7.0");
+        assertThat("1.7.0", is(javaVersion.toString()));
+    }
+
+    @Test
+    public void testCompare() {
+        JavaVersion onePointSix = JavaVersion.parse("1.6");
+        JavaVersion onePointSeven = JavaVersion.parse("1.7");
+        JavaVersion onePointSevenPointZero = JavaVersion.parse("1.7.0");
+        JavaVersion onePointSevenPointOne = JavaVersion.parse("1.7.1");
+        JavaVersion onePointSevenPointTwo = JavaVersion.parse("1.7.2");
+        JavaVersion onePointSevenPointOnePointOne = JavaVersion.parse("1.7.1.1");
+        JavaVersion onePointSevenPointTwoPointOne = JavaVersion.parse("1.7.2.1");
+
+        assertTrue(onePointSix.compareTo(onePointSeven) < 0);
+        assertTrue(onePointSeven.compareTo(onePointSix) > 0);
+        assertTrue(onePointSix.compareTo(onePointSix) == 0);
+        assertTrue(onePointSeven.compareTo(onePointSevenPointZero) == 0);
+        assertTrue(onePointSevenPointOnePointOne.compareTo(onePointSevenPointOne) > 0);
+        assertTrue(onePointSevenPointTwo.compareTo(onePointSevenPointTwoPointOne) < 0);
+    }
+
+    @Test
+    public void testValidVersions() {
+        String[] versions = new String[]{"1.7", "1.7.0", "0.1.7", "1.7.0.80"};
+        for (String version : versions) {
+            assertTrue(JavaVersion.isValid(version));
+        }
+    }
+
+    @Test
+    public void testInvalidVersions() {
+        String[] versions = new String[]{"", "1.7.0_80", "1.7."};
+        for (String version : versions) {
+            assertFalse(JavaVersion.isValid(version));
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
@@ -176,6 +176,25 @@ public class PluginInfoTests extends ESTestCase {
         }
     }
 
+    public void testReadFromPropertiesBadJavaVersionFormat() throws Exception {
+        String pluginName = "fake-plugin";
+        Path pluginDir = createTempDir().resolve(pluginName);
+        writeProperties(pluginDir,
+                "description", "fake desc",
+                "name", pluginName,
+                "elasticsearch.version", Version.CURRENT.toString(),
+                "java.version", "1.7.0_80",
+                "classname", "FakePlugin",
+                "version", "1.0",
+                "jvm", "true");
+        try {
+            PluginInfo.readFromProperties(pluginDir);
+            fail("expected bad java version format exception");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage(), e.getMessage().equals("version string must be a sequence of nonnegative decimal integers separated by \".\"'s and may have leading zeros but was 1.7.0_80"));
+        }
+    }
+
     public void testReadFromPropertiesBogusElasticsearchVersion() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         writeProperties(pluginDir,

--- a/dev-tools/src/main/resources/plugin-metadata/plugin-descriptor.properties
+++ b/dev-tools/src/main/resources/plugin-metadata/plugin-descriptor.properties
@@ -58,6 +58,9 @@ jvm=${elasticsearch.plugin.jvm}
 classname=${elasticsearch.plugin.classname}
 #
 # 'java.version' version of java the code is built against
+# use the system property java.specification.version
+# version string must be a sequence of nonnegative decimal integers
+# separated by "."'s and may have leading zeros
 java.version=${maven.compiler.target}
 #
 # 'elasticsearch.version' version of elasticsearch compiled against


### PR DESCRIPTION
This pull request addresses two issues #12441 and #13009.

The first issue relates to improving the method of Java version comparison in `JarHell#checkVersion`. 

The first improvement here is to add explicit verification of the version format to be of the form specified in the [Java Product Versioning documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html). Specifically:

> Specification version numbers use a Dewey decimal notation consisting of numbers seperated by periods.

This format is also specified in the documentation for [`java.lang.Package#getSpecificationVersion`](https://docs.oracle.com/javase/8/docs/api/java/lang/Package.html#getSpecificationVersion--):

> This version string must be a sequence of nonnegative decimal integers separated by "."'s and may have leading zeros. When version strings are compared the most significant numbers are compared.

The second improvement here is to improve the Java version comparison in `JarHell#checkJavaVersion`. We can rely on the [`java.lang.Package#isCompatibleWith`](https://docs.oracle.com/javase/8/docs/api/java/lang/Package.html#isCompatibleWith-java.lang.String-) method as this uses the `java.specification.version` from the JVM and performs the lexicographic comparison on the above version format for us. Moreover, by utilizing this method we are safe against all possible Java specification versions whereas the current method can only parse those of the form `[0-9](.[0-9]+)?`.

The second issue relates to explicitly enforcing a version format on plugins. Because of the version check in `JarHell#checkJavaVersion` we implicitly require the above version format. We should be explicit about this and add it to the documentation.

Closes #12441, #13009.
