### PR TITLE
Cleanup QueryTest framework and be more strict

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
@@ -100,6 +100,13 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
     }
 
     /**
+     * Returns the parents type name
+     */
+    public String type() {
+        return type;
+    }
+
+    /**
      *  Returns inner hit definition in the scope of this query and reusing the defined type and query.
      */
     public QueryInnerHits innerHit() {

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  */
 public class NotQueryParser extends BaseQueryParser<NotQueryBuilder> {
 
-    private static final ParseField QUERY_FIELD = new ParseField("filter", "query");
+    private static final ParseField QUERY_FIELD = new ParseField("query", "filter");
 
     @Inject
     public NotQueryParser() {

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryParser.java
@@ -78,7 +78,7 @@ public class NotQueryParser extends BaseQueryParser<NotQueryBuilder> {
         }
 
         if (!queryFound) {
-            throw new QueryParsingException(parseContext, "filter is required when using `not` query");
+            throw new QueryParsingException(parseContext, "query is required when using `not` query");
         }
 
         NotQueryBuilder notQueryBuilder = new NotQueryBuilder(query);

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -104,16 +104,7 @@ public class TermsQueryParser extends BaseQueryParser {
         if (fieldName == null) {
             throw new QueryParsingException(parseContext, "terms query requires a field name, followed by array of terms or a document lookup specification");
         }
-        TermsQueryBuilder termsQueryBuilder;
-        if (values == null) {
-            termsQueryBuilder = new TermsQueryBuilder(fieldName);
-        } else {
-            termsQueryBuilder = new TermsQueryBuilder(fieldName, values);
-        }
-        return termsQueryBuilder
-                .disableCoord(disableCoord)
-                .minimumShouldMatch(minShouldMatch)
-                .termsLookup(termsLookup)
+        return new TermsQueryBuilder(fieldName, values, minShouldMatch, disableCoord, termsLookup)
                 .boost(boost)
                 .queryName(queryName);
     }

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
-public abstract class BaseTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>> extends BaseQueryTestCase<QB> {
+public abstract class AbstractTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>> extends AbstractQueryTestCase<QB> {
 
     @Override
     protected final QB doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/AndQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AndQueryBuilderTests.java
@@ -30,7 +30,7 @@ import java.util.*;
 import static org.hamcrest.CoreMatchers.*;
 
 @SuppressWarnings("deprecation")
-public class AndQueryBuilderTests extends BaseQueryTestCase<AndQueryBuilder> {
+public class AndQueryBuilderTests extends AbstractQueryTestCase<AndQueryBuilder> {
 
     /**
      * @return a AndQueryBuilder with random limit between 0 and 20

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -31,7 +31,7 @@ import java.util.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class BoolQueryBuilderTests extends BaseQueryTestCase<BoolQueryBuilder> {
+public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilder> {
 
     @Override
     protected BoolQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoostingQueryBuilderTests.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 
-public class BoostingQueryBuilderTests extends BaseQueryTestCase<BoostingQueryBuilder> {
+public class BoostingQueryBuilderTests extends AbstractQueryTestCase<BoostingQueryBuilder> {
 
     @Override
     protected BoostingQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/CommonTermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/CommonTermsQueryBuilderTests.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class CommonTermsQueryBuilderTests extends BaseQueryTestCase<CommonTermsQueryBuilder> {
+public class CommonTermsQueryBuilderTests extends AbstractQueryTestCase<CommonTermsQueryBuilder> {
 
     @Override
     protected CommonTermsQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.*;
 
-public class ConstantScoreQueryBuilderTests extends BaseQueryTestCase<ConstantScoreQueryBuilder> {
+public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<ConstantScoreQueryBuilder> {
 
     /**
      * @return a {@link ConstantScoreQueryBuilder} with random boost between 0.1f and 2.0f

--- a/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTests.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
 
-public class DisMaxQueryBuilderTests extends BaseQueryTestCase<DisMaxQueryBuilder> {
+public class DisMaxQueryBuilderTests extends AbstractQueryTestCase<DisMaxQueryBuilder> {
 
     /**
      * @return a {@link DisMaxQueryBuilder} with random inner queries

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class ExistsQueryBuilderTests extends BaseQueryTestCase<ExistsQueryBuilder> {
+public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBuilder> {
 
     @Override
     protected ExistsQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/FQueryFilterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FQueryFilterBuilderTests.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.*;
 
 @SuppressWarnings("deprecation")
-public class FQueryFilterBuilderTests extends BaseQueryTestCase<FQueryFilterBuilder> {
+public class FQueryFilterBuilderTests extends AbstractQueryTestCase<FQueryFilterBuilder> {
 
     /**
      * @return a FQueryFilterBuilder with random inner query

--- a/core/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTests.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class FieldMaskingSpanQueryBuilderTests extends BaseQueryTestCase<FieldMaskingSpanQueryBuilder> {
+public class FieldMaskingSpanQueryBuilderTests extends AbstractQueryTestCase<FieldMaskingSpanQueryBuilder> {
 
     @Override
     protected FieldMaskingSpanQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/FilteredQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FilteredQueryBuilderTests.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 
 @SuppressWarnings("deprecation")
-public class FilteredQueryBuilderTests extends BaseQueryTestCase<FilteredQueryBuilder> {
+public class FilteredQueryBuilderTests extends AbstractQueryTestCase<FilteredQueryBuilder> {
 
     @Override
     protected FilteredQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class FuzzyQueryBuilderTests extends BaseQueryTestCase<FuzzyQueryBuilder> {
+public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuilder> {
 
     @Override
     protected FuzzyQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class GeoDistanceRangeQueryTests extends BaseQueryTestCase<GeoDistanceRangeQueryBuilder> {
+public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanceRangeQueryBuilder> {
 
     @Override
     protected GeoDistanceRangeQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/GeohashCellQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeohashCellQueryBuilderTests.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class GeohashCellQueryBuilderTests extends BaseQueryTestCase<GeohashCellQuery.Builder> {
+public class GeohashCellQueryBuilderTests extends AbstractQueryTestCase<Builder> {
 
     @Override
     protected Builder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/HasChildQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasChildQueryBuilderTests.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class HasChildQueryBuilderTests extends BaseQueryTestCase<HasChildQueryBuilder> {
+public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQueryBuilder> {
     protected static final String PARENT_TYPE = "parent";
     protected static final String CHILD_TYPE = "child";
 
@@ -108,7 +108,7 @@ public class HasChildQueryBuilderTests extends BaseQueryTestCase<HasChildQueryBu
         return new HasChildQueryBuilder(CHILD_TYPE,
                 RandomQueryBuilder.createQuery(random()), max, min,
                 RandomPicks.randomFrom(random(), ScoreType.values()),
-                SearchContext.current() == null ? null : new QueryInnerHits("inner_hits_name", innerHit));
+                randomBoolean()  ? null : new QueryInnerHits("inner_hits_name", innerHit));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
@@ -40,7 +40,7 @@ import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class HasParentQueryBuilderTests extends BaseQueryTestCase<HasParentQueryBuilder> {
+public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQueryBuilder> {
     protected static final String PARENT_TYPE = "parent";
     protected static final String CHILD_TYPE = "child";
 
@@ -105,7 +105,7 @@ public class HasParentQueryBuilderTests extends BaseQueryTestCase<HasParentQuery
         InnerHitsBuilder.InnerHit innerHit = new InnerHitsBuilder.InnerHit().setSize(100).addSort(STRING_FIELD_NAME, SortOrder.ASC);
         return new HasParentQueryBuilder(PARENT_TYPE,
                 RandomQueryBuilder.createQuery(random()),randomBoolean(),
-                SearchContext.current() == null ? null : new QueryInnerHits("inner_hits_name", innerHit));
+                randomBoolean() ? null : new QueryInnerHits("inner_hits_name", innerHit));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class IdsQueryBuilderTests extends BaseQueryTestCase<IdsQueryBuilder> {
+public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder> {
 
     /**
      * check that parser throws exception on missing values field

--- a/core/src/test/java/org/elasticsearch/index/query/IndicesQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IndicesQueryBuilderTests.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-public class IndicesQueryBuilderTests extends BaseQueryTestCase<IndicesQueryBuilder> {
+public class IndicesQueryBuilderTests extends AbstractQueryTestCase<IndicesQueryBuilder> {
 
     @Override
     protected IndicesQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/LimitQueryBuilderTests.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class LimitQueryBuilderTests extends BaseQueryTestCase<LimitQueryBuilder> {
+public class LimitQueryBuilderTests extends AbstractQueryTestCase<LimitQueryBuilder> {
 
     /**
      * @return a LimitQueryBuilder with random limit between 0 and 20

--- a/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTests.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class MatchAllQueryBuilderTests extends BaseQueryTestCase<MatchAllQueryBuilder> {
+public class MatchAllQueryBuilderTests extends AbstractQueryTestCase<MatchAllQueryBuilder> {
 
     @Override
     protected MatchAllQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/MatchNoneQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchNoneQueryBuilderTests.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class MatchNoneQueryBuilderTests extends BaseQueryTestCase {
+public class MatchNoneQueryBuilderTests extends AbstractQueryTestCase {
 
     @Override
     protected boolean supportsBoostAndQueryName() {

--- a/core/src/test/java/org/elasticsearch/index/query/MissingQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MissingQueryBuilderTests.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.is;
 
-public class MissingQueryBuilderTests extends BaseQueryTestCase<MissingQueryBuilder> {
+public class MissingQueryBuilderTests extends AbstractQueryTestCase<MissingQueryBuilder> {
 
     @Override
     protected MissingQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTests.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
 
-public class NotQueryBuilderTests extends BaseQueryTestCase<NotQueryBuilder> {
+public class NotQueryBuilderTests extends AbstractQueryTestCase<NotQueryBuilder> {
 
     /**
      * @return a NotQueryBuilder with random limit between 0 and 20

--- a/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -69,15 +70,6 @@ public class NotQueryBuilderTests extends AbstractQueryTestCase<NotQueryBuilder>
     @Override
     protected Map<String, NotQueryBuilder> getAlternateVersions() {
         Map<String, NotQueryBuilder> alternateVersions = new HashMap<>();
-
-        NotQueryBuilder testQuery1 = new NotQueryBuilder(createTestQueryBuilder().innerQuery());
-        String contentString1 = "{\n" +
-                "    \"not\" : {\n" +
-                "        \"filter\" : " + testQuery1.innerQuery().toString() + "\n" +
-                "    }\n" +
-                "}";
-        alternateVersions.put(contentString1, testQuery1);
-
         QueryBuilder innerQuery = createTestQueryBuilder().innerQuery();
         //not doesn't support empty query when query/filter element is not specified
         if (innerQuery != EmptyQueryBuilder.PROTOTYPE) {
@@ -88,6 +80,24 @@ public class NotQueryBuilderTests extends AbstractQueryTestCase<NotQueryBuilder>
         }
 
         return alternateVersions;
+    }
+
+
+    public void testDeprecatedXContent() throws IOException {
+        String deprecatedJson = "{\n" +
+                "    \"not\" : {\n" +
+                "        \"filter\" : " + EmptyQueryBuilder.PROTOTYPE.toString() + "\n" +
+                "    }\n" +
+                "}";
+        try {
+            parseQuery(deprecatedJson);
+            fail("filter is deprecated");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Deprecated field [filter] used, expected [query] instead", ex.getMessage());
+        }
+
+        NotQueryBuilder queryBuilder = (NotQueryBuilder) parseQuery(deprecatedJson, ParseFieldMatcher.EMPTY);
+        assertEquals(EmptyQueryBuilder.PROTOTYPE, queryBuilder.innerQuery());
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/OrQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/OrQueryBuilderTests.java
@@ -30,7 +30,7 @@ import java.util.*;
 import static org.hamcrest.CoreMatchers.*;
 
 @SuppressWarnings("deprecation")
-public class OrQueryBuilderTests extends BaseQueryTestCase<OrQueryBuilder> {
+public class OrQueryBuilderTests extends AbstractQueryTestCase<OrQueryBuilder> {
 
     /**
      * @return an OrQueryBuilder with random limit between 0 and 20

--- a/core/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class PrefixQueryBuilderTests extends BaseQueryTestCase<PrefixQueryBuilder> {
+public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBuilder> {
 
     @Override
     protected PrefixQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/QueryFilterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryFilterBuilderTests.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.*;
 
 @SuppressWarnings("deprecation")
-public class QueryFilterBuilderTests extends BaseQueryTestCase<QueryFilterBuilder> {
+public class QueryFilterBuilderTests extends AbstractQueryTestCase<QueryFilterBuilder> {
 
     @Override
     protected QueryFilterBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -35,7 +35,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.*;
 
-public class QueryStringQueryBuilderTests extends BaseQueryTestCase<QueryStringQueryBuilder> {
+public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStringQueryBuilder> {
 
     @Override
     protected QueryStringQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
@@ -62,7 +62,7 @@ public class RandomQueryBuilder {
         // for now, only use String Rangequeries for MultiTerm test, numeric and date makes little sense
         // see issue #12123 for discussion
         // Prefix / Fuzzy / RegEx / Wildcard can go here later once refactored and they have random query generators
-        RangeQueryBuilder query = new RangeQueryBuilder(BaseQueryTestCase.STRING_FIELD_NAME);
+        RangeQueryBuilder query = new RangeQueryBuilder(AbstractQueryTestCase.STRING_FIELD_NAME);
         query.from("a" + RandomStrings.randomAsciiOfLengthBetween(r, 1, 10));
         query.to("z" + RandomStrings.randomAsciiOfLengthBetween(r, 1, 10));
         return query;

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class RangeQueryBuilderTests extends BaseQueryTestCase<RangeQueryBuilder> {
+public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuilder> {
 
     @Override
     protected RangeQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
@@ -30,7 +30,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class RegexpQueryBuilderTests extends BaseQueryTestCase<RegexpQueryBuilder> {
+public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBuilder> {
 
     @Override
     protected RegexpQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class ScriptQueryBuilderTests extends BaseQueryTestCase<ScriptQueryBuilder> {
+public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBuilder> {
 
     @Override
     protected ScriptQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -32,7 +32,7 @@ import java.util.*;
 
 import static org.hamcrest.Matchers.*;
 
-public class SimpleQueryStringBuilderTests extends BaseQueryTestCase<SimpleQueryStringBuilder> {
+public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQueryStringBuilder> {
 
     @Override
     protected SimpleQueryStringBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTests.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class SpanContainingQueryBuilderTests extends BaseQueryTestCase<SpanContainingQueryBuilder> {
+public class SpanContainingQueryBuilderTests extends AbstractQueryTestCase<SpanContainingQueryBuilder> {
 
     @Override
     protected SpanContainingQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTests.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import static org.elasticsearch.index.query.QueryBuilders.spanTermQuery;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class SpanFirstQueryBuilderTests extends BaseQueryTestCase<SpanFirstQueryBuilder> {
+public class SpanFirstQueryBuilderTests extends AbstractQueryTestCase<SpanFirstQueryBuilder> {
 
     @Override
     protected SpanFirstQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class SpanMultiTermQueryBuilderTests extends BaseQueryTestCase<SpanMultiTermQueryBuilder> {
+public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMultiTermQueryBuilder> {
 
     @Override
     protected SpanMultiTermQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTests.java
@@ -30,7 +30,7 @@ import java.util.Iterator;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class SpanNearQueryBuilderTests extends BaseQueryTestCase<SpanNearQueryBuilder> {
+public class SpanNearQueryBuilderTests extends AbstractQueryTestCase<SpanNearQueryBuilder> {
 
     @Override
     protected SpanNearQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTests.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.index.query.QueryBuilders.spanNearQuery;
 import static org.elasticsearch.index.query.QueryBuilders.spanTermQuery;
 import static org.hamcrest.Matchers.*;
 
-public class SpanNotQueryBuilderTests extends BaseQueryTestCase<SpanNotQueryBuilder> {
+public class SpanNotQueryBuilderTests extends AbstractQueryTestCase<SpanNotQueryBuilder> {
 
     @Override
     protected SpanNotQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTests.java
@@ -30,7 +30,7 @@ import java.util.Iterator;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class SpanOrQueryBuilderTests extends BaseQueryTestCase<SpanOrQueryBuilder> {
+public class SpanOrQueryBuilderTests extends AbstractQueryTestCase<SpanOrQueryBuilder> {
 
     @Override
     protected SpanOrQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class SpanTermQueryBuilderTests extends BaseTermQueryTestCase<SpanTermQueryBuilder> {
+public class SpanTermQueryBuilderTests extends AbstractTermQueryTestCase<SpanTermQueryBuilder> {
 
     @Override
     protected SpanTermQueryBuilder createQueryBuilder(String fieldName, Object value) {

--- a/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTests.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class SpanWithinQueryBuilderTests extends BaseQueryTestCase<SpanWithinQueryBuilder> {
+public class SpanWithinQueryBuilderTests extends AbstractQueryTestCase<SpanWithinQueryBuilder> {
 
     @Override
     protected SpanWithinQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/TemplateQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TemplateQueryBuilderTests.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
-public class TemplateQueryBuilderTests extends BaseQueryTestCase<TemplateQueryBuilder> {
+public class TemplateQueryBuilderTests extends AbstractQueryTestCase<TemplateQueryBuilder> {
 
     /**
      * The query type all template tests will be based on.

--- a/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class TermQueryBuilderTests extends BaseTermQueryTestCase<TermQueryBuilder> {
+public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBuilder> {
 
     /**
      * @return a TermQuery with random field name and value, optional random boost and queryname

--- a/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -34,6 +35,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -47,11 +49,6 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
     public void mockTermsLookupFetchService() {
         termsLookupFetchService = new MockTermsLookupFetchService();
         queryParserService().setTermsLookupFetchService(termsLookupFetchService);
-    }
-
-    @Override
-    protected ParseFieldMatcher getDefaultParseFieldMatcher() {
-        return ParseFieldMatcher.EMPTY;
     }
 
     @Override
@@ -70,12 +67,6 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
             // right now the mock service returns us a list of strings
             query = new TermsQueryBuilder(randomBoolean() ? randomAsciiOfLengthBetween(1,10) : STRING_FIELD_NAME);
             query.termsLookup(randomTermsLookup());
-        }
-        if (randomBoolean()) {
-            query.minimumShouldMatch(randomInt(100) + "%");
-        }
-        if (randomBoolean()) {
-            query.disableCoord(randomBoolean());
         }
         return query;
     }
@@ -205,6 +196,50 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
                 "}";
         QueryBuilder termsQueryBuilder = parseQuery(query);
         assertThat(termsQueryBuilder.validate().validationErrors().size(), is(1));
+    }
+
+    public void testDeprecatedXContent() throws IOException {
+        String query = "{\n" +
+                "  \"terms\": {\n" +
+                "    \"field\": [\n" +
+                "      \"blue\",\n" +
+                "      \"pill\"\n" +
+                "    ],\n" +
+                "    \"disable_coord\": true\n" +
+                "  }\n" +
+                "}";
+        try {
+            parseQuery(query);
+            fail("disable_coord is deprecated");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Deprecated field [disable_coord] used, replaced by [Use [bool] query instead]", ex.getMessage());
+        }
+
+        TermsQueryBuilder queryBuilder = (TermsQueryBuilder) parseQuery(query, ParseFieldMatcher.EMPTY);
+        TermsQueryBuilder copy = assertSerialization(queryBuilder);
+        assertTrue(queryBuilder.disableCoord());
+        assertTrue(copy.disableCoord());
+
+        String randomMinShouldMatch = RandomPicks.randomFrom(random(), Arrays.asList("min_match", "min_should_match", "minimum_should_match"));
+        query = "{\n" +
+                "  \"terms\": {\n" +
+                "    \"field\": [\n" +
+                "      \"blue\",\n" +
+                "      \"pill\"\n" +
+                "    ],\n" +
+                "    \"" + randomMinShouldMatch +"\": \"42%\"\n" +
+                "  }\n" +
+                "}";
+        try {
+            parseQuery(query);
+            fail(randomMinShouldMatch + " is deprecated");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Deprecated field [" + randomMinShouldMatch + "] used, replaced by [Use [bool] query instead]", ex.getMessage());
+        }
+        queryBuilder = (TermsQueryBuilder) parseQuery(query, ParseFieldMatcher.EMPTY);
+        copy = assertSerialization(queryBuilder);
+        assertEquals("42%", queryBuilder.minimumShouldMatch());
+        assertEquals("42%", copy.minimumShouldMatch());
     }
 
     private static class MockTermsLookupFetchService extends TermsLookupFetchService {

--- a/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.search.termslookup.TermsLookupFetchService;
 import org.elasticsearch.indices.cache.query.terms.TermsLookup;
@@ -38,7 +39,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.*;
 
-public class TermsQueryBuilderTests extends BaseQueryTestCase<TermsQueryBuilder> {
+public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuilder> {
 
     private MockTermsLookupFetchService termsLookupFetchService;
 
@@ -46,6 +47,11 @@ public class TermsQueryBuilderTests extends BaseQueryTestCase<TermsQueryBuilder>
     public void mockTermsLookupFetchService() {
         termsLookupFetchService = new MockTermsLookupFetchService();
         queryParserService().setTermsLookupFetchService(termsLookupFetchService);
+    }
+
+    @Override
+    protected ParseFieldMatcher getDefaultParseFieldMatcher() {
+        return ParseFieldMatcher.EMPTY;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.*;
 
-public class TypeQueryBuilderTests extends BaseQueryTestCase<TypeQueryBuilder> {
+public class TypeQueryBuilderTests extends AbstractQueryTestCase<TypeQueryBuilder> {
 
     @Override
     protected TypeQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class WildcardQueryBuilderTests extends BaseQueryTestCase<WildcardQueryBuilder> {
+public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQueryBuilder> {
 
     @Override
     protected WildcardQueryBuilder doCreateTestQueryBuilder() {

--- a/core/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-public class WrapperQueryBuilderTests extends BaseQueryTestCase<WrapperQueryBuilder> {
+public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQueryBuilder> {
 
     @Override
     protected boolean supportsBoostAndQueryName() {


### PR DESCRIPTION
This commit contains:
- renaming BaseQueryTestCase to AbstractQueryTestCase
- uses always STRICT parsing when parsing from builders XContent
- ensures that SearchContext is only but always available during toQuery but never during parse phase
- adds a way to override the default ParseFieldMatcher to allow queries to set deprecated API by default

this also found a bug
