### PR TITLE
Test that packages don't start elasticsearch

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
@@ -72,6 +72,10 @@ setup() {
     # This isn't perfect by any means but its something.
     sleep 1
     ! ps aux | grep elasticsearch | grep java
+    # You might be tempted to use jps instead of the above but that'd have to
+    # look like:
+    # ! sudo -u elasticsearch jps | grep -i elasticsearch
+    # which isn't really easier to read than the above.
 }
 
 @test "[DEB] test elasticsearch" {

--- a/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/30_deb_package.bats
@@ -67,6 +67,13 @@ setup() {
     verify_package_installation
 }
 
+@test "[DEB] elasticsearch isn't started by package install" {
+    # Wait a second to give Elasticsearch a change to start if it is going to.
+    # This isn't perfect by any means but its something.
+    sleep 1
+    ! ps aux | grep elasticsearch | grep java
+}
+
 @test "[DEB] test elasticsearch" {
     start_elasticsearch_service
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -66,6 +66,13 @@ setup() {
     verify_package_installation
 }
 
+@test "[RPM] elasticsearch isn't started by package install" {
+    # Wait a second to give Elasticsearch a change to start if it is going to.
+    # This isn't perfect by any means but its something.
+    sleep 1
+    ! ps aux | grep elasticsearch | grep java
+}
+
 @test "[RPM] test elasticsearch" {
     start_elasticsearch_service
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/60_systemd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/60_systemd.bats
@@ -46,6 +46,14 @@ setup() {
     systemctl daemon-reload
 }
 
+@test "[SYSTEMD] daemon isn't enabled on restart" {
+    # Rather than restart the VM we just ask systemd if it plans on starting
+    # elasticsearch on restart. Not as strong as a restart but much much
+    # faster.
+    run systemctl is-enabled elasticsearch.service
+    [ "$output" = "disabled" ]
+}
+
 @test "[SYSTEMD] enable" {
     systemctl enable elasticsearch.service
 

--- a/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
@@ -57,6 +57,9 @@ setup() {
     # Rather than restart the VM which would be slow we check for the symlinks
     # that init.d uses to restart the application on startup.
     ! find /etc/rc[0123456].d | grep elasticsearch
+    # Note that we don't use -iname above because that'd have to look like:
+    # [ $(find /etc/rc[0123456].d -iname "elasticsearch*" | wc -l) -eq 0 ]
+    # Which isn't really clearer than what we do use.
 }
 
 @test "[INIT.D] start" {

--- a/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
@@ -37,9 +37,26 @@ setup() {
     skip_not_dpkg_or_rpm
 }
 
+@test "[INIT.D] remove any leftover configuration to start elasticsearch on restart" {
+    # This configuration can be added with a command like:
+    # $ sudo update-rc.d elasticsearch defaults 95 10
+    # but we want to test that the RPM _doesn't_ add it on its own.
+    # Note that it'd be incorrect to use:
+    # $ sudo update-rc.d elasticsearch disable
+    # here because that'd prevent elasticsearch from installing the symlinks
+    # that cause it to be started on restart.
+    sudo update-rc.d -f elasticsearch remove
+}
+
 @test "[INIT.D] install elasticsearch" {
     clean_before_test
     install_package
+}
+
+@test "[INIT.D] daemon isn't enabled on restart" {
+    # Rather than restart the VM which would be slow we check for the symlinks
+    # that init.d uses to restart the application on startup.
+    ! find /etc/rc[0123456].d | grep elasticsearch
 }
 
 @test "[INIT.D] start" {


### PR DESCRIPTION
We don't want either the deb or rpm package to start elasticsearch as soon
as they install nor do we want the package to register elasticsearch to
start on restart. That action is reserved for the administrator. This adds
tests for that.

Closes #13122
