### PR TITLE
[build] Update Apache Maven Enforcer plugin to 1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.4.1</version>
                     <executions>
                         <execution>
                             <id>enforce-versions</id>


### PR DESCRIPTION
``` xml
<plugin>
 <groupId>org.apache.maven.plugins</groupId>
 <artifactId>maven-enforcer-plugin</artifactId>
 <version>1.4.1</version>
</plugin>
```
# Release Notes - Maven Enforcer - Version 1.4.1

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317520&version=12330766
## Bugs:
- [MENFORCER-222] - RequireSameVersion rule regression between 1.3 and 1.4
- [MENFORCER-224] - Regression from 1.3.1 to 1.4 with bannedDependencies rule
- [MENFORCER-229] - Ban Distribution Management documentation example doesn't work
- [MENFORCER-237] - Resources Link to codehaus is wrong
## Improvements:
- [MENFORCER-223] - Upgrade mrm-maven-plugin to 1.0-beta-2
- [MENFORCER-227] - Document nullability with @Nonnull on EnforcerRule API
- [MENFORCER-233] - Upgrade maven-invoker-plugin to 2.0.0
- [MENFORCER-235] - Use maven-fluido-skin 1.4
- [MENFORCER-236] - Upgrade maven-assembly-plugin version from 2.4 to 2.5.5 in integration test
- [MENFORCER-238] - Upgrade plexus-utils to 3.0.22
