### PR TITLE
[build] enforce maven version for rpm module

### DIFF
--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -36,6 +36,27 @@
         </filters>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven-version-for-rpm</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.2.3</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- No need to have some source jar for the RPM -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
When RPM module is supposed to be built, we need to have at least maven 3.2.3 to build the package.

Otherwise the finalName we get is `elasticsearch-2.0.0-beta1_SNAPSHOT20150820131523.noarch.rpm` instead of `elasticsearch-2.0.0-beta1-SNAPSHOT.rpm`.
