### PR TITLE
Fix InternalEngineTests.testTranslogReplayWithFailure to expect AssertionError as well

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1728,7 +1728,9 @@ public class InternalEngineTests extends ESTestCase {
                     engine = createEngine(store, primaryTranslogDir);
                     started = true;
                     break;
-                } catch (EngineCreationFailureException ex) {
+                } catch (EngineCreationFailureException | AssertionError ex) {
+                    // IndexWriter can throw AssertionError on init (if asserts are enabled) if we throw FNFE/NSFE when it asserts that all
+                    // referenced files in the current commit point do exist
                 }
             }
 


### PR DESCRIPTION
This PR fixes this build failure: http://build-us-00.elastic.co/job/es_core_master_small/4162/

The seed repros, which is nice!

The issue is IndexWriter asserts on init that all index files referenced by the commit point its opening do in fact exist, but it checks that by trying to open each one and detecting FNFE/NFSE, which this test randomly throws.

I just fixed the test to allow for AssertionError on init ...
