### PR TITLE
Better simulate problematic plugins permissions in unit tests.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -251,6 +251,7 @@
                             <includes>
                                 <include>org/elasticsearch/test/**/*</include>
                                 <include>org/elasticsearch/bootstrap/BootstrapForTesting.class</include>
+                                <include>org/elasticsearch/bootstrap/MockPluginPolicy.class</include>
                                 <include>org/elasticsearch/common/cli/CliToolTestCase.class</include>
                                 <include>org/elasticsearch/common/cli/CliToolTestCase$*.class</include>
                             </includes>
@@ -279,7 +280,7 @@
                                 <include>rest-api-spec/**/*</include>
                                 <include>org/elasticsearch/test/**/*</include>
                                 <include>org/elasticsearch/bootstrap/BootstrapForTesting.class</include>
-                                <include>org/elasticsearch/bootstrap/XTestSecurityManager*.class</include>
+                                <include>org/elasticsearch/bootstrap/MockPluginPolicy.class</include>
                                 <include>org/elasticsearch/common/cli/CliToolTestCase.class</include>
                                 <include>org/elasticsearch/common/cli/CliToolTestCase$*.class</include>
                                 <include>org/elasticsearch/cluster/MockInternalClusterInfoService.class</include>

--- a/core/src/test/java/org/elasticsearch/bootstrap/MockPluginPolicy.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/MockPluginPolicy.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.logging.Loggers;
+import org.junit.Assert;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.security.CodeSource;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.security.cert.Certificate;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Simulates in unit tests per-plugin permissions.
+ * Unit tests for plugins do not have a proper plugin structure,
+ * so we don't know which codebases to apply the permission to.
+ * <p>
+ * As an approximation, we just exclude es/test/framework classes,
+ * because they will be present in stacks and fail tests for the 
+ * simple case where an AccessController block is missing.
+ */
+final class MockPluginPolicy extends Policy {
+    final ESPolicy standardPolicy;
+    final PermissionCollection extraPermissions;
+    final Set<CodeSource> extraSources;
+
+    /**
+     * Create a new MockPluginPolicy with dynamic {@code permissions} and
+     * adding the extra plugin permissions from {@code insecurePluginProp} to
+     * all code except test classes.
+     */
+    MockPluginPolicy(Permissions permissions, String insecurePluginProp) throws Exception {
+        // the hack begins!
+
+        // parse whole policy file, with and without the substitution, compute the delta
+        standardPolicy = new ESPolicy(permissions);
+
+        URL bogus = new URL("file:/bogus"); // its "any old codebase" this time: generic permissions
+        PermissionCollection smallPermissions = standardPolicy.template.getPermissions(new CodeSource(bogus, (Certificate[])null)); 
+        Set<Permission> small = new HashSet<>(Collections.list(smallPermissions.elements()));
+
+        // set the URL for the property substitution, this time it will also have special permissions
+        System.setProperty(insecurePluginProp, bogus.toString());
+        ESPolicy biggerPolicy = new ESPolicy(permissions);
+        System.clearProperty(insecurePluginProp);
+        PermissionCollection bigPermissions = biggerPolicy.template.getPermissions(new CodeSource(bogus, (Certificate[])null));
+        Set<Permission> big = new HashSet<>(Collections.list(bigPermissions.elements()));
+
+        // compute delta to remove all the generic permissions
+        // we want equals() vs implies() for this check, in case we need 
+        // to pass along any UnresolvedPermission to the plugin
+        big.removeAll(small);
+
+        // build collection of the special permissions for easy checking
+        extraPermissions = new Permissions();
+        for (Permission p : big) {
+            extraPermissions.add(p);
+        }
+
+        // every element in classpath except test-classes/
+        extraSources = new HashSet<CodeSource>();
+        for (URL location : JarHell.parseClassPath()) {
+            Path path = PathUtils.get(location.toURI());
+            String baseName = path.getFileName().toString();
+            if (baseName.contains("test-classes") == false) {
+              extraSources.add(new CodeSource(location, (Certificate[])null));
+            }
+        }
+        // exclude some obvious places
+        // es core
+        extraSources.remove(Bootstrap.class.getProtectionDomain().getCodeSource());
+        // es test framework
+        extraSources.remove(getClass().getProtectionDomain().getCodeSource());
+        // lucene test framework
+        extraSources.remove(LuceneTestCase.class.getProtectionDomain().getCodeSource());
+        // test runner
+        extraSources.remove(RandomizedRunner.class.getProtectionDomain().getCodeSource());
+        // junit library
+        extraSources.remove(Assert.class.getProtectionDomain().getCodeSource());
+
+        Loggers.getLogger(getClass()).debug("Apply permissions [{}] to codebases [{}]", extraPermissions, extraSources);
+    }
+
+    @Override
+    public boolean implies(ProtectionDomain domain, Permission permission) {
+        if (standardPolicy.implies(domain, permission)) {
+            return true;
+        } else if (extraSources.contains(domain.getCodeSource())) {
+            return extraPermissions.implies(permission);
+        } else {
+            return false;
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/bootstrap/MockPluginPolicy.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/MockPluginPolicy.java
@@ -46,7 +46,9 @@ import java.util.Set;
  * <p>
  * As an approximation, we just exclude es/test/framework classes,
  * because they will be present in stacks and fail tests for the 
- * simple case where an AccessController block is missing.
+ * simple case where an AccessController block is missing, because
+ * java security checks every codebase in the stacktrace, and we
+ * are sure to pollute it.
  */
 final class MockPluginPolicy extends Policy {
     final ESPolicy standardPolicy;

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
@@ -242,8 +242,7 @@ public class GceUnicastHostsProvider extends AbstractComponent implements Unicas
 
             }
         } catch (Throwable e) {
-            logger.warn("Exception caught during discovery {} : {}", e.getClass().getName(), e.getMessage());
-            logger.trace("Exception caught during discovery", e);
+            logger.warn("Exception caught during discovery: {}", e, e.getMessage());
         }
 
         logger.debug("{} node(s) added", cachedDiscoNodes.size());


### PR DESCRIPTION
We don't have a plugin .zip for unit tests, so we can't do it
correctly. But we can approximate it better, so that if code
is simply missing an AccessController block at least tests will fail.

Cloud-gce unit tests now fail, as they should: they are missing some blocks
around problematic GCE code but we don't yet have the integ tests to catch them.
David only found this out via manual testing on https://github.com/elastic/elasticsearch/pull/13612

I will merge in his changes (to separate out from that unrelated PR) and add anything else missing until unit tests are passing.

Currently the plugins in question are cloud ones, and so we need to 
get the best we can out of the tests we have.
