### PR TITLE
Prevent losing stacktraces when exceptions occur

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -291,7 +291,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     /**
      * Renders a cause exception as xcontent
      */
-    protected final void causeToXContent(XContentBuilder builder, Params params) throws IOException {
+    protected void causeToXContent(XContentBuilder builder, Params params) throws IOException {
         final Throwable cause = getCause();
         if (cause != null && params.paramAsBoolean(REST_EXCEPTION_SKIP_CAUSE, REST_EXCEPTION_SKIP_CAUSE_DEFAULT) == false) {
             builder.field("caused_by");

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
@@ -251,7 +251,7 @@ public class TransportMultiPercolateAction extends HandledTransportAction<MultiP
                     }
 
                     if (item.failed()) {
-                        shardResults.set(shardId.id(), new BroadcastShardOperationFailedException(shardId, item.error().string()));
+                        shardResults.set(shardId.id(), new BroadcastShardOperationFailedException(shardId, item.error()));
                     } else {
                         shardResults.set(shardId.id(), item.response());
                     }

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportShardMultiPercolateAction.java
@@ -103,7 +103,7 @@ public class TransportShardMultiPercolateAction extends TransportSingleShardActi
                     throw (ElasticsearchException) t;
                 } else {
                     logger.debug("{} failed to multi percolate", t, request.shardId());
-                    responseItem = new Response.Item(slot, new StringText(ExceptionsHelper.detailedMessage(t)));
+                    responseItem = new Response.Item(slot, t);
                 }
             }
             response.items.add(responseItem);
@@ -231,7 +231,7 @@ public class TransportShardMultiPercolateAction extends TransportSingleShardActi
                     item.response.writeTo(out);
                 } else {
                     out.writeBoolean(false);
-                    out.writeText(item.error);
+                    out.writeThrowable(item.error);
                 }
             }
         }
@@ -248,7 +248,7 @@ public class TransportShardMultiPercolateAction extends TransportSingleShardActi
                     shardResponse.readFrom(in);
                     items.add(new Item(slot, shardResponse));
                 } else {
-                    items.add(new Item(slot, in.readText()));
+                    items.add(new Item(slot, (Throwable)in.readThrowable()));
                 }
             }
         }
@@ -257,7 +257,7 @@ public class TransportShardMultiPercolateAction extends TransportSingleShardActi
 
             private final int slot;
             private final PercolateShardResponse response;
-            private final Text error;
+            private final Throwable error;
 
             public Item(Integer slot, PercolateShardResponse response) {
                 this.slot = slot;
@@ -265,7 +265,7 @@ public class TransportShardMultiPercolateAction extends TransportSingleShardActi
                 this.error = null;
             }
 
