### PR TITLE
Fix centos-6 tests

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
+++ b/qa/vagrant/src/test/resources/packaging/scripts/70_sysv_initd.bats
@@ -40,12 +40,13 @@ setup() {
 @test "[INIT.D] remove any leftover configuration to start elasticsearch on restart" {
     # This configuration can be added with a command like:
     # $ sudo update-rc.d elasticsearch defaults 95 10
-    # but we want to test that the RPM _doesn't_ add it on its own.
+    # but we want to test that the RPM and deb _don't_ add it on its own.
     # Note that it'd be incorrect to use:
     # $ sudo update-rc.d elasticsearch disable
     # here because that'd prevent elasticsearch from installing the symlinks
     # that cause it to be started on restart.
-    sudo update-rc.d -f elasticsearch remove
+    sudo update-rc.d -f elasticsearch remove || true
+    sudo chkconfig elasticsearch off || true
 }
 
 @test "[INIT.D] install elasticsearch" {


### PR DESCRIPTION
Right now we execute some debian-isms in the init.d tests. This switches to
trying both the debian and centos ways to stop services from starting
automatically.
