### PR TITLE
Add two phased commit to Cluster State publishing

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.support.LoggerMessageFormat;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
@@ -597,7 +598,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 IndexNotFoundException.class,
                 ShardNotFoundException.class,
                 NotSerializableExceptionWrapper.class,
-                org.elasticsearch.discovery.zen.publish.PublishClusterStateAction.FailedToCommitException.class
+                Discovery.FailedToCommitClusterStateException.class
         };
         Map<String, Constructor<? extends ElasticsearchException>> mapping = new HashMap<>(exceptions.length);
         for (Class<? extends ElasticsearchException> e : exceptions) {

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -596,7 +596,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 ResourceNotFoundException.class,
                 IndexNotFoundException.class,
                 ShardNotFoundException.class,
-                NotSerializableExceptionWrapper.class
+                NotSerializableExceptionWrapper.class,
+                org.elasticsearch.discovery.zen.publish.PublishClusterStateAction.FailedToCommitException.class
         };
         Map<String, Constructor<? extends ElasticsearchException>> mapping = new HashMap<>(exceptions.length);
         for (Class<? extends ElasticsearchException> e : exceptions) {

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -195,6 +195,7 @@ public class ClusterModule extends AbstractModule {
         registerClusterDynamicSetting(DestructiveOperations.REQUIRES_NAME, Validator.EMPTY);
         registerClusterDynamicSetting(DiscoverySettings.PUBLISH_TIMEOUT, Validator.TIME_NON_NEGATIVE);
         registerClusterDynamicSetting(DiscoverySettings.PUBLISH_DIFF_ENABLE, Validator.BOOLEAN);
+        registerClusterDynamicSetting(DiscoverySettings.COMMIT_TIMEOUT, Validator.TIME_NON_NEGATIVE);
         registerClusterDynamicSetting(HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING, Validator.MEMORY_SIZE);
         registerClusterDynamicSetting(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING, Validator.MEMORY_SIZE);
         registerClusterDynamicSetting(HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_OVERHEAD_SETTING, Validator.NON_NEGATIVE_DOUBLE);

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -256,7 +256,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
     }
 
     // Used for testing and logging to determine how this cluster state was send over the wire
-    boolean wasReadFromDiff() {
+    public boolean wasReadFromDiff() {
         return wasReadFromDiff;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.StringText;
-import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.*;
@@ -485,8 +484,8 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                     logger.debug("publishing cluster state version [{}]", newClusterState.version());
                     try {
                         discoveryService.publish(clusterChangedEvent, ackListener);
-                    } catch (Throwable t) {
-                        logger.warn("failing [{}]: failed to publish cluster state version [{}]", t, source, newClusterState.version());
+                    } catch (Discovery.FailedToCommitClusterStateException t) {
+                        logger.warn("failing [{}]: failed to commit cluster state version [{}]", t, source, newClusterState.version());
                         updateTask.onFailure(source, t);
                         return;
                     }

--- a/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -482,8 +482,14 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
                 // we publish here before we send a notification to all the listeners, since if it fails
                 // we don't want to notify
                 if (newClusterState.nodes().localNodeMaster()) {
-                    logger.debug("publishing cluster state version {}", newClusterState.version());
-                    discoveryService.publish(clusterChangedEvent, ackListener);
+                    logger.debug("publishing cluster state version [{}]", newClusterState.version());
+                    try {
+                        discoveryService.publish(clusterChangedEvent, ackListener);
+                    } catch (Throwable t) {
+                        logger.warn("failing [{}]: failed to publish cluster state version [{}]", t, source, newClusterState.version());
+                        updateTask.onFailure(source, t);
+                        return;
+                    }
                 }
 
                 // update the current cluster state

--- a/core/src/main/java/org/elasticsearch/discovery/Discovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/Discovery.java
@@ -19,14 +19,16 @@
 
 package org.elasticsearch.discovery;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingService;
-import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.node.service.NodeService;
+
+import java.io.IOException;
 
 /**
  * A pluggable module allowing to implement discovery of other nodes, publishing of the cluster
@@ -60,11 +62,29 @@ public interface Discovery extends LifecycleComponent<Discovery> {
      *
      * The {@link AckListener} allows to keep track of the ack received from nodes, and verify whether
      * they updated their own cluster state or not.
+     *
+     * The method is guaranteed to throw a {@link FailedToCommitClusterStateException} if the change is not committed and should be rejected.
+     * Any other exception signals the something wrong happened but the change is committed.
      */
     void publish(ClusterChangedEvent clusterChangedEvent, AckListener ackListener);
 
-    public static interface AckListener {
+    interface AckListener {
         void onNodeAck(DiscoveryNode node, @Nullable Throwable t);
         void onTimeout();
+    }
+
+    class FailedToCommitClusterStateException extends ElasticsearchException {
+
+        public FailedToCommitClusterStateException(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public FailedToCommitClusterStateException(String msg, Object... args) {
+            super(msg, args);
+        }
+
+        public FailedToCommitClusterStateException(String msg, Throwable cause, Object... args) {
+            super(msg, cause, args);
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -59,17 +59,17 @@ public class DiscoverySettings extends AbstractComponent {
     public final static ClusterBlock NO_MASTER_BLOCK_WRITES = new ClusterBlock(NO_MASTER_BLOCK_ID, "no master", true, false, RestStatus.SERVICE_UNAVAILABLE, EnumSet.of(ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA_WRITE));
 
     private volatile ClusterBlock noMasterBlock;
-    private volatile TimeValue publishTimeout = DEFAULT_PUBLISH_TIMEOUT;
-    private volatile TimeValue commitTimeout = DEFAULT_COMMIT_TIMEOUT;
-    private volatile boolean publishDiff = DEFAULT_PUBLISH_DIFF_ENABLE;
+    private volatile TimeValue publishTimeout;
+    private volatile TimeValue commitTimeout;
+    private volatile boolean publishDiff;
 
     @Inject
     public DiscoverySettings(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
         nodeSettingsService.addListener(new ApplySettings());
         this.noMasterBlock = parseNoMasterBlock(settings.get(NO_MASTER_BLOCK, DEFAULT_NO_MASTER_BLOCK));
-        this.publishTimeout = settings.getAsTime(PUBLISH_TIMEOUT, publishTimeout);
-        this.commitTimeout = settings.getAsTime(COMMIT_TIMEOUT, publishTimeout);
+        this.publishTimeout = settings.getAsTime(PUBLISH_TIMEOUT, DEFAULT_PUBLISH_TIMEOUT);
+        this.commitTimeout = settings.getAsTime(COMMIT_TIMEOUT, DEFAULT_COMMIT_TIMEOUT);
         this.publishDiff = settings.getAsBoolean(PUBLISH_DIFF_ENABLE, DEFAULT_PUBLISH_DIFF_ENABLE);
     }
 

--- a/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -60,7 +60,7 @@ public class DiscoverySettings extends AbstractComponent {
         nodeSettingsService.addListener(new ApplySettings());
         this.noMasterBlock = parseNoMasterBlock(settings.get(NO_MASTER_BLOCK, DEFAULT_NO_MASTER_BLOCK));
         this.publishTimeout = settings.getAsTime(PUBLISH_TIMEOUT, publishTimeout);
-        this.commitTimeout = settings.getAsTime(PUBLISH_TIMEOUT, publishTimeout);
+        this.commitTimeout = settings.getAsTime(COMMIT_TIMEOUT, publishTimeout);
         this.publishDiff = settings.getAsBoolean(PUBLISH_DIFF_ENABLE, DEFAULT_PUBLISH_DIFF_ENABLE);
     }
 
@@ -89,6 +89,13 @@ public class DiscoverySettings extends AbstractComponent {
                 if (newPublishTimeout.millis() != publishTimeout.millis()) {
                     logger.info("updating [{}] from [{}] to [{}]", PUBLISH_TIMEOUT, publishTimeout, newPublishTimeout);
                     publishTimeout = newPublishTimeout;
+                }
+            }
+            TimeValue newCommitTimeout = settings.getAsTime(COMMIT_TIMEOUT, null);
+            if (newCommitTimeout != null) {
+                if (newCommitTimeout.millis() != commitTimeout.millis()) {
+                    logger.info("updating [{}] from [{}] to [{}]", COMMIT_TIMEOUT, commitTimeout, newCommitTimeout);
+                    commitTimeout = newCommitTimeout;
                 }
             }
             String newNoMasterBlockValue = settings.get(NO_MASTER_BLOCK);

--- a/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -36,10 +36,12 @@ import java.util.EnumSet;
 public class DiscoverySettings extends AbstractComponent {
 
     public static final String PUBLISH_TIMEOUT = "discovery.zen.publish_timeout";
+    public static final String COMMIT_TIMEOUT = "discovery.zen.commit_timeout";
     public static final String NO_MASTER_BLOCK = "discovery.zen.no_master_block";
     public static final String PUBLISH_DIFF_ENABLE = "discovery.zen.publish_diff.enable";
 
     public static final TimeValue DEFAULT_PUBLISH_TIMEOUT = TimeValue.timeValueSeconds(30);
+    public static final TimeValue DEFAULT_COMMIT_TIMEOUT = TimeValue.timeValueSeconds(1);
     public static final String DEFAULT_NO_MASTER_BLOCK = "write";
     public final static int NO_MASTER_BLOCK_ID = 2;
     public final static boolean DEFAULT_PUBLISH_DIFF_ENABLE = true;
@@ -49,6 +51,7 @@ public class DiscoverySettings extends AbstractComponent {
 
     private volatile ClusterBlock noMasterBlock;
     private volatile TimeValue publishTimeout = DEFAULT_PUBLISH_TIMEOUT;
+    private volatile TimeValue commitTimeout = DEFAULT_COMMIT_TIMEOUT;
     private volatile boolean publishDiff = DEFAULT_PUBLISH_DIFF_ENABLE;
 
     @Inject
@@ -57,6 +60,7 @@ public class DiscoverySettings extends AbstractComponent {
         nodeSettingsService.addListener(new ApplySettings());
         this.noMasterBlock = parseNoMasterBlock(settings.get(NO_MASTER_BLOCK, DEFAULT_NO_MASTER_BLOCK));
         this.publishTimeout = settings.getAsTime(PUBLISH_TIMEOUT, publishTimeout);
+        this.commitTimeout = settings.getAsTime(PUBLISH_TIMEOUT, publishTimeout);
         this.publishDiff = settings.getAsBoolean(PUBLISH_DIFF_ENABLE, DEFAULT_PUBLISH_DIFF_ENABLE);
     }
 
@@ -65,6 +69,10 @@ public class DiscoverySettings extends AbstractComponent {
      */
     public TimeValue getPublishTimeout() {
         return publishTimeout;
+    }
+
+    public TimeValue getCommitTimeout() {
+        return commitTimeout;
     }
 
     public ClusterBlock getNoMasterBlock() {

--- a/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoverySettings.java
@@ -35,13 +35,22 @@ import java.util.EnumSet;
  */
 public class DiscoverySettings extends AbstractComponent {
 
+    /**
+     * sets the timeout for a complete publishing cycle, including both sending and committing. the master
+     * will continute to process the next cluster state update after this time has elapsed
+     **/
     public static final String PUBLISH_TIMEOUT = "discovery.zen.publish_timeout";
+
+    /**
+     * sets the timeout for receiving enough acks for a specific cluster state and committing it. failing
+     * to receive responses within this window will cause the cluster state change to be rejected.
+     */
     public static final String COMMIT_TIMEOUT = "discovery.zen.commit_timeout";
     public static final String NO_MASTER_BLOCK = "discovery.zen.no_master_block";
     public static final String PUBLISH_DIFF_ENABLE = "discovery.zen.publish_diff.enable";
 
     public static final TimeValue DEFAULT_PUBLISH_TIMEOUT = TimeValue.timeValueSeconds(30);
-    public static final TimeValue DEFAULT_COMMIT_TIMEOUT = TimeValue.timeValueSeconds(1);
+    public static final TimeValue DEFAULT_COMMIT_TIMEOUT = TimeValue.timeValueSeconds(30);
     public static final String DEFAULT_NO_MASTER_BLOCK = "write";
     public final static int NO_MASTER_BLOCK_ID = 2;
     public final static boolean DEFAULT_PUBLISH_DIFF_ENABLE = true;

--- a/core/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
@@ -333,9 +333,9 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
                         }
                         try {
                             newNodeSpecificClusterState = discovery.lastProcessedClusterState.readDiffFrom(StreamInput.wrap(clusterStateDiffBytes)).apply(discovery.lastProcessedClusterState);
-                            logger.debug("sending diff cluster state version with size {} to [{}]", clusterStateDiffBytes.length, discovery.localNode.getName());
+                            logger.trace("sending diff cluster state version [{}] with size {} to [{}]", clusterState.version(), clusterStateDiffBytes.length, discovery.localNode.getName());
                         } catch (IncompatibleClusterStateVersionException ex) {
-                            logger.warn("incompatible cluster state version - resending complete cluster state", ex);
+                            logger.warn("incompatible cluster state version [{}] - resending complete cluster state", ex, clusterState.version());
                         }
                     }
                     if (newNodeSpecificClusterState == null) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -331,7 +331,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         nodesFD.updateNodesAndPing(clusterChangedEvent.state());
         try {
             publishClusterState.publish(clusterChangedEvent, electMaster.minimumMasterNodes(), ackListener);
-        } catch (PublishClusterStateAction.FailedToCommitException t) {
+        } catch (FailedToCommitClusterStateException t) {
             // cluster service logs a WARN message
             logger.debug("failed to publish cluster state version [{}] (not enough nodes acknowledged, min master nodes [{}])", clusterChangedEvent.state().version(), electMaster.minimumMasterNodes());
             clusterService.submitStateUpdateTask("zen-disco-failed-to-publish", Priority.IMMEDIATE, new ClusterStateUpdateTask() {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -876,8 +876,8 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             return;
         }
         if (!currentNodes.masterNodeId().equals(newClusterState.nodes().masterNodeId())) {
-            logger.warn("received a cluster state from a different master then the current one, rejecting (received {}, current {})", newClusterState.nodes().masterNode(), currentNodes.masterNode());
-            throw new IllegalStateException("cluster state from a different master then the current one, rejecting (received " + newClusterState.nodes().masterNode() + ", current " + currentNodes.masterNode() + ")");
+            logger.warn("received a cluster state from a different master than the current one, rejecting (received {}, current {})", newClusterState.nodes().masterNode(), currentNodes.masterNode());
+            throw new IllegalStateException("cluster state from a different master than the current one, rejecting (received " + newClusterState.nodes().masterNode() + ", current " + currentNodes.masterNode() + ")");
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.service.InternalClusterService;
@@ -199,7 +200,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         this.nodesFD = new NodesFaultDetection(settings, threadPool, transportService, clusterName);
         this.nodesFD.addListener(new NodeFaultDetectionListener());
 
-        this.publishClusterState = new PublishClusterStateAction(settings, transportService, this, new NewClusterStateListener(), discoverySettings);
+        this.publishClusterState = new PublishClusterStateAction(settings, transportService, this, new NewClusterStateListener(), discoverySettings, clusterName);
         this.pingService.setPingContextProvider(this);
         this.membership = new MembershipAction(settings, clusterService, transportService, this, new MembershipListener());
 
@@ -329,7 +330,24 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             throw new IllegalStateException("Shouldn't publish state when not master");
         }
         nodesFD.updateNodesAndPing(clusterChangedEvent.state());
-        publishClusterState.publish(clusterChangedEvent, ackListener);
+        try {
+            publishClusterState.publish(clusterChangedEvent, electMaster.minimumMasterNodes(), ackListener);
+        } catch (PublishClusterStateAction.FailedToCommitException t) {
+            logger.warn("failed to publish [{}] (not enough nodes acknowledged, min master nodes [{}])", clusterChangedEvent.state().version(), electMaster.minimumMasterNodes());
+            clusterService.submitStateUpdateTask("zen-disco-failed-to-publish", Priority.IMMEDIATE, new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    return rejoin(currentState, "failed to publish to min_master_nodes");
+                }
+
+                @Override
+                public void onFailure(String source, Throwable t) {
+                    logger.error("unexpected failure during [{}]", t, source);
+                }
+
+            });
+            throw t;
+        }
     }
 
     /**
@@ -677,12 +695,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
     void handleNewClusterStateFromMaster(ClusterState newClusterState, final PublishClusterStateAction.NewClusterStateListener.NewStateProcessed newStateProcessed) {
         final ClusterName incomingClusterName = newClusterState.getClusterName();
-        /* The cluster name can still be null if the state comes from a node that is prev 1.1.1*/
-        if (incomingClusterName != null && !incomingClusterName.equals(this.clusterName)) {
-            logger.warn("received cluster state from [{}] which is also master but with a different cluster name [{}]", newClusterState.nodes().masterNode(), incomingClusterName);
-            newStateProcessed.onNewClusterStateFailed(new IllegalStateException("received state from a node that is not part of the cluster"));
-            return;
-        }
         if (localNodeMaster()) {
             logger.debug("received cluster state from [{}] which is also master with cluster name [{}]", newClusterState.nodes().masterNode(), incomingClusterName);
             final ClusterState newState = newClusterState;
@@ -705,101 +717,97 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
 
             });
         } else {
-            if (newClusterState.nodes().localNode() == null) {
-                logger.warn("received a cluster state from [{}] and not part of the cluster, should not happen", newClusterState.nodes().masterNode());
-                newStateProcessed.onNewClusterStateFailed(new IllegalStateException("received state from a node that is not part of the cluster"));
-            } else {
-
-                final ProcessClusterState processClusterState = new ProcessClusterState(newClusterState);
-                processNewClusterStates.add(processClusterState);
-
-                assert newClusterState.nodes().masterNode() != null : "received a cluster state without a master";
-                assert !newClusterState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock()) : "received a cluster state with a master block";
-
-                clusterService.submitStateUpdateTask("zen-disco-receive(from master [" + newClusterState.nodes().masterNode() + "])", Priority.URGENT, new ProcessedClusterStateNonMasterUpdateTask() {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        // we already processed it in a previous event
-                        if (processClusterState.processed) {
-                            return currentState;
-                        }
-
-                        // TODO: once improvement that we can do is change the message structure to include version and masterNodeId
-                        // at the start, this will allow us to keep the "compressed bytes" around, and only parse the first page
-                        // to figure out if we need to use it or not, and only once we picked the latest one, parse the whole state
 
 
-                        ClusterState updatedState = selectNextStateToProcess(processNewClusterStates);
-                        if (updatedState == null) {
-                            updatedState = currentState;
-                        }
-                        if (shouldIgnoreOrRejectNewClusterState(logger, currentState, updatedState)) {
-                            return currentState;
-                        }
+            final ProcessClusterState processClusterState = new ProcessClusterState(newClusterState);
+            processNewClusterStates.add(processClusterState);
 
-                        // we don't need to do this, since we ping the master, and get notified when it has moved from being a master
-                        // because it doesn't have enough master nodes...
-                        //if (!electMaster.hasEnoughMasterNodes(newState.nodes())) {
-                        //    return disconnectFromCluster(newState, "not enough master nodes on new cluster state wreceived from [" + newState.nodes().masterNode() + "]");
-                        //}
+            assert newClusterState.nodes().masterNode() != null : "received a cluster state without a master";
+            assert !newClusterState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock()) : "received a cluster state with a master block";
 
-                        // check to see that we monitor the correct master of the cluster
-                        if (masterFD.masterNode() == null || !masterFD.masterNode().equals(updatedState.nodes().masterNode())) {
-                            masterFD.restart(updatedState.nodes().masterNode(), "new cluster state received and we are monitoring the wrong master [" + masterFD.masterNode() + "]");
-                        }
+            clusterService.submitStateUpdateTask("zen-disco-receive(from master [" + newClusterState.nodes().masterNode() + "])", Priority.URGENT, new ProcessedClusterStateNonMasterUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    // we already processed it in a previous event
+                    if (processClusterState.processed) {
+                        return currentState;
+                    }
 
-                        if (currentState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock())) {
-                            // its a fresh update from the master as we transition from a start of not having a master to having one
-                            logger.debug("got first state from fresh master [{}]", updatedState.nodes().masterNodeId());
-                            long count = clusterJoinsCounter.incrementAndGet();
-                            logger.trace("updated cluster join cluster to [{}]", count);
-
-                            return updatedState;
-                        }
+                    // TODO: once improvement that we can do is change the message structure to include version and masterNodeId
+                    // at the start, this will allow us to keep the "compressed bytes" around, and only parse the first page
+                    // to figure out if we need to use it or not, and only once we picked the latest one, parse the whole state
 
 
-                        // some optimizations to make sure we keep old objects where possible
-                        ClusterState.Builder builder = ClusterState.builder(updatedState);
+                    ClusterState updatedState = selectNextStateToProcess(processNewClusterStates);
+                    if (updatedState == null) {
+                        updatedState = currentState;
+                    }
+                    if (shouldIgnoreOrRejectNewClusterState(logger, currentState, updatedState)) {
+                        return currentState;
+                    }
 
-                        // if the routing table did not change, use the original one
-                        if (updatedState.routingTable().version() == currentState.routingTable().version()) {
-                            builder.routingTable(currentState.routingTable());
-                        }
-                        // same for metadata
-                        if (updatedState.metaData().version() == currentState.metaData().version()) {
-                            builder.metaData(currentState.metaData());
-                        } else {
-                            // if its not the same version, only copy over new indices or ones that changed the version
-                            MetaData.Builder metaDataBuilder = MetaData.builder(updatedState.metaData()).removeAllIndices();
-                            for (IndexMetaData indexMetaData : updatedState.metaData()) {
-                                IndexMetaData currentIndexMetaData = currentState.metaData().index(indexMetaData.index());
-                                if (currentIndexMetaData != null && currentIndexMetaData.isSameUUID(indexMetaData.indexUUID()) &&
-                                        currentIndexMetaData.version() == indexMetaData.version()) {
-                                    // safe to reuse
-                                    metaDataBuilder.put(currentIndexMetaData, false);
-                                } else {
-                                    metaDataBuilder.put(indexMetaData, false);
-                                }
+                    // we don't need to do this, since we ping the master, and get notified when it has moved from being a master
+                    // because it doesn't have enough master nodes...
+                    //if (!electMaster.hasEnoughMasterNodes(newState.nodes())) {
+                    //    return disconnectFromCluster(newState, "not enough master nodes on new cluster state wreceived from [" + newState.nodes().masterNode() + "]");
+                    //}
+
+                    // check to see that we monitor the correct master of the cluster
+                    if (masterFD.masterNode() == null || !masterFD.masterNode().equals(updatedState.nodes().masterNode())) {
+                        masterFD.restart(updatedState.nodes().masterNode(), "new cluster state received and we are monitoring the wrong master [" + masterFD.masterNode() + "]");
+                    }
+
+                    if (currentState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock())) {
+                        // its a fresh update from the master as we transition from a start of not having a master to having one
+                        logger.debug("got first state from fresh master [{}]", updatedState.nodes().masterNodeId());
+                        long count = clusterJoinsCounter.incrementAndGet();
+                        logger.trace("updated cluster join cluster to [{}]", count);
+
+                        return updatedState;
+                    }
+
+
+                    // some optimizations to make sure we keep old objects where possible
+                    ClusterState.Builder builder = ClusterState.builder(updatedState);
+
+                    // if the routing table did not change, use the original one
+                    if (updatedState.routingTable().version() == currentState.routingTable().version()) {
+                        builder.routingTable(currentState.routingTable());
+                    }
+                    // same for metadata
+                    if (updatedState.metaData().version() == currentState.metaData().version()) {
+                        builder.metaData(currentState.metaData());
+                    } else {
+                        // if its not the same version, only copy over new indices or ones that changed the version
+                        MetaData.Builder metaDataBuilder = MetaData.builder(updatedState.metaData()).removeAllIndices();
+                        for (IndexMetaData indexMetaData : updatedState.metaData()) {
+                            IndexMetaData currentIndexMetaData = currentState.metaData().index(indexMetaData.index());
+                            if (currentIndexMetaData != null && currentIndexMetaData.isSameUUID(indexMetaData.indexUUID()) &&
+                                    currentIndexMetaData.version() == indexMetaData.version()) {
+                                // safe to reuse
+                                metaDataBuilder.put(currentIndexMetaData, false);
+                            } else {
+                                metaDataBuilder.put(indexMetaData, false);
                             }
-                            builder.metaData(metaDataBuilder);
                         }
-
-                        return builder.build();
+                        builder.metaData(metaDataBuilder);
                     }
 
-                    @Override
-                    public void onFailure(String source, Throwable t) {
-                        logger.error("unexpected failure during [{}]", t, source);
-                        newStateProcessed.onNewClusterStateFailed(t);
-                    }
+                    return builder.build();
+                }
 
-                    @Override
-                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                        sendInitialStateEventIfNeeded();
-                        newStateProcessed.onNewClusterStateProcessed();
-                    }
-                });
-            }
+                @Override
+                public void onFailure(String source, Throwable t) {
+                    logger.error("unexpected failure during [{}]", t, source);
+                    newStateProcessed.onNewClusterStateFailed(t);
+                }
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    sendInitialStateEventIfNeeded();
+                    newStateProcessed.onNewClusterStateProcessed();
+                }
+            });
         }
     }
 
@@ -848,18 +856,28 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
      * If the second condition fails we ignore the cluster state.
      */
     static boolean shouldIgnoreOrRejectNewClusterState(ESLogger logger, ClusterState currentState, ClusterState newClusterState) {
-        if (currentState.nodes().masterNodeId() == null) {
-            return false;
-        }
-        if (!currentState.nodes().masterNodeId().equals(newClusterState.nodes().masterNodeId())) {
-            logger.warn("received a cluster state from a different master then the current one, rejecting (received {}, current {})", newClusterState.nodes().masterNode(), currentState.nodes().masterNode());
-            throw new IllegalStateException("cluster state from a different master than the current one, rejecting (received " + newClusterState.nodes().masterNode() + ", current " + currentState.nodes().masterNode() + ")");
-        } else if (newClusterState.version() < currentState.version()) {
+        rejectNewClusterStateIfNeeded(logger, currentState.nodes(), newClusterState);
+        if (currentState.nodes().masterNodeId() != null && newClusterState.version() < currentState.version()) {
             // if the new state has a smaller version, and it has the same master node, then no need to process it
             logger.debug("received a cluster state that has a lower version than the current one, ignoring (received {}, current {})", newClusterState.version(), currentState.version());
             return true;
         } else {
             return false;
+        }
+    }
+
+    /**
+     * In the case we follow an elected master the new cluster state needs to have the same elected master
+     * This method checks for this and throws an exception if needed
+     */
+
+    public static void rejectNewClusterStateIfNeeded(ESLogger logger, DiscoveryNodes currentNodes, ClusterState newClusterState) {
+        if (currentNodes.masterNodeId() == null) {
+            return;
+        }
+        if (!currentNodes.masterNodeId().equals(newClusterState.nodes().masterNodeId())) {
+            logger.warn("received a cluster state from a different master then the current one, rejecting (received {}, current {})", newClusterState.nodes().masterNode(), currentNodes.masterNode());
+            throw new IllegalStateException("cluster state from a different master then the current one, rejecting (received " + newClusterState.nodes().masterNode() + ", current " + currentNodes.masterNode() + ")");
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
@@ -439,7 +439,11 @@ public class PublishClusterStateAction extends AbstractComponent {
     }
 
 
-    public class FailedToCommitException extends ElasticsearchException {
+    public static class FailedToCommitException extends ElasticsearchException {
+
+        public FailedToCommitException(StreamInput in) throws IOException {
+            super(in);
+        }
 
         public FailedToCommitException(String msg, Object... args) {
             super(msg, args);

--- a/core/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
@@ -20,11 +20,9 @@
 package org.elasticsearch.discovery.zen.publish;
 
 import com.google.common.collect.Maps;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.Diff;
-import org.elasticsearch.cluster.IncompatibleClusterStateVersionException;
+import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -41,13 +39,17 @@ import org.elasticsearch.discovery.BlockingClusterStatePublishResponseHandler;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
+import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -55,7 +57,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class PublishClusterStateAction extends AbstractComponent {
 
-    public static final String ACTION_NAME = "internal:discovery/zen/publish";
+    public static final String SEND_ACTION_NAME = "internal:discovery/zen/publish/send";
+    public static final String COMMIT_ACTION_NAME = "internal:discovery/zen/publish/commit";
 
     public interface NewClusterStateListener {
 
@@ -73,34 +76,41 @@ public class PublishClusterStateAction extends AbstractComponent {
     private final DiscoveryNodesProvider nodesProvider;
     private final NewClusterStateListener listener;
     private final DiscoverySettings discoverySettings;
+    private final ClusterName clusterName;
 
     public PublishClusterStateAction(Settings settings, TransportService transportService, DiscoveryNodesProvider nodesProvider,
-                                     NewClusterStateListener listener, DiscoverySettings discoverySettings) {
+                                     NewClusterStateListener listener, DiscoverySettings discoverySettings, ClusterName clusterName) {
         super(settings);
         this.transportService = transportService;
         this.nodesProvider = nodesProvider;
         this.listener = listener;
         this.discoverySettings = discoverySettings;
-        transportService.registerRequestHandler(ACTION_NAME, BytesTransportRequest.class, ThreadPool.Names.SAME, new PublishClusterStateRequestHandler());
+        this.clusterName = clusterName;
+        transportService.registerRequestHandler(SEND_ACTION_NAME, BytesTransportRequest.class, ThreadPool.Names.SAME, new SendClusterStateRequestHandler());
+        transportService.registerRequestHandler(COMMIT_ACTION_NAME, CommitClusterStateRequest.class, ThreadPool.Names.SAME, new CommitClusterStateRequestHandler());
     }
 
     public void close() {
-        transportService.removeHandler(ACTION_NAME);
+        transportService.removeHandler(SEND_ACTION_NAME);
+        transportService.removeHandler(COMMIT_ACTION_NAME);
     }
 
-    public void publish(ClusterChangedEvent clusterChangedEvent, final Discovery.AckListener ackListener) {
+    public void publish(ClusterChangedEvent clusterChangedEvent, int minMasterNodes, final Discovery.AckListener ackListener) {
         Set<DiscoveryNode> nodesToPublishTo = new HashSet<>(clusterChangedEvent.state().nodes().size());
         DiscoveryNode localNode = nodesProvider.nodes().localNode();
+        int totalMasterNodes = 0;
         for (final DiscoveryNode node : clusterChangedEvent.state().nodes()) {
-            if (node.equals(localNode)) {
-                continue;
+            if (node.isMasterNode()) {
+                totalMasterNodes++;
             }
-            nodesToPublishTo.add(node);
+            if (node.equals(localNode) == false) {
+                nodesToPublishTo.add(node);
+            }
         }
-        publish(clusterChangedEvent, nodesToPublishTo, new AckClusterStatePublishResponseHandler(nodesToPublishTo, ackListener));
+        publish(clusterChangedEvent, minMasterNodes, totalMasterNodes, nodesToPublishTo, new AckClusterStatePublishResponseHandler(nodesToPublishTo, ackListener));
     }
 
-    private void publish(final ClusterChangedEvent clusterChangedEvent, final Set<DiscoveryNode> nodesToPublishTo,
+    private void publish(final ClusterChangedEvent clusterChangedEvent, int minMasterNodes, int totalMasterNodes, final Set<DiscoveryNode> nodesToPublishTo,
                          final BlockingClusterStatePublishResponseHandler publishResponseHandler) {
 
         Map<Version, BytesReference> serializedStates = Maps.newHashMap();
@@ -111,6 +121,7 @@ public class PublishClusterStateAction extends AbstractComponent {
         final AtomicBoolean timedOutWaitingForNodes = new AtomicBoolean(false);
         final TimeValue publishTimeout = discoverySettings.getPublishTimeout();
         final boolean sendFullVersion = !discoverySettings.getPublishDiff() || previousState == null;
+        final SendingController sendingController = new SendingController(clusterChangedEvent.state(), minMasterNodes, totalMasterNodes, publishResponseHandler);
         Diff<ClusterState> diff = null;
 
         for (final DiscoveryNode node : nodesToPublishTo) {
@@ -119,14 +130,16 @@ public class PublishClusterStateAction extends AbstractComponent {
             // per node when we send it over the wire, compress it while we are at it...
             // we don't send full version if node didn't exist in the previous version of cluster state
             if (sendFullVersion || !previousState.nodes().nodeExists(node.id())) {
-                sendFullClusterState(clusterState, serializedStates, node, timedOutWaitingForNodes, publishTimeout, publishResponseHandler);
+                sendFullClusterState(clusterState, serializedStates, node, timedOutWaitingForNodes, publishTimeout, sendingController);
             } else {
                 if (diff == null) {
                     diff = clusterState.diff(previousState);
                 }
-                sendClusterStateDiff(clusterState, diff, serializedDiffs, node, timedOutWaitingForNodes, publishTimeout, publishResponseHandler);
+                sendClusterStateDiff(clusterState, diff, serializedDiffs, node, timedOutWaitingForNodes, publishTimeout, sendingController);
             }
         }
+
+        sendingController.waitForCommit(discoverySettings.getCommitTimeout());
 
         if (publishTimeout.millis() > 0) {
             // only wait if the publish timeout is configured...
@@ -148,7 +161,7 @@ public class PublishClusterStateAction extends AbstractComponent {
 
     private void sendFullClusterState(ClusterState clusterState, @Nullable Map<Version, BytesReference> serializedStates,
                                       DiscoveryNode node, AtomicBoolean timedOutWaitingForNodes, TimeValue publishTimeout,
-                                      BlockingClusterStatePublishResponseHandler publishResponseHandler) {
+                                      SendingController sendingController) {
         BytesReference bytes = null;
         if (serializedStates != null) {
             bytes = serializedStates.get(node.version());
@@ -161,16 +174,16 @@ public class PublishClusterStateAction extends AbstractComponent {
                 }
             } catch (Throwable e) {
                 logger.warn("failed to serialize cluster_state before publishing it to node {}", e, node);
-                publishResponseHandler.onFailure(node, e);
+                sendingController.onNodeSendFailed(node, e);
                 return;
             }
         }
-        publishClusterStateToNode(clusterState, bytes, node, timedOutWaitingForNodes, publishTimeout, publishResponseHandler, false);
+        sendClusterStateToNode(clusterState, bytes, node, timedOutWaitingForNodes, publishTimeout, sendingController, false);
     }
 
     private void sendClusterStateDiff(ClusterState clusterState, Diff diff, Map<Version, BytesReference> serializedDiffs, DiscoveryNode node,
                                       AtomicBoolean timedOutWaitingForNodes, TimeValue publishTimeout,
-                                      BlockingClusterStatePublishResponseHandler publishResponseHandler) {
+                                      SendingController sendingController) {
         BytesReference bytes = serializedDiffs.get(node.version());
         if (bytes == null) {
             try {
@@ -178,23 +191,23 @@ public class PublishClusterStateAction extends AbstractComponent {
                 serializedDiffs.put(node.version(), bytes);
             } catch (Throwable e) {
                 logger.warn("failed to serialize diff of cluster_state before publishing it to node {}", e, node);
-                publishResponseHandler.onFailure(node, e);
+                sendingController.onNodeSendFailed(node, e);
                 return;
             }
         }
-        publishClusterStateToNode(clusterState, bytes, node, timedOutWaitingForNodes, publishTimeout, publishResponseHandler, true);
+        sendClusterStateToNode(clusterState, bytes, node, timedOutWaitingForNodes, publishTimeout, sendingController, true);
     }
 
-    private void publishClusterStateToNode(final ClusterState clusterState, BytesReference bytes,
-                                           final DiscoveryNode node, final AtomicBoolean timedOutWaitingForNodes,
-                                           final TimeValue publishTimeout,
-                                           final BlockingClusterStatePublishResponseHandler publishResponseHandler,
-                                           final boolean sendDiffs) {
+    private void sendClusterStateToNode(final ClusterState clusterState, BytesReference bytes,
+                                        final DiscoveryNode node, final AtomicBoolean timedOutWaitingForNodes,
+                                        final TimeValue publishTimeout,
+                                        final SendingController sendingController,
+                                        final boolean sendDiffs) {
         try {
             TransportRequestOptions options = TransportRequestOptions.options().withType(TransportRequestOptions.Type.STATE).withCompress(false);
             // no need to put a timeout on the options here, because we want the response to eventually be received
             // and not log an error if it arrives after the timeout
-            transportService.sendRequest(node, ACTION_NAME,
+            transportService.sendRequest(node, SEND_ACTION_NAME,
                     new BytesTransportRequest(bytes, node.version()),
                     options, // no need to compress, we already compressed the bytes
 
@@ -205,25 +218,58 @@ public class PublishClusterStateAction extends AbstractComponent {
                             if (timedOutWaitingForNodes.get()) {
                                 logger.debug("node {} responded for cluster state [{}] (took longer than [{}])", node, clusterState.version(), publishTimeout);
                             }
-                            publishResponseHandler.onResponse(node);
+                            sendingController.onNodeSendAck(node);
                         }
 
                         @Override
                         public void handleException(TransportException exp) {
                             if (sendDiffs && exp.unwrapCause() instanceof IncompatibleClusterStateVersionException) {
                                 logger.debug("resending full cluster state to node {} reason {}", node, exp.getDetailedMessage());
-                                sendFullClusterState(clusterState, null, node, timedOutWaitingForNodes, publishTimeout, publishResponseHandler);
+                                sendFullClusterState(clusterState, null, node, timedOutWaitingForNodes, publishTimeout, sendingController);
                             } else {
                                 logger.debug("failed to send cluster state to {}", exp, node);
-                                publishResponseHandler.onFailure(node, exp);
+                                sendingController.onNodeSendFailed(node, exp);
                             }
                         }
                     });
         } catch (Throwable t) {
             logger.warn("error sending cluster state to {}", t, node);
+            sendingController.onNodeSendFailed(node, t);
+        }
+    }
+
+    private void sendCommitToNode(final DiscoveryNode node, final ClusterState clusterState, final BlockingClusterStatePublishResponseHandler publishResponseHandler) {
+        try {
+            logger.trace("sending commit for cluster state (uuid: [{}], version [{}]) to [{}]", clusterState.stateUUID(), clusterState.version(), node);
+            TransportRequestOptions options = TransportRequestOptions.options().withType(TransportRequestOptions.Type.STATE).withCompress(false);
+            // no need to put a timeout on the options here, because we want the response to eventually be received
+            // and not log an error if it arrives after the timeout
+            transportService.sendRequest(node, COMMIT_ACTION_NAME,
+                    new CommitClusterStateRequest(clusterState.stateUUID()),
+                    options, // no need to compress, we already compressed the bytes
+
+                    new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+
+                        @Override
+                        public void handleResponse(TransportResponse.Empty response) {
+//                            if (timedOutWaitingForNodes.get()) {
+                            logger.debug("node {} responded to cluster state commit [{}]", node, clusterState.version());
+//                            }
+                            publishResponseHandler.onResponse(node);
+                        }
+
+                        @Override
+                        public void handleException(TransportException exp) {
+                            logger.debug("failed to commit cluster state (uuid [{}], version [{}]) to {}", exp, clusterState.stateUUID(), clusterState.version(), node);
+                            publishResponseHandler.onFailure(node, exp);
+                        }
+                    });
+        } catch (Throwable t) {
+            logger.warn("error sending cluster state commit (uuid [{}], version [{}]) to {}", t, clusterState.stateUUID(), clusterState.version(), node);
             publishResponseHandler.onFailure(node, t);
         }
     }
+
 
     public static BytesReference serializeFullClusterState(ClusterState clusterState, Version nodeVersion) throws IOException {
         BytesStreamOutput bStream = new BytesStreamOutput();
@@ -245,8 +291,10 @@ public class PublishClusterStateAction extends AbstractComponent {
         return bStream.bytes();
     }
 
-    private class PublishClusterStateRequestHandler implements TransportRequestHandler<BytesTransportRequest> {
-        private ClusterState lastSeenClusterState;
+    private Object lastSeenClusterStateMutex = new Object();
+    private ClusterState lastSeenClusterState;
+
+    private class SendClusterStateRequestHandler implements TransportRequestHandler<BytesTransportRequest> {
 
         @Override
         public void messageReceived(BytesTransportRequest request, final TransportChannel channel) throws Exception {
@@ -258,24 +306,57 @@ public class PublishClusterStateAction extends AbstractComponent {
                 in = request.bytes().streamInput();
             }
             in.setVersion(request.version());
-            synchronized (this) {
+            synchronized (lastSeenClusterStateMutex) {
+                final ClusterState incomingState;
                 // If true we received full cluster state - otherwise diffs
                 if (in.readBoolean()) {
-                    lastSeenClusterState = ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode());
-                    logger.debug("received full cluster state version {} with size {}", lastSeenClusterState.version(), request.bytes().length());
+                    incomingState = ClusterState.Builder.readFrom(in, nodesProvider.nodes().localNode());
+                    logger.debug("received full cluster state version [{}] with size [{}]", incomingState.version(), request.bytes().length());
                 } else if (lastSeenClusterState != null) {
                     Diff<ClusterState> diff = lastSeenClusterState.readDiffFrom(in);
-                    lastSeenClusterState = diff.apply(lastSeenClusterState);
-                    logger.debug("received diff cluster state version {} with uuid {}, diff size {}", lastSeenClusterState.version(), lastSeenClusterState.stateUUID(), request.bytes().length());
+                    incomingState = diff.apply(lastSeenClusterState);
+                    logger.debug("received diff cluster state version [{}] with uuid [{}], diff size [{}]", incomingState.version(), incomingState.stateUUID(), request.bytes().length());
                 } else {
                     logger.debug("received diff for but don't have any local cluster state - requesting full state");
                     throw new IncompatibleClusterStateVersionException("have no local cluster state");
                 }
+                // sanity check incoming state
+                final ClusterName incomingClusterName = incomingState.getClusterName();
+                if (!incomingClusterName.equals(PublishClusterStateAction.this.clusterName)) {
+                    logger.warn("received cluster state from [{}] which is also master but with a different cluster name [{}]", incomingState.nodes().masterNode(), incomingClusterName);
+                    throw new IllegalStateException("received state from a node that is not part of the cluster");
+                }
+                if (incomingState.nodes().localNode() == null) {
+                    logger.warn("received a cluster state from [{}] and not part of the cluster, should not happen", incomingState.nodes().masterNode());
+                    throw new IllegalStateException("received state from a node that is not part of the cluster");
+                }
+                // state from another master requires more subtle checks, so we let it pass for now (it will be checked in ZenDiscovery)
+                if (nodesProvider.nodes().localNodeMaster() == false) {
+                    ZenDiscovery.rejectNewClusterStateIfNeeded(logger, nodesProvider.nodes(), incomingState);
+                }
+
+                lastSeenClusterState = incomingState;
                 lastSeenClusterState.status(ClusterState.ClusterStateStatus.RECEIVED);
+            }
+            channel.sendResponse(TransportResponse.Empty.INSTANCE);
+        }
+    }
+
+    private class CommitClusterStateRequestHandler implements TransportRequestHandler<CommitClusterStateRequest> {
+        @Override
+        public void messageReceived(CommitClusterStateRequest request, final TransportChannel channel) throws Exception {
+            ClusterState committedClusterState;
+            synchronized (lastSeenClusterStateMutex) {
+                committedClusterState = lastSeenClusterState;
+            }
+            if (committedClusterState.stateUUID().equals(request.stateUUID) == false) {
+                // nocommit: we need something better here
+                channel.sendResponse(TransportResponse.Empty.INSTANCE);
+                return;
             }
 
             try {
-                listener.onNewClusterState(lastSeenClusterState, new NewClusterStateListener.NewStateProcessed() {
+                listener.onNewClusterState(committedClusterState, new NewClusterStateListener.NewStateProcessed() {
                     @Override
                     public void onNewClusterStateProcessed() {
                         try {
@@ -303,5 +384,111 @@ public class PublishClusterStateAction extends AbstractComponent {
                 }
             }
         }
+    }
+
+    static class CommitClusterStateRequest extends TransportRequest {
+
+        String stateUUID;
+
+        public CommitClusterStateRequest() {
+        }
+
+        public CommitClusterStateRequest(String stateUUID) {
+            this.stateUUID = stateUUID;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            stateUUID = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(stateUUID);
+        }
+    }
+
+
+    public class FailedToCommitException extends ElasticsearchException {
+
+        public FailedToCommitException(String msg) {
+            super(msg);
+        }
+    }
+
+    class SendingController {
+
+        private final ClusterState clusterState;
+        private final BlockingClusterStatePublishResponseHandler publishResponseHandler;
+        volatile int neededMastersToCommit;
+        int pendingMasterNodes;
+        final ArrayList<DiscoveryNode> sendAckedBeforeCommit = new ArrayList<>();
+        final CountDownLatch comittedOrFailed;
+        final AtomicBoolean committed;
+
+        private SendingController(ClusterState clusterState, int minMasterNodes, int totalMasterNodes, BlockingClusterStatePublishResponseHandler publishResponseHandler) {
+            this.clusterState = clusterState;
+            this.publishResponseHandler = publishResponseHandler;
+            this.neededMastersToCommit = Math.max(0, minMasterNodes - 1); // we are one of the master nodes
+            this.pendingMasterNodes = totalMasterNodes - 1;
+            this.committed = new AtomicBoolean(neededMastersToCommit == 0);
+            this.comittedOrFailed = new CountDownLatch(committed.get() ? 0 : 1);
+        }
+
+        public void waitForCommit(TimeValue commitTimeout) {
+            try {
+                comittedOrFailed.await(commitTimeout.millis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+
+            }
+            if (committed.get() == false) {
+                throw new FailedToCommitException("failed to get enough masters to ack sent cluster state. [" + neededMastersToCommit + "] left");
+            }
+        }
+
+        synchronized public void onNodeSendAck(DiscoveryNode node) {
+            if (committed.get() == false) {
+                sendAckedBeforeCommit.add(node);
+                if (node.isMasterNode()) {
+                    onMasterNodeSendAck(node);
+                }
+            } else {
+                assert sendAckedBeforeCommit.isEmpty();
+                sendCommitToNode(node, clusterState, publishResponseHandler);
+            }
+
+        }
+
+        private void onMasterNodeSendAck(DiscoveryNode node) {
+            neededMastersToCommit--;
+            if (neededMastersToCommit == 0) {
+                logger.trace("committing version [{}]", clusterState.version());
+                for (DiscoveryNode nodeToCommit : sendAckedBeforeCommit) {
+                    sendCommitToNode(nodeToCommit, clusterState, publishResponseHandler);
+                }
+                sendAckedBeforeCommit.clear();
+                boolean success = committed.compareAndSet(false, true);
+                assert success;
+                comittedOrFailed.countDown();
+            }
+            onMasterNodeDone(node);
+        }
+
+        private void onMasterNodeDone(DiscoveryNode node) {
+            pendingMasterNodes--;
+            if (pendingMasterNodes == 0) {
+                comittedOrFailed.countDown();
+            }
+        }
+
+        synchronized public void onNodeSendFailed(DiscoveryNode node, Throwable t) {
+            if (node.isMasterNode()) {
+                onMasterNodeDone(node);
+            }
+            publishResponseHandler.onFailure(node, t);
+        }
+
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.disruption.NetworkDelaysPartition;
 import org.elasticsearch.test.disruption.NetworkUnresponsivePartition;
 import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.test.transport.MockTransportService;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -353,6 +354,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
                 .put(ZenDiscovery.SETTING_PING_TIMEOUT, "200ms")
                 .put(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES, 2)
                 .put(DiscoverySettings.COMMIT_TIMEOUT, "100ms") // speed things up
+                .put("plugin.types", MockTransportService.TestPlugin.class.getName())
                 .build();
         internalCluster().startNodesAsync(3, settings).get();
 

--- a/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -27,16 +27,15 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
 import org.elasticsearch.discovery.zen.fd.FaultDetection;
-import org.elasticsearch.discovery.zen.publish.PublishClusterStateAction;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.disruption.NetworkDelaysPartition;
-import org.elasticsearch.test.disruption.NetworkUnresponsivePartition;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.junit.Test;
@@ -393,7 +392,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         logger.debug("--> waiting for cluster state to be processed/rejected");
         latch.await();
 
-        assertThat(failure.get(), instanceOf(PublishClusterStateAction.FailedToCommitException.class));
+        assertThat(failure.get(), instanceOf(Discovery.FailedToCommitClusterStateException.class));
         assertBusy(new Runnable() {
             @Override
             public void run() {

--- a/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -23,24 +23,37 @@ import com.google.common.base.Predicate;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.discovery.zen.ZenDiscovery;
 import org.elasticsearch.discovery.zen.elect.ElectMasterService;
+import org.elasticsearch.discovery.zen.fd.FaultDetection;
+import org.elasticsearch.discovery.zen.publish.PublishClusterStateAction;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.disruption.NetworkDelaysPartition;
+import org.elasticsearch.test.disruption.NetworkUnresponsivePartition;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.test.ESIntegTestCase.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.hamcrest.Matchers.*;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
@@ -331,5 +344,70 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         logger.info("--> verifying no node left and master is up");
         assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(nodeCount)).get().isTimedOut());
+    }
+
+    public void testCanNotPublishWithoutMinMastNodes() throws Exception {
+        Settings settings = settingsBuilder()
+                .put("discovery.type", "zen")
+                .put(FaultDetection.SETTING_PING_TIMEOUT, "1h") // disable it
+                .put(ZenDiscovery.SETTING_PING_TIMEOUT, "200ms")
+                .put(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES, 2)
+                .put(DiscoverySettings.COMMIT_TIMEOUT, "100ms") // speed things up
+                .build();
+        internalCluster().startNodesAsync(3, settings).get();
+
+        final String master = internalCluster().getMasterName();
+        Set<String> otherNodes = new HashSet<>(Arrays.asList(internalCluster().getNodeNames()));
+        otherNodes.remove(master);
+        NetworkDelaysPartition partition = new NetworkDelaysPartition(Collections.singleton(master), otherNodes, 60000, random());
+        internalCluster().setDisruptionScheme(partition);
+        partition.startDisrupting();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        logger.debug("--> submitting for cluster state to be rejected");
+        final ClusterService masterClusterService = internalCluster().clusterService(master);
+        masterClusterService.submitStateUpdateTask("test", new ProcessedClusterStateUpdateTask() {
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                latch.countDown();
+            }
+
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                MetaData.Builder metaData = MetaData.builder(currentState.metaData()).persistentSettings(
+                        Settings.builder().put(currentState.metaData().persistentSettings()).put("_SHOULD_NOT_BE_THERE_", true).build()
+                );
+                return ClusterState.builder(currentState).metaData(metaData).build();
+            }
+
+            @Override
+            public void onFailure(String source, Throwable t) {
+                failure.set(t);
+                latch.countDown();
+            }
+        });
+
+        logger.debug("--> waiting for cluster state to be processed/rejected");
+        latch.await();
+
+        assertThat(failure.get(), instanceOf(PublishClusterStateAction.FailedToCommitException.class));
+        assertBusy(new Runnable() {
+            @Override
+            public void run() {
+                assertThat(masterClusterService.state().nodes().masterNode(), nullValue());
+            }
+        });
+
+        partition.stopDisrupting();
+
+        logger.debug("--> waiting for cluster to heal");
+        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes("3").setWaitForEvents(Priority.LANGUID));
+
+        for (String node : internalCluster().getNodeNames()) {
+            Settings nodeSetting = internalCluster().clusterService(node).state().metaData().settings();
+            assertThat(node + " processed the cluster state despite of a min master node violation", nodeSetting.get("_SHOULD_NOT_BE_THERE_"), nullValue());
+        }
+
     }
 }

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -828,7 +828,11 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
 
         logger.info("blocking cluster state publishing from master [{}] to non master [{}]", masterNode, nonMasterNode);
         MockTransportService masterTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, masterNode);
-        masterTransportService.addFailToSendNoConnectRule(discoveryNodes.localNode(), PublishClusterStateAction.ACTION_NAME);
+        if (randomBoolean()) {
+            masterTransportService.addFailToSendNoConnectRule(discoveryNodes.localNode(), PublishClusterStateAction.SEND_ACTION_NAME);
+        } else {
+            masterTransportService.addFailToSendNoConnectRule(discoveryNodes.localNode(), PublishClusterStateAction.COMMIT_ACTION_NAME);
+        }
 
         logger.info("allowing requests from non master [{}] to master [{}], waiting for two join request", nonMasterNode, masterNode);
         final CountDownLatch countDownLatch = new CountDownLatch(2);

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryIT.java
@@ -205,7 +205,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
 
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Exception> reference = new AtomicReference<>();
-        internalCluster().getInstance(TransportService.class, noneMasterNode).sendRequest(node, PublishClusterStateAction.ACTION_NAME, new BytesTransportRequest(bytes, Version.CURRENT), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+        internalCluster().getInstance(TransportService.class, noneMasterNode).sendRequest(node, PublishClusterStateAction.SEND_ACTION_NAME, new BytesTransportRequest(bytes, Version.CURRENT), new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
 
             @Override
             public void handleResponse(TransportResponse.Empty response) {

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTest.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTest.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.transport.DummyTransportAddress;
-import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
@@ -46,7 +45,6 @@ public class ZenDiscoveryUnitTest extends ESTestCase {
 
         DiscoveryNodes.Builder currentNodes = DiscoveryNodes.builder();
         currentNodes.masterNodeId("a").put(new DiscoveryNode("a", DummyTransportAddress.INSTANCE, Version.CURRENT));
-        ;
         DiscoveryNodes.Builder newNodes = DiscoveryNodes.builder();
         newNodes.masterNodeId("a").put(new DiscoveryNode("a", DummyTransportAddress.INSTANCE, Version.CURRENT));
 

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTest.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTest.java
@@ -19,9 +19,13 @@
 
 package org.elasticsearch.discovery.zen;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
@@ -41,9 +45,10 @@ public class ZenDiscoveryUnitTest extends ESTestCase {
         ClusterName clusterName = new ClusterName("abc");
 
         DiscoveryNodes.Builder currentNodes = DiscoveryNodes.builder();
-        currentNodes.masterNodeId("a");
+        currentNodes.masterNodeId("a").put(new DiscoveryNode("a", DummyTransportAddress.INSTANCE, Version.CURRENT));
+        ;
         DiscoveryNodes.Builder newNodes = DiscoveryNodes.builder();
-        newNodes.masterNodeId("a");
+        newNodes.masterNodeId("a").put(new DiscoveryNode("a", DummyTransportAddress.INSTANCE, Version.CURRENT));
 
         ClusterState.Builder currentState = ClusterState.builder(clusterName);
         currentState.nodes(currentNodes);
@@ -61,7 +66,8 @@ public class ZenDiscoveryUnitTest extends ESTestCase {
         assertFalse("should not ignore, because new state's version is higher to current state's version", shouldIgnoreOrRejectNewClusterState(logger, currentState.build(), newState.build()));
 
         currentNodes = DiscoveryNodes.builder();
-        currentNodes.masterNodeId("b");
+        currentNodes.masterNodeId("b").put(new DiscoveryNode("b", DummyTransportAddress.INSTANCE, Version.CURRENT));
+        ;
         // version isn't taken into account, so randomize it to ensure this.
         if (randomBoolean()) {
             currentState.version(2);

--- a/core/src/test/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateActionTests.java
@@ -354,7 +354,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
 
 
     /**
-     * Test concurrent publishing works correctly (although not strictly required, it's a good testamne
+     * Test not waiting publishing works correctly (i.e., publishing times out)
      */
     @Test
     public void testSimultaneousClusterStatePublishing() throws Exception {
@@ -447,9 +447,9 @@ public class PublishClusterStateActionTests extends ESTestCase {
         try {
             publishStateAndWait(nodeA.action, unserializableClusterState, previousClusterState);
             fail("cluster state published despite of diff errors");
-        } catch (ElasticsearchException e) {
+        } catch (Discovery.FailedToCommitClusterStateException e) {
             assertThat(e.getCause(), notNullValue());
-            assertThat(e.getCause().getMessage(), containsString("Simulated"));
+            assertThat(e.getCause().getMessage(), containsString("failed to serialize"));
         }
     }
 
@@ -475,7 +475,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
         try {
             publishState(master.action, clusterState, previousState, masterNodes + randomIntBetween(1, 5));
             fail("cluster state publishing didn't fail despite of not having enough nodes");
-        } catch (PublishClusterStateAction.FailedToCommitException expected) {
+        } catch (Discovery.FailedToCommitClusterStateException expected) {
             logger.debug("failed to publish as expected", expected);
         }
     }
@@ -554,7 +554,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
             if (expectingToCommit == false) {
                 fail("cluster state publishing didn't fail despite of not have enough nodes");
             }
-        } catch (PublishClusterStateAction.FailedToCommitException exception) {
+        } catch (Discovery.FailedToCommitClusterStateException exception) {
             logger.debug("failed to publish as expected", exception);
             if (expectingToCommit) {
                 throw exception;
@@ -697,7 +697,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
             try {
                 publishState(master.action, state, master.clusterState, 2).await(1, TimeUnit.HOURS);
                 success = true;
-            } catch (PublishClusterStateAction.FailedToCommitException OK) {
+            } catch (Discovery.FailedToCommitClusterStateException OK) {
                 success = false;
             }
             logger.debug("--> publishing [{}], verifying...", success ? "succeeded" : "failed");

--- a/core/src/test/java/org/elasticsearch/test/disruption/NetworkDelaysPartition.java
+++ b/core/src/test/java/org/elasticsearch/test/disruption/NetworkDelaysPartition.java
@@ -60,6 +60,10 @@ public class NetworkDelaysPartition extends NetworkPartition {
         this(nodesSideOne, nodesSideTwo, DEFAULT_DELAY_MIN, DEFAULT_DELAY_MAX, random);
     }
 
+    public NetworkDelaysPartition(Set<String> nodesSideOne, Set<String> nodesSideTwo, long delay, Random random) {
+        this(nodesSideOne, nodesSideTwo, delay, delay, random);
+    }
+
     public NetworkDelaysPartition(Set<String> nodesSideOne, Set<String> nodesSideTwo, long delayMin, long delayMax, Random random) {
         super(nodesSideOne, nodesSideTwo, random);
         this.delayMin = delayMin;
@@ -69,7 +73,7 @@ public class NetworkDelaysPartition extends NetworkPartition {
 
     @Override
     public synchronized void startDisrupting() {
-        duration = new TimeValue(delayMin + random.nextInt((int) (delayMax - delayMin)));
+        duration = new TimeValue(delayMin == delayMax ? delayMin : delayMin + random.nextInt((int) (delayMax - delayMin)));
         super.startDisrupting();
     }
 

--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -108,12 +108,18 @@ considered failed. Defaults to `3`.
 The master node is the only node in a cluster that can make changes to the
 cluster state. The master node processes one cluster state update at a time,
 applies the required changes and publishes the updated cluster state to all
-the other nodes in the cluster. Each node receives the publish message,
-updates its own cluster state and replies to the master node, which waits for
-all nodes to respond, up to a timeout, before going ahead processing the next
-updates in the queue. The `discovery.zen.publish_timeout` is set by default
-to 30 seconds and can be changed dynamically through the
-<<cluster-update-settings,cluster update settings api>>
+the other nodes in the cluster. Each node receives the publish message, acknowledges
+it but do *not* yet apply it. If the master does not receive acknowledgement from
+at least `discovery.zen.minimum_master_nodes` nodes within a certain time (controlled by
+the `discovery.zen.commit_timeout` setting and defaults to 30 seconds) the cluster state
+change is rejected.
+
+Once enough nodes have responded, the cluster state is committed and a message will
+be sent to all the nodes. The nodes then proceed and apply the new cluster state to their
+internal state. The master node waits for all nodes to respond, up to a timeout, before
+going ahead processing the next updates in the queue. The `discovery.zen.publish_timeout` is
+set by default to 30 seconds and is measured from the moment the publishing started. Both
+timeout settings can be changed dynamically through the <<cluster-update-settings,cluster update settings api>>
 
 [float]
 [[no-master-block]]

--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -109,13 +109,13 @@ The master node is the only node in a cluster that can make changes to the
 cluster state. The master node processes one cluster state update at a time,
 applies the required changes and publishes the updated cluster state to all
 the other nodes in the cluster. Each node receives the publish message, acknowledges
-it but do *not* yet apply it. If the master does not receive acknowledgement from
+it, but does *not* yet apply it. If the master does not receive acknowledgement from
 at least `discovery.zen.minimum_master_nodes` nodes within a certain time (controlled by
 the `discovery.zen.commit_timeout` setting and defaults to 30 seconds) the cluster state
 change is rejected.
 
 Once enough nodes have responded, the cluster state is committed and a message will
-be sent to all the nodes. The nodes then proceed and apply the new cluster state to their
+be sent to all the nodes. The nodes then proceed to apply the new cluster state to their
 internal state. The master node waits for all nodes to respond, up to a timeout, before
 going ahead processing the next updates in the queue. The `discovery.zen.publish_timeout` is
 set by default to 30 seconds and is measured from the moment the publishing started. Both

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -59,16 +59,16 @@ We are committed to tracking down and fixing all the issues that are posted.
 === Use two phase commit for Cluster State publishing (STATUS: ONGOING)
 
 A master node in Elasticsearch continuously https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#fault-detection[monitors the cluster nodes]
-and removes any node from the cluster that doesn't respond to it's pings in a timely
-fashion. If the master is left with less nodes than the `discovery.zen.minimum_master_nodes`
+and removes any node from the cluster that doesn't respond to its pings in a timely
+fashion. If the master is left with fewer nodes than the `discovery.zen.minimum_master_nodes`
 settings, it will step down and a new master election will start.
 
-When a network partition occurs causing a master to loose many followers, there is a
-short window of time until detects it and master steps down. During that window, the
-master may erroneously accept and ack cluster state changes. To avoid this, we introduce
+When a network partition causes a master node to lose many followers, there is a short window
+in time until the node loss is detected and the master steps down. During that window, the
+master may erroneously accept and acknowledge cluster state changes. To avoid this, we introduce
 a new phase to cluster state publishing where the proposed cluster state is sent to all nodes
-but is not yet committed. Only once enough nodes (`minimum_master_nodes`) actively acknowledge
-the change, it is committed and commit messages are sent to the nodes. See See {GIT}13062[#13062].
+but is not yet committed. Only once enough nodes (`discovery.zen.minimum_master_nodes`) actively acknowledge
+the change, it is committed and commit messages are sent to the nodes. See {GIT}13062[#13062].
 
 [float]
 === Make index creation more user friendly (STATUS: ONGOING)

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -56,6 +56,21 @@ If you encounter an issue, https://github.com/elasticsearch/elasticsearch/issues
 We are committed to tracking down and fixing all the issues that are posted.
 
 [float]
+=== Use two phase commit for Cluster State publishing (STATUS: ONGOING)
+
+A master node in Elasticsearch continuously https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#fault-detection[monitors the cluster nodes]
+and removes any node from the cluster that doesn't respond to it's pings in a timely
+fashion. If the master is left with less nodes than the `discovery.zen.minimum_master_nodes`
+settings, it will step down and a new master election will start.
+
+When a network partition occurs causing a master to loose many followers, there is a
+short window of time until detects it and master steps down. During that window, the
+master may erroneously accept and ack cluster state changes. To avoid this, we introduce
+a new phase to cluster state publishing where the proposed cluster state is sent to all nodes
+but is not yet committed. Only once enough nodes (`minimum_master_nodes`) actively acknowledge
+the change, it is committed and commit messages are sent to the nodes. See See {GIT}13062[#13062].
+
+[float]
 === Make index creation more user friendly (STATUS: ONGOING)
 
 Today, Elasticsearch returns as soon as a create-index request has been processed,


### PR DESCRIPTION
When publishing a new cluster state, the master will send it to all the node of the cluster, noting down how many _master_ nodes responded successfully. The nodes do not yet process the new cluster state, but rather park it in memory. As soon as at least minimum master nodes have ack-ed the cluster state change, it is committed and a commit request is sent to all the node that responded so far (and will respond in the future). Once receiving the commit requests the nodes continue to process the cluster state change as they did before this change.

A few notable comments:
1. For this change to have effect, min master nodes must be configured.
2. All basic cluster state validation is done in the first phase of publish and is thus now part of `ShardOperationResult`
3. A new `COMMIT_TIMEOUT` settings is introduced, dictating how long a master should wait for nodes to ack the first phase. Unlike `PUBLISH_TIMEOUT`, if waiting for a commit times out, the cluster state change will be rejected.
4. Failing to achieve a min master node of acks, will cause the master to step down as it clearly doesn't have enough active followers.
5. Previously there was a short window between the moment a master lost it's followers and it stepping down because of node fault detection failures. In this short window, the master could process any change (but fail to publish it). This PR closes this gap to 0.

I still have one no commit and some docs to add but I think we can start the review cycles.

@brwe @imotov and @jasontedor  - can you have a **careful** look when you have time?
