### PR TITLE
For Azure, support multiple storage accounts and secondary endpoints (which are readonly)

### DIFF
--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/AzureModule.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/AzureModule.java
@@ -145,8 +145,8 @@ public class AzureModule extends AbstractModule {
             return false;
         }
 
-        if (isPropertyMissing(settings, Storage.ACCOUNT) ||
-                isPropertyMissing(settings, Storage.KEY)) {
+        if (isArrayMissing(settings, Storage.ACCOUNT) ||
+                isArrayMissing(settings, Storage.KEY)) {
             logger.debug("azure repository is not set using [{}] and [{}] properties",
                     Storage.ACCOUNT,
                     Storage.KEY);
@@ -165,4 +165,10 @@ public class AzureModule extends AbstractModule {
         return false;
     }
 
+    public static boolean isArrayMissing(Settings settings, String name) throws ElasticsearchException {
+        if (settings.getAsArray(name) == null) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -61,7 +61,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     @Override
     public boolean blobExists(String blobName) {
         try {
-            return blobStore.client().blobExists(blobStore.container(), buildKey(blobName));
+            return blobStore.blobExists(blobStore.container(), buildKey(blobName));
         } catch (URISyntaxException | StorageException e) {
             logger.warn("can not access [{}] in container {{}}: {}", blobName, blobStore.container(), e.getMessage());
         }
@@ -71,7 +71,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     @Override
     public InputStream openInput(String blobName) throws IOException {
         try {
-            return blobStore.client().getInputStream(blobStore.container(), buildKey(blobName));
+            return blobStore.getInputStream(blobStore.container(), buildKey(blobName));
         } catch (StorageException e) {
             if (e.getHttpStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                 throw new FileNotFoundException(e.getMessage());
@@ -85,7 +85,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     @Override
     public OutputStream createOutput(String blobName) throws IOException {
         try {
-            return new AzureOutputStream(blobStore.client().getOutputStream(blobStore.container(), buildKey(blobName)));
+            return new AzureOutputStream(blobStore.getOutputStream(blobStore.container(), buildKey(blobName)));
         } catch (StorageException e) {
             if (e.getHttpStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                 throw new FileNotFoundException(e.getMessage());
@@ -101,7 +101,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         try {
-            blobStore.client().deleteBlob(blobStore.container(), buildKey(blobName));
+            blobStore.deleteBlob(blobStore.container(), buildKey(blobName));
         } catch (URISyntaxException | StorageException e) {
             logger.warn("can not access [{}] in container {{}}: {}", blobName, blobStore.container(), e.getMessage());
             throw new IOException(e);
@@ -112,7 +112,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     public Map<String, BlobMetaData> listBlobsByPrefix(@Nullable String prefix) throws IOException {
 
         try {
-            return blobStore.client().listBlobsByPrefix(blobStore.container(), keyPath, prefix);
+            return blobStore.listBlobsByPrefix(blobStore.container(), keyPath, prefix);
         } catch (URISyntaxException | StorageException e) {
             logger.warn("can not access [{}] in container {{}}: {}", prefix, blobStore.container(), e.getMessage());
             throw new IOException(e);
@@ -127,7 +127,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
 
             logger.debug("moving blob [{}] to [{}] in container {{}}", source, target, blobStore.container());
 
-            blobStore.client().moveBlob(blobStore.container(), source, target);
+            blobStore.moveBlob(blobStore.container(), source, target);
         } catch (URISyntaxException e) {
             logger.warn("can not move blob [{}] to [{}] in container {{}}: {}", sourceBlobName, targetBlobName, blobStore.container(), e.getMessage());
             throw new IOException(e);

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobStore.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobStore.java
@@ -20,8 +20,10 @@
 package org.elasticsearch.cloud.azure.blobstore;
 
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.LocationMode;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -30,10 +32,17 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoryName;
 import org.elasticsearch.repositories.RepositorySettings;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Locale;
+import java.util.Map;
+
 import java.net.URISyntaxException;
 
 import static org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage.CONTAINER;
 import static org.elasticsearch.repositories.azure.AzureRepository.CONTAINER_DEFAULT;
+import static org.elasticsearch.repositories.azure.AzureRepository.Repository;
 
 /**
  *
@@ -42,6 +51,8 @@ public class AzureBlobStore extends AbstractComponent implements BlobStore {
 
     private final AzureStorageService client;
 
+    private final String accountName;
+    private final LocationMode locMode;
     private final String container;
     private final String repositoryName;
 
@@ -52,15 +63,22 @@ public class AzureBlobStore extends AbstractComponent implements BlobStore {
         this.client = client;
         this.container = repositorySettings.settings().get("container", settings.get(CONTAINER, CONTAINER_DEFAULT));
         this.repositoryName = name.getName();
+
+        this.accountName = repositorySettings.settings().get(Repository.ACCOUNT, null);
+        // NOTE: null account means to use the first one specified in config
+        
+        String modeStr = repositorySettings.settings().get(Repository.LOCATION_MODE, null);
+        if (modeStr == null) {
+            this.locMode = LocationMode.PRIMARY_ONLY;
+        }
+        else {
+            this.locMode = LocationMode.valueOf(modeStr.toUpperCase(Locale.ROOT));
+        }
     }
 
     @Override
     public String toString() {
         return container;
-    }
-
-    public AzureStorageService client() {
-        return client;
     }
 
     public String container() {
@@ -80,7 +98,7 @@ public class AzureBlobStore extends AbstractComponent implements BlobStore {
         }
 
         try {
-            client.deleteFiles(container, keyPath);
+            this.client.deleteFiles(this.accountName, this.locMode, container, keyPath);
         } catch (URISyntaxException | StorageException e) {
             logger.warn("can not remove [{}] in container {{}}: {}", keyPath, container, e.getMessage());
         }
@@ -88,5 +106,55 @@ public class AzureBlobStore extends AbstractComponent implements BlobStore {
 
     @Override
     public void close() {
+    }
+
+    public boolean doesContainerExist(String container)
+    {
+        return this.client.doesContainerExist(this.accountName, this.locMode, container);
+    }
+
+    public void removeContainer(String container) throws URISyntaxException, StorageException
+    {
+        this.client.removeContainer(this.accountName, this.locMode, container);
+    }
+
+    public void createContainer(String container) throws URISyntaxException, StorageException
+    {
+        this.client.createContainer(this.accountName, this.locMode, container);
+    }
+
+    public void deleteFiles(String container, String path) throws URISyntaxException, StorageException
+    {
+        this.client.deleteFiles(this.accountName, this.locMode, container, path);
+    }
+
+    public boolean blobExists(String container, String blob) throws URISyntaxException, StorageException
+    {
+        return this.client.blobExists(this.accountName, this.locMode, container, blob);
+    }
+
+    public void deleteBlob(String container, String blob) throws URISyntaxException, StorageException
+    {
+        this.client.deleteBlob(this.accountName, this.locMode, container, blob);
+    }
+
+    public InputStream getInputStream(String container, String blob) throws URISyntaxException, StorageException
+    {
+        return this.client.getInputStream(this.accountName, this.locMode, container, blob);
+    }
+
+    public OutputStream getOutputStream(String container, String blob) throws URISyntaxException, StorageException
+    {
+        return this.client.getOutputStream(this.accountName, this.locMode, container, blob);
+    }
+
+    public Map<String,BlobMetaData> listBlobsByPrefix(String container, String keyPath, String prefix) throws URISyntaxException, StorageException
+    {
+        return this.client.listBlobsByPrefix(this.accountName, this.locMode, container, keyPath, prefix);
+    }
+
+    public void moveBlob(String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException
+    {
+        this.client.moveBlob(this.accountName, this.locMode, container, sourceBlob, targetBlob);
     }
 }

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.LocationMode;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 
 import java.io.InputStream;
@@ -42,23 +43,23 @@ public interface AzureStorageService {
         public static final String COMPRESS = "repositories.azure.compress";
     }
 
-    boolean doesContainerExist(String container);
+    boolean doesContainerExist(String account, LocationMode mode, String container);
 
-    void removeContainer(String container) throws URISyntaxException, StorageException;
+    void removeContainer(String account, LocationMode mode, String container) throws URISyntaxException, StorageException;
 
-    void createContainer(String container) throws URISyntaxException, StorageException;
+    void createContainer(String account, LocationMode mode, String container) throws URISyntaxException, StorageException;
 
-    void deleteFiles(String container, String path) throws URISyntaxException, StorageException;
+    void deleteFiles(String account, LocationMode mode, String container, String path) throws URISyntaxException, StorageException;
 
-    boolean blobExists(String container, String blob) throws URISyntaxException, StorageException;
+    boolean blobExists(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException;
 
-    void deleteBlob(String container, String blob) throws URISyntaxException, StorageException;
+    void deleteBlob(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException;
 
-    InputStream getInputStream(String container, String blob) throws URISyntaxException, StorageException;
+    InputStream getInputStream(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException;
 
-    OutputStream getOutputStream(String container, String blob) throws URISyntaxException, StorageException;
+    OutputStream getOutputStream(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException;
 
-    Map<String,BlobMetaData> listBlobsByPrefix(String container, String keyPath, String prefix) throws URISyntaxException, StorageException;
+    Map<String,BlobMetaData> listBlobsByPrefix(String account, LocationMode mode, String container, String keyPath, String prefix) throws URISyntaxException, StorageException;
 
-    void moveBlob(String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException;
+    void moveBlob(String account, LocationMode mode, String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException;
 }

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.LocationMode;
 import com.microsoft.azure.storage.blob.*;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.blobstore.BlobMetaData;
@@ -37,6 +38,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 
+import java.util.Hashtable;
 import static org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage.*;
 
 /**
@@ -45,44 +47,81 @@ import static org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage.
 public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureStorageServiceImpl>
     implements AzureStorageService {
 
-    private final String account;
-    private final String key;
-    private final String blob;
-
-    private CloudBlobClient client;
-
+    private final String[] accounts;
+    private final String[] keys;
+    private final Map<String, CloudBlobClient> clients;
+    
     @Inject
     public AzureStorageServiceImpl(Settings settings) {
         super(settings);
-        // We try to load storage API settings from `cloud.azure.`
-        account = settings.get(ACCOUNT);
-        key = settings.get(KEY);
-        blob = "http://" + account + ".blob.core.windows.net/";
 
-        try {
-            if (account != null) {
-                logger.trace("creating new Azure storage client using account [{}], key [{}], blob [{}]", account, key, blob);
+        this.accounts = settings.getAsArray(ACCOUNT);
+        this.keys = settings.getAsArray(KEY);
+        this.clients = new Hashtable<String, CloudBlobClient>();
 
-                String storageConnectionString =
-                        "DefaultEndpointsProtocol=http;"
-                                + "AccountName="+ account +";"
-                                + "AccountKey=" + key;
-
-                // Retrieve storage account from connection-string.
-                CloudStorageAccount storageAccount = CloudStorageAccount.parse(storageConnectionString);
-
-                // Create the blob client.
-                client = storageAccount.createCloudBlobClient();
-            }
-        } catch (Exception e) {
-            // Can not start Azure Storage Client
-            logger.error("can not start azure storage client: {}", e.getMessage());
+        if (this.accounts.length != this.keys.length) {
+            throw new IllegalArgumentException("Azure cloud plug-in accounts and keys arrays must be the same length");
         }
     }
 
-    @Override
-    public boolean doesContainerExist(String container) {
+    private CloudBlobClient CreateClient(String account, String key)
+    {
         try {
+            String blob = "http://" + account + ".blob.core.windows.net/";
+            logger.trace("creating new Azure storage client using account [{}], key [{}], blob [{}]", account, key, blob);
+
+            String storageConnectionString =
+                    "DefaultEndpointsProtocol=http;"
+                            + "AccountName="+ account +";"
+                            + "AccountKey=" + key;
+
+            // Retrieve storage account from connection-string.
+            CloudStorageAccount storageAccount = CloudStorageAccount.parse(storageConnectionString);
+
+            // Create the blob client.
+            CloudBlobClient client = storageAccount.createCloudBlobClient();
+            return client;
+        } catch (Exception e) {
+            logger.error("can not create azure storage client: {}", e.getMessage());
+            return null;
+        }
+    }
+    
+    private CloudBlobClient getSelectedClient(String account, LocationMode mode) {
+        if (account == null) {
+            // for backwards compatibility, not specifying an account means to use the first one in the list
+            account = this.accounts[0];
+        }
+        
+        CloudBlobClient client = this.clients.get(account);
+
+        if (client == null) {
+            for (int i = 0; i < this.accounts.length; i++) {
+                if (this.accounts[i].equals(account)) {
+                    client = this.CreateClient(account, this.keys[i]);
+                    if (client != null) {
+                        this.clients.put(account, client);
+                    }
+                    break;
+                }
+            }
+        }
+        
+        if (client != null)
+        {
+            // NOTE: for now, just set the location mode in case it is different; 
+            // only one mode per storage account can be active at a time
+            client.getDefaultRequestOptions().setLocationMode(mode);
+            return client;
+        }
+
+        throw new IllegalArgumentException("Azure cloud plug-in cannot create storage client; account not found");
+    }
+    
+    @Override
+    public boolean doesContainerExist(String account, LocationMode mode, String container) {
+        try {
+            CloudBlobClient client = this.getSelectedClient(account, mode);
             CloudBlobContainer blob_container = client.getContainerReference(container);
             return blob_container.exists();
         } catch (Exception e) {
@@ -92,7 +131,8 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
-    public void removeContainer(String container) throws URISyntaxException, StorageException {
+    public void removeContainer(String account, LocationMode mode, String container) throws URISyntaxException, StorageException {
+        CloudBlobClient client = this.getSelectedClient(account, mode);
         CloudBlobContainer blob_container = client.getContainerReference(container);
         // TODO Should we set some timeout and retry options?
         /*
@@ -106,8 +146,9 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
-    public void createContainer(String container) throws URISyntaxException, StorageException {
+    public void createContainer(String account, LocationMode mode, String container) throws URISyntaxException, StorageException {
         try {
+            CloudBlobClient client = this.getSelectedClient(account, mode);
             CloudBlobContainer blob_container = client.getContainerReference(container);
             logger.trace("creating container [{}]", container);
             blob_container.createIfNotExists();
@@ -118,22 +159,24 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
-    public void deleteFiles(String container, String path) throws URISyntaxException, StorageException {
+    public void deleteFiles(String account, LocationMode mode, String container, String path) throws URISyntaxException, StorageException {
         logger.trace("delete files container [{}], path [{}]", container, path);
 
         // Container name must be lower case.
+        CloudBlobClient client = this.getSelectedClient(account, mode);
         CloudBlobContainer blob_container = client.getContainerReference(container);
         if (blob_container.exists()) {
             for (ListBlobItem blobItem : blob_container.listBlobs(path)) {
                 logger.trace("removing blob [{}]", blobItem.getUri());
-                deleteBlob(container, blobItem.getUri().toString());
+                deleteBlob(account, mode, container, blobItem.getUri().toString());
             }
         }
     }
 
     @Override
-    public boolean blobExists(String container, String blob) throws URISyntaxException, StorageException {
+    public boolean blobExists(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException {
         // Container name must be lower case.
+        CloudBlobClient client = this.getSelectedClient(account, mode);
         CloudBlobContainer blob_container = client.getContainerReference(container);
         if (blob_container.exists()) {
             CloudBlockBlob azureBlob = blob_container.getBlockBlobReference(blob);
@@ -144,10 +187,11 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
-    public void deleteBlob(String container, String blob) throws URISyntaxException, StorageException {
+    public void deleteBlob(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException {
         logger.trace("delete blob for container [{}], blob [{}]", container, blob);
 
         // Container name must be lower case.
+        CloudBlobClient client = this.getSelectedClient(account, mode);
         CloudBlobContainer blob_container = client.getContainerReference(container);
         if (blob_container.exists()) {
             logger.trace("container [{}]: blob [{}] found. removing.", container, blob);
@@ -157,22 +201,29 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
-    public InputStream getInputStream(String container, String blob) throws URISyntaxException, StorageException {
+    public InputStream getInputStream(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException {
         logger.trace("reading container [{}], blob [{}]", container, blob);
+        CloudBlobClient client = this.getSelectedClient(account, mode);
         return client.getContainerReference(container).getBlockBlobReference(blob).openInputStream();
     }
 
     @Override
-    public OutputStream getOutputStream(String container, String blob) throws URISyntaxException, StorageException {
+    public OutputStream getOutputStream(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException {
         logger.trace("writing container [{}], blob [{}]", container, blob);
+        CloudBlobClient client = this.getSelectedClient(account, mode);
         return client.getContainerReference(container).getBlockBlobReference(blob).openOutputStream();
     }
 
     @Override
-    public Map<String, BlobMetaData> listBlobsByPrefix(String container, String keyPath, String prefix) throws URISyntaxException, StorageException {
+    public Map<String, BlobMetaData> listBlobsByPrefix(String account, LocationMode mode, String container, String keyPath, String prefix) throws URISyntaxException, StorageException {
+        // NOTE: this should be here: if (prefix == null) prefix = "";
+        // however, this is really inefficient since deleteBlobsByPrefix enumerates everything and 
+        // then does a prefix match on the result; it should just call listBlobsByPrefix with the prefix!
+        
         logger.debug("listing container [{}], keyPath [{}], prefix [{}]", container, keyPath, prefix);
         MapBuilder<String, BlobMetaData> blobsBuilder = MapBuilder.newMapBuilder();
 
+        CloudBlobClient client = this.getSelectedClient(account, mode);
         CloudBlobContainer blobContainer = client.getContainerReference(container);
         if (blobContainer.exists()) {
             for (ListBlobItem blobItem : blobContainer.listBlobs(keyPath + (prefix == null ? "" : prefix))) {
@@ -200,8 +251,10 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
-    public void moveBlob(String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException {
+    public void moveBlob(String account, LocationMode mode, String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException {
         logger.debug("moveBlob container [{}], sourceBlob [{}], targetBlob [{}]", container, sourceBlob, targetBlob);
+
+        CloudBlobClient client = this.getSelectedClient(account, mode);
         CloudBlobContainer blob_container = client.getContainerReference(container);
         CloudBlockBlob blobSource = blob_container.getBlockBlobReference(sourceBlob);
         if (blobSource.exists()) {

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.repositories.azure;
 
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.LocationMode;
 import org.elasticsearch.cloud.azure.blobstore.AzureBlobStore;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -40,6 +41,7 @@ import org.elasticsearch.snapshots.SnapshotCreationException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Azure file system implementation of the BlobStoreRepository
@@ -58,6 +60,8 @@ public class AzureRepository extends BlobStoreRepository {
     public final static String CONTAINER_DEFAULT = "elasticsearch-snapshots";
 
     static public final class Repository {
+        public static final String ACCOUNT = "account";
+        public static final String LOCATION_MODE = "location_mode";
         public static final String CONTAINER = "container";
         public static final String CHUNK_SIZE = "chunk_size";
         public static final String COMPRESS = "compress";
@@ -71,6 +75,9 @@ public class AzureRepository extends BlobStoreRepository {
     private ByteSizeValue chunkSize;
 
     private boolean compress;
+
+    private String accountName;
+    private LocationMode locMode;
 
     @Inject
     public AzureRepository(RepositoryName name, RepositorySettings repositorySettings,
@@ -92,6 +99,15 @@ public class AzureRepository extends BlobStoreRepository {
 
         this.compress = repositorySettings.settings().getAsBoolean(Repository.COMPRESS,
                 settings.getAsBoolean(Storage.COMPRESS, false));
+        this.accountName = repositorySettings.settings().get(Repository.ACCOUNT, null);
+        String modeStr = repositorySettings.settings().get(Repository.LOCATION_MODE, null);
+        if (modeStr == null) {
+            this.locMode = LocationMode.PRIMARY_ONLY;
+        }
+        else {
+            this.locMode = LocationMode.valueOf(modeStr.toUpperCase(Locale.ROOT));
+        }
+
         String basePath = repositorySettings.settings().get(Repository.BASE_PATH, null);
 
         if (Strings.hasLength(basePath)) {
@@ -141,9 +157,9 @@ public class AzureRepository extends BlobStoreRepository {
     @Override
     public void initializeSnapshot(SnapshotId snapshotId, List<String> indices, MetaData metaData) {
         try {
-            if (!blobStore.client().doesContainerExist(blobStore.container())) {
+            if (!blobStore.doesContainerExist(blobStore.container())) {
                 logger.debug("container [{}] does not exist. Creating...", blobStore.container());
-                blobStore.client().createContainer(blobStore.container());
+                blobStore.createContainer(blobStore.container());
             }
             super.initializeSnapshot(snapshotId, indices, metaData);
         } catch (StorageException e) {
@@ -158,9 +174,13 @@ public class AzureRepository extends BlobStoreRepository {
     @Override
     public String startVerification() {
         try {
-            if (!blobStore.client().doesContainerExist(blobStore.container())) {
+            if (!blobStore.doesContainerExist(blobStore.container())) {
                 logger.debug("container [{}] does not exist. Creating...", blobStore.container());
-                blobStore.client().createContainer(blobStore.container());
+                blobStore.createContainer(blobStore.container());
+            }
+            if (this.locMode == LocationMode.SECONDARY_ONLY || this.locMode == LocationMode.SECONDARY_THEN_PRIMARY) {
+                // secondary end point is readonly; can't do any more verification at this level
+                return null;
             }
             return super.startVerification();
         } catch (StorageException e) {

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTest.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTest.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cloud.azure;
 
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.LocationMode;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.cloud.azure.storage.AzureStorageServiceMock;
@@ -112,6 +113,6 @@ public abstract class AbstractAzureRepositoryServiceTest extends AbstractAzureTe
         String container = internalCluster().getInstance(Settings.class).get("repositories.azure.container");
         logger.info("--> remove blobs in container [{}]", container);
         AzureStorageService client = internalCluster().getInstance(AzureStorageService.class);
-        client.deleteFiles(container, path);
+        client.deleteFiles(null, LocationMode.PRIMARY_ONLY, container, path);
     }
 }

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.LocationMode;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
@@ -51,46 +52,46 @@ public class AzureStorageServiceMock extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
-    public boolean doesContainerExist(String container) {
+    public boolean doesContainerExist(String account, LocationMode mode, String container) {
         return true;
     }
 
     @Override
-    public void removeContainer(String container) {
+    public void removeContainer(String account, LocationMode mode, String container) {
     }
 
     @Override
-    public void createContainer(String container) {
+    public void createContainer(String account, LocationMode mode, String container) {
     }
 
     @Override
-    public void deleteFiles(String container, String path) {
+    public void deleteFiles(String account, LocationMode mode, String container, String path) {
     }
 
     @Override
-    public boolean blobExists(String container, String blob) {
+    public boolean blobExists(String account, LocationMode mode, String container, String blob) {
         return blobs.containsKey(blob);
     }
 
     @Override
-    public void deleteBlob(String container, String blob) {
+    public void deleteBlob(String account, LocationMode mode, String container, String blob) {
         blobs.remove(blob);
     }
 
     @Override
-    public InputStream getInputStream(String container, String blob) {
+    public InputStream getInputStream(String account, LocationMode mode, String container, String blob) {
         return new ByteArrayInputStream(blobs.get(blob).toByteArray());
     }
 
     @Override
-    public OutputStream getOutputStream(String container, String blob) throws URISyntaxException, StorageException {
+    public OutputStream getOutputStream(String account, LocationMode mode, String container, String blob) throws URISyntaxException, StorageException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         blobs.put(blob, outputStream);
         return outputStream;
     }
 
     @Override
-    public Map<String, BlobMetaData> listBlobsByPrefix(String container, String keyPath, String prefix) {
+    public Map<String, BlobMetaData> listBlobsByPrefix(String account, LocationMode mode, String container, String keyPath, String prefix) {
         MapBuilder<String, BlobMetaData> blobsBuilder = MapBuilder.newMapBuilder();
         for (String blobName : blobs.keySet()) {
             if (startsWithIgnoreCase(blobName, prefix)) {
@@ -101,7 +102,7 @@ public class AzureStorageServiceMock extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
-    public void moveBlob(String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException {
+    public void moveBlob(String account, LocationMode mode, String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException {
         for (String blobName : blobs.keySet()) {
             if (endsWithIgnoreCase(blobName, sourceBlob)) {
                 ByteArrayOutputStream outputStream = blobs.get(blobName);

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotRestoreITest.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotRestoreITest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.repositories.azure;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.LocationMode;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
@@ -478,7 +479,7 @@ public class AzureSnapshotRestoreITest extends AbstractAzureTest {
 
             public void run()  {
                 try {
-                    storageService.createContainer(container);
+                    storageService.createContainer(null, LocationMode.PRIMARY_ONLY, container);
                     logger.debug(" -> container created...");
                 } catch (URISyntaxException e) {
                     // Incorrect URL. This should never happen.
@@ -490,7 +491,7 @@ public class AzureSnapshotRestoreITest extends AbstractAzureTest {
                 }
             }
         }, 30, TimeUnit.SECONDS);
-        storageService.removeContainer(container);
+        storageService.removeContainer(null, LocationMode.PRIMARY_ONLY, container);
 
         ClusterAdminClient client = client().admin().cluster();
         logger.info("-->  creating azure repository while container is being removed");
@@ -529,7 +530,7 @@ public class AzureSnapshotRestoreITest extends AbstractAzureTest {
         Settings settings = readSettingsFromFile();
         AzureStorageService client = new AzureStorageServiceImpl(settings);
         for (String container : containers) {
-            client.removeContainer(container);
+            client.removeContainer(null, LocationMode.PRIMARY_ONLY, container);
         }
     }
 }


### PR DESCRIPTION
…to ES master.

Enhancements as discussed on https://github.com/craigwi/elasticsearch-cloud-azure/releases/tag/v2.7.1-craigwi:

1.supports multiple storage accounts; cloud.azure.storage.account and cloud.azure.storage.key may now be an array of accounts / keys; the arrays must be the same length; the account at an index must match the key at the same index.

2.an Azure repository specification ("type" : "azure") allows for two new settings. "account" specifies the name of the account to be used and must be one of the items in cloud.azure.storage.account. If "account" is not specified, the first item in the list of accounts is used. The other new setting "location_mode" may be used to specify the endpoint. This defaults to "primary_only" and may also be "primary_then_secondary", "secondary_only" or "secondary_then_primary".

3.when a repository is registered using "secondary_only" or "secondary_then_primary" as the "location_mode", the verification of the repository is limited to checking that the container specified exists; in particular the tests-\* files are not created because the secondary endpoint is read only.

NOTE: for a given storage account, only one location_mode can be active at a time.

An example showing settings in elasticsearch.yml:

cloud.azure.storage.account: [ "azstorageaccount1", "mystorage2" ]
cloud.azure.storage.key: [ "", "" ]

A sample repository specification using the secondary endpoint:

{ "type": "azure", "settings": { "account" : "mystorage2", "container": "snapshots-20150701",
 "location_mode": "secondary_only"}}
