### PR TITLE
Reenable spaces in paths during integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,8 @@
         <tests.ifNoTests>fail</tests.ifNoTests>
         <skip.unit.tests>${skipTests}</skip.unit.tests>
         <skip.integ.tests>${skipTests}</skip.integ.tests>
-        <integ.scratch>${project.build.directory}/integ-tests</integ.scratch>
-        <integ.deps>${project.build.directory}/integ-deps</integ.deps>
+        <integ.scratch>${project.build.directory}/integ tests</integ.scratch>
+        <integ.deps>${project.build.directory}/integ deps</integ.deps>
         <integ.temp>${integ.scratch}/temp</integ.temp>
         <integ.http.port>9400</integ.http.port>
         <integ.transport.port>9500</integ.transport.port>


### PR DESCRIPTION
Reenable running integration tests with spaces in paths now that https://github.com/elastic/elasticsearch/commit/a80317c4b39df375d869093ea5a793a74913b66e lives on both `master` and `2.0`

cc @rjernst @clintongormley 

Close #12848 
