### PR TITLE
Refactor of GeoPolygonQuery

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -19,32 +19,55 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.search.geo.GeoPolygonQuery;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQueryBuilder> {
 
     public static final String NAME = "geo_polygon";
 
-    public static final String POINTS = GeoPolygonQueryParser.POINTS;
+    static final GeoPolygonQueryBuilder PROTOTYPE = new GeoPolygonQueryBuilder("");
 
-    private final String name;
+    private final String fieldName;
 
-    private final List<GeoPoint> shell = new ArrayList<>();
+    private final List<GeoPoint> shell;
 
-    static final GeoPolygonQueryBuilder PROTOTYPE = new GeoPolygonQueryBuilder(null);
+    private boolean coerce = false;
 
-    private Boolean coerce;
+    private boolean ignoreMalformed = false;
 
-    private Boolean ignoreMalformed;
+    public GeoPolygonQueryBuilder(String fieldName) {
+        this(fieldName, new ArrayList<>());
+    }
 
-    public GeoPolygonQueryBuilder(String name) {
-        this.name = name;
+    public GeoPolygonQueryBuilder(String fieldName, List<GeoPoint> points) {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("fieldName must not be null");
+        }
+        if (points == null) {
+            throw new IllegalArgumentException("polygon must not be null");
+        }
+        this.fieldName = fieldName;
+        this.shell = points;
+    }
+
+    public String fieldName() {
+        return fieldName;
     }
 
     /**
@@ -67,36 +90,153 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
         return this;
     }
 
+    public List<GeoPoint> points() {
+        return shell;
+    }
+
     public GeoPolygonQueryBuilder coerce(boolean coerce) {
+        if (coerce) {
+            this.ignoreMalformed = true;
+        }
         this.coerce = coerce;
         return this;
     }
 
+    public boolean coerce() {
+        return this.coerce;
+    }
+
     public GeoPolygonQueryBuilder ignoreMalformed(boolean ignoreMalformed) {
-        this.ignoreMalformed = ignoreMalformed;
+        if (coerce == false) {
+            this.ignoreMalformed = ignoreMalformed;
+        }
         return this;
+    }
+
+    public boolean ignoreMalformed() {
+        return ignoreMalformed;
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        QueryValidationException errors = null;
+        if (fieldName == null) {
+            errors = QueryValidationException.addValidationError(NAME, "field must not be null", errors);
+        }
+        if (shell.isEmpty()) {
+            errors = QueryValidationException.addValidationError(NAME, "no points defined for geo_polygon query", errors);
+        } else {
+            GeoPoint start = shell.get(0);
+            if (start.equals(shell.get(shell.size() - 1))) {
+                if (shell.size() < 4) {
+                    errors = QueryValidationException.addValidationError(NAME, "too few points defined for geo_polygon query", errors);
+                }
+            } else {
+                if (shell.size() < 3) {
+                    errors = QueryValidationException.addValidationError(NAME, "too few points defined for geo_polygon query", errors);
+                }
+            }
+        }
+        return errors;
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+
+        if (!shell.get(shell.size() - 1).equals(shell.get(0))) {
+            shell.add(shell.get(0));
+        }
+
+        final boolean indexCreatedBeforeV2_0 = context.parseContext().shardContext().indexVersionCreated().before(Version.V_2_0_0);
+        // validation was not available prior to 2.x, so to support bwc
+        // percolation queries we only ignore_malformed on 2.x created indexes
+        if (!indexCreatedBeforeV2_0 && !ignoreMalformed) {
+            for (GeoPoint point : shell) {
+                if (point.lat() > 90.0 || point.lat() < -90.0) {
+                    throw new QueryShardException(context, "illegal latitude value [{}] for [{}]", point.lat(),
+                            GeoPolygonQueryBuilder.NAME);
+                }
+                if (point.lon() > 180.0 || point.lon() < -180) {
+                    throw new QueryShardException(context, "illegal longitude value [{}] for [{}]", point.lon(),
+                            GeoPolygonQueryBuilder.NAME);
+                }
+            }
+        }
+
+        if (coerce) {
+            for (GeoPoint point : shell) {
+                GeoUtils.normalizePoint(point, coerce, coerce);
+            }
+        }
+
+        MappedFieldType fieldType = context.fieldMapper(fieldName);
+        if (fieldType == null) {
+            throw new QueryShardException(context, "failed to find geo_point field [" + fieldName + "]");
+        }
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+            throw new QueryShardException(context, "field [" + fieldName + "] is not a geo_point field");
+        }
+
+        IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
+        return new GeoPolygonQuery(indexFieldData, shell.toArray(new GeoPoint[shell.size()]));
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
 
-        builder.startObject(name);
-        builder.startArray(POINTS);
+        builder.startObject(fieldName);
+        builder.startArray(GeoPolygonQueryParser.POINTS_FIELD.getPreferredName());
         for (GeoPoint point : shell) {
             builder.startArray().value(point.lon()).value(point.lat()).endArray();
         }
         builder.endArray();
         builder.endObject();
 
-        if (coerce != null) {
-            builder.field("coerce", coerce);
-        }
-        if (ignoreMalformed != null) {
-            builder.field("ignore_malformed", ignoreMalformed);
-        }
+        builder.field(GeoPolygonQueryParser.COERCE_FIELD.getPreferredName(), coerce);
+        builder.field(GeoPolygonQueryParser.IGNORE_MALFORMED_FIELD.getPreferredName(), ignoreMalformed);
+
         printBoostAndQueryName(builder);
         builder.endObject();
+    }
+
+    @Override
+    protected GeoPolygonQueryBuilder doReadFrom(StreamInput in) throws IOException {
+        String fieldName = in.readString();
+        List<GeoPoint> shell = new ArrayList<>();
+        int size = in.readVInt();
+        for (int i = 0; i < size; i++) {
+            shell.add(new GeoPoint(in.readDouble(), in.readDouble()));
+        }
+        GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(fieldName, shell);
+        builder.coerce = in.readBoolean();
+        builder.ignoreMalformed = in.readBoolean();
+        return builder;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeVInt(shell.size());
+        for (GeoPoint point : shell) {
+            out.writeDouble(point.lat());
+            out.writeDouble(point.lon());
+        }
+        out.writeBoolean(coerce);
+        out.writeBoolean(ignoreMalformed);
+    }
+
+    @Override
+    protected boolean doEquals(GeoPolygonQueryBuilder other) {
+        return Objects.equals(coerce, other.coerce)
+                && Objects.equals(fieldName, other.fieldName)
+                && Objects.equals(ignoreMalformed, other.ignoreMalformed)
+                && Objects.equals(shell, other.shell);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(coerce, fieldName, ignoreMalformed, shell);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import com.spatial4j.core.shape.jts.JtsGeometry;
+import com.vividsolutions.jts.geom.Coordinate;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.search.geo.GeoPolygonQuery;
+import org.elasticsearch.test.geo.RandomShapeGenerator;
+import org.elasticsearch.test.geo.RandomShapeGenerator.ShapeType;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygonQueryBuilder> {
+
+    @Override
+    protected GeoPolygonQueryBuilder doCreateTestQueryBuilder() {
+        GeoPolygonQueryBuilder builder;
+        List<GeoPoint> polygon = randomPolygon(randomIntBetween(4, 50));
+        if (randomBoolean()) {
+            builder = new GeoPolygonQueryBuilder(GEO_FIELD_NAME, polygon);
+        } else {
+            builder = new GeoPolygonQueryBuilder(GEO_FIELD_NAME);
+            for (GeoPoint point : polygon) {
+                int method = randomInt(2);
+                switch (method) {
+                case 0:
+                    builder.addPoint(point);
+                    break;
+                case 1:
+                    builder.addPoint(point.geohash());
+                    break;
+                case 2:
+                    builder.addPoint(point.lat(), point.lon());
+                    break;
+                }
+            }
+        }
+        builder.coerce(randomBoolean());
+        builder.ignoreMalformed(randomBoolean());
+        return builder;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(GeoPolygonQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        assertThat(query, instanceOf(GeoPolygonQuery.class));
+        GeoPolygonQuery geoQuery = (GeoPolygonQuery) query;
+        assertThat(geoQuery.fieldName(), equalTo(queryBuilder.fieldName()));
+        List<GeoPoint> queryBuilderPoints = queryBuilder.points();
+        GeoPoint[] queryPoints = geoQuery.points();
+        assertThat(queryPoints.length, equalTo(queryBuilderPoints.size()));
+        if (queryBuilder.coerce()) {
+            for (int i = 0; i < queryBuilderPoints.size(); i++) {
+                GeoPoint queryBuilderPoint = queryBuilderPoints.get(i);
+                GeoUtils.normalizePoint(queryBuilderPoint, true, true);
+                assertThat(queryPoints[i], equalTo(queryBuilderPoint));
+            }
+        } else {
+            for (int i = 0; i < queryBuilderPoints.size(); i++) {
+                assertThat(queryPoints[i], equalTo(queryBuilderPoints.get(i)));
+            }
+        }
+
+    }
+
+    /**
+     * Overridden here to ensure the test is only run if at least one type is
+     * present in the mappings. Geo queries do not execute if the field is not
+     * explicitly mapped
+     */
+    @Override
+    public void testToQuery() throws IOException {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        super.testToQuery();
+    }
+
+    public List<GeoPoint> randomPolygon(int numPoints) {
+        ShapeBuilder shapeBuilder = null;
+        // This is a temporary fix because sometimes the RandomShapeGenerator
+        // returns null. This is if there is an error generating the polygon. So
+        // in this case keep trying until we successfully generate one
+        while (shapeBuilder == null) {
+            shapeBuilder = RandomShapeGenerator.createShapeWithin(getRandom(), null, ShapeType.POLYGON);
+        }
+        JtsGeometry shape = (JtsGeometry) shapeBuilder.build();
+        Coordinate[] coordinates = shape.getGeom().getCoordinates();
+        ArrayList<GeoPoint> polygonPoints = new ArrayList<>();
+        for (Coordinate coord : coordinates) {
+            polygonPoints.add(new GeoPoint(coord.y, coord.x));
+        }
+        return polygonPoints;
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullFieldName() {
+        new GeoPolygonQueryBuilder(null);
+    }
+
+    @Test
+    public void testEmptyPolygon() {
+        GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(GEO_FIELD_NAME);
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoPolygonQueryBuilder.NAME
+                + "] no points defined for geo_polygon query"));
+    }
+
+    @Test
+    public void testInvalidClosedPolygon() {
+        GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(GEO_FIELD_NAME);
+        builder.addPoint(new GeoPoint(0, 90));
+        builder.addPoint(new GeoPoint(90, 90));
+        builder.addPoint(new GeoPoint(0, 90));
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoPolygonQueryBuilder.NAME
+                + "] too few points defined for geo_polygon query"));
+    }
+
+    @Test
+    public void testInvalidOpenPolygon() {
+        GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(GEO_FIELD_NAME);
+        builder.addPoint(new GeoPoint(0, 90));
+        builder.addPoint(new GeoPoint(90, 90));
+        QueryValidationException exception = builder.validate();
+        assertThat(exception, notNullValue());
+        assertThat(exception.validationErrors(), notNullValue());
+        assertThat(exception.validationErrors().size(), equalTo(1));
+        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoPolygonQueryBuilder.NAME
+                + "] too few points defined for geo_polygon query"));
+    }
+
+    public void testDeprecatedXContent() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+        builder.startObject();
+        builder.startObject("geo_polygon");
+        builder.startObject(GEO_FIELD_NAME);
+        builder.startArray("points");
+        builder.value("0,0");
+        builder.value("0,90");
+        builder.value("90,90");
+        builder.value("90,0");
+        builder.endArray();
+        builder.endObject();
+        builder.field("normalize", true); // deprecated
+        builder.endObject();
+        builder.endObject();
+        try {
+            parseQuery(builder.string());
+            fail("normalize is deprecated");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Deprecated field [normalize] used, expected [coerce] instead", ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Moving the query building functionality from the parser to the builders
new toQuery() method analogous to other recent query refactorings.

Relates to #10217

PR goes against the query-refactoring branch
