### PR TITLE
Enable S3SignerType

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -110,11 +110,11 @@ The available values are:
 * `cn-north` (`cn-north-1`)
 
 [[discovery-ec2-usage-signer]]
-===== EC2/S3 Signer API
+===== EC2 Signer API
 
-If you are using a compatible EC2 or S3 service, they might be using an older API to sign the requests.
-You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.ec2.signer` and `cloud.aws.s3.signer`)
-with the right signer to use. Defaults to `AWS4SignerType`.
+If you are using a compatible EC2 service, they might be using an older API to sign the requests.
+You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.ec2.signer`)
+with the right signer to use.
 
 [[discovery-ec2-discovery]]
 ==== EC2 Discovery

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -113,11 +113,14 @@ The available values are:
 * `cn-north` (`cn-north-1`)
 
 [[repository-s3-usage-signer]]
-===== EC2/S3 Signer API
+===== S3 Signer API
 
-If you are using a compatible EC2 or S3 service, they might be using an older API to sign the requests.
-You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.ec2.signer` and `cloud.aws.s3.signer`)
-with the right signer to use. Defaults to `AWS4SignerType`.
+If you are using a S3 compatible service, they might be using an older API to sign the requests.
+You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.s3.signer`) with the right
+signer to use.
+
+If you are using a compatible S3 service which do not support Version 4 signing process, you may need to
+use `S3SignerType`, which is Signature Version 2.
 
 [[repository-s3-repository]]
 ==== S3 Repository

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -99,11 +99,7 @@ public class AwsEc2Service extends AbstractLifecycleComponent<AwsEc2Service> {
         String awsSigner = settings.get("cloud.aws.ec2.signer", settings.get("cloud.aws.signer"));
         if (awsSigner != null) {
             logger.debug("using AWS API signer [{}]", awsSigner);
-            try {
-                AwsSigner.configureSigner(awsSigner, clientConfiguration);
-            } catch (IllegalArgumentException e) {
-                logger.warn("wrong signer set for [cloud.aws.ec2.signer] or [cloud.aws.signer]: [{}]", awsSigner);
-            }
+            AwsSigner.configureSigner(awsSigner, clientConfiguration);
         }
 
         AWSCredentialsProvider credentials;

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsSigner.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsSigner.java
@@ -21,22 +21,18 @@ package org.elasticsearch.cloud.aws;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.SignerFactory;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 
 public class AwsSigner {
+
+    private static final ESLogger logger = Loggers.getLogger(AwsSigner.class);
 
     private AwsSigner() {
 
     }
 
-    /**
-     * Add a AWS API Signer.
-     * @param signer Signer to use
-     * @param configuration AWS Client configuration
-     * @throws IllegalArgumentException if signer does not exist
-     */
-    public static void configureSigner(String signer, ClientConfiguration configuration)
-        throws IllegalArgumentException {
-
+    protected static void validateSignerType(String signer) throws IllegalArgumentException {
         if (signer == null) {
             throw new IllegalArgumentException("[null] signer set");
         }
@@ -45,9 +41,23 @@ public class AwsSigner {
             // We check this signer actually exists in AWS SDK
             // It throws a IllegalArgumentException if not found
             SignerFactory.getSignerByTypeAndService(signer, null);
-            configuration.setSignerOverride(signer);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("wrong signer set [" + signer + "]");
         }
+    }
+
+    /**
+     * Add a AWS API Signer.
+     * @param signer Signer to use
+     * @param configuration AWS Client configuration
+     */
+    public static void configureSigner(String signer, ClientConfiguration configuration) {
+        try {
+            validateSignerType(signer);
+        } catch (IllegalArgumentException e) {
+            logger.warn(e.getMessage());
+        }
+
+        configuration.setSignerOverride(signer);
     }
 }

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/cloud/aws/AWSSignersTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/cloud/aws/AWSSignersTests.java
@@ -35,6 +35,15 @@ public class AWSSignersTests extends ESTestCase {
         assertThat(signerTester("AWS4SignerType"), is(true));
         assertThat(signerTester("NoOpSignerType"), is(true));
         assertThat(signerTester("UndefinedSigner"), is(false));
+
+        assertThat(signerTester("S3SignerType"), is(false));
+        assertThat(signerTester("AWSS3V4SignerType"), is(false));
+
+        ClientConfiguration configuration = new ClientConfiguration();
+        AwsSigner.configureSigner("AWS4SignerType", configuration);
+        assertEquals(configuration.getSignerOverride(), "AWS4SignerType");
+        AwsSigner.configureSigner("AWS3SignerType", configuration);
+        assertEquals(configuration.getSignerOverride(), "AWS3SignerType");
     }
 
     /**
@@ -44,7 +53,7 @@ public class AWSSignersTests extends ESTestCase {
      */
     private boolean signerTester(String signer) {
         try {
-            AwsSigner.configureSigner(signer, new ClientConfiguration());
+            AwsSigner.validateSignerType(signer);
             return true;
         } catch (IllegalArgumentException e) {
             return false;

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -134,11 +134,7 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
         String awsSigner = settings.get("cloud.aws.s3.signer", settings.get("cloud.aws.signer"));
         if (awsSigner != null) {
             logger.debug("using AWS API signer [{}]", awsSigner);
-            try {
-                AwsSigner.configureSigner(awsSigner, clientConfiguration);
-            } catch (IllegalArgumentException e) {
-                logger.warn("wrong signer set for [cloud.aws.s3.signer] or [cloud.aws.signer]: [{}]", awsSigner);
-            }
+            AwsSigner.configureSigner(awsSigner, clientConfiguration, endpoint);
         }
 
         AWSCredentialsProvider credentials;


### PR DESCRIPTION
This PR enable user with S3SignerType, which is v2 signer type some of S3 compatible services but without V4 signer type would need this setting.

Related to https://github.com/elastic/elasticsearch/issues/13332
