### PR TITLE
Installing plugin without checksums ends up downloading from github

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
@@ -27,7 +27,6 @@ import org.elasticsearch.*;
 import org.elasticsearch.common.Base64;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.ByteArray;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -37,9 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
-import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 /**
  *
@@ -152,12 +149,6 @@ public class HttpDownloadHelper {
         } catch (FileNotFoundException | NoSuchFileException e) {
             // checksum file doesn't exist
             return false;
-        } catch (IOException e) {
-            if (ExceptionsHelper.unwrapCause(e) instanceof FileNotFoundException) {
-                // checksum file didn't exist
-                return false;
-            }
-            throw e;
         } finally {
             IOUtils.deleteFilesIgnoringExceptions(checksumFile);
         }
@@ -378,9 +369,6 @@ public class HttpDownloadHelper {
                         responseCode == HttpURLConnection.HTTP_MOVED_TEMP ||
                         responseCode == HttpURLConnection.HTTP_SEE_OTHER) {
                     String newLocation = httpConnection.getHeaderField("Location");
-                    String message = aSource
-                            + (responseCode == HttpURLConnection.HTTP_MOVED_PERM ? " permanently"
-                            : "") + " moved to " + newLocation;
                     URL newURL = new URL(newLocation);
                     if (!redirectionAllowed(aSource, newURL)) {
                         return null;
@@ -426,7 +414,7 @@ public class HttpDownloadHelper {
                 }
             }
             if (is == null) {
-                throw new IOException("Can't get " + source + " to " + dest, lastEx);
+                throw lastEx;
             }
 
             os = Files.newOutputStream(dest);


### PR DESCRIPTION
```
bin/plugin install lmenezes/elasticsearch-kopf/develop
-> Installing lmenezes/elasticsearch-kopf/develop...
Trying http://download.elastic.co/lmenezes/elasticsearch-kopf/elasticsearch-kopf-develop.zip ...
Trying http://search.maven.org/remotecontent?filepath=lmenezes/elasticsearch-kopf/develop/elasticsearch-kopf-develop.zip ...
Trying https://oss.sonatype.org/service/local/repositories/releases/content/lmenezes/elasticsearch-kopf/develop/elasticsearch-kopf-develop.zip ...
Trying https://github.com/lmenezes/elasticsearch-kopf/archive/develop.zip ...
Downloading .................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................DONE
Verifying https://github.com/lmenezes/elasticsearch-kopf/archive/develop.zip checksums if available ...
Trying https://github.com/lmenezes/elasticsearch-kopf/archive/master.zip ...
Downloading ....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................DONE
Verifying https://github.com/lmenezes/elasticsearch-kopf/archive/master.zip checksums if available ...
```

This happens because we don't have anymore ElasticsearchWrapperException here but standard java exceptions.

Closes #13196.
