### PR TITLE
Make mlockall configuration easier.

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
@@ -75,16 +75,18 @@ class JNANatives {
         }
 
         // mlockall failed for some reason
-        logger.warn("Unable to lock JVM Memory: error=" + errno + ",reason=" + errMsg + ". This can result in part of the JVM being swapped out.");
+        logger.warn("Unable to lock JVM Memory: error=" + errno + ",reason=" + errMsg);
+        logger.warn("This can result in part of the JVM being swapped out.");
         if (errno == JNACLibrary.ENOMEM) {
             if (rlimitSuccess) {
                 logger.warn("Increase RLIMIT_MEMLOCK, soft limit: " + rlimitToString(softLimit) + ", hard limit: " + rlimitToString(hardLimit));
                 if (Constants.LINUX) {
                     // give specific instructions for the linux case to make it easy
+                    String user = System.getProperty("user.name");
                     logger.warn("These can be adjusted by modifying /etc/security/limits.conf, for example: \n" +
-                                "\t# allow user 'esuser' mlockall\n" +
-                                "\tesuser soft memlock unlimited\n" +
-                                "\tesuser hard memlock unlimited"
+                                "\t# allow user '" + user + "' mlockall\n" +
+                                "\t" + user + " soft memlock unlimited\n" +
+                                "\t" + user + " hard memlock unlimited"
                                );
                     logger.warn("If you are logged in interactively, you will have to re-login for the new limits to take effect.");
                 }


### PR DESCRIPTION
If the user tries to enable mlockall, chances are it will not work without some additional OS-level configuration. Today we try help show you how to get it working, but instead of using `esuser` in the example, we should just use the current username (user.name is always available from java). This means if they just blindly copy/paste it will work.

```
[2015-08-22 09:54:24,332][WARN ][org.elasticsearch.bootstrap] Unable to lock JVM Memory: error=12,reason=Cannot allocate memory
[2015-08-22 09:54:24,332][WARN ][org.elasticsearch.bootstrap] This can result in part of the JVM being swapped out.
[2015-08-22 09:54:24,332][WARN ][org.elasticsearch.bootstrap] Increase RLIMIT_MEMLOCK, soft limit: 65536, hard limit: 65536
[2015-08-22 09:54:24,332][WARN ][org.elasticsearch.bootstrap] These can be adjusted by modifying /etc/security/limits.conf, for example: 
    # allow user 'rmuir' mlockall
    rmuir soft memlock unlimited
    rmuir hard memlock unlimited
[2015-08-22 09:54:24,332][WARN ][org.elasticsearch.bootstrap] If you are logged in interactively, you will have to re-login for the new limits to take effect.
```
