### PR TITLE
Don't print lots of noise on IPv4 only hosts.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -52,6 +52,31 @@ public abstract class NetworkUtils {
      */
     @Deprecated
     static final boolean PREFER_V6 = Boolean.parseBoolean(System.getProperty("java.net.preferIPv6Addresses", "false"));
+
+    /**
+     * True if we can bind to a v6 address. Its silly, but for *binding* we have a need to know
+     * if the stack works. this can prevent scary noise on IPv4-only hosts.
+     * @deprecated transition mechanism only, do not use
+     */
+    @Deprecated
+    public static final boolean SUPPORTS_V6;
+
+    static {
+        boolean v = false;
+        try {
+            for (NetworkInterface nic : getInterfaces()) {
+                for (InetAddress address : Collections.list(nic.getInetAddresses())) {
+                    if (address instanceof Inet6Address) {
+                        v = true;
+                        break;
+                    }
+                }
+            }
+        } catch (SecurityException | SocketException misconfiguration) {
+            v = true; // be optimistic, you misconfigure, then you get noise to your screen
+        }
+        SUPPORTS_V6 = v;
+    }
     
     /** Sorts an address by preference. This way code like publishing can just pick the first one */
     static int sortKey(InetAddress address, boolean prefer_v6) {

--- a/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -122,7 +122,6 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
     public static final String DEFAULT_PORT_RANGE = "9300-9400";
     public static final String DEFAULT_PROFILE = "default";
 
-    private static final List<String> LOCAL_ADDRESSES = Arrays.asList("127.0.0.1", "[::1]");
     protected final NetworkService networkService;
     protected final Version version;
 
@@ -714,7 +713,13 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
 
     @Override
     public List<String> getLocalAddresses() {
-        return LOCAL_ADDRESSES;
+        List<String> local = new ArrayList<>();
+        local.add("127.0.0.1");
+        // check if v6 is supported, if so, v4 will also work via mapped addresses.
+        if (NetworkUtils.SUPPORTS_V6) {
+            local.add("::1");
+        }
+        return local;
     }
 
     @Override


### PR DESCRIPTION
If the machine doesn't support IPv6, or if the user disabled it
with -Djava.net.preferIPv4Stack, or if the user disabled it with
ES_USE_IPV4, we will still try to bind a socket to ::1 out of box,
and we will see lots of exceptions logged to the console.

It is harmless noise but not a great experience.
