### PR TITLE
Replace LoadingCache usage with a simple ConcurrentHashMap

### DIFF
--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -110,6 +110,8 @@ com.google.common.collect.ImmutableSortedMap
 com.google.common.base.Charsets
 com.google.common.base.Function
 com.google.common.collect.Collections2
+com.google.common.cache.LoadingCache
+com.google.common.cache.CacheLoader
 
 @defaultMessage Do not violate java's access system
 java.lang.reflect.AccessibleObject#setAccessible(boolean)


### PR DESCRIPTION
This commit replaces the usage of LoadedCache with a simple CHM and calls
to computeIfAbsent and adds LoadingCache and CacheLoader to forbidden APIs

Relates to #13224
