### PR TITLE
Fix compiler warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,6 +15,10 @@
     <name>Elasticsearch: Core</name>
     <description>Elasticsearch - Open Source, Distributed, RESTful Search Engine</description>
 
+    <properties>
+        <xlint.options>-Xlint:-cast,-deprecation,-fallthrough,-overrides,-rawtypes,-serial,-try,-unchecked</xlint.options>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -36,6 +36,8 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Arrays;
+
 /**
  * Close index action
  */
@@ -92,7 +94,7 @@ public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIn
 
             @Override
             public void onFailure(Throwable t) {
-                logger.debug("failed to close indices [{}]", t, concreteIndices);
+                logger.debug("failed to close indices [{}]", t, (Object)concreteIndices);
                 listener.onFailure(t);
             }
         });

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -36,6 +36,8 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Arrays;
+
 /**
  * Open index action
  */
@@ -92,7 +94,7 @@ public class TransportOpenIndexAction extends TransportMasterNodeAction<OpenInde
 
             @Override
             public void onFailure(Throwable t) {
-                logger.debug("failed to open indices [{}]", t, concreteIndices);
+                logger.debug("failed to open indices [{}]", t, (Object)concreteIndices);
                 listener.onFailure(t);
             }
         });

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -35,6 +35,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Arrays;
+
 /**
  *
  */
@@ -90,7 +92,7 @@ public class TransportUpdateSettingsAction extends TransportMasterNodeAction<Upd
 
             @Override
             public void onFailure(Throwable t) {
-                logger.debug("failed to update settings on indices [{}]", t, concreteIndices);
+                logger.debug("failed to update settings on indices [{}]", t, (Object)concreteIndices);
                 listener.onFailure(t);
             }
         });

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -668,6 +668,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
             return result;
         }
 
