### PR TITLE
Packaging tests use Java 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,25 +34,23 @@ Vagrant.configure(2) do |config|
     config.vm.box = "ubuntu/vivid64"
     ubuntu_common config
   end
-  config.vm.define "wheezy" do |config|
-    config.vm.box = "debian/wheezy64"
-    deb_common(config)
-  end
+  # Wheezy's backports don't contain Openjdk 8 and the backflips required to
+  # get the sun jdk on there just aren't worth it. We have jessie for testing
+  # debian and it works fine.
   config.vm.define "jessie" do |config|
     config.vm.box = "debian/jessie64"
-    deb_common(config)
+    deb_common config,
+      'echo deb http://http.debian.net/debian jessie-backports main > /etc/apt/sources.list.d/backports.list', 'backports'
   end
   config.vm.define "centos-6" do |config|
-    # TODO switch from chef to boxcutter to provide?
-    config.vm.box = "chef/centos-6.6"
-    rpm_common(config)
+    config.vm.box = "boxcutter/centos67"
+    rpm_common config
   end
   config.vm.define "centos-7" do |config|
     # There is a centos/7 box but it doesn't have rsync or virtualbox guest
     # stuff on there so its slow to use. So chef it is....
-    # TODO switch from chef to boxcutter to provide?
-    config.vm.box = "chef/centos-7.0"
-    rpm_common(config)
+    config.vm.box = "boxcutter/centos71"
+    rpm_common config
   end
   # This box hangs _forever_ on ```yum check-update```. I have no idea why.
   # config.vm.define "oel-6", autostart: false do |config|
@@ -61,14 +59,14 @@ Vagrant.configure(2) do |config|
   # end
   config.vm.define "oel-7" do |config|
     config.vm.box = "boxcutter/oel70"
-    rpm_common(config)
+    rpm_common config
   end
   config.vm.define "fedora-22" do |config|
     # Fedora hosts their own 'cloud' images that aren't in Vagrant's Atlas but
     # and are missing required stuff like rsync. It'd be nice if we could use
     # them but they much slower to get up and running then the boxcutter image.
     config.vm.box = "boxcutter/fedora22"
-    dnf_common(config)
+    dnf_common config
   end
   # Switch the default share for the project root from /vagrant to
   # /elasticsearch because /vagrant is confusing when there is a project inside
@@ -105,28 +103,46 @@ SOURCE_PROMPT
 end
 
 def ubuntu_common(config)
-  # Ubuntu is noisy
+  deb_common config, 'apt-add-repository -y ppa:openjdk-r/ppa > /dev/null 2>&1', 'openjdk-r-*'
+end
+
+def deb_common(config, add_openjdk_repository_command, openjdk_list)
   # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
   config.vm.provision "fix-no-tty", type: "shell" do |s|
       s.privileged = false
       s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
   end
