### PR TITLE
Term Vectors: splits the actual results from the response

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
@@ -27,6 +27,7 @@ import org.apache.lucene.search.BoostAttribute;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.termvectors.TermVectorsRequest.Flag;
 import org.elasticsearch.common.Nullable;
@@ -102,6 +103,26 @@ public class TermVectorsResponse extends ActionResponse implements ToXContent {
     }
 
     TermVectorsResponse() {
+    }
+
+    public TermVectorsResponse(TermVectorsResult result) {
+        this.index = result.getConcreteIndex();
+        this.type = result.getType();
+        this.id = result.getId();
+
+        if (result.getDocVersion() != null) {
+            setDocVersion(result.getDocVersion());
+        }
+        setArtificial(result.getArtificial());
+        setExists(result.getExists());
+        try {
+            if (result.getTermVectorsByField() != null) {
+                setFields(result.getTermVectorsByField(), result.getSelectedFields(), result.getFlags(),
+                        result.getTopLevelFields(), result.getDfs(), result.getTermVectorsFilter());
+            }
+        } catch (Throwable ex) {
+            throw new ElasticsearchException("failed to execute term vector request", ex);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResult.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResult.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.termvectors;
+
+import org.apache.lucene.index.Fields;
+import org.elasticsearch.search.dfs.AggregatedDfs;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public class TermVectorsResult {
+
+    private String concreteIndex;
+    private String type;
+    private String id;
+
+    private Long docVersion;
+    private boolean exists = false;
+    private boolean artificial = false;
+    private Fields termVectorsByField;
+    private Set<String> selectedFields;
+    private EnumSet<TermVectorsRequest.Flag> flags;
+    private Fields topLevelFields;
+    private AggregatedDfs dfs;
+    private TermVectorsFilter termVectorsFilter;
+
+    public TermVectorsResult(String concreteIndex, String type, String id) {
+        this.concreteIndex = concreteIndex;
+        this.type = type;
+        this.id = id;
+    }
+
+    public void setDocVersion(Long docVersion) {
+        this.docVersion = docVersion;
+    }
+
+    public void setArtificial(boolean artificial) {
+        this.artificial = artificial;
+    }
+
+    public void setExists(boolean exists) {
+        this.exists = exists;
+    }
+
+    public void setFields(Fields termVectorsByField, Set<String> selectedFields, EnumSet<TermVectorsRequest.Flag> flags,
+                          Fields topLevelFields, AggregatedDfs dfs, TermVectorsFilter termVectorsFilter) {
+        this.termVectorsByField = termVectorsByField;
+        this.selectedFields = selectedFields;
+        this.flags = flags;
+        this.topLevelFields = topLevelFields;
+        this.dfs = dfs;
+        this.termVectorsFilter = termVectorsFilter;
+    }
+
+    public Long getDocVersion() {
+        return docVersion;
+    }
+
+    public boolean getArtificial() {
+        return artificial;
+    }
+
+    public boolean getExists() {
+        return exists;
+    }
+
+    public Fields getTermVectorsByField() {
+        return termVectorsByField;
+    }
+
+    public Fields getTopLevelFields() {
+        return topLevelFields;
+    }
+
+    public Set<String> getSelectedFields() {
+        return selectedFields;
+    }
+
+    public AggregatedDfs getDfs() {
+        return dfs;
+    }
+
+    public TermVectorsFilter getTermVectorsFilter() {
+        return termVectorsFilter;
+    }
+
+    public EnumSet<TermVectorsRequest.Flag> getFlags() {
+        return flags;
+    }
+
+    public String getConcreteIndex() {
+        return concreteIndex;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
@@ -81,7 +81,8 @@ public class TransportShardMultiTermsVectorAction extends TransportSingleShardAc
             try {
                 IndexService indexService = indicesService.indexServiceSafe(request.index());
                 IndexShard indexShard = indexService.shardSafe(shardId.id());
-                TermVectorsResponse termVectorsResponse = indexShard.termVectorsService().getTermVectors(termVectorsRequest, shardId.getIndex());
+                TermVectorsResult result = indexShard.termVectorsService().getTermVectors(termVectorsRequest, shardId.getIndex());
+                TermVectorsResponse termVectorsResponse = new TermVectorsResponse(result);
                 termVectorsResponse.updateTookInMillis(termVectorsRequest.startTime());
                 response.add(request.locations.get(i), termVectorsResponse);
             } catch (Throwable t) {

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TransportTermVectorsAction.java
@@ -83,7 +83,8 @@ public class TransportTermVectorsAction extends TransportSingleShardAction<TermV
     protected TermVectorsResponse shardOperation(TermVectorsRequest request, ShardId shardId) {
         IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         IndexShard indexShard = indexService.shardSafe(shardId.id());
-        TermVectorsResponse response = indexShard.termVectorsService().getTermVectors(request, shardId.getIndex());
+        TermVectorsResult result = indexShard.termVectorsService().getTermVectors(request, shardId.getIndex());
+        TermVectorsResponse response = new TermVectorsResponse(result);
         response.updateTookInMillis(request.startTime());
         return response;
     }

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -143,6 +143,7 @@ import org.elasticsearch.search.fetch.innerhits.InnerHitsFetchSubPhase;
 import org.elasticsearch.search.fetch.matchedqueries.MatchedQueriesFetchSubPhase;
 import org.elasticsearch.search.fetch.script.ScriptFieldsFetchSubPhase;
 import org.elasticsearch.search.fetch.source.FetchSourceSubPhase;
+import org.elasticsearch.search.fetch.termvectors.TermVectorsFetchSubPhase;
 import org.elasticsearch.search.fetch.version.VersionFetchSubPhase;
 import org.elasticsearch.search.highlight.HighlightPhase;
 import org.elasticsearch.search.highlight.Highlighter;
@@ -237,6 +238,7 @@ public class SearchModule extends AbstractModule {
         fetchSubPhaseMultibinder.addBinding().to(FieldDataFieldsFetchSubPhase.class);
         fetchSubPhaseMultibinder.addBinding().to(ScriptFieldsFetchSubPhase.class);
         fetchSubPhaseMultibinder.addBinding().to(FetchSourceSubPhase.class);
+        fetchSubPhaseMultibinder.addBinding().to(TermVectorsFetchSubPhase.class);
         fetchSubPhaseMultibinder.addBinding().to(VersionFetchSubPhase.class);
         fetchSubPhaseMultibinder.addBinding().to(MatchedQueriesFetchSubPhase.class);
         fetchSubPhaseMultibinder.addBinding().to(HighlightPhase.class);

--- a/core/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsFetchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsFetchContext.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.termvectors;
+
+import org.elasticsearch.search.fetch.FetchSubPhaseContext;
+
+public class TermVectorsFetchContext extends FetchSubPhaseContext {
+
+    private String[] field = null;
+
+    public TermVectorsFetchContext() {
+    }
+
+    public void setFields(String[] field) {
+        this.field = field;
+    }
+
+    public String[] getFields() {
+        return field;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsFetchParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsFetchParseElement.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.termvectors;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.fetch.FetchSubPhaseParseElement;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TermVectorsFetchParseElement extends FetchSubPhaseParseElement<TermVectorsFetchContext> {
+
+    @Override
+    protected void innerParse(XContentParser parser, TermVectorsFetchContext termVectorsFetchContext, SearchContext searchContext) throws Exception {
+        List<String> fields = new ArrayList<>();
+        XContentParser.Token token = parser.currentToken();
+        if (token == XContentParser.Token.START_ARRAY) {
+            while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                fields.add(parser.text());
+            }
+        } else {
+            throw new IllegalStateException("Expected a START_ARRAY but got " + token);
+        }
+        termVectorsFetchContext.setFields(fields.toArray(new String[0]));
+    }
+
+    @Override
+    protected FetchSubPhase.ContextFactory getContextFactory() {
+        return TermVectorsFetchSubPhase.CONTEXT_FACTORY;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/termvectors/TermVectorsFetchSubPhase.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.termvectors;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.termvectors.TermVectorsRequest;
+import org.elasticsearch.action.termvectors.TermVectorsResponse;
+import org.elasticsearch.action.termvectors.TermVectorsResult;
+import org.elasticsearch.search.SearchHitField;
+import org.elasticsearch.search.SearchParseElement;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.search.internal.InternalSearchHitField;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TermVectorsFetchSubPhase implements FetchSubPhase {
+
+    public static final ContextFactory<TermVectorsFetchContext> CONTEXT_FACTORY = new ContextFactory<TermVectorsFetchContext>() {
+
+        @Override
+        public String getName() {
+            return NAMES[0];
+        }
+
+        @Override
+        public TermVectorsFetchContext newContextInstance() {
+            return new TermVectorsFetchContext();
+        }
+    };
+
+    public TermVectorsFetchSubPhase() {
+    }
+
+    public static final String[] NAMES = {"term_vectors_fetch"};
+
+    @Override
+    public Map<String, ? extends SearchParseElement> parseElements() {
+        return ImmutableMap.of("term_vectors_fetch", new TermVectorsFetchParseElement());
+    }
+
+    @Override
+    public boolean hitsExecutionNeeded(SearchContext context) {
+        return false;
+    }
+
+    @Override
+    public void hitsExecute(SearchContext context, InternalSearchHit[] hits) {
+    }
+
+    @Override
+    public boolean hitExecutionNeeded(SearchContext context) {
+        return context.getFetchSubPhaseContext(CONTEXT_FACTORY).hitExecutionNeeded();
+    }
+
+    @Override
+    public void hitExecute(SearchContext context, HitContext hitContext) {
+        String[] fields = context.getFetchSubPhaseContext(CONTEXT_FACTORY).getFields();
+
+        if (hitContext.hit().fieldsOrNull() == null) {
+            hitContext.hit().fields(new HashMap<>());
+        }
+        SearchHitField hitField = hitContext.hit().fields().get(NAMES[0]);
+        if (hitField == null) {
+            hitField = new InternalSearchHitField(NAMES[0], new ArrayList<>(1));
+            hitContext.hit().fields().put(NAMES[0], hitField);
+        }
+
+        String index = context.indexShard().indexService().index().getName();
+        String type = hitContext.hit().type();
+        String id = hitContext.hit().id();
+
+        TermVectorsResult result = context.indexShard().termVectorsService().getTermVectors(
+                new TermVectorsRequest(index, type, id).selectedFields(fields), index);
+        try {
+            getTermVectors(result, fields, false, hitField);
+        } catch (IOException e) {
+            throw new ElasticsearchException(e.getMessage());
+        }
+    }
+
+    private void getTermVectors(TermVectorsResult result, String[] fields, boolean useResponse, SearchHitField hitField) throws IOException {
+        Map<String, Integer> tv = new HashMap<>();
+        Fields termVector;
+        if (useResponse) {
+            termVector = new TermVectorsResponse(result).getFields();
+        } else {
+            termVector = result.getTermVectorsByField();
+        }
+        try {
+            for (String fieldName : fields) {
+                final TermsEnum termsEnum = termVector.terms(fieldName).iterator();
+                BytesRef term;
+                while((term = termsEnum.next()) != null) {
+                    final PostingsEnum docs = termsEnum.postings(null);
+                    int freq = 0;
+                    while(docs != null && docs.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                        freq += docs.freq();
+                    }
+                    tv.put(term.utf8ToString(), freq);
+                }
+            }
+            hitField.values().add(tv);
+        } catch (IOException e) {
+            throw new ElasticsearchException(e.getMessage());
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
@@ -26,6 +26,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.termvectors.TermVectorsRequest;
 import org.elasticsearch.action.termvectors.TermVectorsResponse;
+import org.elasticsearch.action.termvectors.TermVectorsResult;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -165,7 +166,8 @@ public class FetchSubPhasePluginIT extends ESIntegTestCase {
                 hitField = new InternalSearchHitField(NAMES[0], new ArrayList<>(1));
                 hitContext.hit().fields().put(NAMES[0], hitField);
             }
-            TermVectorsResponse termVector = context.indexShard().termVectorsService().getTermVectors(new TermVectorsRequest(context.indexShard().indexService().index().getName(), hitContext.hit().type(), hitContext.hit().id()), context.indexShard().indexService().index().getName());
+            TermVectorsResult result = context.indexShard().termVectorsService().getTermVectors(new TermVectorsRequest(context.indexShard().indexService().index().getName(), hitContext.hit().type(), hitContext.hit().id()), context.indexShard().indexService().index().getName());
+            TermVectorsResponse termVector = new TermVectorsResponse(result);
             try {
                 Map<String, Integer> tv = new HashMap<>();
                 TermsEnum terms = termVector.getFields().terms(field).iterator();


### PR DESCRIPTION
Today term vectors are always written into a bytes stream regardless as to
whether they have been asked on the shard or by the client. This WIP consists
of splitting the Term Vectors response from the actual returned fields. This
leads, for example, to a speed improvement in fetch sub phase in which the
returned fields could be used as is, and are not turned into a bytes stream,
only to be read again immediately after.
