### PR TITLE
RestUtils.decodeQueryString ignores the URI fragment when parsing a query string

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/support/RestUtils.java
+++ b/core/src/main/java/org/elasticsearch/rest/support/RestUtils.java
@@ -59,12 +59,14 @@ public class RestUtils {
         if (fromIndex >= s.length()) {
             return;
         }
+        
+        int queryStringLength = s.contains("#") ? s.indexOf("#") : s.length();
 
         String name = null;
         int pos = fromIndex; // Beginning of the unprocessed region
         int i;       // End of the unprocessed region
         char c = 0;  // Current character
-        for (i = fromIndex; i < s.length(); i++) {
+        for (i = fromIndex; i < queryStringLength; i++) {
             c = s.charAt(i);
             if (c == '=' && name == null) {
                 if (pos != i) {

--- a/core/src/test/java/org/elasticsearch/rest/util/RestUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/util/RestUtilsTests.java
@@ -139,6 +139,16 @@ public class RestUtilsTests extends ESTestCase {
         assertCorsSettingRegexIsNull("");
         assertThat(RestUtils.getCorsSettingRegex(Settings.EMPTY), is(nullValue()));
     }
+    
+    public void testCrazyURL() {
+        Map<String, String> params = newHashMap();
+
+        // This is a valid URL
+        String uri = "example.com/:@-._~!$&'()*+,=;:@-._~!$&'()*+,=:@-._~!$&'()*+,==?/?:@-._~!$'()*+,;=/?:@-._~!$'()*+,;==#/?:@-._~!$&'()*+,;=";
+        RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
+        assertThat(params.get("/?:@-._~!$'()* ,;"), equalTo("/?:@-._~!$'()* ,;=="));
+        assertThat(params.size(), equalTo(1));
+    }
 
     private void assertCorsSettingRegexIsNull(String settingsValue) {
         assertThat(RestUtils.getCorsSettingRegex(settingsBuilder().put("http.cors.allow-origin", settingsValue).build()), is(nullValue()));


### PR DESCRIPTION
Fixes #13320 
