### PR TITLE
Add plugin modules before (almost all) others

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -324,6 +324,10 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
         modules.add(new IndexNameModule(index));
         modules.add(new LocalNodeIdModule(localNodeId));
         modules.add(new IndexSettingsModule(index, indexSettings));
+        // plugin modules must be added here, before others or we can get crazy injection errors...
+        for (Module pluginModule : pluginsService.indexModules(indexSettings)) {
+            modules.add(pluginModule);
+        }
         modules.add(new IndexStoreModule(indexSettings));
         modules.add(new AnalysisModule(indexSettings, indicesAnalysisService));
         modules.add(new SimilarityModule(indexSettings));
@@ -332,10 +336,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
         modules.add(new MapperServiceModule());
         modules.add(new IndexAliasesServiceModule());
         modules.add(new IndexModule(indexSettings));
-
-        for (Module pluginModule : pluginsService.indexModules(indexSettings)) {
-            modules.add(pluginModule);
-        }
+        
         pluginsService.processModules(modules);
 
         Injector indexInjector;

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -160,6 +160,10 @@ public class Node implements Releasable {
             ModulesBuilder modules = new ModulesBuilder();
             modules.add(new Version.Module(version));
             modules.add(new CircuitBreakerModule(settings));
+            // plugin modules must be added here, before others or we can get crazy injection errors...
+            for (Module pluginModule : pluginsService.nodeModules()) {
+                modules.add(pluginModule);
+            }
             modules.add(new PluginsModule(pluginsService));
             modules.add(new SettingsModule(settings));
             modules.add(new NodeModule(this));
@@ -188,9 +192,7 @@ public class Node implements Releasable {
             modules.add(new RepositoriesModule());
             modules.add(new TribeModule());
 
-            for (Module pluginModule : pluginsService.nodeModules()) {
-                modules.add(pluginModule);
-            }
+
             pluginsService.processModules(modules);
 
             injector = modules.createInjector();


### PR DESCRIPTION
This change makes modules added by plugins come before others, as it was
before #12783. The order of configuration, and thereby binding, happens
in the order modules are received, and without this change, some plugins
can get _insane_ guice errors (500mb stack trace).