-            public Item(Integer slot, Text error) {
+            public Item(Integer slot, Throwable error) {
                 this.slot = slot;
                 this.error = error;
                 this.response = null;
@@ -279,7 +279,7 @@ public class TransportShardMultiPercolateAction extends TransportSingleShardActi
                 return response;
             }
 
-            public Text error() {
+            public Throwable error() {
                 return error;
             }
 

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TransportShardMultiTermsVectorAction.java
@@ -90,7 +90,7 @@ public class TransportShardMultiTermsVectorAction extends TransportSingleShardAc
                 } else {
                     logger.debug("{} failed to execute multi term vectors for [{}]/[{}]", t, shardId, termVectorsRequest.type(), termVectorsRequest.id());
                     response.add(request.locations.get(i),
-                            new MultiTermVectorsResponse.Failure(request.index(), termVectorsRequest.type(), termVectorsRequest.id(), ExceptionsHelper.detailedMessage(t)));
+                            new MultiTermVectorsResponse.Failure(request.index(), termVectorsRequest.type(), termVectorsRequest.id(), t));
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -28,9 +28,11 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.apache.lucene.util.Version;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -83,11 +85,12 @@ import java.util.zip.Checksum;
  */
 public class Store extends AbstractIndexShardComponent implements Closeable, RefCounted {
 
-    private static final String CODEC = "store";
-    private static final int VERSION_STACK_TRACE = 1; // we write the stack trace too since 1.4.0
-    private static final int VERSION_START = 0;
-    private static final int VERSION = VERSION_STACK_TRACE;
-    private static final String CORRUPTED = "corrupted_";
+    static final String CODEC = "store";
+    static final int VERSION_WRITE_THROWABLE= 2; // we write throwable since 2.0
+    static final int VERSION_STACK_TRACE = 1; // we write the stack trace too since 1.4.0
+    static final int VERSION_START = 0;
+    static final int VERSION = VERSION_WRITE_THROWABLE;
+    static final String CORRUPTED = "corrupted_";
     public static final String INDEX_STORE_STATS_REFRESH_INTERVAL = "index.store.stats_refresh_interval";
 
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
@@ -562,16 +565,31 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             if (file.startsWith(CORRUPTED)) {
                 try (ChecksumIndexInput input = directory.openChecksumInput(file, IOContext.READONCE)) {
                     int version = CodecUtil.checkHeader(input, CODEC, VERSION_START, VERSION);
-                    String msg = input.readString();
-                    StringBuilder builder = new StringBuilder(shardId.toString());
-                    builder.append(" Preexisting corrupted index [");
-                    builder.append(file).append("] caused by: ");
-                    builder.append(msg);
-                    if (version == VERSION_STACK_TRACE) {
-                        builder.append(System.lineSeparator());
-                        builder.append(input.readString());
+
+                    if (version == VERSION_WRITE_THROWABLE) {
+                        final int size = input.readVInt();
+                        final byte[] buffer = new byte[size];
+                        input.readBytes(buffer, 0, buffer.length);
+                        StreamInput in = StreamInput.wrap(buffer);
+                        Throwable t = in.readThrowable();
+                        if (t instanceof CorruptIndexException) {
+                            ex.add((CorruptIndexException) t);
+                        } else {
+                            ex.add(new CorruptIndexException(t.getMessage(), "preexisting_corruption", t));
+                        }
+                    } else {
+                        assert version == VERSION_START || version == VERSION_STACK_TRACE;
+                        String msg = input.readString();
+                        StringBuilder builder = new StringBuilder(shardId.toString());
+                        builder.append(" Preexisting corrupted index [");
+                        builder.append(file).append("] caused by: ");
+                        builder.append(msg);
+                        if (version == VERSION_STACK_TRACE) {
+                            builder.append(System.lineSeparator());
+                            builder.append(input.readString());
+                        }
+                        ex.add(new CorruptIndexException(builder.toString(), "preexisting_corruption"));
                     }
-                    ex.add(new CorruptIndexException(builder.toString(), "preexisting_corruption"));
                     CodecUtil.checkFooter(input);
                 }
             }
@@ -1446,8 +1464,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             String uuid = CORRUPTED + Strings.randomBase64UUID();
             try (IndexOutput output = this.directory().createOutput(uuid, IOContext.DEFAULT)) {
                 CodecUtil.writeHeader(output, CODEC, VERSION);
-                output.writeString(ExceptionsHelper.detailedMessage(exception, true, 0)); // handles null exception
-                output.writeString(ExceptionsHelper.stackTrace(exception));
+                BytesStreamOutput out = new BytesStreamOutput();
+                out.writeThrowable(exception);
+                BytesReference bytes = out.bytes();
+                output.writeVInt(bytes.length());
+                output.writeBytes(bytes.array(), bytes.arrayOffset(), bytes.length());
                 CodecUtil.writeFooter(output);
             } catch (IOException ex) {
                 logger.warn("Can't mark store as corrupted", ex);

--- a/core/src/main/java/org/elasticsearch/repositories/VerificationFailure.java
+++ b/core/src/main/java/org/elasticsearch/repositories/VerificationFailure.java
@@ -31,13 +31,13 @@ public class VerificationFailure implements Streamable {
 
     private String nodeId;
 
-    private String cause;
+    private Throwable cause;
 
     VerificationFailure() {
 
     }
 
-    public VerificationFailure(String nodeId, String cause) {
+    public VerificationFailure(String nodeId, Throwable cause) {
         this.nodeId = nodeId;
         this.cause = cause;
     }
@@ -46,20 +46,20 @@ public class VerificationFailure implements Streamable {
         return nodeId;
     }
 
-    public String cause() {
+    public Throwable cause() {
         return cause;
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         nodeId = in.readOptionalString();
-        cause = in.readOptionalString();
+        cause = in.readThrowable();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(nodeId);
-        out.writeOptionalString(cause);
+        out.writeThrowable(cause);
     }
 
     public static VerificationFailure readNode(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/core/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -86,7 +86,7 @@ public class VerifyNodeRepositoryAction  extends AbstractComponent {
                     doVerify(repository, verificationToken);
                 } catch (Throwable t) {
                     logger.warn("[{}] failed to verify repository", t, repository);
-                    errors.add(new VerificationFailure(node.id(), ExceptionsHelper.detailedMessage(t)));
+                    errors.add(new VerificationFailure(node.id(), t));
                 }
                 if (counter.decrementAndGet() == 0) {
                     finishVerification(listener, nodes, errors);
@@ -102,7 +102,7 @@ public class VerifyNodeRepositoryAction  extends AbstractComponent {
 
                     @Override
                     public void handleException(TransportException exp) {
-                        errors.add(new VerificationFailure(node.id(), ExceptionsHelper.detailedMessage(exp)));
+                        errors.add(new VerificationFailure(node.id(), exp));
                         if (counter.decrementAndGet() == 0) {
                             finishVerification(listener, nodes, errors);
                         }

--- a/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptCompilationException.java
+++ b/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptCompilationException.java
@@ -30,8 +30,8 @@ import java.io.IOException;
  * correctly serialized between nodes.
  */
 public class GroovyScriptCompilationException extends ElasticsearchException {
-    public GroovyScriptCompilationException(String message) {
-        super(message);
+    public GroovyScriptCompilationException(String message, Throwable cause) {
+        super(message, cause);
     }
 
     public GroovyScriptCompilationException(StreamInput in) throws IOException{

--- a/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -116,7 +116,7 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
             if (logger.isTraceEnabled()) {
                 logger.trace("exception compiling Groovy script:", e);
             }
-            throw new GroovyScriptCompilationException(ExceptionsHelper.detailedMessage(e));
+            throw new GroovyScriptCompilationException("failed to compile groovy script", e);
         }
     }
 
@@ -250,7 +250,7 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
                 if (logger.isTraceEnabled()) {
                     logger.trace("failed to run " + compiledScript, e);
                 }
-                throw new GroovyScriptExecutionException("failed to run " + compiledScript + ": " + ExceptionsHelper.detailedMessage(e));
+                throw new GroovyScriptExecutionException("failed to run " + compiledScript, e);
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptExecutionException.java
+++ b/core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptExecutionException.java
@@ -30,8 +30,9 @@ import java.io.IOException;
  * correctly serialized between nodes.
  */
 public class GroovyScriptExecutionException extends ElasticsearchException {
-    public GroovyScriptExecutionException(String message) {
-        super(message);
+
+    public GroovyScriptExecutionException(String message, Throwable cause) {
+        super(message, cause);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorIT.java
@@ -312,7 +312,7 @@ public class MultiPercolatorIT extends ESIntegTestCase {
             assertThat(item.getResponse().getShardFailures().length, equalTo(test.numPrimaries));
             for (ShardOperationFailedException shardFailure : item.getResponse().getShardFailures()) {
                 assertThat(shardFailure.reason(), containsString("Failed to derive xcontent"));
-                assertThat(shardFailure.status().getStatus(), equalTo(500));
+                assertThat(shardFailure.status().getStatus(), equalTo(400));
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.index.Index;
@@ -150,6 +151,8 @@ public class BytesRestResponseTests extends ESTestCase {
         String text = response.content().toUtf8();
         String expected = "{\"error\":{\"root_cause\":[{\"type\":\"test_query_parsing_exception\",\"reason\":\"foobar\",\"index\":\"foo\"}],\"type\":\"search_phase_execution_exception\",\"reason\":\"all shards failed\",\"phase\":\"search\",\"grouped\":true,\"failed_shards\":[{\"shard\":1,\"index\":\"foo\",\"node\":\"node_1\",\"reason\":{\"type\":\"test_query_parsing_exception\",\"reason\":\"foobar\",\"index\":\"foo\"}}]},\"status\":400}";
         assertEquals(expected.trim(), text.trim());
+        String stackTrace = ExceptionsHelper.stackTrace(ex);
+        assertTrue(stackTrace.contains("Caused by: [foo] TestQueryParsingException[foobar]"));
     }
 
     public static class WithHeadersException extends ElasticsearchException {

--- a/core/src/test/java/org/elasticsearch/routing/SimpleRoutingIT.java
+++ b/core/src/test/java/org/elasticsearch/routing/SimpleRoutingIT.java
@@ -449,12 +449,12 @@ public class SimpleRoutingIT extends ESIntegTestCase {
         assertThat(multiTermVectorsResponse.getResponses().length, equalTo(2));
         assertThat(multiTermVectorsResponse.getResponses()[0].getId(), equalTo("1"));
         assertThat(multiTermVectorsResponse.getResponses()[0].isFailed(), equalTo(true));
-        assertThat(multiTermVectorsResponse.getResponses()[0].getFailure().getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
+        assertThat(multiTermVectorsResponse.getResponses()[0].getFailure().getCause().getMessage(), equalTo("routing is required for [test]/[type1]/[1]"));
         assertThat(multiTermVectorsResponse.getResponses()[0].getResponse(), nullValue());
         assertThat(multiTermVectorsResponse.getResponses()[1].getId(), equalTo("2"));
         assertThat(multiTermVectorsResponse.getResponses()[1].isFailed(), equalTo(true));
         assertThat(multiTermVectorsResponse.getResponses()[1].getResponse(),nullValue());
-        assertThat(multiTermVectorsResponse.getResponses()[1].getFailure().getMessage(), equalTo("routing is required for [test]/[type1]/[2]"));
+        assertThat(multiTermVectorsResponse.getResponses()[1].getFailure().getCause().getMessage(), equalTo("routing is required for [test]/[type1]/[2]"));
     }
 
     private static String indexOrAlias() {

--- a/core/src/test/java/org/elasticsearch/script/GroovySecurityIT.java
+++ b/core/src/test/java/org/elasticsearch/script/GroovySecurityIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.groovy.GroovyScriptExecutionException;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -32,6 +33,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 /**
  * Tests for the Groovy security permissions
@@ -126,9 +128,10 @@ public class GroovySecurityIT extends ESIntegTestCase {
         // TODO: GroovyScriptExecutionException needs work:
         // fix it to preserve cause so we don't do this flaky string-check stuff
         for (ShardSearchFailure fail : fails) {
+            assertThat(fail.getCause(), instanceOf(GroovyScriptExecutionException.class));
             assertTrue("unexpected exception" + fail.getCause(),
                        // different casing, depending on jvm impl...
-                       fail.getCause().toString().toLowerCase(Locale.ROOT).contains("accesscontrolexception[access denied"));
+                       fail.getCause().toString().toLowerCase(Locale.ROOT).contains("[access denied"));
         }
     }
 }

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cloud.aws.network;
 
 import org.apache.lucene.util.IOUtils;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cloud.aws.AwsEc2Service;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.network.NetworkService.CustomNameResolver;
@@ -113,9 +112,9 @@ public class Ec2NameResolver extends AbstractComponent implements CustomNameReso
             return new InetAddress[] { InetAddress.getByName(metadataResult) };
         } catch (IOException e) {
             if (warnOnFailure) {
-                logger.warn("failed to get metadata for [" + type.configName + "]: " + ExceptionsHelper.detailedMessage(e));
+                logger.warn("failed to get metadata for [" + type.configName + "]", e);
             } else {
-                logger.debug("failed to get metadata for [" + type.configName + "]: " + ExceptionsHelper.detailedMessage(e));
+                logger.debug("failed to get metadata for [" + type.configName + "]", e);
             }
             return null;
         } finally {

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/node/Ec2CustomNodeAttributes.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/node/Ec2CustomNodeAttributes.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cloud.aws.node;
 
 import org.apache.lucene.util.IOUtils;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cloud.aws.AwsEc2Service;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -68,7 +67,7 @@ public class Ec2CustomNodeAttributes extends AbstractComponent implements Discov
             }
             ec2Attributes.put("aws_availability_zone", metadataResult);
         } catch (IOException e) {
-            logger.debug("failed to get metadata for [placement/availability-zone]: " + ExceptionsHelper.detailedMessage(e));
+            logger.debug("failed to get metadata for [placement/availability-zone]", e);
         } finally {
             IOUtils.closeWhileHandlingException(in);
         }


### PR DESCRIPTION
This commit removes unnecesssary use of ExceptionHelpers where we actually
should serialize / deserialize the actual exception. This commit also
fixes one of the oddest problems where the actual exception was never
rendered / printed if `all shards failed` due to a missing cause.

This commit unfortunately doesn't fix Snapshot/Restore which is almost
unfixable since it has to serialize XContent and read from it which can't
transport exceptions.
