### PR TITLE
Make FunctionScore work on unmapped field with `missing` parameter

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -57,7 +57,7 @@ public class FieldValueFactorFunction extends ScoreFunction {
     public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) {
         final SortedNumericDoubleValues values;
         if(indexFieldData == null) {
-            values = FieldData.emptySortedNumericDoubles(0);
+            values = FieldData.emptySortedNumericDoubles(ctx.reader().maxDoc());
         } else {
             values = this.indexFieldData.load(ctx).getDoubleValues();
         }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -54,13 +54,24 @@ public class FieldValueFactorFunction extends ScoreFunction {
 
     @Override
     public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) {
-        final SortedNumericDoubleValues values = this.indexFieldData.load(ctx).getDoubleValues();
+        final SortedNumericDoubleValues values;
+        if(indexFieldData == null) {
+            values = null;
+        } else {
+            values = this.indexFieldData.load(ctx).getDoubleValues();
+        }
+
         return new LeafScoreFunction() {
 
             @Override
             public double score(int docId, float subQueryScore) {
-                values.setDocument(docId);
-                final int numValues = values.count();
+                final int numValues;
+                if(values == null){
+                    numValues = 0;
+                } else {
+                    values.setDocument(docId);
+                    numValues = values.count();
+                }
                 double value;
                 if (numValues > 0) {
                     value = values.valueAt(0);

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.lucene.search.function;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 
@@ -56,7 +57,7 @@ public class FieldValueFactorFunction extends ScoreFunction {
     public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) {
         final SortedNumericDoubleValues values;
         if(indexFieldData == null) {
-            values = null;
+            values = FieldData.emptySortedNumericDoubles(0);
         } else {
             values = this.indexFieldData.load(ctx).getDoubleValues();
         }
@@ -65,13 +66,8 @@ public class FieldValueFactorFunction extends ScoreFunction {
 
             @Override
             public double score(int docId, float subQueryScore) {
-                final int numValues;
-                if(values == null){
-                    numValues = 0;
-                } else {
-                    values.setDocument(docId);
-                    numValues = values.count();
-                }
+                values.setDocument(docId);
+                final int numValues = values.count();
                 double value;
                 if (numValues > 0) {
                     value = values.valueAt(0);

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -104,6 +104,15 @@ public class FunctionScoreFieldValueIT extends ESIntegTestCase {
                 .get();
         assertOrderedSearchHits(response, "1", "2", "3");
 
+        // field is not mapped but we're defaulting it to 100 so all documents should have the same score
+        response = client().prepareSearch("test")
+                .setExplain(randomBoolean())
+                .setQuery(functionScoreQuery(matchAllQuery(),
+                        fieldValueFactorFunction("notmapped").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL).missing(100)))
+                .get();
+        assertEquals(response.getHits().getAt(0).score(), response.getHits().getAt(2).score(), 0);
+
+
         // n divided by 0 is infinity, which should provoke an exception.
         try {
             response = client().prepareSearch("test")


### PR DESCRIPTION
#10948: FunctionScore wont raise an exception if the field is not mapped and the user provided an 'missing' value.

P.S: Will greatly appreciate any feedback regarding my code, today is my first day trying to help the elasticsearch community. Thanks!

Closes #10948
