### PR TITLE
Add *Exception(Throwable cause) constructors/ call where appropriate

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchCorruptionException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchCorruptionException.java
@@ -42,15 +42,6 @@ public class ElasticsearchCorruptionException extends IOException {
      * @param ex the exception cause
      */
     public ElasticsearchCorruptionException(Throwable ex) {
-        this(ex.getMessage());
-        if (ex != null) {
-            this.setStackTrace(ex.getStackTrace());
-        }
-        Throwable[] suppressed = ex.getSuppressed();
-        if (suppressed != null) {
-            for (Throwable supressedExc : suppressed) {
-                addSuppressed(supressedExc);
-            }
-        }
+        super(ex);
     }
 }

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -51,6 +51,9 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     private static final Map<Class<? extends ElasticsearchException>, ElasticsearchExceptionHandle> CLASS_TO_ELASTICSEARCH_EXCEPTION_HANDLE;
     private final Map<String, List<String>> headers = new HashMap<>();
 
+    public ElasticsearchException(Throwable cause) {
+        super(cause);
+    }
     /**
      * Construct a <code>ElasticsearchException</code> with the specified detail message.
      *

--- a/core/src/main/java/org/elasticsearch/ElasticsearchTimeoutException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchTimeoutException.java
@@ -33,8 +33,12 @@ public class ElasticsearchTimeoutException extends ElasticsearchException {
         super(in);
     }
 
+    public ElasticsearchTimeoutException(Throwable cause) {
+        super(cause);
+    }
+
     public ElasticsearchTimeoutException(String message, Object... args) {
-        super(message);
+        super(message, args);
     }
 
     public ElasticsearchTimeoutException(String message, Throwable cause, Object... args) {

--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -47,14 +47,14 @@ public final class ExceptionsHelper {
         if (t instanceof RuntimeException) {
             return (RuntimeException) t;
         }
-        return new ElasticsearchException(t.getMessage(), t);
+        return new ElasticsearchException(t);
     }
 
     public static ElasticsearchException convertToElastic(Throwable t) {
         if (t instanceof ElasticsearchException) {
             return (ElasticsearchException) t;
         }
-        return new ElasticsearchException(t.getMessage(), t);
+        return new ElasticsearchException(t);
     }
 
     public static RestStatus status(Throwable t) {
@@ -160,7 +160,7 @@ public final class ExceptionsHelper {
             main = useOrSuppress(main, ex);
         }
         if (main != null) {
-            throw new ElasticsearchException(main.getMessage(), main);
+            throw new ElasticsearchException(main);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
+++ b/core/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
@@ -69,7 +69,7 @@ public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements
         try {
             return get(timeout, unit);
         } catch (TimeoutException e) {
-            throw new ElasticsearchTimeoutException(e.getMessage());
+            throw new ElasticsearchTimeoutException(e);
         } catch (InterruptedException e) {
             throw new IllegalStateException("Future got interrupted", e);
         } catch (ExecutionException e) {

--- a/core/src/main/java/org/elasticsearch/common/inject/TypeConverterBindingProcessor.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/TypeConverterBindingProcessor.java
@@ -106,7 +106,7 @@ class TypeConverterBindingProcessor extends AbstractProcessor {
                             try {
                                 return Class.forName(value);
                             } catch (ClassNotFoundException e) {
-                                throw new RuntimeException(e.getMessage());
+                                throw new RuntimeException(e);
                             }
                         }
 
@@ -135,7 +135,7 @@ class TypeConverterBindingProcessor extends AbstractProcessor {
                     } catch (IllegalAccessException e) {
                         throw new AssertionError(e);
                     } catch (InvocationTargetException e) {
-                        throw new RuntimeException(e.getTargetException().getMessage());
+                        throw new RuntimeException(e.getTargetException());
                     }
                 }
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -244,7 +244,7 @@ public class Analysis {
             return loadWordList(reader, "#");
         } catch (IOException ioe) {
             String message = String.format(Locale.ROOT, "IOException while reading %s_path: %s", settingPrefix, ioe.getMessage());
-            throw new IllegalArgumentException(message);
+            throw new IllegalArgumentException(message, ioe);
         }
     }
 
@@ -291,7 +291,7 @@ public class Analysis {
             return FileSystemUtils.newBufferedReader(path.toUri().toURL(), StandardCharsets.UTF_8);
         } catch (IOException ioe) {
             String message = String.format(Locale.ROOT, "IOException while reading %s_path: %s", settingPrefix, ioe.getMessage());
-            throw new IllegalArgumentException(message);
+            throw new IllegalArgumentException(message, ioe);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/compound/HyphenationCompoundWordTokenFilterFactory.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/compound/HyphenationCompoundWordTokenFilterFactory.java
@@ -62,7 +62,7 @@ public class HyphenationCompoundWordTokenFilterFactory extends AbstractCompoundW
         try {
             hyphenationTree = HyphenationCompoundWordTokenFilter.getHyphenationTree(new InputSource(Files.newInputStream(hyphenationPatternsFile)));
         } catch (Exception e) {
-            throw new IllegalArgumentException("Exception while reading hyphenation_patterns_path: " + e.getMessage());
+            throw new IllegalArgumentException("Exception while reading hyphenation_patterns_path.", e);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexFieldData.java
@@ -78,7 +78,7 @@ public abstract class AbstractIndexFieldData<FD extends AtomicFieldData> extends
             if (e instanceof ElasticsearchException) {
                 throw (ElasticsearchException) e;
             } else {
-                throw new ElasticsearchException(e.getMessage(), e);
+                throw new ElasticsearchException(e);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -70,7 +70,7 @@ public abstract class AbstractIndexOrdinalsFieldData extends AbstractIndexFieldD
             if (e instanceof ElasticsearchException) {
                 throw (ElasticsearchException) e;
             } else {
-                throw new ElasticsearchException(e.getMessage(), e);
+                throw new ElasticsearchException(e);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -146,7 +146,7 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
             if (e instanceof ElasticsearchException) {
                 throw (ElasticsearchException) e;
             } else {
-                throw new ElasticsearchException(e.getMessage(), e);
+                throw new ElasticsearchException(e);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
@@ -73,7 +73,7 @@ public class SortedSetDVOrdinalsIndexFieldData extends DocValuesIndexFieldData i
             if (e instanceof ElasticsearchException) {
                 throw (ElasticsearchException) e;
             } else {
-                throw new ElasticsearchException(e.getMessage(), e);
+                throw new ElasticsearchException(e);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/search/lookup/LeafIndexLookup.java
+++ b/core/src/main/java/org/elasticsearch/search/lookup/LeafIndexLookup.java
@@ -134,7 +134,7 @@ public class LeafIndexLookup extends MinimalMap<String, IndexField> {
                 indexField = new IndexField(stringField, this);
                 indexFields.put(stringField, indexField);
             } catch (IOException e) {
-                throw new ElasticsearchException(e.getMessage());
+                throw new ElasticsearchException(e);
             }
         }
         return indexField;

--- a/core/src/main/java/org/elasticsearch/transport/PlainTransportFuture.java
+++ b/core/src/main/java/org/elasticsearch/transport/PlainTransportFuture.java
@@ -59,7 +59,7 @@ public class PlainTransportFuture<V extends TransportResponse> extends BaseFutur
         try {
             return get(timeout, unit);
         } catch (TimeoutException e) {
-            throw new ElasticsearchTimeoutException(e.getMessage());
+            throw new ElasticsearchTimeoutException(e);
         } catch (InterruptedException e) {
             throw new IllegalStateException("Future got interrupted", e);
         } catch (ExecutionException e) {

--- a/core/src/main/java/org/elasticsearch/transport/ResponseHandlerFailureTransportException.java
+++ b/core/src/main/java/org/elasticsearch/transport/ResponseHandlerFailureTransportException.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class ResponseHandlerFailureTransportException extends TransportException {
 
     public ResponseHandlerFailureTransportException(Throwable cause) {
-        super(cause.getMessage(), cause);
+        super(cause);
     }
 
     public ResponseHandlerFailureTransportException(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/transport/TransportException.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportException.java
@@ -28,6 +28,10 @@ import java.io.IOException;
  *
  */
 public class TransportException extends ElasticsearchException {
+    public TransportException(Throwable cause) {
+        super(cause);
+    }
+
     public TransportException(StreamInput in) throws IOException {
         super(in);
     }

--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -187,7 +187,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
                 if (e instanceof RuntimeException) {
                     throw (RuntimeException) e;
                 }
-                throw new ElasticsearchException(e.getMessage(), e);
+                throw new ElasticsearchException(e);
             }
         }
     }


### PR DESCRIPTION
This is a first step towards getting rid of exceptions lacking context as part of #10021:

In some of our internal exceptions we do not declare a constructor that accepts just the cause-Throwable as argument. As a result on exception creation we sometimes did the following:

throw new Exception(cause.getMessage())

thus loosing all stacktrace information that might have been available.

This PR adds the missing constructors and calls them where appropriate.

@rmuir adding you as assignee as you raised the original issue. Feel free to delegate to whoever you see better fit to review.
