### PR TITLE
`simple_query_string` overrides boost coming from lucene

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -219,7 +219,7 @@ public class SimpleQueryStringParser implements QueryParser {
         }
 
         if (query != null) {
-            query.setBoost(boost);
+            query.setBoost(boost * query.getBoost());
         }
 
         return query;

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -2540,6 +2540,23 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
     }
 
     @Test
+    public void testSimpleQueryStringBoost() throws Exception {
+        IndexQueryParserService queryParser = queryParser();
+        SimpleQueryStringBuilder simpleQueryStringBuilder = new SimpleQueryStringBuilder("test");
+        simpleQueryStringBuilder.field("body", 5);
+        Query parsedQuery = queryParser.parse(simpleQueryStringBuilder.toString()).query();
+        assertThat(parsedQuery, instanceOf(TermQuery.class));
+        assertThat(parsedQuery.getBoost(), equalTo(5f));
+
+        simpleQueryStringBuilder = new SimpleQueryStringBuilder("test");
+        simpleQueryStringBuilder.field("body", 5);
+        simpleQueryStringBuilder.boost(2);
+        parsedQuery = queryParser.parse(simpleQueryStringBuilder.toString()).query();
+        assertThat(parsedQuery, instanceOf(TermQuery.class));
+        assertThat(parsedQuery.getBoost(), equalTo(10f));
+    }
+
+    @Test
     public void testMatchWithFuzzyTranspositions() throws Exception {
         IndexQueryParserService queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/match-with-fuzzy-transpositions.json");


### PR DESCRIPTION
SimpleQueryStringParser applies whatever boost the query holds, even if the default 1, to the query obtained from parsing of the query string. that might contain its boost, for instance if it resolved to a simple query like term (single term query against a single field). We should rather multiply the existing boost with the boost set to the query, same as we do in query_string

Relates to #13272
