### PR TITLE
This commit removes com.google.common.io

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/core/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -21,9 +21,11 @@ package org.elasticsearch.common.io;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.util.Callback;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -240,5 +242,22 @@ public abstract class Streams {
                 callback.handle(line);
             }
         }
+    }
+
+    public static byte[] toByteArray(InputStream in) throws IOException {
+        Preconditions.checkNotNull(in, "No InputStream specified");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        // Does not close or flush either stream.
+        byte[] buf = new byte[BUFFER_SIZE];
+        while (true) {
+            int r = in.read(buf);
+            if (r == -1) {
+                break;
+            }
+            out.write(buf, 0, r);
+        }
+
+        return out.toByteArray();
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/core/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -245,7 +245,10 @@ public abstract class Streams {
     }
 
     public static byte[] toByteArray(InputStream in) throws IOException {
-        Preconditions.checkNotNull(in, "No InputStream specified");
+
+        if (in == null) {
+            throw new NullPointerException("No InputStream specified");
+        }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         // Does not close or flush either stream.

--- a/core/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/core/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -20,11 +20,11 @@
 package org.elasticsearch.http;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
 
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.service.NodeService;
@@ -141,7 +141,7 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
         if (request.method() == RestRequest.Method.GET) {
             try {
                 try (InputStream stream = getClass().getResourceAsStream("/config/favicon.ico")) {
-                    byte[] content = ByteStreams.toByteArray(stream);
+                    byte[] content = Streams.toByteArray(stream);
                     BytesRestResponse restResponse = new BytesRestResponse(RestStatus.OK, "image/x-icon", content);
                     channel.sendResponse(restResponse);
                 }

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.repositories.blobstore;
 
-import com.google.common.io.ByteStreams;
 import org.apache.lucene.store.RateLimiter;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
@@ -36,6 +35,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.compress.NotXContentException;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -592,7 +592,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
      */
     protected List<SnapshotId> readSnapshotList() throws IOException {
         try (InputStream blob = snapshotsBlobContainer.openInput(SNAPSHOTS_FILE)) {
-            final byte[] data = ByteStreams.toByteArray(blob);
+            final byte[] data = Streams.toByteArray(blob);
             ArrayList<SnapshotId> snapshots = new ArrayList<>();
             try (XContentParser parser = XContentHelper.createParser(new BytesArray(data))) {
                 if (parser.nextToken() == XContentParser.Token.START_OBJECT) {

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.repositories.blobstore;
 
-import com.google.common.io.ByteStreams;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
@@ -29,6 +28,7 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
@@ -95,7 +95,7 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
      */
     public T readBlob(BlobContainer blobContainer, String blobName) throws IOException {
         try (InputStream inputStream = blobContainer.openInput(blobName)) {
-            byte[] bytes = ByteStreams.toByteArray(inputStream);
+            byte[] bytes = Streams.toByteArray(inputStream);
             final String resourceDesc = "ChecksumBlobStoreFormat.readBlob(blob=\"" + blobName + "\")";
             try (ByteArrayIndexInput indexInput = new ByteArrayIndexInput(resourceDesc, bytes)) {
                 CodecUtil.checksumEntireFile(indexInput);

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/LegacyBlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/LegacyBlobStoreFormat.java
@@ -18,10 +18,10 @@
  */
 package org.elasticsearch.repositories.blobstore;
 
-import com.google.common.io.ByteStreams;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.xcontent.FromXContentBuilder;
 import org.elasticsearch.common.xcontent.ToXContent;
 
@@ -53,7 +53,7 @@ public class LegacyBlobStoreFormat<T extends ToXContent> extends BlobStoreFormat
      */
     public T readBlob(BlobContainer blobContainer, String blobName) throws IOException {
         try (InputStream inputStream = blobContainer.openInput(blobName)) {
-            return read(new BytesArray(ByteStreams.toByteArray(inputStream)));
+            return read(new BytesArray(Streams.toByteArray(inputStream)));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/io/StreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/StreamsTests.java
@@ -94,4 +94,11 @@ public class StreamsTests extends ESTestCase {
         input.close();
     }
 
+    public void testToByteArray() throws IOException {
+        byte[] input = new byte[] { 0, 1, 2, 3 };
+        ByteArrayInputStream in = new ByteArrayInputStream(input);
+        byte[] output = Streams.toByteArray(in);
+        assertThat(output, equalTo(input));
+    }
+
 }

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.plugins;
 
-import com.google.common.io.Files;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.http.client.HttpDownloadHelper;
@@ -63,8 +62,8 @@ public class PluginManagerUnitTests extends ESTestCase {
         Environment environment = new Environment(settings);
 
         PluginManager.PluginHandle pluginHandle = new PluginManager.PluginHandle(pluginName, "version", "user");
-        String configDirPath = Files.simplifyPath(pluginHandle.configDir(environment).normalize().toString());
-        String expectedDirPath = Files.simplifyPath(genericConfigFolder.resolve(pluginName).normalize().toString());
+        String configDirPath = pluginHandle.configDir(environment).normalize().toString();
+        String expectedDirPath = genericConfigFolder.resolve(pluginName).normalize().toString();
 
         assertThat(configDirPath, is(expectedDirPath));
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -37,7 +37,10 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.junit.Test;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
@@ -1279,5 +1282,19 @@ public class SuggestSearchIT extends ESIntegTestCase {
             }
             return actionGet.getSuggest();
         }
+    }
+
+    private List <String> readLines(String path) throws IOException {
+        final List<String> result = new ArrayList<>();
+
+        final InputStream resourceAsStream =   SuggestSearchIT.class.getResourceAsStream(path);
+        BufferedReader in = new BufferedReader(new InputStreamReader(resourceAsStream, Charsets.UTF_8));
+        String line = null;
+
+        while((line = in.readLine()) != null){
+            result.add(line);
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
This PR removes and forbids `com.google.common.io.Files`, `com.google.common.io.ByteStreams`, and `com.google.common.io.Resources`

See https://github.com/elastic/elasticsearch/issues/13224.
