### PR TITLE
Forbid Guava in all instead of core

### DIFF
--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -86,3 +86,19 @@ java.net.InetAddress#getHostName()
 java.net.InetAddress#getCanonicalHostName()
 
 java.net.InetSocketAddress#getHostName() @ Use getHostString() instead, which avoids a DNS lookup
+
+@defaultMessage avoid adding additional dependencies on Guava
+com.google.common.collect.Lists
+com.google.common.collect.ImmutableList
+com.google.common.base.Objects
+com.google.common.base.Predicate
+com.google.common.base.Predicates
+com.google.common.base.Strings
+com.google.common.base.Throwables
+com.google.common.collect.Maps
+com.google.common.collect.Sets
+com.google.common.base.Preconditions#checkNotNull(java.lang.Object)
+com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.Object)
+com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.String, java.lang.Object[])
+com.google.common.collect.ImmutableSortedSet
+com.google.common.collect.Queues

--- a/dev-tools/src/main/resources/forbidden/core-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/core-signatures.txt
@@ -83,19 +83,3 @@ java.util.concurrent.Future#cancel(boolean)
 @defaultMessage Don't try reading from paths that are not configured in Environment, resolve from Environment instead
 org.elasticsearch.common.io.PathUtils#get(java.lang.String, java.lang.String[])
 org.elasticsearch.common.io.PathUtils#get(java.net.URI)
-
-@defaultMessage avoid adding additional dependencies on Guava
-com.google.common.collect.Lists
-com.google.common.collect.ImmutableList
-com.google.common.base.Objects
-com.google.common.base.Predicate
-com.google.common.base.Predicates
-com.google.common.base.Strings
-com.google.common.base.Throwables
-com.google.common.collect.Maps
-com.google.common.collect.Sets
-com.google.common.base.Preconditions#checkNotNull(java.lang.Object)
-com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.Object)
-com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.String, java.lang.Object[])
-com.google.common.collect.ImmutableSortedSet
-com.google.common.collect.Queues


### PR DESCRIPTION
Now that Guava is no longer shaded, it can be forbidden in all instead
of core.

Relates #13224
