### PR TITLE
Remove and forbid use of com.google.common.collect.Maps

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsAction;
@@ -193,6 +192,7 @@ import org.elasticsearch.common.inject.multibindings.MapBinder;
 import org.elasticsearch.common.inject.multibindings.Multibinder;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -201,7 +201,7 @@ import java.util.Map;
  */
 public class ActionModule extends AbstractModule {
 
-    private final Map<String, ActionEntry> actions = Maps.newHashMap();
+    private final Map<String, ActionEntry> actions = new HashMap<>();
     private final List<Class<? extends ActionFilter>> actionFilters = new ArrayList<>();
 
     static class ActionEntry<Request extends ActionRequest, Response extends ActionResponse> {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.cluster.health;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -39,6 +38,7 @@ import org.elasticsearch.rest.RestStatus;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -67,7 +67,7 @@ public class ClusterHealthResponse extends ActionResponse implements Iterable<Cl
     boolean timedOut = false;
     ClusterHealthStatus status = ClusterHealthStatus.RED;
     private List<String> validationFailures;
-    Map<String, ClusterIndexHealth> indices = Maps.newHashMap();
+    Map<String, ClusterIndexHealth> indices = new HashMap<>();
 
     ClusterHealthResponse() {
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterIndexHealth.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterIndexHealth.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.cluster.health;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -32,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -62,7 +62,7 @@ public class ClusterIndexHealth implements Iterable<ClusterShardHealth>, Streama
 
     private ClusterHealthStatus status = ClusterHealthStatus.RED;
 
-    private final Map<Integer, ClusterShardHealth> shards = Maps.newHashMap();
+    private final Map<Integer, ClusterShardHealth> shards = new HashMap<>();
 
     private List<String> validationFailures;
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -25,11 +25,11 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SnapshotId;
-import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -43,11 +43,11 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 
 /**
@@ -146,7 +146,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
             if (nodeSnapshotStatuses != null) {
                 nodeSnapshotStatusMap = nodeSnapshotStatuses.getNodesMap();
             } else {
-                nodeSnapshotStatusMap = newHashMap();
+                nodeSnapshotStatusMap = new HashMap<>();
             }
 
             for (SnapshotsInProgress.Entry entry : currentSnapshots) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateRequest;
@@ -28,10 +27,9 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.TransportMessage;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Cluster state update request that allows to create an index
@@ -47,11 +45,11 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     private Settings settings = Settings.Builder.EMPTY_SETTINGS;
 
-    private final Map<String, String> mappings = Maps.newHashMap();
+    private final Map<String, String> mappings = new HashMap<>();
 
     private final Set<Alias> aliases = Sets.newHashSet();
 
-    private final Map<String, IndexMetaData.Custom> customs = newHashMap();
+    private final Map<String, IndexMetaData.Custom> customs = new HashMap<>();
 
     private final Set<ClusterBlock> blocks = Sets.newHashSet();
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -37,13 +37,17 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
 import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
@@ -66,11 +70,11 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
 
     private Settings settings = EMPTY_SETTINGS;
 
-    private final Map<String, String> mappings = newHashMap();
+    private final Map<String, String> mappings = new HashMap<>();
 
     private final Set<Alias> aliases = Sets.newHashSet();
 
-    private final Map<String, IndexMetaData.Custom> customs = newHashMap();
+    private final Map<String, IndexMetaData.Custom> customs = new HashMap<>();
 
     private boolean updateAllTypes = false;
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.recovery;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction;
@@ -42,6 +41,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -70,7 +70,7 @@ public class TransportRecoveryAction extends TransportBroadcastByNodeAction<Reco
 
     @Override
     protected RecoveryResponse newResponse(RecoveryRequest request, int totalShards, int successfulShards, int failedShards, List<RecoveryState> responses, List<ShardOperationFailedException> shardFailures, ClusterState clusterState) {
-        Map<String, List<RecoveryState>> shardResponses = Maps.newHashMap();
+        Map<String, List<RecoveryState>> shardResponses = new HashMap<>();
         for (RecoveryState recoveryState : responses) {
             if (recoveryState == null) {
                 continue;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndexSegments.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndexSegments.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.segments;
 
-import com.google.common.collect.Maps;
-
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,7 @@ public class IndexSegments implements Iterable<IndexShardSegments> {
     IndexSegments(String index, ShardSegments[] shards) {
         this.index = index;
 
-        Map<Integer, List<ShardSegments>> tmpIndexShards = Maps.newHashMap();
+        Map<Integer, List<ShardSegments>> tmpIndexShards = new HashMap<>();
         for (ShardSegments shard : shards) {
             List<ShardSegments> lst = tmpIndexShards.get(shard.getShardRouting().id());
             if (lst == null) {
@@ -44,7 +43,7 @@ public class IndexSegments implements Iterable<IndexShardSegments> {
             }
             lst.add(shard);
         }
-        indexShards = Maps.newHashMap();
+        indexShards = new HashMap<>();
         for (Map.Entry<Integer, List<ShardSegments>> entry : tmpIndexShards.entrySet()) {
             indexShards.put(entry.getKey(), new IndexShardSegments(entry.getValue().get(0).getShardRouting().shardId(), entry.getValue().toArray(new ShardSegments[entry.getValue().size()])));
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.segments;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.action.ShardOperationFailedException;
@@ -35,6 +34,7 @@ import org.elasticsearch.index.engine.Segment;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,7 +58,7 @@ public class IndicesSegmentResponse extends BroadcastResponse implements ToXCont
         if (indicesSegments != null) {
             return indicesSegments;
         }
-        Map<String, IndexSegments> indicesSegments = Maps.newHashMap();
+        Map<String, IndexSegments> indicesSegments = new HashMap<>();
 
         Set<String> indices = Sets.newHashSet();
         for (ShardSegments shard : shards) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexStats.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
-import com.google.common.collect.Maps;
-
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +52,7 @@ public class IndexStats implements Iterable<IndexShardStats> {
         if (indexShards != null) {
             return indexShards;
         }
-        Map<Integer, List<ShardStats>> tmpIndexShards = Maps.newHashMap();
+        Map<Integer, List<ShardStats>> tmpIndexShards = new HashMap<>();
         for (ShardStats shard : shards) {
             List<ShardStats> lst = tmpIndexShards.get(shard.getShardRouting().id());
             if (lst == null) {
@@ -62,7 +61,7 @@ public class IndexStats implements Iterable<IndexShardStats> {
             }
             lst.add(shard);
         }
-        indexShards = Maps.newHashMap();
+        indexShards = new HashMap<>();
         for (Map.Entry<Integer, List<ShardStats>> entry : tmpIndexShards.entrySet()) {
             indexShards.put(entry.getKey(), new IndexShardStats(entry.getValue().get(0).getShardRouting().shardId(), entry.getValue().toArray(new ShardStats[entry.getValue().size()])));
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.admin.indices.stats;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
@@ -34,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -85,7 +85,7 @@ public class IndicesStatsResponse extends BroadcastResponse implements ToXConten
         if (indicesStats != null) {
             return indicesStats;
         }
-        Map<String, IndexStats> indicesStats = Maps.newHashMap();
+        Map<String, IndexStats> indicesStats = new HashMap<>();
 
         Set<String> indices = Sets.newHashSet();
         for (ShardStats shard : shards) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -33,14 +33,18 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
@@ -64,11 +68,11 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
 
     private Settings settings = EMPTY_SETTINGS;
 
-    private Map<String, String> mappings = newHashMap();
+    private Map<String, String> mappings = new HashMap<>();
 
     private final Set<Alias> aliases = newHashSet();
     
-    private Map<String, IndexMetaData.Custom> customs = newHashMap();
+    private Map<String, IndexMetaData.Custom> customs = new HashMap<>();
 
     PutIndexTemplateRequest() {
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/IndexUpgradeStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/IndexUpgradeStatus.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.upgrade.get;
 
-import com.google.common.collect.Maps;
-
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,7 @@ public class IndexUpgradeStatus implements Iterable<IndexShardUpgradeStatus> {
     IndexUpgradeStatus(String index, ShardUpgradeStatus[] shards) {
         this.index = index;
 
-        Map<Integer, List<ShardUpgradeStatus>> tmpIndexShards = Maps.newHashMap();
+        Map<Integer, List<ShardUpgradeStatus>> tmpIndexShards = new HashMap<>();
         for (ShardUpgradeStatus shard : shards) {
             List<ShardUpgradeStatus> lst = tmpIndexShards.get(shard.getShardRouting().id());
             if (lst == null) {
@@ -44,7 +43,7 @@ public class IndexUpgradeStatus implements Iterable<IndexShardUpgradeStatus> {
             }
             lst.add(shard);
         }
-        indexShards = Maps.newHashMap();
+        indexShards = new HashMap<>();
         for (Map.Entry<Integer, List<ShardUpgradeStatus>> entry : tmpIndexShards.entrySet()) {
             indexShards.put(entry.getKey(), new IndexShardUpgradeStatus(entry.getValue().get(0).getShardRouting().shardId(), entry.getValue().toArray(new ShardUpgradeStatus[entry.getValue().size()])));
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.upgrade.get;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
@@ -31,6 +30,7 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,7 +52,7 @@ public class UpgradeStatusResponse extends BroadcastResponse implements ToXConte
         if (indicesUpgradeStatus != null) {
             return indicesUpgradeStatus;
         }
-        Map<String, IndexUpgradeStatus> indicesUpgradeStats = Maps.newHashMap();
+        Map<String, IndexUpgradeStatus> indicesUpgradeStats = new HashMap<>();
 
         Set<String> indices = Sets.newHashSet();
         for (ShardUpgradeStatus shard : shards) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
@@ -45,11 +45,11 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 
 /**
@@ -72,8 +72,8 @@ public class TransportUpgradeAction extends TransportBroadcastByNodeAction<Upgra
 
     @Override
     protected UpgradeResponse newResponse(UpgradeRequest request, int totalShards, int successfulShards, int failedShards, List<ShardUpgradeResult> shardUpgradeResults, List<ShardOperationFailedException> shardFailures, ClusterState clusterState) {
-        Map<String, Integer> successfulPrimaryShards = newHashMap();
-        Map<String, Tuple<Version, org.apache.lucene.util.Version>> versions = newHashMap();
+        Map<String, Integer> successfulPrimaryShards = new HashMap<>();
+        Map<String, Tuple<Version, org.apache.lucene.util.Version>> versions = new HashMap<>();
         for (ShardUpgradeResult result : shardUpgradeResults) {
             successfulShards++;
             String index = result.getShardId().getIndex();
@@ -101,7 +101,7 @@ public class TransportUpgradeAction extends TransportBroadcastByNodeAction<Upgra
                 versions.put(index, new Tuple<>(version, luceneVersion));
             }
         }
-        Map<String, Tuple<org.elasticsearch.Version, String>> updatedVersions = newHashMap();
+        Map<String, Tuple<org.elasticsearch.Version, String>> updatedVersions = new HashMap<>();
         MetaData metaData = clusterState.metaData();
         for (Map.Entry<String, Tuple<Version, org.apache.lucene.util.Version>> versionEntry : versions.entrySet()) {
             String index = versionEntry.getKey();

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/UpgradeResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/UpgradeResponse.java
@@ -27,10 +27,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * A response for optimize action.
@@ -54,7 +53,7 @@ public class UpgradeResponse extends BroadcastResponse {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         int size = in.readVInt();
-        versions = newHashMap();
+        versions = new HashMap<>();
         for (int i=0; i<size; i++) {
             String index = in.readString();
             Version upgradeVersion = Version.readVersion(in);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/UpgradeSettingsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/UpgradeSettingsRequest.java
@@ -27,9 +27,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
@@ -79,7 +79,7 @@ public class UpgradeSettingsRequest extends AcknowledgedRequest<UpgradeSettingsR
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         int size = in.readVInt();
-        versions = newHashMap();
+        versions = new HashMap<>();
         for (int i=0; i<size; i++) {
             String index = in.readString();
             Version upgradeVersion = Version.readVersion(in);

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.bulk;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
@@ -246,7 +245,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         }
 
         // first, go over all the requests and create a ShardId -> Operations mapping
-        Map<ShardId, List<BulkItemRequest>> requestsByShard = Maps.newHashMap();
+        Map<ShardId, List<BulkItemRequest>> requestsByShard = new HashMap<>();
 
         for (int i = 0; i < bulkRequest.requests.size(); i++) {
             ActionRequest request = bulkRequest.requests.get(i);

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchHelper.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.search.type;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.elasticsearch.action.search.SearchRequest;
@@ -36,6 +35,7 @@ import org.elasticsearch.search.internal.InternalScrollSearchRequest;
 import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -114,7 +114,7 @@ public abstract class TransportSearchHelper {
         if (attributesSize == 0) {
             attributes = ImmutableMap.of();
         } else {
-            attributes = Maps.newHashMapWithExpectedSize(attributesSize);
+            attributes = new HashMap<>(attributesSize);
             for (int i = 0; i < attributesSize; i++) {
                 String element = elements[index++];
                 int sep = element.indexOf(':');

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.support.broadcast.node;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.IndicesRequest;
@@ -57,6 +56,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -247,7 +247,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
 
             logger.trace("resolving shards for [{}] based on cluster state version [{}]", actionName, clusterState.version());
             ShardsIterator shardIt = shards(clusterState, request, concreteIndices);
-            nodeIds = Maps.newHashMap();
+            nodeIds = new HashMap<>();
 
             for (ShardRouting shard : shardIt.asUnordered()) {
                 if (shard.assignedToNode()) {

--- a/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.support.nodes;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
@@ -28,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -79,7 +79,7 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
 
     public Map<String, TNodeResponse> getNodesMap() {
         if (nodesMap == null) {
-            nodesMap = Maps.newHashMap();
+            nodesMap = new HashMap<>();
             for (TNodeResponse nodeResponse : nodes) {
                 nodesMap.put(nodeResponse.getNode().id(), nodeResponse);
             }

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.termvectors;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
@@ -39,7 +38,13 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.VersionType;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -423,7 +428,7 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
      * Override the analyzer used at each field when generating term vectors.
      */
     public TermVectorsRequest perFieldAnalyzer(Map<String, String> perFieldAnalyzer) {
-        this.perFieldAnalyzer = perFieldAnalyzer != null && perFieldAnalyzer.size() != 0 ? Maps.newHashMap(perFieldAnalyzer) : null;
+        this.perFieldAnalyzer = perFieldAnalyzer != null && perFieldAnalyzer.size() != 0 ? new HashMap<>(perFieldAnalyzer) : null;
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -53,8 +53,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
-
 /**
  * Helper for translating an update request to an index, delete request or update response.
  */
@@ -291,7 +289,7 @@ public class UpdateHelper extends AbstractComponent {
                 Object value = sourceLookup.extractValue(field);
                 if (value != null) {
                     if (fields == null) {
-                        fields = newHashMapWithExpectedSize(2);
+                        fields = new HashMap<>(2);
                     }
                     GetField getField = fields.get(field);
                     if (getField == null) {

--- a/core/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/core/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -32,8 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
-
 public final class DiffableUtils {
     private DiffableUtils() {
     }
@@ -152,7 +150,7 @@ public final class DiffableUtils {
 
         @Override
         public ImmutableMap<String, T> apply(ImmutableMap<String, T> map) {
-            HashMap<String, T> builder = newHashMap();
+            HashMap<String, T> builder = new HashMap<>();
             builder.putAll(map);
 
             for (String part : deletes) {
@@ -233,14 +231,14 @@ public final class DiffableUtils {
 
         protected MapDiff() {
             deletes = new ArrayList<>();
-            diffs = newHashMap();
-            adds = newHashMap();
+            diffs = new HashMap<>();
+            adds = new HashMap<>();
         }
 
         protected MapDiff(StreamInput in, KeyedReader<T> reader) throws IOException {
             deletes = new ArrayList<>();
-            diffs = newHashMap();
-            adds = newHashMap();
+            diffs = new HashMap<>();
+            adds = new HashMap<>();
             int deletesCount = in.readVInt();
             for (int i = 0; i < deletesCount; i++) {
                 deletes.add(in.readString());

--- a/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -34,10 +34,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Meta data about snapshots that are currently executing
@@ -155,7 +154,7 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
         }
 
         private ImmutableMap<String, List<ShardId>> findWaitingIndices(ImmutableMap<ShardId, ShardSnapshotStatus> shards) {
-            Map<String, List<ShardId>> waitingIndicesMap = newHashMap();
+            Map<String, List<ShardId>> waitingIndicesMap = new HashMap<>();
             for (ImmutableMap.Entry<ShardId, ShardSnapshotStatus> entry : shards.entrySet()) {
                 if (entry.getValue().state() == State.WAITING) {
                     List<ShardId> waitingShards = waitingIndicesMap.get(entry.getKey().getIndex());

--- a/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -21,7 +21,6 @@ package org.elasticsearch.cluster.block;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -31,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -272,7 +272,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
 
         private Set<ClusterBlock> global = Sets.newHashSet();
 
-        private Map<String, Set<ClusterBlock>> indices = Maps.newHashMap();
+        private Map<String, Set<ClusterBlock>> indices = new HashMap<>();
 
         public Builder() {
         }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -50,8 +51,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 public class IndexNameExpressionResolver extends AbstractComponent {
 
@@ -324,7 +323,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
                         if (!aliasMetaData.searchRoutingValues().isEmpty()) {
                             // Routing alias
                             if (routings == null) {
-                                routings = newHashMap();
+                                routings = new HashMap<>();
                             }
                             Set<String> r = routings.get(concreteIndex);
                             if (r == null) {
@@ -345,7 +344,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
                                 if (paramRouting != null) {
                                     Set<String> r = new HashSet<>(paramRouting);
                                     if (routings == null) {
-                                        routings = newHashMap();
+                                        routings = new HashMap<>();
                                     }
                                     routings.put(concreteIndex, r);
                                 } else {
@@ -364,7 +363,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
                     if (paramRouting != null) {
                         Set<String> r = new HashSet<>(paramRouting);
                         if (routings == null) {
-                            routings = newHashMap();
+                            routings = new HashMap<>();
                         }
                         routings.put(expression, r);
                     } else {
@@ -388,7 +387,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
     private Map<String, Set<String>> resolveSearchRoutingAllIndices(MetaData metaData, String routing) {
         if (routing != null) {
             Set<String> r = Strings.splitStringByCommaToSet(routing);
-            Map<String, Set<String>> routings = newHashMap();
+            Map<String, Set<String>> routings = new HashMap<>();
             String[] concreteIndices = metaData.concreteAllIndices();
             for (String index : concreteIndices) {
                 routings.put(index, r);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cluster.metadata;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.base.Charsets;
-import com.google.common.collect.Maps;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
@@ -36,7 +35,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
-import org.elasticsearch.cluster.metadata.IndexMetaData.*;
+import org.elasticsearch.cluster.metadata.IndexMetaData.Custom;
+import org.elasticsearch.cluster.metadata.IndexMetaData.State;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -81,6 +81,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -88,7 +89,12 @@ import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.cluster.metadata.IndexMetaData.*;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_CREATION_DATE;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_CREATED;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 
 /**
@@ -245,12 +251,12 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     // find templates, highest order are better matching
                     List<IndexTemplateMetaData> templates = findTemplates(request, currentState, indexTemplateFilter);
 
-                    Map<String, Custom> customs = Maps.newHashMap();
+                    Map<String, Custom> customs = new HashMap<>();
 
                     // add the request mapping
-                    Map<String, Map<String, Object>> mappings = Maps.newHashMap();
+                    Map<String, Map<String, Object>> mappings = new HashMap<>();
 
-                    Map<String, AliasMetaData> templatesAliases = Maps.newHashMap();
+                    Map<String, AliasMetaData> templatesAliases = new HashMap<>();
 
                     List<String> templateNames = new ArrayList<>();
 
@@ -392,7 +398,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     }
 
                     // now, update the mappings with the actual source
-                    Map<String, MappingMetaData> mappingsMetaData = Maps.newHashMap();
+                    Map<String, MappingMetaData> mappingsMetaData = new HashMap<>();
                     for (DocumentMapper mapper : mapperService.docMappers(true)) {
                         MappingMetaData mappingMd = new MappingMetaData(mapper);
                         mappingsMetaData.put(mapper.type(), mappingMd);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesClusterStateUpdateRequest;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
@@ -38,6 +37,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.IndicesService;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -70,7 +70,7 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
             @Override
             public ClusterState execute(final ClusterState currentState) {
                 List<String> indicesToClose = new ArrayList<>();
-                Map<String, IndexService> indices = Maps.newHashMap();
+                Map<String, IndexService> indices = new HashMap<>();
                 try {
                     for (AliasAction aliasAction : request.actions()) {
                         aliasValidator.validateAliasAction(aliasAction, currentState.metaData());

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -39,6 +38,7 @@ import org.elasticsearch.indices.IndexTemplateMissingException;
 import org.elasticsearch.indices.InvalidIndexTemplateException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -239,9 +239,9 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
         int order;
         String template;
         Settings settings = Settings.Builder.EMPTY_SETTINGS;
-        Map<String, String> mappings = Maps.newHashMap();
+        Map<String, String> mappings = new HashMap<>();
         List<Alias> aliases = new ArrayList<>();
-        Map<String, IndexMetaData.Custom> customs = Maps.newHashMap();
+        Map<String, IndexMetaData.Custom> customs = new HashMap<>();
 
         TimeValue masterTimeout = MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -49,11 +48,10 @@ import org.elasticsearch.percolator.PercolatorService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static com.google.common.collect.Maps.newHashMap;
 /**
  * Service responsible for submitting mapping changes
  */
@@ -141,7 +139,7 @@ public class MetaDataMappingService extends AbstractComponent {
 
         // break down to tasks per index, so we can optimize the on demand index service creation
         // to only happen for the duration of a single index processing of its respective events
-        Map<String, List<MappingTask>> tasksPerIndex = Maps.newHashMap();
+        Map<String, List<MappingTask>> tasksPerIndex = new HashMap<>();
         for (MappingTask task : allTasks) {
             if (task.index == null) {
                 logger.debug("ignoring a mapping task of type [{}] with a null index.", task);
@@ -372,8 +370,8 @@ public class MetaDataMappingService extends AbstractComponent {
                         }
                     }
 
-                    Map<String, DocumentMapper> newMappers = newHashMap();
-                    Map<String, DocumentMapper> existingMappers = newHashMap();
+                    Map<String, DocumentMapper> newMappers = new HashMap<>();
+                    Map<String, DocumentMapper> existingMappers = new HashMap<>();
                     for (String index : request.indices()) {
                         IndexService indexService = indicesService.indexServiceSafe(index);
                         // try and parse it (no need to add it here) so we can bail early in case of parsing exception
@@ -427,7 +425,7 @@ public class MetaDataMappingService extends AbstractComponent {
                         throw new InvalidTypeNameException("Document mapping type name can't start with '_'");
                     }
 
-                    final Map<String, MappingMetaData> mappings = newHashMap();
+                    final Map<String, MappingMetaData> mappings = new HashMap<>();
                     for (Map.Entry<String, DocumentMapper> entry : newMappers.entrySet()) {
                         String index = entry.getKey();
                         // do the actual merge here on the master, and update the mapping source

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeService.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.cluster.node;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -45,7 +45,7 @@ public class DiscoveryNodeService extends AbstractComponent {
     }
 
     public Map<String, String> buildAttributes() {
-        Map<String, String> attributes = Maps.newHashMap(settings.getByPrefix("node.").getAsMap());
+        Map<String, String> attributes = new HashMap<>(settings.getByPrefix("node.").getAsMap());
         attributes.remove("name"); // name is extracted in other places
         if (attributes.containsKey("client")) {
             if (attributes.get("client").equals("false")) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 
 /**
@@ -56,11 +55,11 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     private final RoutingTable routingTable;
 
-    private final Map<String, RoutingNode> nodesToShards = newHashMap();
+    private final Map<String, RoutingNode> nodesToShards = new HashMap<>();
 
     private final UnassignedShards unassignedShards = new UnassignedShards(this);
 
-    private final Map<ShardId, List<ShardRouting>> assignedShards = newHashMap();
+    private final Map<ShardId, List<ShardRouting>> assignedShards = new HashMap<>();
 
     private final ImmutableOpenMap<String, ClusterState.Custom> customs;
 
@@ -85,7 +84,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         this.routingTable = clusterState.routingTable();
         this.customs = clusterState.customs();
 
-        Map<String, List<ShardRouting>> nodesToShards = newHashMap();
+        Map<String, List<ShardRouting>> nodesToShards = new HashMap<>();
         // fill in the nodeToShards with the "live" nodes
         for (ObjectCursor<DiscoveryNode> cursor : clusterState.nodes().dataNodes().values()) {
             nodesToShards.put(cursor.value.id(), new ArrayList<ShardRouting>());

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -35,11 +35,10 @@ import org.elasticsearch.index.IndexNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Represents a global cluster-wide routing table for all indices including the
@@ -345,7 +344,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
     public static class Builder {
 
         private long version;
-        private final Map<String, IndexRoutingTable> indicesRouting = newHashMap();
+        private final Map<String, IndexRoutingTable> indicesRouting = new HashMap<>();
 
         public Builder() {
 
@@ -362,7 +361,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             // this is being called without pre initializing the routing table, so we must copy over the version as well
             this.version = routingNodes.routingTable().version();
 
-            Map<String, IndexRoutingTable.Builder> indexRoutingTableBuilders = newHashMap();
+            Map<String, IndexRoutingTable.Builder> indexRoutingTableBuilders = new HashMap<>();
             for (RoutingNode routingNode : routingNodes) {
                 for (ShardRouting shardRoutingEntry : routingNode) {
                     // every relocating shard has a double entry, ignore the target one.

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTableValidation.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTableValidation.java
@@ -27,10 +27,9 @@ import org.elasticsearch.common.io.stream.Streamable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Encapsulates the result of a routing table validation and provides access to
@@ -100,7 +99,7 @@ public class RoutingTableValidation implements Streamable {
     public void addIndexFailure(String index, String failure) {
         valid = false;
         if (indicesFailures == null) {
-            indicesFailures = newHashMap();
+            indicesFailures = new HashMap<>();
         }
         List<String> indexFailures = indicesFailures.get(index);
         if (indexFailures == null) {
@@ -131,7 +130,7 @@ public class RoutingTableValidation implements Streamable {
         if (size == 0) {
             indicesFailures = ImmutableMap.of();
         } else {
-            indicesFailures = newHashMap();
+            indicesFailures = new HashMap<>();
             for (int i = 0; i < size; i++) {
                 String index = in.readString();
                 int size2 = in.readVInt();

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationExplanation.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationExplanation.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,6 +27,7 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -77,7 +77,7 @@ public class AllocationExplanation implements Streamable {
         }
     }
 
-    private final Map<ShardId, List<NodeExplanation>> explanations = Maps.newHashMap();
+    private final Map<ShardId, List<NodeExplanation>> explanations = new HashMap<>();
 
     /**
      * Create and add a node explanation to this explanation referencing a shard  

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cluster.routing.allocation.decider;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
-import com.google.common.collect.Maps;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -135,7 +134,7 @@ public class AwarenessAllocationDecider extends AllocationDecider {
         super(settings);
         this.awarenessAttributes = settings.getAsArray(CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTES);
 
-        forcedAwarenessAttributes = Maps.newHashMap();
+        forcedAwarenessAttributes = new HashMap<>();
         Map<String, Settings> forceGroups = settings.getGroups(CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP);
         for (Map.Entry<String, Settings> entry : forceGroups.entrySet()) {
             String[] aValues = entry.getValue().getAsArray("values");

--- a/core/src/main/java/org/elasticsearch/common/Table.java
+++ b/core/src/main/java/org/elasticsearch/common/Table.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,8 +32,8 @@ public class Table {
 
     private List<Cell> headers = new ArrayList<>();
     private List<List<Cell>> rows = new ArrayList<>();
-    private Map<String, List<Cell>> map = Maps.newHashMap();
-    private Map<String, Cell> headerMap = Maps.newHashMap();
+    private Map<String, List<Cell>> map = new HashMap<>();
+    private Map<String, Cell> headerMap = new HashMap<>();
     private List<Cell> currentCells;
     private boolean inHeaders = false;
 

--- a/core/src/main/java/org/elasticsearch/common/cli/CheckFileCommand.java
+++ b/core/src/main/java/org/elasticsearch/common/cli/CheckFileCommand.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.cli;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 
@@ -30,6 +29,7 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -69,9 +69,9 @@ public abstract class CheckFileCommand extends CliTool.Command {
             return doExecute(settings, env);
         }
 
-        Map<Path, Set<PosixFilePermission>> permissions = Maps.newHashMapWithExpectedSize(paths.length);
-        Map<Path, String> owners = Maps.newHashMapWithExpectedSize(paths.length);
-        Map<Path, String> groups = Maps.newHashMapWithExpectedSize(paths.length);
+        Map<Path, Set<PosixFilePermission>> permissions = new HashMap<>(paths.length);
+        Map<Path, String> owners = new HashMap<>(paths.length);
+        Map<Path, String> groups = new HashMap<>(paths.length);
 
         if (paths != null && paths.length > 0) {
             for (Path path : paths) {

--- a/core/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashMap.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashMap.java
@@ -20,12 +20,20 @@
 package org.elasticsearch.common.collect;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import com.google.common.collect.UnmodifiableIterator;
 import org.apache.lucene.util.mutable.MutableValueInt;
 
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * An immutable map whose writes result in a new copy of the map to be created.
@@ -128,7 +136,7 @@ public final class CopyOnWriteHashMap<K, V> extends AbstractMap<K, V> {
         @Override
         void visit(Deque<Map.Entry<K, V>> entries, Deque<Node<K, V>> nodes) {
             for (int i = 0; i < keys.length; ++i) {
-                entries.add(Maps.immutableEntry(keys[i], values[i]));
+                entries.add(new AbstractMap.SimpleImmutableEntry<>(keys[i], values[i]));
             }
         }
 
@@ -278,7 +286,7 @@ public final class CopyOnWriteHashMap<K, V> extends AbstractMap<K, V> {
                 } else {
                     @SuppressWarnings("unchecked")
                     final V value = (V) sub;
-                    entries.add(Maps.immutableEntry(keys[i], value));
+                    entries.add(new AbstractMap.SimpleImmutableEntry<>(keys[i], value));
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashSet.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashSet.java
@@ -22,8 +22,8 @@ package org.elasticsearch.common.collect;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ForwardingSet;
-import com.google.common.collect.Maps;
 
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -81,7 +81,7 @@ public class CopyOnWriteHashSet<T> extends ForwardingSet<T> {
         final Collection<Entry<T, Boolean>> asMapEntries = Collections2.transform(entries,new Function<T, Map.Entry<T, Boolean>>() {
             @Override
             public Entry<T, Boolean> apply(T input) {
-                return Maps.immutableEntry(input, true);
+                return new AbstractMap.SimpleImmutableEntry<>(input, true);
             }
         });
         CopyOnWriteHashMap<T, Boolean> updated = this.map.copyAndPutAll(asMapEntries);

--- a/core/src/main/java/org/elasticsearch/common/collect/MapBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/MapBuilder.java
@@ -21,9 +21,8 @@ package org.elasticsearch.common.collect;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  *
@@ -38,14 +37,14 @@ public class MapBuilder<K, V> {
         return new MapBuilder<>(map);
     }
 
-    private Map<K, V> map = newHashMap();
+    private Map<K, V> map = new HashMap<>();
 
     public MapBuilder() {
-        this.map = newHashMap();
+        this.map = new HashMap<>();
     }
 
     public MapBuilder(Map<K, V> map) {
-        this.map = newHashMap(map);
+        this.map = new HashMap<>(map);
     }
 
     public MapBuilder<K, V> putAll(Map<K, V> map) {

--- a/core/src/main/java/org/elasticsearch/common/inject/InheritingState.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/InheritingState.java
@@ -17,7 +17,6 @@
 package org.elasticsearch.common.inject;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.inject.internal.BindingImpl;
 import org.elasticsearch.common.inject.internal.Errors;
 import org.elasticsearch.common.inject.internal.InstanceBindingImpl;
@@ -30,6 +29,8 @@ import org.elasticsearch.common.inject.spi.TypeListenerBinding;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,10 +44,10 @@ class InheritingState implements State {
     private final State parent;
 
     // Must be a linked hashmap in order to preserve order of bindings in Modules.
-    private final Map<Key<?>, Binding<?>> explicitBindingsMutable = Maps.newLinkedHashMap();
+    private final Map<Key<?>, Binding<?>> explicitBindingsMutable = new LinkedHashMap<>();
     private final Map<Key<?>, Binding<?>> explicitBindings
             = Collections.unmodifiableMap(explicitBindingsMutable);
-    private final Map<Class<? extends Annotation>, Scope> scopes = Maps.newHashMap();
+    private final Map<Class<? extends Annotation>, Scope> scopes = new HashMap<>();
     private final List<MatcherAndConverter> converters = new ArrayList<>();
     private final List<TypeListenerBinding> listenerBindings = new ArrayList<>();
     private WeakKeySet blacklistedKeys = new WeakKeySet();
@@ -150,7 +151,7 @@ class InheritingState implements State {
 
     @Override
     public void makeAllBindingsToEagerSingletons(Injector injector) {
-        Map<Key<?>, Binding<?>> x = Maps.newLinkedHashMap();
+        Map<Key<?>, Binding<?>> x = new LinkedHashMap<>();
         for (Map.Entry<Key<?>, Binding<?>> entry : this.explicitBindingsMutable.entrySet()) {
             Key key = entry.getKey();
             BindingImpl<?> binding = (BindingImpl<?>) entry.getValue();

--- a/core/src/main/java/org/elasticsearch/common/inject/Initializer.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/Initializer.java
@@ -16,12 +16,12 @@
 
 package org.elasticsearch.common.inject;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.inject.internal.Errors;
 import org.elasticsearch.common.inject.internal.ErrorsException;
 import org.elasticsearch.common.inject.spi.InjectionPoint;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -49,7 +49,7 @@ class Initializer {
     /**
      * Maps instances that need injection to a source that registered them
      */
-    private final Map<Object, InjectableReference<?>> pendingInjection = Maps.newIdentityHashMap();
+    private final Map<Object, InjectableReference<?>> pendingInjection = new IdentityHashMap<>();
 
     /**
      * Registers an instance for member injection when that step is performed.

--- a/core/src/main/java/org/elasticsearch/common/inject/InjectorImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/InjectorImpl.java
@@ -17,7 +17,6 @@
 package org.elasticsearch.common.inject;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.Classes;
 import org.elasticsearch.common.inject.internal.Annotations;
 import org.elasticsearch.common.inject.internal.BindingImpl;
@@ -50,6 +49,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,7 +72,7 @@ class InjectorImpl implements Injector, Lookups {
     /**
      * Just-in-time binding cache. Guarded by state.lock()
      */
-    Map<Key<?>, BindingImpl<?>> jitBindings = Maps.newHashMap();
+    Map<Key<?>, BindingImpl<?>> jitBindings = new HashMap<>();
 
     Lookups lookups = new DeferredLookups(this);
 
@@ -698,7 +698,7 @@ class InjectorImpl implements Injector, Lookups {
     }
 
     private static class BindingsMultimap {
-        final Map<TypeLiteral<?>, List<Binding<?>>> multimap = Maps.newHashMap();
+        final Map<TypeLiteral<?>, List<Binding<?>>> multimap = new HashMap<>();
 
         <T> void put(TypeLiteral<T> type, Binding<T> binding) {
             List<Binding<?>> bindingsForType = multimap.get(type);
@@ -900,7 +900,7 @@ class InjectorImpl implements Injector, Lookups {
         state.clearBlacklisted();
         constructors = new ConstructorInjectorStore(this);
         membersInjectorStore = new MembersInjectorStore(this, state.getTypeListenerBindings());
-        jitBindings = Maps.newHashMap();
+        jitBindings = new HashMap<>();
     }
 
     // ES_GUICE: make all registered bindings act as eager singletons

--- a/core/src/main/java/org/elasticsearch/common/inject/assistedinject/FactoryProvider.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/assistedinject/FactoryProvider.java
@@ -18,7 +18,6 @@ package org.elasticsearch.common.inject.assistedinject;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.inject.ConfigurationException;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Injector;
@@ -37,6 +36,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -241,7 +241,7 @@ public class FactoryProvider<F> implements Provider<F>, HasDependencies {
                     constructors.size(), factoryType, factoryMethods.length);
         }
 
-        Map<ParameterListKey, AssistedConstructor> paramsToConstructor = Maps.newHashMap();
+        Map<ParameterListKey, AssistedConstructor> paramsToConstructor = new HashMap<>();
 
         for (AssistedConstructor c : constructors) {
             if (paramsToConstructor.containsKey(c.getAssistedParameters())) {
@@ -250,7 +250,7 @@ public class FactoryProvider<F> implements Provider<F>, HasDependencies {
             paramsToConstructor.put(c.getAssistedParameters(), c);
         }
 
-        Map<Method, AssistedConstructor<?>> result = Maps.newHashMap();
+        Map<Method, AssistedConstructor<?>> result = new HashMap<>();
         for (Method method : factoryMethods) {
             if (!method.getReturnType().isAssignableFrom(implementationType.getRawType())) {
                 throw newConfigurationException("Return type of method %s is not assignable from %s",

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/InternalContext.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/InternalContext.java
@@ -16,9 +16,9 @@
 
 package org.elasticsearch.common.inject.internal;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.inject.spi.Dependency;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 public final class InternalContext {
 
-    private Map<Object, ConstructionContext<?>> constructionContexts = Maps.newHashMap();
+    private Map<Object, ConstructionContext<?>> constructionContexts = new HashMap<>();
     private Dependency dependency;
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/PrivateElementsImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/PrivateElementsImpl.java
@@ -17,7 +17,6 @@
 package org.elasticsearch.common.inject.internal;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.Key;
@@ -28,11 +27,14 @@ import org.elasticsearch.common.inject.spi.PrivateElements;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * @author jessewilson@google.com (Jesse Wilson)
@@ -93,7 +95,7 @@ public final class PrivateElementsImpl implements PrivateElements {
     @Override
     public Set<Key<?>> getExposedKeys() {
         if (exposedKeysToSources == null) {
-            Map<Key<?>, Object> exposedKeysToSourcesMutable = Maps.newLinkedHashMap();
+            Map<Key<?>, Object> exposedKeysToSourcesMutable = new LinkedHashMap<>();
             for (ExposureBuilder<?> exposureBuilder : exposureBuilders) {
                 exposedKeysToSourcesMutable.put(exposureBuilder.getKey(), exposureBuilder.getSource());
             }

--- a/core/src/main/java/org/elasticsearch/common/inject/util/Modules.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/util/Modules.java
@@ -17,7 +17,6 @@
 package org.elasticsearch.common.inject.util;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Binder;
@@ -36,6 +35,7 @@ import org.elasticsearch.common.inject.spi.ScopeBinding;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -178,7 +178,7 @@ public final class Modules {
                     // execute the original module, skipping all scopes and overridden keys. We only skip each
                     // overridden binding once so things still blow up if the module binds the same thing
                     // multiple times.
-                    final Map<Scope, Object> scopeInstancesInUse = Maps.newHashMap();
+                    final Map<Scope, Object> scopeInstancesInUse = new HashMap<>();
                     final List<ScopeBinding> scopeBindings = new ArrayList<>();
                     new ModuleWriter(binder()) {
                         @Override

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -22,7 +22,6 @@ package org.elasticsearch.common.settings;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Maps;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Strings;
@@ -118,7 +117,7 @@ public final class Settings implements ToXContent {
      * The settings as a structured {@link java.util.Map}.
      */
     public Map<String, Object> getAsStructuredMap() {
-        Map<String, Object> map = Maps.newHashMapWithExpectedSize(2);
+        Map<String, Object> map = new HashMap<>(2);
         for (Map.Entry<String, String> entry : settings.entrySet()) {
             processSetting(map, "", entry.getKey(), entry.getValue());
         }
@@ -148,7 +147,7 @@ public final class Settings implements ToXContent {
             String rest = setting.substring(prefixLength + 1);
             Object existingValue = map.get(prefix + key);
             if (existingValue == null) {
-                Map<String, Object> newMap = Maps.newHashMapWithExpectedSize(2);
+                Map<String, Object> newMap = new HashMap<>(2);
                 processSetting(newMap, "", rest, value);
                 map.put(key, newMap);
             } else {
@@ -1181,7 +1180,7 @@ public final class Settings implements ToXContent {
                         return true;
                     }
                 };
-            for (Map.Entry<String, String> entry : Maps.newHashMap(map).entrySet()) {
+            for (Map.Entry<String, String> entry : new HashMap<>(map).entrySet()) {
                 String value = propertyPlaceholder.replacePlaceholders(entry.getValue(), placeholderResolver);
                 // if the values exists and has length, we should maintain it  in the map
                 // otherwise, the replace process resolved into removing it
@@ -1200,7 +1199,7 @@ public final class Settings implements ToXContent {
          * If a setting doesn't start with the prefix, the builder appends the prefix to such setting.
          */
         public Builder normalizePrefix(String prefix) {
-            Map<String, String> replacements = Maps.newHashMap();
+            Map<String, String> replacements = new HashMap<>();
             Iterator<Map.Entry<String, String>> iterator = map.entrySet().iterator();
             while(iterator.hasNext()) {
                 Map.Entry<String, String> entry = iterator.next();

--- a/core/src/main/java/org/elasticsearch/common/settings/loader/PropertiesSettingsLoader.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/loader/PropertiesSettingsLoader.java
@@ -25,10 +25,9 @@ import org.elasticsearch.common.io.FastStringReader;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Settings loader that loads (parses) the settings in a properties format.
@@ -41,7 +40,7 @@ public class PropertiesSettingsLoader implements SettingsLoader {
         FastStringReader reader = new FastStringReader(source);
         try {
             props.load(reader);
-            Map<String, String> result = newHashMap();
+            Map<String, String> result = new HashMap<>();
             for (Map.Entry entry : props.entrySet()) {
                 result.put((String) entry.getKey(), (String) entry.getValue());
             }
@@ -57,7 +56,7 @@ public class PropertiesSettingsLoader implements SettingsLoader {
         StreamInput stream = StreamInput.wrap(source);
         try {
             props.load(stream);
-            Map<String, String> result = newHashMap();
+            Map<String, String> result = new HashMap<>();
             for (Map.Entry entry : props.entrySet()) {
                 result.put((String) entry.getKey(), (String) entry.getValue());
             }

--- a/core/src/main/java/org/elasticsearch/common/settings/loader/SettingsLoader.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/loader/SettingsLoader.java
@@ -23,10 +23,9 @@ import org.elasticsearch.common.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Provides the ability to load settings (in the form of a simple Map) from
@@ -37,7 +36,7 @@ public interface SettingsLoader {
     static class Helper {
 
         public static Map<String, String> loadNestedFromMap(@Nullable Map map) {
-            Map<String, String> settings = newHashMap();
+            Map<String, String> settings = new HashMap<>();
             if (map == null) {
                 return settings;
             }

--- a/core/src/main/java/org/elasticsearch/common/settings/loader/XContentSettingsLoader.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/loader/XContentSettingsLoader.java
@@ -26,10 +26,9 @@ import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Settings loader that loads (parses) the settings in a xcontent format by flattening them
@@ -55,7 +54,7 @@ public abstract class XContentSettingsLoader implements SettingsLoader {
 
     public Map<String, String> load(XContentParser jp) throws IOException {
         StringBuilder sb = new StringBuilder();
-        Map<String, String> settings = newHashMap();
+        Map<String, String> settings = new HashMap<>();
         List<String> path = new ArrayList<>();
         XContentParser.Token token = jp.nextToken();
         if (token == null) {

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common.xcontent;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -35,6 +34,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -250,7 +250,7 @@ public class XContentHelper {
                     List mergedList = new ArrayList();
                     if (allListValuesAreMapsOfOne(defaultList) && allListValuesAreMapsOfOne(contentList)) {
                         // all are in the form of [ {"key1" : {}}, {"key2" : {}} ], merge based on keys
-                        Map<String, Map<String, Object>> processed = Maps.newLinkedHashMap();
+                        Map<String, Map<String, Object>> processed = new LinkedHashMap<>();
                         for (Object o : contentList) {
                             Map<String, Object> map = (Map<String, Object>) o;
                             Map.Entry<String, Object> entry = map.entrySet().iterator().next();

--- a/core/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.common.xcontent.support;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -135,7 +135,7 @@ public class XContentMapValues {
     }
 
     public static Map<String, Object> filter(Map<String, Object> map, String[] includes, String[] excludes) {
-        Map<String, Object> result = Maps.newHashMap();
+        Map<String, Object> result = new HashMap<>();
         filter(map, result, includes == null ? Strings.EMPTY_ARRAY : includes, excludes == null ? Strings.EMPTY_ARRAY : excludes, new StringBuilder());
         return result;
     }
@@ -201,7 +201,7 @@ public class XContentMapValues {
 
 
             if (entry.getValue() instanceof Map) {
-                Map<String, Object> innerInto = Maps.newHashMap();
+                Map<String, Object> innerInto = new HashMap<>();
                 // if we had an exact match, we want give deeper excludes their chance
                 filter((Map<String, Object>) entry.getValue(), innerInto, exactIncludeMatch ? Strings.EMPTY_ARRAY : includes, excludes, sb);
                 if (exactIncludeMatch || !innerInto.isEmpty()) {
@@ -228,7 +228,7 @@ public class XContentMapValues {
 
         for (Object o : from) {
             if (o instanceof Map) {
-                Map<String, Object> innerInto = Maps.newHashMap();
+                Map<String, Object> innerInto = new HashMap<>();
                 filter((Map<String, Object>) o, innerInto, includes, excludes, sb);
                 if (!innerInto.isEmpty()) {
                     to.add(innerInto);

--- a/core/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/publish/PublishClusterStateAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.discovery.zen.publish;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -42,9 +41,17 @@ import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.zen.DiscoveryNodesProvider;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.*;
+import org.elasticsearch.transport.BytesTransportRequest;
+import org.elasticsearch.transport.EmptyTransportResponseHandler;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequestHandler;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -103,8 +110,8 @@ public class PublishClusterStateAction extends AbstractComponent {
     private void publish(final ClusterChangedEvent clusterChangedEvent, final Set<DiscoveryNode> nodesToPublishTo,
                          final BlockingClusterStatePublishResponseHandler publishResponseHandler) {
 
-        Map<Version, BytesReference> serializedStates = Maps.newHashMap();
-        Map<Version, BytesReference> serializedDiffs = Maps.newHashMap();
+        Map<Version, BytesReference> serializedStates = new HashMap<>();
+        Map<Version, BytesReference> serializedDiffs = new HashMap<>();
 
         final ClusterState clusterState = clusterChangedEvent.state();
         final ClusterState previousState = clusterChangedEvent.previousState();

--- a/core/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.gateway;
 
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -30,6 +30,7 @@ import org.elasticsearch.env.NodeEnvironment;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -109,7 +110,7 @@ public class DanglingIndicesState extends AbstractComponent {
             return ImmutableMap.of();
         }
 
-        Map<String, IndexMetaData>  newIndices = Maps.newHashMap();
+        Map<String, IndexMetaData>  newIndices = new HashMap<>();
         for (String indexName : indices) {
             if (metaData.hasIndex(indexName) == false && danglingIndices.containsKey(indexName) == false) {
                 try {

--- a/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.gateway;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Nullable;
@@ -34,6 +33,7 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -61,16 +61,16 @@ public class MetaStateService extends AbstractComponent {
         this.nodeEnv = nodeEnv;
         this.format = XContentType.fromRestContentType(settings.get(FORMAT_SETTING, "smile"));
         if (this.format == XContentType.SMILE) {
-            Map<String, String> params = Maps.newHashMap();
+            Map<String, String> params = new HashMap<>();
             params.put("binary", "true");
             formatParams = new ToXContent.MapParams(params);
-            Map<String, String> gatewayModeParams = Maps.newHashMap();
+            Map<String, String> gatewayModeParams = new HashMap<>();
             gatewayModeParams.put("binary", "true");
             gatewayModeParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_GATEWAY);
             gatewayModeFormatParams = new ToXContent.MapParams(gatewayModeParams);
         } else {
             formatParams = ToXContent.EMPTY_PARAMS;
-            Map<String, String> gatewayModeParams = Maps.newHashMap();
+            Map<String, String> gatewayModeParams = new HashMap<>();
             gatewayModeParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_GATEWAY);
             gatewayModeFormatParams = new ToXContent.MapParams(gatewayModeParams);
         }

--- a/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.gateway;
 
-import com.google.common.collect.Maps;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -36,6 +35,7 @@ import org.elasticsearch.index.settings.IndexSettings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -193,7 +193,7 @@ public abstract class PrimaryShardAllocator extends AbstractComponent {
      */
     NodesAndVersions buildNodesAndVersions(ShardRouting shard, boolean recoveryOnAnyNode, Set<String> ignoreNodes,
                                            AsyncShardFetch.FetchResult<TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> shardState) {
-        final Map<DiscoveryNode, Long> nodesWithVersion = Maps.newHashMap();
+        final Map<DiscoveryNode, Long> nodesWithVersion = new HashMap<>();
         int numberOfAllocationsFound = 0;
         long highestVersion = -1;
         for (TransportNodesListGatewayStartedShards.NodeGatewayStartedShards nodeShardState : shardState.getData().values()) {

--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
-
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
@@ -30,7 +29,12 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.inject.*;
+import org.elasticsearch.common.inject.CreationException;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.Injectors;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
@@ -47,7 +51,12 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.settings.IndexSettingsService;
-import org.elasticsearch.index.shard.*;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardModule;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.index.shard.StoreRecoveryService;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.IndexStore;
 import org.elasticsearch.index.store.Store;
@@ -69,7 +78,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.common.collect.MapBuilder.newMapBuilder;
 
 /**
@@ -411,7 +419,7 @@ public class IndexService extends AbstractIndexComponent implements IndexCompone
             return;
         }
         logger.debug("[{}] closing... (reason: [{}])", shardId, reason);
-        HashMap<Integer, IndexShardInjectorPair> tmpShardsMap = newHashMap(shards);
+        HashMap<Integer, IndexShardInjectorPair> tmpShardsMap = new HashMap<>(shards);
         IndexShardInjectorPair indexShardInjectorPair = tmpShardsMap.remove(shardId);
         indexShard = indexShardInjectorPair.getIndexShard();
         shardInjector = indexShardInjectorPair.getInjector();

--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisModule.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.analysis;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Scopes;
 import org.elasticsearch.common.inject.assistedinject.FactoryProvider;
@@ -29,6 +28,7 @@ import org.elasticsearch.index.analysis.compound.DictionaryCompoundWordTokenFilt
 import org.elasticsearch.index.analysis.compound.HyphenationCompoundWordTokenFilterFactory;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
@@ -45,7 +45,7 @@ public class AnalysisModule extends AbstractModule {
         }
 
         public static class CharFiltersBindings {
-            private final Map<String, Class<? extends CharFilterFactory>> charFilters = Maps.newHashMap();
+            private final Map<String, Class<? extends CharFilterFactory>> charFilters = new HashMap<>();
 
             public CharFiltersBindings() {
             }
@@ -60,7 +60,7 @@ public class AnalysisModule extends AbstractModule {
         }
 
         public static class TokenFiltersBindings {
-            private final Map<String, Class<? extends TokenFilterFactory>> tokenFilters = Maps.newHashMap();
+            private final Map<String, Class<? extends TokenFilterFactory>> tokenFilters = new HashMap<>();
 
             public TokenFiltersBindings() {
             }
@@ -75,7 +75,7 @@ public class AnalysisModule extends AbstractModule {
         }
 
         public static class TokenizersBindings {
-            private final Map<String, Class<? extends TokenizerFactory>> tokenizers = Maps.newHashMap();
+            private final Map<String, Class<? extends TokenizerFactory>> tokenizers = new HashMap<>();
 
             public TokenizersBindings() {
             }
@@ -90,7 +90,7 @@ public class AnalysisModule extends AbstractModule {
         }
 
         public static class AnalyzersBindings {
-            private final Map<String, Class<? extends AnalyzerProvider>> analyzers = Maps.newHashMap();
+            private final Map<String, Class<? extends AnalyzerProvider>> analyzers = new HashMap<>();
 
             public AnalyzersBindings() {
             }
@@ -107,10 +107,10 @@ public class AnalysisModule extends AbstractModule {
 
     private final LinkedList<AnalysisBinderProcessor> processors = new LinkedList<>();
 
-    private final Map<String, Class<? extends CharFilterFactory>> charFilters = Maps.newHashMap();
-    private final Map<String, Class<? extends TokenFilterFactory>> tokenFilters = Maps.newHashMap();
-    private final Map<String, Class<? extends TokenizerFactory>> tokenizers = Maps.newHashMap();
-    private final Map<String, Class<? extends AnalyzerProvider>> analyzers = Maps.newHashMap();
+    private final Map<String, Class<? extends CharFilterFactory>> charFilters = new HashMap<>();
+    private final Map<String, Class<? extends TokenFilterFactory>> tokenFilters = new HashMap<>();
+    private final Map<String, Class<? extends TokenizerFactory>> tokenizers = new HashMap<>();
+    private final Map<String, Class<? extends AnalyzerProvider>> analyzers = new HashMap<>();
 
     public AnalysisModule(Settings settings, IndicesAnalysisService indicesAnalysisService) {
         Objects.requireNonNull(indicesAnalysisService);

--- a/core/src/main/java/org/elasticsearch/index/analysis/AnalysisService.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/AnalysisService.java
@@ -34,9 +34,8 @@ import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 
 import java.io.Closeable;
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  *
@@ -66,7 +65,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
                            @Nullable Map<String, TokenFilterFactoryFactory> tokenFilterFactoryFactories) {
         super(index, indexSettings);
         Settings defaultSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.indexCreated(indexSettings)).build();
-        Map<String, TokenizerFactory> tokenizers = newHashMap();
+        Map<String, TokenizerFactory> tokenizers = new HashMap<>();
         if (tokenizerFactoryFactories != null) {
             Map<String, Settings> tokenizersSettings = indexSettings.getGroups("index.analysis.tokenizer");
             for (Map.Entry<String, TokenizerFactoryFactory> entry : tokenizerFactoryFactories.entrySet()) {
@@ -101,7 +100,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
 
         this.tokenizers = ImmutableMap.copyOf(tokenizers);
 
-        Map<String, CharFilterFactory> charFilters = newHashMap();
+        Map<String, CharFilterFactory> charFilters = new HashMap<>();
         if (charFilterFactoryFactories != null) {
             Map<String, Settings> charFiltersSettings = indexSettings.getGroups("index.analysis.char_filter");
             for (Map.Entry<String, CharFilterFactoryFactory> entry : charFilterFactoryFactories.entrySet()) {
@@ -136,7 +135,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
 
         this.charFilters = ImmutableMap.copyOf(charFilters);
 
-        Map<String, TokenFilterFactory> tokenFilters = newHashMap();
+        Map<String, TokenFilterFactory> tokenFilters = new HashMap<>();
         if (tokenFilterFactoryFactories != null) {
             Map<String, Settings> tokenFiltersSettings = indexSettings.getGroups("index.analysis.filter");
             for (Map.Entry<String, TokenFilterFactoryFactory> entry : tokenFilterFactoryFactories.entrySet()) {
@@ -171,7 +170,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
         }
         this.tokenFilters = ImmutableMap.copyOf(tokenFilters);
 
-        Map<String, AnalyzerProvider> analyzerProviders = newHashMap();
+        Map<String, AnalyzerProvider> analyzerProviders = new HashMap<>();
         if (analyzerFactoryFactories != null) {
             Map<String, Settings> analyzersSettings = indexSettings.getGroups("index.analysis.analyzer");
             for (Map.Entry<String, AnalyzerProviderFactory> entry : analyzerFactoryFactories.entrySet()) {
@@ -214,7 +213,7 @@ public class AnalysisService extends AbstractIndexComponent implements Closeable
             analyzerProviders.put("default_search_quoted", analyzerProviders.get("default_search"));
         }
 
-        Map<String, NamedAnalyzer> analyzers = newHashMap();
+        Map<String, NamedAnalyzer> analyzers = new HashMap<>();
         for (AnalyzerProvider analyzerFactory : analyzerProviders.values()) {
             /*
              * Lucene defaults positionIncrementGap to 0 in all analyzers but

--- a/core/src/main/java/org/elasticsearch/index/analysis/NumericDateAnalyzer.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/NumericDateAnalyzer.java
@@ -20,11 +20,11 @@
 package org.elasticsearch.index.analysis;
 
 import com.carrotsearch.hppc.IntObjectHashMap;
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class NumericDateAnalyzer extends NumericAnalyzer<NumericDateTokenizer> {
 
-    private static final Map<String, IntObjectHashMap<NamedAnalyzer>> globalAnalyzers = Maps.newHashMap();
+    private static final Map<String, IntObjectHashMap<NamedAnalyzer>> globalAnalyzers = new HashMap<>();
 
     public static synchronized NamedAnalyzer buildNamedAnalyzer(FormatDateTimeFormatter formatter, int precisionStep) {
         IntObjectHashMap<NamedAnalyzer> precisionMap = globalAnalyzers.get(formatter.format());

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.index.fielddata;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
@@ -31,7 +29,17 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.fielddata.plain.*;
+import org.elasticsearch.index.fielddata.plain.BytesBinaryDVIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.DisabledIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.DoubleArrayIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.FloatArrayIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.GeoPointBinaryDVIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.GeoPointDoubleArrayIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.IndexIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.PackedArrayIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.ParentChildIndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
@@ -44,6 +52,7 @@ import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -140,7 +149,7 @@ public class IndexFieldDataService extends AbstractIndexComponent {
 
     private final IndicesFieldDataCache indicesFieldDataCache;
     // the below map needs to be modified under a lock
-    private final Map<String, IndexFieldDataCache> fieldDataCaches = Maps.newHashMap();
+    private final Map<String, IndexFieldDataCache> fieldDataCaches = new HashMap<>();
     private final MapperService mapperService;
     private static final IndexFieldDataCache.Listener DEFAULT_NOOP_LISTENER = new IndexFieldDataCache.Listener() {
         @Override

--- a/core/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/core/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -20,7 +20,6 @@ package org.elasticsearch.index.fieldvisitor;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.util.BytesRef;
@@ -41,12 +40,11 @@ import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Base {@link StoredFieldsVisitor} that retrieves all non-redundant metadata.
@@ -209,7 +207,7 @@ public class FieldsVisitor extends StoredFieldVisitor {
 
     void addValue(String name, Object value) {
         if (fieldsValues == null) {
-            fieldsValues = newHashMap();
+            fieldsValues = new HashMap<>();
         }
 
         List<Object> values = fieldsValues.get(name);

--- a/core/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -35,11 +35,11 @@ import org.elasticsearch.search.lookup.SourceLookup;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
 import static org.elasticsearch.index.get.GetField.readGetField;
 
 /**
@@ -288,7 +288,7 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContent {
             if (size == 0) {
                 fields = ImmutableMap.of();
             } else {
-                fields = newHashMapWithExpectedSize(size);
+                fields = new HashMap<>(size);
                 for (int i = 0; i < size; i++) {
                     GetField field = readGetField(in);
                     fields.put(field.getName(), field);

--- a/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.get;
 
 import com.google.common.collect.Sets;
-
 import org.apache.lucene.index.Term;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
@@ -37,8 +36,16 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
-import org.elasticsearch.index.mapper.*;
-import org.elasticsearch.index.mapper.internal.*;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.Uid;
+import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
+import org.elasticsearch.index.mapper.internal.RoutingFieldMapper;
+import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
+import org.elasticsearch.index.mapper.internal.TTLFieldMapper;
+import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
+import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.translog.Translog;
@@ -55,8 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
 
 /**
  */
@@ -253,7 +258,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                     }
                     if (value != null) {
                         if (fields == null) {
-                            fields = newHashMapWithExpectedSize(2);
+                            fields = new HashMap<>(2);
                         }
                         if (value instanceof List) {
                             fields.put(field, new GetField(field, (List) value));
@@ -378,7 +383,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
                 if (value != null) {
                     if (fields == null) {
-                        fields = newHashMapWithExpectedSize(2);
+                        fields = new HashMap<>(2);
                     }
                     if (value instanceof List) {
                         fields.put(field, new GetField(field, (List) value));

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.mapper;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.analysis.Analyzer;
 import org.elasticsearch.common.collect.CopyOnWriteHashMap;
@@ -29,6 +28,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.analysis.FieldNameAnalyzer;
 
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -68,19 +68,19 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
         FieldNameAnalyzer indexAnalyzer = this.indexAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper, Map.Entry<String, Analyzer>>() {
             @Override
             public Map.Entry<String, Analyzer> apply(FieldMapper input) {
-                return Maps.immutableEntry(input.fieldType().names().indexName(), (Analyzer)input.fieldType().indexAnalyzer());
+                return new AbstractMap.SimpleImmutableEntry<>(input.fieldType().names().indexName(), (Analyzer)input.fieldType().indexAnalyzer());
             }
         }));
         FieldNameAnalyzer searchAnalyzer = this.searchAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper, Map.Entry<String, Analyzer>>() {
             @Override
             public Map.Entry<String, Analyzer> apply(FieldMapper input) {
-                return Maps.immutableEntry(input.fieldType().names().indexName(), (Analyzer)input.fieldType().searchAnalyzer());
+                return new AbstractMap.SimpleImmutableEntry<>(input.fieldType().names().indexName(), (Analyzer)input.fieldType().searchAnalyzer());
             }
         }));
         FieldNameAnalyzer searchQuoteAnalyzer = this.searchQuoteAnalyzer.copyAndAddAll(Collections2.transform(newMappers, new Function<FieldMapper, Map.Entry<String, Analyzer>>() {
             @Override
             public Map.Entry<String, Analyzer> apply(FieldMapper input) {
-                return Maps.immutableEntry(input.fieldType().names().indexName(), (Analyzer)input.fieldType().searchQuoteAnalyzer());
+                return new AbstractMap.SimpleImmutableEntry<>(input.fieldType().names().indexName(), (Analyzer)input.fieldType().searchQuoteAnalyzer());
             }
         }));
         return new DocumentFieldMappers(map, indexAnalyzer, searchAnalyzer, searchQuoteAnalyzer);

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -21,8 +21,6 @@ package org.elasticsearch.index.mapper;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Maps;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseFieldMatcher;
@@ -38,10 +36,33 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.analysis.AnalysisService;
-import org.elasticsearch.index.mapper.core.*;
+import org.elasticsearch.index.mapper.core.BinaryFieldMapper;
+import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.core.ByteFieldMapper;
+import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
+import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
+import org.elasticsearch.index.mapper.core.FloatFieldMapper;
+import org.elasticsearch.index.mapper.core.IntegerFieldMapper;
+import org.elasticsearch.index.mapper.core.LongFieldMapper;
+import org.elasticsearch.index.mapper.core.ShortFieldMapper;
+import org.elasticsearch.index.mapper.core.StringFieldMapper;
+import org.elasticsearch.index.mapper.core.TokenCountFieldMapper;
+import org.elasticsearch.index.mapper.core.TypeParsers;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
-import org.elasticsearch.index.mapper.internal.*;
+import org.elasticsearch.index.mapper.internal.AllFieldMapper;
+import org.elasticsearch.index.mapper.internal.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.internal.IdFieldMapper;
+import org.elasticsearch.index.mapper.internal.IndexFieldMapper;
+import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
+import org.elasticsearch.index.mapper.internal.RoutingFieldMapper;
+import org.elasticsearch.index.mapper.internal.SourceFieldMapper;
+import org.elasticsearch.index.mapper.internal.TTLFieldMapper;
+import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
+import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
+import org.elasticsearch.index.mapper.internal.UidFieldMapper;
+import org.elasticsearch.index.mapper.internal.VersionFieldMapper;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
@@ -51,6 +72,7 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -168,7 +190,7 @@ public class DocumentMapperParser {
             mapping = t.v2();
         }
         if (mapping == null) {
-            mapping = Maps.newHashMap();
+            mapping = new HashMap<>();
         }
         return parse(type, mapping, defaultSource);
     }
@@ -187,7 +209,7 @@ public class DocumentMapperParser {
             mapping = t.v2();
         }
         if (mapping == null) {
-            mapping = Maps.newHashMap();
+            mapping = new HashMap<>();
         }
         return parse(type, mapping, defaultSource);
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/CompletionFieldMapper.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.mapper.core;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -60,6 +59,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.TreeMap;
 
 import static org.elasticsearch.index.mapper.MapperBuilders.completionField;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
@@ -372,7 +372,7 @@ public class CompletionFieldMapper extends FieldMapper {
                         throw new IllegalArgumentException("Unknown field name[" + currentFieldName + "], must be one of " + ALLOWED_CONTENT_FIELD_NAMES);
                     }
                 } else if (Fields.CONTEXT.equals(currentFieldName)) {
-                    SortedMap<String, ContextConfig> configs = Maps.newTreeMap(); 
+                    SortedMap<String, ContextConfig> configs = new TreeMap<>();
                     
                     if (token == Token.START_OBJECT) {
                         while ((token = parser.nextToken()) != Token.END_OBJECT) {
@@ -385,7 +385,7 @@ public class CompletionFieldMapper extends FieldMapper {
                                 configs.put(name, mapping.parseContext(context, parser));
                             }
                         }
-                        contextConfig = Maps.newTreeMap();
+                        contextConfig = new TreeMap<>();
                         for (ContextMapping mapping : fieldType().getContextMapping().values()) {
                             ContextConfig config = configs.get(mapping.name());
                             contextConfig.put(mapping.name(), config==null ? mapping.defaultConfig() : config);
@@ -443,7 +443,7 @@ public class CompletionFieldMapper extends FieldMapper {
         }
 
         if(contextConfig == null) {
-            contextConfig = Maps.newTreeMap();
+            contextConfig = new TreeMap<>();
             for (ContextMapping mapping : fieldType().getContextMapping().values()) {
                 contextConfig.put(mapping.name(), mapping.defaultConfig());
             }

--- a/core/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/object/DynamicTemplate.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.index.mapper.object;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MapperParsingException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -168,7 +168,7 @@ public class DynamicTemplate {
     }
 
     private Map<String, Object> processMap(Map<String, Object> map, String name, String dynamicType) {
-        Map<String, Object> processedMap = Maps.newHashMap();
+        Map<String, Object> processedMap = new HashMap<>();
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             String key = entry.getKey().replace("{name}", name).replace("{dynamic_type}", dynamicType).replace("{dynamicType}", dynamicType);
             Object value = entry.getValue();

--- a/core/src/main/java/org/elasticsearch/index/percolator/QueriesLoaderCollector.java
+++ b/core/src/main/java/org/elasticsearch/index/percolator/QueriesLoaderCollector.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.index.percolator;
 
-import com.google.common.collect.Maps;
-
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
@@ -37,13 +35,14 @@ import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  */
 final class QueriesLoaderCollector extends SimpleCollector {
 
-    private final Map<BytesRef, Query> queries = Maps.newHashMap();
+    private final Map<BytesRef, Query> queries = new HashMap<>();
     private final FieldsVisitor fieldsVisitor = new FieldsVisitor(true);
     private final PercolatorQueriesRegistry percolator;
     private final IndexFieldData<?> uidFieldData;

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryParser.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import com.google.common.collect.Maps;
-
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
@@ -32,6 +30,7 @@ import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.index.search.MultiMatchQuery;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -62,7 +61,7 @@ public class MultiMatchQueryParser implements QueryParser {
         MultiMatchQueryBuilder.Type type = null;
         MultiMatchQuery multiMatchQuery = new MultiMatchQuery(parseContext);
         String minimumShouldMatch = null;
-        Map<String, Float> fieldNameWithBoosts = Maps.newHashMap();
+        Map<String, Float> fieldNameWithBoosts = new HashMap<>();
         String queryName = null;
         XContentParser.Token token;
         String currentFieldName = null;

--- a/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryParseContext.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.index.query;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.MapperQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserSettings;
@@ -90,7 +88,7 @@ public class QueryParseContext {
 
     private final IndexQueryParserService indexQueryParser;
 
-    private final Map<String, Query> namedQueries = Maps.newHashMap();
+    private final Map<String, Query> namedQueries = new HashMap<>();
 
     private final MapperQueryParser queryParser = new MapperQueryParser(this);
 

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryParser.java
@@ -38,10 +38,9 @@ import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  *
@@ -99,7 +98,7 @@ public class ScriptQueryParser implements QueryParser {
             ScriptParameterValue scriptValue = scriptParameterParser.getDefaultScriptParameterValue();
             if (scriptValue != null) {
                 if (params == null) {
-                    params = newHashMap();
+                    params = new HashMap<>();
                 }
                 script = new Script(scriptValue.script(), scriptValue.scriptType(), scriptParameterParser.lang(), params);
             }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionParser.java
@@ -21,7 +21,6 @@
 
 package org.elasticsearch.index.query.functionscore.script;
 
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreFunction;
@@ -37,9 +36,8 @@ import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
 import org.elasticsearch.script.SearchScript;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  *
@@ -86,7 +84,7 @@ public class ScriptScoreFunctionParser implements ScoreFunctionParser {
             ScriptParameterValue scriptValue = scriptParameterParser.getDefaultScriptParameterValue();
             if (scriptValue != null) {
                 if (vars == null) {
-                    vars = newHashMap();
+                    vars = new HashMap<>();
                 }
                 script = new Script(scriptValue.script(), scriptValue.scriptType(), scriptParameterParser.lang(), vars);
             }

--- a/core/src/main/java/org/elasticsearch/index/similarity/SimilarityModule.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/SimilarityModule.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.index.similarity;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Scopes;
 import org.elasticsearch.common.inject.assistedinject.FactoryProvider;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -42,7 +42,7 @@ public class SimilarityModule extends AbstractModule {
     public static final String SIMILARITY_SETTINGS_PREFIX = "index.similarity";
 
     private final Settings settings;
-    private final Map<String, Class<? extends SimilarityProvider>> similarities = Maps.newHashMap();
+    private final Map<String, Class<? extends SimilarityProvider>> similarities = new HashMap<>();
 
     public SimilarityModule(Settings settings) {
         this.settings = settings;

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -33,11 +33,10 @@ import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.F
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Contains information about all snapshot for the given shard in repository
@@ -56,9 +55,9 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
     public BlobStoreIndexShardSnapshots(List<SnapshotFiles> shardSnapshots) {
         this.shardSnapshots = Collections.unmodifiableList(new ArrayList<>(shardSnapshots));
         // Map between blob names and file info
-        Map<String, FileInfo> newFiles = newHashMap();
+        Map<String, FileInfo> newFiles = new HashMap<>();
         // Map between original physical names and file info
-        Map<String, List<FileInfo>> physicalFiles = newHashMap();
+        Map<String, List<FileInfo>> physicalFiles = new HashMap<>();
         for (SnapshotFiles snapshot : shardSnapshots) {
             // First we build map between filenames in the repo and their original file info
             // this map will be used in the next loop
@@ -89,7 +88,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
     private BlobStoreIndexShardSnapshots(ImmutableMap<String, FileInfo> files, List<SnapshotFiles> shardSnapshots) {
         this.shardSnapshots = shardSnapshots;
         this.files = files;
-        Map<String, List<FileInfo>> physicalFiles = newHashMap();
+        Map<String, List<FileInfo>> physicalFiles = new HashMap<>();
         for (SnapshotFiles snapshot : shardSnapshots) {
             for (FileInfo fileInfo : snapshot.indexFiles()) {
                 List<FileInfo> physicalFileList = physicalFiles.get(fileInfo.physicalName());
@@ -237,7 +236,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
         if (token == null) { // New parser
             token = parser.nextToken();
         }
-        Map<String, List<String>> snapshotsMap = newHashMap();
+        Map<String, List<String>> snapshotsMap = new HashMap<>();
         ImmutableMap.Builder<String, FileInfo> filesBuilder = ImmutableMap.builder();
         if (token == XContentParser.Token.START_OBJECT) {
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
@@ -20,10 +20,9 @@ package org.elasticsearch.index.snapshots.blobstore;
 
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Contains a list of files participating in a snapshot
@@ -69,7 +68,7 @@ public class SnapshotFiles {
      */
     public FileInfo findPhysicalIndexFile(String physicalName) {
         if (physicalFiles == null) {
-            Map<String, FileInfo> files = newHashMap();
+            Map<String, FileInfo> files = new HashMap<>();
             for(FileInfo fileInfo : indexFiles) {
                 files.put(fileInfo.physicalName(), fileInfo);
             }

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Maps;
 import org.apache.lucene.store.LockObtainFailedException;
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
@@ -99,7 +98,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.collect.MapBuilder.newMapBuilder;
@@ -246,7 +244,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
             }
         }
 
-        Map<Index, List<IndexShardStats>> statsByShard = Maps.newHashMap();
+        Map<Index, List<IndexShardStats>> statsByShard = new HashMap<>();
         for (IndexServiceInjectorPair value : indices.values()) {
             IndexService indexService = value.getIndexService();
             for (IndexShard indexShard : indexService) {
@@ -395,7 +393,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                 }
 
                 logger.debug("[{}] closing ... (reason [{}])", index, reason);
-                Map<String, IndexServiceInjectorPair> tmpMap = newHashMap(indices);
+                Map<String, IndexServiceInjectorPair> tmpMap = new HashMap<>(indices);
                 IndexServiceInjectorPair remove = tmpMap.remove(index);
                 indexService = remove.getIndexService();
                 indexInjector = remove.getInjector();

--- a/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
@@ -50,6 +49,7 @@ import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -170,7 +170,7 @@ public class NodeIndicesStats implements Streamable, ToXContent {
         stats = CommonStats.readCommonStats(in);
         if (in.readBoolean()) {
             int entries = in.readVInt();
-            statsByShard = Maps.newHashMap();
+            statsByShard = new HashMap<>();
             for (int i = 0; i < entries; i++) {
                 Index index = Index.readIndexName(in);
                 int indexShardListSize = in.readVInt();
@@ -241,7 +241,7 @@ public class NodeIndicesStats implements Streamable, ToXContent {
     }
 
     private Map<Index, CommonStats> createStatsByIndex() {
-        Map<Index, CommonStats> statsMap = Maps.newHashMap();
+        Map<Index, CommonStats> statsMap = new HashMap<>();
         for (Map.Entry<Index, List<IndexShardStats>> entry : statsByShard.entrySet()) {
             if (!statsMap.containsKey(entry.getKey())) {
                 statsMap.put(entry.getKey(), new CommonStats());

--- a/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltCacheFactory.java
+++ b/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltCacheFactory.java
@@ -18,10 +18,10 @@
  */
 package org.elasticsearch.indices.analysis;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -81,7 +81,7 @@ public class PreBuiltCacheFactory {
      */
     private static class PreBuiltCacheStrategyElasticsearch<T> implements PreBuiltCache<T> {
 
-        Map<Version, T> mapModel = Maps.newHashMapWithExpectedSize(2);
+        Map<Version, T> mapModel = new HashMap<>(2);
 
         @Override
         public T get(Version version) {
@@ -99,7 +99,7 @@ public class PreBuiltCacheFactory {
      */
     private static class PreBuiltCacheStrategyLucene<T> implements PreBuiltCache<T> {
 
-        private Map<org.apache.lucene.util.Version, T> mapModel = Maps.newHashMapWithExpectedSize(2);
+        private Map<org.apache.lucene.util.Version, T> mapModel = new HashMap<>(2);
 
         @Override
         public T get(Version version) {

--- a/core/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
+++ b/core/src/main/java/org/elasticsearch/indices/query/IndicesQueriesRegistry.java
@@ -20,13 +20,12 @@
 package org.elasticsearch.indices.query;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryParser;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -37,7 +36,7 @@ public class IndicesQueriesRegistry extends AbstractComponent {
     @Inject
     public IndicesQueriesRegistry(Settings settings, Set<QueryParser> injectedQueryParsers) {
         super(settings);
-        Map<String, QueryParser> queryParsers = Maps.newHashMap();
+        Map<String, QueryParser> queryParsers = new HashMap<>();
         for (QueryParser queryParser : injectedQueryParsers) {
             for (String name : queryParser.names()) {
                 queryParsers.put(name, queryParser);

--- a/core/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -19,18 +19,14 @@
 
 package org.elasticsearch.indices.recovery;
 
-import com.google.common.collect.Maps;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.Store;
-import org.elasticsearch.index.store.StoreFileMetaData;
 import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
-import java.util.Map;
 
 /**
  *

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -21,9 +21,12 @@ package org.elasticsearch.repositories;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.*;
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateRequest;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -43,10 +46,10 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
 
 /**
@@ -265,7 +268,7 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
 
             logger.trace("processing new index repositories for state version [{}]", event.state().version());
 
-            Map<String, RepositoryHolder> survivors = newHashMap();
+            Map<String, RepositoryHolder> survivors = new HashMap<>();
             // First, remove repositories that are no longer there
             for (Map.Entry<String, RepositoryHolder> entry : repositories.entrySet()) {
                 if (newMetaData == null || newMetaData.repository(entry.getKey()) == null) {
@@ -370,7 +373,7 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
             // Closing previous version
             closeRepository(repositoryMetaData.name(), previous);
         }
-        Map<String, RepositoryHolder> newRepositories = newHashMap(repositories);
+        Map<String, RepositoryHolder> newRepositories = new HashMap<>(repositories);
         newRepositories.put(repositoryMetaData.name(), holder);
         repositories = ImmutableMap.copyOf(newRepositories);
         return true;

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreFormat.java
@@ -18,14 +18,17 @@
  */
 package org.elasticsearch.repositories.blobstore;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.common.xcontent.FromXContentBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -44,7 +47,7 @@ public abstract class BlobStoreFormat<T extends ToXContent> {
     protected static final ToXContent.Params SNAPSHOT_ONLY_FORMAT_PARAMS;
 
     static {
-        Map<String, String> snapshotOnlyParams = Maps.newHashMap();
+        Map<String, String> snapshotOnlyParams = new HashMap<>();
         // when metadata is serialized certain elements of the metadata shouldn't be included into snapshot
         // exclusion of these elements is done by setting MetaData.CONTEXT_MODE_PARAM to MetaData.CONTEXT_MODE_SNAPSHOT
         snapshotOnlyParams.put(MetaData.CONTEXT_MODE_PARAM, MetaData.CONTEXT_MODE_SNAPSHOT);

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/template/get/RestGetIndexTemplateAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.rest.action.admin.indices.template.get;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.client.Client;
@@ -28,9 +27,16 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -65,7 +71,7 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
             public RestResponse buildResponse(GetIndexTemplatesResponse getIndexTemplatesResponse, XContentBuilder builder) throws Exception {
                 boolean templateExists = getIndexTemplatesResponse.getIndexTemplates().size() > 0;
 
-                Map<String, String> paramsMap = Maps.newHashMap();
+                Map<String, String> paramsMap = new HashMap<>();
                 paramsMap.put("reduce_mappings", "true");
                 ToXContent.Params params = new ToXContent.DelegatingMapParams(paramsMap, request);
 

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.cat;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -36,14 +35,21 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolStats;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -95,11 +101,11 @@ public class RestThreadPoolAction extends AbstractCatAction {
     private final static Map<String, String> THREAD_POOL_TO_ALIAS;
 
     static {
-        ALIAS_TO_THREAD_POOL = Maps.newHashMapWithExpectedSize(SUPPORTED_NAMES.length);
+        ALIAS_TO_THREAD_POOL = new HashMap<>(SUPPORTED_NAMES.length);
         for (String supportedThreadPool : SUPPORTED_NAMES) {
             ALIAS_TO_THREAD_POOL.put(supportedThreadPool.substring(0, 3), supportedThreadPool);
         }
-        THREAD_POOL_TO_ALIAS = Maps.newHashMapWithExpectedSize(SUPPORTED_NAMES.length);
+        THREAD_POOL_TO_ALIAS = new HashMap<>(SUPPORTED_NAMES.length);
         for (int i = 0; i < SUPPORTED_NAMES.length; i++) {
             THREAD_POOL_TO_ALIAS.put(SUPPORTED_NAMES[i], SUPPORTED_ALIASES[i]);
         }

--- a/core/src/main/java/org/elasticsearch/script/ScriptContextRegistry.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptContextRegistry.java
@@ -22,8 +22,8 @@ package org.elasticsearch.script;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -37,7 +37,7 @@ public final class ScriptContextRegistry {
     private final ImmutableMap<String, ScriptContext> scriptContexts;
 
     ScriptContextRegistry(Iterable<ScriptContext.Plugin> customScriptContexts) {
-        Map<String, ScriptContext> scriptContexts = Maps.newHashMap();
+        Map<String, ScriptContext> scriptContexts = new HashMap<>();
         for (ScriptContext.Standard scriptContext : ScriptContext.Standard.values()) {
             scriptContexts.put(scriptContext.getKey(), scriptContext);
         }

--- a/core/src/main/java/org/elasticsearch/script/ScriptModes.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModes.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.script;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService.ScriptType;
@@ -44,13 +43,13 @@ public class ScriptModes {
     ScriptModes(Map<String, ScriptEngineService> scriptEngines, ScriptContextRegistry scriptContextRegistry, Settings settings) {
         //filter out the native engine as we don't want to apply fine grained settings to it.
         //native scripts are always on as they are static by definition.
-        Map<String, ScriptEngineService> filteredEngines = Maps.newHashMap(scriptEngines);
+        Map<String, ScriptEngineService> filteredEngines = new HashMap<>(scriptEngines);
         filteredEngines.remove(NativeScriptEngineService.NAME);
         this.scriptModes = buildScriptModeSettingsMap(settings, filteredEngines, scriptContextRegistry);
     }
 
     private static ImmutableMap<String, ScriptMode> buildScriptModeSettingsMap(Settings settings, Map<String, ScriptEngineService> scriptEngines, ScriptContextRegistry scriptContextRegistry) {
-        HashMap<String, ScriptMode> scriptModesMap = Maps.newHashMap();
+        HashMap<String, ScriptMode> scriptModesMap = new HashMap<>();
 
         //file scripts are enabled by default, for any language
         addGlobalScriptTypeModes(scriptEngines.keySet(), scriptContextRegistry, ScriptType.FILE, ScriptMode.ON, scriptModesMap);

--- a/core/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.script;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
 import org.elasticsearch.common.inject.multibindings.Multibinder;
@@ -30,6 +29,7 @@ import org.elasticsearch.script.groovy.GroovyScriptEngineService;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ public class ScriptModule extends AbstractModule {
 
     private final List<Class<? extends ScriptEngineService>> scriptEngines = new ArrayList<>();
 
-    private final Map<String, Class<? extends NativeScriptFactory>> scripts = Maps.newHashMap();
+    private final Map<String, Class<? extends NativeScriptFactory>> scripts = new HashMap<>();
 
     private final List<ScriptContext.Plugin> customScriptContexts = new ArrayList<>();
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -40,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.common.util.CollectionUtils.eagerTransform;
 
 /**
@@ -100,13 +98,13 @@ public class InternalAggregations implements Aggregations, ToXContent, Streamabl
     @Override
     public Map<String, Aggregation> getAsMap() {
         if (aggregationsAsMap == null) {
-            Map<String, InternalAggregation> aggregationsAsMap = newHashMap();
+            Map<String, InternalAggregation> aggregationsAsMap = new HashMap<>();
             for (InternalAggregation aggregation : aggregations) {
                 aggregationsAsMap.put(aggregation.getName(), aggregation);
             }
             this.aggregationsAsMap = aggregationsAsMap;
         }
-        return Maps.transformValues(aggregationsAsMap, SUPERTYPE_CAST);
+        return new HashMap<>(aggregationsAsMap);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ValuesSourceAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ValuesSourceAggregationBuilder.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.search.aggregations;
 
-import com.google.common.collect.Maps;
-
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService.ScriptType;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTerms.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.significant;
 
-import com.google.common.collect.Maps;
-
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -151,7 +149,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
     @Override
     public SignificantTerms.Bucket getBucketByKey(String term) {
         if (bucketMap == null) {
-            bucketMap = Maps.newHashMapWithExpectedSize(buckets.size());
+            bucketMap = new HashMap<>(buckets.size());
             for (Bucket bucket : buckets) {
                 bucketMap.put(bucket.getKeyAsString(), bucket);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/ScriptHeuristic.java
@@ -41,9 +41,8 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 public class ScriptHeuristic extends SignificanceHeuristic {
 
@@ -162,7 +161,7 @@ public class ScriptHeuristic extends SignificanceHeuristic {
                 ScriptParameterValue scriptValue = scriptParameterParser.getDefaultScriptParameterValue();
                 if (scriptValue != null) {
                     if (params == null) {
-                        params = newHashMap();
+                        params = new HashMap<>();
                     }
                     script = new Script(scriptValue.script(), scriptValue.scriptType(), scriptParameterParser.lang(), params);
                 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -19,9 +19,7 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
@@ -36,6 +34,7 @@ import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -147,7 +146,7 @@ public abstract class InternalTerms<A extends InternalTerms, B extends InternalT
     @Override
     public Terms.Bucket getBucketByKey(String term) {
         if (bucketMap == null) {
-            bucketMap = Maps.newHashMapWithExpectedSize(buckets.size());
+            bucketMap = new HashMap<>(buckets.size());
             for (Bucket bucket : buckets) {
                 bucketMap.put(bucket.getKeyAsString(), bucket);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParser.java
@@ -43,9 +43,8 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  *
@@ -163,7 +162,7 @@ public class ValuesSourceParser<VS extends ValuesSource> {
             ScriptParameterValue scriptValue = scriptParameterParser.getDefaultScriptParameterValue();
             if (scriptValue != null) {
                 if (input.params == null) {
-                    input.params = newHashMap();
+                    input.params = new HashMap<>();
                 }
                 input.script = new Script(scriptValue.script(), scriptValue.scriptType(), scriptParameterParser.lang(), input.params);
             }

--- a/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/FetchSubPhase.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.fetch;
 
-import com.google.common.collect.Maps;
-
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -29,6 +27,7 @@ import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.search.internal.SearchContext;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -76,7 +75,7 @@ public interface FetchSubPhase {
 
         public Map<String, Object> cache() {
             if (cache == null) {
-                cache = Maps.newHashMap();
+                cache = new HashMap<>();
             }
             return cache;
         }

--- a/core/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/script/ScriptFieldsParseElement.java
@@ -30,9 +30,8 @@ import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.internal.SearchContext;
 
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * <pre>
@@ -85,7 +84,7 @@ public class ScriptFieldsParseElement implements SearchParseElement {
                     ScriptParameterValue scriptValue = scriptParameterParser.getDefaultScriptParameterValue();
                     if (scriptValue != null) {
                         if (params == null) {
-                            params = newHashMap();
+                            params = new HashMap<>();
                         }
                         script = new Script(scriptValue.script(), scriptValue.scriptType(), scriptParameterParser.lang(), params);
                     }

--- a/core/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/FastVectorHighlighter.java
@@ -18,10 +18,20 @@
  */
 package org.elasticsearch.search.highlight;
 
-import com.google.common.collect.Maps;
 import org.apache.lucene.search.highlight.Encoder;
-import org.apache.lucene.search.vectorhighlight.*;
+import org.apache.lucene.search.vectorhighlight.BaseFragmentsBuilder;
+import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
+import org.apache.lucene.search.vectorhighlight.CustomFieldQuery;
+import org.apache.lucene.search.vectorhighlight.FieldFragList;
 import org.apache.lucene.search.vectorhighlight.FieldPhraseList.WeightedPhraseInfo;
+import org.apache.lucene.search.vectorhighlight.FieldQuery;
+import org.apache.lucene.search.vectorhighlight.FragListBuilder;
+import org.apache.lucene.search.vectorhighlight.FragmentsBuilder;
+import org.apache.lucene.search.vectorhighlight.ScoreOrderFragmentsBuilder;
+import org.apache.lucene.search.vectorhighlight.SimpleBoundaryScanner;
+import org.apache.lucene.search.vectorhighlight.SimpleFieldFragList;
+import org.apache.lucene.search.vectorhighlight.SimpleFragListBuilder;
+import org.apache.lucene.search.vectorhighlight.SingleFragListBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -33,6 +43,7 @@ import org.elasticsearch.search.highlight.vectorhighlight.SourceSimpleFragmentsB
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -186,6 +197,6 @@ public class FastVectorHighlighter implements Highlighter {
         public org.apache.lucene.search.vectorhighlight.FastVectorHighlighter fvh;
         public FieldQuery noFieldMatchFieldQuery;
         public FieldQuery fieldMatchFieldQuery;
-        public Map<FieldMapper, MapperHighlightEntry> mappers = Maps.newHashMap();
+        public Map<FieldMapper, MapperHighlightEntry> mappers = new HashMap<>();
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/HighlightPhase.java
@@ -36,10 +36,9 @@ import org.elasticsearch.search.internal.SearchContext;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  *
@@ -77,7 +76,7 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
 
     @Override
     public void hitExecute(SearchContext context, HitContext hitContext) {
-        Map<String, HighlightField> highlightFields = newHashMap();
+        Map<String, HighlightField> highlightFields = new HashMap<>();
         for (SearchContextHighlight.Field field : context.highlight().fields()) {
             Collection<String> fieldNamesToHighlight;
             if (Regex.isSimpleMatchPattern(field.field())) {

--- a/core/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/PlainHighlighter.java
@@ -18,12 +18,19 @@
  */
 package org.elasticsearch.search.highlight;
 
-import com.google.common.collect.Maps;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
-import org.apache.lucene.search.highlight.*;
+import org.apache.lucene.search.highlight.Encoder;
+import org.apache.lucene.search.highlight.Formatter;
+import org.apache.lucene.search.highlight.Fragmenter;
+import org.apache.lucene.search.highlight.NullFragmenter;
+import org.apache.lucene.search.highlight.QueryScorer;
+import org.apache.lucene.search.highlight.SimpleFragmenter;
+import org.apache.lucene.search.highlight.SimpleHTMLFormatter;
+import org.apache.lucene.search.highlight.SimpleSpanFragmenter;
+import org.apache.lucene.search.highlight.TextFragment;
 import org.apache.lucene.util.BytesRefHash;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ExceptionsHelper;
@@ -37,6 +44,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +65,7 @@ public class PlainHighlighter implements Highlighter {
         Encoder encoder = field.fieldOptions().encoder().equals("html") ? HighlightUtils.Encoders.HTML : HighlightUtils.Encoders.DEFAULT;
 
         if (!hitContext.cache().containsKey(CACHE_KEY)) {
-            Map<FieldMapper, org.apache.lucene.search.highlight.Highlighter> mappers = Maps.newHashMap();
+            Map<FieldMapper, org.apache.lucene.search.highlight.Highlighter> mappers = new HashMap<>();
             hitContext.cache().put(CACHE_KEY, mappers);
         }
         @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/PostingsHighlighter.java
@@ -18,12 +18,14 @@
  */
 package org.elasticsearch.search.highlight;
 
-import com.google.common.collect.Maps;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.highlight.Encoder;
-import org.apache.lucene.search.postingshighlight.*;
+import org.apache.lucene.search.postingshighlight.CustomPassageFormatter;
+import org.apache.lucene.search.postingshighlight.CustomPostingsHighlighter;
+import org.apache.lucene.search.postingshighlight.CustomSeparatorBreakIterator;
+import org.apache.lucene.search.postingshighlight.Snippet;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.text.StringText;
@@ -34,7 +36,12 @@ import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.text.BreakIterator;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class PostingsHighlighter implements Highlighter {
 
@@ -169,7 +176,7 @@ public class PostingsHighlighter implements Highlighter {
     }
 
     private static class HighlighterEntry {
-        Map<FieldMapper, MapperHighlighterEntry> mappers = Maps.newHashMap();
+        Map<FieldMapper, MapperHighlighterEntry> mappers = new HashMap<>();
     }
 
     private static class MapperHighlighterEntry {

--- a/core/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/SearchContextHighlight.java
@@ -19,10 +19,14 @@
 
 package org.elasticsearch.search.highlight;
 
-import com.google.common.collect.Maps;
 import org.apache.lucene.search.Query;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -332,7 +336,7 @@ public class SearchContextHighlight {
                     fieldOptions.fragmenter = globalOptions.fragmenter;
                 }
                 if ((fieldOptions.options == null || fieldOptions.options.size() == 0) && globalOptions.options != null) {
-                    fieldOptions.options = Maps.newHashMap(globalOptions.options);
+                    fieldOptions.options = new HashMap<>(globalOptions.options);
                 }
                 if (fieldOptions.highlightQuery == null && globalOptions.highlightQuery != null) {
                     fieldOptions.highlightQuery = globalOptions.highlightQuery;

--- a/core/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/core/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -18,20 +18,18 @@
  */
 package org.elasticsearch.search.lookup;
 
-import com.google.common.collect.Maps;
-
+import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
-import org.apache.lucene.index.LeafReaderContext;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -40,7 +38,7 @@ import java.util.Set;
  */
 public class LeafDocLookup implements Map {
 
-    private final Map<String, ScriptDocValues> localCacheFieldData = Maps.newHashMapWithExpectedSize(4);
+    private final Map<String, ScriptDocValues> localCacheFieldData = new HashMap<>(4);
 
     private final MapperService mapperService;
     private final IndexFieldDataService fieldDataService;

--- a/core/src/main/java/org/elasticsearch/search/lookup/LeafFieldsLookup.java
+++ b/core/src/main/java/org/elasticsearch/search/lookup/LeafFieldsLookup.java
@@ -19,8 +19,6 @@
 package org.elasticsearch.search.lookup;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-
 import org.apache.lucene.index.LeafReader;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
@@ -31,6 +29,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,7 +47,7 @@ public class LeafFieldsLookup implements Map {
 
     private int docId = -1;
 
-    private final Map<String, FieldLookup> cachedFieldData = Maps.newHashMap();
+    private final Map<String, FieldLookup> cachedFieldData = new HashMap<>();
 
     private final SingleFieldsVisitor fieldVisitor;
 

--- a/core/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -51,9 +51,8 @@ import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  *
@@ -118,7 +117,7 @@ public class ScriptSortParser implements SortParser {
             ScriptParameterValue scriptValue = scriptParameterParser.getDefaultScriptParameterValue();
             if (scriptValue != null) {
                 if (params == null) {
-                    params = newHashMap();
+                    params = new HashMap<>();
                 }
                 script = new Script(scriptValue.script(), scriptValue.scriptType(), scriptParameterParser.lang(), params);
             }

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestParseElement.java
@@ -29,9 +29,8 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.collect.Maps.newHashMap;
 
 /**
  *
@@ -57,7 +56,7 @@ public final class SuggestParseElement implements SearchParseElement {
 
         BytesRef globalText = null;
         String fieldName = null;
-        Map<String, SuggestionContext> suggestionContexts = newHashMap();
+        Map<String, SuggestionContext> suggestionContexts = new HashMap<>();
 
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -18,10 +18,9 @@
  */
 package org.elasticsearch.search.suggest.completion;
 
-import com.google.common.collect.Maps;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.suggest.Lookup;
@@ -30,7 +29,6 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.text.StringText;
-import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.SuggestContextParser;
 import org.elasticsearch.search.suggest.Suggester;
@@ -39,6 +37,7 @@ import org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry.Op
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +60,7 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
         completionSuggestion.addTerm(completionSuggestEntry);
 
         String fieldName = suggestionContext.getField();
-        Map<String, CompletionSuggestion.Entry.Option> results = Maps.newHashMapWithExpectedSize(indexReader.leaves().size() * suggestionContext.getSize());
+        Map<String, CompletionSuggestion.Entry.Option> results = new HashMap<>(indexReader.leaves().size() * suggestionContext.getSize());
         for (LeafReaderContext atomicReaderContext : indexReader.leaves()) {
             LeafReader atomicReader = atomicReaderContext.reader();
             Terms terms = atomicReader.fields().terms(fieldName);

--- a/core/src/main/java/org/elasticsearch/search/suggest/context/ContextBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/context/ContextBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.suggest.context;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
@@ -27,6 +26,7 @@ import org.elasticsearch.index.mapper.DocumentMapperParser;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
+import java.util.TreeMap;
 
 public abstract class ContextBuilder<E extends ContextMapping> {
 
@@ -97,7 +97,7 @@ public abstract class ContextBuilder<E extends ContextMapping> {
             throws ElasticsearchParseException {
         if (configuration instanceof Map) {
             Map<String, Object> configurations = (Map<String, Object>)configuration;
-            SortedMap<String, ContextMapping> mappings = Maps.newTreeMap();
+            SortedMap<String, ContextMapping> mappings = new TreeMap<>();
             for (Entry<String,Object> config : configurations.entrySet()) {
                 String name = config.getKey();
                 mappings.put(name, loadMapping(name, (Map<String, Object>) config.getValue(), indexVersionCreated));

--- a/core/src/main/java/org/elasticsearch/search/suggest/context/ContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/context/ContextMapping.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.suggest.context;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.search.suggest.analyzing.XAnalyzingSuggester;
 import org.apache.lucene.util.automaton.Automata;
@@ -43,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * A {@link ContextMapping} is used t define a context that may used
@@ -57,10 +57,10 @@ public abstract class ContextMapping implements ToXContent {
     public static final char SEPARATOR = '\u001D';
 
     /** Dummy Context Mapping that should be used if no context is used*/
-    public static final SortedMap<String, ContextMapping> EMPTY_MAPPING = Maps.newTreeMap();
+    public static final SortedMap<String, ContextMapping> EMPTY_MAPPING = new TreeMap<>();
 
     /** Dummy Context Config matching the Dummy Mapping by providing an empty context*/
-    public static final SortedMap<String, ContextConfig> EMPTY_CONFIG = Maps.newTreeMap();
+    public static final SortedMap<String, ContextConfig> EMPTY_CONFIG = new TreeMap<>();
     
     /** Dummy Context matching the Dummy Mapping by not wrapping a {@link TokenStream} */
     public static final Context EMPTY_CONTEXT = new Context(EMPTY_CONFIG, null);

--- a/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -80,6 +80,7 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -88,9 +89,17 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.elasticsearch.cluster.metadata.IndexMetaData.*;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_CREATION_DATE;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_LEGACY_ROUTING_HASH_FUNCTION;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_LEGACY_ROUTING_USE_TYPE;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_CREATED;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_MINIMUM_COMPATIBLE;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_UPGRADED;
 import static org.elasticsearch.cluster.metadata.MetaDataIndexStateService.INDEX_CLOSED_BLOCK;
 
 /**
@@ -373,7 +382,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                     }
                     Settings normalizedChangeSettings = Settings.settingsBuilder().put(changeSettings).normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX).build();
                     IndexMetaData.Builder builder = IndexMetaData.builder(indexMetaData);
-                    Map<String, String> settingsMap = newHashMap(indexMetaData.settings().getAsMap());
+                    Map<String, String> settingsMap = new HashMap<>(indexMetaData.settings().getAsMap());
                     List<String> simpleMatchPatterns = new ArrayList<>();
                     for (String ignoredSetting : ignoreSettings) {
                         if (!Regex.isSimpleMatchPattern(ignoredSetting)) {
@@ -550,7 +559,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                             if (entry.snapshotId().equals(updateSnapshotState.snapshotId())) {
                                 logger.trace("[{}] Updating shard [{}] with status [{}]", updateSnapshotState.snapshotId(), updateSnapshotState.shardId(), updateSnapshotState.status().state());
                                 if (shards == null) {
-                                    shards = newHashMap(entry.shards());
+                                    shards = new HashMap<>(entry.shards());
                                 }
                                 shards.put(updateSnapshotState.shardId(), updateSnapshotState.status());
                                 changedCount++;
@@ -563,7 +572,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
                             } else {
                                 logger.info("restore [{}] is done", entry.snapshotId());
                                 if (batchedRestoreInfo == null) {
-                                    batchedRestoreInfo = newHashMap();
+                                    batchedRestoreInfo = new HashMap<>();
                                 }
                                 assert !batchedRestoreInfo.containsKey(entry.snapshotId());
                                 batchedRestoreInfo.put(entry.snapshotId(),
@@ -684,7 +693,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
     }
 
     private Map<String, String> renamedIndices(RestoreRequest request, List<String> filteredIndices) {
-        Map<String, String> renamedIndices = newHashMap();
+        Map<String, String> renamedIndices = new HashMap<>();
         for (String index : filteredIndices) {
             String renamedIndex = index;
             if (request.renameReplacement() != null && request.renamePattern() != null) {

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -57,6 +57,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -66,7 +67,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.cluster.SnapshotsInProgress.completed;
 
 /**
@@ -192,7 +192,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent<SnapshotSh
      */
     private void processIndexShardSnapshots(ClusterChangedEvent event) {
         SnapshotsInProgress snapshotsInProgress = event.state().custom(SnapshotsInProgress.TYPE);
-        Map<SnapshotId, SnapshotShards> survivors = newHashMap();
+        Map<SnapshotId, SnapshotShards> survivors = new HashMap<>();
         // First, remove snapshots that are no longer there
         for (Map.Entry<SnapshotId, SnapshotShards> entry : shardSnapshots.entrySet()) {
             if (snapshotsInProgress != null && snapshotsInProgress.snapshot(entry.getKey()) != null) {
@@ -202,13 +202,13 @@ public class SnapshotShardsService extends AbstractLifecycleComponent<SnapshotSh
 
         // For now we will be mostly dealing with a single snapshot at a time but might have multiple simultaneously running
         // snapshots in the future
-        Map<SnapshotId, Map<ShardId, IndexShardSnapshotStatus>> newSnapshots = newHashMap();
+        Map<SnapshotId, Map<ShardId, IndexShardSnapshotStatus>> newSnapshots = new HashMap<>();
         // Now go through all snapshots and update existing or create missing
         final String localNodeId = clusterService.localNode().id();
         if (snapshotsInProgress != null) {
             for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
                 if (entry.state() == SnapshotsInProgress.State.STARTED) {
-                    Map<ShardId, IndexShardSnapshotStatus> startedShards = newHashMap();
+                    Map<ShardId, IndexShardSnapshotStatus> startedShards = new HashMap<>();
                     SnapshotShards snapshotShards = shardSnapshots.get(entry.snapshotId());
                     for (Map.Entry<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shard : entry.shards().entrySet()) {
                         // Add all new shards to start processing on
@@ -519,7 +519,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent<SnapshotSh
                     int changedCount = 0;
                     final List<SnapshotsInProgress.Entry> entries = new ArrayList<>();
                     for (SnapshotsInProgress.Entry entry : snapshots.entries()) {
-                        final Map<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards = newHashMap();
+                        final Map<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards = new HashMap<>();
                         boolean updated = false;
 
                         for (int i = 0; i < batchSize; i++) {

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.threadpool;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.common.Nullable;
@@ -43,11 +42,21 @@ import org.elasticsearch.node.settings.NodeSettingsService;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.collect.MapBuilder.newMapBuilder;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
@@ -129,7 +138,7 @@ public class ThreadPool extends AbstractComponent {
                 .put(Names.FETCH_SHARD_STORE, settingsBuilder().put("type", "scaling").put("keep_alive", "5m").put("size", availableProcessors * 2).build())
                 .build();
 
-        Map<String, ExecutorHolder> executors = Maps.newHashMap();
+        Map<String, ExecutorHolder> executors = new HashMap<>();
         for (Map.Entry<String, Settings> executor : defaultExecutorTypeSettings.entrySet()) {
             executors.put(executor.getKey(), build(executor.getKey(), groupSettings.get(executor.getKey()), executor.getValue()));
         }

--- a/core/src/main/java/org/elasticsearch/transport/TransportInfo.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportInfo.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.transport;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -85,7 +85,7 @@ public class TransportInfo implements Streamable, ToXContent {
         address = BoundTransportAddress.readBoundTransportAddress(in);
         int size = in.readVInt();
         if (size > 0) {
-            profileAddresses = Maps.newHashMapWithExpectedSize(size);
+            profileAddresses = new HashMap<>(size);
             for (int i = 0; i < size; i++) {
                 String key = in.readString();
                 BoundTransportAddress value = BoundTransportAddress.readBoundTransportAddress(in);

--- a/core/src/main/java/org/elasticsearch/transport/TransportModule.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportModule.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.transport;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -30,6 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.local.LocalTransport;
 import org.elasticsearch.transport.netty.NettyTransport;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -46,8 +46,8 @@ public class TransportModule extends AbstractModule {
     private final ESLogger logger;
     private final Settings settings;
 
-    private final Map<String, Class<? extends TransportService>> transportServices = Maps.newHashMap();
-    private final Map<String, Class<? extends Transport>> transports = Maps.newHashMap();
+    private final Map<String, Class<? extends TransportService>> transportServices = new HashMap<>();
+    private final Map<String, Class<? extends Transport>> transports = new HashMap<>();
     private Class<? extends TransportService> configuredTransportService;
     private Class<? extends Transport> configuredTransport;
     private String configuredTransportServiceSource;

--- a/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/netty/NettyTransport.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.transport.netty;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -98,6 +96,7 @@ import java.nio.channels.CancelledKeyException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -116,7 +115,18 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.elasticsearch.common.network.NetworkService.TcpSettings.*;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_BLOCKING;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_BLOCKING_CLIENT;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_BLOCKING_SERVER;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_CONNECT_TIMEOUT;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_DEFAULT_CONNECT_TIMEOUT;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_DEFAULT_RECEIVE_BUFFER_SIZE;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_DEFAULT_SEND_BUFFER_SIZE;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_KEEP_ALIVE;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_NO_DELAY;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_RECEIVE_BUFFER_SIZE;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_REUSE_ADDRESS;
+import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_SEND_BUFFER_SIZE;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.common.transport.NetworkExceptionHelper.isCloseConnectionException;
 import static org.elasticsearch.common.transport.NetworkExceptionHelper.isConnectException;
@@ -282,7 +292,7 @@ public class NettyTransport extends AbstractLifecycleComponent<Transport> implem
                 // extract default profile first and create standard bootstrap
                 Map<String, Settings> profiles = settings.getGroups("transport.profiles", true);
                 if (!profiles.containsKey(DEFAULT_PROFILE)) {
-                    profiles = Maps.newHashMap(profiles);
+                    profiles = new HashMap<>(profiles);
                     profiles.put(DEFAULT_PROFILE, Settings.EMPTY);
                 }
 

--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.tribe;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -52,6 +51,7 @@ import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.rest.RestStatus;
 
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -125,7 +125,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
     public TribeService(Settings settings, ClusterService clusterService, DiscoveryService discoveryService) {
         super(settings);
         this.clusterService = clusterService;
-        Map<String, Settings> nodesSettings = Maps.newHashMap(settings.getGroups("tribe", true));
+        Map<String, Settings> nodesSettings = new HashMap<>(settings.getGroups("tribe", true));
         nodesSettings.remove("blocks"); // remove prefix settings that don't indicate a client
         nodesSettings.remove("on_conflict"); // remove prefix settings that don't indicate a client
         for (Map.Entry<String, Settings> entry : nodesSettings.entrySet()) {

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/template/put/MetaDataIndexTemplateServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/template/put/MetaDataIndexTemplateServiceTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.template.put;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -33,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -45,7 +45,7 @@ public class MetaDataIndexTemplateServiceTests extends ESTestCase {
         PutRequest request = new PutRequest("test", "test_shards");
         request.template("test_shards*");
 
-        Map<String, Object> map = Maps.newHashMap();
+        Map<String, Object> map = new HashMap<>();
         map.put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "0");
         request.settings(Settings.settingsBuilder().put(map).build());
 
@@ -60,7 +60,7 @@ public class MetaDataIndexTemplateServiceTests extends ESTestCase {
         PutRequest request = new PutRequest("test", "putTemplate shards");
         request.template("_test_shards*");
 
-        Map<String, Object> map = Maps.newHashMap();
+        Map<String, Object> map = new HashMap<>();
         map.put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "0");
         request.settings(Settings.settingsBuilder().put(map).build());
 

--- a/core/src/test/java/org/elasticsearch/benchmark/search/aggregations/PercentilesAggregationSearchBenchmark.java
+++ b/core/src/test/java/org/elasticsearch/benchmark/search/aggregations/PercentilesAggregationSearchBenchmark.java
@@ -19,24 +19,28 @@
 
 package org.elasticsearch.benchmark.search.aggregations;
 
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
-
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.StopWatch;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.SizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentiles;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.client.Requests.createIndexRequest;
@@ -170,7 +174,7 @@ public class PercentilesAggregationSearchBenchmark {
                 throw new Error("Expected " + NUM_DOCS + " documents, got " + (count - 1));
             }
             Map<String, Object> percentilesUnsorted = client.get(getRequest(d.indexName()).type("values").id("percentiles")).actionGet().getSourceAsMap();
-            SortedMap<Double, Double> percentiles = Maps.newTreeMap();
+            SortedMap<Double, Double> percentiles = new TreeMap<>();
             for (Map.Entry<String, Object> entry : percentilesUnsorted.entrySet()) {
                 percentiles.put(Double.parseDouble(entry.getKey()), (Double) entry.getValue());
             }
@@ -178,7 +182,7 @@ public class PercentilesAggregationSearchBenchmark {
             System.out.println();
             SearchResponse resp = client.prepareSearch(d.indexName()).setSize(0).addAggregation(percentiles("pcts").field("v").percentiles(PERCENTILES)).execute().actionGet();
             Percentiles pcts = resp.getAggregations().get("pcts");
-            Map<Double, Double> asMap = Maps.newLinkedHashMap();
+            Map<Double, Double> asMap = new LinkedHashMap<>();
             double sumOfErrorSquares = 0;
             for (Percentile percentile : pcts) {
                 asMap.put(percentile.getPercent(), percentile.getValue());

--- a/core/src/test/java/org/elasticsearch/cache/recycler/MockPageCacheRecycler.java
+++ b/core/src/test/java/org/elasticsearch/cache/recycler/MockPageCacheRecycler.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cache.recycler;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.recycler.Recycler.V;
@@ -30,16 +29,18 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class MockPageCacheRecycler extends PageCacheRecycler {
 
-    private static final ConcurrentMap<Object, Throwable> ACQUIRED_PAGES = Maps.newConcurrentMap();
+    private static final ConcurrentMap<Object, Throwable> ACQUIRED_PAGES = new ConcurrentHashMap<>();
 
     public static void ensureAllPagesAreReleased() throws Exception {
-        final Map<Object, Throwable> masterCopy = Maps.newHashMap(ACQUIRED_PAGES);
+        final Map<Object, Throwable> masterCopy = new HashMap<>(ACQUIRED_PAGES);
         if (!masterCopy.isEmpty()) {
             // not empty, we might be executing on a shared cluster that keeps on obtaining
             // and releasing pages, lets make sure that after a reasonable timeout, all master

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffPublishingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffPublishingTests.java
@@ -50,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -57,13 +58,16 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.google.common.collect.Maps.newHashMap;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ClusterStateDiffPublishingTests extends ESTestCase {
 
     protected ThreadPool threadPool;
-    protected Map<String, MockNode> nodes = newHashMap();
+    protected Map<String, MockNode> nodes = new HashMap<>();
 
     public static class MockNode {
         public final DiscoveryNode discoveryNode;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -37,15 +37,17 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
-import java.util.Collection;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class MockDiskUsagesIT extends ESIntegTestCase {
@@ -124,7 +126,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
         cis.setN3Usage(realNodeNames.get(2), new DiskUsage(nodes.get(2), "n3", "_na_", 100, 0)); // nothing free on node3
 
         // Retrieve the count of shards on each node
-        final Map<String, Integer> nodesToShardCount = newHashMap();
+        final Map<String, Integer> nodesToShardCount = new HashMap<>();
 
         assertBusy(new Runnable() {
             @Override

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -20,19 +20,22 @@
 package org.elasticsearch.cluster.serialization;
 
 import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.DiffableUtils.KeyedReader;
-import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.io.stream.*;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.StreamableReader;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class DiffableTests extends ESTestCase {
@@ -44,7 +47,7 @@ public class DiffableTests extends ESTestCase {
         builder.put("bar", new TestDiffable("2"));
         builder.put("baz", new TestDiffable("3"));
         ImmutableMap<String, TestDiffable> before = builder.build();
-        Map<String, TestDiffable> map = newHashMap();
+        Map<String, TestDiffable> map = new HashMap<>();
         map.putAll(before);
         map.remove("bar");
         map.put("baz", new TestDiffable("4"));

--- a/core/src/test/java/org/elasticsearch/common/blobstore/BlobStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/common/blobstore/BlobStoreTests.java
@@ -33,9 +33,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
@@ -71,7 +71,7 @@ public class BlobStoreTests extends ESTestCase {
         assertThat(container.listBlobs().size(), equalTo(0));
         int numberOfFooBlobs = randomIntBetween(0, 10);
         int numberOfBarBlobs = randomIntBetween(3, 20);
-        Map<String, Long> generatedBlobs = newHashMap();
+        Map<String, Long> generatedBlobs = new HashMap<>();
         for (int i = 0; i < numberOfFooBlobs; i++) {
             int length = randomIntBetween(10, 100);
             String name = "foo-" + i + "-";

--- a/core/src/test/java/org/elasticsearch/common/lucene/index/FreqTermsEnumTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/index/FreqTermsEnumTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.lucene.index;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.document.Document;
@@ -50,6 +49,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -79,9 +79,9 @@ public class FreqTermsEnumTests extends ESTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        referenceAll = Maps.newHashMap();
-        referenceNotDeleted = Maps.newHashMap();
-        referenceFilter = Maps.newHashMap();
+        referenceAll = new HashMap<>();
+        referenceNotDeleted = new HashMap<>();
+        referenceFilter = new HashMap<>();
 
         Directory dir = newDirectory();
         IndexWriterConfig conf = newIndexWriterConfig(new KeywordAnalyzer()); // use keyword analyzer we rely on the stored field holding the exact term.

--- a/core/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
+++ b/core/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
@@ -22,9 +22,9 @@ package org.elasticsearch.common.path;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -54,7 +54,7 @@ public class PathTrieTests extends ESTestCase {
         assertThat(trie.retrieve("a/b/c/d"), nullValue());
         assertThat(trie.retrieve("g/t/x"), equalTo("three"));
 
-        Map<String, String> params = newHashMap();
+        Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("index1/insert/12", params), equalTo("bingo"));
         assertThat(params.size(), equalTo(2));
         assertThat(params.get("index"), equalTo("index1"));
@@ -74,7 +74,7 @@ public class PathTrieTests extends ESTestCase {
         trie.insert("/a/{type}", "test1");
         trie.insert("/b/{name}", "test2");
 
-        Map<String, String> params = newHashMap();
+        Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/a/test", params), equalTo("test1"));
         assertThat(params.get("type"), equalTo("test"));
 
@@ -89,7 +89,7 @@ public class PathTrieTests extends ESTestCase {
         trie.insert("/a/c/{name}", "test1");
         trie.insert("/b/{name}", "test2");
 
-        Map<String, String> params = newHashMap();
+        Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/a/c/test", params), equalTo("test1"));
         assertThat(params.get("name"), equalTo("test"));
 
@@ -108,7 +108,7 @@ public class PathTrieTests extends ESTestCase {
         trie.insert("{test}/{testB}", "test5");
         trie.insert("{test}/x/{testC}", "test6");
 
-        Map<String, String> params = newHashMap();
+        Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/b", params), equalTo("test2"));
         assertThat(trie.retrieve("/b/a", params), equalTo("test4"));
         assertThat(trie.retrieve("/v/x", params), equalTo("test5"));
@@ -121,7 +121,7 @@ public class PathTrieTests extends ESTestCase {
         trie.insert("{x}/{y}/{z}", "test1");
         trie.insert("{x}/_y/{k}", "test2");
 
-        Map<String, String> params = newHashMap();
+        Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/a/b/c", params), equalTo("test1"));
         assertThat(params.get("x"), equalTo("a"));
         assertThat(params.get("y"), equalTo("b"));
@@ -141,23 +141,23 @@ public class PathTrieTests extends ESTestCase {
         trie.insert("/{test}/_endpoint", "test4");
         trie.insert("/*/{test}/_endpoint", "test5");
 
-        Map<String, String> params = newHashMap();
+        Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/x/*", params), equalTo("test1"));
         assertThat(params.get("test"), equalTo("*"));
 
-        params = newHashMap();
+        params = new HashMap<>();
         assertThat(trie.retrieve("/b/a", params), equalTo("test2"));
         assertThat(params.get("test"), equalTo("b"));
 
-        params = newHashMap();
+        params = new HashMap<>();
         assertThat(trie.retrieve("/*", params), equalTo("test3"));
         assertThat(params.get("test"), equalTo("*"));
 
-        params = newHashMap();
+        params = new HashMap<>();
         assertThat(trie.retrieve("/*/_endpoint", params), equalTo("test4"));
         assertThat(params.get("test"), equalTo("*"));
 
-        params = newHashMap();
+        params = new HashMap<>();
         assertThat(trie.retrieve("a/*/_endpoint", params), equalTo("test5"));
         assertThat(params.get("test"), equalTo("*"));
     }

--- a/core/src/test/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/core/src/test/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.SeedUtils;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
@@ -33,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -53,7 +53,7 @@ public class MockBigArrays extends BigArrays {
     private static final ConcurrentMap<Object, Object> ACQUIRED_ARRAYS = new ConcurrentHashMap<>();
 
     public static void ensureAllArraysAreReleased() throws Exception {
-        final Map<Object, Object> masterCopy = Maps.newHashMap(ACQUIRED_ARRAYS);
+        final Map<Object, Object> masterCopy = new HashMap<>(ACQUIRED_ARRAYS);
         if (!masterCopy.isEmpty()) {
             // not empty, we might be executing on a shared cluster that keeps on obtaining
             // and releasing arrays, lets make sure that after a reasonable timeout, all master

--- a/core/src/test/java/org/elasticsearch/index/query/TemplateQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TemplateQueryIT.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.index.query;
 
-import com.google.common.collect.Maps;
-
 import org.elasticsearch.action.index.IndexRequest.OpType;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.indexedscripts.delete.DeleteIndexedScriptResponse;
@@ -213,7 +211,7 @@ public class TemplateQueryIT extends ESIntegTestCase {
         index("test", "type", "5", jsonBuilder().startObject().field("otherField", "foo").endObject());
         refresh();
 
-        Map<String, Object> templateParams = Maps.newHashMap();
+        Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("mySize", "2");
         templateParams.put("myField", "theField");
         templateParams.put("myValue", "foo");
@@ -333,7 +331,7 @@ public class TemplateQueryIT extends ESIntegTestCase {
 
         indexRandom(true, builders);
 
-        Map<String, Object> templateParams = Maps.newHashMap();
+        Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("fieldParam", "foo");
 
         SearchResponse searchResponse = client().prepareSearch("test").setTypes("type")
@@ -396,7 +394,7 @@ public class TemplateQueryIT extends ESIntegTestCase {
 
         indexRandom(true, builders);
 
-        Map<String, Object> templateParams = Maps.newHashMap();
+        Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("fieldParam", "foo");
 
         SearchResponse searchResponse = client()
@@ -480,7 +478,7 @@ public class TemplateQueryIT extends ESIntegTestCase {
             GetIndexedScriptResponse getResponse = client().prepareGetIndexedScript(MustacheScriptEngineService.NAME, "git01").get();
             assertTrue(getResponse.isExists());
 
-            Map<String, Object> templateParams = Maps.newHashMap();
+            Map<String, Object> templateParams = new HashMap<>();
             templateParams.put("P_Keyword1", "dev");
 
             try {

--- a/core/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.indices;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -40,6 +39,7 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -234,7 +234,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
 
     private static class IndexShardStateChangeListener extends IndicesLifecycle.Listener {
         //we keep track of all the states (ordered) a shard goes through
-        final ConcurrentMap<ShardId, List<IndexShardState>> shardStates = Maps.newConcurrentMap();
+        final ConcurrentMap<ShardId, List<IndexShardState>> shardStates = new ConcurrentHashMap<>();
         Settings creationSettings = Settings.EMPTY;
         Settings afterCloseSettings = Settings.EMPTY;
 

--- a/core/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.analysis;
 
-import com.google.common.collect.Maps;
 import org.apache.lucene.analysis.Analyzer;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
@@ -30,8 +29,9 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
-import java.util.Collection;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -52,7 +52,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
 
     @Test
     public void testThatPreBuiltAnalyzersAreNotClosedOnIndexClose() throws Exception {
-        Map<PreBuiltAnalyzers, List<Version>> loadedAnalyzers = Maps.newHashMap();
+        Map<PreBuiltAnalyzers, List<Version>> loadedAnalyzers = new HashMap<>();
         List<String> indexNames = new ArrayList<>();
         final int numIndices = scaledRandomIntBetween(2, 4);
         for (int i = 0; i < numIndices; i++) {
@@ -92,7 +92,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
             String randomIndex = indexNames.get(randomInt(indexNames.size()-1));
             String randomId = randomInt() + "";
 
-            Map<String, Object> data = Maps.newHashMap();
+            Map<String, Object> data = new HashMap<>();
             data.put("foo", randomAsciiOfLength(scaledRandomIntBetween(5, 50)));
 
             index(randomIndex, "type", randomId, data);

--- a/core/src/test/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.mapping;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -29,13 +28,22 @@ import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
-import static org.elasticsearch.cluster.metadata.IndexMetaData.*;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_METADATA_BLOCK;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_METADATA;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_READ;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_WRITE;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_READ_ONLY;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
     
@@ -148,7 +156,7 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
     //fix #6552
     public void testSimpleGetFieldMappingsWithPretty() throws Exception {
         assertAcked(prepareCreate("index").addMapping("type", getMappingForType("type")));
-        Map<String, String> params = Maps.newHashMap();
+        Map<String, String> params = new HashMap<>();
         params.put("pretty", "true");
         ensureYellow();
         GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings("index").setTypes("type").setFields("field1", "obj.subfield").get();

--- a/core/src/test/java/org/elasticsearch/rest/HeadersAndContextCopyClientTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/HeadersAndContextCopyClientTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.rest;
 
-import com.google.common.collect.Maps;
-
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -101,7 +99,7 @@ public class HeadersAndContextCopyClientTests extends ESTestCase {
         Set<String> usefulRestHeaders = new HashSet<>(copiedHeaders.keySet());
         usefulRestHeaders.addAll(randomMap(randomIntBetween(0, 10), "useful-").keySet());
         Map<String, String> restContext = randomContext(randomIntBetween(0, 10));
-        Map<String, String> transportContext = Maps.difference(randomContext(randomIntBetween(0, 10)), restContext).entriesOnlyOnLeft();
+        Map<String, String> transportContext = onlyOnLeft(randomContext(randomIntBetween(0, 10)), restContext);
 
         Map<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(transportHeaders);
@@ -147,7 +145,7 @@ public class HeadersAndContextCopyClientTests extends ESTestCase {
         Set<String> usefulRestHeaders = new HashSet<>(copiedHeaders.keySet());
         usefulRestHeaders.addAll(randomMap(randomIntBetween(0, 10), "useful-").keySet());
         Map<String, String> restContext = randomContext(randomIntBetween(0, 10));
-        Map<String, String> transportContext = Maps.difference(randomContext(randomIntBetween(0, 10)), restContext).entriesOnlyOnLeft();
+        Map<String, String> transportContext = onlyOnLeft(randomContext(randomIntBetween(0, 10)), restContext);
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(transportHeaders);
@@ -193,7 +191,7 @@ public class HeadersAndContextCopyClientTests extends ESTestCase {
         Set<String> usefulRestHeaders = new HashSet<>(copiedHeaders.keySet());
         usefulRestHeaders.addAll(randomMap(randomIntBetween(0, 10), "useful-").keySet());
         Map<String, String> restContext = randomContext(randomIntBetween(0, 10));
-        Map<String, String> transportContext = Maps.difference(randomContext(randomIntBetween(0, 10)), restContext).entriesOnlyOnLeft();
+        Map<String, String> transportContext = onlyOnLeft(randomContext(randomIntBetween(0, 10)), restContext);
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(transportHeaders);
@@ -239,7 +237,7 @@ public class HeadersAndContextCopyClientTests extends ESTestCase {
         Set<String> usefulRestHeaders = new HashSet<>(copiedHeaders.keySet());
         usefulRestHeaders.addAll(randomMap(randomIntBetween(0, 10), "useful-").keySet());
         Map<String, String> restContext = randomContext(randomIntBetween(0, 10));
-        Map<String, String> transportContext = Maps.difference(randomContext(randomIntBetween(0, 10)), restContext).entriesOnlyOnLeft();
+        Map<String, String> transportContext = onlyOnLeft(randomContext(randomIntBetween(0, 10)), restContext);
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(transportHeaders);
@@ -280,7 +278,7 @@ public class HeadersAndContextCopyClientTests extends ESTestCase {
         Set<String> usefulRestHeaders = new HashSet<>(copiedHeaders.keySet());
         usefulRestHeaders.addAll(randomMap(randomIntBetween(0, 10), "useful-").keySet());
         Map<String, String> restContext = randomContext(randomIntBetween(0, 10));
-        Map<String, String> transportContext = Maps.difference(randomContext(randomIntBetween(0, 10)), restContext).entriesOnlyOnLeft();
+        Map<String, String> transportContext = onlyOnLeft(randomContext(randomIntBetween(0, 10)), restContext);
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(transportHeaders);
@@ -320,7 +318,7 @@ public class HeadersAndContextCopyClientTests extends ESTestCase {
         Set<String> usefulRestHeaders = new HashSet<>(copiedHeaders.keySet());
         usefulRestHeaders.addAll(randomMap(randomIntBetween(0, 10), "useful-").keySet());
         Map<String, String> restContext = randomContext(randomIntBetween(0, 10));
-        Map<String, String> transportContext = Maps.difference(randomContext(randomIntBetween(0, 10)), restContext).entriesOnlyOnLeft();
+        Map<String, String> transportContext = onlyOnLeft(randomContext(randomIntBetween(0, 10)), restContext);
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.putAll(transportHeaders);
@@ -422,5 +420,15 @@ public class HeadersAndContextCopyClientTests extends ESTestCase {
                 assertThat(context.get(key), equalTo(request.getFromContext(key)));
             }
         }
+    }
+
+    private static Map<String, String> onlyOnLeft(Map<String, String> left, Map<String, String> right) {
+        Map<String, String> map = new HashMap<>();
+        for (Map.Entry<String, String> entry : left.entrySet()) {
+            if (!right.containsKey(entry.getKey())) {
+                map.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return map;
     }
 }

--- a/core/src/test/java/org/elasticsearch/rest/util/RestUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/util/RestUtilsTests.java
@@ -24,13 +24,15 @@ import org.elasticsearch.rest.support.RestUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  *
@@ -39,7 +41,7 @@ public class RestUtilsTests extends ESTestCase {
 
     @Test
     public void testDecodeQueryString() {
-        Map<String, String> params = newHashMap();
+        Map<String, String> params = new HashMap<>();
 
         String uri = "something?test=value";
         RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);
@@ -66,7 +68,7 @@ public class RestUtilsTests extends ESTestCase {
 
     @Test
     public void testDecodeQueryStringEdgeCases() {
-        Map<String, String> params = newHashMap();
+        Map<String, String> params = new HashMap<>();
 
         String uri = "something?";
         RestUtils.decodeQueryString(uri, uri.indexOf('?') + 1, params);

--- a/core/src/test/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
+++ b/core/src/test/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
@@ -25,10 +25,10 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.elasticsearch.cluster.metadata.AliasAction.newAddAliasAction;
 import static org.hamcrest.Matchers.equalTo;
@@ -133,13 +133,13 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
 
 
     private <K, V> Map<K, V> newMap(K key, V value) {
-        Map<K, V> r = newHashMap();
+        Map<K, V> r = new HashMap<>();
         r.put(key, value);
         return r;
     }
 
     private <K, V> Map<K, V> newMap(K key1, V value1, K key2, V value2) {
-        Map<K, V> r = newHashMap();
+        Map<K, V> r = new HashMap<>();
         r.put(key1, value1);
         r.put(key2, value2);
         return r;

--- a/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.script;
 
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptService.ScriptType;
@@ -32,7 +34,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -57,7 +63,7 @@ public class ScriptModesTests extends ESTestCase {
         //randomly register custom script contexts
         int randomInt = randomIntBetween(0, 3);
         //prevent duplicates using map
-        Map<String, ScriptContext.Plugin> contexts = Maps.newHashMap();
+        Map<String, ScriptContext.Plugin> contexts = new HashMap<>();
         for (int i = 0; i < randomInt; i++) {
             String plugin = randomAsciiOfLength(randomIntBetween(1, 10));
             String operation = randomAsciiOfLength(randomIntBetween(1, 30));
@@ -241,7 +247,7 @@ public class ScriptModesTests extends ESTestCase {
     }
 
     private ScriptContext[] complementOf(ScriptContext... scriptContexts) {
-        Map<String, ScriptContext> copy = Maps.newHashMap();
+        Map<String, ScriptContext> copy = new HashMap<>();
         for (ScriptContext scriptContext : scriptContextRegistry.scriptContexts()) {
             copy.put(scriptContext.getKey(), scriptContext);
         }

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -19,8 +19,6 @@
 package org.elasticsearch.script;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-
 import org.elasticsearch.common.ContextAndHeaderHolder;
 import org.elasticsearch.common.HasContextAndHeaders;
 import org.elasticsearch.common.Nullable;
@@ -83,7 +81,7 @@ public class ScriptServiceTests extends ESTestCase {
         //randomly register custom script contexts
         int randomInt = randomIntBetween(0, 3);
         //prevent duplicates using map
-        Map<String, ScriptContext.Plugin> contexts = Maps.newHashMap();
+        Map<String, ScriptContext.Plugin> contexts = new HashMap<>();
         for (int i = 0; i < randomInt; i++) {
             String plugin;
             do {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.aggregations;
 
 import com.carrotsearch.hppc.IntHashSet;
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -48,8 +47,19 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.*;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.extendedStats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.percentiles;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 
@@ -131,7 +141,7 @@ public class EquivalenceIT extends ESIntegTestCase {
         Range range = resp.getAggregations().get("range");
         List<? extends Bucket> buckets = range.getBuckets();
 
-        HashMap<String, Bucket> bucketMap = Maps.newHashMapWithExpectedSize(buckets.size());
+        HashMap<String, Bucket> bucketMap = new HashMap<>(buckets.size());
         for (Bucket bucket : buckets) {
             bucketMap.put(bucket.getKeyAsString(), bucket);
         }

--- a/core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java
@@ -50,17 +50,44 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
-import static com.google.common.collect.Maps.newHashMap;
-import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
+import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
+import static org.elasticsearch.index.query.QueryBuilders.hasParentQuery;
+import static org.elasticsearch.index.query.QueryBuilders.idsQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
+import static org.elasticsearch.index.query.QueryBuilders.notQuery;
+import static org.elasticsearch.index.query.QueryBuilders.prefixQuery;
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.scriptFunction;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.weightFactorFunction;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
-import static org.hamcrest.Matchers.*;
+import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHit;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  *
@@ -302,7 +329,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                 .addMapping("parent")
                 .addMapping("child", "_parent", "type=parent"));
         ensureGreen();
-        Map<String, Set<String>> parentToChildren = newHashMap();
+        Map<String, Set<String>> parentToChildren = new HashMap<>();
         // Childless parent
         client().prepareIndex("test", "parent", "p0").setSource("p_field", "p0").get();
         parentToChildren.put("p0", new HashSet<String>());

--- a/core/src/test/java/org/elasticsearch/search/highlight/CustomHighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/CustomHighlighterSearchIT.java
@@ -18,9 +18,7 @@
  */
 package org.elasticsearch.search.highlight;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -31,9 +29,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
-import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHighlight;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -71,7 +69,7 @@ public class CustomHighlighterSearchIT extends ESIntegTestCase {
     public void testThatCustomHighlighterCanBeConfiguredPerField() throws Exception {
         HighlightBuilder.Field highlightConfig = new HighlightBuilder.Field("name");
         highlightConfig.highlighterType("test-custom");
-        Map<String, Object> options = Maps.newHashMap();
+        Map<String, Object> options = new HashMap<>();
         options.put("myFieldOption", "someValue");
         highlightConfig.options(options);
 
@@ -86,7 +84,7 @@ public class CustomHighlighterSearchIT extends ESIntegTestCase {
 
     @Test
     public void testThatCustomHighlighterCanBeConfiguredGlobally() throws Exception {
-        Map<String, Object> options = Maps.newHashMap();
+        Map<String, Object> options = new HashMap<>();
         options.put("myGlobalOption", "someValue");
 
         SearchResponse searchResponse = client().prepareSearch("test").setTypes("test")

--- a/core/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test.rest;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -65,7 +64,7 @@ public class RestTestExecutionContext implements Closeable {
      */
     public RestResponse callApi(String apiName, Map<String, String> params, List<Map<String, Object>> bodies) throws IOException, RestException  {
         //makes a copy of the parameters before modifying them for this specific request
-        HashMap<String, String> requestParams = Maps.newHashMap(params);
+        HashMap<String, String> requestParams = new HashMap<>(params);
         for (Map.Entry<String, String> entry : requestParams.entrySet()) {
             if (stash.isStashedValue(entry.getValue())) {
                 entry.setValue(stash.unstashValue(entry.getValue()).toString());

--- a/core/src/test/java/org/elasticsearch/test/rest/Stash.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/Stash.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.test.rest;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -27,6 +26,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +40,7 @@ public class Stash implements ToXContent {
 
     public static final Stash EMPTY = new Stash();
 
-    private final Map<String, Object> stash = Maps.newHashMap();
+    private final Map<String, Object> stash = new HashMap<>();
 
     /**
      * Allows to saved a specific field in the stash as key-value pair
@@ -90,7 +90,7 @@ public class Stash implements ToXContent {
      * Recursively unstashes map values if needed
      */
     public Map<String, Object> unstashMap(Map<String, Object> map) {
-        Map<String, Object> copy = Maps.newHashMap(map);
+        Map<String, Object> copy = new HashMap<>(map);
         unstashObject(copy);
         return copy;
     }

--- a/core/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.test.rest.client;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -57,6 +56,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -138,7 +138,7 @@ public class RestClient implements Closeable {
         Map<String, String> requestParams = null;
         if (params != null) {
             //makes a copy of the parameters before modifying them for this specific request
-            requestParams = Maps.newHashMap(params);
+            requestParams = new HashMap<>(params);
             //ignore is a special parameter supported by the clients, shouldn't be sent to es
             String ignoreString = requestParams.remove("ignore");
             if (Strings.hasLength(ignoreString)) {
@@ -192,7 +192,7 @@ public class RestClient implements Closeable {
         HttpRequestBuilder httpRequestBuilder = httpRequestBuilder();
 
         //divide params between ones that go within query string and ones that go within path
-        Map<String, String> pathParts = Maps.newHashMap();
+        Map<String, String> pathParts = new HashMap<>();
         if (params != null) {
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 if (restApi.getPathParts().contains(entry.getKey())) {

--- a/core/src/test/java/org/elasticsearch/test/rest/client/http/HttpRequestBuilder.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/client/http/HttpRequestBuilder.java
@@ -19,8 +19,13 @@
 package org.elasticsearch.test.rest.client.http;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Maps;
-import org.apache.http.client.methods.*;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.elasticsearch.client.support.Headers;
@@ -37,6 +42,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -59,9 +65,9 @@ public class HttpRequestBuilder {
 
     private String path = "";
 
-    private final Map<String, String> params = Maps.newHashMap();
+    private final Map<String, String> params = new HashMap<>();
 
-    private final Map<String, String> headers = Maps.newHashMap();
+    private final Map<String, String> headers = new HashMap<>();
 
     private String method = HttpGetWithEntity.METHOD_NAME;
 

--- a/core/src/test/java/org/elasticsearch/test/rest/parser/RestTestSuiteParseContext.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/parser/RestTestSuiteParseContext.java
@@ -18,12 +18,16 @@
  */
 package org.elasticsearch.test.rest.parser;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.rest.section.*;
+import org.elasticsearch.test.rest.section.DoSection;
+import org.elasticsearch.test.rest.section.ExecutableSection;
+import org.elasticsearch.test.rest.section.SetupSection;
+import org.elasticsearch.test.rest.section.SkipSection;
+import org.elasticsearch.test.rest.section.TestSection;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -36,7 +40,7 @@ public class RestTestSuiteParseContext {
     private static final RestTestSectionParser TEST_SECTION_PARSER = new RestTestSectionParser();
     private static final SkipSectionParser SKIP_SECTION_PARSER = new SkipSectionParser();
     private static final DoSectionParser DO_SECTION_PARSER = new DoSectionParser();
-    private static final Map<String, RestTestFragmentParser<? extends ExecutableSection>> EXECUTABLE_SECTIONS_PARSERS = Maps.newHashMap();
+    private static final Map<String, RestTestFragmentParser<? extends ExecutableSection>> EXECUTABLE_SECTIONS_PARSERS = new HashMap<>();
     static {
         EXECUTABLE_SECTIONS_PARSERS.put("do", DO_SECTION_PARSER);
         EXECUTABLE_SECTIONS_PARSERS.put("set", new SetSectionParser());

--- a/core/src/test/java/org/elasticsearch/test/rest/section/ApiCallSection.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/section/ApiCallSection.java
@@ -20,10 +20,10 @@ package org.elasticsearch.test.rest.section;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +33,7 @@ import java.util.Map;
 public class ApiCallSection {
 
     private final String api;
-    private final Map<String, String> params = Maps.newHashMap();
+    private final Map<String, String> params = new HashMap<>();
     private final List<Map<String, Object>> bodies = new ArrayList<>();
 
     public ApiCallSection(String api) {

--- a/core/src/test/java/org/elasticsearch/test/rest/section/DoSection.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/section/DoSection.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test.rest.section;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.logging.ESLogger;
@@ -28,11 +27,16 @@ import org.elasticsearch.test.rest.client.RestException;
 import org.elasticsearch.test.rest.client.RestResponse;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.common.collect.Tuple.tuple;
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -125,7 +129,7 @@ public class DoSection implements ExecutableSection {
                 + restResponse.getStatusCode() + " " + restResponse.getReasonPhrase() + "] [" + restResponse.getBodyAsString() + "]";
     }
 
-    private static Map<String, Tuple<String, org.hamcrest.Matcher<Integer>>> catches = Maps.newHashMap();
+    private static Map<String, Tuple<String, org.hamcrest.Matcher<Integer>>> catches = new HashMap<>();
 
     static {
         catches.put("missing", tuple("404", equalTo(404)));

--- a/core/src/test/java/org/elasticsearch/test/rest/section/SetSection.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/section/SetSection.java
@@ -18,10 +18,10 @@
  */
 package org.elasticsearch.test.rest.section;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.test.rest.RestTestExecutionContext;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class SetSection implements ExecutableSection {
 
-    private Map<String, String> stash = Maps.newHashMap();
+    private Map<String, String> stash = new HashMap<>();
 
     public void addSet(String responseField, String stashedField) {
         stash.put(responseField, stashedField);

--- a/core/src/test/java/org/elasticsearch/test/rest/spec/RestApi.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/spec/RestApi.java
@@ -18,11 +18,11 @@
  */
 package org.elasticsearch.test.rest.spec;
 
-import com.google.common.collect.Maps;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -198,7 +198,7 @@ public class RestApi {
         }
 
         private static Map<String,String> extractParts(String input) {
-            Map<String, String> parts = Maps.newHashMap();
+            Map<String, String> parts = new HashMap<>();
             Matcher matcher = PLACEHOLDERS_PATTERN.matcher(input);
             while (matcher.find()) {
                 //key is e.g. {index}

--- a/core/src/test/java/org/elasticsearch/test/rest/spec/RestSpec.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/spec/RestSpec.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.test.rest.spec;
 
-import com.google.common.collect.Maps;
-
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.rest.support.FileUtils;
@@ -30,13 +28,14 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Holds the elasticsearch REST spec
  */
 public class RestSpec {
-    Map<String, RestApi> restApiMap = Maps.newHashMap();
+    Map<String, RestApi> restApiMap = new HashMap<>();
 
     private RestSpec() {
     }

--- a/core/src/test/java/org/elasticsearch/test/rest/support/FileUtils.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/support/FileUtils.java
@@ -18,9 +18,7 @@
  */
 package org.elasticsearch.test.rest.support;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.PathUtils;
 
@@ -35,6 +33,7 @@ import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -81,7 +80,7 @@ public final class FileUtils {
      * Each path is looked up in the classpath, or optionally from {@code fileSystem} if its not null.
      */
     public static Map<String, Set<Path>> findYamlSuites(FileSystem fileSystem, String optionalPathPrefix, final String... paths) throws IOException {
-        Map<String, Set<Path>> yamlSuites = Maps.newHashMap();
+        Map<String, Set<Path>> yamlSuites = new HashMap<>();
         for (String path : paths) {
             collectFiles(resolveFile(fileSystem, optionalPathPrefix, path, YAML_SUFFIX), YAML_SUFFIX, yamlSuites);
         }

--- a/core/src/test/java/org/elasticsearch/update/UpdateByNativeScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateByNativeScriptIT.java
@@ -18,9 +18,7 @@
  */
 package org.elasticsearch.update;
 
-import com.google.common.collect.Maps;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.AbstractExecutableScript;
 import org.elasticsearch.script.ExecutableScript;
@@ -35,6 +33,7 @@ import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.hasKey;
@@ -58,7 +57,7 @@ public class UpdateByNativeScriptIT extends ESIntegTestCase {
 
         index("test", "type", "1", "text", "value");
 
-        Map<String, Object> params = Maps.newHashMap();
+        Map<String, Object> params = new HashMap<>();
         params.put("foo", "SETVALUE");
         client().prepareUpdate("test", "type", "1")
                 .setScript(new Script("custom", ScriptService.ScriptType.INLINE, NativeScriptEngineService.NAME, params)).get();
@@ -94,7 +93,7 @@ public class UpdateByNativeScriptIT extends ESIntegTestCase {
 
     static class CustomScript extends AbstractExecutableScript {
         private Map<String, Object> params;
-        private Map<String, Object> vars = Maps.newHashMapWithExpectedSize(2);
+        private Map<String, Object> vars = new HashMap<>(2);
 
         public CustomScript(Map<String, Object> params) {
             this.params = params;

--- a/dev-tools/src/main/resources/forbidden/core-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/core-signatures.txt
@@ -92,3 +92,4 @@ com.google.common.base.Predicate
 com.google.common.base.Predicates
 com.google.common.base.Strings
 com.google.common.base.Throwables
+com.google.common.collect.Maps

--- a/plugins/discovery-multicast/src/main/java/org/elasticsearch/plugin/discovery/multicast/MulticastChannel.java
+++ b/plugins/discovery-multicast/src/main/java/org/elasticsearch/plugin/discovery/multicast/MulticastChannel.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.plugin.discovery.multicast;
 
-import com.google.common.collect.Maps;
-
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -30,7 +28,13 @@ import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.Settings;
 
 import java.io.Closeable;
-import java.net.*;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MulticastSocket;
+import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -165,7 +169,7 @@ public abstract class MulticastChannel implements Closeable {
      */
     private final static class Shared extends MulticastChannel {
 
-        private static final Map<Config, Shared> sharedChannels = Maps.newHashMap();
+        private static final Map<Config, Shared> sharedChannels = new HashMap<>();
         private static final Object mutex = new Object(); // global mutex so we don't sync on static methods (.class)
 
         static MulticastChannel getSharedChannel(Listener listener, Config config) throws Exception {


### PR DESCRIPTION
This commit removes and now forbids all uses of
com.google.common.collect.Maps across the codebase. This is one of many
steps in the eventual removal of Guava as a dependency.

Relates #13224
