### PR TITLE
Default _cat verbose to false

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
@@ -68,7 +68,7 @@ public class RestTable {
 
     public static RestResponse buildTextPlainResponse(Table table, RestChannel channel) throws IOException {
         RestRequest request = channel.request();
-        boolean verbose = request.paramAsBoolean("v", true);
+        boolean verbose = request.paramAsBoolean("v", false);
 
         List<DisplayHeader> headers = buildDisplayHeaders(table, request);
         int[] width = buildWidths(table, request, verbose, headers);

--- a/docs/reference/migration/migrate_2_0/stats.asciidoc
+++ b/docs/reference/migration/migrate_2_0/stats.asciidoc
@@ -45,16 +45,6 @@ used separately to control whether `routing_nodes` should be returned.
 
 The deprecated index status API has been removed.
 
-==== `cat` APIs verbose by default
-
-The `cat` APIs now default to being verbose, which means they output column
-headers by default. Verbosity can be turned off with the `v` parameter:
-
-[source,sh]
------------------
-GET _cat/shards?v=0
------------------
-
 ==== Nodes Stats API
 
 Queue lengths are now reported as basic numeric so they can easily processed by code. Before we used a human

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -32,7 +32,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -37,7 +37,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -32,7 +32,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -37,7 +37,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         },
         "fields": {
           "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
@@ -33,7 +33,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -42,7 +42,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -26,7 +26,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -33,7 +33,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -24,7 +24,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -32,7 +32,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -28,7 +28,7 @@
         "v": {
           "type": "boolean",
           "description": "Verbose mode. Display column headers",
-          "default": true
+          "default": false
         },
         "full_id": {
           "type": "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
@@ -17,8 +17,7 @@
 "Empty cluster":
 
   - do:
-      cat.aliases:
-        v: false
+      cat.aliases: {}
 
   - match:
       $body: |
@@ -38,8 +37,7 @@
             name:  test_alias
 
   - do:
-      cat.aliases:
-        v: false
+      cat.aliases: {}
 
   - match:
       $body: |
@@ -75,8 +73,7 @@
                     term:
                         foo: bar
   - do:
-      cat.aliases:
-        v: false
+      cat.aliases: {}
 
   - match:
       $body: |
@@ -108,14 +105,12 @@
   - do:
       cat.aliases:
         name: test_1
-        v: false
 
   - match:
       $body: /^test_1 .+ \n$/
 
   - do:
       cat.aliases:
-        v: false
         name: test_2
 
   - match:
@@ -123,7 +118,6 @@
 
   - do:
       cat.aliases:
-        v: false
         name: test_*
 
   - match:
@@ -178,8 +172,7 @@
 
   - do:
         cat.aliases:
-          v: false
-          h:      [index, alias]
+            h:      [index, alias]
 
   - match:
       $body: /^ test \s+ test_1 \s+ $/
@@ -195,9 +188,3 @@
                 index \s+ alias  \s+ \n
                 test  \s+ test_1 \s+ \n
             $/
-
-
-
-
-
-

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.allocation/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.allocation/10_basic.yaml
@@ -3,7 +3,6 @@
   - do:
       cat.allocation:
         help: true
-        v: false
 
   - match:
       $body: |
@@ -21,8 +20,7 @@
 "Empty cluster":
 
   - do:
-      cat.allocation:
-        v: false
+      cat.allocation: {}
 
   - match:
       $body: |
@@ -51,8 +49,7 @@
             wait_for_status: yellow
 
   - do:
-        cat.allocation:
-          v: false
+        cat.allocation: {}
 
   - match:
       $body: |
@@ -82,7 +79,6 @@
   - do:
         cat.allocation:
             node_id: _master
-            v: false
 
   - match:
       $body: |
@@ -102,7 +98,6 @@
   - do:
         cat.allocation:
             node_id: non_existent
-            v: false
 
   - match:
       $body: |
@@ -116,7 +111,6 @@
    - do:
          cat.allocation:
            node_id: "*"
-           v: false
 
    - match:
        $body: |
@@ -215,7 +209,6 @@
   - do:
       cat.allocation:
         bytes: g
-        v: false
 
   - match:
       $body: |
@@ -231,4 +224,3 @@
                 \n
               )+
             $/
-

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.count/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.count/10_basic.yaml
@@ -14,8 +14,7 @@
 "Test cat count output":
 
   - do:
-      cat.count:
-        v: false
+      cat.count: {}
 
   - match:
       $body: |
@@ -31,8 +30,7 @@
         refresh: true
 
   - do:
-      cat.count:
-        v: false
+      cat.count: {}
 
   - match:
       $body: |
@@ -50,7 +48,6 @@
   - do:
       cat.count:
         h: count
-        v: false
 
   - match:
       $body: |
@@ -61,7 +58,6 @@
   - do:
       cat.count:
         index: index1
-        v: false
 
   - match:
       $body: |
@@ -77,4 +73,3 @@
       $body: |
                /^  epoch  \s+  timestamp          \s+  count  \s+  \n
                    \d+    \s+  \d{2}:\d{2}:\d{2}  \s+  \d+    \s+  \n  $/
-

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.fielddata/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.fielddata/10_basic.yaml
@@ -17,8 +17,7 @@
 "Test cat fielddata output":
 
   - do:
-      cat.fielddata:
-        v: false
+      cat.fielddata: {}
 
   - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.health/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.health/10_basic.yaml
@@ -28,8 +28,7 @@
 "Empty cluster":
 
   - do:
-      cat.health:
-        v: false
+      cat.health: {}
 
   - match:
       $body: |

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yaml
@@ -2,8 +2,7 @@
 "Test cat indices output":
 
   - do:
-      cat.indices:
-        v: false
+      cat.indices: {}
 
   - match:
       $body: |
@@ -20,8 +19,7 @@
        cluster.health:
          wait_for_status: yellow
   - do:
-      cat.indices:
-        v: false
+      cat.indices: {}
 
   - match:
       $body: |

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodeattrs/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodeattrs/10_basic.yaml
@@ -6,8 +6,7 @@
       reason:   "Waiting for #12558"
 
   - do:
-      cat.nodeattrs:
-        v: false
+      cat.nodeattrs: {}
 
   - match:
       $body: |

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yaml
@@ -2,8 +2,7 @@
 "Test cat nodes output":
 
   - do:
-      cat.nodes:
-        v: false
+      cat.nodes: {}
 
   - match:
       $body: |

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.recovery/10_basic.yaml
@@ -2,8 +2,7 @@
 "Test cat recovery output":
 
   - do:
-      cat.recovery:
-        v: false
+      cat.recovery: {}
 
   - match:
       $body: |
@@ -20,8 +19,7 @@
        cluster.health:
          wait_for_status: yellow
   - do:
-      cat.recovery:
-        v: false
+      cat.recovery: {}
 
   - match:
       $body: |

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yaml
@@ -26,8 +26,7 @@
 "Test cat segments output":
 
   - do:
-      cat.segments:
-        v: false
+      cat.segments: {}
 
   - match:
       $body: |
@@ -50,8 +49,7 @@
        cluster.health:
          wait_for_status: green
   - do:
-      cat.segments:
-        v: false
+      cat.segments: {}
   - match:
       $body: |
                  /^(index1 \s+ \d \s+ (p|r) \s+ \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3} \s+ _\d (\s\d){3} \s+
@@ -81,8 +79,7 @@
 
 
   - do:
-      cat.segments:
-        v: false
+      cat.segments: {}
   - match:
       $body: |
                   /^(index(1|2) .+ \n?){2}$/
@@ -90,7 +87,6 @@
   - do:
       cat.segments:
         index: index2
-        v: false
   - match:
       $body: |
                   /^(index2 .+ \n?)$/
@@ -118,4 +114,3 @@
       catch: forbidden
       cat.segments:
         index: index1
-        v: false

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
@@ -77,8 +77,7 @@
 "Test cat shards output":
 
   - do:
-      cat.shards:
-        v: false
+      cat.shards: {}
 
   - match:
       $body: |
@@ -95,8 +94,7 @@
        cluster.health:
          wait_for_status: yellow
   - do:
-      cat.shards:
-        v: false
+      cat.shards: {}
 
   - match:
       $body: |
@@ -115,8 +113,7 @@
          wait_for_relocating_shards: 0
 
   - do:
-      cat.shards:
-        v: false
+      cat.shards: {}
   - match:
       $body: |
                /^(index(1|2) \s+ \d \s+ (p|r) \s+ ((STARTED|INITIALIZING|RELOCATING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){15}$/
@@ -124,7 +121,6 @@
   - do:
       cat.shards:
         index: index2
-        v: false
   - match:
       $body: |
                /^(index2 \s+ \d \s+ (p|r) \s+ ((STARTED|INITIALIZING|RELOCATING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){5}$/
@@ -146,8 +142,6 @@
   - do:
       cat.shards:
         index: index3
-        v: false
   - match:
       $body: |
                /^(index3 \s+ \d \s+ (p|s) \s+ ((STARTED|INITIALIZING|RELOCATING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){2}$/
-               

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.thread_pool/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.thread_pool/10_basic.yaml
@@ -2,8 +2,7 @@
 "Test cat thread_pool output":
 
   - do:
-      cat.thread_pool:
-        v: false
+      cat.thread_pool: {}
 
   - match:
       $body: |
@@ -22,7 +21,6 @@
   - do:
       cat.thread_pool:
           h: pid,id,h,i,po
-          v: false
 
   - match:
       $body: |


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/8927 changed the `_cat` APIs to default to verbose.  This was released in 2.0.0-beta1, but then we decided to revert to previous behaviour.

Closes #13156
