### PR TITLE
Improve IndexingMemoryController a bit

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -94,8 +94,11 @@ public final class EngineConfig {
     public static final String INDEX_GC_DELETES_SETTING = "index.gc_deletes";
 
     /**
-     * Index setting to control the initial index buffer size.
-     * This setting is <b>not</b> realtime updateable.
+     * Index setting to control the initial index buffer size.  NOTE: this setting is somewhat
+     * useless, since IndexingMemoryController will take over quickly and partition the
+     * indices.memory.index_buffer_size for this node across all shards.
+     *
+     * <p>This setting is <b>not</b> realtime updateable.
      */
     public static final String INDEX_BUFFER_SIZE_SETTING = "index.buffer_size";
 

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -666,7 +666,6 @@ public class InternalEngine extends Engine {
         // since it flushes the index as well (though, in terms of concurrency, we are allowed to do it)
         try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
-            updateIndexWriterSettings();
             searcherManager.maybeRefreshBlocking();
         } catch (AlreadyClosedException e) {
             ensureOpen();
@@ -736,7 +735,6 @@ public class InternalEngine extends Engine {
          */
         try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
-            updateIndexWriterSettings();
             if (flushLock.tryLock() == false) {
                 // if we can't get the lock right away we block if needed otherwise barf
                 if (waitIfOngoing) {
@@ -954,7 +952,6 @@ public class InternalEngine extends Engine {
         }
     }
 
-
     /**
      * Closes the engine without acquiring the write lock. This should only be
      * called while the write lock is hold or in a disaster condition ie. if the engine
@@ -1168,8 +1165,6 @@ public class InternalEngine extends Engine {
         return indexWriter.getConfig();
     }
 
-
-
     private final class EngineMergeScheduler extends ElasticsearchConcurrentMergeScheduler {
         private final AtomicInteger numMergesInFlight = new AtomicInteger(0);
         private final AtomicBoolean isThrottling = new AtomicBoolean();
@@ -1245,11 +1240,10 @@ public class InternalEngine extends Engine {
 
     public void onSettingsChanged() {
         mergeScheduler.refreshConfig();
+        updateIndexWriterSettings();
     }
 
     public MergeStats getMergeStats() {
         return mergeScheduler.stats();
     }
-
-
 }

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1241,6 +1241,10 @@ public class InternalEngine extends Engine {
     public void onSettingsChanged() {
         mergeScheduler.refreshConfig();
         updateIndexWriterSettings();
+        // config().getVersionMapSize() may have changed:
+        checkVersionMapRefresh();
+        // config().isEnableGcDeletes() or config.getGcDeletesInMillis() may have changed:
+        maybePruneDeletedTombstones();
     }
 
     public MergeStats getMergeStats() {

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -996,6 +996,9 @@ public class IndexShard extends AbstractIndexShardComponent {
 
         // update engine if it is already started.
         if (preValue.bytes() != shardIndexingBufferSize.bytes()) {
+            // so we push changes these changes down to IndexWriter:
+            engine.onSettingsChanged();
+
             if (shardIndexingBufferSize == EngineConfig.INACTIVE_SHARD_INDEXING_BUFFER) {
                 // it's inactive: make sure we do a refresh / full IW flush in this case, since the memory
                 // changes only after a "data" change has happened to the writer
@@ -1009,9 +1012,6 @@ public class IndexShard extends AbstractIndexShardComponent {
             } else {
                 logger.debug("updating index_buffer_size from [{}] to [{}]", preValue, shardIndexingBufferSize);
             }
-
-            // so we push changes these changes down to IndexWriter:
-            engine.onSettingsChanged();
         }
 
         engine.getTranslog().updateBuffer(shardTranslogBufferSize);

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -115,9 +115,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-/**
- *
- */
 public class IndexShard extends AbstractIndexShardComponent {
 
     private final ThreadPool threadPool;
@@ -985,16 +982,17 @@ public class IndexShard extends AbstractIndexShardComponent {
     }
 
     public void updateBufferSize(ByteSizeValue shardIndexingBufferSize, ByteSizeValue shardTranslogBufferSize) {
-        Engine engine = engineUnsafe();
-        if (engine == null) {
-            logger.debug("updateBufferSize: engine is closed; skipping");
-            return;
-        }
 
         final EngineConfig config = engineConfig;
         final ByteSizeValue preValue = config.getIndexingBufferSize();
 
         config.setIndexingBufferSize(shardIndexingBufferSize);
+
+        Engine engine = engineUnsafe();
+        if (engine == null) {
+            logger.debug("updateBufferSize: engine is closed; skipping");
+            return;
+        }
 
         // update engine if it is already started.
         if (preValue.bytes() != shardIndexingBufferSize.bytes()) {
@@ -1278,6 +1276,8 @@ public class IndexShard extends AbstractIndexShardComponent {
         return engine;
     }
 
+    /** NOTE: returns null if engine is not yet started (e.g. recovery phase 1, copying over index files, is still running), or if engine is
+     *  closed. */
     protected Engine engineUnsafe() {
         return this.currentEngineReference.get();
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1137,8 +1137,6 @@ public class IndexShard extends AbstractIndexShardComponent {
             indexingService.onRefreshSettings(settings);
             if (change) {
                 engine().onSettingsChanged();
-                // TODO: why force a refresh here...?
-                refresh("apply settings");
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
+++ b/core/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
@@ -207,10 +207,10 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
                     indexShard.markAsInactive();
                 } catch (EngineClosedException e) {
                     // ignore
-                    logger.debug("ignore EngineClosedException while marking shard [{}][{}] as inactive", indexShard.shardId().index().name(), indexShard.shardId().id());
+                    logger.trace("ignore EngineClosedException while marking shard [{}][{}] as inactive", indexShard.shardId().index().name(), indexShard.shardId().id());
                 } catch (FlushNotAllowedEngineException e) {
                     // ignore
-                    logger.debug("ignore FlushNotAllowedException while marking shard [{}][{}] as inactive", indexShard.shardId().index().name(), indexShard.shardId().id());
+                    logger.trace("ignore FlushNotAllowedException while marking shard [{}][{}] as inactive", indexShard.shardId().index().name(), indexShard.shardId().id());
                 }
             }
 

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -315,6 +315,7 @@ public class InternalEngineTests extends ESTestCase {
             assertThat(segments.get(0).isCompound(), equalTo(defaultCompound));
 
             engine.config().setCompoundOnFlush(false);
+            engine.onSettingsChanged();
 
             ParsedDocument doc3 = testParsedDocument("3", "3", "test", null, -1, -1, testDocumentWithTextField(), B_3, null);
             engine.create(new Engine.Create(newUid("3"), doc3));
@@ -363,6 +364,7 @@ public class InternalEngineTests extends ESTestCase {
             assertThat(segments.get(1).isCompound(), equalTo(false));
 
             engine.config().setCompoundOnFlush(true);
+            engine.onSettingsChanged();
             ParsedDocument doc4 = testParsedDocument("4", "4", "test", null, -1, -1, testDocumentWithTextField(), B_3, null);
             engine.create(new Engine.Create(newUid("4"), doc4));
             engine.refresh("test");

--- a/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
@@ -338,6 +338,7 @@ public class ShadowEngineTests extends ESTestCase {
 
 
         primaryEngine.config().setCompoundOnFlush(false);
+        primaryEngine.onSettingsChanged();
 
         ParsedDocument doc3 = testParsedDocument("3", "3", "test", null, -1, -1, testDocumentWithTextField(), B_3, null);
         primaryEngine.create(new Engine.Create(newUid("3"), doc3));
@@ -410,6 +411,8 @@ public class ShadowEngineTests extends ESTestCase {
         replicaEngine.refresh("test");
 
         primaryEngine.config().setCompoundOnFlush(true);
+        primaryEngine.onSettingsChanged();
+
         ParsedDocument doc4 = testParsedDocument("4", "4", "test", null, -1, -1, testDocumentWithTextField(), B_3, null);
         primaryEngine.create(new Engine.Create(newUid("4"), doc4));
         primaryEngine.refresh("test");

--- a/core/src/test/java/org/elasticsearch/indices/memory/IndexingMemoryControllerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/memory/IndexingMemoryControllerIT.java
@@ -147,6 +147,8 @@ public class IndexingMemoryControllerIT extends ESIntegTestCase {
     public void testIndexBufferNotPercent() throws InterruptedException {
         // #13487: Make sure you can specify non-percent sized index buffer and not hit NPE
         createNode(Settings.builder().put(IndexingMemoryController.INDEX_BUFFER_SIZE_SETTING, "32mb").build());
+        // ... and that it took:
+        assertEquals(32*1024*1024, internalCluster().getInstance(IndexingMemoryController.class).indexingBufferSize().bytes());
     }
 
     private void createNode(Settings settings) {

--- a/core/src/test/java/org/elasticsearch/indices/memory/IndexingMemoryControllerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/memory/IndexingMemoryControllerIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.SegmentsStats;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
@@ -109,6 +110,43 @@ public class IndexingMemoryControllerIT extends ESIntegTestCase {
                             shard1.engine().config().getIndexingBufferSize().bytes() + "]"
             );
         }
+
+        // Make sure we also pushed the tiny indexing buffer down to the underlying IndexWriter:
+        assertEquals(EngineConfig.INACTIVE_SHARD_INDEXING_BUFFER.bytes(), getIWBufferSize("test1"));
+    }
+
+    private long getIWBufferSize(String indexName) {
+        return client().admin().indices().prepareStats(indexName).get().getTotal().getSegments().getIndexWriterMaxMemoryInBytes();
+    }
+
+    @Test
+    public void testIndexBufferSizeTwoShards() throws InterruptedException {
+        createNode(Settings.builder().put("indices.memory.shard_inactive_time", "100000h",
+                                          IndexingMemoryController.INDEX_BUFFER_SIZE_SETTING, "32mb",
+                                          IndexShard.INDEX_REFRESH_INTERVAL, "-1").build());
+
+        // Create two active indices, sharing 32 MB indexing buffer:
+        prepareCreate("test3").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).get();
+        prepareCreate("test4").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).get();
+
+        ensureGreen();
+
+        index("test3", "type", "1", "f", 1);
+        index("test4", "type", "1", "f", 1);
+
+        // .. then make sure we really pushed the update (16 MB for each) down to the IndexWriter, even if refresh nor flush occurs:
+        if (awaitBusy(() -> getIWBufferSize("test3") == 16*1024*1024) == false) {
+            fail("failed to update shard indexing buffer size for test3 index to 16 MB; got: " + getIWBufferSize("test3"));
+        }
+        if (awaitBusy(() -> getIWBufferSize("test4") == 16*1024*1024) == false) {
+            fail("failed to update shard indexing buffer size for test4 index to 16 MB; got: " + getIWBufferSize("test4"));
+        }
+    }
+
+    @Test
+    public void testIndexBufferNotPercent() throws InterruptedException {
+        // #13487: Make sure you can specify non-percent sized index buffer and not hit NPE
+        createNode(Settings.builder().put(IndexingMemoryController.INDEX_BUFFER_SIZE_SETTING, "32mb").build());
     }
 
     private void createNode(Settings settings) {

--- a/core/src/test/java/org/elasticsearch/indices/memory/IndexingMemoryControllerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/memory/IndexingMemoryControllerIT.java
@@ -79,7 +79,7 @@ public class IndexingMemoryControllerIT extends ESIntegTestCase {
     @Test
     public void testIndexBufferSizeUpdateInactiveShard() throws InterruptedException {
 
-        createNode(Settings.builder().put("indices.memory.shard_inactive_time", "100ms").build());
+        createNode(Settings.builder().put(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING, "100ms").build());
 
         prepareCreate("test1").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1, IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0).get();
 
@@ -121,7 +121,7 @@ public class IndexingMemoryControllerIT extends ESIntegTestCase {
 
     @Test
     public void testIndexBufferSizeTwoShards() throws InterruptedException {
-        createNode(Settings.builder().put("indices.memory.shard_inactive_time", "100000h",
+        createNode(Settings.builder().put(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING, "100000h",
                                           IndexingMemoryController.INDEX_BUFFER_SIZE_SETTING, "32mb",
                                           IndexShard.INDEX_REFRESH_INTERVAL, "-1").build());
 
@@ -158,7 +158,7 @@ public class IndexingMemoryControllerIT extends ESIntegTestCase {
                         .put(EsExecutors.PROCESSORS, 1) // limit the number of threads created
                         .put("http.enabled", false)
                         .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true) // make sure we get what we set :)
-                        .put("indices.memory.interval", "100ms")
+                        .put(IndexingMemoryController.SHARD_INACTIVE_INTERVAL_TIME_SETTING, "100ms")
                         .put(settings)
         );
     }


### PR DESCRIPTION
I started by trying to explain the test failure in #13487, but failed so far, but then in the process found some other things to fix:
- The `IndexingMemoryController` sets indexing buffer sizes for each shard, but then doesn't always push those changes down to `IndexWriter`
- Instead, we push settings changes down to IW only during flush and refresh, but I think this just hides bugs, and for some configurations could be quite a while ... we should push changes immediately whenever settings are updated
- If you try to specify `indices.memory.index_buffer_size` in the node settings to a bytes (not %) value, you'll hit NPE on starting up the node
- Removed some dead code, added some missing units (time -> timeMS) in variable names
- We currently wait for all merges in a shard to finish before considering it inactive, but I think that's not necessary, i.e. we can safely drop the indexing buffer for an inactive shard while merges are still running.  Other shards can use that heap.

I think we should separately fix these (this PR) ... but I'll keep trying to explain the original test failure.

I did add some more `logger.debug` so maybe next failure reveals something.
