### PR TITLE
[qa] Add smoke test client module

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -297,6 +297,11 @@
     <startup-elasticsearch/>
   </target>
 
+  <!-- unzip core release artifact then start ES -->
+  <target name="start-external-cluster" depends="setup-workspace">
+    <startup-elasticsearch/>
+  </target>
+
   <target name="stop-external-cluster" if="integ.pidfile.exists">
     <stop-node/>
   </target>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -147,6 +147,7 @@
     <modules>
         <module>smoke-test-plugins</module>
         <module>smoke-test-multinode</module>
+        <module>smoke-test-client</module>
     </modules>
 
     <profiles>

--- a/qa/smoke-test-client/pom.xml
+++ b/qa/smoke-test-client/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>elasticsearch-qa</artifactId>
+        <groupId>org.elasticsearch.qa</groupId>
+        <version>2.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+      This test unzips and starts elasticsearch.
+      It then creates a Java Client and makes sure simple
+      Java API calls works nicely
+
+      It will also helps to better document the Java API reference guide
+      and keep it up-to-date when API is changing.
+    -->
+
+    <artifactId>smoke-test-client</artifactId>
+    <name>QA: Smoke Test Client</name>
+    <description>Test the Java Client against a running cluster</description>
+    <packaging>pom</packaging>
+
+    <properties>
+        <skip.unit.tests>true</skip.unit.tests>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <!-- shared test resources like log4j.properties -->
+            <testResource>
+                <directory>${elasticsearch.tools.directory}/shared-test-resources</directory>
+                <filtering>false</filtering>
+            </testResource>
+        </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>integ-setup-dependencies</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.integ.tests}</skip>
+                            <useBaseVersion>true</useBaseVersion>
+                            <outputDirectory>${integ.deps}/plugins</outputDirectory>
+
+                            <artifactItems>
+                                <!-- elasticsearch distribution -->
+                                <artifactItem>
+                                    <groupId>org.elasticsearch.distribution.zip</groupId>
+                                    <artifactId>elasticsearch</artifactId>
+                                    <version>${elasticsearch.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${integ.deps}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <!-- start up external cluster -->
+                    <execution>
+                        <id>integ-setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.integ.tests}</skip>
+                            <target>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="start-external-cluster">
+                                    <property name="tests.jvm.argline" value="${tests.jvm.argline}"/>
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!-- shut down external cluster -->
+                    <execution>
+                        <id>integ-teardown</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.integ.tests}</skip>
+                            <target>
+                                <ant antfile="${elasticsearch.integ.antfile}" target="stop-external-cluster"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.smoketest;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * {@link ESSmokeClientTestCase} is an abstract base class to run integration
+ * tests against an external Elasticsearch Cluster.
+ * <p/>
+ * You can define a list of transport addresses from where you can reach your cluster
+ * by setting "tests.cluster" system property. It defaults to "localhost:9300".
+ * <p/>
+ * All tests can be run from maven using mvn install as maven will start an external cluster first.
+ * <p/>
+ * If you want to debug this module from your IDE, then start an external cluster by yourself
+ * then run JUnit. If you changed the default port, set "tests.cluster=localhost:PORT" when running
+ * your test.
+ */
+public abstract class ESSmokeClientTestCase extends LuceneTestCase {
+
+    /**
+     * Key used to eventually switch to using an external cluster and provide its transport addresses
+     */
+    public static final String TESTS_CLUSTER = "tests.cluster";
+
+    /**
+     * Defaults to localhost:9300
+     */
+    public static final String TESTS_CLUSTER_DEFAULT = "localhost:9300";
+
+    protected static ESLogger logger = ESLoggerFactory.getLogger(ESSmokeClientTestCase.class.getName());
+
+    private static final AtomicInteger counter = new AtomicInteger();
+    private static Client client;
+    private static String clusterAddresses;
+    protected String index;
+
+    private static Client startClient(Path tempDir, TransportAddress... transportAddresses) {
+        Settings clientSettings = Settings.settingsBuilder()
+                .put("name", "qa_smoke_client_" + counter.getAndIncrement())
+                .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // prevents any settings to be replaced by system properties.
+                .put("client.transport.ignore_cluster_name", true)
+                .put("path.home", tempDir)
+                .put("node.mode", "network").build(); // we require network here!
+
+        TransportClient.Builder transportClientBuilder = TransportClient.builder().settings(clientSettings);
+        TransportClient client = transportClientBuilder.build().addTransportAddresses(transportAddresses);
+
+        logger.info("--> Elasticsearch Java TransportClient started");
+
+        Exception clientException = null;
+        try {
+            ClusterHealthResponse health = client.admin().cluster().prepareHealth().get();
+            logger.info("--> connected to [{}] cluster which is running [{}] node(s).",
+                    health.getClusterName(), health.getNumberOfNodes());
+        } catch (Exception e) {
+            clientException = e;
+        }
+
+        assumeNoException("Sounds like your cluster is not running at " + clusterAddresses, clientException);
+
+        return client;
+    }
+
+    private static Client startClient() throws UnknownHostException {
+        String[] stringAddresses = clusterAddresses.split(",");
+        TransportAddress[] transportAddresses = new TransportAddress[stringAddresses.length];
+        int i = 0;
+        for (String stringAddress : stringAddresses) {
+            String[] split = stringAddress.split(":");
+            if (split.length < 2) {
+                throw new IllegalArgumentException("address [" + clusterAddresses + "] not valid");
+            }
+            try {
+                transportAddresses[i++] = new InetSocketTransportAddress(InetAddress.getByName(split[0]), Integer.valueOf(split[1]));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("port is not valid, expected number but was [" + split[1] + "]");
+            }
+        }
+        return startClient(createTempDir(), transportAddresses);
+    }
+
+    public static Client getClient() {
+        if (client == null) {
+            try {
+                client = startClient();
+            } catch (UnknownHostException e) {
+                logger.error("can not start the client", e);
+            }
+            assertThat(client, notNullValue());
+        }
+        return client;
+    }
+
+    @BeforeClass
+    public static void initializeSettings() throws UnknownHostException {
+        clusterAddresses = System.getProperty(TESTS_CLUSTER);
+        if (clusterAddresses == null || clusterAddresses.isEmpty()) {
+            clusterAddresses = TESTS_CLUSTER_DEFAULT;
+            logger.info("[{}] not set. Falling back to [{}]", TESTS_CLUSTER, TESTS_CLUSTER_DEFAULT);
+        }
+    }
+
+    @AfterClass
+    public static void stopTransportClient() {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
+
+    @Before
+    public void defineIndexName() {
+        doClean();
+        index = "qa-smoke-test-client-" + randomAsciiOfLength(10).toLowerCase(Locale.getDefault());
+    }
+
+    @After
+    public void cleanIndex() {
+        doClean();
+    }
+
+    private void doClean() {
+        if (client != null) {
+            try {
+                client.admin().indices().prepareDelete(index).get();
+            } catch (Exception e) {
+                // We ignore this cleanup exception
+            }
+        }
+    }
+
+}

--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/SmokeTestClientIT.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/SmokeTestClientIT.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.smoketest;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class SmokeTestClientIT extends ESSmokeClientTestCase {
+
+    /**
+     * Check that we are connected to a cluster named "elasticsearch".
+     */
+    @Test
+    public void testSimpleClient() {
+        Client client = getClient();
+
+        // START SNIPPET: java-doc-admin-cluster-health
+        ClusterHealthResponse health = client.admin().cluster().prepareHealth().setWaitForYellowStatus().get();
+        // END SNIPPET: java-doc-admin-cluster-health
+        assertThat(health.getClusterName(), is("elasticsearch"));
+    }
+
+    /**
+     * Create an index and index some docs
+     */
+    @Test
+    public void testPutDocument() {
+        Client client = getClient();
+
+        // START SNIPPET: java-doc-index-doc-simple
+        client.prepareIndex(index, "doc", "1")  // Index, Type, Id
+                .setSource("foo", "bar")        // Simple document: { "foo" : "bar" }
+                .get();                         // Execute and wait for the result
+        // END SNIPPET: java-doc-index-doc-simple
+
+        // START SNIPPET: java-doc-admin-indices-refresh
+        // Prepare a refresh action on a given index, execute and wait for the result
+        client.admin().indices().prepareRefresh(index).get();
+        // END SNIPPET: java-doc-admin-indices-refresh
+
+        // START SNIPPET: java-doc-search-simple
+        SearchResponse searchResponse = client.prepareSearch(index).get();
+        assertThat(searchResponse.getHits().getTotalHits(), is(1L));
+        // END SNIPPET: java-doc-search-simple
+    }
+}
+


### PR DESCRIPTION
This commit adds a new smoke test for testing client as a end Java user.

It starts a cluster in `pre-integration-test` phase, then execute the client operations defined as JUnit tests within `integration-test` phase and then stop the external cluster in `post-integration-test` phase.

You can also run test classes from your IDE.
- Start an external node on your machine with `bin/elasticsearch` (note that you can test Java API regressions if you run an older or newer node version)
- Run the JUnit test. By default, it will run tests on `localhost:9300` but you can change this setting using system property `tests.cluster`. It also expects the default `cluster.name` (`elasticsearch`).

This commit also starts adding [snippets as defined by Maven](https://maven.apache.org/guides/mini/guide-snippet-macro.html) to help keeping automatically synchronized the Java reference guide with the current code.

Our documentation builder tool does not support snippets though but we will most likely support it at some point.

This is a followup for #13252. See https://github.com/elastic/elasticsearch/pull/13252#discussion_r38508098
