### PR TITLE
Improve startup exceptions (especially file permissions etc)

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -118,25 +118,25 @@ final class Security {
     static Permissions createPermissions(Environment environment) throws IOException {
         Permissions policy = new Permissions();
         // read-only dirs
-        addPath(policy, environment.binFile(), "read,readlink");
-        addPath(policy, environment.libFile(), "read,readlink");
-        addPath(policy, environment.pluginsFile(), "read,readlink");
-        addPath(policy, environment.configFile(), "read,readlink");
-        addPath(policy, environment.scriptsFile(), "read,readlink");
+        addPath(policy, "path.home", environment.binFile(), "read,readlink");
+        addPath(policy, "path.home", environment.libFile(), "read,readlink");
+        addPath(policy, "path.plugins", environment.pluginsFile(), "read,readlink");
+        addPath(policy, "path.conf", environment.configFile(), "read,readlink");
+        addPath(policy, "path.scripts", environment.scriptsFile(), "read,readlink");
         // read-write dirs
-        addPath(policy, environment.tmpFile(), "read,readlink,write,delete");
-        addPath(policy, environment.logsFile(), "read,readlink,write,delete");
+        addPath(policy, "java.io.tmpdir", environment.tmpFile(), "read,readlink,write,delete");
+        addPath(policy, "path.logs", environment.logsFile(), "read,readlink,write,delete");
         if (environment.sharedDataFile() != null) {
-            addPath(policy, environment.sharedDataFile(), "read,readlink,write,delete");
+            addPath(policy, "path.shared_data", environment.sharedDataFile(), "read,readlink,write,delete");
         }
         for (Path path : environment.dataFiles()) {
-            addPath(policy, path, "read,readlink,write,delete");
+            addPath(policy, "path.data", path, "read,readlink,write,delete");
         }
         for (Path path : environment.dataWithClusterFiles()) {
-            addPath(policy, path, "read,readlink,write,delete");
+            addPath(policy, "path.data", path, "read,readlink,write,delete");
         }
         for (Path path : environment.repoFiles()) {
-            addPath(policy, path, "read,readlink,write,delete");
+            addPath(policy, "path.repo", path, "read,readlink,write,delete");
         }
         if (environment.pidFile() != null) {
             // we just need permission to remove the file if its elsewhere.
@@ -145,10 +145,20 @@ final class Security {
         return policy;
     }
     
-    /** Add access to path (and all files underneath it */
-    static void addPath(Permissions policy, Path path, String permissions) throws IOException {
-        // paths may not exist yet
-        ensureDirectoryExists(path);
+    /**
+     * Add access to path (and all files underneath it
+     * @param policy current policy to add permissions to
+     * @param configurationName the configuration name associated with the path (for error messages only)
+     * @param path the path itself
+     * @param permissions set of filepermissions to grant to the path
+     */
+    static void addPath(Permissions policy, String configurationName, Path path, String permissions) {
+        // paths may not exist yet, this also checks accessibility
+        try {
+            ensureDirectoryExists(path);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to access '" + configurationName + "' (" + path + ")", e);
+        }
 
         // add each path twice: once for itself, again for files underneath it
         policy.add(new FilePermission(path.toString(), permissions));

--- a/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
@@ -59,10 +59,7 @@ class StartupError extends RuntimeException {
             cause = getFirstGuiceCause((CreationException)cause);
         }
         
-        String message = cause.getMessage();
-        if (message == null) {
-            message = "Unknown Error";
-        }
+        String message = cause.toString();
         s.println(message);
         
         if (cause != null) {

--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -107,7 +107,7 @@ public class PluginsService extends AbstractComponent {
           List<Bundle> bundles = getPluginBundles(environment);
           tupleBuilder.addAll(loadBundles(bundles));
         } catch (IOException ex) {
-          throw new IllegalStateException(ex);
+          throw new IllegalStateException("Unable to initialize plugins", ex);
         }
 
         plugins = tupleBuilder.build();
@@ -279,9 +279,10 @@ public class PluginsService extends AbstractComponent {
     }
 
     static List<Bundle> getPluginBundles(Environment environment) throws IOException {
-        ESLogger logger = Loggers.getLogger(Bootstrap.class);
+        ESLogger logger = Loggers.getLogger(PluginsService.class);
 
         Path pluginsDirectory = environment.pluginsFile();
+        // TODO: remove this leniency, but tests bogusly rely on it
         if (!isAccessibleDirectory(pluginsDirectory, logger)) {
             return Collections.emptyList();
         }

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -101,7 +101,7 @@ public class BootstrapForTesting {
                     }
                 }
                 // java.io.tmpdir
-                Security.addPath(perms, javaTmpDir, "read,readlink,write,delete");
+                Security.addPath(perms, "java.io.tmpdir", javaTmpDir, "read,readlink,write,delete");
                 // custom test config file
                 if (Strings.hasLength(System.getProperty("tests.config"))) {
                     perms.add(new FilePermission(System.getProperty("tests.config"), "read,readlink"));

--- a/core/src/test/java/org/elasticsearch/bootstrap/SecurityTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/SecurityTests.java
@@ -244,7 +244,7 @@ public class SecurityTests extends ESTestCase {
             assumeNoException("test cannot create symbolic links with security manager enabled", e);
         }
         Permissions permissions = new Permissions();
-        Security.addPath(permissions, link, "read");
+        Security.addPath(permissions, "testing", link, "read");
         assertExactPermissions(new FilePermission(link.toString(), "read"), permissions);
         assertExactPermissions(new FilePermission(link.resolve("foo").toString(), "read"), permissions);
         assertExactPermissions(new FilePermission(target.toString(), "read"), permissions);


### PR DESCRIPTION
Its probably likely users will configure paths and have issues (file not found, bad file permissions, etc).
Today the failure is pitiful:

```
Exception in thread "main" /path
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:384)
        at java.nio.file.Files.createDirectory(Files.java:674)
        at java.nio.file.Files.createAndCheckIsDirectory(Files.java:781)
        at java.nio.file.Files.createDirectories(Files.java:767)
        at org.elasticsearch.bootstrap.Security.ensureDirectoryExists(Security.java:171)
        at org.elasticsearch.bootstrap.Security.addPath(Security.java:151)
        at org.elasticsearch.bootstrap.Security.createPermissions(Security.java:133)
        at org.elasticsearch.bootstrap.Security.configure(Security.java:57)
        at org.elasticsearch.bootstrap.Bootstrap.setupSecurity(Bootstrap.java:188)
        at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:166)
        at org.elasticsearch.bootstrap.Bootstrap.doMain(Bootstrap.java:281)
        at org.elasticsearch.bootstrap.Bootstrap.main(Bootstrap.java:228)
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:28)
Refer to the log for complete error details.
```

We need more context here, like this:

```
Exception in thread "main" java.lang.IllegalStateException: Unable to access 'path.data' (/path/to/data)
Likely root cause: java.nio.file.AccessDeniedException: /path
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:384)
        at java.nio.file.Files.createDirectory(Files.java:674)
        at java.nio.file.Files.createAndCheckIsDirectory(Files.java:781)
        at java.nio.file.Files.createDirectories(Files.java:767)
        at org.elasticsearch.bootstrap.Security.ensureDirectoryExists(Security.java:181)
        at org.elasticsearch.bootstrap.Security.addPath(Security.java:158)
        at org.elasticsearch.bootstrap.Security.createPermissions(Security.java:133)
        at org.elasticsearch.bootstrap.Security.configure(Security.java:57)
        at org.elasticsearch.bootstrap.Bootstrap.setupSecurity(Bootstrap.java:188)
        at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:166)
        at org.elasticsearch.bootstrap.Bootstrap.doMain(Bootstrap.java:281)
        at org.elasticsearch.bootstrap.Bootstrap.main(Bootstrap.java:228)
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:28)
Refer to the log for complete error details.
```
