### PR TITLE
Move position_offset_gap default change

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -65,20 +65,20 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
         // NOTE, when adding defaults here, make sure you add them in the builder
         public static final String NULL_VALUE = null;
         /**
-         * Post 2.1 default for position_offset_gap. Set to 100 so that
+         * Post 2.0 default for position_offset_gap. Set to 100 so that
          * phrase queries of reasonably high slop will not match across field
          * values.
          */
         public static final int POSITION_OFFSET_GAP = 100;
-        public static final int POSITION_OFFSET_GAP_PRE_2_1 = 0;
+        public static final int POSITION_OFFSET_GAP_PRE_2_0 = 0;
         public static final int IGNORE_ABOVE = -1;
 
         /**
          * The default position_offset_gap for a particular version of Elasticsearch.
          */
         public static int positionOffsetGap(Version version) {
-            if (version.before(Version.V_2_1_0)) {
-                return POSITION_OFFSET_GAP_PRE_2_1;
+            if (version.before(Version.V_2_0_0_beta1)) {
+                return POSITION_OFFSET_GAP_PRE_2_0;
             }
             return POSITION_OFFSET_GAP;
         }

--- a/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
@@ -446,7 +446,7 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
     }
 
     void assertPositionOffsetGapDefaults(String indexName, Version version) throws Exception {
-        if (version.before(Version.V_2_1_0)) {
+        if (version.before(Version.V_2_0_0_beta1)) {
             StringFieldMapperPositionOffsetGapTests.assertGapIsZero(client(), indexName, "doc");
         } else {
             StringFieldMapperPositionOffsetGapTests.assertGapIsOneHundred(client(), indexName, "doc");

--- a/docs/reference/migration/migrate_2_0/mapping.asciidoc
+++ b/docs/reference/migration/migrate_2_0/mapping.asciidoc
@@ -384,7 +384,10 @@ The `compress` and `compress_threshold` options have been removed from the
 default.  If you would like to increase compression levels, use the new
 <<index-codec,`index.codec: best_compression`>> setting instead.
 
-
-
-
-
+==== position_offset_gap
+The default `position_offset_gap` is now 100. Indexes created in Elasticsearch
+2.0.0 will default to using 100 and indexes created before that will continue
+to use the old default of 0. This was done to prevent phrase queries from
+matching across different values of the same term unexpectedly. Specifically,
+100 was chosen to cause phrase queries with slops up to 99 to match only within
+a single value of a field.

--- a/docs/reference/migration/migrate_2_1.asciidoc
+++ b/docs/reference/migration/migrate_2_1.asciidoc
@@ -25,13 +25,3 @@ GET /my_index/_search?scroll=2m
 Scroll requests sorted by `_doc` have been optimized to more efficiently resume
 from where the previous request stopped, so this will have the same performance
 characteristics as the former `scan` search type.
-
-=== Mapping changes
-
-==== position_offset_gap
-The default `position_offset_gap` is now 100. Indexes created in Elasticsearch
-2.1.0 will default to using 100 and indexes created before that will continue
-to use the old default of 0. This was done to prevent phrase queries from
-matching across different values of the same term unexpectedly. Specifically,
-100 was chosen to cause phrase queries with slops up to 99 to match only within
-a single value of a field.


### PR DESCRIPTION
Until a couple of hours ago we expected the position_offset_gap to default
to 0 in 2.0 and 100 in 2.1. We decided it was worth backporting that new
default to 2.0. So now that its backported we need to teach 2.1 that 2.0
also defaults to 100.
