### PR TITLE
Enable security manager by default in tests (e.g. IDEs)

### DIFF
--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -80,7 +80,7 @@ public class BootstrapForTesting {
         }
 
         // install security manager if requested
-        if (systemPropertyAsBoolean("tests.security.manager", false)) {
+        if (systemPropertyAsBoolean("tests.security.manager", true)) {
             try {
                 Security.setCodebaseProperties();
                 // initialize paths the same exact way as bootstrap.


### PR DESCRIPTION
Otherwise people will be confused when they use maven.
