### PR TITLE
Add missing support for escape to QueryStringQueryBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -68,7 +68,6 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
 
     private Locale locale;
 
-
     private float boost = -1;
 
     private Fuzziness fuzziness;
@@ -98,6 +97,8 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
 
     /** To limit effort spent determinizing regexp queries. */
     private Integer maxDeterminizedStates;
+
+    private Boolean escape;
 
     public QueryStringQueryBuilder(String queryString) {
         this.queryString = queryString;
@@ -159,11 +160,11 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
     /**
      * Sets the boolean operator of the query parser used to parse the query string.
      * <p/>
-     * <p>In default mode ({@link FieldQueryBuilder.Operator#OR}) terms without any modifiers
+     * <p>In default mode ({@link Operator#OR}) terms without any modifiers
      * are considered optional: for example <code>capital of Hungary</code> is equal to
      * <code>capital OR of OR Hungary</code>.
      * <p/>
-     * <p>In {@link FieldQueryBuilder.Operator#AND} mode terms are considered to be in conjunction: the
+     * <p>In {@link Operator#AND} mode terms are considered to be in conjunction: the
      * above mentioned query is parsed as <code>capital AND of AND Hungary</code>
      */
     public QueryStringQueryBuilder defaultOperator(Operator defaultOperator) {
@@ -342,6 +343,14 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
         return this;
     }
 
+    /**
+     * Set to <tt>true</tt> to enable escaping of the query string
+     */
+    public QueryStringQueryBuilder escape(boolean escape) {
+        this.escape = escape;
+        return this;
+    }
+
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(QueryStringQueryParser.NAME);
@@ -430,6 +439,9 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
         }
         if (timeZone != null) {
             builder.field("time_zone", timeZone);
+        }
+        if (escape != null) {
+            builder.field("escape", escape);
         }
         builder.endObject();
     }


### PR DESCRIPTION
QueryStringQueryParser parses `escape`, but java api users had no chance to actually set it.
