### PR TITLE
Add more permissions for bouncycastle

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -121,4 +121,5 @@ grant {
   
   // needed to allow installation of bouncycastle crypto provider
   permission java.security.SecurityPermission "putProviderProperty.BC";
+  permission java.security.SecurityPermission "insertProvider.BC";
 };


### PR DESCRIPTION
As explained in [bouncy castle doc](http://www.bouncycastle.org/wiki/display/JA1/Using+the+Bouncy+Castle+Provider's+ImplicitlyCA+Facility), we need to have:

```
grant {
   permission java.security.SecurityPermission "putProviderProperty.BC";
   permission java.security.SecurityPermission "insertProvider.BC";
};
```

Mapper attachment plugin needs that to run properly.

Note that it looks like master branch does not require that change which looks strange to me. See https://github.com/elastic/elasticsearch/pull/13001#issuecomment-134245012.

Closes #13001
