### PR TITLE
Add GeoPoint in StreamInput/StreamOutput

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.text.StringAndBytesText;
 import org.elasticsearch.common.text.Text;
 import org.joda.time.DateTime;
@@ -420,9 +421,15 @@ public abstract class StreamInput extends InputStream {
                 return readDoubleArray();
             case 21:
                 return readBytesRef();
+            case 22:
+                return readGeoPoint();
             default:
                 throw new IOException("Can't read unknown type [" + type + "]");
         }
+    }
+
+    public GeoPoint readGeoPoint() throws IOException {
+        return new GeoPoint(readDouble(), readDouble());
     }
 
     public int[] readIntArray() throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -30,6 +30,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.text.Text;
 import org.joda.time.ReadableInstant;
 
@@ -408,6 +409,10 @@ public abstract class StreamOutput extends OutputStream {
         } else if (value instanceof BytesRef) {
             writeByte((byte) 21);
             writeBytesRef((BytesRef) value);
+        } else if (type == GeoPoint.class) {
+            writeByte((byte) 22);
+            writeDouble(((GeoPoint) value).lat());
+            writeDouble(((GeoPoint) value).lon());
         } else {
             throw new IOException("Can't write type [" + type + "]");
         }


### PR DESCRIPTION
Fixes transport serialization for geo_point type in multi node environment (possibility to use geo_point in script and fielddata_fields).

Closes #13340
