### PR TITLE
[maven] assembly: elasticsearch is already excluded

### DIFF
--- a/dev-tools/src/main/resources/plugin-metadata/plugin-assembly.xml
+++ b/dev-tools/src/main/resources/plugin-metadata/plugin-assembly.xml
@@ -18,9 +18,6 @@
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <useTransitiveDependencies>true</useTransitiveDependencies>
-            <excludes>
-                <exclude>org.elasticsearch:elasticsearch</exclude>
-            </excludes>
         </dependencySet>
     </dependencySets>
 </assembly>

--- a/plugins/jvm-example/src/main/assemblies/plugin.xml
+++ b/plugins/jvm-example/src/main/assemblies/plugin.xml
@@ -28,9 +28,6 @@
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <useTransitiveDependencies>true</useTransitiveDependencies>
-            <excludes>
-                <exclude>org.elasticsearch:elasticsearch</exclude>
-            </excludes>
         </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
As elasticsearch is marked as provided we don't need to explicitly exclude it from the assembly descriptor.

We get a warning today for all plugins, the following:

```
[INFO] --- maven-assembly-plugin:2.5.5:single (default) @ repository-s3 ---
[INFO] Reading assembly descriptor: /path/to/plugin-assembly.xml
[WARNING] The following patterns were never triggered in this artifact exclusion filter:
o  'org.elasticsearch:elasticsearch'
[INFO] Building zip: /path/to/target/releases/repository-s3-3.0.0-SNAPSHOT.zip
[INFO] 
```

It now gives:

```
[INFO] --- maven-assembly-plugin:2.5.5:single (default) @ repository-s3 ---
[INFO] Reading assembly descriptor: /path/to/plugin-assembly.xml
[INFO] Building zip: /path/to/target/releases/repository-s3-3.0.0-SNAPSHOT.zip
[INFO] 
```

I marked it as 2.0 as well as I think it does not hurt. But we can port it only in 2.1.
