### PR TITLE
Clean up more bats tests

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
@@ -34,50 +34,39 @@ load packaging_test_utils
 
 # Cleans everything for the 1st execution
 setup() {
-    if [ "$BATS_TEST_NUMBER" -eq 1 ]; then
-        clean_before_test
-    fi
+    skip_not_dpkg
 }
 
 ##################################
 # Install DEB package
 ##################################
 @test "[DEB] dpkg command is available" {
-    skip_not_dpkg
-    run dpkg --version
-    [ "$status" -eq 0 ]
+    clean_before_test
+    dpkg --version
 }
 
 @test "[DEB] package is available" {
-    skip_not_dpkg
     count=$(find . -type f -name 'elastic*.deb' | wc -l)
     [ "$count" -eq 1 ]
 }
 
 @test "[DEB] package is not installed" {
-    skip_not_dpkg
-    run dpkg -s 'elasticsearch' >&2
+    run dpkg -s 'elasticsearch'
     [ "$status" -eq 1 ]
 }
 
 @test "[DEB] install package" {
-    skip_not_dpkg
-    run dpkg -i elasticsearch*.deb >&2
-    [ "$status" -eq 0 ]
+    dpkg -i elasticsearch*.deb
 }
 
 @test "[DEB] package is installed" {
-    skip_not_dpkg
-    run dpkg -s 'elasticsearch' >&2
-    [ "$status" -eq 0 ]
+    dpkg -s 'elasticsearch'
 }
 
 ##################################
 # Check that the package is correctly installed
 ##################################
 @test "[DEB] verify package installation" {
-    skip_not_dpkg
-
     verify_package_installation
 }
 
