### PR TITLE
[build] move heapdump to target/heapdump dir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <tests.timezone>random</tests.timezone>
         <es.logger.level>ERROR</es.logger.level>
         <tests.heap.size>512m</tests.heap.size>
-        <tests.heapdump.path>${basedir}/logs/</tests.heapdump.path>
+        <tests.heapdump.path>${project.build.directory}/heapdump/</tests.heapdump.path>
         <tests.topn>5</tests.topn>
         <execution.hint.file>.local-${elasticsearch.version}-execution-hints.log</execution.hint.file>
         <execution.hint.integ.file>.local-${elasticsearch.version}-integ-execution-hints.log</execution.hint.integ.file>


### PR DESCRIPTION
Each time you run mvn test, you end up creating a `.logs` empty dir.

Instead of writing for each plugin in the `./logs` dir, I'd recommend writing this in `./target/heapdump`.

This dir is cleanup automatically when you run `mvn clean`.
