### PR TITLE
Remove support for address resolving in InetSocketTransportAddress

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -83,7 +83,6 @@ public class NetworkService extends AbstractComponent {
     public NetworkService(Settings settings) {
         super(settings);
         IfConfig.logIfNecessary();
-        InetSocketTransportAddress.setResolveAddress(settings.getAsBoolean("network.address.serialization.resolve", false));
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/InetSocketTransportAddress.java
@@ -33,7 +33,7 @@ import java.net.InetSocketAddress;
  */
 public final class InetSocketTransportAddress implements TransportAddress {
 
-    public static final InetSocketTransportAddress PROTO = new InetSocketTransportAddress(new InetSocketAddress("127.0.0.1", 0));
+    public static final InetSocketTransportAddress PROTO = new InetSocketTransportAddress();
 
     private final InetSocketAddress address;
 
@@ -49,6 +49,10 @@ public final class InetSocketTransportAddress implements TransportAddress {
         }
         int port = in.readInt();
         this.address = new InetSocketAddress(inetAddress, port);
+    }
+
+    private InetSocketTransportAddress() {
+        address = null;
     }
 
     public InetSocketTransportAddress(InetAddress address, int port) {


### PR DESCRIPTION
this commit removes all support for reverse host name resolving from
InetSocketTransportAddress. This class now only returns IP addresses.

Closes #13014
