### PR TITLE
Add unit test for ShardPath.selectNewPathForShard

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -325,7 +325,7 @@ public class IndexService extends AbstractIndexComponent implements IndexCompone
                 // Count up how many shards are currently on each data path:
                 Map<Path,Integer> dataPathToShardCount = new HashMap<>();
                 for(IndexShard shard : this) {
-                    Path dataPath = NodeEnvironment.shardStatePathToDataPath(shard.shardPath().getShardStatePath());
+                    Path dataPath = shard.shardPath().getRootStatePath();
                     Integer curCount = dataPathToShardCount.get(dataPath);
                     if (curCount == null) {
                         curCount = 0;

--- a/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -204,8 +204,6 @@ public final class ShardPath {
         final Path dataPath;
         final Path statePath;
 
-        final String indexUUID = indexSettings.get(IndexMetaData.SETTING_INDEX_UUID, IndexMetaData.INDEX_UUID_NA_VALUE);
-
         if (NodeEnvironment.hasCustomDataPath(indexSettings)) {
             dataPath = env.resolveCustomLocation(indexSettings, shardId);
             statePath = env.nodePaths()[0].resolve(shardId);
@@ -245,6 +243,8 @@ public final class ShardPath {
             statePath = bestPath.resolve(shardId);
             dataPath = statePath;
         }
+
+        final String indexUUID = indexSettings.get(IndexMetaData.SETTING_INDEX_UUID, IndexMetaData.INDEX_UUID_NA_VALUE);
 
         return new ShardPath(NodeEnvironment.hasCustomDataPath(indexSettings), dataPath, statePath, indexUUID, shardId);
     }

--- a/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTest.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.shard;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
+import org.apache.lucene.mockfile.FilterFileSystem;
+import org.apache.lucene.mockfile.FilterFileSystemProvider;
+import org.apache.lucene.mockfile.FilterPath;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileStoreAttributeView;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.common.settings.Settings.settingsBuilder;
+
+public class NewPathForShardTest extends ESTestCase {
+
+    // Sneakiness to install a mock filesystem to pretend how much free space we have on each path.data:
+
+    private static MockFileStore aFileStore = new MockFileStore("mocka");
+    private static MockFileStore bFileStore = new MockFileStore("mockb");
+    private static FileSystem origFileSystem;
+
+    @BeforeClass
+    public static void installMockUsableSpaceFS() throws Exception {
+        // Necessary so when Environment.clinit runs, to gather all FileStores, it sees ours:
+        Field field = PathUtils.class.getDeclaredField("DEFAULT");
+        field.setAccessible(true);
+        // nocommit can't double Filter maybe?
+        // origFileSystem = (FileSystem) field.get(null);
+        origFileSystem = FileSystems.getDefault();
+        FileSystem mock = new MockUsableSpaceFileSystemProvider().getFileSystem(getBaseTempDirForTestClass().toUri());
+        field.set(null, mock);
+        assertEquals(mock, PathUtils.getDefaultFileSystem());
+    }
+
+    @AfterClass
+    public static void removeMockUsableSpaceFS() throws Exception {
+        Field field = PathUtils.class.getDeclaredField("DEFAULT");
+        field.setAccessible(true);
+        field.set(null, origFileSystem);
+        origFileSystem = null;
+        aFileStore = null;
+        bFileStore = null;
+    }
+
+    /** Mock file system that fakes usable space for each FileStore */
+    static class MockUsableSpaceFileSystemProvider extends FilterFileSystemProvider {
+    
+        public MockUsableSpaceFileSystemProvider() {
+            super("mockusablespace://", FileSystems.getDefault());
+            final List<FileStore> fileStores = new ArrayList<>();
+            fileStores.add(aFileStore);
+            fileStores.add(bFileStore);
+            fileSystem = new FilterFileSystem(this, origFileSystem) {
+                    @Override
+                    public Iterable<FileStore> getFileStores() {
+                        return fileStores;
+                    }
+                };
+        }
+
+        @Override
+        public FileStore getFileStore(Path path) throws IOException {
+            if (path.toString().contains("/a/")) {
+                return aFileStore;
+            } else {
+                return bFileStore;
+            }
+        }
+    }
+
+    static class MockFileStore extends FileStore {
+
+        public long usableSpace;
+
+        private final String desc;
+
+        public MockFileStore(String desc) {
+            this.desc = desc;
+        }
+    
+        @Override
+        public String type() {
+            return "mock";
+        }
+
+        @Override
+        public String name() {
+            return "mock";
+        }
+
+        @Override
+        public String toString() {
+            return desc;
+        }
+
+        // TODO: we can enable mocking of these when we need them later:
+
+        @Override
+        public boolean isReadOnly() {
+            return false;
+        }
+
+        @Override
+        public long getTotalSpace() throws IOException {
+            return usableSpace*3;
+        }
+
+        @Override
+        public long getUsableSpace() throws IOException {
+            return usableSpace;
+        }
+
+        @Override
+        public long getUnallocatedSpace() throws IOException {
+            return usableSpace*2;
+        }
+
+        @Override
+        public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
+            return false;
+        }
+
+        @Override
+        public boolean supportsFileAttributeView(String name) {
+            return false;
+        }
+
+        @Override
+        public <V extends FileStoreAttributeView> V getFileStoreAttributeView(Class<V> type) {
+            return null;
+        }
+
+        @Override
+        public Object getAttribute(String attribute) throws IOException {
+            return null;
+        }
+    }
+
+    public void testSelectNewPathForShard() throws Exception {
+        Path path = createTempDir();
+
+        String[] paths = new String[2];
+        paths[0] = path.resolve("a").toString();
+        paths[1] = path.resolve("b").toString();
+
+        Settings settings = Settings.builder()
+            .put("path.home", path)
+            .putArray("path.data", paths).build();
+        NodeEnvironment nodeEnv = new NodeEnvironment(settings, new Environment(settings));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTest.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTest.java
@@ -39,6 +39,7 @@ import org.apache.lucene.mockfile.FilterFileSystem;
 import org.apache.lucene.mockfile.FilterFileSystemProvider;
 import org.apache.lucene.mockfile.FilterPath;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -54,6 +55,7 @@ import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 
 /** Separate test class from ShardPathTests because we need static (BeforeClass) setup to install mock filesystems... */
+@SuppressForbidden(reason = "ProviderMismatchException if I try to use PathUtils.getDefault instead")
 public class NewPathForShardTest extends ESTestCase {
 
     // Sneakiness to install mock file stores so we can pretend how much free space we have on each path.data:
@@ -84,6 +86,7 @@ public class NewPathForShardTest extends ESTestCase {
     }
 
     /** Mock file system that fakes usable space for each FileStore */
+    @SuppressForbidden(reason = "ProviderMismatchException if I try to use PathUtils.getDefault instead")
     static class MockUsableSpaceFileSystemProvider extends FilterFileSystemProvider {
     
         public MockUsableSpaceFileSystemProvider() {

--- a/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTest.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTest.java
@@ -219,7 +219,7 @@ public class NewPathForShardTest extends ESTestCase {
         dataPathToShardCount.put(NodeEnvironment.shardStatePathToDataPath(result1.getDataPath()), 1);
         ShardPath result2 = ShardPath.selectNewPathForShard(nodeEnv, shardId, Settings.EMPTY, 100, dataPathToShardCount);
 
-        // This was the original failure: on a node with 2 disks that have nearly equal
+        // #11122: this was the original failure: on a node with 2 disks that have nearly equal
         // free space, we would always allocate all N incoming shards to the one path that
         // had the most free space, never using the other drive unless new shards arrive
         // after the first shards started using storage:


### PR DESCRIPTION
In #11185 we fixed this method to be more careful to not allocate a bunch of sudden new shards to a single path on path.data when other paths have nearly the same usable space.

This change just adds a unit test for that method, by mocking the filesystem that `NodeEnvironment` sees, so we can easily fake how much usable space each path on path.data sees.

The hardest part here was the mocking infra (I spent quite a while battling `ProviderMismatchException`!!), and after that I simplified `selectNewPathForShard` to not take `IndexShard` to make unit testing possible, then I created a basic test case to show the original failure.

Aside/rant: the method really is one giant hack, making a silly guess at how large a shard will grow to be when in many cases (existing shards being replicated/reallocated) we know exactly how much disk space it will eventually use up, at least once it's done copying the segments over.  For newly allocated shards we could probably make more informed guesses, e.g. if it's a Marvel shard it will be small, if it's another daily/hourly index we can predict, etc.  And finally we separately need the disk allocator to be able to reallocate shards from one path on path.data to another, within a single node or across nodes ... but these are all separate from just adding this test case :)
