### PR TITLE
Remove and forbid use of com.google.common.base.Objects

### DIFF
--- a/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -42,13 +42,13 @@ import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.support.QueryParsers;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfNeeded;
 
@@ -572,7 +572,7 @@ public class MapperQueryParser extends QueryParser {
     protected Query getWildcardQuery(String field, String termStr) throws ParseException {
         if (termStr.equals("*")) {
             // we want to optimize for match all query for the "*:*", and "*" cases
-            if ("*".equals(field) || Objects.equal(field, this.field)) {
+            if ("*".equals(field) || Objects.equals(field, this.field)) {
                 String actualField = field;
                 if (actualField == null) {
                     actualField = this.field;

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
@@ -17,7 +17,6 @@
 
 package org.elasticsearch.common.inject.internal;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.common.inject.ConfigurationException;
@@ -29,6 +28,7 @@ import java.lang.reflect.*;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -192,7 +192,7 @@ public class MoreTypes {
             // TODO: save a .clone() call
             ParameterizedType pa = (ParameterizedType) a;
             ParameterizedType pb = (ParameterizedType) b;
-            return Objects.equal(pa.getOwnerType(), pb.getOwnerType())
+            return Objects.equals(pa.getOwnerType(), pb.getOwnerType())
                     && pa.getRawType().equals(pb.getRawType())
                     && Arrays.equals(pa.getActualTypeArguments(), pb.getActualTypeArguments());
 

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/Dependency.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/Dependency.java
@@ -16,12 +16,12 @@
 
 package org.elasticsearch.common.inject.spi;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.common.inject.Key;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -100,16 +100,16 @@ public final class Dependency<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(injectionPoint, parameterIndex, key);
+        return Objects.hash(injectionPoint, parameterIndex, key);
     }
 
     @Override
     public boolean equals(Object o) {
         if (o instanceof Dependency) {
             Dependency dependency = (Dependency) o;
-            return Objects.equal(injectionPoint, dependency.injectionPoint)
-                    && Objects.equal(parameterIndex, dependency.parameterIndex)
-                    && Objects.equal(key, dependency.key);
+            return Objects.equals(injectionPoint, dependency.injectionPoint)
+                    && Objects.equals(parameterIndex, dependency.parameterIndex)
+                    && Objects.equals(key, dependency.key);
         } else {
             return false;
         }

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/Message.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/Message.java
@@ -16,7 +16,6 @@
 
 package org.elasticsearch.common.inject.spi;
 
-import com.google.common.base.Objects;
 import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.internal.Errors;
 import org.elasticsearch.common.inject.internal.SourceProvider;
@@ -26,6 +25,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -119,7 +119,7 @@ public final class Message implements Serializable, Element {
             return false;
         }
         Message e = (Message) o;
-        return message.equals(e.message) && Objects.equal(cause, e.cause) && sources.equals(e.sources);
+        return message.equals(e.message) && Objects.equals(cause, e.cause) && sources.equals(e.sources);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.common.xcontent;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
-
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -39,6 +37,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 
@@ -225,7 +224,7 @@ public class XContentHelper {
                 modified = true;
                 continue;
             }
-            modified = !Objects.equal(old, changesEntry.getValue());
+            modified = !Objects.equals(old, changesEntry.getValue());
         }
         return modified;
     }

--- a/core/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/local/LocalDiscovery.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.discovery.local;
 
-import com.google.common.base.Objects;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -42,6 +41,7 @@ import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
@@ -357,7 +357,7 @@ public class LocalDiscovery extends AbstractLifecycleComponent<Discovery> implem
                     discovery.clusterService.submitStateUpdateTask("local-disco-receive(from master)", new ProcessedClusterStateNonMasterUpdateTask() {
                         @Override
                         public ClusterState execute(ClusterState currentState) {
-                            if (nodeSpecificClusterState.version() < currentState.version() && Objects.equal(nodeSpecificClusterState.nodes().masterNodeId(), currentState.nodes().masterNodeId())) {
+                            if (nodeSpecificClusterState.version() < currentState.version() && Objects.equals(nodeSpecificClusterState.nodes().masterNodeId(), currentState.nodes().masterNodeId())) {
                                 return currentState;
                             }
 

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.discovery.zen;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
@@ -75,6 +74,7 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -822,7 +822,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
                 break;
             }
             // if its not from the same master, then bail
-            if (!Objects.equal(stateToProcess.clusterState.nodes().masterNodeId(), potentialState.clusterState.nodes().masterNodeId())) {
+            if (!Objects.equals(stateToProcess.clusterState.nodes().masterNodeId(), potentialState.clusterState.nodes().masterNodeId())) {
                 break;
             }
             // we are going to use it for sure, poll (remove) it

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.mapper.internal;
 
-import com.google.common.base.Objects;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.index.IndexOptions;
@@ -51,6 +50,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeMapValue;
@@ -329,7 +329,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
     public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
         super.merge(mergeWith, mergeResult);
         ParentFieldMapper fieldMergeWith = (ParentFieldMapper) mergeWith;
-        if (Objects.equal(type, fieldMergeWith.type) == false) {
+        if (Objects.equals(type, fieldMergeWith.type) == false) {
             mergeResult.addConflict("The _parent field's type option can't be changed: [" + type + "]->[" + fieldMergeWith.type + "]");
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/SourceFieldMapper.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.mapper.internal;
 
-import com.google.common.base.Objects;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
@@ -57,6 +56,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeStringValue;
@@ -406,7 +406,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         if (includeDefaults || enabled != Defaults.ENABLED) {
             builder.field("enabled", enabled);
         }
-        if (includeDefaults || !Objects.equal(format, Defaults.FORMAT)) {
+        if (includeDefaults || !Objects.equals(format, Defaults.FORMAT)) {
             builder.field("format", format);
         }
         if (compress != null) {

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
@@ -19,23 +19,27 @@
 
 package org.elasticsearch.index.query;
 
-import com.google.common.base.Objects;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RandomAccessWeight;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.script.*;
+import org.elasticsearch.script.LeafSearchScript;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.script.Script.ScriptField;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptParameterParser;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -141,7 +145,7 @@ public class ScriptQueryParser implements QueryParser {
             if (!super.equals(obj))
                 return false;
             ScriptQuery other = (ScriptQuery) obj;
-            return Objects.equal(script, other.script);
+            return Objects.equals(script, other.script);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.recovery;
 
-import com.google.common.base.Objects;
 import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.store.RateLimiter.SimpleRateLimiter;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -33,6 +32,7 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
+import java.util.Objects;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -207,7 +207,7 @@ public class RecoverySettings extends AbstractComponent implements Closeable {
         @Override
         public void onRefreshSettings(Settings settings) {
             ByteSizeValue maxSizePerSec = settings.getAsBytesSize(INDICES_RECOVERY_MAX_BYTES_PER_SEC, settings.getAsBytesSize(INDICES_RECOVERY_MAX_SIZE_PER_SEC, RecoverySettings.this.maxBytesPerSec));
-            if (!Objects.equal(maxSizePerSec, RecoverySettings.this.maxBytesPerSec)) {
+            if (!Objects.equals(maxSizePerSec, RecoverySettings.this.maxBytesPerSec)) {
                 logger.info("updating [{}] from [{}] to [{}]", INDICES_RECOVERY_MAX_BYTES_PER_SEC, RecoverySettings.this.maxBytesPerSec, maxSizePerSec);
                 RecoverySettings.this.maxBytesPerSec = maxSizePerSec;
                 if (maxSizePerSec.bytes() <= 0) {

--- a/core/src/main/java/org/elasticsearch/search/warmer/IndexWarmersMetaData.java
+++ b/core/src/main/java/org/elasticsearch/search/warmer/IndexWarmersMetaData.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.warmer;
 
-import com.google.common.base.Objects;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Nullable;
@@ -39,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  */
@@ -105,7 +105,7 @@ public class IndexWarmersMetaData extends AbstractDiffable<IndexMetaData.Custom>
             if (!name.equals(entry.name)) return false;
             if (!Arrays.equals(types, entry.types)) return false;
             if (!source.equals(entry.source)) return false;
-            return Objects.equal(requestCache, entry.requestCache);
+            return Objects.equals(requestCache, entry.requestCache);
 
         }
 

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.threadpool;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -46,6 +45,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.*;
 
@@ -345,7 +345,7 @@ public class ThreadPool extends AbstractComponent {
             if (previousExecutorHolder != null) {
                 if ("fixed".equals(previousInfo.getType())) {
                     SizeValue updatedQueueSize = getAsSizeOrUnbounded(settings, "capacity", getAsSizeOrUnbounded(settings, "queue", getAsSizeOrUnbounded(settings, "queue_size", previousInfo.getQueueSize())));
-                    if (Objects.equal(previousInfo.getQueueSize(), updatedQueueSize)) {
+                    if (Objects.equals(previousInfo.getQueueSize(), updatedQueueSize)) {
                         int updatedSize = settings.getAsInt("size", previousInfo.getMax());
                         if (previousInfo.getMax() != updatedSize) {
                             logger.debug("updating thread_pool [{}], type [{}], size [{}], queue_size [{}]", name, type, updatedSize, updatedQueueSize);

--- a/dev-tools/src/main/resources/forbidden/core-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/core-signatures.txt
@@ -87,3 +87,4 @@ org.elasticsearch.common.io.PathUtils#get(java.net.URI)
 @defaultMessage avoid adding additional dependencies on Guava
 com.google.common.collect.Lists
 com.google.common.collect.ImmutableList
+com.google.common.base.Objects


### PR DESCRIPTION
This commit removes and now forbids all uses of
`com.google.common.base.Objects` across the codebase. This is a small
step in the eventual removal of Guava as a dependency.

Relates #13224
