### PR TITLE
network.host must be set for discovery-ec2 plugin

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -165,6 +165,37 @@ The following are a list of settings (prefixed with `discovery.ec2`) that can fu
     Defaults to `3s`. If no unit like `ms`, `s` or `m` is specified,
     milliseconds are used.
 
+
+[IMPORTANT]
+.Binding the network host
+==============================================
+
+It's important to define `network.host` as by default it's bound to `localhost`.
+
+You can use {ref}/modules-network.html[core network host settings] or
+<<discovery-ec2-network-host,ec2 specific host settings>>:
+
+==============================================
+
+[[discovery-ec2-network-host]]
+==== EC2 Network Host
+
+When the `discovery-ec2` plugin is installed, the following are also allowed
+as valid network host settings:
+
+[cols="<,<",options="header",]
+|==================================================================
+|EC2 Host Value |Description
+|`_ec2:privateIpv4_` |The private IP address (ipv4) of the machine.
+|`_ec2:privateDns_` |The private host of the machine.
+|`_ec2:publicIpv4_` |The public IP address (ipv4) of the machine.
+|`_ec2:publicDns_` |The public host of the machine.
+|`_ec2:privateIp_` |equivalent to _ec2:privateIpv4_.
+|`_ec2:publicIp_` |equivalent to _ec2:publicIpv4_.
+|`_ec2_` |equivalent to _ec2:privateIpv4_.
+|==================================================================
+
+
 [[discovery-ec2-permissions]]
 ===== Recommended EC2 Permissions
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -51,20 +51,8 @@ provided network interface. For example `_en0:ipv4_`.
 provided network interface. For example `_en0:ipv6_`.
 |=======================================================================
 
-When the `discovery-ec2` plugin is installed, the following are also allowed
-as valid network host settings:
-
-[cols="<,<",options="header",]
-|==================================================================
-|EC2 Host Value |Description
-|`_ec2:privateIpv4_` |The private IP address (ipv4) of the machine.
-|`_ec2:privateDns_` |The private host of the machine.
-|`_ec2:publicIpv4_` |The public IP address (ipv4) of the machine.
-|`_ec2:publicDns_` |The public host of the machine.
-|`_ec2_` |Less verbose option for the private ip address.
-|`_ec2:privateIp_` |Less verbose option for the private ip address.
-|`_ec2:publicIp_` |Less verbose option for the public ip address.
-|==================================================================
+When the `discovery-ec2` plugin is installed, you can use
+{plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].
 
 [float]
 [[tcp-settings]]


### PR DESCRIPTION
 With 2.0, we now bind to `localhost` by default instead of binding to the network card and use its IP address.

 When the discovery plugin gets from AWS API the list of nodes that should form the cluster, this list is pinged then. But as each node is bound to `localhost`, ping does not get an answer and the node elects itself as the master node.

`network.host` must be set.

 Closes #13589.
