### PR TITLE
use query_string in bool filter docs

### DIFF
--- a/docs/reference/query-dsl/filters/bool-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/bool-filter.asciidoc
@@ -12,7 +12,7 @@ accept a filter.
 {
     "filtered" : {
         "query" : {
-            "queryString" : {
+            "query_string" : {
                 "default_field" : "message",
                 "query" : "elasticsearch"
             }


### PR DESCRIPTION
Closes #13279

`s/queryString/query_string/`

Probably needs to be backported to other 1.x branches as well
