### PR TITLE
MLT: Parser and builder takes same default boost terms value

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -364,7 +364,7 @@ public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQ
 
     // query formation parameters
     private String minimumShouldMatch = null;
-    private float boostTerms = -1;
+    private float boostTerms = 0;  // deactivated
     private Boolean include = null;
 
     // other parameters
@@ -542,7 +542,7 @@ public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQ
     }
 
     /**
-     * Sets the boost factor to use when boosting terms. Defaults to <tt>1</tt>.
+     * Sets the boost factor to use when boosting terms. Defaults to <tt>0</tt> (deactivated).
      */
     public MoreLikeThisQueryBuilder boostTerms(float boostTerms) {
         this.boostTerms = boostTerms;
@@ -670,7 +670,7 @@ public class MoreLikeThisQueryBuilder extends QueryBuilder implements BoostableQ
         if (minimumShouldMatch != null) {
             builder.field(MoreLikeThisQueryParser.Field.MINIMUM_SHOULD_MATCH.getPreferredName(), minimumShouldMatch);
         }
-        if (boostTerms != -1) {
+        if (boostTerms != 0) {
             builder.field(MoreLikeThisQueryParser.Field.BOOST_TERMS.getPreferredName(), boostTerms);
         }
         if (include != null) {


### PR DESCRIPTION
The default value for boost terms in MLT is 0 (deactivated). However, the
builder would consider -1 as being the default value. This makes both the
parser and builder take the same default value for boost terms.
