### PR TITLE
Fix formatting of startup/configuration errors

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -291,7 +291,7 @@ public class Bootstrap {
                 Loggers.enableConsoleLogging();
             }
             
-            throw e;
+            throw new StartupError(e);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
@@ -71,9 +71,12 @@ class StartupError extends RuntimeException {
                 cause = cause.getCause();
             }
 
+            // print the root cause message, only if it differs!
             if (cause != originalCause && (message.equals(cause.toString()) == false)) {
                 s.println("Likely root cause: " + cause);
             }
+
+            // print stacktrace of cause
             StackTraceElement stack[] = cause.getStackTrace();
             int linesWritten = 0;
             for (int i = 0; i < stack.length; i++) {
@@ -110,6 +113,6 @@ class StartupError extends RuntimeException {
                 return cause;
             }
         }
-        throw guice; // we tried
+        return guice; // we tried
     }
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
@@ -71,7 +71,7 @@ class StartupError extends RuntimeException {
                 cause = cause.getCause();
             }
 
-            if (cause != originalCause) {
+            if (cause != originalCause && (message.equals(cause.toString()) == false)) {
                 s.println("Likely root cause: " + cause);
             }
             StackTraceElement stack[] = cause.getStackTrace();

--- a/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
@@ -53,7 +53,8 @@ class StartupError extends RuntimeException {
      */
     @Override
     public void printStackTrace(PrintStream s) {
-        Throwable cause = getCause();
+        Throwable originalCause = getCause();
+        Throwable cause = originalCause;
         if (cause instanceof CreationException) {
             cause = getFirstGuiceCause((CreationException)cause);
         }
@@ -70,7 +71,9 @@ class StartupError extends RuntimeException {
                 cause = cause.getCause();
             }
 
-            s.println("Likely root cause: " + cause);
+            if (cause != originalCause) {
+                s.println("Likely root cause: " + cause);
+            }
             StackTraceElement stack[] = cause.getStackTrace();
             int linesWritten = 0;
             for (int i = 0; i < stack.length; i++) {

--- a/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.common.inject.CreationException;
+import org.elasticsearch.common.inject.spi.Message;
+
+import java.io.PrintStream;
+
+/**
+ * Wraps an exception in a special way that it gets formatted
+ * "reasonably". This means limits on stacktrace frames and
+ * cleanup for guice, and some guidance about consulting full
+ * logs for the whole exception.
+ */
+//TODO: remove this when guice is removed, and exceptions are cleaned up
+//this is horrible, but its what we must do
+class StartupError extends RuntimeException {
+    
+    /** maximum length of a stacktrace, before we truncate it */
+    static final int STACKTRACE_LIMIT = 30;
+    /** all lines from this package are RLE-compressed */
+    static final String GUICE_PACKAGE = "org.elasticsearch.common.inject";
+    
+    /** 
+     * Create a new StartupError that will format {@code cause}
+     * to the console on failure.
+     */
+    StartupError(Throwable cause) {
+        super(cause);
+    }
+
+    /*
+     * This logic actually prints the exception to the console, its
+     * what is invoked by the JVM when we throw the exception from main()
+     */
+    @Override
+    public void printStackTrace(PrintStream s) {
+        Throwable cause = getCause();
+        if (cause instanceof CreationException) {
+            cause = getFirstGuiceCause((CreationException)cause);
+        }
+        
+        String message = cause.getMessage();
+        if (message == null) {
+            message = "Unknown Error";
+        }
+        s.println(message);
+        
+        if (cause != null) {
+            // walk to the root cause
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+
+            s.println("Likely root cause: " + cause);
+            StackTraceElement stack[] = cause.getStackTrace();
+            int linesWritten = 0;
+            for (int i = 0; i < stack.length; i++) {
+                if (linesWritten == STACKTRACE_LIMIT) {
+                    s.println("\t<<<truncated>>>");
+                    break;
+                }
+                String line = stack[i].toString();
+                
+                // skip past contiguous runs of this garbage:
+                if (line.startsWith(GUICE_PACKAGE)) {
+                    while (i + 1 < stack.length && stack[i + 1].toString().startsWith(GUICE_PACKAGE)) {
+                        i++;
+                    }
+                    s.println("\tat <<<guice>>>");
+                    linesWritten++;
+                    continue;
+                }
+
+                s.println("\tat " + line.toString());
+                linesWritten++;
+            }
+        }
+        s.println("Refer to the log for complete error details.");
+    }
+    
+    /** 
+     * Returns first cause from a guice error (it can have multiple).
+     */
+    static Throwable getFirstGuiceCause(CreationException guice) {
+        for (Message message : guice.getErrorMessages()) {
+            Throwable cause = message.getCause();
+            if (cause != null) {
+                return cause;
+            }
+        }
+        throw guice; // we tried
+    }
+}


### PR DESCRIPTION
Previous versions of ES wouldn't give you a stacktrace at all, but just print messages, which left you wondering where that `Nested: NullPointerException;` came from.

On the other hand, currently in 2.0 if you misconfigure something and piss guice off enough, you will get _2MB_ of exceptions to the console. Sorry, that is unusable. It may even OOM your terminal window.

This PR attempts to make a compromise, so users arent horrified, but things can be debugged too:
- It tries to present message and root cause with stacktrace
- Stacktraces are limited to 30 frames, otherwise truncated, with a message they were truncated
- Runs of guice frames are replaced with a marker.
- The user is notified to check the logs for the full error details.

Example:

```
Exception in thread "main" Failed to resolve address for [_bogushost]
Likely root cause: java.net.UnknownHostException: _bogushost: unknown error
    at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
    at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:907)
    at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1302)
    at java.net.InetAddress.getAllByName0(InetAddress.java:1255)
    at java.net.InetAddress.getAllByName(InetAddress.java:1171)
    at java.net.InetAddress.getAllByName(InetAddress.java:1105)
    at org.elasticsearch.transport.netty.NettyTransport.parse(NettyTransport.java:642)
    at org.elasticsearch.transport.netty.NettyTransport.addressesFromString(NettyTransport.java:594)
    at org.elasticsearch.transport.TransportService.addressesFromString(TransportService.java:388)
    at org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing.<init>(UnicastZenPing.java:138)
    at org.elasticsearch.discovery.zen.ping.ZenPingService.<init>(ZenPingService.java:60)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
    at <<<guice>>>
    at org.elasticsearch.node.Node.<init>(Node.java:190)
    at org.elasticsearch.node.NodeBuilder.build(NodeBuilder.java:157)
    at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:177)
    at org.elasticsearch.bootstrap.Bootstrap.main(Bootstrap.java:272)
    at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:28)
Refer to the log for complete error details.
```
