### PR TITLE
add max_number_of_fields to Object mapping to cap mapping growthing

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/MaxNumberOfFieldsMappingException.java
+++ b/src/main/java/org/elasticsearch/index/mapper/MaxNumberOfFieldsMappingException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.rest.RestStatus;
+
+/**
+ */
+public class MaxNumberOfFieldsMappingException extends MapperParsingException {
+
+    public MaxNumberOfFieldsMappingException(String path, String fieldName) {
+        super("[" + fieldName + "] exceeds the max number of fields configured for [" + path + "]");
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
+    }
+}


### PR DESCRIPTION
This is the implementation for https://github.com/elastic/elasticsearch/issues/11443. Added "max_number_of_fields" as an option to object mapping. Discard document if the number of direct sub fields reaches the limit. Default behavior is no limit.
