### PR TITLE
Packaging: Add .noarch suffix to RPM

### DIFF
--- a/dev-tools/prepare_release_candidate.py
+++ b/dev-tools/prepare_release_candidate.py
@@ -85,7 +85,7 @@ NOTE: this script requires JAVA_HOME to point to a Java 7 Runtime
 [1] https://github.com/elastic/elasticsearch/commit/%(hash)s
 [2] http://download.elasticsearch.org/elasticsearch/staging/%(version)s-%(hash)s/org/elasticsearch/distribution/zip/elasticsearch/%(version)s/elasticsearch-%(version)s.zip
 [3] http://download.elasticsearch.org/elasticsearch/staging/%(version)s-%(hash)s/org/elasticsearch/distribution/tar/elasticsearch/%(version)s/elasticsearch-%(version)s.tar.gz
-[4] http://download.elasticsearch.org/elasticsearch/staging/%(version)s-%(hash)s/org/elasticsearch/distribution/rpm/elasticsearch/%(version)s/elasticsearch-%(version)s.rpm
+[4] http://download.elasticsearch.org/elasticsearch/staging/%(version)s-%(hash)s/org/elasticsearch/distribution/rpm/elasticsearch/%(version)s/elasticsearch-%(version)s.noarch.rpm
 [5] http://download.elasticsearch.org/elasticsearch/staging/%(version)s-%(hash)s/org/elasticsearch/distribution/deb/elasticsearch/%(version)s/elasticsearch-%(version)s.deb
 """
 VERBOSE=True

--- a/dev-tools/smoke_test_rc.py
+++ b/dev-tools/smoke_test_rc.py
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     'org/elasticsearch/distribution/tar/elasticsearch/%(version)s/elasticsearch-%(version)s.tar.gz',
     'org/elasticsearch/distribution/zip/elasticsearch/%(version)s/elasticsearch-%(version)s.zip',
     'org/elasticsearch/distribution/deb/elasticsearch/%(version)s/elasticsearch-%(version)s.deb',
-    'org/elasticsearch/distribution/rpm/elasticsearch/%(version)s/elasticsearch-%(version)s.rpm'
+    'org/elasticsearch/distribution/rpm/elasticsearch/%(version)s/elasticsearch-%(version)s.noarch.rpm'
   ]]
   verify_java_version('1.7')
   if url:

--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -370,7 +370,7 @@
       <local name="rpm.file"/>
       <local name="rpm.database"/>
       <local name="rpm.extracted"/>
-      <property name="rpm.file" location="${project.build.directory}/releases/${project.artifactId}-${project.version}.rpm"/>
+      <property name="rpm.file" location="${project.build.directory}/releases/${project.artifactId}-${project.version}.noarch.rpm"/>
       <property name="rpm.database" location="${integ.scratch}/rpm-database"/>
       <property name="rpm.extracted" location="${integ.scratch}/rpm-extracted"/>
       <mkdir dir="${rpm.database}"/>

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -319,6 +319,7 @@
                                     <type>${project.packaging}</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${rpm.outputDirectory}</outputDirectory>
+                                    <destFileName>${project.artifactId}-${project.version}.noarch.${project.packaging}</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/40_rpm_package.bats
@@ -45,7 +45,7 @@ setup() {
 }
 
 @test "[RPM] package is available" {
-    count=$(ls elasticsearch-$(cat version).rpm | wc -l)
+    count=$(ls elasticsearch-$(cat version)*.rpm | wc -l)
     [ "$count" -eq 1 ]
 }
 
@@ -55,7 +55,7 @@ setup() {
 }
 
 @test "[RPM] install package" {
-    rpm -i elasticsearch-$(cat version).rpm
+    rpm -i elasticsearch-$(cat version)*.rpm
 }
 
 @test "[RPM] package is installed" {


### PR DESCRIPTION
This adds back the `.noarch` suffix to the RPM
