### PR TITLE
Remove and forbid use of com.google.common.net.InetAddresses

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -194,6 +194,11 @@
             <artifactId>jna</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <optional>true</optional>
+        </dependency>
 
     </dependencies>
 

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.common.network;
 
-import com.google.common.net.InetAddresses;
-
 import org.elasticsearch.common.SuppressForbidden;
 
 import java.net.Inet6Address;
@@ -168,9 +166,13 @@ public final class NetworkAddress {
         }
                 
         if (port != -1 && address instanceof Inet6Address) {
-            builder.append(InetAddresses.toUriString(address));
+            builder.append("["+ getInet6HostAddress(address)+"]");          
         } else {
-            builder.append(InetAddresses.toAddrString(address));
+            if (address instanceof Inet6Address) {
+                builder.append(getInet6HostAddress(address));  
+            } else {
+                builder.append(address.getHostAddress());
+            }
         }
         
         if (port != -1) {
@@ -179,5 +181,14 @@ public final class NetworkAddress {
         }
         
         return builder.toString();
+    }
+    
+    @SuppressForbidden(reason = "we call toString to avoid a DNS lookup")
+    private static String getInet6HostAddress(InetAddress address) {
+        return address.getHostAddress().replaceAll(":0+([0-9])",":$1")
+                .replaceAll("((?::0\\b){2,}):?(?!\\S*\\b\\1:0\\b)(\\S*)", "::$2")
+                .replaceFirst("^0::", "::")
+                .replaceFirst("%\\d+", "");
+        // see http://stackoverflow.com/a/7044170/4746692
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
@@ -166,11 +166,13 @@ public final class NetworkAddress {
         }
                 
         if (port != -1 && address instanceof Inet6Address) {
-            builder.append("["+address.getHostAddress().replaceAll(":0+([0-9])",":$1").
-                    replaceAll("((?::0\\b){2,}):?(?!\\S*\\b\\1:0\\b)(\\S*)", "::$2")+"]");
-            // see http://stackoverflow.com/a/7044170/4746692
+            builder.append("["+ getInet6HostAddress(address)+"]");          
         } else {
-            builder.append(address.getHostAddress());
+            if (address instanceof Inet6Address) {
+                builder.append(getInet6HostAddress(address));  
+            } else {
+                builder.append(address.getHostAddress());
+            }
         }
         
         if (port != -1) {
@@ -179,5 +181,14 @@ public final class NetworkAddress {
         }
         
         return builder.toString();
+    }
+    
+    @SuppressForbidden(reason = "we call toString to avoid a DNS lookup")
+    private static String getInet6HostAddress(InetAddress address) {
+        return address.getHostAddress().replaceAll(":0+([0-9])",":$1")
+                .replaceAll("((?::0\\b){2,}):?(?!\\S*\\b\\1:0\\b)(\\S*)", "::$2")
+                .replaceFirst("^0::", "::")
+                .replaceFirst("%\\d+", "");
+        // see http://stackoverflow.com/a/7044170/4746692
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.common.network;
 
-import com.google.common.net.InetAddresses;
-
 import org.elasticsearch.common.SuppressForbidden;
 
 import java.net.Inet6Address;
@@ -168,9 +166,11 @@ public final class NetworkAddress {
         }
                 
         if (port != -1 && address instanceof Inet6Address) {
-            builder.append(InetAddresses.toUriString(address));
+            builder.append("["+address.getHostAddress().replaceAll(":0+([0-9])",":$1").
+                    replaceAll("((?::0\\b){2,}):?(?!\\S*\\b\\1:0\\b)(\\S*)", "::$2")+"]");
+            // see http://stackoverflow.com/a/7044170/4746692
         } else {
-            builder.append(InetAddresses.toAddrString(address));
+            builder.append(address.getHostAddress());
         }
         
         if (port != -1) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.index.mapper.ip;
 
-import com.google.common.net.InetAddresses;
+import org.apache.http.conn.util.InetAddressUtils;
 import org.apache.lucene.analysis.NumericTokenStream;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
@@ -74,7 +74,7 @@ public class IpFieldMapper extends NumberFieldMapper {
 
     public static long ipToLong(String ip) {
         try {
-            if (!InetAddresses.isInetAddress(ip)) {
+            if (!(InetAddressUtils.isIPv4Address(ip)||InetAddressUtils.isIPv6Address(ip))) {
                 throw new IllegalArgumentException("failed to parse ip [" + ip + "], not a valid ip address");
             }
             String[] octets = pattern.split(ip);

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -125,6 +125,7 @@ com.google.common.collect.ArrayListMultimap
 com.google.common.collect.HashMultimap
 com.google.common.collect.FluentIterable
 com.google.common.io.Files
+com.google.common.net.InetAddresses
 
 @defaultMessage Do not violate java's access system
 java.lang.reflect.AccessibleObject#setAccessible(boolean)


### PR DESCRIPTION
This commit removes and now forbids all uses of com.google.common.net.InetAddresses across the codebase. This is one of many steps in the eventual removal of Guava as a dependency.

Relates #13224
