### PR TITLE
Estimate HyperLogLog bias via k-NN regression

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/HyperLogLogPlusPlus.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/cardinality/HyperLogLogPlusPlus.java
@@ -62,6 +62,7 @@ public final class HyperLogLogPlusPlus implements Releasable {
     private static final boolean HYPERLOGLOG = true;
     private static final float MAX_LOAD_FACTOR = 0.75f;
     private static final int P2 = 25;
+    private static final int BIAS_K = 6;
 
     /**
      * Compute the required precision so that <code>count</code> distinct entries
@@ -374,23 +375,30 @@ public final class HyperLogLogPlusPlus implements Releasable {
     private double estimateBias(double e) {
         final double[] rawEstimateData = rawEstimateData();
         final double[] biasData = biasData();
-        int index = Arrays.binarySearch(rawEstimateData, e);
-        if (index >= 0) {
-            return biasData[index];
-        } else {
-            index = -1 - index;
-            if (index == 0) {
-                return biasData[0];
-            } else if (index >= biasData.length) {
-                return biasData[biasData.length - 1];
-            } else {
-                double w1 = (e - rawEstimateData[index - 1]);
-                assert w1 >= 0;
-                double w2 = (rawEstimateData[index] - e);
-                assert w2 >= 0;
-                return (biasData[index - 1] * w1 + biasData[index] * w2) / (w1 + w2);
+
+        final double[] weights = new double[BIAS_K];
+        int index = biasData.length - BIAS_K;
+        for (int i = 0; i < rawEstimateData.length; ++i) {
+            final double w = 1.0 / Math.abs(rawEstimateData[i] - e);
+            final int j = i % weights.length;
+            if (Double.isInfinite(w)) {
+                return biasData[i];
+            } else if (weights[j] >= w) {
+                index = i - BIAS_K;
+                break;
             }
+            weights[j] = w;
         }
+
+        double weightSum = 0.0;
+        double biasSum = 0.0;
+        for (int i = 0, j = index; i < BIAS_K; ++i, ++j) {
+            final double w = weights[i];
+            final double b = biasData[j];
+            biasSum += w * b;
+            weightSum += w;
+        }
+        return biasSum / weightSum;
     }
 
     private double[] biasData() {


### PR DESCRIPTION
The implementation this commit replaces was almost k-NN regression with k=2, but had two bugs: (a) it depends on the empirical raw estimates being in strictly non-decreasing order for the binary search (which they are not); and (b) it weights the biases positively with increased distance from the corresponding raw estimate.

“HyperLogLog in Practice” leaves the choice of exact algorithm here fairly vague, just noting: “We use k-nearest neighbor interpolation to get the bias for a given raw estimate (for k = 6).”  The majority of other open source HyperLogLog++ implementations appear to use k-NN regression with uniform weights (and generally k = 6).  Uniform weighting does decrease variance, but also introduces bias at the domain extrema.  This problem, plus the use of the word “interpolation” in the original paper, suggests (inverse) distance-weighted k-NN, as implemented here.
