### PR TITLE
Hack around aws security hole of accessing sun.security.ssl, s3 repository works on java 9 again

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -86,8 +86,6 @@ grant {
   // reflection hacks:
   // needed by groovy engine
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
-  // needed by aws core sdk (TODO: look into this)
-  permission java.lang.RuntimePermission "accessClassInPackage.sun.security.ssl";
   
   // needed by RandomizedRunner
   permission java.lang.RuntimePermission "accessDeclaredMembers";

--- a/plugins/repository-s3/rest-api-spec/test/repository_s3/20_repository.yaml
+++ b/plugins/repository-s3/rest-api-spec/test/repository_s3/20_repository.yaml
@@ -1,9 +1,6 @@
 # Integration tests for Repository S3 component
 #
 "S3 repository can be registereed":
-    - skip:
-        version: "all"
-        reason:  does not work on java9, see https://github.com/aws/aws-sdk-java/pull/432
     - do:
         snapshot.create_repository:
           repository: test_repo_s3_1


### PR DESCRIPTION
Today this is really horrible, and we have a PR sent to fix it, but nobody
does anything: aws/aws-sdk-java#432

With java 9, we cannot even grant the permission, this kind of sheistiness is not allowed,
and s3 repository is completely broken.

The problem is their code is still broken, and won't handle neither SecurityException (our PR)
nor the new InaccessibleObjectException they will get from java 9.

We use a really hacky hack to deliver an exception that their code catches (IllegalAccessException) instead.

This means s3 repository is working on java 9, and we close off access to sun.security.ssl completely
