### PR TITLE
Remove use of underscore as an identifier

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -764,7 +764,7 @@ class DocumentParser implements Closeable {
 
     private static XContentParser transform(Mapping mapping, XContentParser parser) throws IOException {
         Map<String, Object> transformed;
-        try (XContentParser _ = parser) {
+        try (XContentParser autoCloses = parser) {
             transformed = transformSourceAsMap(mapping, parser.mapOrdered());
         }
         XContentBuilder builder = XContentFactory.contentBuilder(parser.contentType()).value(transformed);

--- a/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -208,7 +208,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                 @Override
                 protected void doRun() throws Exception {
                     start.await();
-                    try (ShardLock _ = env.shardLock(new ShardId("foo", 0))) {
+                    try (ShardLock autoCloses = env.shardLock(new ShardId("foo", 0))) {
                         blockLatch.countDown();
                         Thread.sleep(randomIntBetween(1, 10));
                     }
@@ -267,7 +267,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                     for (int i = 0; i < iters; i++) {
                         int shard = randomIntBetween(0, counts.length-1);
                         try {
-                            try (ShardLock _ = env.shardLock(new ShardId("foo", shard), scaledRandomIntBetween(0, 10))) {
+                            try (ShardLock autoCloses = env.shardLock(new ShardId("foo", shard), scaledRandomIntBetween(0, 10))) {
                                 counts[shard].value++;
                                 countsAtomic[shard].incrementAndGet();
                                 assertEquals(flipFlop[shard].incrementAndGet(), 1);


### PR DESCRIPTION
As a refinement to Project Coin ([JEP-213](http://openjdk.java.net/jeps/213), [JDK-8042880](https://bugs.openjdk.java.net/browse/JDK-8042880)), Java 9 is going
to disallow the use of `_` as a one-character identifier. This will be
done by adding `_` as a keyword to the Java language ([JDK-8065599](https://bugs.openjdk.java.net/browse/JDK-8065599)).
Currently, uses of `_` as a one-character identifier are warnings in
the Java 8 compiler. This commit removes all uses of `_` as a
one-character identifier from the codebase.
