### PR TITLE
Remove and forbid use of com.google.common.base.Preconditions#checkNotNull

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionRequestBuilder.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.action;
 
-import com.google.common.base.Preconditions;
 import org.elasticsearch.action.support.PlainListenableActionFuture;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Objects;
 
 /**
  *
@@ -36,7 +37,7 @@ public abstract class ActionRequestBuilder<Request extends ActionRequest, Respon
     protected final ElasticsearchClient client;
 
     protected ActionRequestBuilder(ElasticsearchClient client, Action<Request, Response, RequestBuilder> action, Request request) {
-        Preconditions.checkNotNull(action, "action must not be null");
+        Objects.requireNonNull(action, "action must not be null");
         this.action = action;
         this.request = request;
         this.client = client;

--- a/core/src/main/java/org/elasticsearch/common/inject/AbstractModule.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/AbstractModule.java
@@ -25,8 +25,8 @@ import org.elasticsearch.common.inject.spi.TypeConverter;
 import org.elasticsearch.common.inject.spi.TypeListener;
 
 import java.lang.annotation.Annotation;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
@@ -56,7 +56,7 @@ public abstract class AbstractModule implements Module {
     public final synchronized void configure(Binder builder) {
         checkState(this.binder == null, "Re-entry is not allowed.");
 
-        this.binder = checkNotNull(builder, "builder");
+        this.binder = Objects.requireNonNull(builder, "builder");
         try {
             configure();
         } finally {

--- a/core/src/main/java/org/elasticsearch/common/inject/InheritingState.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/InheritingState.java
@@ -33,8 +33,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * @author jessewilson@google.com (Jesse Wilson)
@@ -54,7 +53,7 @@ class InheritingState implements State {
     private final Object lock;
 
     InheritingState(State parent) {
-        this.parent = checkNotNull(parent, "parent");
+        this.parent = Objects.requireNonNull(parent, "parent");
         this.lock = (parent == State.NONE) ? this : parent.lock();
     }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/Initializer.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/Initializer.java
@@ -23,10 +23,9 @@ import org.elasticsearch.common.inject.spi.InjectionPoint;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Manages and injects instances at injector-creation time. This is made more complicated by
@@ -60,7 +59,7 @@ class Initializer {
      */
     public <T> Initializable<T> requestInjection(InjectorImpl injector, T instance, Object source,
                                                  Set<InjectionPoint> injectionPoints) {
-        checkNotNull(source);
+        Objects.requireNonNull(source);
 
         // short circuit if the object has no injections
         if (instance == null
@@ -118,8 +117,8 @@ class Initializer {
 
         public InjectableReference(InjectorImpl injector, T instance, Object source) {
             this.injector = injector;
-            this.instance = checkNotNull(instance, "instance");
-            this.source = checkNotNull(source, "source");
+            this.instance = Objects.requireNonNull(instance, "instance");
+            this.source = Objects.requireNonNull(source, "source");
         }
 
         public void validate(Errors errors) throws ErrorsException {

--- a/core/src/main/java/org/elasticsearch/common/inject/InjectorShell.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/InjectorShell.java
@@ -35,9 +35,9 @@ import org.elasticsearch.common.inject.spi.TypeListenerBinding;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.elasticsearch.common.inject.Scopes.SINGLETON;
 
@@ -257,7 +257,7 @@ class InjectorShell {
         final Stage stage;
 
         private RootModule(Stage stage) {
-            this.stage = checkNotNull(stage, "stage");
+            this.stage = Objects.requireNonNull(stage, "stage");
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/InternalFactoryToProviderAdapter.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/InternalFactoryToProviderAdapter.java
@@ -19,7 +19,7 @@ package org.elasticsearch.common.inject;
 import org.elasticsearch.common.inject.internal.*;
 import org.elasticsearch.common.inject.spi.Dependency;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * @author crazybob@google.com (Bob Lee)
@@ -35,8 +35,8 @@ class InternalFactoryToProviderAdapter<T> implements InternalFactory<T> {
 
     public InternalFactoryToProviderAdapter(
             Initializable<Provider<? extends T>> initializable, Object source) {
-        this.initializable = checkNotNull(initializable, "provider");
-        this.source = checkNotNull(source, "source");
+        this.initializable = Objects.requireNonNull(initializable, "provider");
+        this.source = Objects.requireNonNull(source, "source");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/Key.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/Key.java
@@ -22,9 +22,9 @@ import org.elasticsearch.common.inject.internal.ToStringBuilder;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Binding key consisting of an injection type and an optional annotation.
@@ -343,7 +343,7 @@ public class Key<T> {
      * Gets the strategy for an annotation.
      */
     static AnnotationStrategy strategyFor(Annotation annotation) {
-        checkNotNull(annotation, "annotation");
+        Objects.requireNonNull(annotation, "annotation");
         Class<? extends Annotation> annotationType = annotation.annotationType();
         ensureRetainedAtRuntime(annotationType);
         ensureIsBindingAnnotation(annotationType);
@@ -359,7 +359,7 @@ public class Key<T> {
      * Gets the strategy for an annotation type.
      */
     static AnnotationStrategy strategyFor(Class<? extends Annotation> annotationType) {
-        checkNotNull(annotationType, "annotation type");
+        Objects.requireNonNull(annotationType, "annotation type");
         ensureRetainedAtRuntime(annotationType);
         ensureIsBindingAnnotation(annotationType);
         return new AnnotationTypeStrategy(annotationType, null);
@@ -414,7 +414,7 @@ public class Key<T> {
         final Annotation annotation;
 
         AnnotationInstanceStrategy(Annotation annotation) {
-            this.annotation = checkNotNull(annotation, "annotation");
+            this.annotation = Objects.requireNonNull(annotation, "annotation");
         }
 
         @Override
@@ -467,7 +467,7 @@ public class Key<T> {
 
         AnnotationTypeStrategy(Class<? extends Annotation> annotationType,
                                Annotation annotation) {
-            this.annotationType = checkNotNull(annotationType, "annotation type");
+            this.annotationType = Objects.requireNonNull(annotationType, "annotation type");
             this.annotation = annotation;
         }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/ScopeBindingProcessor.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/ScopeBindingProcessor.java
@@ -21,8 +21,7 @@ import org.elasticsearch.common.inject.internal.Errors;
 import org.elasticsearch.common.inject.spi.ScopeBinding;
 
 import java.lang.annotation.Annotation;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * Handles {@link Binder#bindScope} commands.
@@ -52,11 +51,11 @@ class ScopeBindingProcessor extends AbstractProcessor {
             // Go ahead and bind anyway so we don't get collateral errors.
         }
 
-        Scope existing = injector.state.getScope(checkNotNull(annotationType, "annotation type"));
+        Scope existing = injector.state.getScope(Objects.requireNonNull(annotationType, "annotation type"));
         if (existing != null) {
             errors.duplicateScopes(existing, annotationType, scope);
         } else {
-            injector.state.putAnnotation(annotationType, checkNotNull(scope, "scope"));
+            injector.state.putAnnotation(annotationType, Objects.requireNonNull(scope, "scope"));
         }
 
         return true;

--- a/core/src/main/java/org/elasticsearch/common/inject/TypeLiteral.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/TypeLiteral.java
@@ -21,11 +21,10 @@ import org.elasticsearch.common.inject.util.Types;
 
 import java.lang.reflect.*;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.elasticsearch.common.inject.internal.MoreTypes.canonicalize;
 
 /**
@@ -85,7 +84,7 @@ public class TypeLiteral<T> {
      */
     @SuppressWarnings("unchecked")
     TypeLiteral(Type type) {
-        this.type = canonicalize(checkNotNull(type, "type"));
+        this.type = canonicalize(Objects.requireNonNull(type, "type"));
         this.rawType = (Class<? super T>) MoreTypes.getRawType(this.type);
         this.hashCode = MoreTypes.hashCode(this.type);
     }

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/AbstractBindingBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/AbstractBindingBuilder.java
@@ -24,8 +24,7 @@ import org.elasticsearch.common.inject.spi.InstanceBinding;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * Bind a value or constant.
@@ -73,7 +72,7 @@ public abstract class AbstractBindingBuilder<T> {
      * Sets the binding to a copy with the specified annotation on the bound key
      */
     protected BindingImpl<T> annotatedWithInternal(Class<? extends Annotation> annotationType) {
-        checkNotNull(annotationType, "annotationType");
+        Objects.requireNonNull(annotationType, "annotationType");
         checkNotAnnotated();
         return setBinding(binding.withKey(
                 Key.get(this.binding.getKey().getTypeLiteral(), annotationType)));
@@ -83,20 +82,20 @@ public abstract class AbstractBindingBuilder<T> {
      * Sets the binding to a copy with the specified annotation on the bound key
      */
     protected BindingImpl<T> annotatedWithInternal(Annotation annotation) {
-        checkNotNull(annotation, "annotation");
+        Objects.requireNonNull(annotation, "annotation");
         checkNotAnnotated();
         return setBinding(binding.withKey(
                 Key.get(this.binding.getKey().getTypeLiteral(), annotation)));
     }
 
     public void in(final Class<? extends Annotation> scopeAnnotation) {
-        checkNotNull(scopeAnnotation, "scopeAnnotation");
+        Objects.requireNonNull(scopeAnnotation, "scopeAnnotation");
         checkNotScoped();
         setBinding(getBinding().withScoping(Scoping.forAnnotation(scopeAnnotation)));
     }
 
     public void in(final Scope scope) {
-        checkNotNull(scope, "scope");
+        Objects.requireNonNull(scope, "scope");
         checkNotScoped();
         setBinding(getBinding().withScoping(Scoping.forInstance(scope)));
     }

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/BindingBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/BindingBuilder.java
@@ -25,9 +25,8 @@ import org.elasticsearch.common.inject.spi.Message;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Bind a non-constant key.
@@ -65,7 +64,7 @@ public class BindingBuilder<T> extends AbstractBindingBuilder<T>
 
     @Override
     public BindingBuilder<T> to(Key<? extends T> linkedKey) {
-        checkNotNull(linkedKey, "linkedKey");
+        Objects.requireNonNull(linkedKey, "linkedKey");
         checkNotTargetted();
         BindingImpl<T> base = getBinding();
         setBinding(new LinkedBindingImpl<>(
@@ -100,7 +99,7 @@ public class BindingBuilder<T> extends AbstractBindingBuilder<T>
 
     @Override
     public BindingBuilder<T> toProvider(Provider<? extends T> provider) {
-        checkNotNull(provider, "provider");
+        Objects.requireNonNull(provider, "provider");
         checkNotTargetted();
 
         // lookup the injection points, adding any errors to the binder's errors list
@@ -127,7 +126,7 @@ public class BindingBuilder<T> extends AbstractBindingBuilder<T>
 
     @Override
     public BindingBuilder<T> toProvider(Key<? extends Provider<? extends T>> providerKey) {
-        checkNotNull(providerKey, "providerKey");
+        Objects.requireNonNull(providerKey, "providerKey");
         checkNotTargetted();
 
         BindingImpl<T> base = getBinding();

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/ExposureBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/ExposureBuilder.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.inject.Key;
 import org.elasticsearch.common.inject.binder.AnnotatedElementBuilder;
 
 import java.lang.annotation.Annotation;
+import java.util.Objects;
 
 /**
  * For private binder's expose() method.
@@ -44,14 +45,14 @@ public class ExposureBuilder<T> implements AnnotatedElementBuilder {
 
     @Override
     public void annotatedWith(Class<? extends Annotation> annotationType) {
-        com.google.common.base.Preconditions.checkNotNull(annotationType, "annotationType");
+        Objects.requireNonNull(annotationType, "annotationType");
         checkNotAnnotated();
         key = Key.get(key.getTypeLiteral(), annotationType);
     }
 
     @Override
     public void annotatedWith(Annotation annotation) {
-        com.google.common.base.Preconditions.checkNotNull(annotation, "annotation");
+        Objects.requireNonNull(annotation, "annotation");
         checkNotAnnotated();
         key = Key.get(key.getTypeLiteral(), annotation);
     }

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/Join.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/Join.java
@@ -22,8 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * Utility for joining pieces of text separated by a delimiter. It can handle
@@ -97,7 +96,7 @@ public final class Join {
      */
     public static String join(
             String delimiter, @Nullable Object firstToken, Object... otherTokens) {
-        checkNotNull(otherTokens);
+        Objects.requireNonNull(otherTokens);
         return join(delimiter, CollectionUtils.asArrayList(firstToken, otherTokens));
     }
 
@@ -207,7 +206,7 @@ public final class Join {
      */
     public static <T extends Appendable> T join(T appendable, String delimiter,
                                                 @Nullable Object firstToken, Object... otherTokens) {
-        checkNotNull(otherTokens);
+        Objects.requireNonNull(otherTokens);
         return join(appendable, delimiter, CollectionUtils.asArrayList(firstToken, otherTokens));
     }
 
@@ -232,8 +231,8 @@ public final class Join {
 
         /* This method is the workhorse of the class */
 
-        checkNotNull(appendable);
-        checkNotNull(delimiter);
+        Objects.requireNonNull(appendable);
+        Objects.requireNonNull(delimiter);
         if (tokens.hasNext()) {
             try {
                 appendOneToken(appendable, tokens.next());
@@ -268,9 +267,9 @@ public final class Join {
      */
     public static <T extends Appendable> T join(T appendable,
                                                 String keyValueSeparator, String entryDelimiter, Map<?, ?> map) {
-        checkNotNull(appendable);
-        checkNotNull(keyValueSeparator);
-        checkNotNull(entryDelimiter);
+        Objects.requireNonNull(appendable);
+        Objects.requireNonNull(keyValueSeparator);
+        Objects.requireNonNull(entryDelimiter);
         Iterator<? extends Map.Entry<?, ?>> entries = map.entrySet().iterator();
         if (entries.hasNext()) {
             try {

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/MatcherAndConverter.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/MatcherAndConverter.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.inject.TypeLiteral;
 import org.elasticsearch.common.inject.matcher.Matcher;
 import org.elasticsearch.common.inject.spi.TypeConverter;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * @author crazybob@google.com (Bob Lee)
@@ -33,8 +33,8 @@ public final class MatcherAndConverter {
 
     public MatcherAndConverter(Matcher<? super TypeLiteral<?>> typeMatcher,
                                TypeConverter typeConverter, Object source) {
-        this.typeMatcher = checkNotNull(typeMatcher, "type matcher");
-        this.typeConverter = checkNotNull(typeConverter, "converter");
+        this.typeMatcher = Objects.requireNonNull(typeMatcher, "type matcher");
+        this.typeConverter = Objects.requireNonNull(typeConverter, "converter");
         this.source = source;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
@@ -31,7 +31,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Static methods for working with types that we aren't publishing in the
@@ -316,7 +315,7 @@ public class MoreTypes {
      * Returns {@code Field.class}, {@code Method.class} or {@code Constructor.class}.
      */
     public static Class<? extends Member> memberType(Member member) {
-        checkNotNull(member, "member");
+        Objects.requireNonNull(member, "member");
 
         if (member instanceof MemberImpl) {
             return ((MemberImpl) member).memberType;
@@ -355,7 +354,7 @@ public class MoreTypes {
     }
 
     public static String memberKey(Member member) {
-        checkNotNull(member, "member");
+        Objects.requireNonNull(member, "member");
 
         return "<NO_MEMBER_KEY>";
     }
@@ -456,7 +455,7 @@ public class MoreTypes {
             this.rawType = canonicalize(rawType);
             this.typeArguments = typeArguments.clone();
             for (int t = 0; t < this.typeArguments.length; t++) {
-                checkNotNull(this.typeArguments[t], "type parameter");
+                Objects.requireNonNull(this.typeArguments[t], "type parameter");
                 checkNotPrimitive(this.typeArguments[t], "type parameters");
                 this.typeArguments[t] = canonicalize(this.typeArguments[t]);
             }
@@ -566,14 +565,14 @@ public class MoreTypes {
             checkArgument(upperBounds.length == 1, "Must have exactly one upper bound.");
 
             if (lowerBounds.length == 1) {
-                checkNotNull(lowerBounds[0], "lowerBound");
+                Objects.requireNonNull(lowerBounds[0], "lowerBound");
                 checkNotPrimitive(lowerBounds[0], "wildcard bounds");
                 checkArgument(upperBounds[0] == Object.class, "bounded both ways");
                 this.lowerBound = canonicalize(lowerBounds[0]);
                 this.upperBound = Object.class;
 
             } else {
-                checkNotNull(upperBounds[0], "upperBound");
+                Objects.requireNonNull(upperBounds[0], "upperBound");
                 checkNotPrimitive(upperBounds[0], "wildcard bounds");
                 this.lowerBound = null;
                 this.upperBound = canonicalize(upperBounds[0]);

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/PrivateElementsImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/PrivateElementsImpl.java
@@ -30,10 +30,10 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
@@ -64,7 +64,7 @@ public final class PrivateElementsImpl implements PrivateElements {
     private Injector injector;
 
     public PrivateElementsImpl(Object source) {
-        this.source = checkNotNull(source, "source");
+        this.source = Objects.requireNonNull(source, "source");
     }
 
     @Override
@@ -89,7 +89,7 @@ public final class PrivateElementsImpl implements PrivateElements {
 
     public void initInjector(Injector injector) {
         checkState(this.injector == null, "injector already initialized");
-        this.injector = checkNotNull(injector, "injector");
+        this.injector = Objects.requireNonNull(injector, "injector");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/ProviderMethodsModule.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/ProviderMethodsModule.java
@@ -32,8 +32,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * Creates bindings to methods annotated with {@literal @}{@link Provides}. Use the scope and
@@ -47,7 +46,7 @@ public final class ProviderMethodsModule implements Module {
     private final TypeLiteral<?> typeLiteral;
 
     private ProviderMethodsModule(Object delegate) {
-        this.delegate = checkNotNull(delegate, "delegate");
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
         this.typeLiteral = TypeLiteral.get(this.delegate.getClass());
     }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/matcher/Matchers.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/matcher/Matchers.java
@@ -22,9 +22,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Matcher implementations. Supports matching classes and methods.
@@ -73,7 +73,7 @@ public class Matchers {
         final Matcher<? super T> delegate;
 
         private Not(Matcher<? super T> delegate) {
-            this.delegate = checkNotNull(delegate, "delegate");
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
         }
 
         @Override
@@ -121,7 +121,7 @@ public class Matchers {
         private final Class<? extends Annotation> annotationType;
 
         public AnnotatedWithType(Class<? extends Annotation> annotationType) {
-            this.annotationType = checkNotNull(annotationType, "annotation type");
+            this.annotationType = Objects.requireNonNull(annotationType, "annotation type");
             checkForRuntimeRetention(annotationType);
         }
 
@@ -163,7 +163,7 @@ public class Matchers {
         private final Annotation annotation;
 
         public AnnotatedWith(Annotation annotation) {
-            this.annotation = checkNotNull(annotation, "annotation");
+            this.annotation = Objects.requireNonNull(annotation, "annotation");
             checkForRuntimeRetention(annotation.annotationType());
         }
 
@@ -205,7 +205,7 @@ public class Matchers {
         private final Class<?> superclass;
 
         public SubclassesOf(Class<?> superclass) {
-            this.superclass = checkNotNull(superclass, "superclass");
+            this.superclass = Objects.requireNonNull(superclass, "superclass");
         }
 
         @Override
@@ -244,7 +244,7 @@ public class Matchers {
         private final Object value;
 
         public Only(Object value) {
-            this.value = checkNotNull(value, "value");
+            this.value = Objects.requireNonNull(value, "value");
         }
 
         @Override
@@ -283,7 +283,7 @@ public class Matchers {
         private final Object value;
 
         public IdenticalTo(Object value) {
-            this.value = checkNotNull(value, "value");
+            this.value = Objects.requireNonNull(value, "value");
         }
 
         @Override
@@ -323,7 +323,7 @@ public class Matchers {
         private final String packageName;
 
         public InPackage(Package targetPackage) {
-            this.targetPackage = checkNotNull(targetPackage, "package");
+            this.targetPackage = Objects.requireNonNull(targetPackage, "package");
             this.packageName = targetPackage.getName();
         }
 
@@ -410,7 +410,7 @@ public class Matchers {
         private final Matcher<? super Class<?>> returnType;
 
         public Returns(Matcher<? super Class<?>> returnType) {
-            this.returnType = checkNotNull(returnType, "return type matcher");
+            this.returnType = Objects.requireNonNull(returnType, "return type matcher");
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/multibindings/Multibinder.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/multibindings/Multibinder.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -208,10 +209,10 @@ public abstract class Multibinder<T> {
 
         private RealMultibinder(Binder binder, TypeLiteral<T> elementType,
                                 String setName, Key<Set<T>> setKey) {
-            this.binder = checkNotNull(binder, "binder");
-            this.elementType = checkNotNull(elementType, "elementType");
-            this.setName = checkNotNull(setName, "setName");
-            this.setKey = checkNotNull(setKey, "setKey");
+            this.binder = Objects.requireNonNull(binder, "binder");
+            this.elementType = Objects.requireNonNull(elementType, "elementType");
+            this.setName = Objects.requireNonNull(setName, "setName");
+            this.setKey = Objects.requireNonNull(setKey, "setKey");
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/name/NamedImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/name/NamedImpl.java
@@ -18,15 +18,14 @@ package org.elasticsearch.common.inject.name;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 class NamedImpl implements Named, Serializable {
 
     private final String value;
 
     public NamedImpl(String value) {
-        this.value = checkNotNull(value, "name");
+        this.value = Objects.requireNonNull(value, "name");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/InjectionRequest.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/InjectionRequest.java
@@ -20,9 +20,8 @@ import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.ConfigurationException;
 import org.elasticsearch.common.inject.TypeLiteral;
 
+import java.util.Objects;
 import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A request to inject the instance fields and methods of an instance. Requests are created
@@ -41,9 +40,9 @@ public final class InjectionRequest<T> implements Element {
     private final T instance;
 
     public InjectionRequest(Object source, TypeLiteral<T> type, T instance) {
-        this.source = checkNotNull(source, "source");
-        this.type = checkNotNull(type, "type");
-        this.instance = checkNotNull(instance, "instance");
+        this.source = Objects.requireNonNull(source, "source");
+        this.type = Objects.requireNonNull(type, "type");
+        this.instance = Objects.requireNonNull(instance, "instance");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/MembersInjectorLookup.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/MembersInjectorLookup.java
@@ -20,7 +20,8 @@ import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.MembersInjector;
 import org.elasticsearch.common.inject.TypeLiteral;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
+
 import static com.google.common.base.Preconditions.checkState;
 
 /**
@@ -40,8 +41,8 @@ public final class MembersInjectorLookup<T> implements Element {
     private MembersInjector<T> delegate;
 
     public MembersInjectorLookup(Object source, TypeLiteral<T> type) {
-        this.source = checkNotNull(source, "source");
-        this.type = checkNotNull(type, "type");
+        this.source = Objects.requireNonNull(source, "source");
+        this.type = Objects.requireNonNull(type, "type");
     }
 
     @Override
@@ -68,7 +69,7 @@ public final class MembersInjectorLookup<T> implements Element {
      */
     public void initializeDelegate(MembersInjector<T> delegate) {
         checkState(this.delegate == null, "delegate already initialized");
-        this.delegate = checkNotNull(delegate, "delegate");
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/Message.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/Message.java
@@ -27,8 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * An error message and the context in which it occurred. Messages are usually created internally by
  * Guice and its extensions. Messages can be created explicitly in a module using {@link
@@ -52,7 +50,7 @@ public final class Message implements Serializable, Element {
      */
     public Message(List<Object> sources, String message, Throwable cause) {
         this.sources = Collections.unmodifiableList(sources);
-        this.message = checkNotNull(message, "message");
+        this.message = Objects.requireNonNull(message, "message");
         this.cause = cause;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/ProviderLookup.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/ProviderLookup.java
@@ -20,7 +20,8 @@ import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.Key;
 import org.elasticsearch.common.inject.Provider;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
+
 import static com.google.common.base.Preconditions.checkState;
 
 /**
@@ -64,8 +65,8 @@ public final class ProviderLookup<T> implements Element {
     private Provider<T> delegate;
 
     public ProviderLookup(Object source, Key<T> key) {
-        this.source = checkNotNull(source, "source");
-        this.key = checkNotNull(key, "key");
+        this.source = Objects.requireNonNull(source, "source");
+        this.key = Objects.requireNonNull(key, "key");
     }
 
     @Override
@@ -89,7 +90,7 @@ public final class ProviderLookup<T> implements Element {
      */
     public void initializeDelegate(Provider<T> delegate) {
         checkState(this.delegate == null, "delegate already initialized");
-        this.delegate = checkNotNull(delegate, "delegate");
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/ScopeBinding.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/ScopeBinding.java
@@ -20,8 +20,7 @@ import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.Scope;
 
 import java.lang.annotation.Annotation;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * Registration of a scope annotation with the scope that implements it. Instances are created
@@ -40,9 +39,9 @@ public final class ScopeBinding implements Element {
     private final Scope scope;
 
     ScopeBinding(Object source, Class<? extends Annotation> annotationType, Scope scope) {
-        this.source = checkNotNull(source, "source");
-        this.annotationType = checkNotNull(annotationType, "annotationType");
-        this.scope = checkNotNull(scope, "scope");
+        this.source = Objects.requireNonNull(source, "source");
+        this.annotationType = Objects.requireNonNull(annotationType, "annotationType");
+        this.scope = Objects.requireNonNull(scope, "scope");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/StaticInjectionRequest.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/StaticInjectionRequest.java
@@ -19,9 +19,8 @@ package org.elasticsearch.common.inject.spi;
 import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.ConfigurationException;
 
+import java.util.Objects;
 import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A request to inject the static fields and methods of a type. Requests are created
@@ -38,8 +37,8 @@ public final class StaticInjectionRequest implements Element {
     private final Class<?> type;
 
     StaticInjectionRequest(Object source, Class<?> type) {
-        this.source = checkNotNull(source, "source");
-        this.type = checkNotNull(type, "type");
+        this.source = Objects.requireNonNull(source, "source");
+        this.type = Objects.requireNonNull(type, "type");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/TypeConverterBinding.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/TypeConverterBinding.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.TypeLiteral;
 import org.elasticsearch.common.inject.matcher.Matcher;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 /**
  * Registration of type converters for matching target types. Instances are created
@@ -39,9 +39,9 @@ public final class TypeConverterBinding implements Element {
 
     TypeConverterBinding(Object source, Matcher<? super TypeLiteral<?>> typeMatcher,
                          TypeConverter typeConverter) {
-        this.source = checkNotNull(source, "source");
-        this.typeMatcher = checkNotNull(typeMatcher, "typeMatcher");
-        this.typeConverter = checkNotNull(typeConverter, "typeConverter");
+        this.source = Objects.requireNonNull(source, "source");
+        this.typeMatcher = Objects.requireNonNull(typeMatcher, "typeMatcher");
+        this.typeConverter = Objects.requireNonNull(typeConverter, "typeConverter");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/core/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common.io;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Preconditions;
 import org.elasticsearch.common.util.Callback;
 
 import java.io.BufferedReader;
@@ -33,6 +32,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Simple utility methods for file and stream copying.
@@ -66,8 +66,8 @@ public abstract class Streams {
      * @throws IOException in case of I/O errors
      */
     public static long copy(InputStream in, OutputStream out, byte[] buffer) throws IOException {
-        Preconditions.checkNotNull(in, "No InputStream specified");
-        Preconditions.checkNotNull(out, "No OutputStream specified");
+        Objects.requireNonNull(in, "No InputStream specified");
+        Objects.requireNonNull(out, "No OutputStream specified");
         try {
             long byteCount = 0;
             int bytesRead;
@@ -100,8 +100,8 @@ public abstract class Streams {
      * @throws IOException in case of I/O errors
      */
     public static void copy(byte[] in, OutputStream out) throws IOException {
-        Preconditions.checkNotNull(in, "No input byte array specified");
-        Preconditions.checkNotNull(out, "No OutputStream specified");
+        Objects.requireNonNull(in, "No input byte array specified");
+        Objects.requireNonNull(out, "No OutputStream specified");
         try {
             out.write(in);
         } finally {
@@ -128,8 +128,8 @@ public abstract class Streams {
      * @throws IOException in case of I/O errors
      */
     public static int copy(Reader in, Writer out) throws IOException {
-        Preconditions.checkNotNull(in, "No Reader specified");
-        Preconditions.checkNotNull(out, "No Writer specified");
+        Objects.requireNonNull(in, "No Reader specified");
+        Objects.requireNonNull(out, "No Writer specified");
         try {
             int byteCount = 0;
             char[] buffer = new char[BUFFER_SIZE];
@@ -163,8 +163,8 @@ public abstract class Streams {
      * @throws IOException in case of I/O errors
      */
     public static void copy(String in, Writer out) throws IOException {
-        Preconditions.checkNotNull(in, "No input String specified");
-        Preconditions.checkNotNull(out, "No Writer specified");
+        Objects.requireNonNull(in, "No input String specified");
+        Objects.requireNonNull(out, "No Writer specified");
         try {
             out.write(in);
         } finally {

--- a/core/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
@@ -24,9 +24,8 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.MutableDateTime;
 import org.joda.time.format.DateTimeFormatter;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A parser for date/time formatted text with optional date math.
@@ -40,7 +39,7 @@ public class DateMathParser {
     private final FormatDateTimeFormatter dateTimeFormatter;
 
     public DateMathParser(FormatDateTimeFormatter dateTimeFormatter) {
-        checkNotNull(dateTimeFormatter);
+        Objects.requireNonNull(dateTimeFormatter);
         this.dateTimeFormatter = dateTimeFormatter;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/property/PropertyPlaceholder.java
+++ b/core/src/main/java/org/elasticsearch/common/property/PropertyPlaceholder.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.common.property;
 
-import com.google.common.base.Preconditions;
 import org.elasticsearch.common.Strings;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
@@ -61,8 +61,8 @@ public class PropertyPlaceholder {
      */
     public PropertyPlaceholder(String placeholderPrefix, String placeholderSuffix,
                                boolean ignoreUnresolvablePlaceholders) {
-        Preconditions.checkNotNull(placeholderPrefix, "Argument 'placeholderPrefix' must not be null.");
-        Preconditions.checkNotNull(placeholderSuffix, "Argument 'placeholderSuffix' must not be null.");
+        Objects.requireNonNull(placeholderPrefix, "Argument 'placeholderPrefix' must not be null.");
+        Objects.requireNonNull(placeholderSuffix, "Argument 'placeholderSuffix' must not be null.");
         this.placeholderPrefix = placeholderPrefix;
         this.placeholderSuffix = placeholderSuffix;
         this.ignoreUnresolvablePlaceholders = ignoreUnresolvablePlaceholders;
@@ -77,7 +77,7 @@ public class PropertyPlaceholder {
      * @return the supplied value with placeholders replaced inline.
      */
     public String replacePlaceholders(String value, PlaceholderResolver placeholderResolver) {
-        Preconditions.checkNotNull(value, "Argument 'value' must not be null.");
+        Objects.requireNonNull(value, "Argument 'value' must not be null.");
         return parseStringValue(value, placeholderResolver, new HashSet<String>());
     }
 

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
@@ -22,10 +22,9 @@ package org.elasticsearch.common.util.concurrent;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.transport.Transports;
 
+import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.AbstractQueuedSynchronizer;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * An abstract implementation of the {@link com.google.common.util.concurrent.ListenableFuture} interface. This
@@ -178,7 +177,7 @@ public abstract class BaseFuture<V> implements Future<V> {
      * @throws Error if the throwable was an {@link Error}.
      */
     protected boolean setException(Throwable throwable) {
-        boolean result = sync.setException(checkNotNull(throwable));
+        boolean result = sync.setException(Objects.requireNonNull(throwable));
         if (result) {
             done();
         }

--- a/core/src/main/java/org/elasticsearch/http/HttpServerModule.java
+++ b/core/src/main/java/org/elasticsearch/http/HttpServerModule.java
@@ -19,12 +19,13 @@
 
 package org.elasticsearch.http;
 
-import com.google.common.base.Preconditions;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.netty.NettyHttpServerTransport;
+
+import java.util.Objects;
 
 /**
  *
@@ -50,8 +51,8 @@ public class HttpServerModule extends AbstractModule {
     }
 
     public void setHttpServerTransport(Class<? extends HttpServerTransport> httpServerTransport, String source) {
-        Preconditions.checkNotNull(httpServerTransport, "Configured http server transport may not be null");
-        Preconditions.checkNotNull(source, "Plugin, that changes transport may not be null");
+        Objects.requireNonNull(httpServerTransport, "Configured http server transport may not be null");
+        Objects.requireNonNull(source, "Plugin, that changes transport may not be null");
         logger.info("Using [{}] as http transport, overridden by [{}]", httpServerTransportClass.getName(), source);
         this.httpServerTransportClass = httpServerTransport;
     }

--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.engine;
 
-import com.google.common.base.Preconditions;
-
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexCommit;
@@ -71,6 +69,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
@@ -100,8 +99,8 @@ public abstract class Engine implements Closeable {
     protected volatile Throwable failedEngine = null;
 
     protected Engine(EngineConfig engineConfig) {
-        Preconditions.checkNotNull(engineConfig.getStore(), "Store must be provided to the engine");
-        Preconditions.checkNotNull(engineConfig.getDeletionPolicy(), "Snapshot deletion policy must be provided to the engine");
+        Objects.requireNonNull(engineConfig.getStore(), "Store must be provided to the engine");
+        Objects.requireNonNull(engineConfig.getDeletionPolicy(), "Snapshot deletion policy must be provided to the engine");
 
         this.engineConfig = engineConfig;
         this.shardId = engineConfig.getShardId();

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/PackedArrayIndexFieldData.java
@@ -72,7 +72,7 @@ public class PackedArrayIndexFieldData extends AbstractIndexFieldData<AtomicNume
                                      FieldDataType fieldDataType, IndexFieldDataCache cache, NumericType numericType,
                                      CircuitBreakerService breakerService) {
         super(index, indexSettings, fieldNames, fieldDataType, cache);
-        Preconditions.checkNotNull(numericType);
+        Objects.requireNonNull(numericType);
         Preconditions.checkArgument(EnumSet.of(NumericType.BOOLEAN, NumericType.BYTE, NumericType.SHORT, NumericType.INT, NumericType.LONG).contains(numericType), getClass().getSimpleName() + " only supports integer types, not " + numericType);
         this.numericType = numericType;
         this.breakerService = breakerService;

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSet;
@@ -68,6 +67,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
@@ -142,7 +142,7 @@ public class DocumentMapper implements ToXContent {
         }
 
         public DocumentMapper build(MapperService mapperService, DocumentMapperParser docMapperParser) {
-            Preconditions.checkNotNull(rootObjectMapper, "Mapper builder must have the root object mapper set");
+            Objects.requireNonNull(rootObjectMapper, "Mapper builder must have the root object mapper set");
             return new DocumentMapper(mapperService, indexSettings, docMapperParser, rootObjectMapper, meta, rootMappers, sourceTransforms, mapperService.mappingLock);
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -20,11 +20,10 @@
 package org.elasticsearch.index.shard;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Preconditions;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.index.CheckIndex;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.UsageTrackingQueryCachingPolicy;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.ThreadInterruptedException;
@@ -110,10 +109,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.channels.ClosedByInterruptException;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -207,8 +203,8 @@ public class IndexShard extends AbstractIndexShardComponent {
         this.deletionPolicy = deletionPolicy;
         this.similarityService = similarityService;
         this.wrappingService = wrappingService;
-        Preconditions.checkNotNull(store, "Store must be provided to the index shard");
-        Preconditions.checkNotNull(deletionPolicy, "Snapshot deletion policy must be provided to the index shard");
+        Objects.requireNonNull(store, "Store must be provided to the index shard");
+        Objects.requireNonNull(deletionPolicy, "Snapshot deletion policy must be provided to the index shard");
         this.engineFactory = factory;
         this.indicesLifecycle = (InternalIndicesLifecycle) indicesLifecycle;
         this.indexSettingsService = indexSettingsService;

--- a/core/src/main/java/org/elasticsearch/transport/TransportModule.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportModule.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.transport;
 
-import com.google.common.base.Preconditions;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -31,6 +30,7 @@ import org.elasticsearch.transport.netty.NettyTransport;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  *
@@ -107,15 +107,15 @@ public class TransportModule extends AbstractModule {
     }
 
     public void setTransportService(Class<? extends TransportService> transportService, String source) {
-        Preconditions.checkNotNull(transportService, "Configured transport service may not be null");
-        Preconditions.checkNotNull(source, "Plugin, that changes transport service may not be null");
+        Objects.requireNonNull(transportService, "Configured transport service may not be null");
+        Objects.requireNonNull(source, "Plugin, that changes transport service may not be null");
         this.configuredTransportService = transportService;
         this.configuredTransportServiceSource = source;
     }
 
     public void setTransport(Class<? extends Transport> transport, String source) {
-        Preconditions.checkNotNull(transport, "Configured transport may not be null");
-        Preconditions.checkNotNull(source, "Plugin, that changes transport may not be null");
+        Objects.requireNonNull(transport, "Configured transport may not be null");
+        Objects.requireNonNull(source, "Plugin, that changes transport may not be null");
         this.configuredTransport = transport;
         this.configuredTransportSource = source;
     }

--- a/dev-tools/src/main/resources/forbidden/core-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/core-signatures.txt
@@ -94,3 +94,6 @@ com.google.common.base.Strings
 com.google.common.base.Throwables
 com.google.common.collect.Maps
 com.google.common.collect.Sets
+com.google.common.base.Preconditions#checkNotNull(java.lang.Object)
+com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.Object)
+com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.String, java.lang.Object[])


### PR DESCRIPTION
This commit removes and now forbids all uses of
com.google.common.base.Preconditions#checkNotNull across the codebase.
This is one of many steps in the eventual removal of Guava as a
dependency.

Relates #13224
