### PR TITLE
Remove broadcast address check.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -27,8 +27,6 @@ import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.InterfaceAddress;
-import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -120,14 +118,6 @@ public class NetworkService extends AbstractComponent {
                 if (address.isMulticastAddress()) {
                     throw new IllegalArgumentException("bind address: {" + NetworkAddress.format(address) + "} is invalid: multicast address");
                 }
-                // check if its broadcast: flat out mistake
-                for (NetworkInterface nic : NetworkUtils.getInterfaces()) {
-                    for (InterfaceAddress intf : nic.getInterfaceAddresses()) {
-                        if (address.equals(intf.getBroadcast())) {
-                            throw new IllegalArgumentException("bind address: {" + NetworkAddress.format(address) + "} is invalid: broadcast address");
-                        }
-                    }
-                }
             }
         }
         return addresses;
@@ -160,14 +150,6 @@ public class NetworkService extends AbstractComponent {
             // check if its multicast: flat out mistake
             if (address.isMulticastAddress()) {
                 throw new IllegalArgumentException("publish address: {" + NetworkAddress.format(address) + "} is invalid: multicast address");
-            }
-            // check if its broadcast: flat out mistake
-            for (NetworkInterface nic : NetworkUtils.getInterfaces()) {
-                for (InterfaceAddress intf : nic.getInterfaceAddresses()) {
-                    if (address.equals(intf.getBroadcast())) {
-                        throw new IllegalArgumentException("publish address: {" + NetworkAddress.format(address) + "} is invalid: broadcast address");
-                    }
-                }
             }
             // wildcard address, probably set by network.host
             if (address.isAnyLocalAddress()) {

--- a/core/src/test/java/org/elasticsearch/common/network/NetworkServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/common/network/NetworkServiceTests.java
@@ -23,11 +23,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.net.InetAddress;
-import java.net.InterfaceAddress;
-import java.net.NetworkInterface;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Tests for network service... try to keep them safe depending upon configuration
@@ -84,41 +79,6 @@ public class NetworkServiceTests extends ESTestCase {
             fail("should have hit exception");
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("invalid: multicast"));
-        }
-    }
-
-    /** 
-     * ensure exception if we bind/publish to broadcast address 
-     */
-    public void testBindPublishBroadcast() throws Exception {
-        NetworkService service = new NetworkService(Settings.EMPTY);
-        // collect any broadcast addresses on the system
-        List<InetAddress> addresses = new ArrayList<>();
-        for (NetworkInterface nic : Collections.list(NetworkInterface.getNetworkInterfaces())) {
-            for (InterfaceAddress intf : nic.getInterfaceAddresses()) {
-                InetAddress address = intf.getBroadcast();
-                if (address != null) {
-                    addresses.add(address);
-                }
-            }
-        }
-        // can easily happen (ipv6-only, localhost-only, ...)
-        assumeTrue("test requires broadcast addresses configured", addresses.size() > 0);
-        // make sure we fail on each one
-        for (InetAddress address : addresses) {
-            try {
-                service.resolveBindHostAddress(NetworkAddress.formatAddress(address));
-                fail("should have hit exception for broadcast address: " + address);
-            } catch (IllegalArgumentException e) {
-                assertTrue(e.getMessage().contains("invalid: broadcast"));
-            }
-            
-            try {
-                service.resolvePublishHostAddress(NetworkAddress.formatAddress(address));
-                fail("should have hit exception for broadcast address: " + address);
-            } catch (IllegalArgumentException e) {
-                assertTrue(e.getMessage().contains("invalid: broadcast"));
-            }
         }
     }
 


### PR DESCRIPTION
This was supposed to just help the user, in case they misconfigured something.
Broadcast is an ipv4 only thing, the only way you can really detect its a broadcast
address, is to look and see if an interface has that address as its broadcast address.

But we cannot trust that container interfaces won't have a crazy setup...

Closes #13327
