### PR TITLE
Cleanup SearchRequest & SearchRequestBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -252,54 +252,13 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     }
 
     /**
-     * The source of the search request. Consider using either {@link #source(byte[])} or
-     * {@link #source(org.elasticsearch.search.builder.SearchSourceBuilder)}.
-     */
-    public SearchRequest source(String source) {
-        this.source = new BytesArray(source);
-        return this;
-    }
-
-    /**
-     * The source of the search request in the form of a map.
-     */
-    public SearchRequest source(Map source) {
-        try {
-            XContentBuilder builder = XContentFactory.contentBuilder(Requests.CONTENT_TYPE);
-            builder.map(source);
-            return source(builder);
-        } catch (IOException e) {
-            throw new ElasticsearchGenerationException("Failed to generate [" + source + "]", e);
-        }
-    }
-
-    public SearchRequest source(XContentBuilder builder) {
-        this.source = builder.bytes();
-        return this;
-    }
-
-    /**
-     * The search source to execute.
-     */
-    public SearchRequest source(byte[] source) {
-        return source(source, 0, source.length);
-    }
-
-
-    /**
-     * The search source to execute.
-     */
-    public SearchRequest source(byte[] source, int offset, int length) {
-        return source(new BytesArray(source, offset, length));
-    }
-
-    /**
      * The search source to execute.
      */
     public SearchRequest source(BytesReference source) {
         this.source = source;
         return this;
     }
