### PR TITLE
Remove unsupported `rewrite` from multi_match query builder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -61,8 +61,6 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
 
     private String minimumShouldMatch;
 
-    private String rewrite = null;
-
     private String fuzzyRewrite = null;
 
     private Boolean useDisMax;
@@ -255,11 +253,6 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
         return this;
     }
 
-    public MultiMatchQueryBuilder rewrite(String rewrite) {
-        this.rewrite = rewrite;
-        return this;
-    }
-
     public MultiMatchQueryBuilder fuzzyRewrite(String fuzzyRewrite) {
         this.fuzzyRewrite = fuzzyRewrite;
         return this;
@@ -366,9 +359,6 @@ public class MultiMatchQueryBuilder extends QueryBuilder implements BoostableQue
         }
         if (minimumShouldMatch != null) {
             builder.field("minimum_should_match", minimumShouldMatch);
-        }
-        if (rewrite != null) {
-            builder.field("rewrite", rewrite);
         }
         if (fuzzyRewrite != null) {
             builder.field("fuzzy_rewrite", fuzzyRewrite);


### PR DESCRIPTION
The `rewrite` option has been removed from the parser with ommit da5fa6c4 and won't parse anymore, however we still have a setter for it in the builder that gets rendered out when used and potentially leads to parsing errors. This PR removes the setter for the unsupported `rewrite` option.

Follow up PR to #13069 
