### PR TITLE
Turn DestructiveOperations.java into a Guice module.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -156,6 +156,7 @@ import org.elasticsearch.action.suggest.TransportSuggestAction;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
+import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.termvectors.*;
 import org.elasticsearch.action.termvectors.dfs.TransportDfsOnlyAction;
@@ -223,6 +224,7 @@ public class ActionModule extends AbstractModule {
         }
         bind(ActionFilters.class).asEagerSingleton();
         bind(AutoCreateIndex.class).asEagerSingleton();
+        bind(DestructiveOperations.class).asEagerSingleton();
         registerAction(NodesInfoAction.INSTANCE, TransportNodesInfoAction.class);
         registerAction(NodesStatsAction.INSTANCE, TransportNodesStatsAction.class);
         registerAction(NodesHotThreadsAction.INSTANCE, TransportNodesHotThreadsAction.class);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -48,10 +48,10 @@ public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIn
     public TransportCloseIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                      ThreadPool threadPool, MetaDataIndexStateService indexStateService,
                                      NodeSettingsService nodeSettingsService, ActionFilters actionFilters,
-                                     IndexNameExpressionResolver indexNameExpressionResolver) {
+                                     IndexNameExpressionResolver indexNameExpressionResolver, DestructiveOperations destructiveOperations) {
         super(settings, CloseIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, CloseIndexRequest.class);
         this.indexStateService = indexStateService;
-        this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
+        this.destructiveOperations = destructiveOperations;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -48,10 +48,10 @@ public class TransportDeleteIndexAction extends TransportMasterNodeAction<Delete
     public TransportDeleteIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                       ThreadPool threadPool, MetaDataDeleteIndexService deleteIndexService,
                                       NodeSettingsService nodeSettingsService, ActionFilters actionFilters,
-                                      IndexNameExpressionResolver indexNameExpressionResolver) {
+                                      IndexNameExpressionResolver indexNameExpressionResolver, DestructiveOperations destructiveOperations) {
         super(settings, DeleteIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, DeleteIndexRequest.class);
         this.deleteIndexService = deleteIndexService;
-        this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
+        this.destructiveOperations = destructiveOperations;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -47,10 +47,11 @@ public class TransportOpenIndexAction extends TransportMasterNodeAction<OpenInde
     @Inject
     public TransportOpenIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
                                     ThreadPool threadPool, MetaDataIndexStateService indexStateService,
-                                    NodeSettingsService nodeSettingsService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+                                    NodeSettingsService nodeSettingsService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                                    DestructiveOperations destructiveOperations) {
         super(settings, OpenIndexAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, OpenIndexRequest.class);
         this.indexStateService = indexStateService;
-        this.destructiveOperations = new DestructiveOperations(logger, settings, nodeSettingsService);
+        this.destructiveOperations = destructiveOperations;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
+++ b/core/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.action.support;
 
+import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.settings.NodeSettingsService;
 
@@ -33,14 +35,11 @@ public final class DestructiveOperations implements NodeSettingsService.Listener
      */
     public static final String REQUIRES_NAME = "action.destructive_requires_name";
 
-    private final ESLogger logger;
+    private final ESLogger logger = Loggers.getLogger(DestructiveOperations.class);
     private volatile boolean destructiveRequiresName;
 
-    // TODO: Turn into a component that can be reused and wired up into all the transport actions where
-    // this helper logic is required. Note: also added the logger as argument, otherwise the same log
-    // statement is printed several times, this can removed once this becomes a component.
-    public DestructiveOperations(ESLogger logger, Settings settings, NodeSettingsService nodeSettingsService) {
-        this.logger = logger;
+    @Inject
+    public DestructiveOperations(Settings settings, NodeSettingsService nodeSettingsService) {
         destructiveRequiresName = settings.getAsBoolean(DestructiveOperations.REQUIRES_NAME, false);
         nodeSettingsService.addListener(this);
     }
@@ -70,7 +69,7 @@ public final class DestructiveOperations implements NodeSettingsService.Listener
 
     @Override
     public void onRefreshSettings(Settings settings) {
-        boolean newValue = settings.getAsBoolean("action.destructive_requires_name", destructiveRequiresName);
+        boolean newValue = settings.getAsBoolean(DestructiveOperations.REQUIRES_NAME, destructiveRequiresName);
         if (destructiveRequiresName != newValue) {
             logger.info("updating [action.operate_all_indices] from [{}] to [{}]", destructiveRequiresName, newValue);
             this.destructiveRequiresName = newValue;

--- a/core/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
+++ b/core/src/main/java/org/elasticsearch/action/support/DestructiveOperations.java
@@ -19,27 +19,25 @@
 
 package org.elasticsearch.action.support;
 
+import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.settings.NodeSettingsService;
 
 /**
  * Helper for dealing with destructive operations and wildcard usage.
  */
-public final class DestructiveOperations implements NodeSettingsService.Listener {
+public final class DestructiveOperations extends AbstractComponent implements NodeSettingsService.Listener {
 
     /**
      * Setting which controls whether wildcard usage (*, prefix*, _all) is allowed.
      */
     public static final String REQUIRES_NAME = "action.destructive_requires_name";
-
-    private final ESLogger logger = Loggers.getLogger(DestructiveOperations.class);
     private volatile boolean destructiveRequiresName;
 
     @Inject
     public DestructiveOperations(Settings settings, NodeSettingsService nodeSettingsService) {
+        super(settings);
         destructiveRequiresName = settings.getAsBoolean(DestructiveOperations.REQUIRES_NAME, false);
         nodeSettingsService.addListener(this);
     }


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/4665

Inject DestructiveOperations object rather than use new.

Use constant rather than hard-coded string
