### PR TITLE
Refactors GeoDistanceQueryBuilder/-Parser

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/Numbers.java
+++ b/core/src/main/java/org/elasticsearch/common/Numbers.java
@@ -171,4 +171,12 @@ public final class Numbers {
         return longToBytes(Double.doubleToRawLongBits(val));
     }
 
+    /** Returns true if value is neither NaN nor infinite. */
+    public static boolean isValidDouble(double value) {
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
@@ -21,6 +21,9 @@ package org.elasticsearch.common.geo;
 
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.SloppyMath;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.GeoPointValues;
@@ -28,17 +31,17 @@ import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortingNumericDoubleValues;
-
+import java.io.IOException;
 import java.util.Locale;
 
 /**
  * Geo distance calculation.
  */
-public enum GeoDistance {
+public enum GeoDistance implements Writeable<GeoDistance> {
     /**
      * Calculates distance as points on a plane. Faster, but less accurate than {@link #ARC}.
      */
-    PLANE() {
+    PLANE {
         @Override
         public double calculate(double sourceLatitude, double sourceLongitude, double targetLatitude, double targetLongitude, DistanceUnit unit) {
             double px = targetLongitude - sourceLongitude;
@@ -60,7 +63,7 @@ public enum GeoDistance {
     /**
      * Calculates distance factor.
      */
-    FACTOR() {
+    FACTOR {
         @Override
         public double calculate(double sourceLatitude, double sourceLongitude, double targetLatitude, double targetLongitude, DistanceUnit unit) {
             double longitudeDifference = targetLongitude - sourceLongitude;
@@ -82,7 +85,7 @@ public enum GeoDistance {
     /**
      * Calculates distance as points on a globe.
      */
-    ARC() {
+    ARC {
         @Override
         public double calculate(double sourceLatitude, double sourceLongitude, double targetLatitude, double targetLongitude, DistanceUnit unit) {
             double x1 = sourceLatitude * Math.PI / 180D;
@@ -109,7 +112,7 @@ public enum GeoDistance {
      * Calculates distance as points on a globe in a sloppy way. Close to the pole areas the accuracy
      * of this function decreases.
      */
-    SLOPPY_ARC() {
+    SLOPPY_ARC {
 
         @Override
         public double normalize(double distance, DistanceUnit unit) {
@@ -127,12 +130,31 @@ public enum GeoDistance {
         }
     };
 
+    /** Returns a GeoDistance object as read from the StreamInput. */
+    @Override
+    public GeoDistance readFrom(StreamInput in) throws IOException {
+        int ord = in.readVInt();
+        if (ord < 0 || ord >= values().length) {
+            throw new IOException("Unknown GeoDistance ordinal [" + ord + "]");
+        }
+        return GeoDistance.values()[ord];
+    }
+
+    public static GeoDistance readGeoDistanceFrom(StreamInput in) throws IOException {
+        return DEFAULT.readFrom(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(this.ordinal());
+    }
+
     /**
      * Default {@link GeoDistance} function. This method should be used, If no specific function has been selected.
      * This is an alias for <code>SLOPPY_ARC</code>
      */
-    public static final GeoDistance DEFAULT = SLOPPY_ARC; 
-    
+    public static final GeoDistance DEFAULT = SLOPPY_ARC;
+
     public abstract double normalize(double distance, DistanceUnit unit);
 
     public abstract double calculate(double sourceLatitude, double sourceLongitude, double targetLatitude, double targetLongitude, DistanceUnit unit);
@@ -180,14 +202,14 @@ public enum GeoDistance {
 
     /**
      * Get a {@link GeoDistance} according to a given name. Valid values are
-     * 
+     *
      * <ul>
      *     <li><b>plane</b> for <code>GeoDistance.PLANE</code></li>
      *     <li><b>sloppy_arc</b> for <code>GeoDistance.SLOPPY_ARC</code></li>
      *     <li><b>factor</b> for <code>GeoDistance.FACTOR</code></li>
      *     <li><b>arc</b> for <code>GeoDistance.ARC</code></li>
      * </ul>
-     * 
+     *
      * @param name name of the {@link GeoDistance}
      * @return a {@link GeoDistance}
      */
@@ -336,7 +358,7 @@ public enum GeoDistance {
 
     /**
      * Basic implementation of {@link FixedSourceDistance}. This class keeps the basic parameters for a distance
-     * functions based on a fixed source. Namely latitude, longitude and unit. 
+     * functions based on a fixed source. Namely latitude, longitude and unit.
      */
     public static abstract class FixedSourceDistanceBase implements FixedSourceDistance {
         protected final double sourceLatitude;
@@ -349,7 +371,7 @@ public enum GeoDistance {
             this.unit = unit;
         }
     }
-    
+
     public static class ArcFixedSourceDistance extends FixedSourceDistanceBase {
 
         public ArcFixedSourceDistance(double sourceLatitude, double sourceLongitude, DistanceUnit unit) {

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -19,6 +19,11 @@
 
 package org.elasticsearch.common.geo;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import java.io.IOException;
+
 
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.XGeoHashUtils;
@@ -27,11 +32,14 @@ import org.apache.lucene.util.XGeoUtils;
 /**
  *
  */
-public final class GeoPoint {
+public final class GeoPoint implements Writeable<GeoPoint> {
 
     private double lat;
     private double lon;
     private final static double TOLERANCE = XGeoUtils.TOLERANCE;
+    
+    // for serialization purposes
+    private static final GeoPoint PROTOTYPE = new GeoPoint(Double.NaN, Double.NaN);
 
     public GeoPoint() {
     }
@@ -152,8 +160,7 @@ public final class GeoPoint {
     }
 
     public static GeoPoint parseFromLatLon(String latLon) {
-        GeoPoint point = new GeoPoint();
-        point.resetFromString(latLon);
+        GeoPoint point = new GeoPoint(latLon);
         return point;
     }
 
@@ -167,5 +174,22 @@ public final class GeoPoint {
 
     public static GeoPoint fromIndexLong(long indexLong) {
         return new GeoPoint().resetFromIndexHash(indexLong);
+    }
+    
+    @Override
+    public GeoPoint readFrom(StreamInput in) throws IOException {
+        double lat = in.readDouble();
+        double lon = in.readDouble();
+        return new GeoPoint(lat, lon);
+    }
+
+    public static GeoPoint readGeoPointFrom(StreamInput in) throws IOException {
+        return PROTOTYPE.readFrom(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeDouble(lat);
+        out.writeDouble(lon);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -34,10 +34,19 @@ import java.io.IOException;
  */
 public class GeoUtils {
 
+    /** Maximum valid latitude in degrees. */
+    public static final double MAX_LAT = 90.0;
+    /** Minimum valid latitude in degrees. */
+    public static final double MIN_LAT = -90.0;
+    /** Maximum valid longitude in degrees. */
+    public static final double MAX_LON = 180.0;
+    /** Minimum valid longitude in degrees. */
+    public static final double MIN_LON = -180.0;
+
     public static final String LATITUDE = GeoPointFieldMapper.Names.LAT;
     public static final String LONGITUDE = GeoPointFieldMapper.Names.LON;
     public static final String GEOHASH = GeoPointFieldMapper.Names.GEOHASH;
-    
+
     /** Earth ellipsoid major axis defined by WGS 84 in meters */
     public static final double EARTH_SEMI_MAJOR_AXIS = 6378137.0;      // meters (WGS 84)
 
@@ -55,6 +64,22 @@ public class GeoUtils {
 
     /** Earth ellipsoid polar distance in meters */
     public static final double EARTH_POLAR_DISTANCE = Math.PI * EARTH_SEMI_MINOR_AXIS;
+
+    /** Returns true if latitude is actually a valid latitude value.*/
+    public static boolean isValidLatitude(double latitude) {
+        if (Double.isNaN(latitude) || Double.isInfinite(latitude) || latitude < GeoUtils.MIN_LAT || latitude > GeoUtils.MAX_LAT) {
+            return false;
+        }
+        return true;
+    }
+
+    /** Returns true if longitude is actually a valid longitude value. */
+    public static boolean isValidLongitude(double longitude) {
+        if (Double.isNaN(longitude) || Double.isNaN(longitude) || longitude < GeoUtils.MIN_LON || longitude > GeoUtils.MAX_LON) {
+            return false;
+        }
+        return true;
+    }
 
     /**
      * Return an approximate value of the diameter of the earth (in meters) at the given latitude (in radians).

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -19,115 +19,328 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 
+/**
+ * Filter results of a query to include only those within a specific distance to some
+ * geo point.
+ * */
 public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQueryBuilder> {
 
+    /** Name of the query in the query dsl. */
     public static final String NAME = "geo_distance";
+    /** Default for latitude normalization (as of this writing true).*/
+    public static final boolean DEFAULT_NORMALIZE_LAT = true;
+    /** Default for longitude normalization (as of this writing true). */
+    public static final boolean DEFAULT_NORMALIZE_LON = true;
+    /** Default for distance unit computation. */
+    public static final DistanceUnit DEFAULT_DISTANCE_UNIT = DistanceUnit.DEFAULT;
+    /** Default for geo distance computation. */
+    public static final GeoDistance DEFAULT_GEO_DISTANCE = GeoDistance.DEFAULT;
+    /** Default for optimising query through pre computed bounding box query. */
+    public static final String DEFAULT_OPTIMIZE_BBOX = "memory";
+    /** Default for coercing lon/lat values to a standard coordinate system */
+    public static final boolean DEFAULT_COERCE = false;
+    /** Default for accepting accept geo points with invalid latitude or longitude */
+    public static final boolean DEFAULT_IGNORE_MALFORMED = false;
 
-    private final String name;
+    private final String fieldName;
+    /** Distance from center to cover. */
+    private double distance;
+    /** Point to use as center. */
+    private GeoPoint center = new GeoPoint(Double.NaN, Double.NaN);
+    /** Algorithm to use for distance computation. */
+    private GeoDistance geoDistance = DEFAULT_GEO_DISTANCE;
+    /** Whether or not to use a bbox for pre-filtering. TODO change to enum? */
+    private String optimizeBbox = DEFAULT_OPTIMIZE_BBOX;
+    /** Whether or not to normalize longitude and latitude values to a standard coordinate system */
+    private boolean coerce = DEFAULT_COERCE;
+    /** Whether or not to accept geo points with invalid latitude or longitude */
+    private boolean ignoreMalformed = DEFAULT_IGNORE_MALFORMED;
 
-    private String distance;
+    static final GeoDistanceQueryBuilder PROTOTYPE = new GeoDistanceQueryBuilder();
 
-    private double lat;
-
-    private double lon;
-
-    private String geohash;
-
-    private GeoDistance geoDistance;
-
-    private String optimizeBbox;
-
-    static final GeoDistanceQueryBuilder PROTOTYPE = new GeoDistanceQueryBuilder(null);
-
-    private Boolean coerce;
-
-    private Boolean ignoreMalformed;
-
-    public GeoDistanceQueryBuilder(String name) {
-        this.name = name;
+    /** For serialization purposes only. */
+    private GeoDistanceQueryBuilder() {
+        this.fieldName = null;
     }
 
+    /**
+     * Construct new GeoDistanceQueryBuilder.
+     * @param fieldName name of indexed geo field to operate distance computation on.
+     * */
+    public GeoDistanceQueryBuilder(String fieldName) {
+        if (Strings.isEmpty(fieldName)) {
+            throw new IllegalArgumentException("fieldName must not be null or empty");
+        }
+        this.fieldName = fieldName;
+    }
+
+    /** Name of the field this query is operating on. */
+    public String fieldName() {
+        return this.fieldName;
+    }
+
+    /** Sets the center point for the query.
+     * @param point the center of the query
+     **/
+    public GeoDistanceQueryBuilder point(GeoPoint point) {
+        if (point == null) {
+            throw new IllegalArgumentException("center point must not be null");
+        }
+        this.center = point;
+        return this;
+    }
+
+    /**
+     * Sets the center point of the query.
+     * @param lat latitude of center
+     * @param lon longitude of center
+     * */
     public GeoDistanceQueryBuilder point(double lat, double lon) {
-        this.lat = lat;
-        this.lon = lon;
+        this.center = new GeoPoint(lat, lon);
         return this;
     }
 
-    public GeoDistanceQueryBuilder lat(double lat) {
-        this.lat = lat;
-        return this;
+    /** Returns the center point of the distance query. */
+    public GeoPoint point() {
+        return this.center;
     }
 
-    public GeoDistanceQueryBuilder lon(double lon) {
-        this.lon = lon;
-        return this;
-    }
-
+    /** Sets the distance from the center using the default distance unit.*/
     public GeoDistanceQueryBuilder distance(String distance) {
-        this.distance = distance;
+        if (Strings.isEmpty(distance)) {
+            throw new IllegalArgumentException("distance must not be null or empty");
+        }
+        return this.distance(distance, DistanceUnit.DEFAULT);
+    }
+
+    /** Sets the distance from the center for this query. */
+    public GeoDistanceQueryBuilder distance(String distance, DistanceUnit unit) {
+        if (Strings.isEmpty(distance)) {
+            throw new IllegalArgumentException("distance must not be null or empty");
+        }
+        if (unit == null) {
+            throw new IllegalArgumentException("distance unit must not be null");
+        }
+        this.distance = DistanceUnit.parse(distance, unit, DistanceUnit.DEFAULT);
         return this;
     }
 
+    /** Sets the distance from the center for this query. */
     public GeoDistanceQueryBuilder distance(double distance, DistanceUnit unit) {
-        this.distance = unit.toString(distance);
+        if (unit == null) {
+            throw new IllegalArgumentException("distance unit must not be null");
+        }
+        this.distance = DistanceUnit.DEFAULT.convert(distance, unit);
         return this;
     }
 
+    /** Returns the distance configured as radius. */
+    public double distance() {
+        return distance;
+    }
+
+    /** Sets the center point for this query. */
     public GeoDistanceQueryBuilder geohash(String geohash) {
-        this.geohash = geohash;
+        if (Strings.isEmpty(geohash)) {
+            throw new IllegalArgumentException("geohash must not be null or empty");
+        }
+        this.center.resetFromGeoHash(geohash);
         return this;
     }
 
+    /** Which type of geo distance calculation method to use. */
     public GeoDistanceQueryBuilder geoDistance(GeoDistance geoDistance) {
+        if (geoDistance == null) {
+            throw new IllegalArgumentException("geoDistance must not be null");
+        }
         this.geoDistance = geoDistance;
         return this;
     }
 
+    /** Returns geo distance calculation type to use. */
+    public GeoDistance geoDistance() {
+        return this.geoDistance;
+    }
+
+    /**
+     * Set this to memory or indexed if before running the distance
+     * calculation you want to limit the candidates to hits in the
+     * enclosing bounding box.
+     **/
     public GeoDistanceQueryBuilder optimizeBbox(String optimizeBbox) {
+        if (Strings.isEmpty(optimizeBbox)) {
+            throw new IllegalArgumentException("optimizeBbox must not be null or empty");
+        }
         this.optimizeBbox = optimizeBbox;
         return this;
     }
 
+    /**
+     * Returns whether or not to run a BoundingBox query prior to
+     * distance query for optimization purposes.*/
+    public String optimizeBbox() {
+        return this.optimizeBbox;
+    }
+
     public GeoDistanceQueryBuilder coerce(boolean coerce) {
         this.coerce = coerce;
+        if (this.coerce) {
+            this.ignoreMalformed = true;
+        }
         return this;
     }
 
     public GeoDistanceQueryBuilder ignoreMalformed(boolean ignoreMalformed) {
-        this.ignoreMalformed = ignoreMalformed;
+        if (coerce == false) {
+            this.ignoreMalformed = ignoreMalformed;
+        }
         return this;
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext shardContext) throws IOException {
+        QueryValidationException exception = checkLatLon(shardContext.indexVersionCreated().before(Version.V_2_0_0));
+        if (exception != null) {
+            throw new QueryShardException(shardContext, "couldn't validate latitude/ longitude values", exception);
+        }
+
+        if (coerce) {
+            GeoUtils.normalizePoint(center, coerce, coerce);
+        }
+
+        double normDistance = geoDistance.normalize(this.distance, DistanceUnit.DEFAULT);
+
+        MappedFieldType fieldType = shardContext.fieldMapper(fieldName);
+        if (fieldType == null) {
+            throw new QueryShardException(shardContext, "failed to find geo_point field [" + fieldName + "]");
+        }
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+            throw new QueryShardException(shardContext, "field [" + fieldName + "] is not a geo_point field");
+        }
+        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+
+        IndexGeoPointFieldData indexFieldData = shardContext.getForField(fieldType);
+        Query query = new GeoDistanceRangeQuery(center, null, normDistance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
+        return query;
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
-        if (geohash != null) {
-            builder.field(name, geohash);
-        } else {
-            builder.startArray(name).value(lon).value(lat).endArray();
-        }
+        builder.startArray(fieldName).value(center.lon()).value(center.lat()).endArray();
         builder.field("distance", distance);
         if (geoDistance != null) {
             builder.field("distance_type", geoDistance.name().toLowerCase(Locale.ROOT));
         }
-        if (optimizeBbox != null) {
-            builder.field("optimize_bbox", optimizeBbox);
-        }
-        if (coerce != null) {
-            builder.field("coerce", coerce);
-        }
-        if (ignoreMalformed != null) {
-            builder.field("ignore_malformed", ignoreMalformed);
-        }
+        builder.field("optimize_bbox", optimizeBbox);
+        builder.field("coerce", coerce);
+        builder.field("ignore_malformed", ignoreMalformed);
         printBoostAndQueryName(builder);
         builder.endObject();
+    }
+
+    @Override
+    public int doHashCode() {
+        return Objects.hash(center, geoDistance, optimizeBbox, distance, coerce, ignoreMalformed);
+    }
+
+    @Override
+    public boolean doEquals(GeoDistanceQueryBuilder other) {
+        return Objects.equals(fieldName, other.fieldName) &&
+                (distance == other.distance) &&
+                (coerce == other.coerce) &&
+                (ignoreMalformed == other.ignoreMalformed) &&
+                Objects.equals(center, other.center) &&
+                Objects.equals(optimizeBbox, other.optimizeBbox) &&
+                Objects.equals(geoDistance, other.geoDistance);
+    }
+
+    @Override
+    protected GeoDistanceQueryBuilder doReadFrom(StreamInput in) throws IOException {
+        String fieldName = in.readString();
+        GeoDistanceQueryBuilder result = new GeoDistanceQueryBuilder(fieldName);
+        result.distance = in.readDouble();
+        result.coerce = in.readBoolean();
+        result.ignoreMalformed = in.readBoolean();
+        result.center = GeoPoint.readGeoPointFrom(in);
+        result.optimizeBbox = in.readString();
+        result.geoDistance = GeoDistance.readGeoDistanceFrom(in);
+        return result;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeDouble(distance);
+        out.writeBoolean(coerce);
+        out.writeBoolean(ignoreMalformed);
+        center.writeTo(out);
+        out.writeString(optimizeBbox);
+        geoDistance.writeTo(out);
+    }
+
+    @Override
+    public QueryValidationException validate() {
+        QueryValidationException validationException = null;
+        if (!ignoreMalformed) {
+            if (Numbers.isValidDouble(center.getLat()) == false) {
+                validationException = addValidationError("center point latitude is invalid number: " + center.getLat(), validationException);
+            }
+            if (Numbers.isValidDouble(center.getLon()) == false) {
+                validationException = addValidationError("center point longitude is invalid number: " + center.getLon(),
+                        validationException);
+            }
+        }
+
+        if (Strings.isEmpty(fieldName)) {
+            validationException = addValidationError("field name must be non-null and non-empty", validationException);
+        }
+        if (optimizeBbox != null && !(optimizeBbox.equals("none") || optimizeBbox.equals("memory") || optimizeBbox.equals("indexed"))) {
+            validationException = QueryValidationException.addValidationError(NAME, "optimizeBbox must be one of [none, memory, indexed]",
+                    validationException);
+        }
+        return validationException;
+    }
+
+    /**
+     * @param indexCreatedBeforeV2_0
+     * @return
+     */
+    private QueryValidationException checkLatLon(boolean indexCreatedBeforeV2_0) {
+        // validation was not available prior to 2.x, so to support bwc percolation queries we only ignore_malformed on 2.x created indexes
+        if (ignoreMalformed || indexCreatedBeforeV2_0) {
+            return null;
+        }
+
+        QueryValidationException validationException = null;
+        // For everything post 2.0, validate latitude and longitude unless validation was explicitly turned off
+        if (GeoUtils.isValidLatitude(center.getLat()) == false) {
+            validationException = addValidationError("center point latitude is invalid: " + center.getLat(), validationException);
+        }
+        if (GeoUtils.isValidLongitude(center.getLon()) == false) {
+            validationException = addValidationError("center point longitude is invalid: " + center.getLon(), validationException);
+        }
+        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -19,22 +19,18 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.Query;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
-import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
 import java.io.IOException;
 
 /**
+ * Parses a GeoDistanceQuery. See also
+ *
  * <pre>
  * {
  *     "name.lat" : 1.1,
@@ -42,11 +38,7 @@ import java.io.IOException;
  * }
  * </pre>
  */
-public class GeoDistanceQueryParser extends BaseQueryParserTemp {
-
-    @Inject
-    public GeoDistanceQueryParser() {
-    }
+public class GeoDistanceQueryParser extends BaseQueryParser {
 
     @Override
     public String[] names() {
@@ -54,8 +46,7 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
     }
 
     @Override
-    public Query parse(QueryShardContext context) throws IOException, QueryParsingException {
-        QueryParseContext parseContext = context.parseContext();
+    public QueryBuilder fromXContent(QueryParseContext parseContext) throws IOException, QueryParsingException {
         XContentParser parser = parseContext.parser();
 
         XContentParser.Token token;
@@ -63,16 +54,15 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String queryName = null;
         String currentFieldName = null;
-        GeoPoint point = new GeoPoint();
+        GeoPoint point = new GeoPoint(Double.NaN, Double.NaN);
         String fieldName = null;
-        double distance = 0;
         Object vDistance = null;
-        DistanceUnit unit = DistanceUnit.DEFAULT;
-        GeoDistance geoDistance = GeoDistance.DEFAULT;
-        String optimizeBbox = "memory";
-        final boolean indexCreatedBeforeV2_0 = parseContext.shardContext().indexVersionCreated().before(Version.V_2_0_0);
-        boolean coerce = false;
-        boolean ignoreMalformed = false;
+        DistanceUnit unit = GeoDistanceQueryBuilder.DEFAULT_DISTANCE_UNIT;
+        GeoDistance geoDistance = GeoDistanceQueryBuilder.DEFAULT_GEO_DISTANCE;
+        String optimizeBbox = GeoDistanceQueryBuilder.DEFAULT_OPTIMIZE_BBOX;
+        boolean coerce = GeoDistanceQueryBuilder.DEFAULT_COERCE;
+        boolean ignoreMalformed = GeoDistanceQueryBuilder.DEFAULT_IGNORE_MALFORMED;
+
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -102,15 +92,15 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
                     }
                 }
             } else if (token.isValue()) {
-                if (currentFieldName.equals("distance")) {
+                if ("distance".equals(currentFieldName)) {
                     if (token == XContentParser.Token.VALUE_STRING) {
                         vDistance = parser.text(); // a String
                     } else {
                         vDistance = parser.numberValue(); // a Number
                     }
-                } else if (currentFieldName.equals("unit")) {
+                } else if ("unit".equals(currentFieldName)) {
                     unit = DistanceUnit.fromString(parser.text());
-                } else if (currentFieldName.equals("distance_type") || currentFieldName.equals("distanceType")) {
+                } else if ("distance_type".equals(currentFieldName) || "distanceType".equals(currentFieldName)) {
                     geoDistance = GeoDistance.fromString(parser.text());
                 } else if (currentFieldName.endsWith(GeoPointFieldMapper.Names.LAT_SUFFIX)) {
                     point.resetLat(parser.doubleValue());
@@ -127,12 +117,12 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
                     boost = parser.floatValue();
                 } else if ("optimize_bbox".equals(currentFieldName) || "optimizeBbox".equals(currentFieldName)) {
                     optimizeBbox = parser.textOrNull();
-                } else if ("coerce".equals(currentFieldName) || (indexCreatedBeforeV2_0 && "normalize".equals(currentFieldName))) {
+                } else if ("coerce".equals(currentFieldName) || ("normalize".equals(currentFieldName))) {
                     coerce = parser.booleanValue();
                     if (coerce == true) {
                         ignoreMalformed = true;
                     }
-                } else if ("ignore_malformed".equals(currentFieldName) && coerce == false) {
+                } else if ("ignore_malformed".equals(currentFieldName)) {
                     ignoreMalformed = parser.booleanValue();
                 } else {
                     point.resetFromString(parser.text());
@@ -141,46 +131,24 @@ public class GeoDistanceQueryParser extends BaseQueryParserTemp {
             }
         }
 
-        // validation was not available prior to 2.x, so to support bwc percolation queries we only ignore_malformed on 2.x created indexes
-        if (!indexCreatedBeforeV2_0 && !ignoreMalformed) {
-            if (point.lat() > 90.0 || point.lat() < -90.0) {
-                throw new QueryParsingException(parseContext, "illegal latitude value [{}] for [{}]", point.lat(), GeoDistanceQueryBuilder.NAME);
-            }
-            if (point.lon() > 180.0 || point.lon() < -180) {
-                throw new QueryParsingException(parseContext, "illegal longitude value [{}] for [{}]", point.lon(), GeoDistanceQueryBuilder.NAME);
-            }
-        }
-
-        if (coerce) {
-            GeoUtils.normalizePoint(point, coerce, coerce);
-        }
-
         if (vDistance == null) {
             throw new QueryParsingException(parseContext, "geo_distance requires 'distance' to be specified");
-        } else if (vDistance instanceof Number) {
-            distance = DistanceUnit.DEFAULT.convert(((Number) vDistance).doubleValue(), unit);
+        }
+
+        GeoDistanceQueryBuilder qb = new GeoDistanceQueryBuilder(fieldName);
+        if (vDistance instanceof Number) {
+            qb.distance(((Number) vDistance).doubleValue(), unit);
         } else {
-            distance = DistanceUnit.parse((String) vDistance, unit, DistanceUnit.DEFAULT);
+            qb.distance((String) vDistance, unit);
         }
-        distance = geoDistance.normalize(distance, DistanceUnit.DEFAULT);
-
-        MappedFieldType fieldType = parseContext.shardContext().fieldMapper(fieldName);
-        if (fieldType == null) {
-            throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
-        }
-        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
-            throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
-        }
-        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
-
-
-        IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
-        Query query = new GeoDistanceRangeQuery(point, null, distance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
-        if (queryName != null) {
-            context.addNamedQuery(queryName, query);
-        }
-        query.setBoost(boost);
-        return query;
+        qb.point(point);
+        qb.coerce(coerce);
+        qb.ignoreMalformed(ignoreMalformed);
+        qb.optimizeBbox(optimizeBbox);
+        qb.geoDistance(geoDistance);
+        qb.boost(boost);
+        qb.queryName(queryName);
+        return qb;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -151,11 +151,11 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
         // percolation queries we only ignore_malformed on 2.x created indexes
         if (!indexCreatedBeforeV2_0 && !ignoreMalformed) {
             for (GeoPoint point : shell) {
-                if (point.lat() > 90.0 || point.lat() < -90.0) {
+                if (!GeoUtils.isValidLatitude(point.lat())) {
                     throw new QueryShardException(context, "illegal latitude value [{}] for [{}]", point.lat(),
                             GeoPolygonQueryBuilder.NAME);
                 }
-                if (point.lon() > 180.0 || point.lon() < -180) {
+                if (!GeoUtils.isValidLongitude(point.lat())) {
                     throw new QueryShardException(context, "illegal longitude value [{}] for [{}]", point.lon(),
                             GeoPolygonQueryBuilder.NAME);
                 }
@@ -205,7 +205,7 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
         List<GeoPoint> shell = new ArrayList<>();
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
-            shell.add(new GeoPoint(in.readDouble(), in.readDouble()));
+            shell.add(GeoPoint.readGeoPointFrom(in));
         }
         GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(fieldName, shell);
         builder.coerce = in.readBoolean();
@@ -218,8 +218,7 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
         out.writeString(fieldName);
         out.writeVInt(shell.size());
         for (GeoPoint point : shell) {
-            out.writeDouble(point.lat());
-            out.writeDouble(point.lon());
+            point.writeTo(out);
         }
         out.writeBoolean(coerce);
         out.writeBoolean(ignoreMalformed);

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import com.spatial4j.core.shape.Point;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
+import org.elasticsearch.test.geo.RandomShapeGenerator;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDistanceQueryBuilder> {
+
+    @Override
+    protected GeoDistanceQueryBuilder doCreateTestQueryBuilder() {
+        GeoDistanceQueryBuilder qb = new GeoDistanceQueryBuilder(GEO_POINT_FIELD_NAME);
+        String distance = "" + randomDouble();
+        if (randomBoolean()) {
+            DistanceUnit unit = randomFrom(DistanceUnit.values());
+            distance = distance + unit.toString();
+        }
+        int selector = randomIntBetween(0, 2);
+        switch (selector) {
+            case 0:
+                qb.distance(randomDouble(), randomFrom(DistanceUnit.values()));
+                break;
+            case 1:
+                qb.distance(distance, randomFrom(DistanceUnit.values()));
+                break;
+            case 2:
+                qb.distance(distance);
+                break;
+        }
+
+        Point p = RandomShapeGenerator.xRandomPoint(random());
+        qb.point(new GeoPoint(p.getY(), p.getX()));
+
+        if (randomBoolean()) {
+            qb.coerce(randomBoolean());
+        }
+
+        if (randomBoolean()) {
+            qb.ignoreMalformed(randomBoolean());
+        }
+
+        if (randomBoolean()) {
+            qb.optimizeBbox(randomFrom("none", "memory", "indexed"));
+        }
+
+        if (randomBoolean()) {
+            qb.geoDistance(randomFrom(GeoDistance.values()));
+        }
+        return qb;
+    }
+
+    public void testIllegalValues() {
+        try {
+            if (randomBoolean()) {
+                new GeoDistanceQueryBuilder("");
+            } else {
+                new GeoDistanceQueryBuilder(null);
+            }
+            fail("must not be null or empty");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        GeoDistanceQueryBuilder query = new GeoDistanceQueryBuilder("fieldName");
+        try {
+            if (randomBoolean()) {
+                query.distance("");
+            } else {
+                query.distance(null);
+            }
+            fail("must not be null or empty");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        try {
+            if (randomBoolean()) {
+                query.distance("", DistanceUnit.DEFAULT);
+            } else {
+                query.distance(null, DistanceUnit.DEFAULT);
+            }
+            fail("must not be null or empty");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        try {
+            query.distance("1", null);
+            fail("must not be null");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        try {
+            query.distance(1, null);
+            fail("must not be null");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        try {
+            query.geohash(null);
+            fail("geohash must not be null");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        try {
+            query.geoDistance(null);
+            fail("geodistance must not be null");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        try {
+            query.optimizeBbox(null);
+            fail("optimizeBbox must not be null");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+    }
+
+    /**
+     * Overridden here to ensure the test is only run if at least one type is
+     * present in the mappings. Geo queries do not execute if the field is not
+     * explicitly mapped
+     */
+    @Override
+    @Test
+    public void testToQuery() throws IOException {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        super.testToQuery();
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(GeoDistanceQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        assertThat(query, instanceOf(GeoDistanceRangeQuery.class));
+        GeoDistanceRangeQuery geoQuery = (GeoDistanceRangeQuery) query;
+        assertThat(geoQuery.fieldName(), equalTo(queryBuilder.fieldName()));
+        if (queryBuilder.point() != null) {
+            assertThat(geoQuery.lat(), equalTo(queryBuilder.point().lat()));
+            assertThat(geoQuery.lon(), equalTo(queryBuilder.point().lon()));
+        }
+        assertThat(geoQuery.geoDistance(), equalTo(queryBuilder.geoDistance()));
+        assertThat(geoQuery.minInclusiveDistance(), equalTo(Double.NEGATIVE_INFINITY));
+        double distance = queryBuilder.distance();
+        if (queryBuilder.geoDistance() != null) {
+                distance = queryBuilder.geoDistance().normalize(distance, DistanceUnit.DEFAULT);
+        }
+        assertThat(geoQuery.maxInclusiveDistance(), closeTo(distance, Math.abs(distance) / 1000));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
@@ -145,6 +145,7 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
      * explicitly mapped
      */
     @Override
+    @Test
     public void testToQuery() throws IOException {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         super.testToQuery();

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoDistanceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoDistanceIT.java
@@ -75,7 +75,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         indexRandom(true, client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("name", "New York")
                 .startObject("location").field("lat", 40.7143528).field("lon", -74.0059731).endObject()
-                .endObject()), 
+                .endObject()),
         // to NY: 5.286 km
         client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject()
                 .field("name", "Times Square")
@@ -394,7 +394,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
 
         // Doc with missing geo point is first, is consistent with 0.20.x
         assertHitCount(searchResponse, 2);
-        assertOrderedSearchHits(searchResponse, "2", "1");        
+        assertOrderedSearchHits(searchResponse, "2", "1");
         assertThat(((Number) searchResponse.getHits().getAt(0).sortValues()[0]).doubleValue(), equalTo(Double.MAX_VALUE));
         assertThat(((Number) searchResponse.getHits().getAt(1).sortValues()[0]).doubleValue(), closeTo(5286d, 10d));
     }
@@ -508,7 +508,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
                         .startObject("location").field("lat", 40.7143528).field("lon", -74.0059731).endObject()
                     .endObject()
                 .endArray()
-                .endObject()), 
+                .endObject()),
         client().prepareIndex("companies", "company", "2").setSource(jsonBuilder().startObject()
                 .field("name", "company 2")
                 .startArray("branches")
@@ -641,7 +641,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
                 RestStatus.BAD_REQUEST,
                 containsString("sort_mode [sum] isn't supported for sorting by geo distance"));
     }
-    
+
     /**
      * Issue 3073
      */
@@ -681,12 +681,12 @@ public class GeoDistanceIT extends ESIntegTestCase {
                 .setQuery(QueryBuilders.matchAllQuery())
                 .setPostFilter(QueryBuilders.geoDistanceQuery("pin")
                         .geoDistance(GeoDistance.ARC)
-                        .lat(lat).lon(lon)
+                        .point(lat, lon)
                         .distance("1m"))
                 .execute().actionGet();
 
         assertHitCount(result, 1);
-    } 
+    }
 
     private double randomLon() {
         return randomDouble() * 360 - 180;

--- a/core/src/test/java/org/elasticsearch/test/ESTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESTestCase.java
@@ -225,7 +225,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     // -----------------------------------------------------------------
-    // Test facilities and facades for subclasses. 
+    // Test facilities and facades for subclasses.
     // -----------------------------------------------------------------
 
     // TODO: replaces uses of getRandom() with random()
@@ -303,6 +303,35 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     public static double randomDouble() {
         return random().nextDouble();
+    }
+
+    /**
+     * Returns a double value in the interval [start, end) if lowerInclusive is
+     * set to true, (start, end) otherwise.
+     *
+     * @param start lower bound of interval to draw uniformly distributed random numbers from
+     * @param end upper bound
+     * @param lowerInclusive whether or not to include lower end of the interval
+     * */
+    public static double randomDoubleBetween(double start, double end, boolean lowerInclusive) {
+        double result = 0.0;
+
+        if (start == -Double.MAX_VALUE || end == Double.MAX_VALUE) {
+            // formula below does not work with very large doubles
+            result = Double.longBitsToDouble(randomLong());
+            while (result < start || result > end || Double.isNaN(result)) {
+                result = Double.longBitsToDouble(randomLong());
+            }
+        } else {
+            result = randomDouble();
+            if (lowerInclusive == false) {
+                while (result <= 0.0) {
+                    result = randomDouble();
+                }
+            }
+            result = result * end + (1.0 - result) * start;
+        }
+        return result;
     }
 
     public static long randomLong() {
@@ -481,7 +510,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     @Override
     public Path getDataPath(String relativePath) {
-        // we override LTC behavior here: wrap even resources with mockfilesystems, 
+        // we override LTC behavior here: wrap even resources with mockfilesystems,
         // because some code is buggy when it comes to multiple nio.2 filesystems
         // (e.g. FileSystemUtils, and likely some tests)
         try {

--- a/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
+++ b/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
@@ -229,7 +229,7 @@ public class RandomShapeGenerator {
         }
     }
 
-    protected static Point xRandomPoint(Random r) {
+    public static Point xRandomPoint(Random r) {
         return xRandomPointIn(r, ctx.getWorldBounds());
     }
 
@@ -243,7 +243,7 @@ public class RandomShapeGenerator {
         return p;
     }
 
-    protected static Rectangle xRandomRectangle(Random r, Point nearP) {
+    public static Rectangle xRandomRectangle(Random r, Point nearP) {
         Rectangle bounds = ctx.getWorldBounds();
         if (nearP == null)
             nearP = xRandomPointIn(r, bounds);

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -99,3 +99,8 @@ and `unlike` methods.
 
 The deprecated `docs(Item... docs)`, `ignoreLike(Item... docs)`,
 `ignoreLike(String... likeText)`, `addItem(Item... likeItems)` have been removed.
+
+==== GeoDistanceQueryBuilder
+
+Removing individual setters for lon() and lat() values, both values should be set together
+ using point(lon, lat).


### PR DESCRIPTION
Splits parsing and Lucene query generation. Switches from storing lat/lon
separately to using GeoPoint instead.

Relates to #10217
