### PR TITLE
Warmers delete _all should not throw exception when no warmers

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -92,7 +92,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                 MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
 
                 boolean globalFoundAtLeastOne = false;
-                boolean deleteAll = Arrays.asList(request.names()).contains("_all");
+                boolean deleteAll = Arrays.asList(request.names()).contains(MetaData.ALL);
                 for (String index : concreteIndices) {
                     IndexMetaData indexMetaData = currentState.metaData().index(index);
                     if (indexMetaData == null) {
@@ -104,7 +104,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                         for (IndexWarmersMetaData.Entry entry : warmers.entries()) {
                             boolean keepWarmer = true;
                             for (String warmer : request.names()) {
-                                if (Regex.simpleMatch(warmer, entry.name()) || warmer.equals("_all")) {
+                                if (Regex.simpleMatch(warmer, entry.name()) || warmer.equals(MetaData.ALL)) {
                                     globalFoundAtLeastOne = true;
                                     keepWarmer =  false;
                                     // don't add it...

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -124,7 +124,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                     }
                 }
 
-                if (!globalFoundAtLeastOne && deleteAll == false) {
+                if (globalFoundAtLeastOne == false && deleteAll == false) {
                     throw new IndexWarmerMissingException(request.names());
                 }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -96,6 +96,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                 for (int i=0; i<request.names().length; i++){
                     if (request.names()[i].equals(MetaData.ALL)) {
                         deleteAll = true;
+                        break;
                     }
                 }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -144,7 +144,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                         if (warmers != null) {
                             for (IndexWarmersMetaData.Entry entry : warmers.entries()) {
                                 for (String warmer : request.names()) {
-                                    if (Regex.simpleMatch(warmer, entry.name()) || warmer.equals("_all")) {
+                                    if (Regex.simpleMatch(warmer, entry.name()) || warmer.equals(MetaData.ALL)) {
                                         logger.info("[{}] delete warmer [{}]", index, entry.name());
                                     }
                                 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -92,6 +92,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                 MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
 
                 boolean globalFoundAtLeastOne = false;
+                boolean deleteAll = Arrays.asList(request.names()).contains("_all");
                 for (String index : concreteIndices) {
                     IndexMetaData indexMetaData = currentState.metaData().index(index);
                     if (indexMetaData == null) {
@@ -123,7 +124,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                     }
                 }
 
-                if (!globalFoundAtLeastOne) {
+                if (!globalFoundAtLeastOne && deleteAll == false) {
                     throw new IndexWarmerMissingException(request.names());
                 }
 
@@ -142,6 +143,8 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                                     }
                                 }
                             }
+                        } else if(deleteAll){
+                            logger.info("no warmers to delete on indice [{}]", index);
                         }
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -92,7 +92,13 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                 MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
 
                 boolean globalFoundAtLeastOne = false;
-                boolean deleteAll = Arrays.asList(request.names()).contains(MetaData.ALL);
+                boolean deleteAll = false;
+                for (int i=0; i<request.names().length; i++){
+                    if (request.names()[i].equals(MetaData.ALL)) {
+                        deleteAll = true;
+                    }
+                }
+                
                 for (String index : concreteIndices) {
                     IndexMetaData indexMetaData = currentState.metaData().index(index);
                     if (indexMetaData == null) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/TransportDeleteWarmerAction.java
@@ -98,7 +98,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                         deleteAll = true;
                     }
                 }
-                
+
                 for (String index : concreteIndices) {
                     IndexMetaData indexMetaData = currentState.metaData().index(index);
                     if (indexMetaData == null) {
@@ -150,7 +150,7 @@ public class TransportDeleteWarmerAction extends TransportMasterNodeAction<Delet
                                 }
                             }
                         } else if(deleteAll){
-                            logger.info("no warmers to delete on indice [{}]", index);
+                            logger.debug("no warmers to delete on index [{}]", index);
                         }
                     }
                 }

--- a/core/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerIT.java
@@ -173,6 +173,16 @@ public class SimpleIndicesWarmerIT extends ESIntegTestCase {
         }
     }
 
+    @Test // issue 8991
+    public void deleteAllIndexWarmerDoesNotThrowWhenNoWarmers() {
+        createIndex("test");
+        try {
+            client().admin().indices().prepareDeleteWarmer().setIndices("test").setNames("_all").execute().actionGet();
+        } catch (Exception ex) {
+            fail("should not throw exception when deleting _all warmers");
+        }
+    }
+
     @Test
     public void deleteIndexWarmerTest() {
         createIndex("test");

--- a/core/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerIT.java
@@ -179,6 +179,10 @@ public class SimpleIndicesWarmerIT extends ESIntegTestCase {
         DeleteWarmerResponse deleteWarmerResponse = client().admin().indices().prepareDeleteWarmer()
                 .setIndices("test").setNames("_all").execute().actionGet();
         assertThat(deleteWarmerResponse.isAcknowledged(), equalTo(true));
+
+        deleteWarmerResponse = client().admin().indices().prepareDeleteWarmer()
+                .setIndices("test").setNames("foo", "_all", "bar").execute().actionGet();
+        assertThat(deleteWarmerResponse.isAcknowledged(), equalTo(true));
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/warmer/SimpleIndicesWarmerIT.java
@@ -176,11 +176,9 @@ public class SimpleIndicesWarmerIT extends ESIntegTestCase {
     @Test // issue 8991
     public void deleteAllIndexWarmerDoesNotThrowWhenNoWarmers() {
         createIndex("test");
-        try {
-            client().admin().indices().prepareDeleteWarmer().setIndices("test").setNames("_all").execute().actionGet();
-        } catch (Exception ex) {
-            fail("should not throw exception when deleting _all warmers");
-        }
+        DeleteWarmerResponse deleteWarmerResponse = client().admin().indices().prepareDeleteWarmer()
+                .setIndices("test").setNames("_all").execute().actionGet();
+        assertThat(deleteWarmerResponse.isAcknowledged(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
I think this fixes #8991. It will not throw exceptions when the request is to delete "_all" warmers but log it.
