### PR TITLE
Snapshot restore request should accept indices options

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -537,7 +537,9 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
                         throw new IllegalArgumentException("malformed ignore_index_settings section, should be an array of strings");
                     }
             } else {
-                throw new IllegalArgumentException("Unknown parameter " + name);
+                if (IndicesOptions.isIndicesOptions(name) == false) {
+                    throw new IllegalArgumentException("Unknown parameter " + name);
+                }
             }
         }
         indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.lenientExpandOpen()));

--- a/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -154,6 +154,16 @@ public class IndicesOptions {
                 defaultSettings);
     }
 
+    /**
+     * Returns true if the name represents a valid name for one of the indices option
+     * false otherwise
+     */
+    public static boolean isIndicesOptions(String name) {
+        return "expand_wildcards".equals(name) || "expandWildcards".equals(name) ||
+                "ignore_unavailable".equals(name) || "ignoreUnavailable".equals(name) ||
+                "allow_no_indices".equals(name) || "allowNoIndices".equals(name);
+    }
+
     public static IndicesOptions fromParameters(Object wildcardsString, Object ignoreUnavailableString, Object allowNoIndicesString, IndicesOptions defaultSettings) {
         if (wildcardsString == null && ignoreUnavailableString == null && allowNoIndicesString == null) {
             return defaultSettings;

--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotRequestsTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotRequestsTests.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+public class SnapshotRequestsTests extends ESTestCase {
+    @Test
+    public void testRestoreSnapshotRequestParsing() throws IOException {
+
+        RestoreSnapshotRequest request = new RestoreSnapshotRequest("test-repo", "test-snap");
+
+        XContentBuilder builder = jsonBuilder().startObject();
+
+        if(randomBoolean()) {
+            builder.field("indices", "foo,bar,baz");
+        } else {
+            builder.startArray("indices");
+            builder.value("foo");
+            builder.value("bar");
+            builder.value("baz");
+            builder.endArray();
+        }
+
+        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        if (indicesOptions.expandWildcardsClosed()) {
+            if (indicesOptions.expandWildcardsOpen()) {
+                builder.field("expand_wildcards", "all");
+            } else {
+                builder.field("expand_wildcards", "closed");
+            }
+        } else {
+            if (indicesOptions.expandWildcardsOpen()) {
+                builder.field("expand_wildcards", "open");
+            } else {
+                builder.field("expand_wildcards", "none");
+            }
+        }
+        builder.field("allow_no_indices", indicesOptions.allowNoIndices());
+        builder.field("rename_pattern", "rename-from");
+        builder.field("rename_replacement", "rename-to");
+        boolean partial = randomBoolean();
+        builder.field("partial", partial);
+        builder.startObject("settings").field("set1", "val1").endObject();
+        builder.startObject("index_settings").field("set1", "val2").endObject();
+        if (randomBoolean()) {
+            builder.field("ignore_index_settings", "set2,set3");
+        } else {
+            builder.startArray("ignore_index_settings");
+            builder.value("set2");
+            builder.value("set3");
+            builder.endArray();
+        }
+
+        byte[] bytes = builder.endObject().bytes().toBytes();
+
+
+        request.source(bytes);
+
+        assertEquals("test-repo", request.repository());
+        assertEquals("test-snap", request.snapshot());
+        assertArrayEquals(request.indices(), new String[]{"foo", "bar", "baz"});
+        assertEquals("rename-from", request.renamePattern());
+        assertEquals("rename-to", request.renameReplacement());
+        assertEquals(partial, request.partial());
+        assertEquals("val1", request.settings().get("set1"));
+        assertArrayEquals(request.ignoreIndexSettings(), new String[]{"set2", "set3"});
+
+    }
+
+    @Test
+    public void testCreateSnapshotRequestParsing() throws IOException {
+
+        CreateSnapshotRequest request = new CreateSnapshotRequest("test-repo", "test-snap");
+
+        XContentBuilder builder = jsonBuilder().startObject();
+
+        if(randomBoolean()) {
+            builder.field("indices", "foo,bar,baz");
+        } else {
+            builder.startArray("indices");
+            builder.value("foo");
+            builder.value("bar");
+            builder.value("baz");
+            builder.endArray();
+        }
+
+        IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        if (indicesOptions.expandWildcardsClosed()) {
+            if (indicesOptions.expandWildcardsOpen()) {
+                builder.field("expand_wildcards", "all");
+            } else {
+                builder.field("expand_wildcards", "closed");
+            }
+        } else {
+            if (indicesOptions.expandWildcardsOpen()) {
+                builder.field("expand_wildcards", "open");
+            } else {
+                builder.field("expand_wildcards", "none");
+            }
+        }
+        builder.field("allow_no_indices", indicesOptions.allowNoIndices());
+        boolean partial = randomBoolean();
+        builder.field("partial", partial);
+        builder.startObject("settings").field("set1", "val1").endObject();
+        builder.startObject("index_settings").field("set1", "val2").endObject();
+        if (randomBoolean()) {
+            builder.field("ignore_index_settings", "set2,set3");
+        } else {
+            builder.startArray("ignore_index_settings");
+            builder.value("set2");
+            builder.value("set3");
+            builder.endArray();
+        }
+
+        byte[] bytes = builder.endObject().bytes().toBytes();
+
+
+        request.source(bytes);
+
+        assertEquals("test-repo", request.repository());
+        assertEquals("test-snap", request.snapshot());
+        assertArrayEquals(request.indices(), new String[]{"foo", "bar", "baz"});
+        assertEquals(partial, request.partial());
+        assertEquals("val1", request.settings().get("set1"));
+    }
+
+}


### PR DESCRIPTION
Fixes an issue introduced in #10744 as a result of which the restore request stopped accepting indices options such as ignore_unavailable.

Fixes #13335
