### PR TITLE
Ban setAccessible from core code, restore monitoring stats under java 9

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionRequest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  */
 public abstract class ActionRequest<T extends ActionRequest> extends TransportRequest {
 
-    protected ActionRequest() {
+    public ActionRequest() {
         super();
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -47,7 +47,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
     private String waitForNodes = "";
     private Priority waitForEvents = null;
 
-    ClusterHealthRequest() {
+    public ClusterHealthRequest() {
     }
 
     public ClusterHealthRequest(String... indices) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -124,7 +124,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         if (request.waitForNodes().isEmpty()) {
             waitFor--;
         }
-        if (request.indices().length == 0) { // check that they actually exists in the meta data
+        if (request.indices() == null || request.indices().length == 0) { // check that they actually exists in the meta data
             waitFor--;
         }
 
@@ -199,7 +199,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         if (request.waitForActiveShards() != -1 && response.getActiveShards() >= request.waitForActiveShards()) {
             waitForCounter++;
         }
-        if (request.indices().length > 0) {
+        if (request.indices() != null && request.indices().length > 0) {
             try {
                 indexNameExpressionResolver.concreteIndices(clusterState, IndicesOptions.strictExpand(), request.indices());
                 waitForCounter++;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -38,7 +38,7 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
     boolean ignoreIdleThreads = true;
 
     // for serialization
-    NodesHotThreadsRequest() {
+    public NodesHotThreadsRequest() {
 
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -94,11 +94,11 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<NodesHo
         return false;
     }
 
-    static class NodeRequest extends BaseNodeRequest {
+    public static class NodeRequest extends BaseNodeRequest {
 
         NodesHotThreadsRequest request;
 
-        NodeRequest() {
+        public NodeRequest() {
         }
 
         NodeRequest(String nodeId, NodesHotThreadsRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -88,11 +88,11 @@ public class TransportNodesInfoAction extends TransportNodesAction<NodesInfoRequ
         return false;
     }
 
-    static class NodeInfoRequest extends BaseNodeRequest {
+    public static class NodeInfoRequest extends BaseNodeRequest {
 
         NodesInfoRequest request;
 
-        NodeInfoRequest() {
+        public NodeInfoRequest() {
         }
 
         NodeInfoRequest(String nodeId, NodesInfoRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -42,7 +42,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     private boolean breaker;
     private boolean script;
 
-    protected NodesStatsRequest() {
+    public NodesStatsRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -88,11 +88,11 @@ public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRe
         return false;
     }
 
-    static class NodeStatsRequest extends BaseNodeRequest {
+    public static class NodeStatsRequest extends BaseNodeRequest {
 
         NodesStatsRequest request;
 
-        NodeStatsRequest() {
+        public NodeStatsRequest() {
         }
 
         NodeStatsRequest(String nodeId, NodesStatsRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/DeleteRepositoryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/DeleteRepositoryRequest.java
@@ -37,7 +37,7 @@ public class DeleteRepositoryRequest extends AcknowledgedRequest<DeleteRepositor
 
     private String name;
 
-    DeleteRepositoryRequest() {
+    public DeleteRepositoryRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequest.java
@@ -36,7 +36,7 @@ public class GetRepositoriesRequest extends MasterNodeReadRequest<GetRepositorie
 
     private String[] repositories = Strings.EMPTY_ARRAY;
 
-    GetRepositoriesRequest() {
+    public GetRepositoriesRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequest.java
@@ -55,7 +55,7 @@ public class PutRepositoryRequest extends AcknowledgedRequest<PutRepositoryReque
 
     private Settings settings = EMPTY_SETTINGS;
 
-    PutRepositoryRequest() {
+    public PutRepositoryRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryRequest.java
@@ -37,7 +37,7 @@ public class VerifyRepositoryRequest extends AcknowledgedRequest<VerifyRepositor
 
     private String name;
 
-    VerifyRepositoryRequest() {
+    public VerifyRepositoryRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -79,7 +79,7 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
 
     private boolean waitForCompletion;
 
-    CreateSnapshotRequest() {
+    public CreateSnapshotRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -41,7 +41,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
 
     private String[] snapshots = Strings.EMPTY_ARRAY;
 
-    GetSnapshotsRequest() {
+    public GetSnapshotsRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -64,7 +64,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     private Settings indexSettings = EMPTY_SETTINGS;
     private String[] ignoreIndexSettings = Strings.EMPTY_ARRAY;
 
-    RestoreSnapshotRequest() {
+    public RestoreSnapshotRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -137,7 +137,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
         return true;
     }
 
-    static class Request extends BaseNodesRequest<Request> {
+    public static class Request extends BaseNodesRequest<Request> {
 
         private SnapshotId[] snapshotIds;
 
@@ -203,11 +203,11 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
     }
 
 
-    static class NodeRequest extends BaseNodeRequest {
+    public static class NodeRequest extends BaseNodeRequest {
 
         private SnapshotId[] snapshotIds;
 
-        NodeRequest() {
+        public NodeRequest() {
         }
 
         NodeRequest(String nodeId, TransportNodesSnapshotsStatus.Request request) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  */
 public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
 
-    ClusterStatsRequest() {
+    public ClusterStatsRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -145,11 +145,11 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
         return false;
     }
 
-    static class ClusterStatsNodeRequest extends BaseNodeRequest {
+    public static class ClusterStatsNodeRequest extends BaseNodeRequest {
 
         ClusterStatsRequest request;
 
-        ClusterStatsNodeRequest() {
+        public ClusterStatsNodeRequest() {
         }
 
         ClusterStatsNodeRequest(String nodeId, ClusterStatsRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheRequest.java
@@ -37,7 +37,7 @@ public class ClearIndicesCacheRequest extends BroadcastRequest<ClearIndicesCache
     private String[] fields = null;
     
 
-    ClearIndicesCacheRequest() {
+    public ClearIndicesCacheRequest() {
     }
 
     public ClearIndicesCacheRequest(String... indices) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
@@ -39,7 +39,7 @@ public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> im
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
 
-    CloseIndexRequest() {
+    public CloseIndexRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -78,7 +78,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
 
     private boolean updateAllTypes = false;
 
-    CreateIndexRequest() {
+    public CreateIndexRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -44,7 +44,7 @@ public class DeleteIndexRequest extends MasterNodeRequest<DeleteIndexRequest> im
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);
     private TimeValue timeout = AcknowledgedRequest.DEFAULT_ACK_TIMEOUT;
 
-    DeleteIndexRequest() {
+    public DeleteIndexRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
@@ -37,7 +37,7 @@ public class IndicesExistsRequest extends MasterNodeReadRequest<IndicesExistsReq
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
 
     // for serialization
-    IndicesExistsRequest() {
+    public IndicesExistsRequest() {
 
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
@@ -38,7 +38,7 @@ public class TypesExistsRequest extends MasterNodeReadRequest<TypesExistsRequest
 
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
-    TypesExistsRequest() {
+    public TypesExistsRequest() {
     }
 
     public TypesExistsRequest(String[] indices, String... types) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequest.java
@@ -42,7 +42,7 @@ public class FlushRequest extends BroadcastRequest<FlushRequest> {
     private boolean force = false;
     private boolean waitIfOngoing = false;
 
-    FlushRequest() {
+    public FlushRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsIndexRequest.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-class GetFieldMappingsIndexRequest extends SingleShardRequest<GetFieldMappingsIndexRequest> {
+public class GetFieldMappingsIndexRequest extends SingleShardRequest<GetFieldMappingsIndexRequest> {
 
     private boolean probablySingleFieldRequest;
     private boolean includeDefaults;
@@ -38,7 +38,7 @@ class GetFieldMappingsIndexRequest extends SingleShardRequest<GetFieldMappingsIn
 
     private OriginalIndices originalIndices;
 
-    GetFieldMappingsIndexRequest() {
+    public GetFieldMappingsIndexRequest() {
     }
 
     GetFieldMappingsIndexRequest(GetFieldMappingsRequest other, String index, boolean probablySingleFieldRequest) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -65,7 +65,7 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
 
     private boolean updateAllTypes = false;
 
-    PutMappingRequest() {
+    public PutMappingRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
@@ -39,7 +39,7 @@ public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> impl
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, false, true);
 
-    OpenIndexRequest() {
+    public OpenIndexRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequest.java
@@ -33,7 +33,7 @@ import org.elasticsearch.action.support.broadcast.BroadcastRequest;
  */
 public class RefreshRequest extends BroadcastRequest<RefreshRequest> {
 
-    RefreshRequest() {
+    public RefreshRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -48,7 +48,7 @@ public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsReq
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
     private Settings settings = EMPTY_SETTINGS;
 
-    UpdateSettingsRequest() {
+    public UpdateSettingsRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresRequest.java
@@ -46,7 +46,7 @@ public class IndicesShardStoresRequest extends MasterNodeReadRequest<IndicesShar
         this.indices = indices;
     }
 
-    IndicesShardStoresRequest() {
+    public IndicesShardStoresRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -74,7 +74,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
     
     private Map<String, IndexMetaData.Custom> customs = new HashMap<>();
 
-    PutIndexTemplateRequest() {
+    public PutIndexTemplateRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/ShardUpgradeRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/ShardUpgradeRequest.java
@@ -30,11 +30,11 @@ import java.io.IOException;
 /**
  *
  */
-final class ShardUpgradeRequest extends BroadcastShardRequest {
+public final class ShardUpgradeRequest extends BroadcastShardRequest {
 
     private UpgradeRequest request = new UpgradeRequest();
 
-    ShardUpgradeRequest() {
+    public ShardUpgradeRequest() {
     }
 
     ShardUpgradeRequest(ShardId shardId, UpgradeRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/UpgradeSettingsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/UpgradeSettingsRequest.java
@@ -39,7 +39,7 @@ public class UpgradeSettingsRequest extends AcknowledgedRequest<UpgradeSettingsR
 
     private Map<String, Tuple<Version, String>> versions;
 
-    UpgradeSettingsRequest() {
+    public UpgradeSettingsRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  * Internal validate request executed directly against a specific index shard.
  */
-class ShardValidateQueryRequest extends BroadcastShardRequest {
+public class ShardValidateQueryRequest extends BroadcastShardRequest {
 
     private BytesReference source;
     private String[] types = Strings.EMPTY_ARRAY;
@@ -43,7 +43,7 @@ class ShardValidateQueryRequest extends BroadcastShardRequest {
     @Nullable
     private String[] filteringAliases;
 
-    ShardValidateQueryRequest() {
+    public ShardValidateQueryRequest() {
 
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -55,7 +55,7 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
 
     long nowInMillis;
 
-    ValidateQueryRequest() {
+    public ValidateQueryRequest() {
         this(Strings.EMPTY_ARRAY);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/template/TransportRenderSearchTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/template/TransportRenderSearchTemplateAction.java
@@ -38,7 +38,7 @@ public class TransportRenderSearchTemplateAction extends HandledTransportAction<
     private final ScriptService scriptService;
 
     @Inject
-    protected TransportRenderSearchTemplateAction(ScriptService scriptService, Settings settings, ThreadPool threadPool,
+    public TransportRenderSearchTemplateAction(ScriptService scriptService, Settings settings, ThreadPool threadPool,
             TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, RenderSearchTemplateAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, RenderSearchTemplateRequest.class);
         this.scriptService = scriptService;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/delete/DeleteWarmerRequest.java
@@ -42,7 +42,7 @@ public class DeleteWarmerRequest extends AcknowledgedRequest<DeleteWarmerRequest
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
     private String[] indices = Strings.EMPTY_ARRAY;
 
-    DeleteWarmerRequest() {
+    public DeleteWarmerRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
@@ -44,7 +44,7 @@ public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> impl
 
     private SearchRequest searchRequest;
 
-    PutWarmerRequest() {
+    public PutWarmerRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -37,7 +37,7 @@ public class BulkShardRequest extends ReplicationRequest<BulkShardRequest> {
 
     private boolean refresh;
 
-    BulkShardRequest() {
+    public BulkShardRequest() {
     }
 
     BulkShardRequest(BulkRequest bulkRequest, String index, int shardId, boolean refresh, BulkItemRequest[] items) {

--- a/core/src/main/java/org/elasticsearch/action/exists/ExistsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/exists/ExistsRequest.java
@@ -55,7 +55,7 @@ public class ExistsRequest extends BroadcastRequest<ExistsRequest> {
 
     long nowInMillis;
 
-    ExistsRequest() {
+    public ExistsRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/exists/ShardExistsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/exists/ShardExistsRequest.java
@@ -29,7 +29,7 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
-class ShardExistsRequest extends BroadcastShardRequest {
+public class ShardExistsRequest extends BroadcastShardRequest {
 
     private float minScore;
 
@@ -42,7 +42,7 @@ class ShardExistsRequest extends BroadcastShardRequest {
     @Nullable
     private String[] filteringAliases;
 
-    ShardExistsRequest() {
+    public ShardExistsRequest() {
     }
 
     ShardExistsRequest(ShardId shardId, @Nullable String[] filteringAliases, ExistsRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -49,7 +49,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
 
     long nowInMillis;
 
-    ExplainRequest() {
+    public ExplainRequest() {
     }
 
     public ExplainRequest(String index, String type, String id) {

--- a/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -63,7 +63,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
     private long version = Versions.MATCH_ANY;
     private boolean ignoreErrorsOnGeneratedFields;
 
-    GetRequest() {
+    public GetRequest() {
         type = "_all";
     }
 

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
@@ -40,7 +40,7 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
     IntArrayList locations;
     List<MultiGetRequest.Item> items;
 
-    MultiGetShardRequest() {
+    public MultiGetShardRequest() {
 
     }
 

--- a/core/src/main/java/org/elasticsearch/action/percolate/PercolateShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/PercolateShardRequest.java
@@ -39,7 +39,7 @@ public class PercolateShardRequest extends BroadcastShardRequest {
     private int numberOfShards;
     private long startTime;
 
-    PercolateShardRequest() {
+    public PercolateShardRequest() {
     }
 
     PercolateShardRequest(ShardId shardId, int numberOfShards, PercolateRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -118,7 +118,7 @@ public class TransportShardMultiPercolateAction extends TransportSingleShardActi
         private String preference;
         private List<Item> items;
 
-        Request() {
+        public Request() {
         }
 
         Request(MultiPercolateRequest multiPercolateRequest, String concreteIndex, int shardId, String preference) {

--- a/core/src/main/java/org/elasticsearch/action/suggest/ShardSuggestRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/suggest/ShardSuggestRequest.java
@@ -30,11 +30,11 @@ import java.io.IOException;
 /**
  * Internal suggest request executed directly against a specific index shard.
  */
-final class ShardSuggestRequest extends BroadcastShardRequest {
+public final class ShardSuggestRequest extends BroadcastShardRequest {
 
     private BytesReference suggestSource;
 
-    ShardSuggestRequest() {
+    public ShardSuggestRequest() {
     }
 
     ShardSuggestRequest(ShardId shardId, SuggestRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/suggest/SuggestRequest.java
@@ -58,7 +58,7 @@ public final class SuggestRequest extends BroadcastRequest<SuggestRequest> {
 
     private BytesReference suggestSource;
 
-    SuggestRequest() {
+    public SuggestRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardRequest.java
@@ -38,7 +38,7 @@ public abstract class BroadcastShardRequest extends TransportRequest implements 
 
     protected OriginalIndices originalIndices;
 
-    protected BroadcastShardRequest() {
+    public BroadcastShardRequest() {
     }
 
     protected BroadcastShardRequest(ShardId shardId, BroadcastRequest request) {

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -405,14 +405,14 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
         }
     }
 
-    protected class NodeRequest extends TransportRequest implements IndicesRequest {
+    public class NodeRequest extends TransportRequest implements IndicesRequest {
         private String nodeId;
 
         private List<ShardRouting> shards;
 
         protected Request indicesLevelRequest;
 
-        protected NodeRequest() {
+        public NodeRequest() {
         }
 
         public NodeRequest(String nodeId, Request request, List<ShardRouting> shards) {

--- a/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
@@ -32,7 +32,7 @@ public abstract class BaseNodeRequest extends TransportRequest {
 
     private String nodeId;
 
-    protected BaseNodeRequest() {
+    public BaseNodeRequest() {
 
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -49,7 +49,7 @@ public abstract class SingleShardRequest<T extends SingleShardRequest> extends A
     ShardId internalShardId;
     private boolean threadedOperation = true;
 
-    protected SingleShardRequest() {
+    public SingleShardRequest() {
     }
 
     protected SingleShardRequest(String index) {

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsShardRequest.java
@@ -37,7 +37,7 @@ public class MultiTermVectorsShardRequest extends SingleShardRequest<MultiTermVe
     IntArrayList locations;
     List<TermVectorsRequest> requests;
 
-    MultiTermVectorsShardRequest() {
+    public MultiTermVectorsShardRequest() {
 
     }
 

--- a/core/src/main/java/org/elasticsearch/action/termvectors/dfs/DfsOnlyRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/dfs/DfsOnlyRequest.java
@@ -44,7 +44,7 @@ public class DfsOnlyRequest extends BroadcastRequest<DfsOnlyRequest> {
 
     long nowInMillis;
 
-    DfsOnlyRequest() {
+    public DfsOnlyRequest() {
 
     }
 

--- a/core/src/main/java/org/elasticsearch/action/termvectors/dfs/ShardDfsOnlyRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/dfs/ShardDfsOnlyRequest.java
@@ -29,11 +29,11 @@ import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 
 import java.io.IOException;
 
-class ShardDfsOnlyRequest extends BroadcastShardRequest {
+public class ShardDfsOnlyRequest extends BroadcastShardRequest {
 
     private ShardSearchTransportRequest shardSearchRequest = new ShardSearchTransportRequest();
 
-    ShardDfsOnlyRequest() {
+    public ShardDfsOnlyRequest() {
 
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
@@ -133,12 +133,12 @@ public class NodeIndexDeletedAction extends AbstractComponent {
         }
     }
 
-    static class NodeIndexDeletedMessage extends TransportRequest {
+    public static class NodeIndexDeletedMessage extends TransportRequest {
 
         String index;
         String nodeId;
 
-        NodeIndexDeletedMessage() {
+        public NodeIndexDeletedMessage() {
         }
 
         NodeIndexDeletedMessage(String index, String nodeId) {
@@ -161,12 +161,12 @@ public class NodeIndexDeletedAction extends AbstractComponent {
         }
     }
 
-    static class NodeIndexStoreDeletedMessage extends TransportRequest {
+    public static class NodeIndexStoreDeletedMessage extends TransportRequest {
 
         String index;
         String nodeId;
 
-        NodeIndexStoreDeletedMessage() {
+        public NodeIndexStoreDeletedMessage() {
         }
 
         NodeIndexStoreDeletedMessage(String index, String nodeId) {

--- a/core/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
@@ -79,7 +79,7 @@ public class NodeMappingRefreshAction extends AbstractComponent {
         private String[] types;
         private String nodeId;
 
-        NodeMappingRefreshRequest() {
+        public NodeMappingRefreshRequest() {
         }
 
         public NodeMappingRefreshRequest(String index, String indexUUID, String[] types, String nodeId) {

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -244,7 +244,7 @@ public class ShardStateAction extends AbstractComponent {
         }
     }
 
-    static class ShardRoutingEntry extends TransportRequest {
+    public static class ShardRoutingEntry extends TransportRequest {
 
         ShardRouting shardRouting;
         String indexUUID = IndexMetaData.INDEX_UUID_NA_VALUE;
@@ -253,7 +253,7 @@ public class ShardStateAction extends AbstractComponent {
 
         volatile boolean processed; // state field, no need to serialize
 
-        ShardRoutingEntry() {
+        public ShardRoutingEntry() {
         }
 
         ShardRoutingEntry(ShardRouting shardRouting, String indexUUID, String message, @Nullable Throwable failure) {

--- a/core/src/main/java/org/elasticsearch/common/inject/DefaultConstructionProxyFactory.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/DefaultConstructionProxyFactory.java
@@ -43,12 +43,6 @@ class DefaultConstructionProxyFactory<T> implements ConstructionProxyFactory<T> 
         @SuppressWarnings("unchecked") // the injection point is for a constructor of T
         final Constructor<T> constructor = (Constructor<T>) injectionPoint.getMember();
 
-        // Use FastConstructor if the constructor is public.
-        if (Modifier.isPublic(constructor.getModifiers())) {
-        } else {
-            constructor.setAccessible(true);
-        }
-
         return new ConstructionProxy<T>() {
             @Override
             public T newInstance(Object... arguments) throws InvocationTargetException {
@@ -57,7 +51,7 @@ class DefaultConstructionProxyFactory<T> implements ConstructionProxyFactory<T> 
                 } catch (InstantiationException e) {
                     throw new AssertionError(e); // shouldn't happen, we know this is a concrete type
                 } catch (IllegalAccessException e) {
-                    throw new AssertionError(e); // a security manager is blocking us, we're hosed
+                    throw new AssertionError("Wrong access modifiers on " + constructor, e); // a security manager is blocking us, we're hosed
                 }
             }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/SingleFieldInjector.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/SingleFieldInjector.java
@@ -39,9 +39,6 @@ class SingleFieldInjector implements SingleMemberInjector {
         this.injectionPoint = injectionPoint;
         this.field = (Field) injectionPoint.getMember();
         this.dependency = injectionPoint.getDependencies().get(0);
-
-        // Ewwwww...
-        field.setAccessible(true);
         factory = injector.getInternalFactory(dependency.getKey(), errors);
     }
 

--- a/core/src/main/java/org/elasticsearch/common/inject/SingleMethodInjector.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/SingleMethodInjector.java
@@ -49,10 +49,6 @@ class SingleMethodInjector implements SingleMemberInjector {
         if (!Modifier.isPrivate(modifiers) && !Modifier.isProtected(modifiers)) {
         }
 
-        if (!Modifier.isPublic(modifiers)) {
-            method.setAccessible(true);
-        }
-
         return new MethodInvoker() {
             @Override
             public Object invoke(Object target, Object... parameters)

--- a/core/src/main/java/org/elasticsearch/common/inject/assistedinject/AssistedConstructor.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/assistedinject/AssistedConstructor.java
@@ -88,7 +88,6 @@ class AssistedConstructor<T> {
      * supplied arguments.
      */
     public T newInstance(Object[] args) throws Throwable {
-        constructor.setAccessible(true);
         try {
             return constructor.newInstance(args);
         } catch (InvocationTargetException e) {

--- a/core/src/main/java/org/elasticsearch/common/inject/assistedinject/FactoryProvider2.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/assistedinject/FactoryProvider2.java
@@ -53,7 +53,7 @@ import static org.elasticsearch.common.inject.internal.Annotations.getKey;
  * @author jessewilson@google.com (Jesse Wilson)
  * @author dtm@google.com (Daniel Martin)
  */
-final class FactoryProvider2<F> implements InvocationHandler, Provider<F> {
+public final class FactoryProvider2<F> implements InvocationHandler, Provider<F> {
 
     /**
      * if a factory method parameter isn't annotated, it gets this annotation.
@@ -173,7 +173,7 @@ final class FactoryProvider2<F> implements InvocationHandler, Provider<F> {
      * all factory methods will be able to build the target types.
      */
     @Inject
-    void initialize(Injector injector) {
+    public void initialize(Injector injector) {
         if (this.injector != null) {
             throw new ConfigurationException(Collections.singletonList(new Message(FactoryProvider2.class,
                 "Factories.create() factories may only be used in one Injector!")));

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/ProviderMethod.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/ProviderMethod.java
@@ -54,8 +54,6 @@ public class ProviderMethod<T> implements ProviderWithDependencies<T> {
         this.method = method;
         this.parameterProviders = parameterProviders;
         this.exposed = method.getAnnotation(Exposed.class) != null;
-
-        method.setAccessible(true);
     }
 
     public Key<T> getKey() {

--- a/core/src/main/java/org/elasticsearch/common/inject/multibindings/Multibinder.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/multibindings/Multibinder.java
@@ -193,7 +193,7 @@ public abstract class Multibinder<T> {
      * <p>We use a subclass to hide 'implements Module, Provider' from the public
      * API.
      */
-    static final class RealMultibinder<T> extends Multibinder<T>
+    public static final class RealMultibinder<T> extends Multibinder<T>
             implements Module, Provider<Set<T>>, HasDependencies {
 
         private final TypeLiteral<T> elementType;
@@ -236,7 +236,7 @@ public abstract class Multibinder<T> {
          * contents are only evaluated when get() is invoked.
          */
         @Inject
-        void initialize(Injector injector) {
+        public void initialize(Injector injector) {
             providers = new ArrayList<>();
             List<Dependency<?>> dependencies = new ArrayList<>();
             for (Binding<?> entry : injector.findBindingsByType(elementType)) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -1131,7 +1131,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
         return rejoinOnMasterGone;
     }
 
-    static class RejoinClusterRequest extends TransportRequest {
+    public static class RejoinClusterRequest extends TransportRequest {
 
         private String fromNodeId;
 
@@ -1139,7 +1139,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent<Discovery> implemen
             this.fromNodeId = fromNodeId;
         }
 
-        RejoinClusterRequest() {
+        public RejoinClusterRequest() {
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/fd/MasterFaultDetection.java
@@ -386,14 +386,14 @@ public class MasterFaultDetection extends FaultDetection {
     }
 
 
-    private static class MasterPingRequest extends TransportRequest {
+    public static class MasterPingRequest extends TransportRequest {
 
         private String nodeId;
 
         private String masterNodeId;
         private ClusterName clusterName;
 
-        private MasterPingRequest() {
+        public MasterPingRequest() {
         }
 
         private MasterPingRequest(String nodeId, String masterNodeId, ClusterName clusterName) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -271,7 +271,7 @@ public class NodesFaultDetection extends FaultDetection {
 
         private long clusterStateVersion = ClusterState.UNKNOWN_VERSION;
 
-        PingRequest() {
+        public PingRequest() {
         }
 
         PingRequest(String nodeId, ClusterName clusterName, DiscoveryNode masterNode, long clusterStateVersion) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/membership/MembershipAction.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/membership/MembershipAction.java
@@ -105,11 +105,11 @@ public class MembershipAction extends AbstractComponent {
                 .txGet(timeout.millis(), TimeUnit.MILLISECONDS);
     }
 
-    static class JoinRequest extends TransportRequest {
+    public static class JoinRequest extends TransportRequest {
 
         DiscoveryNode node;
 
-        private JoinRequest() {
+        public JoinRequest() {
         }
 
         private JoinRequest(DiscoveryNode node) {
@@ -156,9 +156,9 @@ public class MembershipAction extends AbstractComponent {
         }
     }
 
-    static class ValidateJoinRequest extends TransportRequest {
+    public static class ValidateJoinRequest extends TransportRequest {
 
-        ValidateJoinRequest() {
+        public ValidateJoinRequest() {
         }
     }
 
@@ -171,11 +171,11 @@ public class MembershipAction extends AbstractComponent {
         }
     }
 
-    static class LeaveRequest extends TransportRequest {
+    public static class LeaveRequest extends TransportRequest {
 
         private DiscoveryNode node;
 
-        private LeaveRequest() {
+        public LeaveRequest() {
         }
 
         private LeaveRequest(DiscoveryNode node) {

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPing.java
@@ -523,13 +523,13 @@ public class UnicastZenPing extends AbstractLifecycleComponent<ZenPing> implemen
         }
     }
 
-    static class UnicastPingRequest extends TransportRequest {
+    public static class UnicastPingRequest extends TransportRequest {
 
         int id;
         TimeValue timeout;
         PingResponse pingResponse;
 
-        UnicastPingRequest() {
+        public UnicastPingRequest() {
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/core/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -188,12 +188,12 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
         }
     }
 
-    static class AllocateDangledRequest extends TransportRequest {
+    public static class AllocateDangledRequest extends TransportRequest {
 
         DiscoveryNode fromNode;
         IndexMetaData[] indices;
 
-        AllocateDangledRequest() {
+        public AllocateDangledRequest() {
         }
 
         AllocateDangledRequest(DiscoveryNode fromNode, IndexMetaData[] indices) {

--- a/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
@@ -120,7 +120,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
         return true;
     }
 
-    static class Request extends BaseNodesRequest<Request> {
+    public static class Request extends BaseNodesRequest<Request> {
 
         public Request() {
         }
@@ -177,9 +177,9 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
     }
 
 
-    static class NodeRequest extends BaseNodeRequest {
+    public static class NodeRequest extends BaseNodeRequest {
 
-        NodeRequest() {
+        public NodeRequest() {
         }
 
         NodeRequest(String nodeId, TransportNodesListGatewayMetaState.Request request) {

--- a/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -160,7 +160,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         return true;
     }
 
-    static class Request extends BaseNodesRequest<Request> {
+    public static class Request extends BaseNodesRequest<Request> {
 
         private ShardId shardId;
         private String indexUUID;
@@ -233,12 +233,12 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
     }
 
 
-    static class NodeRequest extends BaseNodeRequest {
+    public static class NodeRequest extends BaseNodeRequest {
 
         private ShardId shardId;
         private String indexUUID;
 
-        NodeRequest() {
+        public NodeRequest() {
         }
 
         NodeRequest(String nodeId, TransportNodesListGatewayStartedShards.Request request) {
@@ -275,7 +275,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         private long version = -1;
         private Throwable storeException = null;
 
-        NodeGatewayStartedShards() {
+        public NodeGatewayStartedShards() {
         }
         public NodeGatewayStartedShards(DiscoveryNode node, long version) {
             this(node, version, null);

--- a/core/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/core/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -435,10 +435,10 @@ public class SyncedFlushService extends AbstractComponent {
         return new InFlightOpsResponse(opCount);
     }
 
-    final static class PreSyncedFlushRequest extends TransportRequest {
+    public final static class PreSyncedFlushRequest extends TransportRequest {
         private ShardId shardId;
 
-        PreSyncedFlushRequest() {
+        public PreSyncedFlushRequest() {
         }
 
         public PreSyncedFlushRequest(ShardId shardId) {
@@ -500,7 +500,7 @@ public class SyncedFlushService extends AbstractComponent {
         }
     }
 
-    static final class SyncedFlushRequest extends TransportRequest {
+    public static final class SyncedFlushRequest extends TransportRequest {
 
         private String syncId;
         private Engine.CommitId expectedCommitId;
@@ -600,7 +600,7 @@ public class SyncedFlushService extends AbstractComponent {
     }
 
 
-    static final class InFlightOpsRequest extends TransportRequest {
+    public static final class InFlightOpsRequest extends TransportRequest {
 
         private ShardId shardId;
 

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  *
  */
-class RecoveryCleanFilesRequest extends TransportRequest {
+public class RecoveryCleanFilesRequest extends TransportRequest {
 
     private long recoveryId;
     private ShardId shardId;
@@ -38,7 +38,7 @@ class RecoveryCleanFilesRequest extends TransportRequest {
     private Store.MetadataSnapshot snapshotFiles;
     private int totalTranslogOps = RecoveryState.Translog.UNKNOWN;
 
-    RecoveryCleanFilesRequest() {
+    public RecoveryCleanFilesRequest() {
     }
 
     RecoveryCleanFilesRequest(long recoveryId, ShardId shardId, Store.MetadataSnapshot snapshotFiles, int totalTranslogOps) {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  *
  */
-public final class RecoveryFileChunkRequest extends TransportRequest {  // public for testing
+public final class RecoveryFileChunkRequest extends TransportRequest {
     private boolean lastChunk;
     private long recoveryId;
     private ShardId shardId;
@@ -45,7 +45,7 @@ public final class RecoveryFileChunkRequest extends TransportRequest {  // publi
 
     private int totalTranslogOps;
 
-    RecoveryFileChunkRequest() {
+    public RecoveryFileChunkRequest() {
     }
 
     public RecoveryFileChunkRequest(long recoveryId, ShardId shardId, StoreFileMetaData metaData, long position, BytesReference content,

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
@@ -31,7 +31,7 @@ import java.util.List;
 /**
  *
  */
-class RecoveryFilesInfoRequest extends TransportRequest {
+public class RecoveryFilesInfoRequest extends TransportRequest {
 
     private long recoveryId;
     private ShardId shardId;
@@ -43,7 +43,7 @@ class RecoveryFilesInfoRequest extends TransportRequest {
 
     int totalTranslogOps;
 
-    RecoveryFilesInfoRequest() {
+    public RecoveryFilesInfoRequest() {
     }
 
     RecoveryFilesInfoRequest(long recoveryId, ShardId shardId, List<String> phase1FileNames, List<Long> phase1FileSizes,

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
@@ -29,13 +29,13 @@ import java.io.IOException;
 /**
  *
  */
-class RecoveryFinalizeRecoveryRequest extends TransportRequest {
+public class RecoveryFinalizeRecoveryRequest extends TransportRequest {
 
     private long recoveryId;
 
     private ShardId shardId;
 
-    RecoveryFinalizeRecoveryRequest() {
+    public RecoveryFinalizeRecoveryRequest() {
     }
 
     RecoveryFinalizeRecoveryRequest(long recoveryId, ShardId shardId) {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
@@ -29,13 +29,13 @@ import java.io.IOException;
 /**
  *
  */
-class RecoveryPrepareForTranslogOperationsRequest extends TransportRequest {
+public class RecoveryPrepareForTranslogOperationsRequest extends TransportRequest {
 
     private long recoveryId;
     private ShardId shardId;
     private int totalTranslogOps = RecoveryState.Translog.UNKNOWN;
 
-    RecoveryPrepareForTranslogOperationsRequest() {
+    public RecoveryPrepareForTranslogOperationsRequest() {
     }
 
     RecoveryPrepareForTranslogOperationsRequest(long recoveryId, ShardId shardId, int totalTranslogOps) {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
@@ -31,14 +31,14 @@ import java.util.List;
 /**
  *
  */
-class RecoveryTranslogOperationsRequest extends TransportRequest {
+public class RecoveryTranslogOperationsRequest extends TransportRequest {
 
     private long recoveryId;
     private ShardId shardId;
     private List<Translog.Operation> operations;
     private int totalTranslogOps = RecoveryState.Translog.UNKNOWN;
 
-    RecoveryTranslogOperationsRequest() {
+    public RecoveryTranslogOperationsRequest() {
     }
 
     RecoveryTranslogOperationsRequest(long recoveryId, ShardId shardId, List<Translog.Operation> operations, int totalTranslogOps) {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -47,7 +47,7 @@ public class StartRecoveryRequest extends TransportRequest {
 
     private RecoveryState.Type recoveryType;
 
-    StartRecoveryRequest() {
+    public StartRecoveryRequest() {
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -396,13 +396,13 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
         }
     }
 
-    private static class ShardActiveRequest extends TransportRequest {
+    public static class ShardActiveRequest extends TransportRequest {
         protected TimeValue timeout = null;
         private ClusterName clusterName;
         private String indexUUID;
         private ShardId shardId;
 
-        ShardActiveRequest() {
+        public ShardActiveRequest() {
         }
 
         ShardActiveRequest(ClusterName clusterName, String indexUUID, ShardId shardId, TimeValue timeout) {

--- a/core/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -258,7 +258,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
     }
 
 
-    static class Request extends BaseNodesRequest<Request> {
+    public static class Request extends BaseNodesRequest<Request> {
 
         private ShardId shardId;
 
@@ -331,13 +331,13 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
     }
 
 
-    static class NodeRequest extends BaseNodeRequest {
+    public static class NodeRequest extends BaseNodeRequest {
 
         private ShardId shardId;
 
         private boolean unallocated;
 
-        NodeRequest() {
+        public NodeRequest() {
         }
 
         NodeRequest(String nodeId, TransportNodesListShardStoreMetaData.Request request) {

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -157,12 +157,10 @@ public class OsProbe {
      */
     private static Method getMethod(String methodName) {
         try {
-            Method method = osMxBean.getClass().getMethod(methodName);
-            method.setAccessible(true);
-            return method;
+            return Class.forName("com.sun.management.OperatingSystemMXBean").getMethod(methodName);
         } catch (Throwable t) {
             // not available
+            return null;
         }
-        return null;
     }
 }

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -227,7 +227,6 @@ public class OsStats implements Streamable, ToXContent {
         }
     }
 
-    // TODO: if values are -1, this should return -1 to show its unsupported?
     private static short calculatePercentage(long used, long max) {
         return max <= 0 ? 0 : (short) (Math.round((100d * used) / max));
     }

--- a/core/src/main/java/org/elasticsearch/monitor/process/ProcessProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/process/ProcessProbe.java
@@ -38,8 +38,8 @@ public class ProcessProbe {
     private static final Method getCommittedVirtualMemorySize;
 
     static {
-        getMaxFileDescriptorCountField = getMethod("getMaxFileDescriptorCount");
-        getOpenFileDescriptorCountField = getMethod("getOpenFileDescriptorCount");
+        getMaxFileDescriptorCountField = getUnixMethod("getMaxFileDescriptorCount");
+        getOpenFileDescriptorCountField = getUnixMethod("getOpenFileDescriptorCount");
         getProcessCpuLoad = getMethod("getProcessCpuLoad");
         getProcessCpuTime = getMethod("getProcessCpuTime");
         getCommittedVirtualMemorySize = getMethod("getCommittedVirtualMemorySize");
@@ -163,12 +163,23 @@ public class ProcessProbe {
      */
     private static Method getMethod(String methodName) {
         try {
-            Method method = osMxBean.getClass().getDeclaredMethod(methodName);
-            method.setAccessible(true);
-            return method;
+            return Class.forName("com.sun.management.OperatingSystemMXBean").getMethod(methodName);
         } catch (Throwable t) {
             // not available
+            return null;
         }
-        return null;
+    }
+    
+    /**
+     * Returns a given method of the UnixOperatingSystemMXBean,
+     * or null if the method is not found or unavailable.
+     */
+    private static Method getUnixMethod(String methodName) {
+        try {
+            return Class.forName("com.sun.management.UnixOperatingSystemMXBean").getMethod(methodName);
+        } catch (Throwable t) {
+            // not available
+            return null;
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/core/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -121,12 +121,12 @@ public class VerifyNodeRepositoryAction  extends AbstractComponent {
         blobStoreIndexShardRepository.verify(verificationToken);
     }
 
-    static class VerifyNodeRepositoryRequest extends TransportRequest {
+    public static class VerifyNodeRepositoryRequest extends TransportRequest {
 
         private String repository;
         private String verificationToken;
 
-        VerifyNodeRepositoryRequest() {
+        public VerifyNodeRepositoryRequest() {
         }
 
         VerifyNodeRepositoryRequest(String repository, String verificationToken) {

--- a/core/src/main/java/org/elasticsearch/repositories/uri/URLIndexShardRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/uri/URLIndexShardRepository.java
@@ -31,7 +31,7 @@ import org.elasticsearch.repositories.RepositoryName;
 public class URLIndexShardRepository extends BlobStoreIndexShardRepository {
 
     @Inject
-    URLIndexShardRepository(Settings settings, RepositoryName repositoryName, IndicesService indicesService, ClusterService clusterService) {
+    public URLIndexShardRepository(Settings settings, RepositoryName repositoryName, IndicesService indicesService, ClusterService clusterService) {
         super(settings, repositoryName, indicesService, clusterService);
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestCountAction.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestCountAction extends AbstractCatAction {
 
     @Inject
-    protected RestCountAction(Settings settings, RestController restController, RestController controller, Client client) {
+    public RestCountAction(Settings settings, RestController restController, RestController controller, Client client) {
         super(settings, controller, client);
         restController.registerHandler(GET, "/_cat/count", this);
         restController.registerHandler(GET, "/_cat/count/{index}", this);

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestRecoveryAction.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 public class RestRecoveryAction extends AbstractCatAction {
 
     @Inject
-    protected RestRecoveryAction(Settings settings, RestController restController, RestController controller, Client client) {
+    public RestRecoveryAction(Settings settings, RestController restController, RestController controller, Client client) {
         super(settings, controller, client);
         restController.registerHandler(GET, "/_cat/recovery", this);
         restController.registerHandler(GET, "/_cat/recovery/{index}", this);

--- a/core/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
+++ b/core/src/main/java/org/elasticsearch/search/action/SearchServiceTransportAction.java
@@ -205,10 +205,10 @@ public class SearchServiceTransportAction extends AbstractComponent {
         });
     }
 
-    static class ScrollFreeContextRequest extends TransportRequest {
+    public static class ScrollFreeContextRequest extends TransportRequest {
         private long id;
 
-        ScrollFreeContextRequest() {
+        public ScrollFreeContextRequest() {
         }
 
         ScrollFreeContextRequest(ClearScrollRequest request, long id) {
@@ -237,10 +237,10 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    static class SearchFreeContextRequest extends ScrollFreeContextRequest implements IndicesRequest {
+    public static class SearchFreeContextRequest extends ScrollFreeContextRequest implements IndicesRequest {
         private OriginalIndices originalIndices;
 
-        SearchFreeContextRequest() {
+        public SearchFreeContextRequest() {
         }
 
         SearchFreeContextRequest(SearchRequest request, long id) {
@@ -313,9 +313,9 @@ public class SearchServiceTransportAction extends AbstractComponent {
         }
     }
 
-    static class ClearScrollContextsRequest extends TransportRequest {
+    public static class ClearScrollContextsRequest extends TransportRequest {
 
-        ClearScrollContextsRequest() {
+        public ClearScrollContextsRequest() {
         }
 
         ClearScrollContextsRequest(TransportRequest request) {

--- a/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -1036,14 +1036,14 @@ public class RestoreService extends AbstractComponent implements ClusterStateLis
     /**
      * Internal class that is used to send notifications about finished shard restore operations to master node
      */
-    static class UpdateIndexShardRestoreStatusRequest extends TransportRequest {
+    public static class UpdateIndexShardRestoreStatusRequest extends TransportRequest {
         private SnapshotId snapshotId;
         private ShardId shardId;
         private ShardRestoreStatus status;
 
         volatile boolean processed; // state field, no need to serialize
 
-        private UpdateIndexShardRestoreStatusRequest() {
+        public UpdateIndexShardRestoreStatusRequest() {
 
         }
 

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -410,7 +410,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent<SnapshotSh
     /**
      * Internal request that is used to send changes in snapshot status to master
      */
-    private static class UpdateIndexShardSnapshotStatusRequest extends TransportRequest {
+    public static class UpdateIndexShardSnapshotStatusRequest extends TransportRequest {
         private SnapshotId snapshotId;
         private ShardId shardId;
         private SnapshotsInProgress.ShardSnapshotStatus status;

--- a/core/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java
+++ b/core/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java
@@ -81,12 +81,15 @@ public class RequestHandlerRegistry<Request extends TransportRequest> {
             } catch (NoSuchMethodException e) {
                 throw new IllegalStateException("failed to create constructor (does it have a default constructor?) for request " + request, e);
             }
-            this.requestConstructor.setAccessible(true);
         }
 
         @Override
         public Request call() throws Exception {
-            return requestConstructor.newInstance();
+            try {
+                return requestConstructor.newInstance();
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Could not access '" + requestConstructor + "'. Implementations must be a public class and have a public no-arg ctor.", e);
+            }
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -36,7 +36,7 @@ public abstract class TransportRequest extends TransportMessage<TransportRequest
         }
     }
 
-    protected TransportRequest() {
+    public TransportRequest() {
     }
 
     protected TransportRequest(TransportRequest request) {

--- a/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -447,7 +447,7 @@ public class TransportActionFilterChainTests extends ESTestCase {
         void execute(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain);
     }
 
-    private static class TestRequest extends ActionRequest {
+    public static class TestRequest extends ActionRequest {
         @Override
         public ActionRequestValidationException validate() {
             return null;

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ShardReplicationTests.java
@@ -551,12 +551,12 @@ public class ShardReplicationTests extends ESTestCase {
         };
     }
 
-    static class Request extends ReplicationRequest<Request> {
+    public static class Request extends ReplicationRequest<Request> {
         int shardId;
         public AtomicBoolean processedOnPrimary = new AtomicBoolean();
         public AtomicInteger processedOnReplicas = new AtomicInteger();
 
-        Request() {
+        public Request() {
         }
 
         Request(ShardId shardId) {

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -173,7 +173,7 @@ public class TransportClientNodesServiceTests extends ESTestCase {
         }
     }
 
-    private static class TestRequest extends TransportRequest {
+    public static class TestRequest extends TransportRequest {
 
     }
 

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -54,14 +54,11 @@ public class OsProbeTests extends ESTestCase {
         }
 
         assertNotNull(stats.getMem());
-        // TODO: once java 9 is sorted out make these hard checks (currently 9-ea and 9-ea-jigsaw will differ)
-        if (!Constants.JRE_IS_MINIMUM_JAVA9) {
-            assertThat(stats.getMem().getTotal().bytes(), greaterThan(0L));
-            assertThat(stats.getMem().getFree().bytes(), greaterThan(0L));
-            assertThat(stats.getMem().getFreePercent(), allOf(greaterThanOrEqualTo((short) 0), lessThanOrEqualTo((short) 100)));
-            assertThat(stats.getMem().getUsed().bytes(), greaterThan(0L));
-            assertThat(stats.getMem().getUsedPercent(), allOf(greaterThanOrEqualTo((short) 0), lessThanOrEqualTo((short) 100)));
-        }
+        assertThat(stats.getMem().getTotal().bytes(), greaterThan(0L));
+        assertThat(stats.getMem().getFree().bytes(), greaterThan(0L));
+        assertThat(stats.getMem().getFreePercent(), allOf(greaterThanOrEqualTo((short) 0), lessThanOrEqualTo((short) 100)));
+        assertThat(stats.getMem().getUsed().bytes(), greaterThan(0L));
+        assertThat(stats.getMem().getUsedPercent(), allOf(greaterThanOrEqualTo((short) 0), lessThanOrEqualTo((short) 100)));
 
         assertNotNull(stats.getSwap());
         assertNotNull(stats.getSwap().getTotal());
@@ -73,12 +70,9 @@ public class OsProbeTests extends ESTestCase {
             assertThat(stats.getSwap().getUsed().bytes(), greaterThanOrEqualTo(0L));
         } else {
             // On platforms with no swap
-            // TODO: one java 9 is sorted out make these hard checks (currently 9-ea and 9-ea-jigsaw will differ)
-            if (!Constants.JRE_IS_MINIMUM_JAVA9) {
-                assertThat(stats.getSwap().getTotal().bytes(), equalTo(0L));
-                assertThat(stats.getSwap().getFree().bytes(), equalTo(0L));
-                assertThat(stats.getSwap().getUsed().bytes(), equalTo(0L));
-            }
+            assertThat(stats.getSwap().getTotal().bytes(), equalTo(0L));
+            assertThat(stats.getSwap().getFree().bytes(), equalTo(0L));
+            assertThat(stats.getSwap().getUsed().bytes(), equalTo(0L));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/monitor/process/ProcessProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/process/ProcessProbeTests.java
@@ -51,11 +51,8 @@ public class ProcessProbeTests extends ESTestCase {
             assertThat(stats.getOpenFileDescriptors(), equalTo(-1L));
             assertThat(stats.getMaxFileDescriptors(), equalTo(-1L));
         } else {
-            // TODO: once java 9 is sorted out make these hard checks (currently 9-ea and 9-ea-jigsaw will differ)
-            if (!Constants.JRE_IS_MINIMUM_JAVA9) {
-                assertThat(stats.getOpenFileDescriptors(), greaterThan(0L));
-                assertThat(stats.getMaxFileDescriptors(), greaterThan(0L));
-            }
+            assertThat(stats.getOpenFileDescriptors(), greaterThan(0L));
+            assertThat(stats.getMaxFileDescriptors(), greaterThan(0L));
         }
 
         ProcessStats.Cpu cpu = stats.getCpu();
@@ -65,14 +62,11 @@ public class ProcessProbeTests extends ESTestCase {
         assertThat(cpu.getPercent(), anyOf(lessThan((short) 0), allOf(greaterThanOrEqualTo((short) 0), lessThanOrEqualTo((short) 100))));
 
         // CPU time can return -1 if the the platform does not support this operation, let's see which platforms fail
-        if (!Constants.JRE_IS_MINIMUM_JAVA9) {
-            // TODO: once java 9 is sorted out make these hard checks (currently 9-ea and 9-ea-jigsaw will differ)
-            assertThat(cpu.total, greaterThan(0L));
+        assertThat(cpu.total, greaterThan(0L));
 
-            ProcessStats.Mem mem = stats.getMem();
-            assertNotNull(mem);
-            // Commited total virtual memory can return -1 if not supported, let's see which platforms fail
-            assertThat(mem.totalVirtual, greaterThan(0L));
-        }
+        ProcessStats.Mem mem = stats.getMem();
+        assertNotNull(mem);
+        // Commited total virtual memory can return -1 if not supported, let's see which platforms fail
+        assertThat(mem.totalVirtual, greaterThan(0L));
     }
 }

--- a/core/src/test/java/org/elasticsearch/script/NativeScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/NativeScriptTests.java
@@ -95,7 +95,7 @@ public class NativeScriptTests extends ESTestCase {
         }
     }
 
-    static class MyNativeScriptFactory implements NativeScriptFactory {
+    public static class MyNativeScriptFactory implements NativeScriptFactory {
         @Override
         public ExecutableScript newScript(@Nullable Map<String, Object> params) {
             return new MyScript();

--- a/core/src/test/java/org/elasticsearch/script/ScriptFieldIT.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptFieldIT.java
@@ -77,7 +77,7 @@ public class ScriptFieldIT extends ESIntegTestCase {
         }
     }
 
-    static class IntArrayScriptFactory implements NativeScriptFactory {
+    public static class IntArrayScriptFactory implements NativeScriptFactory {
         @Override
         public ExecutableScript newScript(@Nullable Map<String, Object> params) {
             return new IntScript();
@@ -96,7 +96,7 @@ public class ScriptFieldIT extends ESIntegTestCase {
         }
     }
 
-    static class LongArrayScriptFactory implements NativeScriptFactory {
+    public static class LongArrayScriptFactory implements NativeScriptFactory {
         @Override
         public ExecutableScript newScript(@Nullable Map<String, Object> params) {
             return new LongScript();
@@ -115,7 +115,7 @@ public class ScriptFieldIT extends ESIntegTestCase {
         }
     }
 
-    static class FloatArrayScriptFactory implements NativeScriptFactory {
+    public static class FloatArrayScriptFactory implements NativeScriptFactory {
         @Override
         public ExecutableScript newScript(@Nullable Map<String, Object> params) {
             return new FloatScript();
@@ -134,7 +134,7 @@ public class ScriptFieldIT extends ESIntegTestCase {
         }
     }
 
-    static class DoubleArrayScriptFactory implements NativeScriptFactory {
+    public static class DoubleArrayScriptFactory implements NativeScriptFactory {
         @Override
         public ExecutableScript newScript(@Nullable Map<String, Object> params) {
             return new DoubleScript();

--- a/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -96,7 +96,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
         }
     }
 
-    static class MyNativeScriptFactory implements NativeScriptFactory {
+    public static class MyNativeScriptFactory implements NativeScriptFactory {
         @Override
         public ExecutableScript newScript(@Nullable Map<String, Object> params) {
             return new MyScript();

--- a/core/src/test/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/core/src/test/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -742,7 +742,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     }
 
 
-    static class StringMessageRequest extends TransportRequest {
+    public static class StringMessageRequest extends TransportRequest {
 
         private String message;
         private long timeout;
@@ -752,7 +752,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             this.timeout = timeout;
         }
 
-        StringMessageRequest() {
+        public StringMessageRequest() {
         }
 
         public StringMessageRequest(String message) {
@@ -803,7 +803,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     }
 
 
-    static class Version0Request extends TransportRequest {
+    public static class Version0Request extends TransportRequest {
 
         int value1;
 
@@ -821,7 +821,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         }
     }
 
-    static class Version1Request extends Version0Request {
+    public static class Version1Request extends Version0Request {
 
         int value2;
 
@@ -1213,7 +1213,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         assertTrue(nodeB.address().sameHost(addressB.get()));
     }
 
-    private static class TestRequest extends TransportRequest {
+    public static class TestRequest extends TransportRequest {
     }
 
     private static class TestResponse extends TransportResponse {

--- a/dev-tools/src/main/resources/forbidden/core-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/core-signatures.txt
@@ -83,3 +83,7 @@ java.util.concurrent.Future#cancel(boolean)
 @defaultMessage Don't try reading from paths that are not configured in Environment, resolve from Environment instead
 org.elasticsearch.common.io.PathUtils#get(java.lang.String, java.lang.String[])
 org.elasticsearch.common.io.PathUtils#get(java.net.URI)
+
+@defaultMessage Do not violate java's access system
+java.lang.reflect.AccessibleObject#setAccessible(boolean)
+java.lang.reflect.AccessibleObject#setAccessible(java.lang.reflect.AccessibleObject[], boolean)

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/management/AzureComputeSettingsFilter.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/management/AzureComputeSettingsFilter.java
@@ -29,7 +29,7 @@ import static org.elasticsearch.cloud.azure.management.AzureComputeService.Manag
 public class AzureComputeSettingsFilter extends AbstractComponent {
 
     @Inject
-    protected AzureComputeSettingsFilter(Settings settings, SettingsFilter settingsFilter) {
+    public AzureComputeSettingsFilter(Settings settings, SettingsFilter settingsFilter) {
         super(settings);
         // Cloud management API settings we need to hide
         settingsFilter.addFilter(KEYSTORE_PATH);

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettingsFilter.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettingsFilter.java
@@ -29,7 +29,7 @@ import static org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage.
 public class AzureStorageSettingsFilter extends AbstractComponent {
 
     @Inject
-    protected AzureStorageSettingsFilter(Settings settings, SettingsFilter settingsFilter) {
+    public AzureStorageSettingsFilter(Settings settings, SettingsFilter settingsFilter) {
         super(settings);
         // Cloud storage API settings needed to be hidden
         settingsFilter.addFilter(ACCOUNT);

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AzureComputeServiceSimpleMock.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AzureComputeServiceSimpleMock.java
@@ -52,7 +52,7 @@ public class AzureComputeServiceSimpleMock extends AzureComputeServiceAbstractMo
     }
 
     @Inject
-    protected AzureComputeServiceSimpleMock(Settings settings) {
+    public AzureComputeServiceSimpleMock(Settings settings) {
         super(settings);
     }
 

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
@@ -46,7 +46,7 @@ public class AzureStorageServiceMock extends AbstractLifecycleComponent<AzureSto
     protected Map<String, ByteArrayOutputStream> blobs = new ConcurrentHashMap<>();
 
     @Inject
-    protected AzureStorageServiceMock(Settings settings) {
+    public AzureStorageServiceMock(Settings settings) {
         super(settings);
     }
 

--- a/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
+++ b/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryAction.java
@@ -57,7 +57,7 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
     private final Client client;
 
     @Inject
-    protected TransportDeleteByQueryAction(Settings settings, ThreadPool threadPool, Client client,
+    public TransportDeleteByQueryAction(Settings settings, ThreadPool threadPool, Client client,
                                            TransportSearchAction transportSearchAction,
                                            TransportSearchScrollAction transportSearchScrollAction,
                                            TransportService transportService, ActionFilters actionFilters,

--- a/plugins/discovery-multicast/src/main/java/org/elasticsearch/plugin/discovery/multicast/MulticastZenPing.java
+++ b/plugins/discovery-multicast/src/main/java/org/elasticsearch/plugin/discovery/multicast/MulticastZenPing.java
@@ -352,13 +352,13 @@ public class MulticastZenPing extends AbstractLifecycleComponent<ZenPing> implem
         }
     }
 
-    static class MulticastPingResponse extends TransportRequest {
+    public static class MulticastPingResponse extends TransportRequest {
 
         int id;
 
         PingResponse pingResponse;
 
-        MulticastPingResponse() {
+        public MulticastPingResponse() {
         }
 
         @Override


### PR DESCRIPTION
In addition to being a big security problem, setAccessible is a risk for java 9 migration. We need to clean up our code so we can ban it and eventually enforce this with security manager for third-party code, too, or we may have problems.

Instead of using setAccessible for monitoring stats, we just use the correct interface that is public (but may not be there under some IBM vms). This restores them for java 9, which does not allow what we do today.

Instead of using setAccessible for injection code, use the correct modifier (e.g. public). Injected constructors need to be public. I scanned for problems with `grep` and eclipse call hierarchy and don't think any are missing (I did not trust our tests really would find everything). 

TODO: ban in tests
TODO: ban in security manager at runtime
TODO: make a nice asm-based scan to enforce proper modifiers and similar stuff like this.

Closes #13527
