### PR TITLE
Remove and forbid use of com.google.common.base.Joiner

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.common.util.concurrent;
 
-import com.google.common.base.Joiner;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.Arrays;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -81,7 +82,12 @@ public class EsExecutors {
     }
 
     public static String threadName(Settings settings, String ... names) {
-        return threadName(settings, "[" +  Joiner.on(".").skipNulls().join(names) + "]");
+        String namePrefix =
+                Arrays
+                        .stream(names)
+                        .filter(name -> name != null)
+                        .collect(Collectors.joining(".", "[", "]"));
+        return threadName(settings, namePrefix);
     }
 
     public static String threadName(Settings settings, String namePrefix) {

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -19,14 +19,9 @@
 
 package org.elasticsearch.repositories;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateRequest;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -45,10 +40,8 @@ import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
 
@@ -571,9 +564,10 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
         }
 
         public String failureDescription() {
-            StringBuilder builder = new StringBuilder('[');
-            Joiner.on(", ").appendTo(builder, failures);
-            return builder.append(']').toString();
+            return Arrays
+                    .stream(failures)
+                    .map(failure -> failure.toString())
+                    .collect(Collectors.joining(", ", "[", "]"));
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/search/suggest/context/CategoryContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/context/CategoryContextMapping.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.suggest.context;
 
-import com.google.common.base.Joiner;
 import org.apache.lucene.analysis.PrefixAnalyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.index.IndexableField;
@@ -36,6 +35,8 @@ import org.elasticsearch.index.mapper.ParseContext.Document;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * The {@link CategoryContextMapping} is used to define a {@link ContextMapping} that
@@ -258,12 +259,16 @@ public class CategoryContextMapping extends ContextMapping {
         public String toString() {
             StringBuilder sb = new StringBuilder("FieldConfig(" + fieldname + " = [");
             if (this.values != null && this.values.iterator().hasNext()) {
-                sb.append("(").append(Joiner.on(", ").join(this.values.iterator())).append(")");
+                sb.append(delimitValues(this.values));
             }
             if (this.defaultValues != null && this.defaultValues.iterator().hasNext()) {
-                sb.append(" default(").append(Joiner.on(", ").join(this.defaultValues.iterator())).append(")");
+                sb.append(" default").append(delimitValues(this.defaultValues));
             }
             return sb.append("])").toString();
+        }
+
+        private String delimitValues(Iterable<? extends CharSequence> values) {
+            return StreamSupport.stream(values.spliterator(), false).collect(Collectors.joining(", ", "(", ")"));
         }
 
     }

--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -793,7 +793,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     private Settings.Builder getExcludeSettings(String index, int num, Settings.Builder builder) {
-        String exclude = Joiner.on(',').join(internalCluster().allDataNodesButN(num));
+        String exclude = String.join(",", internalCluster().allDataNodesButN(num));
         builder.put("index.routing.allocation.exclude._name", exclude);
         return builder;
     }

--- a/core/src/test/java/org/elasticsearch/test/rest/client/http/HttpRequestBuilder.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/client/http/HttpRequestBuilder.java
@@ -18,14 +18,7 @@
  */
 package org.elasticsearch.test.rest.client.http;
 
-import com.google.common.base.Joiner;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.*;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.elasticsearch.client.support.Headers;
@@ -44,6 +37,7 @@ import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Executable builder for an http request
@@ -194,7 +188,7 @@ public class HttpRequestBuilder {
             //(e.g. '+' will stay as is) hence when trying to properly encode params manually they will end up double encoded (+ becomes %252B instead of %2B).
             StringBuilder uriBuilder = new StringBuilder(protocol).append("://").append(host).append(":").append(port).append(uri.getRawPath());
             if (params.size() > 0) {
-                uriBuilder.append("?").append(Joiner.on('&').withKeyValueSeparator("=").join(params));
+                uriBuilder.append("?").append(params.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining("&")));
             }
             return URI.create(uriBuilder.toString());
         } catch(URISyntaxException e) {

--- a/core/src/test/java/org/elasticsearch/test/rest/section/ApiCallSection.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/section/ApiCallSection.java
@@ -18,14 +18,9 @@
  */
 package org.elasticsearch.test.rest.section;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represents a test fragment that contains the information needed to call an api
@@ -52,7 +47,7 @@ public class ApiCallSection {
     public void addParam(String key, String value) {
         String existingValue = params.get(key);
         if (existingValue != null) {
-            value = Joiner.on(",").join(existingValue, value);
+            value = existingValue + "," + value;
         }
         this.params.put(key, value);
     }

--- a/dev-tools/src/main/resources/forbidden/#all-signatures.txt#
+++ b/dev-tools/src/main/resources/forbidden/#all-signatures.txt#
@@ -111,6 +111,7 @@ com.google.common.collect.Collections2
 com.google.common.cache.LoadingCache
 com.google.common.cache.CacheLoader
 com.google.common.collect.Iterables
+<<<<<<< HEAD
 com.google.common.util.concurrent.UncheckedExecutionException
 com.google.common.util.concurrent.AtomicLongMap
 com.google.common.primitives.Longs
@@ -119,8 +120,9 @@ com.google.common.collect.UnmodifiableIterator
 com.google.common.collect.ObjectArrays
 com.google.common.collect.Multimap
 com.google.common.collect.MultimapBuilder
-com.google.common.math.LongMath
+=======
 com.google.common.base.Joiner
+>>>>>>> Remove and forbid use of com.google.common.base.Joiner
 
 @defaultMessage Do not violate java's access system
 java.lang.reflect.AccessibleObject#setAccessible(boolean)


### PR DESCRIPTION
This commit removes and now forbids all uses of
com.google.common.base.Joiner across the codebase. This is one of many
steps in the eventual removal of Guava as a dependency.

Relates #13224
