### PR TITLE
Add documentation for setting network.host with azure discovery

### DIFF
--- a/docs/plugins/cloud-azure.asciidoc
+++ b/docs/plugins/cloud-azure.asciidoc
@@ -54,6 +54,18 @@ discovery:
     type: azure
 ----
 
+
+[IMPORTANT]
+.Binding the network host
+==============================================
+
+It's important to define `network.host` as by default it's bound to `localhost`.
+
+You can use {ref}/modules-network.html[core network host settings]. For example `_non_loopback_` or `_en0_`.
+
+==============================================
+
+
 [[cloud-azure-discovery-short]]
 ===== How to start (short story)
 


### PR DESCRIPTION
With 2.0, we now bind to `localhost` by default instead of binding to the network card and use its IP address.

When the discovery plugin gets from Azure API the list of nodes that should form the cluster, this list is pinged then. But as each node is bound to `localhost`, ping does not get an answer and the node elects itself as the master node.

Closes #13591