@@ -85,8 +74,6 @@ setup() {
 # Check that Elasticsearch is working
 ##################################
 @test "[DEB] test elasticsearch" {
-    skip_not_dpkg
-
     start_elasticsearch_service
 
     run_elasticsearch_tests
@@ -96,21 +83,16 @@ setup() {
 # Uninstall DEB package
 ##################################
 @test "[DEB] remove package" {
-    skip_not_dpkg
-    run dpkg -r 'elasticsearch' >&2
-    [ "$status" -eq 0 ]
+    dpkg -r 'elasticsearch'
 }
 
 @test "[DEB] package has been removed" {
-    skip_not_dpkg
-    run dpkg -s 'elasticsearch' >&2
+    run dpkg -s 'elasticsearch'
     [ "$status" -eq 0 ]
     echo "$output" | grep -i "status" | grep -i "deinstall ok"
 }
 
 @test "[DEB] verify package removal" {
-    skip_not_dpkg
-
     # The removal must stop the service
     count=$(ps | grep Elasticsearch | wc -l)
     [ "$count" -eq 0 ]
@@ -146,14 +128,10 @@ setup() {
 }
 
 @test "[DEB] purge package" {
-    skip_not_dpkg
-    run dpkg --purge 'elasticsearch' >&2
-    [ "$status" -eq 0 ]
+    dpkg --purge 'elasticsearch'
 }
 
 @test "[DEB] verify package purge" {
-    skip_not_dpkg
-
     # all remaining files are deleted by the purge
     assert_file_not_exist "/etc/elasticsearch"
     assert_file_not_exist "/etc/elasticsearch/elasticsearch.yml"
@@ -171,7 +149,6 @@ setup() {
 }
 
 @test "[DEB] package has been completly removed" {
-    skip_not_dpkg
-    run dpkg -s 'elasticsearch' >&2
+    run dpkg -s 'elasticsearch'
     [ "$status" -eq 1 ]
 }

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -33,50 +33,39 @@ load packaging_test_utils
 
 # Cleans everything for the 1st execution
 setup() {
-    if [ "$BATS_TEST_NUMBER" -eq 1 ]; then
-        clean_before_test
-    fi
+    skip_not_rpm
 }
 
 ##################################
 # Install RPM package
 ##################################
 @test "[RPM] rpm command is available" {
-    skip_not_rpm
-    run rpm --version
-    [ "$status" -eq 0 ]
+    clean_before_test
+    rpm --version
 }
 
 @test "[RPM] package is available" {
-    skip_not_rpm
     count=$(find . -type f -name 'elastic*.rpm' | wc -l)
     [ "$count" -eq 1 ]
 }
 
 @test "[RPM] package is not installed" {
-    skip_not_rpm
-    run rpm -qe 'elasticsearch' >&2
+    run rpm -qe 'elasticsearch'
     [ "$status" -eq 1 ]
 }
 
 @test "[RPM] install package" {
-    skip_not_rpm
-    run rpm -i elasticsearch*.rpm >&2
-    [ "$status" -eq 0 ]
+    rpm -i elasticsearch*.rpm
 }
 
 @test "[RPM] package is installed" {
-    skip_not_rpm
-    run rpm -qe 'elasticsearch' >&2
-    [ "$status" -eq 0 ]
+    rpm -qe 'elasticsearch'
 }
 
 ##################################
 # Check that the package is correctly installed
 ##################################
 @test "[RPM] verify package installation" {
-    skip_not_rpm
-
     verify_package_installation
 }
 
@@ -84,8 +73,6 @@ setup() {
 # Check that Elasticsearch is working
 ##################################
 @test "[RPM] test elasticsearch" {
-    skip_not_rpm
-
     start_elasticsearch_service
 
     run_elasticsearch_tests
@@ -95,20 +82,15 @@ setup() {
 # Uninstall RPM package
 ##################################
 @test "[RPM] remove package" {
-    skip_not_rpm
-    run rpm -e 'elasticsearch' >&2
-    [ "$status" -eq 0 ]
+    rpm -e 'elasticsearch'
 }
 
 @test "[RPM] package has been removed" {
-    skip_not_rpm
-    run rpm -qe 'elasticsearch' >&2
+    run rpm -qe 'elasticsearch'
     [ "$status" -eq 1 ]
 }
 
 @test "[RPM] verify package removal" {
-    skip_not_rpm
-
     # The removal must stop the service
     count=$(ps | grep Elasticsearch | wc -l)
     [ "$count" -eq 0 ]

--- a/qa/vagrant/src/test/resources/packaging/scripts/60_systemd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/60_systemd.bats
@@ -33,42 +33,27 @@ load packaging_test_utils
 
 # Cleans everything for the 1st execution
 setup() {
-    if [ "$BATS_TEST_NUMBER" -eq 1 ]; then
-        clean_before_test
-    fi
-
-
-    # Installs a package before test
-    if is_dpkg; then
-        dpkg -i elasticsearch*.deb >&2 || true
-    fi
-    if is_rpm; then
-        rpm -i elasticsearch*.rpm >&2 || true
-    fi
+    skip_not_systemd
+    skip_not_dpkg_or_rpm
 }
 
-@test "[SYSTEMD] daemon reload" {
-    skip_not_systemd
+@test "[SYSTEMD] install elasticsearch" {
+    clean_before_test
+    install_package
+}
 
-    run systemctl daemon-reload
-    [ "$status" -eq 0 ]
+@test "[SYSTEMD] daemon reload after install" {
+    systemctl daemon-reload
 }
 
 @test "[SYSTEMD] enable" {
-    skip_not_systemd
+    systemctl enable elasticsearch.service
 
-    run systemctl enable elasticsearch.service
-    [ "$status" -eq 0 ]
-
-    run systemctl is-enabled elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl is-enabled elasticsearch.service
 }
 
 @test "[SYSTEMD] start" {
-    skip_not_systemd
-
-    run systemctl start elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl start elasticsearch.service
 
     wait_for_elasticsearch_status
 
@@ -76,72 +61,53 @@ setup() {
 }
 
 @test "[SYSTEMD] start (running)" {
-    skip_not_systemd
-
-    run systemctl start elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl start elasticsearch.service
 }
 
 @test "[SYSTEMD] is active (running)" {
-    skip_not_systemd
-
     run systemctl is-active elasticsearch.service
     [ "$status" -eq 0 ]
     [ "$output" = "active" ]
 }
 
 @test "[SYSTEMD] status (running)" {
-    skip_not_systemd
-
-    run systemctl status elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl status elasticsearch.service
 }
 
 ##################################
 # Check that Elasticsearch is working
 ##################################
 @test "[SYSTEMD] test elasticsearch" {
-    skip_not_systemd
-
     run_elasticsearch_tests
 }
 
 @test "[SYSTEMD] restart" {
-    skip_not_systemd
-
-    run systemctl restart elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl restart elasticsearch.service
 
     wait_for_elasticsearch_status
 
-    run service elasticsearch status
-    [ "$status" -eq 0 ]
+    service elasticsearch status
 }
 
 @test "[SYSTEMD] stop (running)" {
-    skip_not_systemd
-
-    run systemctl stop elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl stop elasticsearch.service
 
     run systemctl status elasticsearch.service
+    [ "$status" -eq 0 ]
     echo "$output" | grep "Active:" | grep "inactive"
 }
 
 @test "[SYSTEMD] stop (stopped)" {
-    skip_not_systemd
-
-    run systemctl stop elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl stop elasticsearch.service
 
     run systemctl status elasticsearch.service
+    [ "$status" -eq 0 ]
     echo "$output" | grep "Active:" | grep "inactive"
 }
 
 @test "[SYSTEMD] status (stopped)" {
-    skip_not_systemd
-
     run systemctl status elasticsearch.service
+    [ "$status" -eq 0 ]
     echo "$output" | grep "Active:" | grep "inactive"
 }
 
@@ -150,21 +116,15 @@ setup() {
 # but it should not block ES from starting
 # see https://github.com/elastic/elasticsearch/issues/11594
 @test "[SYSTEMD] delete PID_DIR and restart" {
-    skip_not_systemd
+    rm -rf /var/run/elasticsearch
 
-    run rm -rf /var/run/elasticsearch
-    [ "$status" -eq 0 ]
+    systemd-tmpfiles --create
 
-    run systemd-tmpfiles --create
-    [ "$status" -eq 0 ]
-
-    run systemctl start elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl start elasticsearch.service
 
     wait_for_elasticsearch_status
 
     assert_file_exist "/var/run/elasticsearch/elasticsearch.pid"
 
-    run systemctl stop elasticsearch.service
-    [ "$status" -eq 0 ]
+    systemctl stop elasticsearch.service
 }

--- a/qa/vagrant/src/test/resources/packaging/scripts/60_systemd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/60_systemd.bats
@@ -93,7 +93,7 @@ setup() {
     systemctl stop elasticsearch.service
 
     run systemctl status elasticsearch.service
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 3 ] || "Expected exit code 3 meaning stopped"
     echo "$output" | grep "Active:" | grep "inactive"
 }
 
@@ -101,13 +101,13 @@ setup() {
     systemctl stop elasticsearch.service
 
     run systemctl status elasticsearch.service
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 3 ] || "Expected exit code 3 meaning stopped"
     echo "$output" | grep "Active:" | grep "inactive"
 }
 
 @test "[SYSTEMD] status (stopped)" {
     run systemctl status elasticsearch.service
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 3 ] || "Expected exit code 3 meaning stopped"
     echo "$output" | grep "Active:" | grep "inactive"
 }
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
@@ -79,16 +79,16 @@ is_rpm() {
 
 # Skip test if the 'dpkg' command is not supported
 skip_not_dpkg() {
-    if [ ! -x "`which dpkg 2>/dev/null`" ]; then
-        skip "dpkg is not supported"
-    fi
+    is_dpkg || skip "dpkg is not supported"
 }
 
 # Skip test if the 'rpm' command is not supported
 skip_not_rpm() {
-    if [ ! -x "`which rpm 2>/dev/null`" ]; then
-        skip "rpm is not supported"
-    fi
+    is_rpm || skip "rpm is not supported"
+}
+
+skip_not_dpkg_or_rpm() {
+    is_dpkg || is_rpm || skip "only dpkg or rpm systems are supported"
 }
 
 # Returns 0 if the system supports Systemd
@@ -177,17 +177,6 @@ assert_output() {
     echo "$output" | grep -E "$1"
 }
 
-# Install the rpm or deb package
-install_package() {
-    if is_rpm; then
-        rpm -i elasticsearch*.rpm
-    elif is_dpkg; then
-        dpkg -i elasticsearch*.deb
-    else
-        skip "Only rpm or deb supported"
-    fi
-}
-
 # Checks that all directories & files are correctly installed
 # after a package (deb/rpm) install
 verify_package_installation() {
@@ -240,6 +229,17 @@ verify_package_installation() {
         assert_file "/usr/lib/systemd/system/elasticsearch.service" f root 644
         assert_file "/usr/lib/tmpfiles.d/elasticsearch.conf" f root 644
         assert_file "/usr/lib/sysctl.d/elasticsearch.conf" f root 644
+    fi
+}
+
+# Install the rpm or deb package
+install_package() {
+    if is_rpm; then
+        rpm -i elasticsearch*.rpm
+    elif is_dpkg; then
+        dpkg -i elasticsearch*.deb
+    else
+        skip "Only rpm or deb supported"
     fi
 }
 


### PR DESCRIPTION
This cleans up deb, rpm, systemd, and sysvinit tests:
1. Move skip_not_rpm, skip_not_dpkg, etc to the setup() methods for faster
runtime and cleaner code.
2. Removed lots of needless invocations of `run`
3. Created install_package for use in the systemd and sysvinit tests.
4. Removed lots of needless stderr to stdout redirects.

Closes #13075
Related to #13074
