### PR TITLE
Stop o.e.c.s.Settings from leaking Guava dependency

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cluster.metadata;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.Diff;
@@ -33,7 +32,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.node.DiscoveryNodeFilters;
 import org.elasticsearch.cluster.routing.HashFunction;
 import org.elasticsearch.cluster.routing.Murmur3HashFunction;
-import org.elasticsearch.common.Classes;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -218,19 +216,19 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         this.totalNumberOfShards = numberOfShards() * (numberOfReplicas() + 1);
         this.aliases = aliases;
 
-        ImmutableMap<String, String> requireMap = settings.getByPrefix("index.routing.allocation.require.").getAsMap();
+        Map<String, String> requireMap = settings.getByPrefix("index.routing.allocation.require.").getAsMap();
         if (requireMap.isEmpty()) {
             requireFilters = null;
         } else {
             requireFilters = DiscoveryNodeFilters.buildFromKeyValue(AND, requireMap);
         }
-        ImmutableMap<String, String> includeMap = settings.getByPrefix("index.routing.allocation.include.").getAsMap();
+        Map<String, String> includeMap = settings.getByPrefix("index.routing.allocation.include.").getAsMap();
         if (includeMap.isEmpty()) {
             includeFilters = null;
         } else {
             includeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, includeMap);
         }
-        ImmutableMap<String, String> excludeMap = settings.getByPrefix("index.routing.allocation.exclude.").getAsMap();
+        Map<String, String> excludeMap = settings.getByPrefix("index.routing.allocation.exclude.").getAsMap();
         if (excludeMap.isEmpty()) {
             excludeFilters = null;
         } else {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodeFilters;
 import org.elasticsearch.cluster.routing.RoutingNode;
@@ -28,6 +27,8 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.settings.NodeSettingsService;
+
+import java.util.Map;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeFilters.OpType.AND;
 import static org.elasticsearch.cluster.node.DiscoveryNodeFilters.OpType.OR;
@@ -77,19 +78,19 @@ public class FilterAllocationDecider extends AllocationDecider {
     @Inject
     public FilterAllocationDecider(Settings settings, NodeSettingsService nodeSettingsService) {
         super(settings);
-        ImmutableMap<String, String> requireMap = settings.getByPrefix(CLUSTER_ROUTING_REQUIRE_GROUP).getAsMap();
+        Map<String, String> requireMap = settings.getByPrefix(CLUSTER_ROUTING_REQUIRE_GROUP).getAsMap();
         if (requireMap.isEmpty()) {
             clusterRequireFilters = null;
         } else {
             clusterRequireFilters = DiscoveryNodeFilters.buildFromKeyValue(AND, requireMap);
         }
-        ImmutableMap<String, String> includeMap = settings.getByPrefix(CLUSTER_ROUTING_INCLUDE_GROUP).getAsMap();
+        Map<String, String> includeMap = settings.getByPrefix(CLUSTER_ROUTING_INCLUDE_GROUP).getAsMap();
         if (includeMap.isEmpty()) {
             clusterIncludeFilters = null;
         } else {
             clusterIncludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, includeMap);
         }
-        ImmutableMap<String, String> excludeMap = settings.getByPrefix(CLUSTER_ROUTING_EXCLUDE_GROUP).getAsMap();
+        Map<String, String> excludeMap = settings.getByPrefix(CLUSTER_ROUTING_EXCLUDE_GROUP).getAsMap();
         if (excludeMap.isEmpty()) {
             clusterExcludeFilters = null;
         } else {
@@ -148,15 +149,15 @@ public class FilterAllocationDecider extends AllocationDecider {
     class ApplySettings implements NodeSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
-            ImmutableMap<String, String> requireMap = settings.getByPrefix(CLUSTER_ROUTING_REQUIRE_GROUP).getAsMap();
+            Map<String, String> requireMap = settings.getByPrefix(CLUSTER_ROUTING_REQUIRE_GROUP).getAsMap();
             if (!requireMap.isEmpty()) {
                 clusterRequireFilters = DiscoveryNodeFilters.buildFromKeyValue(AND, requireMap);
             }
-            ImmutableMap<String, String> includeMap = settings.getByPrefix(CLUSTER_ROUTING_INCLUDE_GROUP).getAsMap();
+            Map<String, String> includeMap = settings.getByPrefix(CLUSTER_ROUTING_INCLUDE_GROUP).getAsMap();
             if (!includeMap.isEmpty()) {
                 clusterIncludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, includeMap);
             }
-            ImmutableMap<String, String> excludeMap = settings.getByPrefix(CLUSTER_ROUTING_EXCLUDE_GROUP).getAsMap();
+            Map<String, String> excludeMap = settings.getByPrefix(CLUSTER_ROUTING_EXCLUDE_GROUP).getAsMap();
             if (!excludeMap.isEmpty()) {
                 clusterExcludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, excludeMap);
             }

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -31,12 +31,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.property.PropertyPlaceholder;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.settings.loader.SettingsLoaderFactory;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.MemorySizeValue;
-import org.elasticsearch.common.unit.RatioValue;
-import org.elasticsearch.common.unit.SizeValue;
-import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.unit.*;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -45,17 +40,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -108,9 +93,10 @@ public final class Settings implements ToXContent {
 
     /**
      * The settings as a flat {@link java.util.Map}.
+     * @return an unmodifiable map of settings
      */
-    public ImmutableMap<String, String> getAsMap() {
-        return this.settings;
+    public Map<String, String> getAsMap() {
+        return Collections.unmodifiableMap(this.settings);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/core/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test.test;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.client.Client;
@@ -84,7 +83,7 @@ public class InternalTestClusterTests extends ESTestCase {
     }
 
     public static void assertSettings(Settings left, Settings right, boolean checkClusterUniqueSettings) {
-        ImmutableSet<Map.Entry<String, String>> entries0 = left.getAsMap().entrySet();
+        Set<Map.Entry<String, String>> entries0 = left.getAsMap().entrySet();
         Map<String, String> entries1 = right.getAsMap();
         assertThat(entries0.size(), equalTo(entries1.size()));
         for (Map.Entry<String, String> entry : entries0) {

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.tribe;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
@@ -52,9 +51,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -109,7 +106,7 @@ public class TribeIT extends ESIntegTestCase {
     }
 
     private void setupTribeNode(Settings settings) {
-        ImmutableMap<String,String> asMap = internalCluster().getDefaultSettings().getAsMap();
+        Map<String,String> asMap = internalCluster().getDefaultSettings().getAsMap();
         Settings.Builder tribe1Defaults = Settings.builder();
         Settings.Builder tribe2Defaults = Settings.builder();
         for (Map.Entry<String, String> entry : asMap.entrySet()) {


### PR DESCRIPTION
The public `org.elasticsearch.common.settings.Settings#getAsMap` method
leaks the dependency on Guava by returning a
`com.google.common.collect.ImmutableMap`. The leaking of this dependency
should be removed in preparation for the eventual complete removal of
Guava as a dependency.

Relates #13224
