### PR TITLE
update list of available os stats

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -39,7 +39,7 @@ of `indices`, `os`, `process`, `jvm`, `transport`, `http`,
 	pools, number of loaded/unloaded classes
 
 `os`::
-	Operating system stats, load average, cpu, mem, swap
+	Operating system stats, load average, mem, swap
 	(see <<os-stats,OS statistics>>)
 
 `process`::


### PR DESCRIPTION
os cpu information is no longer exposed through the nodes stats api.

Btw, will this be exposed through any other api? Or os cpu information will just no longer be available at all?
