### PR TITLE
`span_containing` and `span_within` override default boost coming from lucene

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryParser.java
@@ -91,7 +91,9 @@ public class SpanContainingQueryParser implements QueryParser {
         }
 
         Query query = new SpanContainingQuery(big, little);
-        query.setBoost(boost);
+        if (boost != 1.0F) {
+            query.setBoost(boost);
+        }
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
@@ -91,7 +91,9 @@ public class SpanWithinQueryParser implements QueryParser {
         }
 
         Query query = new SpanWithinQuery(big, little);
-        query.setBoost(boost);
+        if (boost != 1.0F) {
+            query.setBoost(boost);
+        }
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
         }

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1410,12 +1410,22 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
     @Test
     public void testSpanWithinQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();
-        Query expectedQuery = new SpanWithinQuery(new SpanTermQuery(new Term("age", longToPrefixCoded(34, 0))),
-                                                  new SpanTermQuery(new Term("age", longToPrefixCoded(35, 0))));
-        Query actualQuery = queryParser.parse(spanWithinQuery()
-                                              .big(spanTermQuery("age", 34))
-                                              .little(spanTermQuery("age", 35)))
-                                              .query();
+        SpanTermQuery big = new SpanTermQuery(new Term("age", longToPrefixCoded(34, 0)));
+        big.setBoost(2);
+        SpanTermQuery little = new SpanTermQuery(new Term("age", longToPrefixCoded(35, 0)));
+        little.setBoost(3);
+        Query expectedQuery = new SpanWithinQuery(big, little);
+
+        SpanWithinQueryBuilder spanWithinQueryBuilder = spanWithinQuery()
+                .big(spanTermQuery("age", 34).boost(2))
+                .little(spanTermQuery("age", 35).boost(3));
+        Query actualQuery = queryParser.parse(spanWithinQueryBuilder).query();
+        assertEquals(expectedQuery, actualQuery);
+
+        float boost = randomFloat();
+        expectedQuery.setBoost(boost);
+        spanWithinQueryBuilder.boost(boost);
+        actualQuery = queryParser.parse(spanWithinQueryBuilder).query();
         assertEquals(expectedQuery, actualQuery);
     }
 
@@ -1432,12 +1442,22 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
     @Test
     public void testSpanContainingQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();
-        Query expectedQuery = new SpanContainingQuery(new SpanTermQuery(new Term("age", longToPrefixCoded(34, 0))),
-                                                      new SpanTermQuery(new Term("age", longToPrefixCoded(35, 0))));
-        Query actualQuery = queryParser.parse(spanContainingQuery()
-                                              .big(spanTermQuery("age", 34))
-                                              .little(spanTermQuery("age", 35)))
-                                              .query();
+        SpanTermQuery big = new SpanTermQuery(new Term("age", longToPrefixCoded(34, 0)));
+        big.setBoost(2);
+        SpanTermQuery little = new SpanTermQuery(new Term("age", longToPrefixCoded(35, 0)));
+        little.setBoost(3);
+        Query expectedQuery = new SpanContainingQuery(big, little);
+
+        SpanContainingQueryBuilder spanContainingQueryBuilder = spanContainingQuery()
+                .big(spanTermQuery("age", 34).boost(2))
+                .little(spanTermQuery("age", 35).boost(3));
+        Query actualQuery = queryParser.parse(spanContainingQueryBuilder).query();
+        assertEquals(expectedQuery, actualQuery);
+
+        float boost = randomFloat();
+        expectedQuery.setBoost(boost);
+        spanContainingQueryBuilder.boost(boost);
+        actualQuery = queryParser.parse(spanContainingQueryBuilder).query();
         assertEquals(expectedQuery, actualQuery);
     }
 


### PR DESCRIPTION
SpanContainingQueryParser and SpanWithinQueryParser always set the boost to the parsed lucene query, even if it is the default one. The default boost of the main query though is the boost coming from the inner little (or big) query, value that we end up overriding all the time. We should instead set the boost to the main query only if it differs from the default, to mimic lucene's behaviour.

Relates to #13272