+
 
     /**
      * The search source to execute.
@@ -324,51 +283,6 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
             return this;
         }
         this.extraSource = sourceBuilder.buildAsBytes(Requests.CONTENT_TYPE);
-        return this;
-    }
-
-    public SearchRequest extraSource(Map extraSource) {
-        try {
-            XContentBuilder builder = XContentFactory.contentBuilder(Requests.CONTENT_TYPE);
-            builder.map(extraSource);
-            return extraSource(builder);
-        } catch (IOException e) {
-            throw new ElasticsearchGenerationException("Failed to generate [" + extraSource + "]", e);
-        }
-    }
-
-    public SearchRequest extraSource(XContentBuilder builder) {
-        this.extraSource = builder.bytes();
-        return this;
-    }
-
-    /**
-     * Allows to provide additional source that will use used as well.
-     */
-    public SearchRequest extraSource(String source) {
-        this.extraSource = new BytesArray(source);
-        return this;
-    }
-
-    /**
-     * Allows to provide additional source that will be used as well.
-     */
-    public SearchRequest extraSource(byte[] source) {
-        return extraSource(source, 0, source.length);
-    }
-
-    /**
-     * Allows to provide additional source that will be used as well.
-     */
-    public SearchRequest extraSource(byte[] source, int offset, int length) {
-        return extraSource(new BytesArray(source, offset, length));
-    }
-
-    /**
-     * Allows to provide additional source that will be used as well.
-     */
-    public SearchRequest extraSource(BytesReference source) {
-        this.extraSource = source;
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -806,27 +806,19 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
-     * Sets the source of the request as a json string. Note, settings anything other
+     * Sets the source of the request as a SearchSourceBuilder. Note, settings anything other
      * than the search type will cause this source to be overridden, consider using
-     * {@link #setExtraSource(String)}.
+     * {@link #setExtraSource(SearchSourceBuilder)} instead.
      */
-    public SearchRequestBuilder setSource(String source) {
+    public SearchRequestBuilder setSource(SearchSourceBuilder source) {
         request.source(source);
         return this;
     }
 
     /**
-     * Sets the source of the request as a json string. Allows to set other parameters.
-     */
-    public SearchRequestBuilder setExtraSource(String source) {
-        request.extraSource(source);
-        return this;
-    }
-
-    /**
      * Sets the source of the request as a json string. Note, settings anything other
      * than the search type will cause this source to be overridden, consider using
-     * {@link #setExtraSource(BytesReference)}.
+     * {@link #setExtraSource(SearchSourceBuilder)} instead.
      */
     public SearchRequestBuilder setSource(BytesReference source) {
         request.source(source);
@@ -834,78 +826,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
-     * Sets the source of the request as a json string. Note, settings anything other
-     * than the search type will cause this source to be overridden, consider using
-     * {@link #setExtraSource(byte[])}.
+     * Sets the an addtional source of the request as a SearchSourceBuilder. All values and
+     * settings set on the extra source will override the corresponding settings on the specified
+     * source.
      */
-    public SearchRequestBuilder setSource(byte[] source) {
-        request.source(source);
-        return this;
-    }
-
-    /**
-     * Sets the source of the request as a json string. Allows to set other parameters.
-     */
-    public SearchRequestBuilder setExtraSource(BytesReference source) {
-        request.extraSource(source);
-        return this;
-    }
-
-    /**
-     * Sets the source of the request as a json string. Allows to set other parameters.
-     */
-    public SearchRequestBuilder setExtraSource(byte[] source) {
-        request.extraSource(source);
-        return this;
-    }
-
-    /**
-     * Sets the source of the request as a json string. Note, settings anything other
-     * than the search type will cause this source to be overridden, consider using
-     * {@link #setExtraSource(byte[])}.
-     */
-    public SearchRequestBuilder setSource(byte[] source, int offset, int length) {
-        request.source(source, offset, length);
-        return this;
-    }
-
-    /**
-     * Sets the source of the request as a json string. Allows to set other parameters.
-     */
-    public SearchRequestBuilder setExtraSource(byte[] source, int offset, int length) {
-        request.extraSource(source, offset, length);
-        return this;
-    }
-
-    /**
-     * Sets the source of the request as a json string. Note, settings anything other
-     * than the search type will cause this source to be overridden, consider using
-     * {@link #setExtraSource(byte[])}.
-     */
-    public SearchRequestBuilder setSource(XContentBuilder builder) {
-        request.source(builder);
-        return this;
-    }
-
-    /**
-     * Sets the source of the request as a json string. Allows to set other parameters.
-     */
-    public SearchRequestBuilder setExtraSource(XContentBuilder builder) {
-        request.extraSource(builder);
-        return this;
-    }
-
-    /**
-     * Sets the source of the request as a map. Note, setting anything other than the
-     * search type will cause this source to be overridden, consider using
-     * {@link #setExtraSource(java.util.Map)}.
-     */
-    public SearchRequestBuilder setSource(Map source) {
-        request.source(source);
-        return this;
-    }
-
-    public SearchRequestBuilder setExtraSource(Map source) {
+    public SearchRequestBuilder setExtraSource(SearchSourceBuilder source) {
         request.extraSource(source);
         return this;
     }
@@ -913,36 +838,8 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     /**
      * template stuff
      */
-
     public SearchRequestBuilder setTemplate(Template template) {
         request.template(template);
-        return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setTemplate(Template)} instead.
-     */
-    @Deprecated
-    public SearchRequestBuilder setTemplateName(String templateName) {
-        request.templateName(templateName);
-        return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setTemplate(Template)} instead.
-     */
-    @Deprecated
-    public SearchRequestBuilder setTemplateType(ScriptService.ScriptType templateType) {
-        request.templateType(templateType);
-        return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setTemplate(Template)} instead.
-     */
-    @Deprecated
-    public SearchRequestBuilder setTemplateParams(Map<String, Object> templateParams) {
-        request.templateParams(templateParams);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/warmer/put/RestPutWarmerAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.AcknowledgedRestListener;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -67,6 +68,6 @@ public class RestPutWarmerAction extends BaseRestHandler {
         putWarmerRequest.searchRequest(searchRequest);
         putWarmerRequest.timeout(request.paramAsTime("timeout", putWarmerRequest.timeout()));
         putWarmerRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putWarmerRequest.masterNodeTimeout()));
-        client.admin().indices().putWarmer(putWarmerRequest, new AcknowledgedRestListener<PutWarmerResponse>(channel));
+        client.admin().indices().putWarmer(putWarmerRequest, new AcknowledgedRestListener<>(channel));
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/search/SearchRequestBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchRequestBuilderTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -95,7 +96,7 @@ public class SearchRequestBuilderTests extends ESTestCase {
     public void testStringSourceToString() {
         SearchRequestBuilder searchRequestBuilder = client.prepareSearch();
         String source = "{ \"query\" : { \"match_all\" : {} } }";
-        searchRequestBuilder.setSource(source);
+        searchRequestBuilder.setSource(new BytesArray(source));
         assertThat(searchRequestBuilder.toString(), equalTo(source));
     }
 
@@ -109,7 +110,7 @@ public class SearchRequestBuilderTests extends ESTestCase {
         xContentBuilder.endObject();
         xContentBuilder.endObject();
         xContentBuilder.endObject();
-        searchRequestBuilder.setSource(xContentBuilder);
+        searchRequestBuilder.setSource(xContentBuilder.bytes());
         assertThat(searchRequestBuilder.toString(), equalTo(XContentHelper.convertToJson(xContentBuilder.bytes(), false, true)));
     }
 
@@ -124,7 +125,7 @@ public class SearchRequestBuilderTests extends ESTestCase {
                 "            }\n" +
                 "        }\n" +
                 "        }";
-        SearchRequestBuilder searchRequestBuilder = client.prepareSearch().setSource(source);
+        SearchRequestBuilder searchRequestBuilder = client.prepareSearch().setSource(new BytesArray(source));
         String preToString = searchRequestBuilder.request().source().toUtf8();
         assertThat(searchRequestBuilder.toString(), equalTo(source));
         String postToString = searchRequestBuilder.request().source().toUtf8();

--- a/core/src/test/java/org/elasticsearch/index/query/TemplateQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TemplateQueryIT.java
@@ -99,7 +99,7 @@ public class TemplateQueryIT extends ESIntegTestCase {
                 "        }\n" +
                 "    }\n" +
                 "}";
-        SearchResponse sr = client().prepareSearch().setSource(request)
+        SearchResponse sr = client().prepareSearch().setSource(new BytesArray(request))
                 .execute().actionGet();
         assertNoFailures(sr);
         assertThat(sr.getHits().hits().length, equalTo(0));
@@ -115,7 +115,7 @@ public class TemplateQueryIT extends ESIntegTestCase {
                 "    \"size\":0" +
                 "}";
 
-        sr = client().prepareSearch().setSource(request)
+        sr = client().prepareSearch().setSource(new BytesArray(request))
                 .execute().actionGet();
         assertNoFailures(sr);
         assertThat(sr.getHits().hits().length, equalTo(0));

--- a/core/src/test/java/org/elasticsearch/script/GroovyScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/script/GroovyScriptIT.java
@@ -22,6 +22,7 @@ package org.elasticsearch.script;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
@@ -53,9 +54,9 @@ public class GroovyScriptIT extends ESIntegTestCase {
 
     public void assertScript(String script) {
         SearchResponse resp = client().prepareSearch("test")
-                .setSource("{\"query\": {\"match_all\": {}}," +
+                .setSource(new BytesArray("{\"query\": {\"match_all\": {}}," +
                         "\"sort\":{\"_script\": {\"script\": \""+ script +
-                        "; 1\", \"type\": \"number\", \"lang\": \"groovy\"}}}").get();
+                        "; 1\", \"type\": \"number\", \"lang\": \"groovy\"}}}")).get();
         assertNoFailures(resp);
     }
 

--- a/core/src/test/java/org/elasticsearch/script/GroovySecurityIT.java
+++ b/core/src/test/java/org/elasticsearch/script/GroovySecurityIT.java
@@ -22,6 +22,7 @@ package org.elasticsearch.script;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -106,9 +107,9 @@ public class GroovySecurityIT extends ESIntegTestCase {
     private void assertSuccess(String script) {
         logger.info("--> script: " + script);
         SearchResponse resp = client().prepareSearch("test")
-                .setSource("{\"query\": {\"match_all\": {}}," +
-                        "\"sort\":{\"_script\": {\"script\": \""+ script +
-                        "; doc['foo'].value + 2\", \"type\": \"number\", \"lang\": \"groovy\"}}}").get();
+                .setSource(new BytesArray("{\"query\": {\"match_all\": {}}," +
+                        "\"sort\":{\"_script\": {\"script\": \"" + script +
+                        "; doc['foo'].value + 2\", \"type\": \"number\", \"lang\": \"groovy\"}}}")).get();
         assertNoFailures(resp);
         assertEquals(1, resp.getHits().getTotalHits());
         assertThat(resp.getHits().getAt(0).getSortValues(), equalTo(new Object[]{7.0}));
@@ -117,9 +118,9 @@ public class GroovySecurityIT extends ESIntegTestCase {
     private void assertFailure(String script) {
         logger.info("--> script: " + script);
         SearchResponse resp = client().prepareSearch("test")
-                 .setSource("{\"query\": {\"match_all\": {}}," +
-                            "\"sort\":{\"_script\": {\"script\": \""+ script +
-                            "; doc['foo'].value + 2\", \"type\": \"number\", \"lang\": \"groovy\"}}}").get();
+                 .setSource(new BytesArray("{\"query\": {\"match_all\": {}}," +
+                         "\"sort\":{\"_script\": {\"script\": \"" + script +
+                         "; doc['foo'].value + 2\", \"type\": \"number\", \"lang\": \"groovy\"}}}")).get();
         assertEquals(0, resp.getHits().getTotalHits());
         ShardSearchFailure fails[] = resp.getShardFailures();
         // TODO: GroovyScriptExecutionException needs work:

--- a/core/src/test/java/org/elasticsearch/script/OnDiskScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/script/OnDiskScriptIT.java
@@ -20,6 +20,7 @@ package org.elasticsearch.script;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.mustache.MustacheScriptEngineService;
 import org.elasticsearch.search.SearchHit;
@@ -62,7 +63,7 @@ public class OnDiskScriptIT extends ESIntegTestCase {
         indexRandom(true, builders);
 
         String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"script_file\" : \"script1\" }, \"test2\" : { \"script_file\" : \"script2\", \"params\":{\"factor\":3}  }}, size:1}";
-        SearchResponse searchResponse = client().prepareSearch().setSource(query).setIndices("test").setTypes("scriptTest").get();
+        SearchResponse searchResponse = client().prepareSearch().setSource(new BytesArray(query)).setIndices("test").setTypes("scriptTest").get();
         assertHitCount(searchResponse, 5);
         assertTrue(searchResponse.getHits().hits().length == 1);
         SearchHit sh = searchResponse.getHits().getAt(0);
@@ -81,7 +82,7 @@ public class OnDiskScriptIT extends ESIntegTestCase {
         indexRandom(true, builders);
 
         String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"script_file\" : \"script1\" }, \"test2\" : { \"script_file\" : \"script1\", \"lang\":\"expression\"  }}, size:1}";
-        SearchResponse searchResponse = client().prepareSearch().setSource(query).setIndices("test").setTypes("scriptTest").get();
+        SearchResponse searchResponse = client().prepareSearch().setSource(new BytesArray(query)).setIndices("test").setTypes("scriptTest").get();
         assertHitCount(searchResponse, 5);
         assertTrue(searchResponse.getHits().hits().length == 1);
         SearchHit sh = searchResponse.getHits().getAt(0);
@@ -103,14 +104,14 @@ public class OnDiskScriptIT extends ESIntegTestCase {
 
         String source = "{\"aggs\": {\"test\": { \"terms\" : { \"script_file\":\"script1\", \"lang\": \"expression\" } } } }";
         try {
-            client().prepareSearch("test").setSource(source).get();
+            client().prepareSearch("test").setSource(new BytesArray(source)).get();
             fail("aggs script should have been rejected");
         } catch(Exception e) {
             assertThat(e.toString(), containsString("scripts of type [file], operation [aggs] and lang [expression] are disabled"));
         }
 
         String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"script_file\" : \"script1\", \"lang\":\"expression\" }}, size:1}";
-        SearchResponse searchResponse = client().prepareSearch().setSource(query).setIndices("test").setTypes("scriptTest").get();
+        SearchResponse searchResponse = client().prepareSearch().setSource(new BytesArray(query)).setIndices("test").setTypes("scriptTest").get();
         assertHitCount(searchResponse, 5);
         assertTrue(searchResponse.getHits().hits().length == 1);
         SearchHit sh = searchResponse.getHits().getAt(0);
@@ -124,14 +125,14 @@ public class OnDiskScriptIT extends ESIntegTestCase {
         refresh();
         String source = "{\"aggs\": {\"test\": { \"terms\" : { \"script_file\":\"script1\", \"lang\": \"mustache\" } } } }";
         try {
-            client().prepareSearch("test").setSource(source).get();
+            client().prepareSearch("test").setSource(new BytesArray(source)).get();
             fail("aggs script should have been rejected");
         } catch(Exception e) {
             assertThat(e.toString(), containsString("scripts of type [file], operation [aggs] and lang [mustache] are disabled"));
         }
         String query = "{ \"query\" : { \"match_all\": {}} , \"script_fields\" : { \"test1\" : { \"script_file\" : \"script1\", \"lang\":\"mustache\" }}, size:1}";
         try {
-            client().prepareSearch().setSource(query).setIndices("test").setTypes("scriptTest").get();
+            client().prepareSearch().setSource(new BytesArray(query)).setIndices("test").setTypes("scriptTest").get();
             fail("search script should have been rejected");
         } catch(Exception e) {
             assertThat(e.toString(), containsString("scripts of type [file], operation [search] and lang [mustache] are disabled"));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.script.Script;
@@ -614,8 +615,8 @@ public class TopHitsIT extends ESIntegTestCase {
                 "}";
         try {
             client().prepareSearch("idx").setTypes("type")
-                    .setSource(source)
-                    .get();
+                    .setSource(new BytesArray(source))
+                            .get();
             fail();
         } catch (SearchPhaseExecutionException e) {
             assertThat(e.toString(), containsString("Aggregator [top_tags_hits] of type [top_hits] cannot accept sub-aggregations"));

--- a/core/src/test/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -66,7 +67,7 @@ public class TransportSearchFailuresIT extends ESIntegTestCase {
         assertThat(refreshResponse.getFailedShards(), equalTo(0));
         for (int i = 0; i < 5; i++) {
             try {
-                SearchResponse searchResponse = client().search(searchRequest("test").source("{ xxx }".getBytes(Charsets.UTF_8))).actionGet();
+                SearchResponse searchResponse = client().search(searchRequest("test").source(new BytesArray("{ xxx }"))).actionGet();
                 assertThat(searchResponse.getTotalShards(), equalTo(test.numPrimaries));
                 assertThat(searchResponse.getSuccessfulShards(), equalTo(0));
                 assertThat(searchResponse.getFailedShards(), equalTo(test.numPrimaries));
@@ -95,7 +96,7 @@ public class TransportSearchFailuresIT extends ESIntegTestCase {
 
         for (int i = 0; i < 5; i++) {
             try {
-                SearchResponse searchResponse = client().search(searchRequest("test").source("{ xxx }".getBytes(Charsets.UTF_8))).actionGet();
+                SearchResponse searchResponse = client().search(searchRequest("test").source(new BytesArray("{ xxx }"))).actionGet();
                 assertThat(searchResponse.getTotalShards(), equalTo(test.numPrimaries));
                 assertThat(searchResponse.getSuccessfulShards(), equalTo(0));
                 assertThat(searchResponse.getFailedShards(), equalTo(test.numPrimaries));

--- a/core/src/test/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -320,7 +321,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
 
         //SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(DFS_QUERY_AND_FETCH).scroll(new Scroll(timeValueMinutes(10)))).actionGet();
-        SearchResponse searchResponse = client().prepareSearch("test").setSearchType(DFS_QUERY_AND_FETCH).setScroll("10m").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSearchType(DFS_QUERY_AND_FETCH).setScroll("10m").setSource(source).get();
         assertNoFailures(searchResponse);
         assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
         assertThat(searchResponse.getHits().hits().length, equalTo(60)); // 20 per shard
@@ -377,7 +378,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
         logger.info("Start Testing failed search with wrong query");
         try {
-            SearchResponse searchResponse = client().search(searchRequest("test").source("{ xxx }".getBytes(Charsets.UTF_8))).actionGet();
+            SearchResponse searchResponse = client().search(searchRequest("test").source(new BytesArray("{ xxx }"))).actionGet();
             assertThat(searchResponse.getTotalShards(), equalTo(test.numPrimaries));
             assertThat(searchResponse.getSuccessfulShards(), equalTo(0));
             assertThat(searchResponse.getFailedShards(), equalTo(test.numPrimaries));

--- a/core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.collect.HppcMaps;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.settings.Settings;
@@ -1478,12 +1479,12 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         SearchResponse resp;
         resp = client().prepareSearch("test")
-                .setSource("{\"query\": {\"has_child\": {\"type\": \"posts\", \"query\": {\"match\": {\"field\": \"bar\"}}}}}").get();
+                .setSource(new BytesArray("{\"query\": {\"has_child\": {\"type\": \"posts\", \"query\": {\"match\": {\"field\": \"bar\"}}}}}")).get();
         assertHitCount(resp, 1L);
 
         // Now reverse the order for the type after the query
         resp = client().prepareSearch("test")
-                .setSource("{\"query\": {\"has_child\": {\"query\": {\"match\": {\"field\": \"bar\"}}, \"type\": \"posts\"}}}").get();
+                .setSource(new BytesArray("{\"query\": {\"has_child\": {\"query\": {\"match\": {\"field\": \"bar\"}}, \"type\": \"posts\"}}}")).get();
         assertHitCount(resp, 1L);
 
     }

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.termvectors.TermVectorsRequest;
 import org.elasticsearch.action.termvectors.TermVectorsResponse;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.plugins.Plugin;
@@ -90,7 +91,7 @@ public class FetchSubPhasePluginIT extends ESIntegTestCase {
         String searchSource = jsonBuilder().startObject()
                 .field("term_vectors_fetch", "test")
                 .endObject().string();
-        SearchResponse response = client().prepareSearch().setSource(searchSource).get();
+        SearchResponse response = client().prepareSearch().setSource(new BytesArray(searchSource)).get();
         assertSearchResponse(response);
         assertThat(((Map<String, Integer>) response.getHits().getAt(0).field("term_vectors_fetch").getValues().get(0)).get("i"), equalTo(2));
         assertThat(((Map<String, Integer>) response.getHits().getAt(0).field("term_vectors_fetch").getValues().get(0)).get("am"), equalTo(2));

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.functionscore;
 
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -146,8 +147,8 @@ public class FunctionScoreFieldValueIT extends ESIntegTestCase {
             "  }" +
             "}";
           response = client().prepareSearch("test")
-          .setSource(querySource)
-          .get();
+          .setSource(new BytesArray(querySource))
+                  .get();
           assertFailures(response);
         } catch (SearchPhaseExecutionException e) {
           // This is fine, the query will throw an exception if executed

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -378,8 +379,8 @@ public class FunctionScoreIT extends ESIntegTestCase {
                 .endObject()
                 .endObject().string();
         SearchResponse response = client().search(
-                searchRequest().source(query)
-        ).actionGet();
+                searchRequest().source(new BytesArray(query))
+                ).actionGet();
         assertSearchResponse(response);
         assertThat(response.getHits().getAt(0).score(), equalTo(2.0f));
 
@@ -391,7 +392,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
                 .endObject()
                 .endObject().string();
         response = client().search(
-                searchRequest().source(query)
+                searchRequest().source(new BytesArray(query))
         ).actionGet();
         assertSearchResponse(response);
         assertThat(response.getHits().getAt(0).score(), equalTo(2.0f));

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
@@ -634,7 +634,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                         .field(new HighlightBuilder.Field("field1").numOfFragments(2))
                         .field(new HighlightBuilder.Field("field2").preTags("<field2>").postTags("</field2>").fragmentSize(50).requireFieldMatch(false)));
 
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field1", 0, 2, equalTo(" <global>test</global>"));
         assertHighlight(searchResponse, 0, "field1", 1, 2, equalTo(" <global>test</global>"));
@@ -713,13 +713,13 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(termQuery("field1", "quick"))
                 .highlight(highlight().forceSource(true).field("field1"));
-        assertFailures(client().prepareSearch("test").setSource(searchSource.buildAsBytes()),
+        assertFailures(client().prepareSearch("test").setSource(searchSource),
                 RestStatus.BAD_REQUEST,
                 containsString("source is forced for fields [field1] but type [type1] has disabled _source"));
 
         searchSource = SearchSourceBuilder.searchSource().query(termQuery("field1", "quick"))
                 .highlight(highlight().forceSource(true).field("field*"));
-        assertFailures(client().prepareSearch("test").setSource(searchSource.buildAsBytes()),
+        assertFailures(client().prepareSearch("test").setSource(searchSource),
                 RestStatus.BAD_REQUEST,
                 matches("source is forced for fields \\[field\\d, field\\d\\] but type \\[type1\\] has disabled _source"));
     }
@@ -738,7 +738,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(termQuery("field1", "test"))
                 .highlight(highlight().field("field1").order("score").preTags("<xxx>").postTags("</xxx>"));
 
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
@@ -747,7 +747,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(termQuery("_all", "test"))
                 .highlight(highlight().field("field1").order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
@@ -756,7 +756,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(termQuery("_all", "quick"))
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
 
@@ -765,7 +765,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(prefixQuery("_all", "qui"))
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
 
@@ -774,7 +774,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(constantScoreQuery(prefixQuery("_all", "qui")))
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
 
@@ -783,7 +783,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(boolQuery().should(constantScoreQuery(prefixQuery("_all", "qui"))))
                 .highlight(highlight().field("field2").order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
     }
 
@@ -801,7 +801,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(termQuery("field1", "test"))
                 .highlight(highlight().field("field1", 100, 0).order("score").preTags("<xxx>").postTags("</xxx>"));
 
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
 
@@ -810,7 +810,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(termQuery("_all", "test"))
                 .highlight(highlight().field("field1", 100, 0).order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
 
         // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("this is a <xxx>test</xxx>"));
@@ -820,7 +820,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(termQuery("_all", "quick"))
                 .highlight(highlight().field("field2", 100, 0).order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
 
         // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
@@ -830,7 +830,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(prefixQuery("_all", "qui"))
                 .highlight(highlight().field("field2", 100, 0).order("score").preTags("<xxx>").postTags("</xxx>").requireFieldMatch(false));
 
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
 
         // LUCENE 3.1 UPGRADE: Caused adding the space at the end...
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <xxx>quick</xxx> brown fox jumps over the lazy dog"));
@@ -1399,7 +1399,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(boostingQuery().positive(termQuery("field2", "brown")).negative(termQuery("field2", "foobar")).negativeBoost(0.5f))
                 .highlight(highlight().field("field2").order("score").preTags("<x>").postTags("</x>"));
 
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The quick <x>brown</x> fox jumps over the lazy dog"));
     }
@@ -1418,7 +1418,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(boostingQuery().positive(termQuery("field2", "brown")).negative(termQuery("field2", "foobar")).negativeBoost(0.5f))
                 .highlight(highlight().field("field2").order("score").preTags("<x>").postTags("</x>"));
 
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The quick <x>brown</x> fox jumps over the lazy dog"));
     }
@@ -1438,7 +1438,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .query(commonTermsQuery("field2", "quick brown").cutoffFrequency(100))
                 .highlight(highlight().field("field2").order("score").preTags("<x>").postTags("</x>"));
 
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
     }
 
@@ -1453,7 +1453,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         SearchSourceBuilder source = searchSource().query(commonTermsQuery("field2", "quick brown").cutoffFrequency(100))
                 .highlight(highlight().field("field2").order("score").preTags("<x>").postTags("</x>"));
 
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
     }
@@ -2372,7 +2372,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
         SearchSourceBuilder source = searchSource().query(prefixQuery("field2", "qui"))
                 .highlight(highlight().field("field2"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
 
     }
@@ -2387,7 +2387,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         logger.info("--> highlighting and searching on field2");
         SearchSourceBuilder source = searchSource().query(fuzzyQuery("field2", "quck"))
                 .highlight(highlight().field("field2"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
     }
@@ -2402,7 +2402,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         logger.info("--> highlighting and searching on field2");
         SearchSourceBuilder source = searchSource().query(regexpQuery("field2", "qu[a-l]+k"))
                 .highlight(highlight().field("field2"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
     }
@@ -2417,13 +2417,13 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         logger.info("--> highlighting and searching on field2");
         SearchSourceBuilder source = searchSource().query(wildcardQuery("field2", "qui*"))
                 .highlight(highlight().field("field2"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
 
         source = searchSource().query(wildcardQuery("field2", "qu*k"))
                 .highlight(highlight().field("field2"));
-        searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHitCount(searchResponse, 1l);
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
@@ -2439,7 +2439,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         logger.info("--> highlighting and searching on field2");
         SearchSourceBuilder source = searchSource().query(rangeQuery("field2").gte("aaaa").lt("zzzz"))
                 .highlight(highlight().field("field2"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("<em>aaab</em>"));
     }
@@ -2454,7 +2454,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         logger.info("--> highlighting and searching on field2");
         SearchSourceBuilder source = searchSource().query(queryStringQuery("qui*").defaultField("field2"))
                 .highlight(highlight().field("field2"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
     }
 
@@ -2470,7 +2470,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource().query(constantScoreQuery(regexpQuery("field1", "pho[a-z]+")))
                 .highlight(highlight().field("field1"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("The <em>photography</em> word will get highlighted"));
     }
 
@@ -2489,7 +2489,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .should(matchQuery("field1", "test"))
                 .should(constantScoreQuery(queryStringQuery("field1:photo*"))))
                 .highlight(highlight().field("field1"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("The <em>photography</em> word will get highlighted"));
     }
 
@@ -2505,7 +2505,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource().query(boolQuery().must(prefixQuery("field1", "photo")).should(matchQuery("field1", "test").minimumShouldMatch("0")))
                 .highlight(highlight().field("field1"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("The <em>photography</em> word will get highlighted"));
     }
 
@@ -2521,7 +2521,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         logger.info("--> highlighting and searching on field1");
         SearchSourceBuilder source = searchSource().query(boolQuery().must(queryStringQuery("field1:photo*")).filter(missingQuery("field_null")))
                 .highlight(highlight().field("field1"));
-        SearchResponse searchResponse = client().prepareSearch("test").setSource(source.buildAsBytes()).get();
+        SearchResponse searchResponse = client().prepareSearch("test").setSource(source).get();
         assertHighlight(searchResponse, 0, "field1", 0, 1, equalTo("The <em>photography</em> word will get highlighted"));
     }
 

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.query;
 
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.SimpleQueryStringBuilder;
@@ -269,7 +270,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
                         .flags(SimpleQueryStringFlag.NONE)).get();
         assertHitCount(searchResponse, 0l);
 
-        searchResponse = client().prepareSearch().setSource("{\n" +
+        searchResponse = client().prepareSearch().setSource(new BytesArray("{\n" +
                 "  \"query\": {\n" +
                 "    \"simple_query_string\": {\n" +
                 "      \"query\": \"foo|bar\",\n" +
@@ -277,7 +278,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
                 "      \"flags\": \"NONE\"\n" +
                 "    }\n" +
                 "  }\n" +
-                "}").get();
+                "}")).get();
         assertHitCount(searchResponse, 1l);
 
         searchResponse = client().prepareSearch().setQuery(

--- a/core/src/test/java/org/elasticsearch/search/sort/SimpleSortIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/SimpleSortIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.text.StringAndBytesText;
@@ -1907,7 +1908,7 @@ public class SimpleSortIT extends ESIntegTestCase {
         searchSourceBuilder.endArray();
         searchSourceBuilder.endObject();
 
-        searchResponse = client().prepareSearch().setSource(searchSourceBuilder).execute().actionGet();
+        searchResponse = client().prepareSearch().setSource(searchSourceBuilder.bytes()).execute().actionGet();
         assertOrderedSearchHits(searchResponse, "d1", "d2");
         assertThat((Double) searchResponse.getHits().getAt(0).getSortValues()[0], closeTo(GeoDistance.PLANE.calculate(2.5, 1, 2, 1, DistanceUnit.KILOMETERS), 1.e-4));
         assertThat((Double) searchResponse.getHits().getAt(1).getSortValues()[0], closeTo(GeoDistance.PLANE.calculate(4.5, 1, 2, 1, DistanceUnit.KILOMETERS), 1.e-4));
@@ -1956,7 +1957,7 @@ public class SimpleSortIT extends ESIntegTestCase {
                 .field("distance_type", "plane")
                 .endObject()
                 .endObject().endArray().string();
-        searchResponse = client().prepareSearch().setSource(geoSortRequest)
+        searchResponse = client().prepareSearch().setSource(new BytesArray(geoSortRequest))
                 .execute().actionGet();
         checkCorrectSortOrderForGeoSort(searchResponse);
 
@@ -1967,7 +1968,7 @@ public class SimpleSortIT extends ESIntegTestCase {
                 .field("distance_type", "plane")
                 .endObject()
                 .endObject().endArray().string();
-        searchResponse = client().prepareSearch().setSource(geoSortRequest)
+        searchResponse = client().prepareSearch().setSource(new BytesArray(geoSortRequest))
                 .execute().actionGet();
         checkCorrectSortOrderForGeoSort(searchResponse);
 
@@ -1981,7 +1982,7 @@ public class SimpleSortIT extends ESIntegTestCase {
                 .field("distance_type", "plane")
                 .endObject()
                 .endObject().endArray().string();
-        searchResponse = client().prepareSearch().setSource(geoSortRequest)
+        searchResponse = client().prepareSearch().setSource(new BytesArray(geoSortRequest))
                 .execute().actionGet();
         checkCorrectSortOrderForGeoSort(searchResponse);
     }

--- a/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
+++ b/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
@@ -358,10 +358,7 @@ public class ContextAndHeaderTransportIT extends ESIntegTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("query_string", "star wars");
 
-        SearchResponse searchResponse = transportClient().prepareSearch(queryIndex)
-                .setTemplateName("the_template")
-                .setTemplateParams(params)
-                .setTemplateType(ScriptService.ScriptType.INDEXED)
+        SearchResponse searchResponse = transportClient().prepareSearch(queryIndex).setTemplate(new Template("the_template", ScriptType.INDEXED, MustacheScriptEngineService.NAME, null, params))
                 .get();
 
         assertNoFailures(searchResponse);


### PR DESCRIPTION
We have a gazillion ways to specify the source of the search request.
There is no need to so many we can reduce them dramatically and also remove
some deprecated API.
