### PR TITLE
More portable extraction of short hostname

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -121,7 +121,10 @@ case `uname` in
     ;;
 esac
 
-export HOSTNAME=`hostname -s`
+# full hostname passed through cut for portability on systems that do not support hostname -s
+# export on separate line for shells that do not support combining definition and export
+HOSTNAME=`hostname | cut -d. -f1`
+export HOSTNAME
 
 # manual parsing to find out, if process should be detached
 daemonized=`echo $* | grep -E -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`

--- a/distribution/src/main/resources/bin/plugin
+++ b/distribution/src/main/resources/bin/plugin
@@ -103,6 +103,9 @@ if [ -e "$CONF_FILE" ]; then
   esac
 fi
 
-export HOSTNAME=`hostname -s`
+# full hostname passed through cut for portability on systems that do not support hostname -s
+# export on separate line for shells that do not support combining definition and export
+HOSTNAME=`hostname | cut -d. -f1`
+export HOSTNAME
 
 eval "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Xmx64m -Xms16m -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginManagerCliParser $args


### PR DESCRIPTION
This commit increases the portability of extracting the short hostname
on a Unix-like system.

Closes #13107
