### PR TITLE
Enable SSL for Azure blob storage 

### DIFF
--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -57,14 +57,14 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
         // We try to load storage API settings from `cloud.azure.`
         account = settings.get(ACCOUNT);
         key = settings.get(KEY);
-        blob = "http://" + account + ".blob.core.windows.net/";
+        blob = "https://" + account + ".blob.core.windows.net/";
 
         try {
             if (account != null) {
                 logger.trace("creating new Azure storage client using account [{}], key [{}], blob [{}]", account, key, blob);
 
                 String storageConnectionString =
-                        "DefaultEndpointsProtocol=http;"
+                        "DefaultEndpointsProtocol=https;"
                                 + "AccountName="+ account +";"
                                 + "AccountKey=" + key;
 


### PR DESCRIPTION
In order to increase Security.

The Microsoft Azure storage services support both HTTP and HTTPS; however, using HTTPS is highly recommended.
