### PR TITLE
Fix blob size in writeBlob() method

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -150,12 +150,20 @@ public class BlobStoreIndexShardSnapshot implements ToXContent, FromXContentBuil
         }
 
         /**
-         * Return maximum number of bytes in a part
+         * Returns the size (in bytes) of a given part
          *
-         * @return maximum number of bytes in a part
+         * @return the size (in bytes) of a given part
          */
-        public long partBytes() {
-            return partBytes;
+        public long partBytes(int part) {
+            if (numberOfParts == 1) {
+                return length();
+            }
+            // First and last-but-one parts have a size equal to partBytes
+            if (part < (numberOfParts - 1)) {
+                return partBytes;
+            }
+            // Last part size is deducted from the length and the number of parts
+            return length() % partBytes;
         }
 
         /**

--- a/core/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -63,7 +63,7 @@ public class FileInfoTests extends ESTestCase {
             assertThat(info.physicalName(), equalTo(parsedInfo.physicalName()));
             assertThat(info.length(), equalTo(parsedInfo.length()));
             assertThat(info.checksum(), equalTo(parsedInfo.checksum()));
-            assertThat(info.partBytes(), equalTo(parsedInfo.partBytes()));
+            assertThat(info.partSize(), equalTo(parsedInfo.partSize()));
             assertThat(parsedInfo.metadata().hash().length, equalTo(hash.length));
             assertThat(parsedInfo.metadata().hash(), equalTo(hash));
             assertThat(parsedInfo.metadata().writtenBy(), equalTo(Version.LATEST));


### PR DESCRIPTION
It seems that #13434 computes a wrong blob size when writing snapshot files.

@imotov Can you please have a look?
