### PR TITLE
[test] fix hanging testRefreshDoesNotMissShards

### DIFF
--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -58,6 +58,7 @@ import org.elasticsearch.discovery.zen.publish.PublishClusterStateAction;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.RecoverySource;
+import org.elasticsearch.indices.recovery.RecoveryTarget;
 import org.elasticsearch.indices.store.IndicesStoreIntegrationIT;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -1185,15 +1186,14 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
             this.beginRelocationLatch = beginRelocationLatch;
         }
 
-        @Override
-        public void responseSent(long requestId, String action) {
-            if (action.equals("internal:index/shard/recovery/start_recovery")) {
+        public void requestSent(DiscoveryNode node, long requestId, String action, TransportRequestOptions options) {
+            logger.info("sent response: {}", action);
+            if (action.equals(RecoveryTarget.Actions.FILES_INFO)) {
                 beginRelocationLatch.countDown();
-                logger.info("sent response: {}, relocation starts on source", action);
+                logger.info("request sent: {}, relocation starts on source", action);
             }
         }
     }
-
 
     private void logLocalClusterStates(Client... clients) {
         int counter = 1;

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -1068,9 +1068,9 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
             disruptionNode1.startDisrupting();
 
             endRelocationLatchNode2.await();
-            final Client node3Client = internalCluster().client(node_3);
-            final Client node2Client = internalCluster().client(node_2);
             final Client node1Client = internalCluster().client(node_1);
+            final Client node2Client = internalCluster().client(node_2);
+            final Client node3Client = internalCluster().client(node_3);
             final Client node4Client = internalCluster().client(node_4);
             logger.info("--> index doc");
             logLocalClusterStates(node1Client, node2Client, node3Client, node4Client);


### PR DESCRIPTION
We waited for relocation to start on node_2 but never made sure node_1 knows about
this too. If node_1 does not yet have the cluster state that should trigger relocation
then relocation will never start because we block cluster state processing on node_1.
The log then fills with these messages:

1> [2015-09-02 20:34:59,153][INFO ][discovery                ] sent: internal:index/shard/recovery/start_recovery, relocation starts
1> [2015-09-02 20:34:59,153][DEBUG][indices.recovery         ] [node_t1] delaying recovery of [test][0] as it is not listed as assigned to target node

We have to wait until node_1 sends an acknowledgement that relocation starts
(response to internal:index/shard/recovery/start_recovery).

closes #13316
