### PR TITLE
Remove and forbid use of com.google.common.collect.Queues

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
+++ b/core/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
@@ -20,8 +20,8 @@
 package org.elasticsearch.common.recycler;
 
 import com.carrotsearch.hppc.BitMixer;
-import com.google.common.collect.Queues;
-import org.elasticsearch.ElasticsearchException;
+
+import java.util.ArrayDeque;
 
 public enum Recyclers {
     ;
@@ -44,7 +44,7 @@ public enum Recyclers {
      * Return a recycler based on a deque.
      */
     public static <T> Recycler<T> deque(Recycler.C<T> c, int limit) {
-        return new DequeRecycler<>(c, Queues.<T>newArrayDeque(), limit);
+        return new DequeRecycler<>(c, new ArrayDeque<>(), limit);
     }
 
     /**

--- a/dev-tools/src/main/resources/forbidden/core-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/core-signatures.txt
@@ -98,3 +98,4 @@ com.google.common.base.Preconditions#checkNotNull(java.lang.Object)
 com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.Object)
 com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.String, java.lang.Object[])
 com.google.common.collect.ImmutableSortedSet
+com.google.common.collect.Queues


### PR DESCRIPTION
This commit removes and now forbids all uses of
com.google.common.collect.Queues across the codebase. This is one of
many steps in the eventual removal of Guava as a dependency.

Relates #13224
