### PR TITLE
[test] print test start and end of test setup and cleanup

### DIFF
--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -344,7 +344,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
             cluster().beforeTest(getRandom(), getPerTestTransportClientRatio());
             cluster().wipe();
             randomIndexTemplate();
-            printTestMessage("before");
         } catch (OutOfMemoryError e) {
             if (e.getMessage().contains("unable to create new native thread")) {
                 ESTestCase.printStackDump(logger);
@@ -354,7 +353,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     private void printTestMessage(String message) {
-        if (isSuiteScopedTest(getClass())) {
+        if (isSuiteScopedTest(getClass()) && (getTestName().equals("<unknown>"))) {
             logger.info("[{}]: {} suite", getTestClass().getSimpleName(), message);
         } else {
             logger.info("[{}#{}]: {} test", getTestClass().getSimpleName(), getTestName(), message);
@@ -593,7 +592,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
         boolean success = false;
         try {
             final Scope currentClusterScope = getCurrentClusterScope();
-            printTestMessage("cleaning up after");
             clearDisruptionScheme();
             try {
                 if (cluster() != null) {
@@ -618,7 +616,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
                     clearClusters(); // it is ok to leave persistent / transient cluster state behind if scope is TEST
                 }
             }
-            printTestMessage("cleaned up after");
             success = true;
         } finally {
             if (!success) {
@@ -1953,20 +1950,26 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
     @Before
     public final void before() throws Exception {
+
         if (runTestScopeLifecycle()) {
+            printTestMessage("setup");
             beforeInternal();
         }
+        printTestMessage("starting");
     }
 
 
     @After
     public final void after() throws Exception {
+        printTestMessage("finished");
         // Deleting indices is going to clear search contexts implicitely so we
         // need to check that there are no more in-flight search contexts before
         // we remove indices
         super.ensureAllSearchContextsReleased();
         if (runTestScopeLifecycle()) {
+            printTestMessage("cleaning up after");
             afterInternal(false);
+            printTestMessage("cleaned up after");
         }
     }
 
@@ -1974,6 +1977,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     public static void afterClass() throws Exception {
         if (!runTestScopeLifecycle()) {
             try {
+                INSTANCE.printTestMessage("cleaning up after");
                 INSTANCE.afterInternal(true);
             } finally {
                 INSTANCE = null;
@@ -1999,6 +2003,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             INSTANCE = (ESIntegTestCase) targetClass.newInstance();
             boolean success = false;
             try {
+                INSTANCE.printTestMessage("setup");
                 INSTANCE.beforeInternal();
                 INSTANCE.setupSuiteScopeCluster();
                 success = true;


### PR DESCRIPTION
Currently we do not print start and end of SuiteScope tests which makes it tricky to debug failures. This pr changes this. To show how this looks like I made 3 test classes with annotations 

`@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)` (ScopeTestTest)
`@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)` (ScopeSuiteTest)
`@ESIntegTestCase.SuiteScopeTestCase` (SuiteScopeTest)

and printed out the messages which are now:

```
$ mvn test -Dtests.class=org.elasticsearch.test.test.test.* -Dtests.output=always -Des.logger.level=INFO | grep 'SuiteScopeTest\|ScopeSuiteTest\|ScopeTestTest'
HEARTBEAT J2 PID(33413@darkstar-2): 2015-09-02T12:00:06, stalled for 10.4s at: SuiteScopeTest (suite)
Suite: org.elasticsearch.test.test.test.SuiteScopeTest
  1> [2015-09-02 11:59:59,737][INFO ][test.test.test           ] [SuiteScopeTest]: setup suite
  1> [2015-09-02 12:00:08,918][INFO ][test.test.test           ] [SuiteScopeTest#test1]: starting test
  1> [2015-09-02 12:00:08,918][INFO ][test.test.test           ] [SuiteScopeTest#test1]: finished test
  1> [2015-09-02 12:00:09,086][INFO ][test.test.test           ] [SuiteScopeTest#test2]: starting test
  1> [2015-09-02 12:00:09,087][INFO ][test.test.test           ] [SuiteScopeTest#test2]: finished test
  1> [2015-09-02 12:00:09,088][INFO ][test.test.test           ] [SuiteScopeTest]: cleaning up after suite
Suite: org.elasticsearch.test.test.test.ScopeSuiteTest
  1> [2015-09-02 11:59:59,715][INFO ][test.test.test           ] [ScopeSuiteTest#test1]: setup test
  1> [2015-09-02 12:00:09,361][INFO ][test.test.test           ] [ScopeSuiteTest#test1]: starting test
  1> [2015-09-02 12:00:09,361][INFO ][test.test.test           ] [ScopeSuiteTest#test1]: finished test
  1> [2015-09-02 12:00:09,362][INFO ][test.test.test           ] [ScopeSuiteTest#test1]: cleaning up after test
  1> [2015-09-02 12:00:09,503][INFO ][test.test.test           ] [ScopeSuiteTest#test1]: cleaned up after test
  1> [2015-09-02 12:00:09,753][INFO ][test.test.test           ] [ScopeSuiteTest#test2]: setup test
  1> [2015-09-02 12:00:09,757][INFO ][test                     ] Successfully wiped data directory for node location: /Users/britta/es/core/target/J1/temp/org.elasticsearch.test.test.test.ScopeSuiteTest_D2C2EBA0E34B87CC-001/tempDir-001/data/SUITE-CHILD_VM=[1]-CLUSTER_SEED=[5187104418634291104]-HASH=[753730814E6B]-cluster/nodes/0
  1> [2015-09-02 12:00:09,828][INFO ][test.test.test           ] [ScopeSuiteTest#test2]: starting test
  1> [2015-09-02 12:00:09,828][INFO ][test.test.test           ] [ScopeSuiteTest#test2]: finished test
  1> [2015-09-02 12:00:09,828][INFO ][test.test.test           ] [ScopeSuiteTest#test2]: cleaning up after test
  1> [2015-09-02 12:00:09,862][INFO ][test.test.test           ] [ScopeSuiteTest#test2]: cleaned up after test
Suite: org.elasticsearch.test.test.test.ScopeTestTest
  1> [2015-09-02 11:59:59,404][INFO ][test.test.test           ] [ScopeTestTest#test1]: setup test
  1> [2015-09-02 12:00:09,574][INFO ][test.test.test           ] [ScopeTestTest#test1]: starting test
  1> [2015-09-02 12:00:09,574][INFO ][test.test.test           ] [ScopeTestTest#test1]: finished test
  1> [2015-09-02 12:00:09,576][INFO ][test.test.test           ] [ScopeTestTest#test1]: cleaning up after test
  1> [2015-09-02 12:00:09,708][INFO ][test.test.test           ] [ScopeTestTest#test1]: cleaned up after test
  1> [2015-09-02 12:00:09,940][INFO ][test.test.test           ] [ScopeTestTest#test2]: setup test
  1> [2015-09-02 12:00:10,299][INFO ][test.test.test           ] [ScopeTestTest#test2]: starting test
  1> [2015-09-02 12:00:10,299][INFO ][test.test.test           ] [ScopeTestTest#test2]: finished test
  1> [2015-09-02 12:00:10,299][INFO ][test.test.test           ] [ScopeTestTest#test2]: cleaning up after test
  1> [2015-09-02 12:00:10,377][INFO ][test.test.test           ] [ScopeTestTest#test2]: cleaned up after test
```

and were before:

```
$ mvn test -Dtests.class=org.elasticsearch.test.test.test.* -Dtests.output=always -Des.logger.level=INFO | grep 'SuiteScopeTest\|ScopeSuiteTest\|ScopeTestTest'
HEARTBEAT J2 PID(33463@darkstar-2): 2015-09-02T12:03:41, stalled for 11.7s at: SuiteScopeTest (suite)
Suite: org.elasticsearch.test.test.test.ScopeSuiteTest
  1> [2015-09-02 12:03:44,686][INFO ][test.test.test           ] [ScopeSuiteTest#test1]: before test
  1> [2015-09-02 12:03:44,688][INFO ][test.test.test           ] [ScopeSuiteTest#test1]: cleaning up after test
  1> [2015-09-02 12:03:45,058][INFO ][test.test.test           ] [ScopeSuiteTest#test1]: cleaned up after test
  1> [2015-09-02 12:03:45,291][INFO ][test                     ] Successfully wiped data directory for node location: /Users/britta/es/core/target/J1/temp/org.elasticsearch.test.test.test.ScopeSuiteTest_851DF8D3BEED2F10-001/tempDir-001/data/SUITE-CHILD_VM=[1]-CLUSTER_SEED=[2791181108065013943]-HASH=[7569101256AA]-cluster/nodes/0
  1> [2015-09-02 12:03:45,292][INFO ][test                     ] Successfully wiped data directory for node location: /Users/britta/es/core/target/J1/temp/org.elasticsearch.test.test.test.ScopeSuiteTest_851DF8D3BEED2F10-001/tempDir-001/data/SUITE-CHILD_VM=[1]-CLUSTER_SEED=[2791181108065013943]-HASH=[7569101256AA]-cluster/nodes/2
  1> [2015-09-02 12:03:45,294][INFO ][test                     ] Successfully wiped data directory for node location: /Users/britta/es/core/target/J1/temp/org.elasticsearch.test.test.test.ScopeSuiteTest_851DF8D3BEED2F10-001/tempDir-001/data/SUITE-CHILD_VM=[1]-CLUSTER_SEED=[2791181108065013943]-HASH=[7569101256AA]-cluster/nodes/1
  1> [2015-09-02 12:03:45,323][INFO ][test.test.test           ] [ScopeSuiteTest#test2]: before test
  1> [2015-09-02 12:03:45,324][INFO ][test.test.test           ] [ScopeSuiteTest#test2]: cleaning up after test
  1> [2015-09-02 12:03:45,413][INFO ][test.test.test           ] [ScopeSuiteTest#test2]: cleaned up after test
Suite: org.elasticsearch.test.test.test.SuiteScopeTest
  1> [2015-09-02 12:03:44,946][INFO ][test.test.test           ] [SuiteScopeTest]: before suite
  1> [2015-09-02 12:03:45,203][INFO ][test.test.test           ] [SuiteScopeTest]: cleaning up after suite
  1> [2015-09-02 12:03:45,576][INFO ][test.test.test           ] [SuiteScopeTest]: cleaned up after suite
Suite: org.elasticsearch.test.test.test.ScopeTestTest
  1> [2015-09-02 12:03:43,715][INFO ][test.test.test           ] [ScopeTestTest#test1]: before test
  1> [2015-09-02 12:03:43,717][INFO ][test.test.test           ] [ScopeTestTest#test1]: cleaning up after test
  1> [2015-09-02 12:03:43,994][INFO ][test.test.test           ] [ScopeTestTest#test1]: cleaned up after test
  1> [2015-09-02 12:03:45,478][INFO ][test.test.test           ] [ScopeTestTest#test2]: before test
  1> [2015-09-02 12:03:45,481][INFO ][test.test.test           ] [ScopeTestTest#test2]: cleaning up after test
  1> [2015-09-02 12:03:45,573][INFO ][test.test.test           ] [ScopeTestTest#test2]: cleaned up after test
```