-  deb_common(config)
-end
-
-def deb_common(config)
-  provision(config, "apt-get update", "/var/cache/apt/archives/last_update",
-    "apt-get install -y", "openjdk-7-jdk")
+  provision(config,
+    update_command: "apt-get update",
+    update_tracking_file: "/var/cache/apt/archives/last_update",
+    install_command: "apt-get install -y",
+    java_package: "openjdk-8-jdk",
+    extra: <<-SHELL
+      export DEBIAN_FRONTEND=noninteractive
+      ls /etc/apt/sources.list.d/#{openjdk_list}.list > /dev/null 2>&1 ||
+        (echo "Importing java-8 ppa" &&
+          #{add_openjdk_repository_command} &&
+          apt-get update -o \
+            Dir::Etc::sourcelist="$(ls /etc/apt/sources.list.d/#{openjdk_list}.list)" \
+            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0")
+SHELL
+  )
 end
 
 def rpm_common(config)
-  provision(config, "yum check-update", "/var/cache/yum/last_update",
-    "yum install -y", "java-1.7.0-openjdk-devel")
+  provision(config,
+    update_command: "yum check-update",
+    update_tracking_file: "/var/cache/yum/last_update",
+    install_command: "yum install -y",
+    java_package: "java-1.8.0-openjdk-devel")
 end
 
 def dnf_common(config)
-  provision(config, "dnf check-update", "/var/cache/dnf/last_update",
-    "dnf install -y", "java-1.8.0-openjdk-devel")
+  provision(config,
+    update_command: "dnf check-update",
+    update_tracking_file: "/var/cache/dnf/last_update",
+    install_command: "dnf install -y",
+    java_package: "java-1.8.0-openjdk-devel")
   if Vagrant.has_plugin?("vagrant-cachier")
     # Autodetect doesn't work....
     config.cache.auto_detect = false
@@ -134,24 +150,49 @@ def dnf_common(config)
   end
 end
 
-
-def provision(config, update_command, update_tracking_file, install_command, java_package)
+# Register the main box provisioning script.
+# @param config Vagrant's config object. Required.
+# @param update_command [String] The command used to update the package
+#   manager. Required. Think `apt-get update`.
+# @param update_tracking_file [String] The location of the file tracking the
+#   last time the update command was run. Required. Should be in a place that
+#   is cached by vagrant-cachier.
+# @param install_command [String] The command used to install a package.
+#   Required. Think `apt-get install #{package}`.
+# @param java_package [String] The name of the java package. Required.
+# @param extra [String] Extra provisioning commands run before anything else.
+#   Optional. Used for things like setting up the ppa for Java 8.
+def provision(config,
+    update_command: 'required',
+    update_tracking_file: 'required',
+    install_command: 'required',
+    java_package: 'required',
+    extra: '')
+  # Vagrant run ruby 2.0.0 which doesn't have required named parameters....
+  raise ArgumentError.new('update_command is required') if update_command == 'required'
+  raise ArgumentError.new('update_tracking_file is required') if update_tracking_file == 'required'
+  raise ArgumentError.new('install_command is required') if install_command == 'required'
+  raise ArgumentError.new('java_package is required') if java_package == 'required'
   config.vm.provision "bats dependencies", type: "shell", inline: <<-SHELL
     set -e
+    set -o pipefail
     installed() {
       command -v $1 2>&1 >/dev/null
     }
     install() {
       # Only apt-get update if we haven't in the last day
-      if [ ! -f /tmp/update ] || [ "x$(find /tmp/update -mtime +0)" == "x/tmp/update" ]; then
-          sudo #{update_command} || true
+      if [ ! -f #{update_tracking_file} ] || [ "x$(find #{update_tracking_file} -mtime +0)" == "x#{update_tracking_file}" ]; then
+          #{update_command} || true
           touch #{update_tracking_file}
       fi
-      sudo #{install_command} $1
+      #{install_command} $1
     }
     ensure() {
       installed $1 || install $1
     }
+
+    #{extra}
+
     installed java || install #{java_package}
     ensure curl
     ensure unzip
@@ -161,8 +202,8 @@ def provision(config, update_command, update_tracking_file, install_command, jav
       ensure git
       git clone https://github.com/sstephenson/bats /tmp/bats
       # Centos doesn't add /usr/local/bin to the path....
-      sudo /tmp/bats/install.sh /usr
-      sudo rm -rf /tmp/bats
+      /tmp/bats/install.sh /usr
+      rm -rf /tmp/bats
     }
     cat \<\<VARS > /etc/profile.d/elasticsearch_vars.sh
 export ZIP=/elasticsearch/distribution/zip/target/releases

--- a/qa/vagrant/pom.xml
+++ b/qa/vagrant/pom.xml
@@ -20,7 +20,7 @@
       <testScripts>*.bats</testScripts>
       <testCommand>sudo bats $BATS/${testScripts}</testCommand>
 
-      <allDebBoxes>precise, trusty, vivid, wheezy, jessie</allDebBoxes>
+      <allDebBoxes>precise, trusty, vivid, jessie</allDebBoxes>
       <allRpmBoxes>centos-6, centos-7, fedora-22, oel-7</allRpmBoxes>
 
       <defaultDebBoxes>trusty</defaultDebBoxes>


### PR DESCRIPTION
To do this we:
1. All the rpm based distros we test support Java 8. We just ask to install
it.
2. There is a ppa that works for the Ubuntus. We just add that for them.
3. Debian Jessie has Java 8 in its backports. We just add that repository.
4. Debian Wheezy doesn't have Java 8 easily accessible so we drop it. We
could add it back with Orache Java 8 at a later date but that will take a
few more backflips and won't support things like vagrant-cachier.

This required a ton of rebuilding of vagrant boxes so it also fixes:
1. apt-get update is run too frequently
2. Lots of weird warning messages are spit out of apt-get
3. Switch from the chef provided based images to those provided by boxcutter.
The chef images has left vagrant atlas!

Closes #13366
