### PR TITLE
Packaging test for filesystem scripts

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/20_tar_package.bats
@@ -34,6 +34,8 @@ load tar
 
 setup() {
     skip_not_tar_gz
+    export ESHOME=/tmp/elasticsearch
+    export_elasticsearch_paths
 }
 
 ##################################
@@ -74,6 +76,11 @@ setup() {
 # Check that Elasticsearch is working
 ##################################
 @test "[TAR] test elasticsearch" {
+    # Install scripts used to test script filters and search templates before
+    # starting Elasticsearch so we don't have to wait for elasticsearch to scan for
+    # them.
+    install_elasticsearch_test_scripts
+
     start_elasticsearch_service
 
     run_elasticsearch_tests

--- a/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
@@ -31,10 +31,12 @@
 
 # Load test utilities
 load packaging_test_utils
+load os_package
 
 # Cleans everything for the 1st execution
 setup() {
     skip_not_dpkg
+    export_elasticsearch_paths
 }
 
 ##################################
@@ -79,8 +81,11 @@ setup() {
 }
 
 @test "[DEB] test elasticsearch" {
+    # Install scripts used to test script filters and search templates before
+    # starting Elasticsearch so we don't have to wait for elasticsearch to scan for
+    # them.
+    install_elasticsearch_test_scripts
     start_elasticsearch_service
-
     run_elasticsearch_tests
 }
 
@@ -133,6 +138,8 @@ setup() {
 }
 
 @test "[DEB] purge package" {
+    # User installed scripts aren't removed so we'll just get them ourselves
+    rm -rf $ESSCRIPTS
     dpkg --purge 'elasticsearch'
 }
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -30,10 +30,12 @@
 
 # Load test utilities
 load packaging_test_utils
+load os_package
 
 # Cleans everything for the 1st execution
 setup() {
     skip_not_rpm
+    export_elasticsearch_paths
 }
 
 ##################################
@@ -74,12 +76,17 @@ setup() {
 }
 
 @test "[RPM] test elasticsearch" {
+    # Install scripts used to test script filters and search templates before
+    # starting Elasticsearch so we don't have to wait for elasticsearch to scan for
+    # them.
+    install_elasticsearch_test_scripts
     start_elasticsearch_service
-
     run_elasticsearch_tests
 }
 
 @test "[RPM] remove package" {
+    # User installed scripts aren't removed so we'll just get them ourselves
+    rm -rf $ESSCRIPTS
     rpm -e 'elasticsearch'
 }
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/60_systemd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/60_systemd.bats
@@ -30,11 +30,13 @@
 
 # Load test utilities
 load packaging_test_utils
+load os_package
 
 # Cleans everything for the 1st execution
 setup() {
     skip_not_systemd
     skip_not_dpkg_or_rpm
+    export_elasticsearch_paths
 }
 
 @test "[SYSTEMD] install elasticsearch" {
@@ -61,10 +63,12 @@ setup() {
 }
 
 @test "[SYSTEMD] start" {
+    # Install scripts used to test script filters and search templates before
+    # starting Elasticsearch so we don't have to wait for elasticsearch to scan for
+    # them.
+    install_elasticsearch_test_scripts
     systemctl start elasticsearch.service
-
     wait_for_elasticsearch_status
-
     assert_file_exist "/var/run/elasticsearch/elasticsearch.pid"
 }
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
@@ -30,11 +30,13 @@
 
 # Load test utilities
 load packaging_test_utils
+load os_package
 
 # Cleans everything for the 1st execution
 setup() {
     skip_not_sysvinit
     skip_not_dpkg_or_rpm
+    export_elasticsearch_paths
 }
 
 @test "[INIT.D] remove any leftover configuration to start elasticsearch on restart" {
@@ -64,10 +66,12 @@ setup() {
 }
 
 @test "[INIT.D] start" {
+    # Install scripts used to test script filters and search templates before
+    # starting Elasticsearch so we don't have to wait for elasticsearch to scan for
+    # them.
+    install_elasticsearch_test_scripts
     service elasticsearch start
-
     wait_for_elasticsearch_status
-
     assert_file_exist "/var/run/elasticsearch/elasticsearch.pid"
 }
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/80_upgrade.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/80_upgrade.bats
@@ -32,6 +32,7 @@
 
 # Load test utilities
 load packaging_test_utils
+load os_package
 
 # Cleans everything for the 1st execution
 setup() {
@@ -50,7 +51,7 @@ setup() {
 @test "[UPGRADE] check elasticsearch version is old version" {
     curl -s localhost:9200 | grep \"number\"\ :\ \"$(cat upgrade_from_version)\" || {
         echo "Installed an unexpected version:"
-        curl localhost:9200
+        curl -s localhost:9200
         false
     }
 }

--- a/qa/vagrant/src/test/resources/packaging/scripts/example/scripts/is_guide.groovy
+++ b/qa/vagrant/src/test/resources/packaging/scripts/example/scripts/is_guide.groovy
@@ -1,0 +1,1 @@
+_source['title'] == 'Elasticsearch - The Definitive Guide'

--- a/qa/vagrant/src/test/resources/packaging/scripts/example/scripts/is_guide.mustache
+++ b/qa/vagrant/src/test/resources/packaging/scripts/example/scripts/is_guide.mustache
@@ -1,0 +1,7 @@
+{
+  "query": {
+    "script": {
+      "script_file": "is_guide"
+    }
+  }
+}

--- a/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
@@ -1,0 +1,109 @@
+#!/bin/sh
+
+# This file contains some utilities to test the elasticsearch scripts with
+# the .deb/.rpm packages.
+
+# WARNING: This testing file must be executed as root and can
+# dramatically change your system. It removes the 'elasticsearch'
+# user/group and also many directories. Do not execute this file
+# unless you know exactly what you are doing.
+
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# Export some useful paths.
+export_elasticsearch_paths() {
+    export ESHOME="/usr/share/elasticsearch"
+    export ESPLUGINS="$ESHOME/plugins"
+    export ESCONFIG="/etc/elasticsearch"
+    export ESSCRIPTS="$ESCONFIG/scripts"
+    export ESDATA="/var/lib/elasticsearch"
+    export ESLOG="/var/log/elasticsearch"
+    export ESPIDDIR="/var/run/elasticsearch"
+}
+
+# Install the rpm or deb package.
+# -u upgrade rather than install. This only matters for rpm.
+# -v the version to upgrade to. Defaults to the version under test.
+install_package() {
+    local version=$(cat version)
+    local rpmCommand='-i'
+    while getopts ":uv:" opt; do
+        case $opt in
+            u)
+                rpmCommand='-U'
+                ;;
+            v)
+                version=$OPTARG
+                ;;
+            \?)
+                echo "Invalid option: -$OPTARG" >&2
+                ;;
+        esac
+    done
+    if is_rpm; then
+        rpm $rpmCommand elasticsearch-$version.rpm
+    elif is_dpkg; then
+        dpkg -i elasticsearch-$version.deb
+    else
+        skip "Only rpm or deb supported"
+    fi
+}
+
+# Checks that all directories & files are correctly installed after a deb or
+# rpm install.
+verify_package_installation() {
+    id elasticsearch
+
+    getent group elasticsearch
+
+    assert_file "$ESHOME" d root 755
+    assert_file "$ESHOME/bin" d root 755
+    assert_file "$ESHOME/lib" d root 755
+    assert_file "$ESCONFIG" d root 755
+    assert_file "$ESCONFIG/elasticsearch.yml" f root 644
+    assert_file "$ESCONFIG/logging.yml" f root 644
+    assert_file "$ESDATA" d elasticsearch 755
+    assert_file "$ESLOG" d elasticsearch 755
+    assert_file "$ESPLUGINS" d elasticsearch 755
+    assert_file "$ESPIDDIR" d elasticsearch 755
+    assert_file "$ESHOME/NOTICE.txt" f root 644
+    assert_file "$ESHOME/README.textile" f root 644
+
+    if is_dpkg; then
+        # Env file
+        assert_file "/etc/default/elasticsearch" f root 644
+
+        # Doc files
+        assert_file "/usr/share/doc/elasticsearch" d root 755
+        assert_file "/usr/share/doc/elasticsearch/copyright" f root 644
+    fi
+
+    if is_rpm; then
+        # Env file
+        assert_file "/etc/sysconfig/elasticsearch" f root 644
+        # License file
+        assert_file "/usr/share/elasticsearch/LICENSE.txt" f root 644
+    fi
+
+    if is_systemd; then
+        assert_file "/usr/lib/systemd/system/elasticsearch.service" f root 644
+        assert_file "/usr/lib/tmpfiles.d/elasticsearch.conf" f root 644
+        assert_file "/usr/lib/sysctl.d/elasticsearch.conf" f root 644
+    fi
+}

--- a/qa/vagrant/src/test/resources/packaging/scripts/plugin_test_cases.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/plugin_test_cases.bash
@@ -53,7 +53,6 @@ setup() {
     if [ $BATS_TEST_NUMBER == 1 ] ||
             [[ $BATS_TEST_NAME =~ install_jvm.*example ]] ||
             [ ! -d "$ESHOME" ]; then
-        echo "cleaning" >> /tmp/ss
         clean_before_test
         install
     fi
@@ -69,14 +68,13 @@ if [[ "$BATS_TEST_FILENAME" =~ 25_tar_plugins.bats$ ]]; then
     export ESHOME=/tmp/elasticsearch
     export_elasticsearch_paths
 else
+    load os_package
     if is_rpm; then
         GROUP='RPM PLUGINS'
     elif is_dpkg; then
         GROUP='DEB PLUGINS'
     fi
-    export ESHOME="/usr/share/elasticsearch"
-    export ESPLUGINS="$ESHOME/plugins"
-    export ESCONFIG="/etc/elasticsearch"
+    export_elasticsearch_paths
     install() {
         install_package
         verify_package_installation

--- a/qa/vagrant/src/test/resources/packaging/scripts/tar.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/tar.bash
@@ -70,4 +70,25 @@ move_elasticsearch() {
 export_elasticsearch_paths() {
     export ESPLUGINS="$ESHOME/plugins"
     export ESCONFIG="$ESHOME/config"
+    export ESSCRIPTS="$ESCONFIG/scripts"
+    export ESDATA="$ESHOME/data"
+    export ESLOG="$ESHOME/logs"
+
+}
+
+# Checks that all directories & files are correctly installed
+# after a archive (tar.gz/zip) install
+verify_archive_installation() {
+    assert_file "$ESHOME" d
+    assert_file "$ESHOME/bin" d
+    assert_file "$ESHOME/bin/elasticsearch" f
+    assert_file "$ESHOME/bin/elasticsearch.in.sh" f
+    assert_file "$ESHOME/bin/plugin" f
+    assert_file "$ESCONFIG" d
+    assert_file "$ESCONFIG/elasticsearch.yml" f
+    assert_file "$ESCONFIG/logging.yml" f
+    assert_file "$ESHOME/lib" d
+    assert_file "$ESHOME/NOTICE.txt" f
+    assert_file "$ESHOME/LICENSE.txt" f
+    assert_file "$ESHOME/README.textile" f
 }


### PR DESCRIPTION
Adds a tests for loading scripts from the filesystem for search templates
and for search filters.

Closes #13184
