### PR TITLE
Fix service.bat start/stop issues

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -107,7 +107,7 @@ final class Bootstrap {
                 public boolean handle(int code) {
                     if (CTRL_CLOSE_EVENT == code) {
                         logger.info("running graceful exit on windows");
-                        Bootstrap.INSTANCE.stop();
+                        Bootstrap.stop();
                         return true;
                     }
                     return false;
@@ -205,11 +205,11 @@ final class Bootstrap {
         keepAliveThread.start();
     }
 
-    private void stop() {
+    static void stop() {
         try {
-            Releasables.close(node);
+            Releasables.close(INSTANCE.node);
         } finally {
-            keepAliveLatch.countDown();
+            INSTANCE.keepAliveLatch.countDown();
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -39,4 +39,16 @@ public final class Elasticsearch {
             throw new StartupError(t);
         }
     }
+
+    /**
+     * Required method that's called by Apache Commons procrun when
+     * running as a service on Windows, when the service is stopped.
+     *
+     * http://commons.apache.org/proper/commons-daemon/procrun.html
+     *
+     * NOTE: If this method is renamed and/or moved, make sure to update service.bat!
+     */
+    static void close(String[] args) {
+        Bootstrap.stop();
+    }
 }

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -59,7 +59,7 @@ set ES_GC_OPTS=%ES_GC_OPTS% -XX:+UseCMSInitiatingOccupancyOnly
 REM When running under Java 7
 REM JAVA_OPTS=%JAVA_OPTS% -XX:+UseCondCardMark
 )
-set JAVA_OPTS=%JAVA_OPTS% %ES_GC_OPTS%
+set JAVA_OPTS=%JAVA_OPTS%%ES_GC_OPTS%
 
 if "%ES_GC_LOG_FILE%" == "" goto nogclog
 

--- a/distribution/src/main/resources/bin/service.bat
+++ b/distribution/src/main/resources/bin/service.bat
@@ -159,7 +159,7 @@ if not "%ES_JAVA_OPTS%" == "" set JVM_OPTS=%JVM_OPTS%;%JVM_ES_JAVA_OPTS%
 if "%ES_START_TYPE%" == "" set ES_START_TYPE=manual
 if "%ES_STOP_TIMEOUT%" == "" set ES_STOP_TIMEOUT=0
 
-"%EXECUTABLE%" //IS//%SERVICE_ID% --Startup %ES_START_TYPE% --StopTimeout %ES_STOP_TIMEOUT% --StartClass org.elasticsearch.bootstrap.Elasticsearch --StopClass org.elasticsearch.bootstrap.Elasticsearch --StartMethod main --StopMethod close --Classpath "%ES_CLASSPATH%" --JvmSs %JVM_SS% --JvmMs %JVM_XMS% --JvmMx %JVM_XMX% --JvmOptions %JVM_OPTS% ++JvmOptions %ES_PARAMS% %LOG_OPTS% --PidFile "%SERVICE_ID%.pid" --DisplayName "Elasticsearch %ES_VERSION% (%SERVICE_ID%)" --Description "Elasticsearch %ES_VERSION% Windows Service - http://elasticsearch.org" --Jvm "%JVM_DLL%" --StartMode jvm --StopMode jvm --StartPath "%ES_HOME%"
+"%EXECUTABLE%" //IS//%SERVICE_ID% --Startup %ES_START_TYPE% --StopTimeout %ES_STOP_TIMEOUT% --StartClass org.elasticsearch.bootstrap.Elasticsearch --StopClass org.elasticsearch.bootstrap.Elasticsearch --StartMethod main --StopMethod close --Classpath "%ES_CLASSPATH%" --JvmSs %JVM_SS% --JvmMs %JVM_XMS% --JvmMx %JVM_XMX% --JvmOptions %JVM_OPTS% ++JvmOptions %ES_PARAMS% %LOG_OPTS% --PidFile "%SERVICE_ID%.pid" --DisplayName "Elasticsearch %ES_VERSION% (%SERVICE_ID%)" --Description "Elasticsearch %ES_VERSION% Windows Service - http://elasticsearch.org" --Jvm "%JVM_DLL%" --StartMode jvm --StopMode jvm --StartPath "%ES_HOME%" ++StartParams start
 
 
 if not errorlevel 1 goto installed


### PR DESCRIPTION
This PR addresses a few issues with the service.bat script:

1) Fixes a bug in the concatenation of java options in elasticsearch.in.bat which tripped up Apache Commons Daemon, and caused ES to startup without any params, eventually leading to the "path.home is not configured" exception.

2) service.bat was not passing the `start` argument to ES

3) The service could not be stopped gracefully via the `stop` command because there wasn't a method for procrun to call (`--StopMethod`): http://commons.apache.org/proper/commons-daemon/procrun.html

Closes #13247
Closes #13401
