### PR TITLE
Refactor of GeoDistanceRangeQuery

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryBuilder.java
@@ -19,57 +19,76 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 
 public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistanceRangeQueryBuilder> {
 
     public static final String NAME = "geo_distance_range";
+    public static final boolean DEFAULT_INCLUDE_LOWER = true;
+    public static final boolean DEFAULT_INCLUDE_UPPER = true;
+    public static final GeoDistance DEFAULT_GEO_DISTANCE = GeoDistance.DEFAULT;
+    public static final DistanceUnit DEFAULT_UNIT = DistanceUnit.DEFAULT;
+    public static final String DEFAULT_OPTIMIZE_BBOX = "memory";
+    public static final boolean DEFAULT_COERCE = false;
+    public static final boolean DEFAULT_IGNORE_MALFORMED = false;
 
-    private final String name;
+    private final String fieldName;
 
     private Object from;
     private Object to;
-    private boolean includeLower = true;
-    private boolean includeUpper = true;
+    private boolean includeLower = DEFAULT_INCLUDE_LOWER;
+    private boolean includeUpper = DEFAULT_INCLUDE_UPPER;
 
-    private double lat;
+    private GeoPoint point;
 
-    private double lon;
+    private GeoDistance geoDistance = DEFAULT_GEO_DISTANCE;
 
-    private String geohash;
+    private DistanceUnit unit = DEFAULT_UNIT;
 
-    private GeoDistance geoDistance;
+    private String optimizeBbox = DEFAULT_OPTIMIZE_BBOX;
 
-    private String optimizeBbox;
+    private boolean coerce = DEFAULT_COERCE;
 
-    private Boolean coerce;
-
-    private Boolean ignoreMalformed;
+    private boolean ignoreMalformed = DEFAULT_IGNORE_MALFORMED;
 
     static final GeoDistanceRangeQueryBuilder PROTOTYPE = new GeoDistanceRangeQueryBuilder(null);
 
-    public GeoDistanceRangeQueryBuilder(String name) {
-        this.name = name;
+    public GeoDistanceRangeQueryBuilder(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String fieldName() {
+        return fieldName;
     }
 
     public GeoDistanceRangeQueryBuilder point(double lat, double lon) {
-        this.lat = lat;
-        this.lon = lon;
+        this.point = new GeoPoint(lat, lon);
         return this;
     }
 
-    public GeoDistanceRangeQueryBuilder lat(double lat) {
-        this.lat = lat;
+    public GeoDistanceRangeQueryBuilder point(GeoPoint point) {
+        this.point = point;
         return this;
     }
 
-    public GeoDistanceRangeQueryBuilder lon(double lon) {
-        this.lon = lon;
-        return this;
+    public GeoPoint point() {
+        return point;
     }
 
     public GeoDistanceRangeQueryBuilder from(Object from) {
@@ -77,9 +96,17 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
         return this;
     }
 
+    public Object from() {
+        return from;
+    }
+
     public GeoDistanceRangeQueryBuilder to(Object to) {
         this.to = to;
         return this;
+    }
+
+    public Object to() {
+        return to;
     }
 
     public GeoDistanceRangeQueryBuilder gt(Object from) {
@@ -111,13 +138,21 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
         return this;
     }
 
+    public boolean includeLower() {
+        return includeLower;
+    }
+
     public GeoDistanceRangeQueryBuilder includeUpper(boolean includeUpper) {
         this.includeUpper = includeUpper;
         return this;
     }
 
+    public boolean includeUpper() {
+        return includeUpper;
+    }
+
     public GeoDistanceRangeQueryBuilder geohash(String geohash) {
-        this.geohash = geohash;
+        this.point = new GeoPoint().resetFromGeoHash(geohash);
         return this;
     }
 
@@ -126,47 +161,231 @@ public class GeoDistanceRangeQueryBuilder extends AbstractQueryBuilder<GeoDistan
         return this;
     }
 
+    public GeoDistance geoDistance() {
+        return geoDistance;
+    }
+
+    public GeoDistanceRangeQueryBuilder unit(DistanceUnit unit) {
+        this.unit = unit;
+        return this;
+    }
+
+    public DistanceUnit unit() {
+        return unit;
+    }
+
     public GeoDistanceRangeQueryBuilder optimizeBbox(String optimizeBbox) {
         this.optimizeBbox = optimizeBbox;
         return this;
     }
 
+    public String optimizeBbox() {
+        return optimizeBbox;
+    }
+
     public GeoDistanceRangeQueryBuilder coerce(boolean coerce) {
+        if (coerce) {
+            this.ignoreMalformed = true;
+        }
         this.coerce = coerce;
         return this;
     }
 
+    public boolean coerce() {
+        return this.coerce;
+    }
+
     public GeoDistanceRangeQueryBuilder ignoreMalformed(boolean ignoreMalformed) {
-        this.ignoreMalformed = ignoreMalformed;
+        if (coerce == false) {
+            this.ignoreMalformed = ignoreMalformed;
+        }
         return this;
+    }
+
+    public boolean ignoreMalformed() {
+        return ignoreMalformed;
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        QueryValidationException errors = null;
+        if (fieldName == null) {
+            errors = QueryValidationException.addValidationError(NAME, "fieldName must not be null", errors);
+        }
+        if (point == null) {
+            errors = QueryValidationException.addValidationError(NAME, "point must not be null", errors);
+        }
+        if (from == null && to == null) {
+            errors = QueryValidationException.addValidationError(NAME, "Must define at least one parameter from [from, to]", errors);
+        }
+        if (from != null && !(from instanceof Number || from instanceof String)) {
+            errors = QueryValidationException.addValidationError(NAME, "from must either be a number or a string. Found ["
+                    + from.getClass().getName() + "]", errors);
+        }
+        if (to != null && !(to instanceof Number || to instanceof String)) {
+            errors = QueryValidationException.addValidationError(NAME, "to must either be a number or a string. Found ["
+                    + to.getClass().getName() + "]", errors);
+        }
+        if (optimizeBbox != null && !(optimizeBbox.equals("none") || optimizeBbox.equals("memory") || optimizeBbox.equals("indexed"))) {
+            errors = QueryValidationException.addValidationError(NAME, "optimizeBbox must be one of [none, memory, indexed]", errors);
+        }
+        return errors;
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+
+        final boolean indexCreatedBeforeV2_0 = context.indexVersionCreated().before(Version.V_2_0_0);
+        // validation was not available prior to 2.x, so to support bwc
+        // percolation queries we only ignore_malformed on 2.x created indexes
+        if (!indexCreatedBeforeV2_0 && !ignoreMalformed) {
+            if (point.lat() > 90.0 || point.lat() < -90.0) {
+                throw new QueryShardException(context, "illegal latitude value [{}] for [{}]", point.lat(), NAME);
+            }
+            if (point.lon() > 180.0 || point.lon() < -180) {
+                throw new QueryShardException(context, "illegal longitude value [{}] for [{}]", point.lon(), NAME);
+            }
+        }
+
+        if (coerce) {
+            GeoUtils.normalizePoint(point, coerce, coerce);
+        }
+
+        Double fromValue = null;
+        Double toValue = null;
+        if (from != null) {
+            if (from instanceof Number) {
+                fromValue = unit.toMeters(((Number) from).doubleValue());
+            } else {
+                fromValue = DistanceUnit.parse((String) from, unit, DistanceUnit.DEFAULT);
+            }
+            fromValue = geoDistance.normalize(fromValue, DistanceUnit.DEFAULT);
+        }
+        if (to != null) {
+            if (to instanceof Number) {
+                toValue = unit.toMeters(((Number) to).doubleValue());
+            } else {
+                toValue = DistanceUnit.parse((String) to, unit, DistanceUnit.DEFAULT);
+            }
+            toValue = geoDistance.normalize(toValue, DistanceUnit.DEFAULT);
+        }
+
+        MappedFieldType fieldType = context.fieldMapper(fieldName);
+        if (fieldType == null) {
+            throw new QueryShardException(context, "failed to find geo_point field [" + fieldName + "]");
+        }
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+            throw new QueryShardException(context, "field [" + fieldName + "] is not a geo_point field");
+        }
+        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+
+        IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
+        return new GeoDistanceRangeQuery(point, fromValue, toValue, includeLower, includeUpper, geoDistance, geoFieldType,
+                indexFieldData, optimizeBbox);
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
-        if (geohash != null) {
-            builder.field(name, geohash);
-        } else {
-            builder.startArray(name).value(lon).value(lat).endArray();
+        builder.startArray(fieldName).value(point.lon()).value(point.lat()).endArray();
+        builder.field(GeoDistanceRangeQueryParser.FROM_FIELD.getPreferredName(), from);
+        builder.field(GeoDistanceRangeQueryParser.TO_FIELD.getPreferredName(), to);
+        builder.field(GeoDistanceRangeQueryParser.INCLUDE_LOWER_FIELD.getPreferredName(), includeLower);
+        builder.field(GeoDistanceRangeQueryParser.INCLUDE_UPPER_FIELD.getPreferredName(), includeUpper);
+        if (unit != null) {
+            builder.field(GeoDistanceRangeQueryParser.UNIT_FIELD.getPreferredName(), unit);
         }
-        builder.field("from", from);
-        builder.field("to", to);
-        builder.field("include_lower", includeLower);
-        builder.field("include_upper", includeUpper);
         if (geoDistance != null) {
-            builder.field("distance_type", geoDistance.name().toLowerCase(Locale.ROOT));
+            builder.field(GeoDistanceRangeQueryParser.DISTANCE_TYPE_FIELD.getPreferredName(), geoDistance.name().toLowerCase(Locale.ROOT));
         }
         if (optimizeBbox != null) {
-            builder.field("optimize_bbox", optimizeBbox);
+            builder.field(GeoDistanceRangeQueryParser.OPTIMIZE_BBOX_FIELD.getPreferredName(), optimizeBbox);
         }
-        if (coerce != null) {
-            builder.field("coerce", coerce);
-        }
-        if (ignoreMalformed != null) {
-            builder.field("ignore_malformed", ignoreMalformed);
-        }
+        builder.field(GeoDistanceRangeQueryParser.COERCE_FIELD.getPreferredName(), coerce);
+        builder.field(GeoDistanceRangeQueryParser.IGNORE_MALFORMED_FIELD.getPreferredName(), ignoreMalformed);
         printBoostAndQueryName(builder);
         builder.endObject();
+    }
+
+    @Override
+    protected GeoDistanceRangeQueryBuilder doReadFrom(StreamInput in) throws IOException {
+        GeoDistanceRangeQueryBuilder queryBuilder = new GeoDistanceRangeQueryBuilder(in.readString());
+        double lat = in.readDouble();
+        double lon = in.readDouble();
+        queryBuilder.point = new GeoPoint(lat, lon);
+        queryBuilder.from = in.readGenericValue();
+        queryBuilder.to = in.readGenericValue();
+        queryBuilder.includeLower = in.readBoolean();
+        queryBuilder.includeUpper = in.readBoolean();
+        String unit = in.readOptionalString();
+        if (unit != null) {
+            queryBuilder.unit = DistanceUnit.valueOf(unit);
+        }
+        String geoDistance = in.readOptionalString();
+        if (geoDistance != null) {
+            queryBuilder.geoDistance = GeoDistance.fromString(geoDistance);
+        }
+        queryBuilder.optimizeBbox = in.readOptionalString();
+        queryBuilder.coerce = in.readBoolean();
+        queryBuilder.ignoreMalformed = in.readBoolean();
+        return queryBuilder;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeDouble(point.lat());
+        out.writeDouble(point.lon());
+        out.writeGenericValue(from);
+        out.writeGenericValue(to);
+        out.writeBoolean(includeLower);
+        out.writeBoolean(includeUpper);
+        out.writeOptionalString(unit.name());
+        out.writeOptionalString(geoDistance.name());
+        out.writeOptionalString(optimizeBbox);
+        out.writeBoolean(coerce);
+        out.writeBoolean(ignoreMalformed);
+    }
+
+    @Override
+    protected boolean doEquals(GeoDistanceRangeQueryBuilder other) {
+        if (!Objects.equals(fieldName, other.fieldName)) {
+            return false;
+        }
+        if (!Objects.equals(point, other.point)) {
+            return false;
+        }
+        if (!Objects.equals(from, other.from)) {
+            return false;
+        }
+        if (!Objects.equals(to, other.to)) {
+            return false;
+        }
+        if (!Objects.equals(includeUpper, other.includeUpper)) {
+            return false;
+        }
+        if (!Objects.equals(includeLower, other.includeLower)) {
+            return false;
+        }
+        if (!Objects.equals(geoDistance, other.geoDistance)) {
+            return false;
+        }
+        if (!Objects.equals(optimizeBbox, other.optimizeBbox)) {
+            return false;
+        }
+        if (!Objects.equals(coerce, other.coerce)) {
+            return false;
+        }
+        if (!Objects.equals(ignoreMalformed, other.ignoreMalformed)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(fieldName, point, from, to, includeUpper, includeLower, geoDistance, optimizeBbox, coerce,
+                ignoreMalformed);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class GeoDistanceRangeQueryTests extends BaseQueryTestCase<GeoDistanceRangeQueryBuilder> {
+
+    @Override
+    protected GeoDistanceRangeQueryBuilder doCreateTestQueryBuilder() {
+        GeoDistanceRangeQueryBuilder builder = new GeoDistanceRangeQueryBuilder(GEO_FIELD_NAME);
+        if (randomBoolean()) {
+            builder.geohash(randomGeohash(1, 12));
+        } else {
+            double lat = randomDouble() * 180 - 90;
+            double lon = randomDouble() * 360 - 180;
+            if (randomBoolean()) {
+                builder.point(lat, lon);
+            } else {
+                builder.point(new GeoPoint(lat, lon));
+            }
+        }
+        int fromValue = randomInt(1000000);
+        int toValue = randomIntBetween(fromValue, 1000000);
+        String fromToUnits = randomFrom(DistanceUnit.values()).toString();
+        if (randomBoolean()) {
+            int branch = randomInt(2);
+            switch (branch) {
+            case 0:
+                builder.from(fromValue);
+                break;
+            case 1:
+                builder.to(toValue);
+                break;
+            case 2:
+                builder.from(fromValue);
+                builder.to(toValue);
+                break;
+            }
+        } else {
+            int branch = randomInt(2);
+            switch (branch) {
+            case 0:
+                builder.from(fromValue + fromToUnits);
+                break;
+            case 1:
+                builder.to(toValue + fromToUnits);
+                break;
+            case 2:
+                builder.from(fromValue + fromToUnits);
+                builder.to(toValue + fromToUnits);
+                break;
+            }
+        }
+        if (randomBoolean()) {
+            builder.includeLower(randomBoolean());
+        }
+        if (randomBoolean()) {
+            builder.includeUpper(randomBoolean());
+        }
+        if (randomBoolean()) {
+            builder.geoDistance(randomFrom(GeoDistance.values()));
+        }
+        if (randomBoolean()) {
+            builder.unit(randomFrom(DistanceUnit.values()));
+        }
+        if (randomBoolean()) {
+            builder.optimizeBbox(randomFrom("none", "memory", "indexed"));
+        }
+        if (randomBoolean()) {
+            builder.coerce(randomBoolean());
+        }
+        if (randomBoolean()) {
+            builder.ignoreMalformed(randomBoolean());
+        }
+        return builder;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(GeoDistanceRangeQueryBuilder queryBuilder, Query query, QueryShardContext context)
+            throws IOException {
+        assertThat(query, instanceOf(GeoDistanceRangeQuery.class));
+        GeoDistanceRangeQuery geoQuery = (GeoDistanceRangeQuery) query;
+        assertThat(geoQuery.fieldName(), equalTo(queryBuilder.fieldName()));
+        if (queryBuilder.point() != null) {
+            assertThat(geoQuery.lat(), equalTo(queryBuilder.point().lat()));
+            assertThat(geoQuery.lat(), equalTo(queryBuilder.point().lat()));
+        }
+        assertThat(geoQuery.geoDistance(), equalTo(queryBuilder.geoDistance()));
+        if (queryBuilder.from() != null && queryBuilder.from() instanceof Number) {
+            double fromValue = ((Number) queryBuilder.from()).doubleValue();
+            if (queryBuilder.unit() != null) {
+                fromValue = queryBuilder.unit().toMeters(fromValue);
+            }
+            if (queryBuilder.geoDistance() != null) {
+                fromValue = queryBuilder.geoDistance().normalize(fromValue, DistanceUnit.DEFAULT);
+            }
+            assertThat(geoQuery.minInclusiveDistance(), closeTo(fromValue, Math.abs(fromValue) / 1000));
+        }
+        if (queryBuilder.to() != null && queryBuilder.to() instanceof Number) {
+            double toValue = ((Number) queryBuilder.to()).doubleValue();
+            if (queryBuilder.unit() != null) {
+                toValue = queryBuilder.unit().toMeters(toValue);
+            }
+            if (queryBuilder.geoDistance() != null) {
+                toValue = queryBuilder.geoDistance().normalize(toValue, DistanceUnit.DEFAULT);
+            }
+            assertThat(geoQuery.maxInclusiveDistance(), closeTo(toValue, Math.abs(toValue) / 1000));
+        }
+    }
+
+    @Test
+    public void testNullFieldName() {
+        GeoDistanceRangeQueryBuilder builder = new GeoDistanceRangeQueryBuilder(null);
+        builder.geohash(randomGeohash(1, 20));
+        builder.from(10);
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoDistanceRangeQueryBuilder.NAME + "] fieldName must not be null"));
+    }
+
+    @Test
+    public void testNoPoint() {
+        GeoDistanceRangeQueryBuilder builder = new GeoDistanceRangeQueryBuilder(GEO_FIELD_NAME);
+        builder.from(10);
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoDistanceRangeQueryBuilder.NAME + "] point must not be null"));
+    }
+
+    @Test
+    public void testNoFromOrTo() {
+        GeoDistanceRangeQueryBuilder builder = new GeoDistanceRangeQueryBuilder(GEO_FIELD_NAME);
+        String geohash = randomGeohash(1, 20);
+        builder.geohash(geohash);
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoDistanceRangeQueryBuilder.NAME
+                + "] Must define at least one parameter from [from, to]"));
+    }
+
+    @Test
+    public void testInvalidFrom() {
+        GeoDistanceRangeQueryBuilder builder = new GeoDistanceRangeQueryBuilder(GEO_FIELD_NAME);
+        String geohash = randomGeohash(1, 20);
+        builder.geohash(geohash);
+        builder.from(new DateTime());
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoDistanceRangeQueryBuilder.NAME
+                + "] from must either be a number or a string. Found [" + DateTime.class.getName() + "]"));
+    }
+
+    @Test
+    public void testInvalidTo() {
+        GeoDistanceRangeQueryBuilder builder = new GeoDistanceRangeQueryBuilder(GEO_FIELD_NAME);
+        String geohash = randomGeohash(1, 20);
+        builder.geohash(geohash);
+        builder.to(new DateTime());
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoDistanceRangeQueryBuilder.NAME
+                + "] to must either be a number or a string. Found [" + DateTime.class.getName() + "]"));
+    }
+
+    @Test
+    public void testInvalidOptimizeBBox() {
+        GeoDistanceRangeQueryBuilder builder = new GeoDistanceRangeQueryBuilder(GEO_FIELD_NAME);
+        String geohash = randomGeohash(1, 20);
+        builder.geohash(geohash);
+        builder.from(10);
+        builder.optimizeBbox("foo");
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoDistanceRangeQueryBuilder.NAME
+                + "] optimizeBbox must be one of [none, memory, indexed]"));
+    }
+
+    @Test
+    public void testMultipleValidationErrors() {
+        GeoDistanceRangeQueryBuilder builder = new GeoDistanceRangeQueryBuilder(GEO_FIELD_NAME);
+        double lat = randomDouble() * 360 - 180;
+        double lon = randomDouble() * 360 - 180;
+        builder.point(lat, lon);
+        builder.from(new DateTime());
+        builder.to(new DateTime());
+        builder.optimizeBbox("foo");
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(3));
+    }
+}


### PR DESCRIPTION
Moving the query building functionality from the parser to the builders
new toQuery() method analogous to other recent query refactorings.

This PR contains and AwaitsFix annotation on the toQuery() method because it requires https://github.com/elastic/elasticsearch/pull/13381 to be merged before this test can pass

Also this PR removes the check that the index is created before 2.0 for the normalize parameter. The parameter is now always parsed but as a deprecated parameter. We cannot and should not access the index version during parsing.

Relates to #10217

PR goes against the query-refactoring branch
