### PR TITLE
Update 'loading the sample dataset' section

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -548,6 +548,13 @@ curl -XPOST 'localhost:9200/bank/account/_bulk?pretty' --data-binary @accounts.j
 curl 'localhost:9200/_cat/indices?v'
 --------------------------------------------------
 
+For Windows Operating systems, the @account.json should be double quoted otherwise the json content could not be loaded.
+
+[source,sh]
+--------------------------------------------------
+curl -XPOST 'localhost:9200/bank/account/_bulk?pretty' --data-binary "@accounts.json"
+curl 'localhost:9200/_cat/indices?v'
+--------------------------------------------------
 And the response:
 
 [source,sh]


### PR DESCRIPTION
This command 

``` shell
curl -XPOST 'localhost:9200/bank/account/_bulk?pretty' --data-binary @accounts.json
```

will error out within windows cmd shell (Windows 10 64bit). So on windows @account.json should be double quoted as: 

``` shell
curl -XPOST 'localhost:9200/bank/account/_bulk?pretty' --data-binary "@accounts.json"
```