+        @SuppressWarnings("fallthrough")
         String resolveExpression(String expression, final Context context) {
             if (expression.startsWith(EXPRESSION_LEFT_BOUND) == false || expression.endsWith(EXPRESSION_RIGHT_BOUND) == false) {
                 return expression;

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/TypeEncounter.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/TypeEncounter.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.inject.TypeLiteral;
  * @param <I> the injectable type encountered
  * @since 2.0
  */
+@SuppressWarnings("overloads")
 public interface TypeEncounter<I> {
 
     /**

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -71,7 +71,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         public NodePath(Path path, Environment environment) throws IOException {
             this.path = path;
             this.indicesPath = path.resolve(INDICES_FOLDER);
-            this.fileStore = environment.getFileStore(path);
+            this.fileStore = Environment.getFileStore(path);
             if (fileStore.supportsFileAttributeView("lucene")) {
                 this.spins = (Boolean) fileStore.getAttribute("lucene:spins");
             } else {

--- a/core/src/main/java/org/elasticsearch/gateway/Gateway.java
+++ b/core/src/main/java/org/elasticsearch/gateway/Gateway.java
@@ -34,6 +34,7 @@ import org.elasticsearch.env.NodeEnvironment;
 
 
 import java.nio.file.Path;
+import java.util.Arrays;
 
 /**
  *
@@ -166,7 +167,7 @@ public class Gateway extends AbstractComponent implements ClusterStateListener {
     public void reset() throws Exception {
         try {
             Path[] dataPaths = nodeEnv.nodeDataPaths();
-            logger.trace("removing node data paths: [{}]", dataPaths);
+            logger.trace("removing node data paths: [{}]", (Object)dataPaths);
             IOUtils.rm(dataPaths);
         } catch (Exception ex) {
             logger.debug("failed to delete shard locations", ex);

--- a/core/src/main/java/org/elasticsearch/index/fieldvisitor/SingleFieldsVisitor.java
+++ b/core/src/main/java/org/elasticsearch/index/fieldvisitor/SingleFieldsVisitor.java
@@ -59,6 +59,7 @@ public class SingleFieldsVisitor extends FieldsVisitor {
 
     public void postProcess(MappedFieldType fieldType) {
         if (uid != null) {
+            // TODO: this switch seems very wrong...either each case should be breaking, or this should not be a switch
             switch (field) {
                 case UidFieldMapper.NAME: addValue(field, uid.toString());
                 case IdFieldMapper.NAME: addValue(field, uid.id());

--- a/core/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndicesQueryParser.java
@@ -77,10 +77,10 @@ public class IndicesQueryParser implements QueryParser {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (parseContext.parseFieldMatcher().match(currentFieldName, QUERY_FIELD)) {
-                    innerQuery = new XContentStructure.InnerQuery(parseContext, null);
+                    innerQuery = new XContentStructure.InnerQuery(parseContext, (String[])null);
                     queryFound = true;
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, NO_MATCH_QUERY)) {
-                    innerNoMatchQuery = new XContentStructure.InnerQuery(parseContext, null);
+                    innerNoMatchQuery = new XContentStructure.InnerQuery(parseContext, (String[])null);
                 } else {
                     throw new QueryParsingException(parseContext, "[indices] query does not support [" + currentFieldName + "]");
                 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParserMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParserMapper.java
@@ -59,7 +59,7 @@ public class ScoreFunctionParserMapper {
     public ScoreFunctionParser get(QueryParseContext parseContext, String parserName) {
         ScoreFunctionParser functionParser = get(parserName);
         if (functionParser == null) {
-            throw new QueryParsingException(parseContext, "No function with the name [" + parserName + "] is registered.", null);
+            throw new QueryParsingException(parseContext, "No function with the name [" + parserName + "] is registered.");
         }
         return functionParser;
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/percentile/PercentilesBucketBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/percentile/PercentilesBucketBuilder.java
@@ -40,7 +40,7 @@ public class PercentilesBucketBuilder extends BucketMetricsBuilder<PercentilesBu
     @Override
     protected void doInternalXContent(XContentBuilder builder, Params params) throws IOException {
         if (percents != null) {
-            builder.field(PercentilesBucketParser.PERCENTS.getPreferredName(), percents);
+            builder.field(PercentilesBucketParser.PERCENTS.getPreferredName(), (Object[])percents);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -227,6 +227,7 @@ public class QueryPhase implements SearchPhase {
                                     // set the last emitted doc
                                     scrollContext.lastEmittedDoc = topDocs.scoreDocs[topDocs.scoreDocs.length - 1];
                                 }
+                                break;
                             default:
                                 break;
                             }

--- a/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -442,7 +442,7 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
             for (int i = 0; i < hostAddresses.length; i++) {
                 addresses[i] = NetworkAddress.format(hostAddresses[i]);
             }
-            logger.debug("binding server bootstrap to: {}", addresses);
+            logger.debug("binding server bootstrap to: {}", (Object)addresses);
         }
         for (InetAddress hostAddress : hostAddresses) {
             bindServerBootstrap(name, hostAddress, settings);

--- a/core/src/test/java/org/elasticsearch/bwcompat/BasicAnalysisBackwardCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/BasicAnalysisBackwardCompatibilityIT.java
@@ -60,7 +60,7 @@ public class BasicAnalysisBackwardCompatibilityIT extends ESBackcompatTestCase {
             fields[i] = "type=string,analyzer=" + analyzer;
         }
         assertAcked(prepareCreate("test")
-                .addMapping("type", fields)
+                .addMapping("type", (Object[])fields)
                 .setSettings(indexSettings()));
         ensureYellow();
         InputOutput[] inout = new InputOutput[numFields];

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -114,14 +114,14 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         String[] results = indexNameExpressionResolver.concreteIndices(context, Strings.EMPTY_ARRAY);
         assertEquals(3, results.length);
 
-        results = indexNameExpressionResolver.concreteIndices(context, null);
+        results = indexNameExpressionResolver.concreteIndices(context, (String[])null);
         assertEquals(3, results.length);
 
         context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpand());
         results = indexNameExpressionResolver.concreteIndices(context, Strings.EMPTY_ARRAY);
         assertEquals(4, results.length);
 
-        results = indexNameExpressionResolver.concreteIndices(context, null);
+        results = indexNameExpressionResolver.concreteIndices(context, (String[])null);
         assertEquals(4, results.length);
 
         context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpandOpen());
@@ -348,7 +348,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             assertEquals(2, results.length);
             assertThat(results, arrayContainingInAnyOrder("foo", "foobar"));
 
-            results = indexNameExpressionResolver.concreteIndices(context, null);
+            results = indexNameExpressionResolver.concreteIndices(context, (String[])null);
             assertEquals(0, results.length);
 
             results = indexNameExpressionResolver.concreteIndices(context, Strings.EMPTY_ARRAY);

--- a/core/src/test/java/org/elasticsearch/common/util/MultiDataPathUpgraderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/MultiDataPathUpgraderTests.java
@@ -179,7 +179,7 @@ public class MultiDataPathUpgraderTests extends ESTestCase {
             OldIndexBackwardsCompatibilityIT.copyIndex(logger, src, indexName, multiDataPath);
             final ShardPath shardPath = new ShardPath(false, nodeEnvironment.availableShardPaths(new ShardId(indexName, 0))[0], nodeEnvironment.availableShardPaths(new ShardId(indexName, 0))[0], IndexMetaData.INDEX_UUID_NA_VALUE, new ShardId(indexName, 0));
 
-            logger.info("{}", FileSystemUtils.files(shardPath.resolveIndex()));
+            logger.info("{}", (Object)FileSystemUtils.files(shardPath.resolveIndex()));
 
             MultiDataPathUpgrader helper = new MultiDataPathUpgrader(nodeEnvironment);
             helper.upgrade(new ShardId(indexName, 0), shardPath);

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -148,7 +148,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         ensureGreen();
         NodeEnvironment env = getInstanceFromNode(NodeEnvironment.class);
         Path[] shardPaths = env.availableShardPaths(new ShardId("test", 0));
-        logger.info("--> paths: [{}]", shardPaths);
+        logger.info("--> paths: [{}]", (Object)shardPaths);
         // Should not be able to acquire the lock because it's already open
         try {
             NodeEnvironment.acquireFSLockForPaths(Settings.EMPTY, shardPaths);

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -390,7 +390,7 @@ public class TranslogTests extends ESTestCase {
     }
 
     public void testSnapshotOnClosedTranslog() throws IOException {
-        assertTrue(Files.exists(translogDir.resolve(translog.getFilename(1))));
+        assertTrue(Files.exists(translogDir.resolve(Translog.getFilename(1))));
         translog.add(new Translog.Create("test", "1", new byte[]{1}));
         translog.close();
         try {
@@ -436,14 +436,14 @@ public class TranslogTests extends ESTestCase {
 
 
     public void assertFileIsPresent(Translog translog, long id) {
-        if (Files.exists(translogDir.resolve(translog.getFilename(id)))) {
+        if (Files.exists(translogDir.resolve(Translog.getFilename(id)))) {
             return;
         }
-        fail(translog.getFilename(id) + " is not present in any location: " + translog.location());
+        fail(Translog.getFilename(id) + " is not present in any location: " + translog.location());
     }
 
     public void assertFileDeleted(Translog translog, long id) {
-        assertFalse("translog [" + id + "] still exists", Files.exists(translog.location().resolve(translog.getFilename(id))));
+        assertFalse("translog [" + id + "] still exists", Files.exists(translog.location().resolve(Translog.getFilename(id))));
     }
 
     static class LocationOperation {
@@ -913,7 +913,7 @@ public class TranslogTests extends ESTestCase {
         final Translog.Location lastLocation = translog.add(new Translog.Create("test", "" + translogOperations, Integer.toString(translogOperations).getBytes(Charset.forName("UTF-8"))));
 
         final Checkpoint checkpoint = Checkpoint.read(translog.location().resolve(Translog.CHECKPOINT_FILE_NAME));
-        try (final ImmutableTranslogReader reader = translog.openReader(translog.location().resolve(translog.getFilename(translog.currentFileGeneration())), checkpoint)) {
+        try (final ImmutableTranslogReader reader = translog.openReader(translog.location().resolve(Translog.getFilename(translog.currentFileGeneration())), checkpoint)) {
             assertEquals(lastSynced + 1, reader.totalOperations());
             for (int op = 0; op < translogOperations; op++) {
                 Translog.Location location = locations.get(op);

--- a/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -196,7 +196,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     @Test(expected = ActionRequestValidationException.class)
     public void testCloseNullIndex() {
         Client client = client();
-        client.admin().indices().prepareClose(null).execute().actionGet();
+        client.admin().indices().prepareClose((String[])null).execute().actionGet();
     }
 
     @Test(expected = ActionRequestValidationException.class)
@@ -208,7 +208,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     @Test(expected = ActionRequestValidationException.class)
     public void testOpenNullIndex() {
         Client client = client();
-        client.admin().indices().prepareOpen(null).execute().actionGet();
+        client.admin().indices().prepareOpen((String[])null).execute().actionGet();
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -263,7 +263,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
     @Test
     public void testThatInvalidGetIndexTemplatesFails() throws Exception {
         logger.info("--> get template null");
-        testExpectActionRequestValidationException(null);
+        testExpectActionRequestValidationException((String[])null);
 
         logger.info("--> get template empty");
         testExpectActionRequestValidationException("");

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
@@ -306,9 +306,9 @@ public class MinDocCountIT extends AbstractTermsTestCase {
                     testMinDocCountOnTerms(field, script, order, include, false);
                 } catch (Throwable secondFailure) {
                     logger.error("exception on retry (will re-throw the original in a sec)", secondFailure);
-                } finally {
-                    throw ae;
                 }
+                throw ae;
+
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
@@ -308,7 +308,6 @@ public class MinDocCountIT extends AbstractTermsTestCase {
                     logger.error("exception on retry (will re-throw the original in a sec)", secondFailure);
                 }
                 throw ae;
-
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -1365,7 +1365,8 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1l);
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
 
-        searchResponse = client().prepareSearch().setQuery(constantScoreQuery(idsQuery(null).ids("1"))).get();
+        // TODO: why do we even support passing null??
+        searchResponse = client().prepareSearch().setQuery(constantScoreQuery(idsQuery((String[])null).ids("1"))).get();
         assertHitCount(searchResponse, 1l);
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
 
@@ -1403,7 +1404,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 1l);
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
 
-        searchResponse = client().prepareSearch().setQuery(idsQuery(null).ids("1")).get();
+        searchResponse = client().prepareSearch().setQuery(idsQuery((String[])null).ids("1")).get();
         assertHitCount(searchResponse, 1l);
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
 

--- a/core/src/test/java/org/elasticsearch/search/suggest/ContextSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/ContextSuggestSearchIT.java
@@ -170,7 +170,7 @@ public class ContextSuggestSearchIT extends ESIntegTestCase {
                 .startObject("context")
                 .startObject("location")
                 .field("type", "geo")
-                .array("precision", precisions.toArray(new Integer[precisions.size()]))
+                .array("precision", (Object[])precisions.toArray(new Integer[precisions.size()]))
                 .endObject()
                 .endObject().endObject()
                 .endObject().endObject();
@@ -185,7 +185,7 @@ public class ContextSuggestSearchIT extends ESIntegTestCase {
                 .startObject("context")
                 .startObject("location")
                 .field("type", "geo")
-                .array("precision", precisions.toArray(new Integer[precisions.size()]))
+                .array("precision", (Object[])precisions.toArray(new Integer[precisions.size()]))
                 .endObject()
                 .endObject().endObject()
                 .endObject().endObject();

--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1713,7 +1713,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     /** Helper method to create list of plugins without specifying generic types. */
-    protected static Collection<Class<? extends Plugin>> pluginList(Class<? extends Plugin>... plugins) {
+    @SafeVarargs
+    @SuppressWarnings("varargs") // due to type erasure, the varargs type is non-reifiable, which casues this warning
+    protected final Collection<Class<? extends Plugin>> pluginList(Class<? extends Plugin>... plugins) {
         return Arrays.asList(plugins);
     }
 

--- a/plugins/analysis-icu/pom.xml
+++ b/plugins/analysis-icu/pom.xml
@@ -18,6 +18,7 @@
         <elasticsearch.plugin.classname>org.elasticsearch.plugin.analysis.icu.AnalysisICUPlugin</elasticsearch.plugin.classname>
         <tests.rest.suite>analysis_icu</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <xlint.options>-Xlint:-deprecation</xlint.options>
     </properties>
 
     <dependencies>

--- a/plugins/analysis-phonetic/pom.xml
+++ b/plugins/analysis-phonetic/pom.xml
@@ -18,6 +18,7 @@
        <elasticsearch.plugin.classname>org.elasticsearch.plugin.analysis.AnalysisPhoneticPlugin</elasticsearch.plugin.classname>
        <tests.rest.suite>analysis_phonetic</tests.rest.suite>
        <tests.rest.load_packaged>false</tests.rest.load_packaged>
+       <xlint.options>-Xlint:-rawtypes,-unchecked</xlint.options>
     </properties>
 
     <dependencies>

--- a/plugins/cloud-azure/pom.xml
+++ b/plugins/cloud-azure/pom.xml
@@ -30,6 +30,8 @@ governing permissions and limitations under the License. -->
         <tests.jvms>1</tests.jvms>
         <tests.rest.suite>cloud_azure</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <!-- need -path because there is no resources dir... -->
+        <xlint.options>-Xlint:-path,-serial,-static,-unchecked</xlint.options>
     </properties>
 
     <dependencies>

--- a/plugins/cloud-gce/pom.xml
+++ b/plugins/cloud-gce/pom.xml
@@ -31,6 +31,7 @@ governing permissions and limitations under the License. -->
         <!-- currently has no unit tests -->
         <tests.rest.suite>cloud_gce</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <xlint.options>-Xlint:-rawtypes,-unchecked</xlint.options>
     </properties>
 
     <dependencies>

--- a/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
+++ b/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
@@ -113,7 +113,7 @@ public class DeleteByQueryRequest extends ActionRequest<DeleteByQueryRequest> im
     }
 
     @Override
-    public DeleteByQueryRequest indices(String... indices) {
+    public DeleteByQueryRequest indices(String[] indices) {
         this.indices = indices;
         return this;
     }
@@ -149,7 +149,7 @@ public class DeleteByQueryRequest extends ActionRequest<DeleteByQueryRequest> im
         return this;
     }
 
-    public DeleteByQueryRequest source(Map querySource) {
+    public DeleteByQueryRequest source(Map<String,?> querySource) {
         try {
             XContentBuilder builder = XContentFactory.contentBuilder(Requests.CONTENT_TYPE);
             builder.map(querySource);

--- a/plugins/delete-by-query/src/test/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryActionTests.java
+++ b/plugins/delete-by-query/src/test/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryActionTests.java
@@ -48,7 +48,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
 
     @Test
     public void testExecuteScanFailsOnMissingIndex() {
-        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices("none");
+        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices(new String[]{"none"});
         TestActionListener listener = new TestActionListener();
 
         newAsyncAction(delete, listener).executeScan();
@@ -62,7 +62,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
     public void testExecuteScanFailsOnMalformedQuery() {
         createIndex("test");
 
-        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices("test").source("{...}");
+        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices(new String[]{"test"}).source("{...}");
         TestActionListener listener = new TestActionListener();
 
         newAsyncAction(delete, listener).executeScan();
@@ -83,7 +83,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
         assertHitCount(client().prepareCount("test").get(), numDocs);
 
         final long limit = randomIntBetween(0, numDocs);
-        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices("test").source(boolQuery().must(rangeQuery("num").lte(limit)).buildAsBytes());
+        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices(new String[]{"test"}).source(boolQuery().must(rangeQuery("num").lte(limit)).buildAsBytes());
         TestActionListener listener = new TestActionListener();
 
         newAsyncAction(delete, listener).executeScan();
@@ -139,7 +139,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
         ClearScrollResponse clearScrollResponse = client().prepareClearScroll().addScrollId(scrollId).get();
         assertTrue(clearScrollResponse.isSucceeded());
 
-        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices("test");
+        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices(new String[]{"test"});
         TestActionListener listener = new TestActionListener();
 
         newAsyncAction(delete, listener).executeScroll(searchResponse.getScrollId());
@@ -160,7 +160,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
         String scrollId = searchResponse.getScrollId();
         assertTrue(Strings.hasText(scrollId));
 
-        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices("test").timeout(TimeValue.timeValueSeconds(1));
+        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices(new String[]{"test"}).timeout(TimeValue.timeValueSeconds(1));
         TestActionListener listener = new TestActionListener();
 
         final TransportDeleteByQueryAction.AsyncDeleteByQueryAction async = newAsyncAction(delete, listener);
@@ -183,7 +183,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
         String scrollId = searchResponse.getScrollId();
         assertTrue(Strings.hasText(scrollId));
 
-        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices("test");
+        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices(new String[]{"test"});
         TestActionListener listener = new TestActionListener();
 
         newAsyncAction(delete, listener).executeScroll(searchResponse.getScrollId());
@@ -219,7 +219,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
         assertTrue(Strings.hasText(scrollId));
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(limit));
 
-        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices("test").size(100).source(boolQuery().must(rangeQuery("num").lte(limit)).buildAsBytes());
+        DeleteByQueryRequest delete = new DeleteByQueryRequest().indices(new String[]{"test"}).size(100).source(boolQuery().must(rangeQuery("num").lte(limit)).buildAsBytes());
         TestActionListener listener = new TestActionListener();
 
         newAsyncAction(delete, listener).executeScroll(searchResponse.getScrollId());

--- a/plugins/discovery-ec2/pom.xml
+++ b/plugins/discovery-ec2/pom.xml
@@ -20,6 +20,7 @@
         <tests.jvms>1</tests.jvms>
         <tests.rest.suite>discovery_ec2</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <xlint.options>-Xlint:-rawtypes</xlint.options>
     </properties>
 
     <dependencies>

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
@@ -79,7 +79,7 @@ public class AwsEc2UnicastHostsProvider extends AbstractComponent implements Uni
 
         this.tags = settings.getByPrefix("discovery.ec2.tag.").getAsMap();
 
-        Set<String> availabilityZones = new HashSet();
+        Set<String> availabilityZones = new HashSet<>();
         availabilityZones.addAll(Arrays.asList(settings.getAsArray("discovery.ec2.availability_zones")));
         if (settings.get("discovery.ec2.availability_zones") != null) {
             availabilityZones.addAll(Strings.commaDelimitedListToSet(settings.get("discovery.ec2.availability_zones")));

--- a/plugins/jvm-example/pom.xml
+++ b/plugins/jvm-example/pom.xml
@@ -19,6 +19,7 @@
         <tests.rest.suite>jvm_example</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
         <skip.unit.tests>true</skip.unit.tests>
+        <xlint.options>-Xlint:-rawtypes</xlint.options>
     </properties>
 
     <build>

--- a/plugins/lang-javascript/pom.xml
+++ b/plugins/lang-javascript/pom.xml
@@ -18,6 +18,7 @@
         <elasticsearch.plugin.classname>org.elasticsearch.plugin.javascript.JavaScriptPlugin</elasticsearch.plugin.classname>
         <tests.rest.suite>lang_javascript</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <xlint.options>-Xlint:-rawtypes,-unchecked</xlint.options>
     </properties>
 
     <dependencies>

--- a/plugins/lang-python/pom.xml
+++ b/plugins/lang-python/pom.xml
@@ -18,6 +18,7 @@
         <elasticsearch.plugin.classname>org.elasticsearch.plugin.python.PythonPlugin</elasticsearch.plugin.classname>
         <tests.rest.suite>lang_python</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <xlint.options>-Xlint:-unchecked</xlint.options>
     </properties>
 
     <dependencies>

--- a/plugins/mapper-murmur3/pom.xml
+++ b/plugins/mapper-murmur3/pom.xml
@@ -29,6 +29,7 @@ governing permissions and limitations under the License. -->
         <elasticsearch.plugin.classname>org.elasticsearch.plugin.mapper.MapperMurmur3Plugin</elasticsearch.plugin.classname>
         <tests.rest.suite>mapper_murmur3</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <xlint.options>-Xlint:-rawtypes</xlint.options>
     </properties>
 
     <build>

--- a/plugins/repository-s3/pom.xml
+++ b/plugins/repository-s3/pom.xml
@@ -20,6 +20,7 @@
         <tests.jvms>1</tests.jvms>
         <tests.rest.suite>repository_s3</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <xlint.options>-Xlint:-rawtypes</xlint.options>
     </properties>
 
     <dependencies>

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
@@ -38,7 +38,7 @@ public class TestAwsS3Service extends InternalAwsS3Service {
             return "plugs in mock s3 service";
         }
         public void onModule(S3Module s3Module) {
-            s3Module.s3ServiceImpl = TestAwsS3Service.class;
+            S3Module.s3ServiceImpl = TestAwsS3Service.class;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <jvm.executable>${java.home}${file.separator}bin${file.separator}java</jvm.executable>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Path warnings must be ignored because maven doesnt create the classes output
+             dir when no source files exist (eg for distribution or qa modules) -->
+        <xlint.options>-Xlint:-path</xlint.options>
 
         <!-- libraries -->
         <lucene.version>5.4.0</lucene.version>
@@ -578,14 +581,7 @@
                         <compilerArgs>
                             <arg>-XDignore.symbol.file</arg>
                             <arg>-Xlint:all</arg>
-                            <arg>-Xlint:-cast</arg>
-                            <arg>-Xlint:-deprecation</arg>
-                            <arg>-Xlint:-fallthrough</arg>
-                            <arg>-Xlint:-overrides</arg>
-                            <arg>-Xlint:-rawtypes</arg>
-                            <arg>-Xlint:-serial</arg>
-                            <arg>-Xlint:-try</arg>
-                            <arg>-Xlint:-unchecked</arg>
+                            <arg>${xlint.options}</arg>
                             <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,7 @@
                         <useIncrementalCompilation>false</useIncrementalCompilation>
                         <compilerArgs>
                             <arg>-XDignore.symbol.file</arg>
+                            <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -574,8 +574,18 @@
                              be fixed in version > 3.1
                          -->
                         <useIncrementalCompilation>false</useIncrementalCompilation>
+                        <showWarnings>true</showWarnings>
                         <compilerArgs>
                             <arg>-XDignore.symbol.file</arg>
+                            <arg>-Xlint:all</arg>
+                            <arg>-Xlint:-cast</arg>
+                            <arg>-Xlint:-deprecation</arg>
+                            <arg>-Xlint:-fallthrough</arg>
+                            <arg>-Xlint:-overrides</arg>
+                            <arg>-Xlint:-rawtypes</arg>
+                            <arg>-Xlint:-serial</arg>
+                            <arg>-Xlint:-try</arg>
+                            <arg>-Xlint:-unchecked</arg>
                             <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>


### PR DESCRIPTION
We have a handful of compiler warnings, mostly because of passing an
array to varargs methods. This change fixes these warnings and adds
-Werror so we don't get anymore of these warnings.

Note this does _not_ enable deprecation or unchecked type warnings, so
these remain "hidden". We should work towards removing those as well,
but this is a first step.
