### PR TITLE
Update index_.asciidoc

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -96,7 +96,7 @@ meantime (when reading in order to update, it is recommended to set
 
 [source,js]
 --------------------------------------------------
-curl -XPUT 'localhost:9200/twitter/tweet/1?version=2' -d '{
+curl -XPUT 'localhost:9200/twitter/tweet/1?_version=2' -d '{
     "message" : "elasticsearch now has versioning support, double cool!"
 }'
 --------------------------------------------------


### PR DESCRIPTION
Specifying a version  using `_version=`
Example:

```
PUT /twitter/tweet/1?_version=2
{
    "message" : "elasticsearch now has versioning support, double cool!"
}
```
