### PR TITLE
make sure JAVA_HOME is set before tests are run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,6 +462,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -526,7 +527,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
                     <executions>
                         <execution>
                             <id>enforce-versions</id>
@@ -560,6 +560,21 @@
                             <goals>
                                 <goal>display-info</goal>
                             </goals>
+                        </execution>
+                        <execution>
+                            <id>enforce-java-home-is-set</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireEnvironmentVariable>
+                                        <variableName>JAVA_HOME</variableName>
+                                        <message>"JAVA_HOME must be set and point to the jdk to run the tests"</message>
+                                    </requireEnvironmentVariable>
+                                </rules>
+                                <fail>true</fail>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
relates to #12961 

We did not enforce it before but we need in now since #12961.

Alternatively we could try and find some other way to get the path to `jps` in [stop-node](https://github.com/elastic/elasticsearch/blob/master/dev-tools/src/main/resources/ant/integration-tests.xml#L215).
