### PR TITLE
Cleanup InternalClusterInfoService

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -56,11 +56,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -123,31 +120,6 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         }
     }
 
-    static class InfoListener implements ClusterInfoService.Listener {
-        final AtomicReference<CountDownLatch> collected = new AtomicReference<>(new CountDownLatch(1));
-        volatile ClusterInfo lastInfo = null;
-
-        @Override
-        public void onNewInfo(ClusterInfo info) {
-            lastInfo = info;
-            CountDownLatch latch = collected.get();
-            latch.countDown();
-        }
-
-        public void reset() {
-            lastInfo = null;
-            collected.set(new CountDownLatch(1));
-        }
-
-        public ClusterInfo get() throws InterruptedException {
-            CountDownLatch latch = collected.get();
-            if (!latch.await(10, TimeUnit.SECONDS)) {
-                fail("failed to get a new cluster info");
-            }
-            return lastInfo;
-        }
-    }
-
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
@@ -174,9 +146,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         InternalTestCluster internalTestCluster = internalCluster();
         // Get the cluster info service on the master node
         final InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster.getInstance(ClusterInfoService.class, internalTestCluster.getMasterName());
-        InfoListener listener = new InfoListener();
-        infoService.addListener(listener);
-        ClusterInfo info = listener.get();
+        ClusterInfo info = infoService.refresh();
         assertNotNull("info should not be null", info);
         final Map<String, DiskUsage> leastUsages = info.getNodeLeastAvailableDiskUsages();
         final Map<String, DiskUsage> mostUsages = info.getNodeMostAvailableDiskUsages();
@@ -224,12 +194,8 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         ensureGreen("test");
         InternalTestCluster internalTestCluster = internalCluster();
         InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster.getInstance(ClusterInfoService.class, internalTestCluster.getMasterName());
-        InfoListener listener = new InfoListener();
-        infoService.addListener(listener);
-
         // get one healthy sample
-        infoService.updateOnce();
-        ClusterInfo info = listener.get();
+        ClusterInfo info = infoService.refresh();
         assertNotNull("failed to collect info", info);
         assertThat("some usages are populated", info.getNodeLeastAvailableDiskUsages().size(), Matchers.equalTo(2));
         assertThat("some shard sizes are populated", info.shardSizes.size(), greaterThan(0));
@@ -258,9 +224,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
 
         // timeouts shouldn't clear the info
         timeout.set(true);
-        listener.reset();
-        infoService.updateOnce();
-        info = listener.get();
+        info = infoService.refresh();
         assertNotNull("info should not be null", info);
         // node info will time out both on the request level on the count down latch. this means
         // it is likely to update the node disk usage based on the one response that came be from local
@@ -283,9 +247,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
 
         assertNotNull("failed to find BlockingActionFilter", blockingActionFilter);
         blockingActionFilter.blockActions(blockedActions.toArray(Strings.EMPTY_ARRAY));
-        listener.reset();
-        infoService.updateOnce();
-        info = listener.get();
+        info = infoService.refresh();
         assertNotNull("info should not be null", info);
         assertThat(info.getNodeLeastAvailableDiskUsages().size(), equalTo(0));
         assertThat(info.getNodeMostAvailableDiskUsages().size(), equalTo(0));
@@ -293,9 +255,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
 
         // check we recover
         blockingActionFilter.blockActions();
-        listener.reset();
-        infoService.updateOnce();
-        info = listener.get();
+        info = infoService.refresh();
         assertNotNull("info should not be null", info);
         assertThat(info.getNodeLeastAvailableDiskUsages().size(), equalTo(2));
         assertThat(info.getNodeMostAvailableDiskUsages().size(), equalTo(2));

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -490,8 +490,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         }
         ensureGreen("test");
         InternalClusterInfoService clusterInfoService = (InternalClusterInfoService) getInstanceFromNode(ClusterInfoService.class);
-        InternalClusterInfoService.ClusterInfoUpdateJob job = clusterInfoService.new ClusterInfoUpdateJob(false);
-        job.run();
+        clusterInfoService.refresh();
         ClusterState state = getInstanceFromNode(ClusterService.class).state();
         Long test = clusterInfoService.getClusterInfo().getShardSize(state.getRoutingTable().index("test").getShards().get(0).primaryShard());
         assertNotNull(test);


### PR DESCRIPTION
This commit allows to refresh the info service in a blocking fashion
which allows tests to prevent installing listeners alltogether and
makes the class easier to test. Installing a listnener is always subject
to concurrent modifications where the listener might be called mulitple times
or with stale information which causes tests to fail.

here is a link to a test that seems flaky for that reason http://build-us-00.elastic.co/job/es_core_master_centos/7505/
