### PR TITLE
Remove and forbid the use of com.google.common.base.Predicate(s)?

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.mapping.get;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
@@ -51,8 +49,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.util.CollectionUtils.newLinkedList;
 
@@ -96,14 +96,10 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
             typeIntersection = indexService.mapperService().types();
 
         } else {
-            typeIntersection = Collections2.filter(indexService.mapperService().types(), new Predicate<String>() {
-
-                @Override
-                public boolean apply(String type) {
-                    return Regex.simpleMatch(request.types(), type);
-                }
-
-            });
+            typeIntersection = indexService.mapperService().types()
+                    .stream()
+                    .filter(type -> Regex.simpleMatch(request.types(), type))
+                    .collect(Collectors.toCollection(ArrayList::new));
             if (typeIntersection.isEmpty()) {
                 throw new TypeMissingException(shardId.index(), request.types());
             }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -50,8 +49,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
-import static com.google.common.collect.Maps.filterEntries;
 import static com.google.common.collect.Maps.newHashMap;
 
 public class IndexNameExpressionResolver extends AbstractComponent {
@@ -600,12 +599,11 @@ public class IndexNameExpressionResolver extends AbstractComponent {
                 } else {
                     // Other wildcard expressions:
                     final String pattern = expression;
-                    matches = filterEntries(metaData.getAliasAndIndexLookup(), new Predicate<Map.Entry<String, AliasOrIndex>>() {
-                        @Override
-                        public boolean apply(@Nullable Map.Entry<String, AliasOrIndex> input) {
-                            return Regex.simpleMatch(pattern, input.getKey());
-                        }
-                    });
+                    matches = metaData.getAliasAndIndexLookup()
+                            .entrySet()
+                            .stream()
+                            .filter(e -> Regex.simpleMatch(pattern, e.getKey()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
                 }
                 for (Map.Entry<String, AliasOrIndex> entry : matches.entrySet()) {
                     AliasOrIndex aliasOrIndex = entry.getValue();

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -21,7 +21,6 @@ package org.elasticsearch.cluster.routing;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import org.apache.lucene.util.CollectionUtil;
@@ -40,6 +39,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
@@ -294,7 +294,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         List<ShardRouting> shards = new ArrayList<>();
         for (RoutingNode routingNode : this) {
             for (ShardRouting shardRouting : routingNode) {
-                if (predicate.apply(shardRouting)) {
+                if (predicate.test(shardRouting)) {
                     shards.add(shardRouting);
                 }
             }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
-import com.google.common.base.Predicate;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.IntroSorter;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -40,6 +39,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.settings.NodeSettingsService;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
 
@@ -226,13 +226,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         private final float threshold;
         private final MetaData metaData;
 
-        private final Predicate<ShardRouting> assignedFilter = new Predicate<ShardRouting>() {
-            @Override
-            public boolean apply(ShardRouting input) {
-                return input.assignedToNode();
-            }
-        };
-
+        private final Predicate<ShardRouting> assignedFilter = shard -> shard.assignedToNode();
 
         public Balancer(ESLogger logger, RoutingAllocation allocation, WeightFunction weight, float threshold) {
             this.logger = logger;

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -20,10 +20,8 @@
 package org.elasticsearch.common.settings;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
@@ -1014,7 +1012,7 @@ public final class Settings implements ToXContent {
                 final Matcher matcher = ARRAY_PATTERN.matcher(entry.getKey());
                 if (matcher.matches()) {
                     prefixesToRemove.add(matcher.group(1));
-                } else if (Iterables.any(map.keySet(), startsWith(entry.getKey() + "."))) {
+                } else if (map.keySet().stream().anyMatch(key -> key.startsWith(entry.getKey() + "."))) {
                     prefixesToRemove.add(entry.getKey());
                 }
             }
@@ -1221,24 +1219,6 @@ public final class Settings implements ToXContent {
          */
         public Settings build() {
             return new Settings(Collections.unmodifiableMap(map));
-        }
-    }
-
-    private static StartsWithPredicate startsWith(String prefix) {
-        return new StartsWithPredicate(prefix);
-    }
-
-    private static final class StartsWithPredicate implements Predicate<String> {
-
-        private String prefix;
-
-        public StartsWithPredicate(String prefix) {
-            this.prefix = prefix;
-        }
-
-        @Override
-        public boolean apply(String input) {
-            return input.startsWith(prefix);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/codec/postingsformat/Elasticsearch090PostingsFormat.java
+++ b/core/src/main/java/org/elasticsearch/index/codec/postingsformat/Elasticsearch090PostingsFormat.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.index.codec.postingsformat;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import com.google.common.collect.Iterators;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.FieldsProducer;
@@ -36,6 +34,7 @@ import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 /**
  * This is the old default postings format for Elasticsearch that special cases
@@ -60,13 +59,8 @@ public class Elasticsearch090PostingsFormat extends PostingsFormat {
     public PostingsFormat getDefaultWrapped() {
         return bloomPostings.getDelegate();
     }
-    protected static final Predicate<String> UID_FIELD_FILTER = new Predicate<String>() {
 
-        @Override
-        public boolean apply(String s) {
-            return  UidFieldMapper.NAME.equals(s);
-        }
-    };
+    protected static final Predicate<String> UID_FIELD_FILTER = field -> UidFieldMapper.NAME.equals(field);
 
     @Override
     public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
@@ -71,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.common.collect.MapBuilder.newMapBuilder;
 
@@ -202,19 +202,12 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
                 if (includingDefaultMapping) {
                     iterator = mappers.values().iterator();
                 } else {
-                    iterator = Iterators.filter(mappers.values().iterator(), NOT_A_DEFAULT_DOC_MAPPER);
+                    iterator = mappers.values().stream().filter(mapper -> !DEFAULT_MAPPING.equals(mapper.type())).iterator();
                 }
                 return Iterators.unmodifiableIterator(iterator);
             }
         };
     }
-
-    private static final Predicate<DocumentMapper> NOT_A_DEFAULT_DOC_MAPPER = new Predicate<DocumentMapper>() {
-        @Override
-        public boolean apply(DocumentMapper input) {
-            return !DEFAULT_MAPPING.equals(input.type());
-        }
-    };
 
     public AnalysisService analysisService() {
         return this.analysisService;

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.recovery;
 
-import com.google.common.base.Predicate;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
@@ -58,6 +57,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/LeafBucketCollector.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/LeafBucketCollector.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.search.aggregations;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorer;
 
 import java.io.IOException;
+import java.util.stream.StreamSupport;
 
 /**
  * Per-leaf bucket collector.
@@ -44,13 +44,8 @@ public abstract class LeafBucketCollector implements LeafCollector {
     };
 
     public static LeafBucketCollector wrap(Iterable<LeafBucketCollector> collectors) {
-        final Iterable<LeafBucketCollector> actualCollectors = Iterables.filter(collectors,
-                new Predicate<LeafBucketCollector> () {
-                    @Override
-                    public boolean apply(LeafBucketCollector c) {
-                        return c != NO_OP_COLLECTOR;
-                    }
-        });
+        final Iterable<LeafBucketCollector> actualCollectors =
+                StreamSupport.stream(collectors.spliterator(), false).filter(c -> c != NO_OP_COLLECTOR)::iterator;
         final LeafBucketCollector[] colls = Iterables.toArray(actualCollectors, LeafBucketCollector.class);
         switch (colls.length) {
         case 0:

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.admin.indices.shards;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.google.common.base.Predicate;
 import org.apache.lucene.index.CorruptIndexException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Requests;
@@ -42,6 +41,7 @@ import org.junit.Test;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
@@ -209,7 +209,7 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         }
 
         @Override
-        public boolean apply(Settings settings) {
+        public boolean test(Settings settings) {
             return nodesWithShard.contains(settings.get("name"));
         }
 

--- a/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.bwcompat;
 
-import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import org.apache.lucene.index.IndexWriter;
@@ -292,13 +291,12 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
      * Waits for the index to show up in the cluster state in closed state
      */
     void ensureClosed(final String index) throws InterruptedException {
-        assertTrue(awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object o) {
-                ClusterState state = client().admin().cluster().prepareState().get().getState();
-                return state.metaData().hasIndex(index) && state.metaData().index(index).getState() == IndexMetaData.State.CLOSE;
-            }
-        }));
+        assertTrue(awaitBusy(() -> {
+                            ClusterState state = client().admin().cluster().prepareState().get().getState();
+                            return state.metaData().hasIndex(index) && state.metaData().index(index).getState() == IndexMetaData.State.CLOSE;
+                        }
+                )
+        );
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/cache/recycler/MockPageCacheRecycler.java
+++ b/core/src/test/java/org/elasticsearch/cache/recycler/MockPageCacheRecycler.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cache.recycler;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.common.inject.Inject;
@@ -45,12 +44,8 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
             // not empty, we might be executing on a shared cluster that keeps on obtaining
             // and releasing pages, lets make sure that after a reasonable timeout, all master
             // copy (snapshot) have been released
-            boolean success = ESTestCase.awaitBusy(new Predicate<Object>() {
-                @Override
-                public boolean apply(Object input) {
-                    return Sets.intersection(masterCopy.keySet(), ACQUIRED_PAGES.keySet()).isEmpty();
-                }
-            });
+            boolean success =
+                    ESTestCase.awaitBusy(() -> Sets.intersection(masterCopy.keySet(), ACQUIRED_PAGES.keySet()).isEmpty());
             if (!success) {
                 masterCopy.keySet().retainAll(ACQUIRED_PAGES.keySet());
                 ACQUIRED_PAGES.keySet().removeAll(masterCopy.keySet()); // remove all existing master copy we will report on

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientRetryIT.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientRetryIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.client.transport;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.support.PlainListenableActionFuture;
@@ -30,7 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
@@ -72,12 +70,7 @@ public class TransportClientRetryIT extends ESIntegTestCase {
             int size = cluster().size();
             //kill all nodes one by one, leaving a single master/data node at the end of the loop
             for (int j = 1; j < size; j++) {
-                internalCluster().stopRandomNode(new Predicate<Settings>() {
-                    @Override
-                    public boolean apply(Settings input) {
-                        return true;
-                    }
-                });
+                internalCluster().stopRandomNode(input -> true);
 
                 ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest().local(true);
                 ClusterState clusterState;

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
 import org.elasticsearch.cluster.metadata.IndexTemplateFilter;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
@@ -85,12 +84,7 @@ public class ClusterModuleTests extends ModuleTestCase {
     public void testRegisterClusterDynamicSetting() {
         ClusterModule module = new ClusterModule(Settings.EMPTY);
         module.registerClusterDynamicSetting("foo.bar", Validator.EMPTY);
-        assertInstanceBindingWithAnnotation(module, DynamicSettings.class, new Predicate<DynamicSettings>() {
-            @Override
-            public boolean apply(DynamicSettings dynamicSettings) {
-                return dynamicSettings.hasDynamicSetting("foo.bar");
-            }
-        }, ClusterDynamicSettings.class);
+        assertInstanceBindingWithAnnotation(module, DynamicSettings.class, dynamicSettings -> dynamicSettings.hasDynamicSetting("foo.bar"), ClusterDynamicSettings.class);
     }
 
     public void testRegisterIndexDynamicSettingDuplicate() {
@@ -105,12 +99,7 @@ public class ClusterModuleTests extends ModuleTestCase {
     public void testRegisterIndexDynamicSetting() {
         ClusterModule module = new ClusterModule(Settings.EMPTY);
         module.registerIndexDynamicSetting("foo.bar", Validator.EMPTY);
-        assertInstanceBindingWithAnnotation(module, DynamicSettings.class, new Predicate<DynamicSettings>() {
-            @Override
-            public boolean apply(DynamicSettings dynamicSettings) {
-                return dynamicSettings.hasDynamicSetting("foo.bar");
-            }
-        }, IndexDynamicSettings.class);
+        assertInstanceBindingWithAnnotation(module, DynamicSettings.class, dynamicSettings -> dynamicSettings.hasDynamicSetting("foo.bar"), IndexDynamicSettings.class);
     }
 
     public void testRegisterAllocationDeciderDuplicate() {

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterServiceIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterServiceIT.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.cluster;
 
-import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -570,12 +569,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         invoked2.await();
 
         // whenever we test for no tasks, we need to awaitBusy since this is a live node
-        assertTrue(awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object input) {
-                return clusterService.pendingTasks().isEmpty();
-            }
-        }));
+        assertTrue(awaitBusy(() -> clusterService.pendingTasks().isEmpty()));
         waitNoPendingTasksOnAll();
 
         final CountDownLatch block2 = new CountDownLatch(1);
@@ -688,12 +682,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         internalCluster().stopRandomNonMasterNode();
 
         // there should not be any master as the minimum number of required eligible masters is not met
-        awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object obj) {
-                return clusterService1.state().nodes().masterNode() == null && clusterService1.state().status() == ClusterState.ClusterStateStatus.APPLIED;
-            }
-        });
+        awaitBusy(() -> clusterService1.state().nodes().masterNode() == null && clusterService1.state().status() == ClusterState.ClusterStateStatus.APPLIED);
         assertThat(testService1.master(), is(false));
 
         // bring the node back up

--- a/core/src/test/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.cluster;
 
-import com.google.common.base.Predicate;
-
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -244,14 +242,11 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         logger.info("Cluster state:\n" + clusterState.getState().prettyPrint());
 
         internalCluster().stopRandomDataNode();
-        assertThat(awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object o) {
-                ClusterState state = client().admin().cluster().prepareState().setLocal(true).get().getState();
-                return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
-            }
-        }), equalTo(true));
-
+        assertTrue(awaitBusy(() -> {
+                    ClusterState state = client().admin().cluster().prepareState().setLocal(true).get().getState();
+                    return state.blocks().hasGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ID);
+                }
+        ));
 
         GetResponse getResponse = client().prepareGet("test1", "type1", "1").get();
         assertExists(getResponse);

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterInfoService;
@@ -29,7 +28,14 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.routing.*;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocators;
@@ -37,15 +43,24 @@ import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.ESAllocationTestCase;
-import org.elasticsearch.test.gateway.NoopGatewayAllocator;
 import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESAllocationTestCase;
+import org.elasticsearch.test.gateway.NoopGatewayAllocator;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
-import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.UNASSIGNED;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -899,12 +914,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
     public void logShardStates(ClusterState state) {
         RoutingNodes rn = state.getRoutingNodes();
         logger.info("--> counts: total: {}, unassigned: {}, initializing: {}, relocating: {}, started: {}",
-                rn.shards(new Predicate<ShardRouting>() {
-                    @Override
-                    public boolean apply(ShardRouting input) {
-                        return true;
-                    }
-                }).size(),
+                rn.shards(shard -> true).size(),
                 rn.shardsWithState(UNASSIGNED).size(),
                 rn.shardsWithState(INITIALIZING).size(),
                 rn.shardsWithState(RELOCATING).size(),

--- a/core/src/test/java/org/elasticsearch/common/inject/ModuleTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/inject/ModuleTestCase.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.common.inject;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.common.inject.spi.Element;
 import org.elasticsearch.common.inject.spi.Elements;
 import org.elasticsearch.common.inject.spi.InstanceBinding;
@@ -34,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Base testcase for testing {@link Module} implementations.
@@ -160,7 +160,7 @@ public abstract class ModuleTestCase extends ESTestCase {
                 InstanceBinding binding = (InstanceBinding) element;
                 if (to.equals(binding.getKey().getTypeLiteral().getType())) {
                     if (annotation == null || annotation.equals(binding.getKey().getAnnotationType())) {
-                        assertTrue(tester.apply(to.cast(binding.getInstance())));
+                        assertTrue(tester.test(to.cast(binding.getInstance())));
                         return;
                     }
                 }

--- a/core/src/test/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/core/src/test/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.SeedUtils;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.util.Accountable;
@@ -59,12 +58,7 @@ public class MockBigArrays extends BigArrays {
             // not empty, we might be executing on a shared cluster that keeps on obtaining
             // and releasing arrays, lets make sure that after a reasonable timeout, all master
             // copy (snapshot) have been released
-            boolean success = ESTestCase.awaitBusy(new Predicate<Object>() {
-                @Override
-                public boolean apply(Object input) {
-                    return Sets.intersection(masterCopy.keySet(), ACQUIRED_ARRAYS.keySet()).isEmpty();
-                }
-            });
+            boolean success = ESTestCase.awaitBusy(() -> Sets.intersection(masterCopy.keySet(), ACQUIRED_ARRAYS.keySet()).isEmpty());
             if (!success) {
                 masterCopy.keySet().retainAll(ACQUIRED_ARRAYS.keySet());
                 ACQUIRED_ARRAYS.keySet().removeAll(masterCopy.keySet()); // remove all existing master copy we will report on

--- a/core/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.gateway;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
@@ -286,12 +285,7 @@ public class AsyncShardFetchTests extends ESTestCase {
                             entry = simulations.get(nodeId);
                             if (entry == null) {
                                 // we are simulating a master node switch, wait for it to not be null
-                                awaitBusy(new Predicate<Object>() {
-                                    @Override
-                                    public boolean apply(Object input) {
-                                        return simulations.containsKey(nodeId);
-                                    }
-                                });
+                                awaitBusy(() ->  simulations.containsKey(nodeId));
                             }
                             assert entry != null;
                             entry.executeLatch.await();

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.gateway;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -160,18 +159,15 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
 
 
     private void assertMetaState(final String nodeName, final String indexName, final boolean shouldBe) throws Exception {
-        awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object o) {
-                logger.info("checking if meta state exists...");
-                try {
-                    return shouldBe == metaStateExists(nodeName, indexName);
-                } catch (Throwable t) {
-                    logger.info("failed to load meta state", t);
-                    // TODO: loading of meta state fails rarely if the state is deleted while we try to load it
-                    // this here is a hack, would be much better to use for example a WatchService
-                    return false;
-                }
+        awaitBusy(() -> {
+            logger.info("checking if meta state exists...");
+            try {
+                return shouldBe == metaStateExists(nodeName, indexName);
+            } catch (Throwable t) {
+                logger.info("failed to load meta state", t);
+                // TODO: loading of meta state fails rarely if the state is deleted while we try to load it
+                // this here is a hack, would be much better to use for example a WatchService
+                return false;
             }
         });
         boolean inMetaSate = metaStateExists(nodeName, indexName);

--- a/core/src/test/java/org/elasticsearch/index/TransportIndexFailuresIT.java
+++ b/core/src/test/java/org/elasticsearch/index/TransportIndexFailuresIT.java
@@ -19,14 +19,12 @@
 
 package org.elasticsearch.index;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -36,14 +34,16 @@ import org.elasticsearch.discovery.zen.fd.FaultDetection;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportModule;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
 import java.util.Collection;
 import java.util.List;
 
-import static org.elasticsearch.cluster.routing.ShardRoutingState.*;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.UNASSIGNED;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -142,12 +142,7 @@ public class TransportIndexFailuresIT extends ESIntegTestCase {
         state = getNodeClusterState(randomFrom(nodes.toArray(Strings.EMPTY_ARRAY)));
         RoutingNodes rn = state.getRoutingNodes();
         logger.info("--> counts: total: {}, unassigned: {}, initializing: {}, relocating: {}, started: {}",
-                rn.shards(new Predicate<ShardRouting>() {
-                    @Override
-                    public boolean apply(ShardRouting input) {
-                        return true;
-                    }
-                }).size(),
+                rn.shards(input -> true).size(),
                 rn.shardsWithState(UNASSIGNED).size(),
                 rn.shardsWithState(INITIALIZING).size(),
                 rn.shardsWithState(RELOCATING).size(),

--- a/core/src/test/java/org/elasticsearch/index/codec/postingformat/Elasticsearch090RWPostingsFormat.java
+++ b/core/src/test/java/org/elasticsearch/index/codec/postingformat/Elasticsearch090RWPostingsFormat.java
@@ -19,22 +19,21 @@
 
 package org.elasticsearch.index.codec.postingformat;
 
-import com.google.common.base.Predicates;
 import com.google.common.collect.Iterators;
-
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.common.util.BloomFilter;
-import org.elasticsearch.index.codec.postingsformat.BloomFilterPostingsFormat.BloomFilteredFieldsConsumer;
 import org.elasticsearch.index.codec.postingsformat.BloomFilterPostingsFormat;
+import org.elasticsearch.index.codec.postingsformat.BloomFilterPostingsFormat.BloomFilteredFieldsConsumer;
 import org.elasticsearch.index.codec.postingsformat.Elasticsearch090PostingsFormat;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.stream.StreamSupport;
 
 /** read-write version with blooms for testing */
 public class Elasticsearch090RWPostingsFormat extends Elasticsearch090PostingsFormat {
@@ -55,7 +54,7 @@ public class Elasticsearch090RWPostingsFormat extends Elasticsearch090PostingsFo
                 Fields maskedFields = new FilterLeafReader.FilterFields(fields) {
                     @Override
                     public Iterator<String> iterator() {
-                        return Iterators.filter(this.in.iterator(), Predicates.not(UID_FIELD_FILTER));
+                        return StreamSupport.stream(this.in.spliterator(), false).filter(UID_FIELD_FILTER.negate()).iterator();
                     }
                 };
                 fieldsConsumer.getDelegate().write(maskedFields);

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineMergeIT.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineMergeIT.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.engine;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -65,15 +64,12 @@ public class InternalEngineMergeIT extends ESIntegTestCase {
             logger.info("index round [{}] - segments {}, total merges {}, current merge {}", i, stats.getPrimaries().getSegments().getCount(), stats.getPrimaries().getMerge().getTotal(), stats.getPrimaries().getMerge().getCurrent());
         }
         final long upperNumberSegments = 2 * numOfShards * 10;
-        awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object input) {
-                IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).setMerge(true).get();
-                logger.info("numshards {}, segments {}, total merges {}, current merge {}", numOfShards, stats.getPrimaries().getSegments().getCount(), stats.getPrimaries().getMerge().getTotal(), stats.getPrimaries().getMerge().getCurrent());
-                long current = stats.getPrimaries().getMerge().getCurrent();
-                long count = stats.getPrimaries().getSegments().getCount();
-                return count < upperNumberSegments && current == 0;
-            }
+        awaitBusy(() -> {
+            IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).setMerge(true).get();
+            logger.info("numshards {}, segments {}, total merges {}, current merge {}", numOfShards, stats.getPrimaries().getSegments().getCount(), stats.getPrimaries().getMerge().getTotal(), stats.getPrimaries().getMerge().getCurrent());
+            long current = stats.getPrimaries().getMerge().getCurrent();
+            long count = stats.getPrimaries().getSegments().getCount();
+            return count < upperNumberSegments && current == 0;
         });
         IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).setMerge(true).get();
         logger.info("numshards {}, segments {}, total merges {}, current merge {}", numOfShards, stats.getPrimaries().getSegments().getCount(), stats.getPrimaries().getMerge().getTotal(), stats.getPrimaries().getMerge().getCurrent());

--- a/core/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/core/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -20,7 +20,6 @@ package org.elasticsearch.index.store;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.google.common.base.Charsets;
-import com.google.common.base.Predicate;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.IndexFileNames;
@@ -107,8 +106,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.common.util.CollectionUtils.iterableAsArrayList;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
-import static org.hamcrest.Matchers.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
 public class CorruptedFileIT extends ESIntegTestCase {
@@ -279,13 +286,10 @@ public class CorruptedFileIT extends ESIntegTestCase {
         client().admin().indices().prepareUpdateSettings("test").setSettings(build).get();
         client().admin().cluster().prepareReroute().get();
 
-        boolean didClusterTurnRed = awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object input) {
+        boolean didClusterTurnRed = awaitBusy(() -> {
                 ClusterHealthStatus test = client().admin().cluster()
                         .health(Requests.clusterHealthRequest("test")).actionGet().getStatus();
                 return test == ClusterHealthStatus.RED;
-            }
         }, 5, TimeUnit.MINUTES);// sometimes on slow nodes the replication / recovery is just dead slow
         final ClusterHealthResponse response = client().admin().cluster()
                 .health(Requests.clusterHealthRequest("test")).get();

--- a/core/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.indices;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -45,12 +44,17 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.routing.allocation.decider.DisableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_DISABLE_ALLOCATION;
 import static org.elasticsearch.common.settings.Settings.builder;
-import static org.elasticsearch.index.shard.IndexShardState.*;
+import static org.elasticsearch.index.shard.IndexShardState.CLOSED;
+import static org.elasticsearch.index.shard.IndexShardState.CREATED;
+import static org.elasticsearch.index.shard.IndexShardState.POST_RECOVERY;
+import static org.elasticsearch.index.shard.IndexShardState.RECOVERING;
+import static org.elasticsearch.index.shard.IndexShardState.STARTED;
 import static org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import static org.elasticsearch.test.ESIntegTestCase.Scope;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -203,24 +207,21 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
     private static void assertShardStatesMatch(final IndexShardStateChangeListener stateChangeListener, final int numShards, final IndexShardState... shardStates)
             throws InterruptedException {
 
-        Predicate<Object> waitPredicate = new Predicate<Object>() {
-            @Override
-            public boolean apply(Object input) {
-                if (stateChangeListener.shardStates.size() != numShards) {
+        BooleanSupplier waitPredicate = () -> {
+            if (stateChangeListener.shardStates.size() != numShards) {
+                return false;
+            }
+            for (List<IndexShardState> indexShardStates : stateChangeListener.shardStates.values()) {
+                if (indexShardStates == null || indexShardStates.size() != shardStates.length) {
                     return false;
                 }
-                for (List<IndexShardState> indexShardStates : stateChangeListener.shardStates.values()) {
-                    if (indexShardStates == null || indexShardStates.size() != shardStates.length) {
+                for (int i = 0; i < shardStates.length; i++) {
+                    if (indexShardStates.get(i) != shardStates[i]) {
                         return false;
                     }
-                    for (int i = 0; i < shardStates.length; i++) {
-                        if (indexShardStates.get(i) != shardStates[i]) {
-                            return false;
-                        }
-                    }
                 }
-                return true;
             }
+            return true;
         };
         if (!awaitBusy(waitPredicate, 1, TimeUnit.MINUTES)) {
             fail("failed to observe expect shard states\n" +

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.store;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -55,7 +54,6 @@ import org.elasticsearch.test.disruption.BlockClusterStateProcessing;
 import org.elasticsearch.test.disruption.SingleNodeDisruption;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportModule;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
@@ -400,22 +398,12 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
     }
 
     private boolean waitForShardDeletion(final String server, final String index, final int shard) throws InterruptedException {
-        awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object o) {
-                return !Files.exists(shardDirectory(server, index, shard));
-            }
-        });
+        awaitBusy(() -> !Files.exists(shardDirectory(server, index, shard)));
         return Files.exists(shardDirectory(server, index, shard));
     }
 
     private boolean waitForIndexDeletion(final String server, final String index) throws InterruptedException {
-        awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object o) {
-                return !Files.exists(indexDirectory(server, index));
-            }
-        });
+        awaitBusy(() -> !Files.exists(indexDirectory(server, index)));
         return Files.exists(indexDirectory(server, index));
     }
 

--- a/core/src/test/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.recovery;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
@@ -46,7 +45,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
-import static org.hamcrest.Matchers.equalTo;
 
 public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
@@ -289,19 +287,20 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
             //if there was an error we try to wait and see if at some point it'll get fixed
             logger.info("--> trying to wait");
-            assertThat(awaitBusy(new Predicate<Object>() {
-                @Override
-                public boolean apply(Object o) {
-                    boolean error = false;
-                    for (int i = 0; i < iterations; i++) {
-                        SearchResponse searchResponse = client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get();
-                        if (searchResponse.getHits().totalHits() != numberOfDocs) {
-                            error = true;
-                        }
-                    }
-                    return !error;
-                }
-            }, 5, TimeUnit.MINUTES), equalTo(true));
+            assertTrue(awaitBusy(() -> {
+                                boolean errorOccurred = false;
+                                for (int i = 0; i < iterations; i++) {
+                                    SearchResponse searchResponse = client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get();
+                                    if (searchResponse.getHits().totalHits() != numberOfDocs) {
+                                        errorOccurred = true;
+                                    }
+                                }
+                                return !errorOccurred;
+                            },
+                            5,
+                            TimeUnit.MINUTES
+                    )
+            );
         }
 
         //lets now make the test fail if it was supposed to fail

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -21,7 +21,6 @@ package org.elasticsearch.recovery;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.procedures.IntProcedure;
-import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.lucene.index.IndexFileNames;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -416,13 +415,10 @@ public class RelocationIT extends ESIntegTestCase {
 
         // Lets wait a bit and then move again to hopefully trigger recovery cancellations.
         boolean applied = awaitBusy(
-                new Predicate<Object>() {
-                    @Override
-                    public boolean apply(Object input) {
-                        RecoveryResponse recoveryResponse = internalCluster().client(redNodeName).admin().indices().prepareRecoveries(indexName)
-                                .get();
-                        return !recoveryResponse.shardRecoveryStates().get(indexName).isEmpty();
-                    }
+                () -> {
+                    RecoveryResponse recoveryResponse =
+                            internalCluster().client(redNodeName).admin().indices().prepareRecoveries(indexName).get();
+                    return !recoveryResponse.shardRecoveryStates().get(indexName).isEmpty();
                 }
         );
         assertTrue(applied);

--- a/core/src/test/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
@@ -73,14 +72,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
             } catch (Throwable t) {
             }
         }
-        awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object input) {
-                // we must wait here because the requests to release search contexts might still be in flight
-                // although the search request has already returned
-                return client().admin().indices().prepareStats().execute().actionGet().getTotal().getSearch().getOpenContexts() == 0;
-            }
-        }, 1, TimeUnit.SECONDS);
+        awaitBusy(() -> client().admin().indices().prepareStats().execute().actionGet().getTotal().getSearch().getOpenContexts() == 0, 1, TimeUnit.SECONDS);
         indicesStats = client().admin().indices().prepareStats().execute().actionGet();
         assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0l));
     }

--- a/core/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.snapshots;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -49,6 +48,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
@@ -92,12 +92,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     }
 
     public static void stopNode(final String node) throws IOException {
-        internalCluster().stopRandomNode(new Predicate<Settings>() {
-            @Override
-            public boolean apply(Settings settings) {
-                return settings.get("name").equals(node);
-            }
-        });
+        internalCluster().stopRandomNode(settings -> settings.get("name").equals(node));
     }
 
     public void waitForBlock(String node, String repository, TimeValue timeout) throws InterruptedException {
@@ -186,18 +181,8 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
         public BlockingClusterStateListener(ClusterService clusterService, final String blockOn, final String countOn, Priority passThroughPriority, TimeValue timeout) {
             this.clusterService = clusterService;
-            this.blockOn = new Predicate<ClusterChangedEvent>() {
-                @Override
-                public boolean apply(ClusterChangedEvent clusterChangedEvent) {
-                    return clusterChangedEvent.source().startsWith(blockOn);
-                }
-            };
-            this.countOn = new Predicate<ClusterChangedEvent>() {
-                @Override
-                public boolean apply(ClusterChangedEvent clusterChangedEvent) {
-                    return clusterChangedEvent.source().startsWith(countOn);
-                }
-            };
+            this.blockOn = clusterChangedEvent -> clusterChangedEvent.source().startsWith(blockOn);
+            this.countOn = clusterChangedEvent -> clusterChangedEvent.source().startsWith(countOn);
             this.latch = new CountDownLatch(1);
             this.passThroughPriority = passThroughPriority;
             this.timeout = timeout;
@@ -210,13 +195,13 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
         @Override
         public void clusterChanged(ClusterChangedEvent event) {
-            if (blockOn.apply(event)) {
+            if (blockOn.test(event)) {
                 logger.info("blocking cluster state tasks on [{}]", event.source());
                 assert stopWaitingAt < 0; // Make sure we are the first time here
                 stopWaitingAt = System.currentTimeMillis() + timeout.getMillis();
                 addBlock();
             }
-            if (countOn.apply(event)) {
+            if (countOn.test(event)) {
                 count++;
             }
         }

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.snapshots;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ExceptionsHelper;
@@ -84,8 +83,24 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.shard.IndexShard.INDEX_REFRESH_INTERVAL;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
-import static org.hamcrest.Matchers.*;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAliasesExist;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAliasesMissing;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertIndexTemplateExists;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertIndexTemplateMissing;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
 
@@ -1857,21 +1872,11 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     }
 
     private boolean waitForIndex(final String index, TimeValue timeout) throws InterruptedException {
-        return awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object o) {
-                return client().admin().indices().prepareExists(index).execute().actionGet().isExists();
-            }
-        }, timeout.millis(), TimeUnit.MILLISECONDS);
+        return awaitBusy(() -> client().admin().indices().prepareExists(index).execute().actionGet().isExists(), timeout.millis(), TimeUnit.MILLISECONDS);
     }
 
     private boolean waitForRelocationsToStart(final String index, TimeValue timeout) throws InterruptedException {
-        return awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object o) {
-                return client().admin().cluster().prepareHealth(index).execute().actionGet().getRelocatingShards() > 0;
-            }
-        }, timeout.millis(), TimeUnit.MILLISECONDS);
+        return awaitBusy(() -> client().admin().cluster().prepareHealth(index).execute().actionGet().getRelocatingShards() > 0, timeout.millis(), TimeUnit.MILLISECONDS);
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -19,8 +19,6 @@
 package org.elasticsearch.test;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterators;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
@@ -33,10 +31,12 @@ import org.elasticsearch.common.transport.TransportAddress;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.hamcrest.Matchers.equalTo;
@@ -90,12 +90,10 @@ public class CompositeTestCluster extends TestCluster {
     }
 
     private Collection<ExternalNode> runningNodes() {
-        return Collections2.filter(Arrays.asList(externalNodes), new Predicate<ExternalNode>() {
-            @Override
-            public boolean apply(ExternalNode input) {
-                return input.running();
-            }
-        });
+        return Arrays
+                .stream(externalNodes)
+                .filter(input -> input.running())
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/core/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.test;
 
-import com.google.common.base.Predicate;
-
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -155,18 +153,15 @@ final class ExternalNode implements Closeable {
     }
 
     static boolean waitForNode(final Client client, final String name) throws InterruptedException {
-        return ESTestCase.awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(java.lang.Object input) {
-                final NodesInfoResponse nodeInfos = client.admin().cluster().prepareNodesInfo().get();
-                final NodeInfo[] nodes = nodeInfos.getNodes();
-                for (NodeInfo info : nodes) {
-                    if (name.equals(info.getNode().getName())) {
-                        return true;
-                    }
+        return ESTestCase.awaitBusy(() -> {
+            final NodesInfoResponse nodeInfos = client.admin().cluster().prepareNodesInfo().get();
+            final NodeInfo[] nodes = nodeInfos.getNodes();
+            for (NodeInfo info : nodes) {
+                if (name.equals(info.getNode().getName())) {
+                    return true;
                 }
-                return false;
             }
+            return false;
         }, 30, TimeUnit.SECONDS);
     }
 

--- a/dev-tools/src/main/resources/forbidden/core-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/core-signatures.txt
@@ -88,3 +88,5 @@ org.elasticsearch.common.io.PathUtils#get(java.net.URI)
 com.google.common.collect.Lists
 com.google.common.collect.ImmutableList
 com.google.common.base.Objects
+com.google.common.base.Predicate
+com.google.common.base.Predicates

--- a/plugins/delete-by-query/src/test/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryActionTests.java
+++ b/plugins/delete-by-query/src/test/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryActionTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.deletebyquery;
 
-import com.google.common.base.Predicate;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
@@ -164,13 +163,8 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
         TestActionListener listener = new TestActionListener();
 
         final TransportDeleteByQueryAction.AsyncDeleteByQueryAction async = newAsyncAction(delete, listener);
-        awaitBusy(new Predicate<Object>() {
-            @Override
-            public boolean apply(Object input) {
-                // Wait until the action timed out
-                return async.hasTimedOut();
-            }
-        });
+        // Wait until the action timed out
+        awaitBusy(() -> async.hasTimedOut());
 
         async.executeScroll(searchResponse.getScrollId());
         waitForCompletion("scroll request returns zero documents on expired scroll id", listener);
@@ -419,12 +413,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
     private void waitForCompletion(String testName, final TestActionListener listener) {
         logger.info(" --> waiting for delete-by-query [{}] to complete", testName);
         try {
-            awaitBusy(new Predicate<Object>() {
-                @Override
-                public boolean apply(Object input) {
-                    return listener.isTerminated();
-                }
-            });
+            awaitBusy(() -> listener.isTerminated());
         } catch (InterruptedException e) {
             fail("exception when waiting for delete-by-query [" + testName + "] to complete: " + e.getMessage());
             logger.error("exception when waiting for delete-by-query [{}] to complete", e, testName);


### PR DESCRIPTION
This commit removes and now forbids all uses of
com.google.common.base.Predicate and com.google.common.base.Predicates
across the codebase. This is one of the many steps in the eventual
removal of Guava as a dependency. This was enabled by #13314.

Relates #13224
