### PR TITLE
Do not permit multiple settings files

### DIFF
--- a/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
+++ b/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
@@ -21,6 +21,7 @@ package org.elasticsearch.node.internal;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import com.google.common.collect.UnmodifiableIterator;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.Booleans;
@@ -40,6 +41,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.elasticsearch.common.Strings.cleanPath;
@@ -113,11 +115,20 @@ public class InternalSettingsPreparer {
                 }
             }
             if (loadFromEnv) {
+                boolean settingsFileFound = false;
+                Set<String> foundSuffixes = Sets.newHashSet();
                 for (String allowedSuffix : ALLOWED_SUFFIXES) {
                     Path path = environment.configFile().resolve("elasticsearch" + allowedSuffix);
                     if (Files.exists(path)) {
-                        settingsBuilder.loadFromPath(path);
+                        if (!settingsFileFound) {
+                            settingsBuilder.loadFromPath(path);
+                        }
+                        settingsFileFound = true;
+                        foundSuffixes.add(allowedSuffix);
                     }
+                }
+                if (foundSuffixes.size() > 1) {
+                    throw new SettingsException("multiple settings files found with suffixes: " + Strings.collectionToDelimitedString(foundSuffixes, ","));
                 }
             }
         }


### PR DESCRIPTION
This commit enforces that at most a single settings file is found. If
multiple settings files are found, a SettingsException will be thrown

Closes #13042
