### PR TITLE
Remove test class exclusion for Abstract prefix and rename classes accordingly

### DIFF
--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.TimestampParsingException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.client.AbstractClientHeadersTestCase;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -78,7 +79,6 @@ import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -97,7 +97,7 @@ public class ExceptionSerializationTests extends ESTestCase {
                 org.elasticsearch.test.rest.client.RestException.class,
                 org.elasticsearch.common.util.CancellableThreadsTest.CustomException.class,
                 org.elasticsearch.rest.BytesRestResponseTests.WithHeadersException.class,
-                org.elasticsearch.client.AbstractClientHeadersTests.InternalException.class);
+                AbstractClientHeadersTestCase.InternalException.class);
         FileVisitor<Path> visitor = new FileVisitor<Path>() {
             private Path pkgPrefix = PathUtils.get(path).getParent();
 

--- a/core/src/test/java/org/elasticsearch/NamingConventionTests.java
+++ b/core/src/test/java/org/elasticsearch/NamingConventionTests.java
@@ -48,7 +48,7 @@ public class NamingConventionTests extends ESTestCase {
 
     // see https://github.com/elasticsearch/elasticsearch/issues/9945
     public void testNamingConventions()
-        throws ClassNotFoundException, IOException, URISyntaxException {
+            throws ClassNotFoundException, IOException, URISyntaxException {
         final Set<Class> notImplementing = new HashSet<>();
         final Set<Class> pureUnitTest = new HashSet<>();
         final Set<Class> missingSuffix = new HashSet<>();
@@ -78,7 +78,6 @@ public class NamingConventionTests extends ESTestCase {
                         String filename = file.getFileName().toString();
                         if (filename.endsWith(".class")) {
                             Class<?> clazz = loadClass(filename);
-                            //if (Modifier.isAbstract(clazz.getModifiers()) == false && Modifier.isInterface(clazz.getModifiers()) == false) {
                             if (clazz.getName().endsWith("Tests") ||
                                 clazz.getName().endsWith("Test")) { // don't worry about the ones that match the pattern
 
@@ -104,8 +103,6 @@ public class NamingConventionTests extends ESTestCase {
                                     pureUnitTest.add(clazz);
                                 }
                             }
-                            //}
-
                         }
                     } catch (ClassNotFoundException e) {
                         throw new RuntimeException(e);
@@ -165,25 +162,18 @@ public class NamingConventionTests extends ESTestCase {
             ESTokenStreamTestCase.class.getSimpleName(),
             LuceneTestCase.class.getSimpleName());
         assertTrue("Not all subclasses of " + ESTestCase.class.getSimpleName() +
-                " match the naming convention. Concrete classes must end with [Test|Tests]:\n" + listClasses(missingSuffix),
+                " match the naming convention. Concrete classes must end with [Test|Tests]:\n" + Joiner.on('\n').join(missingSuffix),
             missingSuffix.isEmpty());
-        assertTrue("Classes ending with [Test|Tests] are abstract or interfaces:\n" + listClasses(notRunnable),
+        assertTrue("Classes ending with [Test|Tests] are abstract or interfaces:\n" + Joiner.on('\n').join(notRunnable),
             notRunnable.isEmpty());
-        assertTrue("Found inner classes that are tests, which are excluded from the test runner:\n" + listClasses(innerClasses),
+        assertTrue("Found inner classes that are tests, which are excluded from the test runner:\n" + Joiner.on('\n').join(innerClasses),
             innerClasses.isEmpty());
-        assertTrue("Pure Unit-Test found must subclass one of [" + classesToSubclass +"]:\n" + listClasses(pureUnitTest),
+        assertTrue("Pure Unit-Test found must subclass one of [" + classesToSubclass +"]:\n" + Joiner.on('\n').join(pureUnitTest),
             pureUnitTest.isEmpty());
-        assertTrue("Classes ending with Test|Tests] must subclass [" + classesToSubclass +"]:\n" + listClasses(notImplementing),
+        assertTrue("Classes ending with Test|Tests] must subclass [" + classesToSubclass +"]:\n" + Joiner.on('\n').join(notImplementing),
             notImplementing.isEmpty());
-        assertTrue("Subclasses of ESIntegTestCase should end with IT as they are integration tests:\n" + listClasses(integTestsInDisguise), integTestsInDisguise.isEmpty());
-    }
-
-    static String listClasses(Set<Class> classes) {
-        StringBuilder builder = new StringBuilder();
-        for (Class clazz : classes) {
-            builder.append(clazz.toString() + '\n');
-        }
-        return builder.toString();
+        assertTrue("Subclasses of ESIntegTestCase should end with IT as they are integration tests:\n" + Joiner.on('\n').join(integTestsInDisguise),
+            integTestsInDisguise.isEmpty());
     }
 
     /*

--- a/core/src/test/java/org/elasticsearch/NamingConventionTests.java
+++ b/core/src/test/java/org/elasticsearch/NamingConventionTests.java
@@ -48,11 +48,13 @@ public class NamingConventionTests extends ESTestCase {
 
     // see https://github.com/elasticsearch/elasticsearch/issues/9945
     public void testNamingConventions()
-            throws ClassNotFoundException, IOException, URISyntaxException {
+        throws ClassNotFoundException, IOException, URISyntaxException {
         final Set<Class> notImplementing = new HashSet<>();
         final Set<Class> pureUnitTest = new HashSet<>();
         final Set<Class> missingSuffix = new HashSet<>();
         final Set<Class> integTestsInDisguise = new HashSet<>();
+        final Set<Class> notRunnable = new HashSet<>();
+        final Set<Class> innerClasses = new HashSet<>();
         String[] packages = {"org.elasticsearch", "org.apache.lucene"};
         for (final String packageName : packages) {
             final String path = "/" + packageName.replace('.', '/');
@@ -76,27 +78,33 @@ public class NamingConventionTests extends ESTestCase {
                         String filename = file.getFileName().toString();
                         if (filename.endsWith(".class")) {
                             Class<?> clazz = loadClass(filename);
-                            if (Modifier.isAbstract(clazz.getModifiers()) == false && Modifier.isInterface(clazz.getModifiers()) == false) {
-                                if (clazz.getName().endsWith("Tests") || 
-                                    clazz.getName().endsWith("Test")) { // don't worry about the ones that match the pattern
+                            //if (Modifier.isAbstract(clazz.getModifiers()) == false && Modifier.isInterface(clazz.getModifiers()) == false) {
+                            if (clazz.getName().endsWith("Tests") ||
+                                clazz.getName().endsWith("Test")) { // don't worry about the ones that match the pattern
 
-                                    if (ESIntegTestCase.class.isAssignableFrom(clazz)) {
-                                        integTestsInDisguise.add(clazz);
-                                    }
-                                    if (isTestCase(clazz) == false) {
-                                        notImplementing.add(clazz);
-                                    }
-                                } else if (clazz.getName().endsWith("IT")) {
-                                    if (isTestCase(clazz) == false) {
-                                        notImplementing.add(clazz);
-                                    }
-                                    // otherwise fine
-                                } else if (isTestCase(clazz)) {
+                                if (ESIntegTestCase.class.isAssignableFrom(clazz)) {
+                                    integTestsInDisguise.add(clazz);
+                                }
+                                if (Modifier.isAbstract(clazz.getModifiers()) || Modifier.isInterface(clazz.getModifiers())) {
+                                    notRunnable.add(clazz);
+                                } else if (isTestCase(clazz) == false) {
+                                    notImplementing.add(clazz);
+                                } else if (Modifier.isStatic(clazz.getModifiers())) {
+                                    innerClasses.add(clazz);
+                                }
+                            } else if (clazz.getName().endsWith("IT")) {
+                                if (isTestCase(clazz) == false) {
+                                    notImplementing.add(clazz);
+                                }
+                                // otherwise fine
+                            } else if (Modifier.isAbstract(clazz.getModifiers()) == false && Modifier.isInterface(clazz.getModifiers()) == false) {
+                                if (isTestCase(clazz)) {
                                     missingSuffix.add(clazz);
                                 } else if (junit.framework.Test.class.isAssignableFrom(clazz) || hasTestAnnotation(clazz)) {
                                     pureUnitTest.add(clazz);
                                 }
                             }
+                            //}
 
                         }
                     } catch (ClassNotFoundException e) {
@@ -143,38 +151,56 @@ public class NamingConventionTests extends ESTestCase {
         }
         assertTrue(missingSuffix.remove(WrongName.class));
         assertTrue(missingSuffix.remove(WrongNameTheSecond.class));
+        assertTrue(notRunnable.remove(DummyAbstractTests.class));
+        assertTrue(notRunnable.remove(DummyInterfaceTests.class));
+        assertTrue(innerClasses.remove(InnerTests.class));
         assertTrue(notImplementing.remove(NotImplementingTests.class));
         assertTrue(notImplementing.remove(NotImplementingTest.class));
         assertTrue(pureUnitTest.remove(PlainUnit.class));
         assertTrue(pureUnitTest.remove(PlainUnitTheSecond.class));
 
         String classesToSubclass = Joiner.on(',').join(
-                ESTestCase.class.getSimpleName(),
-                ESTestCase.class.getSimpleName(),
-                ESTokenStreamTestCase.class.getSimpleName(),
-                LuceneTestCase.class.getSimpleName());
+            ESTestCase.class.getSimpleName(),
+            ESTestCase.class.getSimpleName(),
+            ESTokenStreamTestCase.class.getSimpleName(),
+            LuceneTestCase.class.getSimpleName());
         assertTrue("Not all subclasses of " + ESTestCase.class.getSimpleName() +
-                        " match the naming convention. Concrete classes must end with [Test|Tests]: " + missingSuffix.toString(),
-                missingSuffix.isEmpty());
-        assertTrue("Pure Unit-Test found must subclass one of [" + classesToSubclass +"] " + pureUnitTest.toString(),
-                pureUnitTest.isEmpty());
-        assertTrue("Classes ending with Test|Tests] must subclass [" + classesToSubclass +"] " + notImplementing.toString(),
-                notImplementing.isEmpty());
-        assertTrue("Subclasses of ESIntegTestCase should end with IT as they are integration tests: " + integTestsInDisguise, integTestsInDisguise.isEmpty());
+                " match the naming convention. Concrete classes must end with [Test|Tests]:\n" + listClasses(missingSuffix),
+            missingSuffix.isEmpty());
+        assertTrue("Classes ending with [Test|Tests] are abstract or interfaces:\n" + listClasses(notRunnable),
+            notRunnable.isEmpty());
+        assertTrue("Found inner classes that are tests, which are excluded from the test runner:\n" + listClasses(innerClasses),
+            innerClasses.isEmpty());
+        assertTrue("Pure Unit-Test found must subclass one of [" + classesToSubclass +"]:\n" + listClasses(pureUnitTest),
+            pureUnitTest.isEmpty());
+        assertTrue("Classes ending with Test|Tests] must subclass [" + classesToSubclass +"]:\n" + listClasses(notImplementing),
+            notImplementing.isEmpty());
+        assertTrue("Subclasses of ESIntegTestCase should end with IT as they are integration tests:\n" + listClasses(integTestsInDisguise), integTestsInDisguise.isEmpty());
+    }
+
+    static String listClasses(Set<Class> classes) {
+        StringBuilder builder = new StringBuilder();
+        for (Class clazz : classes) {
+            builder.append(clazz.toString() + '\n');
+        }
+        return builder.toString();
     }
 
     /*
      * Some test the test classes
      */
 
-    @SuppressForbidden(reason = "Ignoring test the tester")
-    @Ignore
     public static final class NotImplementingTests {}
-    @SuppressForbidden(reason = "Ignoring test the tester")
-    @Ignore
+
     public static final class NotImplementingTest {}
 
     public static final class WrongName extends ESTestCase {}
+
+    public static abstract class DummyAbstractTests extends ESTestCase {}
+
+    public interface DummyInterfaceTests {}
+
+    public static final class InnerTests extends ESTestCase {}
 
     public static final class WrongNameTheSecond extends ESTestCase {}
 

--- a/core/src/test/java/org/elasticsearch/client/AbstractClientHeadersTestCase.java
+++ b/core/src/test/java/org/elasticsearch/client/AbstractClientHeadersTestCase.java
@@ -64,7 +64,7 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-public abstract class AbstractClientHeadersTests extends ESTestCase {
+public abstract class AbstractClientHeadersTestCase extends ESTestCase {
 
     protected static final Settings HEADER_SETTINGS = Settings.builder()
             .put(Headers.PREFIX + ".key1", "val1")

--- a/core/src/test/java/org/elasticsearch/client/node/NodeClientHeadersTests.java
+++ b/core/src/test/java/org/elasticsearch/client/node/NodeClientHeadersTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.action.GenericAction;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
-import org.elasticsearch.client.AbstractClientHeadersTests;
+import org.elasticsearch.client.AbstractClientHeadersTestCase;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.support.Headers;
 import org.elasticsearch.common.settings.Settings;
@@ -37,7 +37,7 @@ import java.util.HashMap;
 /**
  *
  */
-public class NodeClientHeadersTests extends AbstractClientHeadersTests {
+public class NodeClientHeadersTests extends AbstractClientHeadersTestCase {
 
     private static final ActionFilters EMPTY_FILTERS = new ActionFilters(Collections.<ActionFilter>emptySet());
 

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.action.admin.cluster.node.liveness.LivenessResponse;
 import org.elasticsearch.action.admin.cluster.node.liveness.TransportLivenessAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
-import org.elasticsearch.client.AbstractClientHeadersTests;
+import org.elasticsearch.client.AbstractClientHeadersTestCase;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -48,7 +48,6 @@ import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
-import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -58,7 +57,7 @@ import static org.hamcrest.Matchers.is;
 /**
  *
  */
-public class TransportClientHeadersTests extends AbstractClientHeadersTests {
+public class TransportClientHeadersTests extends AbstractClientHeadersTestCase {
 
     private static final LocalTransportAddress address = new LocalTransportAddress("test");
 

--- a/core/src/test/java/org/elasticsearch/common/compress/AbstractCompressedStreamTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/compress/AbstractCompressedStreamTestCase.java
@@ -37,11 +37,11 @@ import java.util.concurrent.CountDownLatch;
 /**
  * Test streaming compression (e.g. used for recovery)
  */
-public abstract class AbstractCompressedStreamTests extends ESTestCase {
+public abstract class AbstractCompressedStreamTestCase extends ESTestCase {
 
     private final Compressor compressor;
 
-    protected AbstractCompressedStreamTests(Compressor compressor) {
+    protected AbstractCompressedStreamTestCase(Compressor compressor) {
         this.compressor = compressor;
     }
 

--- a/core/src/test/java/org/elasticsearch/common/compress/AbstractCompressedXContentTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/compress/AbstractCompressedXContentTestCase.java
@@ -35,11 +35,11 @@ import static org.hamcrest.Matchers.not;
 /**
  *
  */
-public abstract class AbstractCompressedXContentTests extends ESTestCase {
+public abstract class AbstractCompressedXContentTestCase extends ESTestCase {
 
     private final Compressor compressor;
 
-    protected AbstractCompressedXContentTests(Compressor compressor) {
+    protected AbstractCompressedXContentTestCase(Compressor compressor) {
         this.compressor = compressor;
     }
 

--- a/core/src/test/java/org/elasticsearch/common/compress/deflate/DeflateCompressedStreamTests.java
+++ b/core/src/test/java/org/elasticsearch/common/compress/deflate/DeflateCompressedStreamTests.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.common.compress.deflate;
 
-import org.elasticsearch.common.compress.AbstractCompressedStreamTests;
+import org.elasticsearch.common.compress.AbstractCompressedStreamTestCase;
 
-public class DeflateCompressedStreamTests extends AbstractCompressedStreamTests {
+public class DeflateCompressedStreamTests extends AbstractCompressedStreamTestCase {
 
     public DeflateCompressedStreamTests() {
         super(new DeflateCompressor());

--- a/core/src/test/java/org/elasticsearch/common/compress/deflate/DeflateXContentTests.java
+++ b/core/src/test/java/org/elasticsearch/common/compress/deflate/DeflateXContentTests.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.common.compress.deflate;
 
-import org.elasticsearch.common.compress.AbstractCompressedXContentTests;
+import org.elasticsearch.common.compress.AbstractCompressedXContentTestCase;
 
-public class DeflateXContentTests extends AbstractCompressedXContentTests {
+public class DeflateXContentTests extends AbstractCompressedXContentTestCase {
 
     public DeflateXContentTests() {
         super(new DeflateCompressor());

--- a/core/src/test/java/org/elasticsearch/common/compress/lzf/LZFCompressedStreamTests.java
+++ b/core/src/test/java/org/elasticsearch/common/compress/lzf/LZFCompressedStreamTests.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.common.compress.lzf;
 
-import org.elasticsearch.common.compress.AbstractCompressedStreamTests;
+import org.elasticsearch.common.compress.AbstractCompressedStreamTestCase;
 
-public class LZFCompressedStreamTests extends AbstractCompressedStreamTests {
+public class LZFCompressedStreamTests extends AbstractCompressedStreamTestCase {
 
     public LZFCompressedStreamTests() {
         super(new LZFTestCompressor());

--- a/core/src/test/java/org/elasticsearch/common/compress/lzf/LZFXContentTests.java
+++ b/core/src/test/java/org/elasticsearch/common/compress/lzf/LZFXContentTests.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.common.compress.lzf;
 
-import org.elasticsearch.common.compress.AbstractCompressedXContentTests;
+import org.elasticsearch.common.compress.AbstractCompressedXContentTestCase;
 
-public class LZFXContentTests extends AbstractCompressedXContentTests {
+public class LZFXContentTests extends AbstractCompressedXContentTestCase {
 
     public LZFXContentTests() {
         super(new LZFTestCompressor());

--- a/core/src/test/java/org/elasticsearch/common/recycler/AbstractRecyclerTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/recycler/AbstractRecyclerTestCase.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public abstract class AbstractRecyclerTests extends ESTestCase {
+public abstract class AbstractRecyclerTestCase extends ESTestCase {
 
     // marker states for data
     protected static final byte FRESH = 1;

--- a/core/src/test/java/org/elasticsearch/common/recycler/ConcurrentRecyclerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/recycler/ConcurrentRecyclerTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.common.recycler;
 
-public class ConcurrentRecyclerTests extends AbstractRecyclerTests {
+public class ConcurrentRecyclerTests extends AbstractRecyclerTestCase {
 
     @Override
     protected Recycler<byte[]> newRecycler(int limit) {

--- a/core/src/test/java/org/elasticsearch/common/recycler/LockedRecyclerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/recycler/LockedRecyclerTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.common.recycler;
 
-public class LockedRecyclerTests extends AbstractRecyclerTests {
+public class LockedRecyclerTests extends AbstractRecyclerTestCase {
 
     @Override
     protected Recycler<byte[]> newRecycler(int limit) {

--- a/core/src/test/java/org/elasticsearch/common/recycler/NoneRecyclerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/recycler/NoneRecyclerTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.common.recycler;
 
-public class NoneRecyclerTests extends AbstractRecyclerTests {
+public class NoneRecyclerTests extends AbstractRecyclerTestCase {
 
     @Override
     protected Recycler<byte[]> newRecycler(int limit) {

--- a/core/src/test/java/org/elasticsearch/common/recycler/QueueRecyclerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/recycler/QueueRecyclerTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.common.recycler;
 
-public class QueueRecyclerTests extends AbstractRecyclerTests {
+public class QueueRecyclerTests extends AbstractRecyclerTestCase {
 
     @Override
     protected Recycler<byte[]> newRecycler(int limit) {

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractFilteringJsonGeneratorTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractFilteringJsonGeneratorTestCase.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
-public abstract class AbstractFilteringJsonGeneratorTests extends ESTestCase {
+public abstract class AbstractFilteringJsonGeneratorTestCase extends ESTestCase {
 
     protected abstract XContentType getXContentType();
 

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/JsonFilteringGeneratorTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/JsonFilteringGeneratorTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.xcontent.support.filtering;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
-public class JsonFilteringGeneratorTests extends AbstractFilteringJsonGeneratorTests {
+public class JsonFilteringGeneratorTests extends AbstractFilteringJsonGeneratorTestCase {
 
     @Override
     protected XContentType getXContentType() {

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/YamlFilteringGeneratorTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/YamlFilteringGeneratorTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.xcontent.support.filtering;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
-public class YamlFilteringGeneratorTests extends AbstractFilteringJsonGeneratorTests {
+public class YamlFilteringGeneratorTests extends AbstractFilteringJsonGeneratorTestCase {
 
     @Override
     protected XContentType getXContentType() {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTestCase.java
@@ -24,13 +24,12 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
 import org.elasticsearch.search.MultiValueMode;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
 
-public abstract class AbstractFieldDataImplTests extends AbstractFieldDataTests {
+public abstract class AbstractFieldDataImplTestCase extends AbstractFieldDataTestCase {
 
     protected String one() {
         return "1";

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 
-public abstract class AbstractFieldDataTests extends ESSingleNodeTestCase {
+public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
 
     protected IndexService indexService;
     protected IndexFieldDataService ifdService;

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractNumericFieldDataTestCase.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public abstract class AbstractNumericFieldDataTests extends AbstractFieldDataImplTests {
+public abstract class AbstractNumericFieldDataTestCase extends AbstractFieldDataImplTestCase {
 
     @Override
     protected abstract FieldDataType getFieldDataType();

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -70,7 +70,7 @@ import static org.hamcrest.Matchers.sameInstance;
 
 /**
  */
-public abstract class AbstractStringFieldDataTests extends AbstractFieldDataImplTests {
+public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataImplTestCase {
 
     private void addField(Document d, String name, String value) {
         d.add(new StringField(name, value, Field.Store.YES));

--- a/core/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-public class BinaryDVFieldDataTests extends AbstractFieldDataTests {
+public class BinaryDVFieldDataTests extends AbstractFieldDataTestCase {
 
     @Override
     protected boolean hasDocValues() {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/DoubleFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/DoubleFieldDataTests.java
@@ -27,7 +27,7 @@ import org.apache.lucene.index.Term;
 
 /**
  */
-public class DoubleFieldDataTests extends AbstractNumericFieldDataTests {
+public class DoubleFieldDataTests extends AbstractNumericFieldDataTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/DuelFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/DuelFieldDataTests.java
@@ -56,7 +56,7 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.*;
 
-public class DuelFieldDataTests extends AbstractFieldDataTests {
+public class DuelFieldDataTests extends AbstractFieldDataTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTest.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTest.java
@@ -30,7 +30,7 @@ import java.util.Random;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class FilterFieldDataTest extends AbstractFieldDataTests {
+public class FilterFieldDataTest extends AbstractFieldDataTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/FloatFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/FloatFieldDataTests.java
@@ -26,7 +26,7 @@ import org.apache.lucene.index.Term;
 
 /**
  */
-public class FloatFieldDataTests extends AbstractNumericFieldDataTests {
+public class FloatFieldDataTests extends AbstractNumericFieldDataTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/LongFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/LongFieldDataTests.java
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.lessThan;
 /**
  * Tests for all integer types (byte, short, int, long).
  */
-public class LongFieldDataTests extends AbstractNumericFieldDataTests {
+public class LongFieldDataTests extends AbstractNumericFieldDataTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/PagedBytesStringFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/PagedBytesStringFieldDataTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
 
 /**
  */
-public class PagedBytesStringFieldDataTests extends AbstractStringFieldDataTests {
+public class PagedBytesStringFieldDataTests extends AbstractStringFieldDataTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/ParentChildFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/ParentChildFieldDataTests.java
@@ -30,7 +30,6 @@ import org.apache.lucene.search.*;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
 import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
@@ -49,7 +48,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 /**
  */
-public class ParentChildFieldDataTests extends AbstractFieldDataTests {
+public class ParentChildFieldDataTests extends AbstractFieldDataTestCase {
 
     private final String parentType = "parent";
     private final String childType = "child";

--- a/core/src/test/java/org/elasticsearch/index/fielddata/SortedSetDVStringFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/SortedSetDVStringFieldDataTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.fielddata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder;
 
-public class SortedSetDVStringFieldDataTests extends AbstractStringFieldDataTests {
+public class SortedSetDVStringFieldDataTests extends AbstractStringFieldDataTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
@@ -40,7 +40,7 @@ import org.apache.lucene.search.join.BitDocIdSetCachingWrapperFilter;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.fielddata.AbstractFieldDataTests;
+import org.elasticsearch.index.fielddata.AbstractFieldDataTestCase;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -55,7 +55,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public abstract class AbstractNumberNestedSortingTests extends AbstractFieldDataTests {
+public abstract class AbstractNumberNestedSortingTestCase extends AbstractFieldDataTestCase {
 
     @Test
     public void testNestedSorting() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/search/nested/DoubleNestedSortingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/nested/DoubleNestedSortingTests.java
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class DoubleNestedSortingTests extends AbstractNumberNestedSortingTests {
+public class DoubleNestedSortingTests extends AbstractNumberNestedSortingTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/search/nested/LongNestedSortingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/nested/LongNestedSortingTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.search.MultiValueMode;
 
 /**
  */
-public class LongNestedSortingTests extends AbstractNumberNestedSortingTests {
+public class LongNestedSortingTests extends AbstractNumberNestedSortingTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
@@ -46,7 +46,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.fielddata.AbstractFieldDataTests;
+import org.elasticsearch.index.fielddata.AbstractFieldDataTestCase;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
@@ -65,7 +65,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  */
-public class NestedSortingTests extends AbstractFieldDataTests {
+public class NestedSortingTests extends AbstractFieldDataTestCase {
 
     @Override
     protected FieldDataType getFieldDataType() {

--- a/core/src/test/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/core/src/test/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-public abstract class AbstractSimpleTransportTests extends ESTestCase {
+public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
     protected ThreadPool threadPool;
 

--- a/core/src/test/java/org/elasticsearch/transport/local/SimpleLocalTransportTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/local/SimpleLocalTransportTests.java
@@ -23,9 +23,9 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.AbstractSimpleTransportTests;
+import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
 
-public class SimpleLocalTransportTests extends AbstractSimpleTransportTests {
+public class SimpleLocalTransportTests extends AbstractSimpleTransportTestCase {
 
     @Override
     protected MockTransportService build(Settings settings, Version version, NamedWriteableRegistry namedWriteableRegistry) {

--- a/core/src/test/java/org/elasticsearch/transport/netty/SimpleNettyTransportTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/netty/SimpleNettyTransportTests.java
@@ -27,14 +27,14 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.AbstractSimpleTransportTests;
+import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-public class SimpleNettyTransportTests extends AbstractSimpleTransportTests {
+public class SimpleNettyTransportTests extends AbstractSimpleTransportTestCase {
 
     @Override
     protected MockTransportService build(Settings settings, Version version, NamedWriteableRegistry namedWriteableRegistry) {

--- a/pom.xml
+++ b/pom.xml
@@ -721,7 +721,7 @@
                                     <include>**/*Test.class</include>
                                 </includes>
                                 <excludes>
-                                    <exclude>**/Abstract*.class</exclude>
+                                    <exclude>**/*$*.class</exclude>
                                     <exclude>**/*StressTest.class</exclude>
                                 </excludes>
                             </configuration>


### PR DESCRIPTION
While the list of having exclusions is small, it shouldn't be necessary
at all. Base test cases should be suffixed with TestCase so they are not
picked up by the test class name pattern. This same rule works for
abstract classes as well.

This change renames abstract tests to use the TestCase suffix, adds a
check in naming convention tests, and removes the exclusion from our
test runner configuration. It also excludes inner classes (the only exclude
we should have IMO), so that we have no need to @Ignore the inner test
classes for naming convention tests.
