### PR TITLE
Parent field mapper should always store doc values join field.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -117,12 +117,6 @@ public class ParentFieldMapper extends MetadataFieldMapper {
             parentJoinFieldType.setNames(new MappedFieldType.Names(joinField(documentType)));
             parentJoinFieldType.setFieldDataType(null);
             childJoinFieldType.setNames(new MappedFieldType.Names(joinField(parentType)));
-            if (context.indexCreatedVersion().before(Version.V_2_0_0_beta1)) {
-                childJoinFieldType.setHasDocValues(false);
-                childJoinFieldType.setDocValuesType(DocValuesType.NONE);
-                parentJoinFieldType.setHasDocValues(false);
-                parentJoinFieldType.setDocValuesType(DocValuesType.NONE);
-            }
             return new ParentFieldMapper(fieldType, parentJoinFieldType, childJoinFieldType, parentType, context.indexSettings());
         }
     }
@@ -265,12 +259,6 @@ public class ParentFieldMapper extends MetadataFieldMapper {
     private static MappedFieldType joinFieldTypeForParentType(String parentType, Settings indexSettings) {
         MappedFieldType parentJoinFieldType = Defaults.JOIN_FIELD_TYPE.clone();
         parentJoinFieldType.setNames(new MappedFieldType.Names(joinField(parentType)));
-
-        Version indexCreated = Version.indexCreated(indexSettings);
-        if (indexCreated.before(Version.V_2_0_0_beta1)) {
-            parentJoinFieldType.setHasDocValues(false);
-            parentJoinFieldType.setDocValuesType(DocValuesType.NONE);
-        }
         parentJoinFieldType.freeze();
         return parentJoinFieldType;
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/internal/ParentFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/internal/ParentFieldMapperTests.java
@@ -89,64 +89,6 @@ public class ParentFieldMapperTests extends ESTestCase {
         assertThat(parentFieldMapper.getChildJoinFieldType().docValuesType(), equalTo(DocValuesType.SORTED));
     }
 
-    public void testPre2Dot0LazyLoading() {
-        ParentFieldMapper.Builder builder = new ParentFieldMapper.Builder("child");
-        builder.type("parent");
-        builder.fieldDataSettings(createFDSettings(Loading.LAZY));
-
-        ParentFieldMapper parentFieldMapper = builder.build(new Mapper.BuilderContext(pre2Dot0IndexSettings(), new ContentPath(0)));
-
-        assertThat(parentFieldMapper.getParentJoinFieldType().names().indexName(), equalTo("_parent#child"));
-        assertThat(parentFieldMapper.getParentJoinFieldType().fieldDataType(), nullValue());
-        assertThat(parentFieldMapper.getParentJoinFieldType().hasDocValues(), is(false));
-        assertThat(parentFieldMapper.getParentJoinFieldType().docValuesType(), equalTo(DocValuesType.NONE));
-
-        assertThat(parentFieldMapper.getChildJoinFieldType().names().indexName(), equalTo("_parent#parent"));
-        assertThat(parentFieldMapper.getChildJoinFieldType().fieldDataType().getLoading(), equalTo(Loading.LAZY));
-        assertThat(parentFieldMapper.getChildJoinFieldType().hasDocValues(), is(false));
-        assertThat(parentFieldMapper.getChildJoinFieldType().docValuesType(), equalTo(DocValuesType.NONE));
-    }
-
-    public void testPre2Dot0EagerLoading() {
-        ParentFieldMapper.Builder builder = new ParentFieldMapper.Builder("child");
-        builder.type("parent");
-        builder.fieldDataSettings(createFDSettings(Loading.EAGER));
-
-        ParentFieldMapper parentFieldMapper = builder.build(new Mapper.BuilderContext(pre2Dot0IndexSettings(), new ContentPath(0)));
-
-        assertThat(parentFieldMapper.getParentJoinFieldType().names().indexName(), equalTo("_parent#child"));
-        assertThat(parentFieldMapper.getParentJoinFieldType().fieldDataType(), nullValue());
-        assertThat(parentFieldMapper.getParentJoinFieldType().hasDocValues(), is(false));
-        assertThat(parentFieldMapper.getParentJoinFieldType().docValuesType(), equalTo(DocValuesType.NONE));
-
-        assertThat(parentFieldMapper.getChildJoinFieldType().names().indexName(), equalTo("_parent#parent"));
-        assertThat(parentFieldMapper.getChildJoinFieldType().fieldDataType().getLoading(), equalTo(Loading.EAGER));
-        assertThat(parentFieldMapper.getChildJoinFieldType().hasDocValues(), is(false));
-        assertThat(parentFieldMapper.getChildJoinFieldType().docValuesType(), equalTo(DocValuesType.NONE));
-    }
-
-    public void testPre2Dot0EagerGlobalOrdinalsLoading() {
-        ParentFieldMapper.Builder builder = new ParentFieldMapper.Builder("child");
-        builder.type("parent");
-        builder.fieldDataSettings(createFDSettings(Loading.EAGER_GLOBAL_ORDINALS));
-
-        ParentFieldMapper parentFieldMapper = builder.build(new Mapper.BuilderContext(pre2Dot0IndexSettings(), new ContentPath(0)));
-
-        assertThat(parentFieldMapper.getParentJoinFieldType().names().indexName(), equalTo("_parent#child"));
-        assertThat(parentFieldMapper.getParentJoinFieldType().fieldDataType(), nullValue());
-        assertThat(parentFieldMapper.getParentJoinFieldType().hasDocValues(), is(false));
-        assertThat(parentFieldMapper.getParentJoinFieldType().docValuesType(), equalTo(DocValuesType.NONE));
-
-        assertThat(parentFieldMapper.getChildJoinFieldType().names().indexName(), equalTo("_parent#parent"));
-        assertThat(parentFieldMapper.getChildJoinFieldType().fieldDataType().getLoading(), equalTo(Loading.EAGER_GLOBAL_ORDINALS));
-        assertThat(parentFieldMapper.getChildJoinFieldType().hasDocValues(), is(false));
-        assertThat(parentFieldMapper.getChildJoinFieldType().docValuesType(), equalTo(DocValuesType.NONE));
-    }
-
-    private static Settings pre2Dot0IndexSettings() {
-        return Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_6_3).build();
-    }
-
     private static Settings post2Dot0IndexSettings() {
         return Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_1_0).build();
     }


### PR DESCRIPTION
Now that the pre 2.0 parent child implementation has been removed there is no need to have logic that decides not to store the join doc values field.
