### PR TITLE
NewPathForShardTests is broken every which way from Sunday.

### DIFF
--- a/core/src/test/java/org/elasticsearch/common/io/PathUtilsForTesting.java
+++ b/core/src/test/java/org/elasticsearch/common/io/PathUtilsForTesting.java
@@ -30,7 +30,11 @@ public class PathUtilsForTesting {
     
     /** Sets a new default filesystem for testing */
     public static void setup() {
-        FileSystem mock = LuceneTestCase.getBaseTempDirForTestClass().getFileSystem();
+        installMock(LuceneTestCase.getBaseTempDirForTestClass().getFileSystem());
+    }
+    
+    /** Installs a mock filesystem for testing */
+    public static void installMock(FileSystem mock) {
         PathUtils.DEFAULT = mock;
     }
     


### PR DESCRIPTION
1. FileSystem wrapping code is broken, thats why you get providermismatch exception!
   Instead of fixing this, it SuppressesForbidden!!!!
2. Because it uses SuppressForbidden on the test, the whole thing is lenient, it uses java.io.File for example!
3. Of course it fails consistently on windows because it can't remove files, because it leaks file handles (locks)
   like a sieve since it does not close node environment. With correct wrapping this is always detected by e.g.
   our leak detection FS. Instead of fixing the leak, it assumesFalse(WINDOWS) !!!!!

I do not know how this snuck past me, but I need this fixed to remove setAccessible.
