### PR TITLE
Don't surround -Xloggc log filename with quotes

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.in.sh
+++ b/distribution/src/main/resources/bin/elasticsearch.in.sh
@@ -62,7 +62,7 @@ if [ -n "$ES_GC_LOG_FILE" ]; then
   JAVA_OPTS="$JAVA_OPTS -XX:+PrintClassHistogram"
   JAVA_OPTS="$JAVA_OPTS -XX:+PrintTenuringDistribution"
   JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCApplicationStoppedTime"
-  JAVA_OPTS="$JAVA_OPTS -Xloggc:\"$ES_GC_LOG_FILE\""
+  JAVA_OPTS="$JAVA_OPTS -Xloggc:$ES_GC_LOG_FILE"
 
   # Ensure that the directory for the log file exists: the JVM will not create it.
   mkdir -p "`dirname \"$ES_GC_LOG_FILE\"`"


### PR DESCRIPTION
The `-Xloggc:filename.log` parameter has very strict filename semantics:

```
[A-Z][a-z][0-9]-_.%[p|t]
```

Our script specifies \" and \" to surround it, which makes Java think we
are sending: -Xloggc:"foo.log" and it fails with:

```
Invalid file name for use with -Xloggc: Filename can only contain the characters [A-Z][a-z][0-9]-_.%[p|t] but it has been "foo.log"
Note %p or %t can only be used once
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

We can't quote this, and we should not need to since the valid
characters don't include a space character, so we don't need to worry
about quoting.

Resolves #13277
