### PR TITLE
Remove and forbid use of several com.google.common.util. classes

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/FutureUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/FutureUtils.java
@@ -34,4 +34,5 @@ public class FutureUtils {
         }
         return false;
     }
+
 }

--- a/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.bwcompat;
 
-import com.google.common.util.concurrent.ListenableFuture;
-
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
@@ -50,6 +48,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.hamcrest.Matchers;
@@ -72,6 +71,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.Future;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
@@ -122,20 +122,20 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
     }
 
     void setupCluster() throws Exception {
-        ListenableFuture<List<String>> replicas = internalCluster().startNodesAsync(1); // for replicas
+        InternalTestCluster.Async<List<String>> replicas = internalCluster().startNodesAsync(1); // for replicas
 
         Path baseTempDir = createTempDir();
         // start single data path node
         Settings.Builder nodeSettings = Settings.builder()
             .put("path.data", baseTempDir.resolve("single-path").toAbsolutePath())
             .put("node.master", false); // workaround for dangling index loading issue when node is master
-        ListenableFuture<String> singleDataPathNode = internalCluster().startNodeAsync(nodeSettings.build());
+        InternalTestCluster.Async<String> singleDataPathNode = internalCluster().startNodeAsync(nodeSettings.build());
 
         // start multi data path node
         nodeSettings = Settings.builder()
             .put("path.data", baseTempDir.resolve("multi-path1").toAbsolutePath() + "," + baseTempDir.resolve("multi-path2").toAbsolutePath())
             .put("node.master", false); // workaround for dangling index loading issue when node is master
-        ListenableFuture<String> multiDataPathNode = internalCluster().startNodeAsync(nodeSettings.build());
+        InternalTestCluster.Async<String> multiDataPathNode = internalCluster().startNodeAsync(nodeSettings.build());
 
         // find single data path dir
         Path[] nodePaths = internalCluster().getInstance(NodeEnvironment.class, singleDataPathNode.get()).nodeDataPaths();

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterServiceIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterServiceIT.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.cluster;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -37,6 +36,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -297,8 +297,8 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 .put("discovery.type", "local")
                 .build();
 
-        ListenableFuture<String> master = internalCluster().startNodeAsync(settings);
-        ListenableFuture<String> nonMaster = internalCluster().startNodeAsync(settingsBuilder().put(settings).put("node.master", false).build());
+        InternalTestCluster.Async<String> master = internalCluster().startNodeAsync(settings);
+        InternalTestCluster.Async<String> nonMaster = internalCluster().startNodeAsync(settingsBuilder().put(settings).put("node.master", false).build());
         master.get();
         ensureGreen(); // make sure we have a cluster
 

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -1018,9 +1018,9 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         try {
             configureUnicastCluster(5, null, 1);
             // we could probably write a test without a dedicated master node but it is easier if we use one
-            Future<String> masterNodeFuture = internalCluster().startMasterOnlyNodeAsync();
+            InternalTestCluster.Async<String> masterNodeFuture = internalCluster().startMasterOnlyNodeAsync();
             // node_1 will have the shard in the beginning
-            Future<String> node1Future = internalCluster().startDataOnlyNodeAsync();
+            InternalTestCluster.Async<String> node1Future = internalCluster().startDataOnlyNodeAsync();
             final String masterNode = masterNodeFuture.get();
             final String node_1 = node1Future.get();
             logger.info("--> creating index [test] with one shard and zero replica");
@@ -1200,8 +1200,8 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
     @Test
     public void searchWithRelocationAndSlowClusterStateProcessing() throws Exception {
         configureUnicastCluster(3, null, 1);
-        Future<String> masterNodeFuture = internalCluster().startMasterOnlyNodeAsync();
-        Future<String> node_1Future = internalCluster().startDataOnlyNodeAsync();
+        InternalTestCluster.Async<String> masterNodeFuture = internalCluster().startMasterOnlyNodeAsync();
+        InternalTestCluster.Async<String> node_1Future = internalCluster().startDataOnlyNodeAsync();
 
         final String node_1 = node_1Future.get();
         final String masterNode = masterNodeFuture.get();
@@ -1213,7 +1213,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         );
         ensureGreen("test");
 
-        Future<String> node_2Future = internalCluster().startDataOnlyNodeAsync();
+        InternalTestCluster.Async<String> node_2Future = internalCluster().startDataOnlyNodeAsync();
         final String node_2 = node_2Future.get();
         List<IndexRequestBuilder> indexRequestBuilderList = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
@@ -1265,8 +1265,8 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
     @Test
     public void testIndicesDeleted() throws Exception {
         configureUnicastCluster(3, null, 2);
-        Future<List<String>> masterNodes= internalCluster().startMasterOnlyNodesAsync(2);
-        Future<String> dataNode = internalCluster().startDataOnlyNodeAsync();
+        InternalTestCluster.Async<List<String>> masterNodes= internalCluster().startMasterOnlyNodesAsync(2);
+        InternalTestCluster.Async<String> dataNode = internalCluster().startDataOnlyNodeAsync();
         dataNode.get();
         masterNodes.get();
         ensureStableCluster(3);

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
@@ -60,8 +60,8 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
     public void testMetaIsRemovedIfAllShardsFromIndexRemoved() throws Exception {
         // this test checks that the index state is removed from a data only node once all shards have been allocated away from it
         String masterNode = internalCluster().startMasterOnlyNode(Settings.EMPTY);
-        Future<String> nodeName1 = internalCluster().startDataOnlyNodeAsync();
-        Future<String> nodeName2 = internalCluster().startDataOnlyNodeAsync();
+        InternalTestCluster.Async<String> nodeName1 = internalCluster().startDataOnlyNodeAsync();
+        InternalTestCluster.Async<String> nodeName2 = internalCluster().startDataOnlyNodeAsync();
         String node1 = nodeName1.get();
         String node2 = nodeName2.get();
 

--- a/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexWithShadowReplicasIT.java
@@ -44,7 +44,6 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
@@ -60,7 +59,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -690,8 +688,8 @@ public class IndexWithShadowReplicasIT extends ESIntegTestCase {
         Settings fooSettings = Settings.builder().put(nodeSettings).put("node.affinity", "foo").build();
         Settings barSettings = Settings.builder().put(nodeSettings).put("node.affinity", "bar").build();
 
-        final Future<List<String>> fooNodes = internalCluster().startNodesAsync(2, fooSettings);
-        final Future<List<String>> barNodes = internalCluster().startNodesAsync(2, barSettings);
+        final InternalTestCluster.Async<List<String>> fooNodes = internalCluster().startNodesAsync(2, fooSettings);
+        final InternalTestCluster.Async<List<String>> barNodes = internalCluster().startNodesAsync(2, barSettings);
         fooNodes.get();
         barNodes.get();
         String IDX = "test";

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.recovery;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -50,6 +49,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockFSDirectoryService;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -539,8 +539,8 @@ public class IndexRecoveryIT extends ESIntegTestCase {
         // start a master node
         internalCluster().startNode(nodeSettings);
 
-        ListenableFuture<String> blueFuture = internalCluster().startNodeAsync(Settings.builder().put("node.color", "blue").put(nodeSettings).build());
-        ListenableFuture<String> redFuture = internalCluster().startNodeAsync(Settings.builder().put("node.color", "red").put(nodeSettings).build());
+        InternalTestCluster.Async<String> blueFuture = internalCluster().startNodeAsync(Settings.builder().put("node.color", "blue").put(nodeSettings).build());
+        InternalTestCluster.Async<String> redFuture = internalCluster().startNodeAsync(Settings.builder().put("node.color", "red").put(nodeSettings).build());
         final String blueNodeName = blueFuture.get();
         final String redNodeName = redFuture.get();
 

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -235,9 +235,9 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
     @Test
     @TestLogging("cluster.service:TRACE")
     public void testShardActiveElsewhereDoesNotDeleteAnother() throws Exception {
-        Future<String> masterFuture = internalCluster().startNodeAsync(
+        InternalTestCluster.Async<String> masterFuture = internalCluster().startNodeAsync(
                 Settings.builder().put("node.master", true, "node.data", false).build());
-        Future<List<String>> nodesFutures = internalCluster().startNodesAsync(4,
+        InternalTestCluster.Async<List<String>> nodesFutures = internalCluster().startNodesAsync(4,
                 Settings.builder().put("node.master", false, "node.data", true).build());
 
         final String masterNode = masterFuture.get();

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -21,7 +21,6 @@ package org.elasticsearch.recovery;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.procedures.IntProcedure;
-import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.lucene.index.IndexFileNames;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -59,6 +58,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.Transport;
@@ -365,8 +365,8 @@ public class RelocationIT extends ESIntegTestCase {
     public void testMoveShardsWhileRelocation() throws Exception {
         final String indexName = "test";
 
-        ListenableFuture<String> blueFuture = internalCluster().startNodeAsync(Settings.builder().put("node.color", "blue").build());
-        ListenableFuture<String> redFuture = internalCluster().startNodeAsync(Settings.builder().put("node.color", "red").build());
+        InternalTestCluster.Async<String> blueFuture = internalCluster().startNodeAsync(Settings.builder().put("node.color", "blue").build());
+        InternalTestCluster.Async<String> redFuture = internalCluster().startNodeAsync(Settings.builder().put("node.color", "red").build());
         internalCluster().startNode(Settings.builder().put("node.color", "green").build());
         final String blueNodeName = blueFuture.get();
         final String redNodeName = redFuture.get();

--- a/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -21,7 +21,6 @@ package org.elasticsearch.snapshots;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntSet;
-import com.google.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
@@ -723,7 +722,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         int asyncNodes = between(0, 5);
         logger.info("--> start {} additional nodes asynchronously", asyncNodes);
-        ListenableFuture<List<String>> asyncNodesFuture = internalCluster().startNodesAsync(asyncNodes, settings);
+        InternalTestCluster.Async<List<String>> asyncNodesFuture = internalCluster().startNodesAsync(asyncNodes, settings);
 
         int asyncIndices = between(0, 10);
         logger.info("--> create {} additional indices asynchronously", asyncIndices);

--- a/core/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -62,7 +62,7 @@ public class UpdateThreadPoolSettingsTests extends ESTestCase {
         // Replace with different type
         threadPool.updateSettings(settingsBuilder().put("threadpool.search.type", "same").build());
         assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("same"));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(MoreExecutors.directExecutor().getClass()));
+        assertThat(threadPool.executor(Names.SEARCH), is(ThreadPool.DIRECT_EXECUTOR));
 
         // Replace with different type again
         threadPool.updateSettings(settingsBuilder()

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -102,3 +102,7 @@ com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.Ob
 com.google.common.base.Preconditions#checkNotNull(java.lang.Object, java.lang.String, java.lang.Object[])
 com.google.common.collect.ImmutableSortedSet
 com.google.common.collect.Queues
+com.google.common.util.concurrent.ListenableFuture
+com.google.common.util.concurrent.SettableFuture
+com.google.common.util.concurrent.Futures
+com.google.common.util.concurrent.MoreExecutors


### PR DESCRIPTION
This commit replaces:
- com.google.common.util.concurrent.ListenableFuture
- com.google.common.util.concurrent.SettableFuture
- com.google.common.util.concurrent.Futures
- com.google.common.util.concurrent.MoreExecutors

And forbids its usage via forbidden APIs. This is one of
many steps in the eventual removal of Guava as a dependency.

Relates to #13224
