### PR TITLE
Manual synchronization when iterating over listeners in InternalClusterInfoService

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -44,7 +44,11 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ReceiveTimeoutTransportException;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -77,7 +81,7 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
     private final TransportIndicesStatsAction transportIndicesStatsAction;
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
-    private final Set<Listener> listeners = Collections.synchronizedSet(new HashSet<Listener>());
+    private final List<Listener> listeners = new CopyOnWriteArrayList<>();
 
     @Inject
     public InternalClusterInfoService(Settings settings, NodeSettingsService nodeSettingsService,


### PR DESCRIPTION
Iterating over a synchronized collection created with `Collections.synchronizedSet()` must be manually synchronized.

I hit this one when running an integration test multiple times (`-Dtest.iters=1000`) that uses `NodeService` and `DiskThresholdDecider`:

``` java
Rgs 02, 2015 1:49:36 PM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
WARNING: Uncaught exception in thread: Thread[elasticsearch[node_s0][management][T#3],5,TGRP-NodeStatsCollectorTests]
 java.util.ConcurrentModificationException
    at __randomizedtesting.SeedInfo.seed([F74F37441AC8278A]:0)
    at java.util.HashMap$HashIterator.nextNode(HashMap.java:1429)
    at java.util.HashMap$KeyIterator.next(HashMap.java:1453)
    at org.elasticsearch.cluster.InternalClusterInfoService$ClusterInfoUpdateJob.run(InternalClusterInfoService.java:396)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```
