### PR TITLE
hack jython tests to work on windows.

### DIFF
--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -97,6 +97,7 @@ public class BootstrapForTesting {
                     String filename = path.getFileName().toString();
                     if (filename.contains("jython") && filename.endsWith(".jar")) {
                         // just enough so it won't fail when it does not exist
+                        perms.add(new FilePermission(path.getParent().toString(), "read,readlink"));
                         perms.add(new FilePermission(path.getParent().resolve("Lib").toString(), "read,readlink"));
                     }
                 }


### PR DESCRIPTION
We already have a jython hack, but windows needs access to the "root" holding the jar file (see https://github.com/int3/jython/blob/master/src/org/python/core/PySystemState.java#L571-L616)

Its different on windows, because when canonicalizing the file (case sensitivity), it needs access to the file.

I reproduced the problem in a VM and that `mvn verify` passes with the fix.

relates to #13467 but does not explain why tests apparently were not running with security manager in jenkins for windows, there is something up with maven/jenkins there.
