### PR TITLE
Replace and ban next batch of Guava classes

### DIFF
--- a/core/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
+++ b/core/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
@@ -18,8 +18,6 @@
  */
 package org.apache.lucene.queries;
 
-import com.google.common.primitives.Ints;
-
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReaderContext;
@@ -141,7 +139,7 @@ public abstract class BlendedTermQuery extends Query {
             }
             @Override
             protected int compare(int i, int j) {
-                return Ints.compare(contexts[tieBreak[j]].docFreq(), contexts[tieBreak[i]].docFreq());
+                return Integer.compare(contexts[tieBreak[j]].docFreq(), contexts[tieBreak[i]].docFreq());
             }
         }.sort(0, tieBreak.length);
         int prev = contexts[tieBreak[0]].docFreq();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequestBuilder.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.action.admin.cluster.repositories.get;
 
-import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.util.ArrayUtils;
 
 /**
  * Get repository request builder
@@ -60,7 +60,7 @@ public class GetRepositoriesRequestBuilder extends MasterNodeReadOperationReques
      * @return builder
      */
     public GetRepositoriesRequestBuilder addRepositories(String... repositories) {
-        request.repositories(ObjectArrays.concat(request.repositories(), repositories, String.class));
+        request.repositories(ArrayUtils.concat(request.repositories(), repositories));
         return this;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.get;
 
-import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.util.ArrayUtils;
 
 /**
  * Get snapshots request builder
@@ -81,7 +81,7 @@ public class GetSnapshotsRequestBuilder extends MasterNodeOperationRequestBuilde
      * @return this builder
      */
     public GetSnapshotsRequestBuilder addSnapshots(String... snapshots) {
-        request.snapshots(ObjectArrays.concat(request.snapshots(), snapshots, String.class));
+        request.snapshots(ArrayUtils.concat(request.snapshots(), snapshots));
         return this;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequestBuilder.java
@@ -19,10 +19,9 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
-import com.google.common.collect.ObjectArrays;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.util.ArrayUtils;
 
 /**
  * Snapshots status request builder
@@ -72,7 +71,7 @@ public class SnapshotsStatusRequestBuilder extends MasterNodeOperationRequestBui
      * @return this builder
      */
     public SnapshotsStatusRequestBuilder addSnapshots(String... snapshots) {
-        request.snapshots(ObjectArrays.concat(request.snapshots(), snapshots, String.class));
+        request.snapshots(ArrayUtils.concat(request.snapshots(), snapshots));
         return this;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/BaseAliasesRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/BaseAliasesRequestBuilder.java
@@ -19,13 +19,12 @@
 
 package org.elasticsearch.action.admin.indices.alias.get;
 
-import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.util.ArrayUtils;
 
 /**
  */
@@ -43,7 +42,7 @@ public abstract class BaseAliasesRequestBuilder<Response extends ActionResponse,
 
     @SuppressWarnings("unchecked")
     public Builder addAliases(String... aliases) {
-        request.aliases(ObjectArrays.concat(request.aliases(), aliases, String.class));
+        request.aliases(ArrayUtils.concat(request.aliases(), aliases));
         return (Builder) this;
     }
 
@@ -55,7 +54,7 @@ public abstract class BaseAliasesRequestBuilder<Response extends ActionResponse,
 
     @SuppressWarnings("unchecked")
     public Builder addIndices(String... indices) {
-        request.indices(ObjectArrays.concat(request.indices(), indices, String.class));
+        request.indices(ArrayUtils.concat(request.indices(), indices));
         return (Builder) this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -19,12 +19,11 @@
 
 package org.elasticsearch.action.admin.indices.get;
 
-import com.google.common.collect.ObjectArrays;
-
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.info.ClusterInfoRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.ArrayUtils;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -115,7 +114,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         if (this.features == DEFAULT_FEATURES) {
             return features(features);
         } else {
-            return features(ObjectArrays.concat(featuresAsEnums(), features, Feature.class));
+            return features(ArrayUtils.concat(features(), features, Feature.class));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequestBuilder.java
@@ -19,12 +19,10 @@
 
 package org.elasticsearch.action.admin.indices.mapping.get;
 
-import com.google.common.collect.ObjectArrays;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.util.ArrayUtils;
 
 /** A helper class to build {@link GetFieldMappingsRequest} objects */
 public class GetFieldMappingsRequestBuilder extends ActionRequestBuilder<GetFieldMappingsRequest, GetFieldMappingsResponse, GetFieldMappingsRequestBuilder> {
@@ -39,7 +37,7 @@ public class GetFieldMappingsRequestBuilder extends ActionRequestBuilder<GetFiel
     }
 
     public GetFieldMappingsRequestBuilder addIndices(String... indices) {
-        request.indices(ObjectArrays.concat(request.indices(), indices, String.class));
+        request.indices(ArrayUtils.concat(request.indices(), indices));
         return this;
     }
 
@@ -49,7 +47,7 @@ public class GetFieldMappingsRequestBuilder extends ActionRequestBuilder<GetFiel
     }
 
     public GetFieldMappingsRequestBuilder addTypes(String... types) {
-        request.types(ObjectArrays.concat(request.types(), types, String.class));
+        request.types(ArrayUtils.concat(request.types(), types));
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestBuilder.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.action.admin.indices.settings.get;
 
-import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.util.ArrayUtils;
 
 /**
  */
@@ -38,7 +38,7 @@ public class GetSettingsRequestBuilder extends MasterNodeReadOperationRequestBui
     }
 
     public GetSettingsRequestBuilder addIndices(String... indices) {
-        request.indices(ObjectArrays.concat(request.indices(), indices, String.class));
+        request.indices(ArrayUtils.concat(request.indices(), indices));
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/GetWarmersRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/get/GetWarmersRequestBuilder.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.action.admin.indices.warmer.get;
 
-import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.support.master.info.ClusterInfoRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.util.ArrayUtils;
 
 /**
  * Builder for {@link GetWarmersRequest}
@@ -40,7 +40,7 @@ public class GetWarmersRequestBuilder extends ClusterInfoRequestBuilder<GetWarme
     }
 
     public GetWarmersRequestBuilder addWarmers(String... warmers) {
-        request.warmers(ObjectArrays.concat(request.warmers(), warmers, String.class));
+        request.warmers(ArrayUtils.concat(request.warmers(), warmers));
         return this;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequestBuilder.java
@@ -18,14 +18,12 @@
  */
 package org.elasticsearch.action.support.master.info;
 
-import com.google.common.collect.ObjectArrays;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
-import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.util.ArrayUtils;
 
 /**
  */
@@ -44,7 +42,7 @@ public abstract class ClusterInfoRequestBuilder<Request extends ClusterInfoReque
 
     @SuppressWarnings("unchecked")
     public Builder addIndices(String... indices) {
-        request.indices(ObjectArrays.concat(request.indices(), indices, String.class));
+        request.indices(ArrayUtils.concat(request.indices(), indices));
         return (Builder) this;
     }
 
@@ -56,7 +54,7 @@ public abstract class ClusterInfoRequestBuilder<Request extends ClusterInfoReque
 
     @SuppressWarnings("unchecked")
     public Builder addTypes(String... types) {
-        request.types(ObjectArrays.concat(request.types(), types, String.class));
+        request.types(ArrayUtils.concat(request.types(), types));
         return (Builder) this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFilter.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFilter.java
@@ -54,7 +54,7 @@ public class TermVectorsFilter {
     private final Set<String> selectedFields;
     private AggregatedDfs dfs;
     private Map<Term, ScoreTerm> scoreTerms;
-    private AtomicLongMap<String> sizes;
+    private Map<String, Integer> sizes = new HashMap<>();
     private TFIDFSimilarity similarity;
 
     public TermVectorsFilter(Fields termVectorsByField, Fields topLevelFields, Set<String> selectedFields, @Nullable AggregatedDfs dfs) {
@@ -64,7 +64,6 @@ public class TermVectorsFilter {
 
         this.dfs = dfs;
         this.scoreTerms = new HashMap<>();
-        this.sizes = AtomicLongMap.create();
         this.similarity = new DefaultSimilarity();
     }
 
@@ -228,10 +227,12 @@ public class TermVectorsFilter {
 
             // retain the best terms for quick lookups
             ScoreTerm scoreTerm;
+            int count = 0;
             while ((scoreTerm = queue.pop()) != null) {
                 scoreTerms.put(new Term(scoreTerm.field, scoreTerm.word), scoreTerm);
-                sizes.incrementAndGet(scoreTerm.field);
+                count++;
             }
+            sizes.put(fieldName, count);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import com.google.common.collect.UnmodifiableIterator;
 import org.elasticsearch.common.collect.Tuple;
 
 import java.util.ArrayList;
@@ -106,7 +105,7 @@ public interface AliasOrIndex {
             return new Iterable<Tuple<String, AliasMetaData>>() {
                 @Override
                 public Iterator<Tuple<String, AliasMetaData>> iterator() {
-                    return new UnmodifiableIterator<Tuple<String,AliasMetaData>>() {
+                    return new Iterator<Tuple<String,AliasMetaData>>() {
 
                         int index = 0;
 
@@ -119,6 +118,11 @@ public interface AliasOrIndex {
                         public Tuple<String, AliasMetaData> next() {
                             IndexMetaData indexMetaData = referenceIndexMetaDatas.get(index++);
                             return new Tuple<>(indexMetaData.getIndex(), indexMetaData.getAliases().get(aliasName));
+                        }
+
+                        @Override
+                        public final void remove() {
+                            throw new UnsupportedOperationException();
                         }
 
                     };

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -23,7 +23,6 @@ import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.UnmodifiableIterator;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.Diffable;
@@ -60,18 +59,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.warmer.IndexWarmersMetaData;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
@@ -569,7 +557,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
     }
 
     @Override
-    public UnmodifiableIterator<IndexMetaData> iterator() {
+    public Iterator<IndexMetaData> iterator() {
         return indices.valuesIt();
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cluster.node;
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import com.google.common.collect.UnmodifiableIterator;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.common.Booleans;
@@ -34,11 +33,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.transport.TransportAddress;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * This class holds all {@link DiscoveryNode} in the cluster and provides convenience methods to
@@ -69,7 +64,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     }
 
     @Override
-    public UnmodifiableIterator<DiscoveryNode> iterator() {
+    public Iterator<DiscoveryNode> iterator() {
         return nodes.valuesIt();
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cluster.routing;
 import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.cursors.IntCursor;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
-import com.google.common.collect.UnmodifiableIterator;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -33,12 +32,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -163,7 +157,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
     }
 
     @Override
-    public UnmodifiableIterator<IndexShardRoutingTable> iterator() {
+    public Iterator<IndexShardRoutingTable> iterator() {
         return shards.valuesIt();
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -21,7 +21,6 @@ package org.elasticsearch.cluster.routing;
 
 import com.carrotsearch.hppc.IntSet;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.UnmodifiableIterator;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.Diffable;
 import org.elasticsearch.cluster.DiffableUtils;
@@ -68,7 +67,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
     }
 
     @Override
-    public UnmodifiableIterator<IndexRoutingTable> iterator() {
+    public Iterator<IndexRoutingTable> iterator() {
         return indicesRouting.values().iterator();
     }
 

--- a/core/src/main/java/org/elasticsearch/common/cli/CliToolConfig.java
+++ b/core/src/main/java/org/elasticsearch/common/cli/CliToolConfig.java
@@ -19,13 +19,14 @@
 
 package org.elasticsearch.common.cli;
 
-import com.google.common.collect.ImmutableMap;
-import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  *
@@ -38,18 +39,18 @@ public class CliToolConfig {
 
     private final Class<? extends CliTool> toolType;
     private final String name;
-    private final ImmutableMap<String, Cmd> cmds;
+    private final Map<String, Cmd> cmds;
 
     private static final HelpPrinter helpPrinter = new HelpPrinter();
 
     private CliToolConfig(String name, Class<? extends CliTool> toolType, Cmd[] cmds) {
         this.name = name;
         this.toolType = toolType;
-        ImmutableMap.Builder<String, Cmd> cmdsBuilder = ImmutableMap.builder();
+        final Map<String, Cmd> cmdsMapping = new HashMap<>();
         for (int i = 0; i < cmds.length; i++) {
-            cmdsBuilder.put(cmds[i].name, cmds[i]);
+            cmdsMapping.put(cmds[i].name, cmds[i]);
         }
-        this.cmds = cmdsBuilder.build();
+        this.cmds = Collections.unmodifiableMap(cmdsMapping);
     }
 
     public boolean isSingle() {

--- a/core/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashMap.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/CopyOnWriteHashMap.java
@@ -18,8 +18,6 @@
  */
 
 package org.elasticsearch.common.collect;
-
-import com.google.common.collect.UnmodifiableIterator;
 import org.apache.lucene.util.mutable.MutableValueInt;
 
 import java.lang.reflect.Array;
@@ -420,7 +418,7 @@ public final class CopyOnWriteHashMap<K, V> extends AbstractMap<K, V> {
 
     }
 
-    private static class EntryIterator<K, V> extends UnmodifiableIterator<Map.Entry<K, V>> {
+    private static class EntryIterator<K, V> implements Iterator<Map.Entry<K, V>> {
 
         private final Deque<Map.Entry<K, V>> entries;
         private final Deque<Node<K, V>> nodes;
@@ -446,6 +444,11 @@ public final class CopyOnWriteHashMap<K, V> extends AbstractMap<K, V> {
                 nextNode.visit(entries, nodes);
             }
             return entries.pop();
+        }
+
+        @Override
+        public final void remove() {
+            throw new UnsupportedOperationException();
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/ImmutableOpenIntMap.java
@@ -26,7 +26,6 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.predicates.IntObjectPredicate;
 import com.carrotsearch.hppc.predicates.IntPredicate;
 import com.carrotsearch.hppc.procedures.IntObjectProcedure;
-import com.google.common.collect.UnmodifiableIterator;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -113,9 +112,9 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
     /**
      * Returns a direct iterator over the keys.
      */
-    public UnmodifiableIterator<Integer> keysIt() {
+    public Iterator<Integer> keysIt() {
         final Iterator<IntCursor> iterator = map.keys().iterator();
-        return new UnmodifiableIterator<Integer>() {
+        return new Iterator<Integer>() {
             @Override
             public boolean hasNext() {
                 return iterator.hasNext();
@@ -124,6 +123,11 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
             @Override
             public Integer next() {
                 return iterator.next().value;
+            }
+
+            @Override
+            public final void remove() {
+                throw new UnsupportedOperationException();
             }
         };
     }
@@ -138,9 +142,9 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
     /**
      * Returns a direct iterator over the keys.
      */
-    public UnmodifiableIterator<VType> valuesIt() {
+    public Iterator<VType> valuesIt() {
         final Iterator<ObjectCursor<VType>> iterator = map.values().iterator();
-        return new UnmodifiableIterator<VType>() {
+        return new Iterator<VType>() {
             @Override
             public boolean hasNext() {
                 return iterator.hasNext();
@@ -149,6 +153,11 @@ public final class ImmutableOpenIntMap<VType> implements Iterable<IntObjectCurso
             @Override
             public VType next() {
                 return iterator.next().value;
+            }
+
+            @Override
+            public final void remove() {
+                throw new UnsupportedOperationException();
             }
         };
     }

--- a/core/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -25,7 +25,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.carrotsearch.hppc.predicates.ObjectObjectPredicate;
 import com.carrotsearch.hppc.predicates.ObjectPredicate;
 import com.carrotsearch.hppc.procedures.ObjectObjectProcedure;
-import com.google.common.collect.UnmodifiableIterator;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -120,17 +119,20 @@ public final class ImmutableOpenMap<KType, VType> implements Iterable<ObjectObje
     /**
      * Returns a direct iterator over the keys.
      */
-    public UnmodifiableIterator<KType> keysIt() {
+    public Iterator<KType> keysIt() {
         final Iterator<ObjectCursor<KType>> iterator = map.keys().iterator();
-        return new UnmodifiableIterator<KType>() {
+        return new Iterator<KType>() {
             @Override
-            public boolean hasNext() {
-                return iterator.hasNext();
-            }
+            public boolean hasNext() { return iterator.hasNext(); }
 
             @Override
             public KType next() {
                 return iterator.next().value;
+            }
+
+            @Override
+            public final void remove() {
+                throw new UnsupportedOperationException();
             }
         };
     }
@@ -145,17 +147,20 @@ public final class ImmutableOpenMap<KType, VType> implements Iterable<ObjectObje
     /**
      * Returns a direct iterator over the keys.
      */
-    public UnmodifiableIterator<VType> valuesIt() {
+    public Iterator<VType> valuesIt() {
         final Iterator<ObjectCursor<VType>> iterator = map.values().iterator();
-        return new UnmodifiableIterator<VType>() {
+        return new Iterator<VType>() {
             @Override
-            public boolean hasNext() {
-                return iterator.hasNext();
-            }
+            public boolean hasNext() { return iterator.hasNext(); }
 
             @Override
             public VType next() {
                 return iterator.next().value;
+            }
+
+            @Override
+            public final void remove() {
+                throw new UnsupportedOperationException();
             }
         };
     }

--- a/core/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
@@ -19,19 +19,11 @@
 
 package org.elasticsearch.common.lucene;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
-
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.LeafReader.CoreClosedListener;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardUtils;
 
-import java.io.IOException;
-import java.util.IdentityHashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * A map between segment core cache keys and the shard that these segments
@@ -47,16 +39,16 @@ import java.util.Set;
 public final class ShardCoreKeyMap {
 
     private final Map<Object, ShardId> coreKeyToShard;
-    private final Multimap<String, Object> indexToCoreKey;
+    private final Map<String, Set<Object>> indexToCoreKey;
 
     public ShardCoreKeyMap() {
         coreKeyToShard = new IdentityHashMap<>();
-        indexToCoreKey = HashMultimap.create();
+        indexToCoreKey = new HashMap<>();
     }
 
     /**
      * Register a {@link LeafReader}. This is necessary so that the core cache
-     * key of this reader can be found later using {@link #getCoreCacheKeys(ShardId)}.
+     * key of this reader can be found later using {@link #getCoreKeysForIndex(String)}.
      */
     public void add(LeafReader reader) {
         final ShardId shardId = ShardUtils.extractShardId(reader);
@@ -67,15 +59,22 @@ public final class ShardCoreKeyMap {
         final String index = shardId.getIndex();
         synchronized (this) {
             if (coreKeyToShard.put(coreKey, shardId) == null) {
-                final boolean added = indexToCoreKey.put(index, coreKey);
+                Set<Object> objects = indexToCoreKey.get(index);
+                if (objects == null) {
+                    objects = new HashSet<>();
+                    indexToCoreKey.put(index, objects);
+                }
+                final boolean added = objects.add(coreKey);
                 assert added;
-                reader.addCoreClosedListener(new CoreClosedListener() {
-                    @Override
-                    public void onClose(Object ownerCoreCacheKey) throws IOException {
-                        assert coreKey == ownerCoreCacheKey;
-                        synchronized (ShardCoreKeyMap.this) {
-                            coreKeyToShard.remove(ownerCoreCacheKey);
-                            indexToCoreKey.remove(index, coreKey);
+                reader.addCoreClosedListener(ownerCoreCacheKey -> {
+                    assert coreKey == ownerCoreCacheKey;
+                    synchronized (ShardCoreKeyMap.this) {
+                        coreKeyToShard.remove(ownerCoreCacheKey);
+                        final Set<Object> coreKeys = indexToCoreKey.get(index);
+                        final boolean removed = coreKeys.remove(coreKey);
+                        assert removed;
+                        if (coreKeys.isEmpty()) {
+                            indexToCoreKey.remove(index);
                         }
                     }
                 });
@@ -95,15 +94,35 @@ public final class ShardCoreKeyMap {
      * Get the set of core cache keys associated with the given index.
      */
     public synchronized Set<Object> getCoreKeysForIndex(String index) {
-        return ImmutableSet.copyOf(indexToCoreKey.get(index));
+        final Set<Object> objects = indexToCoreKey.get(index);
+        if (objects == null) {
+            return Collections.emptySet();
+        }
+        // we have to copy otherwise we risk ConcurrentModificationException
+        return Collections.unmodifiableSet(new HashSet<>(objects));
     }
 
     /**
      * Return the number of tracked segments.
      */
     public synchronized int size() {
-        assert indexToCoreKey.size() == coreKeyToShard.size();
+        assert assertSize();
         return coreKeyToShard.size();
+    }
+
+    private synchronized boolean assertSize() {
+        // this is heavy and should only used in assertions
+        boolean assertionsEnabled = false;
+        assert assertionsEnabled = true;
+        if (assertionsEnabled == false) {
+            throw new AssertionError("only run this if assertions are enabled");
+        }
+        Collection<Set<Object>> values = indexToCoreKey.values();
+        int size = 0;
+        for (Set<Object> value : values) {
+            size += value.size();
+        }
+        return size == coreKeyToShard.size();
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/util/ArrayUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/util/ArrayUtils.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.util;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 
 /**
@@ -69,4 +70,22 @@ public class ArrayUtils {
         }
         return index;
     }
+
+    /**
+     * Concatenates 2 arrays
+     */
+    public static String[] concat(String[] one, String[] other) {
+        return concat(one, other, String.class);
+    }
+
+    /**
+     * Concatenates 2 arrays
+     */
+    public static <T> T[] concat(T[] one, T[] other, Class<T> clazz) {
+        T[] target = (T[]) Array.newInstance(clazz, one.length + other.length);
+        System.arraycopy(one, 0, target, 0, one.length);
+        System.arraycopy(other, 0, target, one.length, other.length);
+        return target;
+    }
+
 }

--- a/core/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
+++ b/core/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common.util;
 
 
-import com.google.common.collect.UnmodifiableIterator;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lease.Releasables;
 
@@ -125,7 +124,7 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
 
     @Override
     public Iterator<Cursor<T>> iterator() {
-        return new UnmodifiableIterator<Cursor<T>>() {
+        return new Iterator<Cursor<T>>() {
 
             boolean cached;
             final Cursor<T> cursor;
@@ -160,6 +159,11 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
                 }
                 cached = false;
                 return cursor;
+            }
+
+            @Override
+            public final void remove() {
+                throw new UnsupportedOperationException();
             }
 
         };

--- a/core/src/main/java/org/elasticsearch/http/HttpServer.java
+++ b/core/src/main/java/org/elasticsearch/http/HttpServer.java
@@ -20,16 +20,17 @@
 package org.elasticsearch.http;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
 
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.service.NodeService;
 import org.elasticsearch.rest.*;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.*;
@@ -141,8 +142,9 @@ public class HttpServer extends AbstractLifecycleComponent<HttpServer> {
         if (request.method() == RestRequest.Method.GET) {
             try {
                 try (InputStream stream = getClass().getResourceAsStream("/config/favicon.ico")) {
-                    byte[] content = ByteStreams.toByteArray(stream);
-                    BytesRestResponse restResponse = new BytesRestResponse(RestStatus.OK, "image/x-icon", content);
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    Streams.copy(stream, out);
+                    BytesRestResponse restResponse = new BytesRestResponse(RestStatus.OK, "image/x-icon", out.toByteArray());
                     channel.sendResponse(restResponse);
                 }
             } catch (IOException e) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapper.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.mapper.internal;
 
-import com.google.common.collect.UnmodifiableIterator;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -240,7 +239,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         return new Iterable<String>() {
             @Override
             public Iterator<String> iterator() {
-                return new UnmodifiableIterator<String>() {
+                return new Iterator<String>() {
 
                     int endIndex = nextEndIndex(0);
 
@@ -261,6 +260,11 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
                         final String result = fullPath.substring(0, endIndex);
                         endIndex = nextEndIndex(endIndex + 1);
                         return result;
+                    }
+
+                    @Override
+                    public final void remove() {
+                        throw new UnsupportedOperationException();
                     }
 
                 };

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
@@ -20,14 +20,12 @@
 
 package org.elasticsearch.index.query.functionscore.random;
 
-import com.google.common.primitives.Longs;
 
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.function.RandomScoreFunction;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParsingException;
@@ -66,7 +64,7 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
                         if (parser.numberType() == XContentParser.NumberType.INT) {
                             seed = parser.intValue();
                         } else if (parser.numberType() == XContentParser.NumberType.LONG) {
-                            seed = Longs.hashCode(parser.longValue());
+                            seed = hash(parser.longValue());
                         } else {
                             throw new QueryParsingException(parseContext, "random_score seed must be an int, long or string, not '"
                                     + token.toString() + "'");
@@ -90,12 +88,16 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
         }
 
         if (seed == -1) {
-            seed = Longs.hashCode(parseContext.nowInMillis());
+            seed = hash(parseContext.nowInMillis());
         }
         final ShardId shardId = SearchContext.current().indexShard().shardId();
         final int salt = (shardId.index().name().hashCode() << 10) | shardId.id();
         final IndexFieldData<?> uidFieldData = SearchContext.current().fieldData().getForField(fieldType);
 
         return new RandomScoreFunction(seed, salt, uidFieldData);
+    }
+
+    private static final int hash(long value) {
+        return (int) (value ^ (value >>> 32));
     }
 }

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.repositories.blobstore;
 
-import com.google.common.io.ByteStreams;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
@@ -29,6 +28,7 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
@@ -93,7 +93,9 @@ public class ChecksumBlobStoreFormat<T extends ToXContent> extends BlobStoreForm
      */
     public T readBlob(BlobContainer blobContainer, String blobName) throws IOException {
         try (InputStream inputStream = blobContainer.readBlob(blobName)) {
-            byte[] bytes = ByteStreams.toByteArray(inputStream);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Streams.copy(inputStream, out);
+            final byte[] bytes = out.toByteArray();
             final String resourceDesc = "ChecksumBlobStoreFormat.readBlob(blob=\"" + blobName + "\")";
             try (ByteArrayIndexInput indexInput = new ByteArrayIndexInput(resourceDesc, bytes)) {
                 CodecUtil.checksumEntireFile(indexInput);

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/LegacyBlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/LegacyBlobStoreFormat.java
@@ -18,10 +18,10 @@
  */
 package org.elasticsearch.repositories.blobstore;
 
-import com.google.common.io.ByteStreams;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.blobstore.BlobContainer;
-import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.xcontent.FromXContentBuilder;
 import org.elasticsearch.common.xcontent.ToXContent;
 
@@ -53,7 +53,9 @@ public class LegacyBlobStoreFormat<T extends ToXContent> extends BlobStoreFormat
      */
     public T readBlob(BlobContainer blobContainer, String blobName) throws IOException {
         try (InputStream inputStream = blobContainer.readBlob(blobName)) {
-            return read(new BytesArray(ByteStreams.toByteArray(inputStream)));
+            BytesStreamOutput out = new BytesStreamOutput();
+            Streams.copy(inputStream, out);
+            return read(out.bytes());
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
@@ -33,7 +31,6 @@ import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,7 +164,7 @@ public abstract class InternalTerms<A extends InternalTerms, B extends InternalT
     @Override
     public InternalAggregation doReduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
 
-        Multimap<Object, InternalTerms.Bucket> buckets = ArrayListMultimap.create();
+        Map<Object, List<InternalTerms.Bucket>> buckets = new HashMap<>();
         long sumDocCountError = 0;
         long otherDocCount = 0;
         InternalTerms<A, B> referenceTerms = null;
@@ -208,14 +205,18 @@ public abstract class InternalTerms<A extends InternalTerms, B extends InternalT
             terms.docCountError = thisAggDocCountError;
             for (Bucket bucket : terms.buckets) {
                 bucket.docCountError = thisAggDocCountError;
-                buckets.put(bucket.getKey(), bucket);
+                List<Bucket> bucketList = buckets.get(bucket.getKey());
+                if (bucketList == null) {
+                    bucketList = new ArrayList<>();
+                    buckets.put(bucket.getKey(), bucketList);
+                }
+                bucketList.add(bucket);
             }
         }
 
         final int size = Math.min(requiredSize, buckets.size());
         BucketPriorityQueue ordered = new BucketPriorityQueue(size, order.comparator(null));
-        for (Collection<Bucket> l : buckets.asMap().values()) {
-            List<Bucket> sameTermBuckets = (List<Bucket>) l; // cast is ok according to javadocs
+        for (List<Bucket> sameTermBuckets : buckets.values()) {
             final Bucket b = sameTermBuckets.get(0).reduce(sameTermBuckets, reduceContext);
             if (b.docCountError != -1) {
                 if (sumDocCountError == -1) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentileRanks.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentileRanks.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.percentiles.hdr;
 
-import com.google.common.collect.UnmodifiableIterator;
-
 import org.HdrHistogram.DoubleHistogram;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
@@ -106,7 +104,7 @@ public class InternalHDRPercentileRanks extends AbstractInternalHDRPercentiles i
         return percentileRank;
     }
 
-    public static class Iter extends UnmodifiableIterator<Percentile> {
+    public static class Iter implements Iterator<Percentile> {
 
         private final double[] values;
         private final DoubleHistogram state;
@@ -128,6 +126,11 @@ public class InternalHDRPercentileRanks extends AbstractInternalHDRPercentiles i
             final Percentile next = new InternalPercentile(percentileRank(state, values[i]), values[i]);
             ++i;
             return next;
+        }
+
+        @Override
+        public final void remove() {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentiles.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.percentiles.hdr;
 
-import com.google.common.collect.UnmodifiableIterator;
-
 import org.HdrHistogram.DoubleHistogram;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
@@ -96,7 +94,7 @@ public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles imple
         return TYPE;
     }
 
-    public static class Iter extends UnmodifiableIterator<Percentile> {
+    public static class Iter implements Iterator<Percentile> {
 
         private final double[] percents;
         private final DoubleHistogram state;
@@ -118,6 +116,11 @@ public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles imple
             final Percentile next = new InternalPercentile(percents[i], state.getValueAtPercentile(percents[i]));
             ++i;
             return next;
+        }
+
+        @Override
+        public final void remove() {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/InternalTDigestPercentileRanks.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/InternalTDigestPercentileRanks.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.percentiles.tdigest;
 
-import com.google.common.collect.UnmodifiableIterator;
-
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.metrics.percentiles.InternalPercentile;
@@ -102,7 +100,7 @@ public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPerce
         return percentileRank * 100;
     }
 
-    public static class Iter extends UnmodifiableIterator<Percentile> {
+    public static class Iter implements Iterator<Percentile> {
 
         private final double[] values;
         private final TDigestState state;
@@ -124,6 +122,11 @@ public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPerce
             final Percentile next = new InternalPercentile(percentileRank(state, values[i]), values[i]);
             ++i;
             return next;
+        }
+
+        @Override
+        public final void remove() {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/InternalTDigestPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/InternalTDigestPercentiles.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics.percentiles.tdigest;
 
-import com.google.common.collect.UnmodifiableIterator;
-
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.AggregationStreams;
 import org.elasticsearch.search.aggregations.metrics.percentiles.InternalPercentile;
@@ -92,7 +90,7 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
         return TYPE;
     }
 
-    public static class Iter extends UnmodifiableIterator<Percentile> {
+    public static class Iter implements Iterator<Percentile> {
 
         private final double[] percents;
         private final TDigestState state;
@@ -114,6 +112,11 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
             final Percentile next = new InternalPercentile(percents[i], state.quantile(percents[i] / 100));
             ++i;
             return next;
+        }
+
+        @Override
+        public final void remove() {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/percentile/InternalPercentilesBucket.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/percentile/InternalPercentilesBucket.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.percentile;
 
-import com.google.common.collect.UnmodifiableIterator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -136,7 +135,7 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
         return builder;
     }
 
-    public static class Iter extends UnmodifiableIterator<Percentile> {
+    public static class Iter implements Iterator<Percentile> {
 
         private final double[] percents;
         private final double[] percentiles;
@@ -158,6 +157,11 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
             final Percentile next = new InternalPercentile(percents[i], percentiles[i]);
             ++i;
             return next;
+        }
+
+        @Override
+        public final void remove() {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/util/ArrayUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/ArrayUtilsTests.java
@@ -19,9 +19,12 @@
 
 package org.elasticsearch.common.util;
 
+import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 
@@ -88,6 +91,24 @@ public class ArrayUtilsTests extends ESTestCase {
     private int randomInt(int min, int max) {
         int delta = (int) (Math.random() * (max - min));
         return min + delta;
+    }
+
+    public void testConcat() {
+        assertArrayEquals(new String[]{"a", "b", "c", "d"}, ArrayUtils.concat(new String[]{"a", "b"}, new String[]{"c", "d"}));
+        int firstSize = randomIntBetween(0, 10);
+        String[] first = new String[firstSize];
+        ArrayList<String> sourceOfTruth = new ArrayList<>();
+        for (int i = 0; i < firstSize; i++) {
+            first[i] = randomRealisticUnicodeOfCodepointLengthBetween(0,10);
+            sourceOfTruth.add(first[i]);
+        }
+        int secondSize = randomIntBetween(0, 10);
+        String[] second = new String[secondSize];
+        for (int i = 0; i < secondSize; i++) {
+            second[i] = randomRealisticUnicodeOfCodepointLengthBetween(0, 10);
+            sourceOfTruth.add(second[i]);
+        }
+        assertArrayEquals(sourceOfTruth.toArray(new String[0]), ArrayUtils.concat(first, second));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.plugins;
 
-import com.google.common.io.Files;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.http.client.HttpDownloadHelper;
@@ -63,10 +62,9 @@ public class PluginManagerUnitTests extends ESTestCase {
         Environment environment = new Environment(settings);
 
         PluginManager.PluginHandle pluginHandle = new PluginManager.PluginHandle(pluginName, "version", "user");
-        String configDirPath = Files.simplifyPath(pluginHandle.configDir(environment).normalize().toString());
-        String expectedDirPath = Files.simplifyPath(genericConfigFolder.resolve(pluginName).normalize().toString());
-
-        assertThat(configDirPath, is(expectedDirPath));
+        Path configDirPath = pluginHandle.configDir(environment).normalize();
+        Path expectedDirPath = genericConfigFolder.resolve(pluginName).normalize();
+        assertEquals(configDirPath, expectedDirPath);
     }
 
     @Test

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -111,6 +111,14 @@ com.google.common.collect.Collections2
 com.google.common.cache.LoadingCache
 com.google.common.cache.CacheLoader
 com.google.common.collect.Iterables
+com.google.common.util.concurrent.UncheckedExecutionException
+com.google.common.util.concurrent.AtomicLongMap
+com.google.common.primitives.Longs
+com.google.common.io.ByteStreams
+com.google.common.collect.UnmodifiableIterator
+com.google.common.collect.ObjectArrays
+com.google.common.collect.Multimap
+com.google.common.collect.MultimapBuilder
 
 @defaultMessage Do not violate java's access system
 java.lang.reflect.AccessibleObject#setAccessible(boolean)


### PR DESCRIPTION
This commit replaces and bans:
- com.google.common.util.concurrent.UncheckedExecutionException
- com.google.common.util.concurrent.AtomicLongMap
- com.google.common.primitives.Longs
- com.google.common.io.ByteStreams
- com.google.common.collect.UnmodifiableIterator
- com.google.common.collect.ObjectArrays
- com.google.common.collect.Multimap
- com.google.common.collect.MultimapBuilder

Relates to #13224
