### PR TITLE
Enforce supported Maven versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,6 +543,19 @@
                             </configuration>
                         </execution>
                         <execution>
+                            <id>enforce-maven-version</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireMavenVersion>
+                                        <version>[3.1.0,3.3.0)</version>
+                                    </requireMavenVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                        <execution>
                             <id>print-versions</id>
                             <phase>validate</phase>
                             <goals>


### PR DESCRIPTION
Our builds are currently not compatible with Maven versions `< 3.1.0` and
`>= 3.3.0`. This commit will enforce Maven 3 versions that our builds are
known to be compatible with. We will consider these our supported Maven
versions.

Closes #13022
