### PR TITLE
Query Refactoring: More moving of validation to constructors and setters

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BaseTermQueryBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -105,6 +106,12 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
      * @param value The value of the term
      */
     public BaseTermQueryBuilder(String fieldName, Object value) {
+        if (Strings.isEmpty(fieldName)) {
+            throw new IllegalArgumentException("field name is null or empty");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("value cannot be null");
+        }
         this.fieldName = fieldName;
         this.value = convertToBytesRefIfString(value);
     }
@@ -130,19 +137,6 @@ public abstract class BaseTermQueryBuilder<QB extends BaseTermQueryBuilder<QB>> 
         printBoostAndQueryName(builder);
         builder.endObject();
         builder.endObject();
-    }
-
-    /** Returns a {@link QueryValidationException} if fieldName is null or empty, or if value is null. */
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (fieldName == null || fieldName.isEmpty()) {
-            validationException = addValidationError("field name cannot be null or empty.", validationException);
-        }
-        if (value == null) {
-            validationException = addValidationError("value cannot be null.", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -143,12 +143,6 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
     }
 
     @Override
-    public QueryValidationException validate() {
-        // all fields can be empty or null
-        return null;
-    }
-
-    @Override
     protected IdsQueryBuilder doReadFrom(StreamInput in) throws IOException {
         IdsQueryBuilder idsQueryBuilder = new IdsQueryBuilder(in.readStringArray());
         idsQueryBuilder.addIds(in.readStringArray());

--- a/core/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndicesQueryBuilder.java
@@ -45,6 +45,12 @@ public class IndicesQueryBuilder extends AbstractQueryBuilder<IndicesQueryBuilde
     static final IndicesQueryBuilder PROTOTYPE = new IndicesQueryBuilder(EmptyQueryBuilder.PROTOTYPE, "index");
 
     public IndicesQueryBuilder(QueryBuilder innerQuery, String... indices) {
+        if (innerQuery == null) {
+            throw new IllegalArgumentException("inner query cannot be null");
+        }
+        if (indices == null || indices.length == 0) {
+            throw new IllegalArgumentException("list of indices cannot be null or empty");
+        }
         this.innerQuery = Objects.requireNonNull(innerQuery);
         this.indices = indices;
     }
@@ -61,7 +67,10 @@ public class IndicesQueryBuilder extends AbstractQueryBuilder<IndicesQueryBuilde
      * Sets the query to use when it executes on an index that does not match the indices provided.
      */
     public IndicesQueryBuilder noMatchQuery(QueryBuilder noMatchQuery) {
-        this.noMatchQuery = (noMatchQuery != null) ? noMatchQuery : defaultNoMatchQuery();
+        if (noMatchQuery == null) {
+            throw new IllegalArgumentException("noMatch query cannot be null");
+        }
+        this.noMatchQuery = noMatchQuery;
         return this;
     }
 
@@ -112,20 +121,6 @@ public class IndicesQueryBuilder extends AbstractQueryBuilder<IndicesQueryBuilde
             //if both the wrapped query and the wrapper hold a boost, the main one coming from the wrapper wins
             query.setBoost(boost);
         }
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (this.innerQuery == null) {
-            validationException = addValidationError("inner query cannot be null", validationException);
-        }
-        if (this.indices == null || this.indices.length == 0) {
-            validationException = addValidationError("list of indices cannot be null or empty", validationException);
-        }
-        validationException = validateInnerQuery(innerQuery, validationException);
-        validationException = validateInnerQuery(noMatchQuery, validationException);
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
@@ -50,9 +50,9 @@ public class MissingQueryBuilder extends AbstractQueryBuilder<MissingQueryBuilde
 
     private final String fieldPattern;
 
-    private boolean nullValue = DEFAULT_NULL_VALUE;
+    private final boolean nullValue;
 
-    private boolean existence = DEFAULT_EXISTENCE_VALUE;
+    private final boolean existence;
 
     static final MissingQueryBuilder PROTOTYPE = new MissingQueryBuilder("field", DEFAULT_NULL_VALUE, DEFAULT_EXISTENCE_VALUE);
 

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -58,7 +58,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     public static final MatchQuery.ZeroTermsQuery DEFAULT_ZERO_TERMS_QUERY = MatchQuery.DEFAULT_ZERO_TERMS_QUERY;
 
     private final Object value;
-    private Map<String, Float> fieldsBoosts = new TreeMap<>();
+    private final Map<String, Float> fieldsBoosts;
     private MultiMatchQueryBuilder.Type type = DEFAULT_TYPE;
     private Operator operator = DEFAULT_OPERATOR;
     private String analyzer;
@@ -162,7 +162,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
             out.writeVInt(this.ordinal());
         }
     }
-    
+
     /**
      * Returns the type (for testing)
      */
@@ -177,7 +177,11 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         if (value == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires query value");
         }
+        if (fields == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires fields at initalization time");
+        }
         this.value = value;
+        this.fieldsBoosts = new TreeMap<>();
         for (String field : fields) {
             field(field);
         }
@@ -564,15 +568,6 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
             }
         }
         return newFieldsBoosts;
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (fieldsBoosts.isEmpty()) {
-            validationException = addValidationError("no fields specified for multi_match query.", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
@@ -37,9 +37,12 @@ public class NotQueryBuilder extends AbstractQueryBuilder<NotQueryBuilder> {
 
     private final QueryBuilder filter;
 
-    static final NotQueryBuilder PROTOTYPE = new NotQueryBuilder(null);
+    static final NotQueryBuilder PROTOTYPE = new NotQueryBuilder(EmptyQueryBuilder.PROTOTYPE);
 
     public NotQueryBuilder(QueryBuilder filter) {
+        if (filter == null) {
+            throw new IllegalArgumentException("inner filter cannot be null");
+        }
         this.filter = filter;
     }
 
@@ -66,11 +69,6 @@ public class NotQueryBuilder extends AbstractQueryBuilder<NotQueryBuilder> {
             return null;
         }
         return Queries.not(luceneQuery);
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        return validateInnerQuery(filter, null);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/PrefixQueryBuilder.java
@@ -47,7 +47,7 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
 
     private String rewrite;
 
-    static final PrefixQueryBuilder PROTOTYPE = new PrefixQueryBuilder(null, null);
+    static final PrefixQueryBuilder PROTOTYPE = new PrefixQueryBuilder("field", "value");
 
     /**
      * A Query that matches documents containing terms with a specified prefix.
@@ -56,6 +56,12 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
      * @param value The prefix query
      */
     public PrefixQueryBuilder(String fieldName, String value) {
+        if (Strings.isEmpty(fieldName)) {
+            throw new IllegalArgumentException("field name is null or empty");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("value cannot be null.");
+        }
         this.fieldName = fieldName;
         this.value = value;
     }
@@ -113,18 +119,6 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
         }
 
         return query;
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (Strings.isEmpty(this.fieldName)) {
-            validationException = addValidationError("field name cannot be null or empty.", validationException);
-        }
-        if (this.value == null) {
-            validationException = addValidationError("query text cannot be null", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -313,16 +313,16 @@ public abstract class QueryBuilders {
         return new SpanFirstQueryBuilder(match, end);
     }
 
-    public static SpanNearQueryBuilder spanNearQuery(int slop) {
-        return new SpanNearQueryBuilder(slop);
+    public static SpanNearQueryBuilder spanNearQuery(SpanQueryBuilder initialClause, int slop) {
+        return new SpanNearQueryBuilder(initialClause, slop);
     }
 
     public static SpanNotQueryBuilder spanNotQuery(SpanQueryBuilder include, SpanQueryBuilder exclude) {
         return new SpanNotQueryBuilder(include, exclude);
     }
 
-    public static SpanOrQueryBuilder spanOrQuery() {
-        return new SpanOrQueryBuilder();
+    public static SpanOrQueryBuilder spanOrQuery(SpanQueryBuilder initialClause) {
+        return new SpanOrQueryBuilder(initialClause);
     }
 
     /** Creates a new {@code span_within} builder.

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterBuilder.java
@@ -41,7 +41,7 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
 
     private final QueryBuilder queryBuilder;
 
-    static final QueryFilterBuilder PROTOTYPE = new QueryFilterBuilder(null);
+    static final QueryFilterBuilder PROTOTYPE = new QueryFilterBuilder(EmptyQueryBuilder.PROTOTYPE);
 
     /**
      * A filter that simply wraps a query.
@@ -49,6 +49,9 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
      * @param queryBuilder The query to wrap as a filter
      */
     public QueryFilterBuilder(QueryBuilder queryBuilder) {
+        if (queryBuilder == null) {
+            throw new IllegalArgumentException("inner query cannot be null");
+        }
         this.queryBuilder = queryBuilder;
     }
 
@@ -78,11 +81,6 @@ public class QueryFilterBuilder extends AbstractQueryBuilder<QueryFilterBuilder>
     @Override
     protected void setFinalBoost(Query query) {
         //no-op this query doesn't support boost
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        return validateInnerQuery(queryBuilder, null);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.inject.Inject;
-
 import java.io.IOException;
 
 /**

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -67,10 +67,10 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     public static final Operator DEFAULT_OPERATOR = Operator.OR;
     public static final Locale DEFAULT_LOCALE = Locale.ROOT;
 
-    static final QueryStringQueryBuilder PROTOTYPE = new QueryStringQueryBuilder(null);
-    
+    static final QueryStringQueryBuilder PROTOTYPE = new QueryStringQueryBuilder("");
+
     private final String queryString;
-    
+
     private String defaultField;
     /**
      * Fields to query against. If left empty will query default field,
@@ -104,7 +104,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     private Fuzziness fuzziness = DEFAULT_FUZZINESS;
 
     private int fuzzyPrefixLength = DEFAULT_FUZZY_PREFIX_LENGTH;
-    
+
     private int fuzzyMaxExpansions = DEFAULT_FUZZY_MAX_EXPANSIONS;
 
     private String rewrite;
@@ -127,8 +127,11 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
 
     /** To limit effort spent determinizing regexp queries. */
     private int maxDeterminizedStates = DEFAULT_MAX_DETERMINED_STATES;
-    
+
     public QueryStringQueryBuilder(String queryString) {
+        if (queryString == null) {
+            throw new IllegalArgumentException("query text missing");
+        }
         this.queryString = queryString;
     }
 
@@ -527,15 +530,6 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     @Override
     public String getWriteableName() {
         return NAME;
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (queryString == null) {
-            validationException = addValidationError("query text missing", null);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -114,10 +113,14 @@ public class RangeQueryParser extends BaseQueryParser<RangeQueryBuilder> {
         rangeQuery.to(to);
         rangeQuery.includeLower(includeLower);
         rangeQuery.includeUpper(includeUpper);
-        rangeQuery.timeZone(timeZone);
+        if (timeZone != null) {
+            rangeQuery.timeZone(timeZone);
+        }
         rangeQuery.boost(boost);
         rangeQuery.queryName(queryName);
-        rangeQuery.format(format);
+        if (format != null) {
+            rangeQuery.format(format);
+        }
         return rangeQuery;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -47,24 +47,30 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
     public static final int DEFAULT_MAX_DETERMINIZED_STATES = Operations.DEFAULT_MAX_DETERMINIZED_STATES;
 
     private final String fieldName;
-    
+
     private final String value;
-    
+
     private int flagsValue = DEFAULT_FLAGS_VALUE;
-    
+
     private int maxDeterminizedStates = DEFAULT_MAX_DETERMINIZED_STATES;
-    
+
     private String rewrite;
-    
-    static final RegexpQueryBuilder PROTOTYPE = new RegexpQueryBuilder(null, null);
+
+    static final RegexpQueryBuilder PROTOTYPE = new RegexpQueryBuilder("field", "value");
 
     /**
      * Constructs a new regex query.
-     * 
+     *
      * @param fieldName  The name of the field
      * @param value The regular expression
      */
     public RegexpQueryBuilder(String fieldName, String value) {
+        if (Strings.isEmpty(fieldName)) {
+            throw new IllegalArgumentException("field name is null or empty");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("value cannot be null.");
+        }
         this.fieldName = fieldName;
         this.value = value;
     }
@@ -114,7 +120,7 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         this.maxDeterminizedStates = value;
         return this;
     }
-    
+
     public int maxDeterminizedStates() {
         return this.maxDeterminizedStates;
     }
@@ -123,7 +129,7 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         this.rewrite = rewrite;
         return this;
     }
-    
+
     public String rewrite() {
         return this.rewrite;
     }
@@ -165,18 +171,6 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
             query = regexpQuery;
         }
         return query;
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (Strings.isEmpty(this.fieldName)) {
-            validationException = addValidationError("field name cannot be null or empty.", validationException);
-        }
-        if (this.value == null) {
-            validationException = addValidationError("query text cannot be null", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -39,11 +39,14 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
 
     public static final String NAME = "script";
 
-    static final ScriptQueryBuilder PROTOTYPE = new ScriptQueryBuilder(null);
+    static final ScriptQueryBuilder PROTOTYPE = new ScriptQueryBuilder(new Script(""));
 
     private final Script script;
 
     public ScriptQueryBuilder(Script script) {
+        if (script == null) {
+            throw new IllegalArgumentException("script cannot be null");
+        }
         this.script = script;
     }
 
@@ -67,15 +70,6 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         return new ScriptQuery(script, context.scriptService(), context.lookup());
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (this.script == null) {
-            validationException = addValidationError("script cannot be null", validationException);
-        }
-        return validationException;
     }
 
     static class ScriptQuery extends Query {

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -63,7 +63,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
     /** Name for (de-)serialization. */
     public static final String NAME = "simple_query_string";
 
-    static final SimpleQueryStringBuilder PROTOTYPE = new SimpleQueryStringBuilder(null);
+    static final SimpleQueryStringBuilder PROTOTYPE = new SimpleQueryStringBuilder("");
 
     /** Query text to parse. */
     private final String queryText;
@@ -90,6 +90,9 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
 
     /** Construct a new simple query with this query string. */
     public SimpleQueryStringBuilder(String queryText) {
+        if (queryText == null) {
+            throw new IllegalArgumentException("query text missing");
+        }
         this.queryText = queryText;
     }
 
@@ -243,22 +246,6 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
      */
     public String minimumShouldMatch() {
         return minimumShouldMatch;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * Checks that mandatory queryText is neither null nor empty.
-     * */
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        // Query text is required
-        if (queryText == null) {
-            validationException = addValidationError("query text missing", validationException);
-        }
-
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -37,13 +37,19 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
     public static final String NAME = "span_containing";
     private final SpanQueryBuilder big;
     private final SpanQueryBuilder little;
-    static final SpanContainingQueryBuilder PROTOTYPE = new SpanContainingQueryBuilder(null, null);
+    static final SpanContainingQueryBuilder PROTOTYPE = new SpanContainingQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
 
     /**
      * @param big the big clause, it must enclose {@code little} for a match.
      * @param little the little clause, it must be contained within {@code big} for a match.
      */
     public SpanContainingQueryBuilder(SpanQueryBuilder big, SpanQueryBuilder little) {
+        if (big == null) {
+            throw new IllegalArgumentException("inner clause [big] cannot be null.");
+        }
+        if (little == null) {
+            throw new IllegalArgumentException("inner clause [little] cannot be null.");
+        }
         this.little = little;
         this.big = big;
     }
@@ -80,22 +86,6 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
         Query innerLittle = little.toQuery(context);
         assert innerLittle instanceof SpanQuery;
         return new SpanContainingQuery((SpanQuery) innerBig, (SpanQuery) innerLittle);
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (big == null) {
-            validationException = addValidationError("inner clause [big] cannot be null.", validationException);
-        } else {
-            validationException = validateInnerQuery(big, validationException);
-        }
-        if (little == null) {
-            validationException = addValidationError("inner clause [little] cannot be null.", validationException);
-        } else {
-            validationException = validateInnerQuery(little, validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanFirstQueryBuilder.java
@@ -37,7 +37,7 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
 
     private final int end;
 
-    static final SpanFirstQueryBuilder PROTOTYPE = new SpanFirstQueryBuilder(null, -1);
+    static final SpanFirstQueryBuilder PROTOTYPE = new SpanFirstQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, 0);
 
     /**
      * Query that matches spans queries defined in <code>matchBuilder</code>
@@ -47,6 +47,12 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
      * @throws IllegalArgumentException for negative <code>end</code> positions
      */
     public SpanFirstQueryBuilder(SpanQueryBuilder matchBuilder, int end) {
+        if (matchBuilder == null) {
+            throw new IllegalArgumentException("inner span query cannot be null");
+        }
+        if (end < 0) {
+            throw new IllegalArgumentException("parameter [end] needs to be positive.");
+        }
         this.matchBuilder = matchBuilder;
         this.end = end;
     }
@@ -80,20 +86,6 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
         Query innerSpanQuery = matchBuilder.toQuery(context);
         assert innerSpanQuery instanceof SpanQuery;
         return new SpanFirstQuery((SpanQuery) innerSpanQuery, end);
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (matchBuilder == null) {
-            validationException = addValidationError("inner clause [match] cannot be null.", validationException);
-        } else {
-            validationException = validateInnerQuery(matchBuilder, validationException);
-        }
-        if (end < 0) {
-            validationException = addValidationError("parameter [end] needs to be positive.", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -36,9 +36,12 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
 
     public static final String NAME = "span_multi";
     private final MultiTermQueryBuilder multiTermQueryBuilder;
-    static final SpanMultiTermQueryBuilder PROTOTYPE = new SpanMultiTermQueryBuilder(null);
+    static final SpanMultiTermQueryBuilder PROTOTYPE = new SpanMultiTermQueryBuilder(RangeQueryBuilder.PROTOTYPE);
 
     public SpanMultiTermQueryBuilder(MultiTermQueryBuilder multiTermQueryBuilder) {
+        if (multiTermQueryBuilder == null) {
+            throw new IllegalArgumentException("inner multi term query cannot be null");
+        }
         this.multiTermQueryBuilder = multiTermQueryBuilder;
     }
 
@@ -64,17 +67,6 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
                     + subQuery.getClass().getName());
         }
         return new SpanMultiTermQueryWrapper<>((MultiTermQuery) subQuery);
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (multiTermQueryBuilder == null) {
-            validationException = addValidationError("inner clause ["+ SpanMultiTermQueryParser.MATCH_NAME +"] cannot be null.", validationException);
-        } else {
-            validationException = validateInnerQuery(multiTermQueryBuilder, validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNearQueryParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -85,13 +84,17 @@ public class SpanNearQueryParser extends BaseQueryParser<SpanNearQueryBuilder> {
             }
         }
 
+        if (clauses.isEmpty()) {
+            throw new QueryParsingException(parseContext, "span_near must include [clauses]");
+        }
+
         if (slop == null) {
             throw new QueryParsingException(parseContext, "span_near must include [slop]");
         }
 
-        SpanNearQueryBuilder queryBuilder = new SpanNearQueryBuilder(slop);
-        for (SpanQueryBuilder subQuery : clauses) {
-            queryBuilder.clause(subQuery);
+        SpanNearQueryBuilder queryBuilder = new SpanNearQueryBuilder(clauses.get(0), slop);
+        for (int i = 1; i < clauses.size(); i++) {
+            queryBuilder.clause(clauses.get(i));
         }
         queryBuilder.inOrder(inOrder);
         queryBuilder.collectPayloads(collectPayloads);

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -46,7 +46,7 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
 
     private int post = DEFAULT_POST;
 
-    static final SpanNotQueryBuilder PROTOTYPE = new SpanNotQueryBuilder(null, null);
+    static final SpanNotQueryBuilder PROTOTYPE = new SpanNotQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
 
     /**
      * Construct a span query matching spans from <code>include</code> which
@@ -55,6 +55,12 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
      * @param exclude the span query whose matches must not overlap
      */
     public SpanNotQueryBuilder(SpanQueryBuilder include, SpanQueryBuilder exclude) {
+        if (include == null) {
+            throw new IllegalArgumentException("inner clause [include] cannot be null.");
+        }
+        if (exclude == null) {
+            throw new IllegalArgumentException("inner clause [exclude] cannot be null.");
+        }
         this.include = include;
         this.exclude = exclude;
     }
@@ -138,22 +144,6 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
         assert excludeQuery instanceof SpanQuery;
 
         return new SpanNotQuery((SpanQuery) includeQuery, (SpanQuery) excludeQuery, pre, post);
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (include == null) {
-            validationException = addValidationError("inner clause [include] cannot be null.", validationException);
-        } else {
-            validationException = validateInnerQuery(include, validationException);
-        }
-        if (exclude == null) {
-            validationException = addValidationError("inner clause [exclude] cannot be null.", validationException);
-        } else {
-            validationException = validateInnerQuery(exclude, validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryParser.java
@@ -72,13 +72,14 @@ public class SpanOrQueryParser extends BaseQueryParser<SpanOrQueryBuilder> {
                 }
             }
         }
+
         if (clauses.isEmpty()) {
             throw new QueryParsingException(parseContext, "spanOr must include [clauses]");
         }
 
-        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder();
-        for (SpanQueryBuilder clause : clauses) {
-            queryBuilder.clause(clause);
+        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder(clauses.get(0));
+        for (int i = 1; i < clauses.size(); i++) {
+            queryBuilder.clause(clauses.get(i));
         }
         queryBuilder.boost(boost);
         queryBuilder.queryName(queryName);

--- a/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanTermQueryBuilder.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 public class SpanTermQueryBuilder extends BaseTermQueryBuilder<SpanTermQueryBuilder> implements SpanQueryBuilder<SpanTermQueryBuilder> {
 
     public static final String NAME = "span_term";
-    static final SpanTermQueryBuilder PROTOTYPE = new SpanTermQueryBuilder(null, null);
+    static final SpanTermQueryBuilder PROTOTYPE = new SpanTermQueryBuilder("name", "value");
 
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public SpanTermQueryBuilder(String name, String value) {

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryBuilder.java
@@ -37,7 +37,7 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
     public static final String NAME = "span_within";
     private final SpanQueryBuilder big;
     private final SpanQueryBuilder little;
-    static final SpanWithinQueryBuilder PROTOTYPE = new SpanWithinQueryBuilder(null, null);
+    static final SpanWithinQueryBuilder PROTOTYPE = new SpanWithinQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, SpanTermQueryBuilder.PROTOTYPE);
 
     /**
      * Query that returns spans from <code>little</code> that are contained in a spans from <code>big</code>.
@@ -45,6 +45,12 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
      * @param little the little clause, it must be contained within {@code big} for a match.
      */
     public SpanWithinQueryBuilder(SpanQueryBuilder big, SpanQueryBuilder little) {
+        if (big == null) {
+            throw new IllegalArgumentException("inner clause [big] cannot be null.");
+        }
+        if (little == null) {
+            throw new IllegalArgumentException("inner clause [little] cannot be null.");
+        }
         this.little = little;
         this.big = big;
     }
@@ -85,22 +91,6 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
         Query innerLittle = little.toQuery(context);
         assert innerLittle instanceof SpanQuery;
         return new SpanWithinQuery((SpanQuery) innerBig, (SpanQuery) innerLittle);
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (big == null) {
-            validationException = addValidationError("inner clause [big] cannot be null.", validationException);
-        } else {
-            validationException = validateInnerQuery(big, validationException);
-        }
-        if (little == null) {
-            validationException = addValidationError("inner clause [little] cannot be null.", validationException);
-        } else {
-            validationException = validateInnerQuery(little, validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanWithinQueryParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;

--- a/core/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TemplateQueryBuilder.java
@@ -44,13 +44,16 @@ public class TemplateQueryBuilder extends AbstractQueryBuilder<TemplateQueryBuil
     /** Template to fill. */
     private final Template template;
 
-    static final TemplateQueryBuilder PROTOTYPE = new TemplateQueryBuilder(null);
+    static final TemplateQueryBuilder PROTOTYPE = new TemplateQueryBuilder(new Template("proto"));
 
     /**
      * @param template
      *            the template to use for that query.
      * */
     public TemplateQueryBuilder(Template template) {
+        if (template == null) {
+            throw new IllegalArgumentException("query template cannot be null");
+        }
         this.template = template;
     }
 
@@ -110,15 +113,6 @@ public class TemplateQueryBuilder extends AbstractQueryBuilder<TemplateQueryBuil
     @Override
     protected void setFinalBoost(Query query) {
         //no-op this query doesn't support boost
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (this.template == null) {
-            validationException = addValidationError("query template cannot be null", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
 
     public static final String NAME = "term";
-    static final TermQueryBuilder PROTOTYPE = new TermQueryBuilder(null, null);
+    static final TermQueryBuilder PROTOTYPE = new TermQueryBuilder("name", "value");
 
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public TermQueryBuilder(String fieldName, String value) {

--- a/core/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -39,13 +39,19 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
 
     private final BytesRef type;
 
-    static final TypeQueryBuilder PROTOTYPE = new TypeQueryBuilder((BytesRef) null);
+    static final TypeQueryBuilder PROTOTYPE = new TypeQueryBuilder("type");
 
     public TypeQueryBuilder(String type) {
+        if (type == null) {
+            throw new IllegalArgumentException("[type] cannot be null");
+        }
         this.type = BytesRefs.toBytesRef(type);
     }
 
     TypeQueryBuilder(BytesRef type) {
+        if (type == null) {
+            throw new IllegalArgumentException("[type] cannot be null");
+        }
         this.type = type;
     }
 
@@ -77,15 +83,6 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
             filter = documentMapper.typeFilter();
         }
         return filter;
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (type == null) {
-            validationException = addValidationError("[type] cannot be null", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -52,7 +52,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
 
     private String rewrite;
 
-    static final WildcardQueryBuilder PROTOTYPE = new WildcardQueryBuilder(null, null);
+    static final WildcardQueryBuilder PROTOTYPE = new WildcardQueryBuilder("field", "value");
 
     /**
      * Implements the wildcard search query. Supported wildcards are <tt>*</tt>, which
@@ -66,6 +66,12 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
      * @param value The wildcard query string
      */
     public WildcardQueryBuilder(String fieldName, String value) {
+        if (Strings.isEmpty(fieldName)) {
+            throw new IllegalArgumentException("field name is null or empty");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("value cannot be null.");
+        }
         this.fieldName = fieldName;
         this.value = value;
     }
@@ -123,18 +129,6 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         MultiTermQuery.RewriteMethod rewriteMethod = QueryParsers.parseRewriteMethod(context.parseFieldMatcher(), rewrite, null);
         QueryParsers.setRewriteMethod(query, rewriteMethod);
         return query;
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (Strings.isEmpty(this.fieldName)) {
-            validationException = addValidationError("field name cannot be null or empty.", validationException);
-        }
-        if (this.value == null) {
-            validationException = addValidationError("wildcard cannot be null", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -20,7 +20,10 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
+
 import java.nio.charset.StandardCharsets;
+
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -49,26 +52,35 @@ public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilde
 
     public static final String NAME = "wrapper";
     private final byte[] source;
-    static final WrapperQueryBuilder PROTOTYPE = new WrapperQueryBuilder((byte[]) null);
-
-    /**
-     * Creates a query builder given a query provided as a string
-     */
-    public WrapperQueryBuilder(String source) {
-        this.source = source.getBytes(StandardCharsets.UTF_8);
-    }
+    static final WrapperQueryBuilder PROTOTYPE = new WrapperQueryBuilder((byte[]) new byte[]{0});
 
     /**
      * Creates a query builder given a query provided as a bytes array
      */
     public WrapperQueryBuilder(byte[] source) {
+        if (source == null || source.length == 0) {
+            throw new IllegalArgumentException("query source text cannot be null or empty");
+        }
         this.source = source;
+    }
+
+    /**
+     * Creates a query builder given a query provided as a string
+     */
+    public WrapperQueryBuilder(String source) {
+        if (Strings.isEmpty(source)) {
+            throw new IllegalArgumentException("query source string cannot be null or empty");
+        }
+        this.source = source.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
      * Creates a query builder given a query provided as a {@link BytesReference}
      */
     public WrapperQueryBuilder(BytesReference source) {
+        if (source == null || source.array().length == 0) {
+            throw new IllegalArgumentException("query source text cannot be null or empty");
+        }
         this.source = source.array();
     }
 
@@ -107,15 +119,6 @@ public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilde
     @Override
     protected void setFinalBoost(Query query) {
         //no-op this query doesn't support boost
-    }
-
-    @Override
-    public QueryValidationException validate() {
-        QueryValidationException validationException = null;
-        if (this.source == null || this.source.length == 0) {
-            validationException = addValidationError("query source text cannot be null or empty", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
@@ -24,8 +24,6 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
-
 public abstract class AbstractTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>> extends AbstractQueryTestCase<QB> {
 
     @Override
@@ -75,21 +73,24 @@ public abstract class AbstractTermQueryTestCase<QB extends BaseTermQueryBuilder<
     protected abstract QB createQueryBuilder(String fieldName, Object value);
 
     @Test
-    public void testValidate() throws QueryShardException {
-        QB queryBuilder = createQueryBuilder(randomAsciiOfLengthBetween(1, 30), randomAsciiOfLengthBetween(1, 30));
-        assertNull(queryBuilder.validate());
+    public void testIllegalArguments() throws QueryShardException {
+        try {
+            if (randomBoolean()) {
+                createQueryBuilder(null, randomAsciiOfLengthBetween(1, 30));
+            } else {
+                createQueryBuilder("", randomAsciiOfLengthBetween(1, 30));
+            }
+            fail("fieldname cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
 
-        queryBuilder = createQueryBuilder(null, randomAsciiOfLengthBetween(1, 30));
-        assertNotNull(queryBuilder.validate());
-        assertThat(queryBuilder.validate().validationErrors().size(), is(1));
-
-        queryBuilder = createQueryBuilder("", randomAsciiOfLengthBetween(1, 30));
-        assertNotNull(queryBuilder.validate());
-        assertThat(queryBuilder.validate().validationErrors().size(), is(1));
-
-        queryBuilder = createQueryBuilder("", null);
-        assertNotNull(queryBuilder.validate());
-        assertThat(queryBuilder.validate().validationErrors().size(), is(2));
+        try {
+            createQueryBuilder("field", null);
+            fail("value cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/IndicesQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IndicesQueryBuilderTests.java
@@ -69,35 +69,41 @@ public class IndicesQueryBuilderTests extends AbstractQueryTestCase<IndicesQuery
     }
 
     @Test
-    public void testValidate() {
-        int expectedErrors = 0;
-
-        // inner query
-        QueryBuilder innerQuery;
-        if (randomBoolean()) {
-            // setting innerQuery to null would be caught in the builder already and make validation fail
-            innerQuery = RandomQueryBuilder.createInvalidQuery(random());
-            expectedErrors++;
-        } else {
-            innerQuery = RandomQueryBuilder.createQuery(random());
-        }
-        // indices
-        String[] indices;
-        if (randomBoolean()) {
-            indices = randomBoolean() ? null : new String[0];
-            expectedErrors++;
-        } else {
-            indices = new String[]{"index"};
-        }
-        // no match query
-        QueryBuilder noMatchQuery;
-        if (randomBoolean()) {
-            noMatchQuery = RandomQueryBuilder.createInvalidQuery(random());
-            expectedErrors++;
-        } else {
-            noMatchQuery = RandomQueryBuilder.createQuery(random());
+    public void testIllegalArguments() {
+        try {
+            new IndicesQueryBuilder(null, "index");
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
 
-        assertValidate(new IndicesQueryBuilder(innerQuery, indices).noMatchQuery(noMatchQuery), expectedErrors);
+        try {
+            new IndicesQueryBuilder(EmptyQueryBuilder.PROTOTYPE, (String[]) null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            new IndicesQueryBuilder(EmptyQueryBuilder.PROTOTYPE, new String[0]);
+            fail("cannot be empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        IndicesQueryBuilder indicesQueryBuilder = new IndicesQueryBuilder(EmptyQueryBuilder.PROTOTYPE, "index");
+        try {
+            indicesQueryBuilder.noMatchQuery((QueryBuilder) null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            indicesQueryBuilder.noMatchQuery((String) null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -33,7 +33,6 @@ import java.util.List;
 import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBooleanSubQuery;
 import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.Matchers.is;
 
 public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatchQueryBuilder> {
 
@@ -113,12 +112,27 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     }
 
     @Test
-    public void testValidate() {
-        MultiMatchQueryBuilder multiMatchQueryBuilder = new MultiMatchQueryBuilder("text");
-        assertThat(multiMatchQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegaArguments() {
+        try {
+            new MultiMatchQueryBuilder(null, "field");
+            fail("value must not be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
 
-        multiMatchQueryBuilder = new MultiMatchQueryBuilder("text", "field");
-        assertNull(multiMatchQueryBuilder.validate());
+        try {
+            new MultiMatchQueryBuilder("value", (String[]) null);
+            fail("initial fields must be supplied at construction time must not be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            new MultiMatchQueryBuilder("value", new String[]{""});
+            fail("field names cannot be empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
@@ -35,6 +36,7 @@ import org.elasticsearch.search.fetch.innerhits.InnerHitsContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.TestSearchContext;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,6 +45,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBuilder> {
 
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         MapperService mapperService = queryParserService().mapperService;
@@ -57,6 +60,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
         ).string()), false, false);
     }
 
+    @Override
     protected void setSearchContext(String[] types) {
         final MapperService mapperService = queryParserService().mapperService;
         final IndexFieldDataService fieldData = queryParserService().fieldDataService;
@@ -155,5 +159,30 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
         assertTrue(query instanceof TermsQueryBuilder);
         TermsQueryBuilder tqb = (TermsQueryBuilder) query;
         assertEquals(tqb.values(), Arrays.asList("a", "b"));
+    }
+
+    @Test
+    public void testValidate() {
+        try {
+            new NestedQueryBuilder(null, EmptyQueryBuilder.PROTOTYPE);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            new NestedQueryBuilder("path", null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder("path", EmptyQueryBuilder.PROTOTYPE);
+        try {
+            nestedQueryBuilder.scoreMode(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTests.java
@@ -102,17 +102,11 @@ public class NotQueryBuilderTests extends AbstractQueryTestCase<NotQueryBuilder>
 
     @Test
     public void testValidate() {
-        QueryBuilder innerQuery = null;
-        int totalExpectedErrors = 0;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                innerQuery = RandomQueryBuilder.createInvalidQuery(random());
-            }
-            totalExpectedErrors++;
-        } else {
-            innerQuery = RandomQueryBuilder.createQuery(random());
+        try {
+            new NotQueryBuilder(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        NotQueryBuilder notQuery = new NotQueryBuilder(innerQuery);
-        assertValidate(notQuery, totalExpectedErrors);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBuilder> {
 
@@ -51,17 +50,23 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
     }
 
     @Test
-    public void testValidate() {
-        PrefixQueryBuilder prefixQueryBuilder = new PrefixQueryBuilder("", "prefix");
-        assertThat(prefixQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegalArguments() {
+        try {
+            if (randomBoolean()) {
+                new PrefixQueryBuilder(null, "text");
+            } else {
+                new PrefixQueryBuilder("", "text");
+            }
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
 
-        prefixQueryBuilder = new PrefixQueryBuilder("field", null);
-        assertThat(prefixQueryBuilder.validate().validationErrors().size(), is(1));
-
-        prefixQueryBuilder = new PrefixQueryBuilder("field", "prefix");
-        assertNull(prefixQueryBuilder.validate());
-
-        prefixQueryBuilder = new PrefixQueryBuilder(null, null);
-        assertThat(prefixQueryBuilder.validate().validationErrors().size(), is(2));
+        try {
+            new PrefixQueryBuilder("field", null);
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/QueryFilterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryFilterBuilderTests.java
@@ -68,17 +68,11 @@ public class QueryFilterBuilderTests extends AbstractQueryTestCase<QueryFilterBu
 
     @Test
     public void testValidate() {
-        QueryBuilder innerQuery = null;
-        int totalExpectedErrors = 0;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                innerQuery = RandomQueryBuilder.createInvalidQuery(random());
-            }
-            totalExpectedErrors++;
-        } else {
-            innerQuery = RandomQueryBuilder.createQuery(random());
+        try {
+            new QueryFilterBuilder(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        QueryFilterBuilder fQueryFilter = new QueryFilterBuilder(innerQuery);
-        assertValidate(fQueryFilter, totalExpectedErrors);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -145,13 +145,13 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     }
 
     @Test
-    public void testValidate() {
-        QueryValidationException queryValidationException = createTestQueryBuilder().validate();
-        assertNull(queryValidationException);
-
-        queryValidationException = new QueryStringQueryBuilder(null).validate();
-        assertNotNull(queryValidationException);
-        assertThat(queryValidationException.validationErrors().size(), equalTo(1));
+    public void testIllegalArguments() {
+        try {
+            new QueryStringQueryBuilder(null);
+            fail("null is not allowed");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
@@ -67,21 +67,4 @@ public class RandomQueryBuilder {
         query.to("z" + RandomStrings.randomAsciiOfLengthBetween(r, 1, 10));
         return query;
     }
-
-    /**
-     * Create a new invalid query of a random type
-     * @param r random seed
-     * @return a random {@link QueryBuilder} that is invalid, meaning that calling validate against it
-     * will return an error. We can rely on the fact that a single error will be returned per query.
-     */
-    public static QueryBuilder createInvalidQuery(Random r) {
-        switch (RandomInts.randomIntBetween(r, 0, 1)) {
-            case 0:
-                return new TermQueryBuilder("", "test");
-            case 1:
-                return new SimpleQueryStringBuilder(null);
-            default:
-                throw new UnsupportedOperationException();
-        }
-    }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuilder> {
 
@@ -98,24 +97,40 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     @Test
-    public void testValidate() {
-        RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder("");
-        assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegalArguments() {
+        try {
+            if (randomBoolean()) {
+                new RangeQueryBuilder(null);
+            } else {
+                new RangeQueryBuilder("");
+            }
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
 
-        rangeQueryBuilder = new RangeQueryBuilder("okay").timeZone("UTC");
-        assertNull(rangeQueryBuilder.validate());
+        RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder("test");
+        try {
+            if (randomBoolean()) {
+                rangeQueryBuilder.timeZone(null);
+            } else {
+                rangeQueryBuilder.timeZone("badID");
+            }
+            fail("cannot be null or unknown id");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
 
-        rangeQueryBuilder.timeZone("blab");
-        assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(1));
-
-        rangeQueryBuilder.timeZone("UTC").format("basicDate");
-        assertNull(rangeQueryBuilder.validate());
-
-        rangeQueryBuilder.timeZone("UTC").format("broken_xx");
-        assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(1));
-
-        rangeQueryBuilder.timeZone("xXx").format("broken_xx");
-        assertThat(rangeQueryBuilder.validate().validationErrors().size(), is(2));
+        try {
+            if (randomBoolean()) {
+                rangeQueryBuilder.format(null);
+            } else {
+                rangeQueryBuilder.format("badFormat");
+            }
+            fail("cannot be null or bad format");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBuilder> {
 
@@ -62,17 +61,23 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
     }
 
     @Test
-    public void testValidate() {
-        RegexpQueryBuilder regexQueryBuilder = new RegexpQueryBuilder("", "regex");
-        assertThat(regexQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegalArguments() {
+        try {
+            if (randomBoolean()) {
+                new RegexpQueryBuilder(null, "text");
+            } else {
+                new RegexpQueryBuilder("", "text");
+            }
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
 
-        regexQueryBuilder = new RegexpQueryBuilder("field", null);
-        assertThat(regexQueryBuilder.validate().validationErrors().size(), is(1));
-
-        regexQueryBuilder = new RegexpQueryBuilder("field", "regex");
-        assertNull(regexQueryBuilder.validate());
-
-        regexQueryBuilder = new RegexpQueryBuilder(null, null);
-        assertThat(regexQueryBuilder.validate().validationErrors().size(), is(2));
+        try {
+            new RegexpQueryBuilder("field", null);
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBuilder> {
 
@@ -53,8 +52,12 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
     }
 
     @Test
-    public void testValidate() {
-        ScriptQueryBuilder scriptQueryBuilder = new ScriptQueryBuilder(null);
-        assertThat(scriptQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegalConstructorArg() {
+        try {
+            new ScriptQueryBuilder(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -80,7 +80,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
-import org.elasticsearch.index.query.MoreLikeThisQueryBuilder.Item;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 import org.elasticsearch.index.search.geo.GeoPolygonQuery;
@@ -751,7 +750,7 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         IndexQueryParserService queryParser = queryParser();
         String query = copyToStringFromClasspath("/org/elasticsearch/index/query/not-filter.json");
         Query parsedQuery = queryParser.parse(query).query();
-        Query expected = 
+        Query expected =
                 Queries.not(new TermQuery(new Term("name.first", "shay1")));
         assertEquals(expected, parsedQuery);
     }
@@ -1166,7 +1165,7 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
     @Test
     public void testSpanNearQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(spanNearQuery(12).clause(spanTermQuery("age", 34)).clause(spanTermQuery("age", 35)).clause(spanTermQuery("age", 36)).inOrder(false).collectPayloads(false)).query();
+        Query parsedQuery = queryParser.parse(spanNearQuery(spanTermQuery("age", 34), 12).clause(spanTermQuery("age", 35)).clause(spanTermQuery("age", 36)).inOrder(false).collectPayloads(false)).query();
         assertThat(parsedQuery, instanceOf(SpanNearQuery.class));
         SpanNearQuery spanNearQuery = (SpanNearQuery) parsedQuery;
         assertThat(spanNearQuery.getClauses().length, equalTo(3));
@@ -1208,7 +1207,7 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
     @Test
     public void testSpanOrQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(spanOrQuery().clause(spanTermQuery("age", 34)).clause(spanTermQuery("age", 35)).clause(spanTermQuery("age", 36))).query();
+        Query parsedQuery = queryParser.parse(spanOrQuery(spanTermQuery("age", 34)).clause(spanTermQuery("age", 35)).clause(spanTermQuery("age", 36))).query();
         assertThat(parsedQuery, instanceOf(SpanOrQuery.class));
         SpanOrQuery spanOrQuery = (SpanOrQuery) parsedQuery;
         assertThat(spanOrQuery.getClauses().length, equalTo(3));

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -168,16 +168,13 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     }
 
     @Test
-    public void testValidation() {
-        SimpleQueryStringBuilder qb = createTestQueryBuilder();
-        assertNull(qb.validate());
-    }
-
-    @Test
-    public void testNullQueryTextGeneratesException() {
-        SimpleQueryStringBuilder builder = new SimpleQueryStringBuilder(null);
-        QueryValidationException exception = builder.validate();
-        assertThat(exception, notNullValue());
+    public void testIllegalConstructorArg() {
+        try {
+            new SimpleQueryStringBuilder(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -244,7 +241,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     /*
      * This assumes that Lucene query parsing is being checked already, adding
      * checks only for our parsing extensions.
-     * 
+     *
      * Also this relies on {@link SimpleQueryStringTests} to test most of the
      * actual functionality of query parsing.
      */

--- a/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanContainingQueryBuilderTests.java
@@ -41,31 +41,19 @@ public class SpanContainingQueryBuilderTests extends AbstractQueryTestCase<SpanC
     }
 
     @Test
-    public void testValidate() {
-        int totalExpectedErrors = 0;
-        SpanQueryBuilder bigSpanQueryBuilder;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                bigSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
-            } else {
-                bigSpanQueryBuilder = null;
-            }
-            totalExpectedErrors++;
-        } else {
-            bigSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
+    public void testIllegalArguments() {
+        try {
+            new SpanContainingQueryBuilder(null, SpanTermQueryBuilder.PROTOTYPE);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        SpanQueryBuilder littleSpanQueryBuilder;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                littleSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
-            } else {
-                littleSpanQueryBuilder = null;
-            }
-            totalExpectedErrors++;
-        } else {
-            littleSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
+
+        try {
+            new SpanContainingQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        SpanContainingQueryBuilder queryBuilder = new SpanContainingQueryBuilder(bigSpanQueryBuilder, littleSpanQueryBuilder);
-        assertValidate(queryBuilder, totalExpectedErrors);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanFirstQueryBuilderTests.java
@@ -43,29 +43,6 @@ public class SpanFirstQueryBuilderTests extends AbstractQueryTestCase<SpanFirstQ
         assertThat(query, instanceOf(SpanFirstQuery.class));
     }
 
-    @Test
-    public void testValidate() {
-        int totalExpectedErrors = 0;
-        SpanQueryBuilder innerSpanQueryBuilder;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                innerSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
-            } else {
-                innerSpanQueryBuilder = null;
-            }
-            totalExpectedErrors++;
-        } else {
-            innerSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
-        }
-        int end = randomIntBetween(0, 10);
-        if (randomBoolean()) {
-            end = randomIntBetween(-10, -1);
-            totalExpectedErrors++;
-        }
-        SpanFirstQueryBuilder queryBuilder = new SpanFirstQueryBuilder(innerSpanQueryBuilder, end);
-        assertValidate(queryBuilder, totalExpectedErrors);
-    }
-
     /**
      * test exception on missing `end` and `match` parameter in parser
      */

--- a/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
@@ -47,21 +47,13 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
     }
 
     @Test
-    public void testValidate() {
-        int totalExpectedErrors = 0;
-        MultiTermQueryBuilder multiTermQueryBuilder;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                multiTermQueryBuilder = new RangeQueryBuilder("");
-            } else {
-                multiTermQueryBuilder = null;
-            }
-            totalExpectedErrors++;
-        } else {
-            multiTermQueryBuilder = new RangeQueryBuilder("field");
+    public void testIllegalArgument() {
+        try {
+            new SpanMultiTermQueryBuilder(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        SpanMultiTermQueryBuilder queryBuilder = new SpanMultiTermQueryBuilder(multiTermQueryBuilder);
-        assertValidate(queryBuilder, totalExpectedErrors);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNearQueryBuilderTests.java
@@ -34,10 +34,10 @@ public class SpanNearQueryBuilderTests extends AbstractQueryTestCase<SpanNearQue
 
     @Override
     protected SpanNearQueryBuilder doCreateTestQueryBuilder() {
-        SpanNearQueryBuilder queryBuilder = new SpanNearQueryBuilder(randomIntBetween(-10, 10));
         SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTests().createSpanTermQueryBuilders(randomIntBetween(1, 6));
-        for (SpanTermQueryBuilder clause : spanTermQueries) {
-            queryBuilder.clause(clause);
+        SpanNearQueryBuilder queryBuilder = new SpanNearQueryBuilder(spanTermQueries[0], randomIntBetween(-10, 10));
+        for (int i = 1; i < spanTermQueries.length; i++) {
+            queryBuilder.clause(spanTermQueries[i]);
         }
         queryBuilder.inOrder(randomBoolean());
         queryBuilder.collectPayloads(randomBoolean());
@@ -58,24 +58,20 @@ public class SpanNearQueryBuilderTests extends AbstractQueryTestCase<SpanNearQue
     }
 
     @Test
-    public void testValidate() {
-        SpanNearQueryBuilder queryBuilder = new SpanNearQueryBuilder(1);
-        assertValidate(queryBuilder, 1); // empty clause list
-
-        int totalExpectedErrors = 0;
-        int clauses = randomIntBetween(1, 10);
-        for (int i = 0; i < clauses; i++) {
-            if (randomBoolean()) {
-                if (randomBoolean()) {
-                    queryBuilder.clause(new SpanTermQueryBuilder("", "test"));
-                } else {
-                    queryBuilder.clause(null);
-                }
-                totalExpectedErrors++;
-            } else {
-                queryBuilder.clause(new SpanTermQueryBuilder("name", "value"));
-            }
+    public void testIllegalArguments() {
+        try {
+            new SpanNearQueryBuilder(null, 1);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // ecpected
         }
-        assertValidate(queryBuilder, totalExpectedErrors);
+
+        try {
+            SpanNearQueryBuilder spanNearQueryBuilder = new SpanNearQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, 1);
+            spanNearQueryBuilder.clause(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // ecpected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanNotQueryBuilderTests.java
@@ -60,32 +60,19 @@ public class SpanNotQueryBuilderTests extends AbstractQueryTestCase<SpanNotQuery
     }
 
     @Test
-    public void testValidate() {
-        int totalExpectedErrors = 0;
-        SpanQueryBuilder include;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                include = new SpanTermQueryBuilder("", "test");
-            } else {
-                include = null;
-            }
-            totalExpectedErrors++;
-        } else {
-            include = new SpanTermQueryBuilder("name", "value");
+    public void testIllegalArgument() {
+        try {
+            new SpanNotQueryBuilder(null, SpanTermQueryBuilder.PROTOTYPE);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        SpanQueryBuilder exclude;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                exclude = new SpanTermQueryBuilder("", "test");
-            } else {
-                exclude = null;
-            }
-            totalExpectedErrors++;
-        } else {
-            exclude = new SpanTermQueryBuilder("name", "value");
+        try {
+            new SpanNotQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        SpanNotQueryBuilder queryBuilder = new SpanNotQueryBuilder(include, exclude);
-        assertValidate(queryBuilder, totalExpectedErrors);
     }
 
     @Test
@@ -125,7 +112,7 @@ public class SpanNotQueryBuilderTests extends AbstractQueryTestCase<SpanNotQuery
         builder.field("exclude");
         spanTermQuery("description", "jumped").toXContent(builder, null);
         builder.field("include");
-        spanNearQuery(1).clause(QueryBuilders.spanTermQuery("description", "quick"))
+        spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                 .clause(QueryBuilders.spanTermQuery("description", "fox")).toXContent(builder, null);
         builder.field("dist", 3);
         builder.endObject();
@@ -166,7 +153,7 @@ public class SpanNotQueryBuilderTests extends AbstractQueryTestCase<SpanNotQuery
             builder.startObject();
             builder.startObject(SpanNotQueryBuilder.NAME);
             builder.field("include");
-            spanNearQuery(1).clause(QueryBuilders.spanTermQuery("description", "quick"))
+            spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                     .clause(QueryBuilders.spanTermQuery("description", "fox")).toXContent(builder, null);
             builder.field("dist", 2);
             builder.endObject();
@@ -185,7 +172,7 @@ public class SpanNotQueryBuilderTests extends AbstractQueryTestCase<SpanNotQuery
             builder.startObject();
             builder.startObject(SpanNotQueryBuilder.NAME);
             builder.field("include");
-            spanNearQuery(1).clause(QueryBuilders.spanTermQuery("description", "quick"))
+            spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                     .clause(QueryBuilders.spanTermQuery("description", "fox")).toXContent(builder, null);
             builder.field("exclude");
             spanTermQuery("description", "jumped").toXContent(builder, null);

--- a/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanOrQueryBuilderTests.java
@@ -34,10 +34,10 @@ public class SpanOrQueryBuilderTests extends AbstractQueryTestCase<SpanOrQueryBu
 
     @Override
     protected SpanOrQueryBuilder doCreateTestQueryBuilder() {
-        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder();
         SpanTermQueryBuilder[] spanTermQueries = new SpanTermQueryBuilderTests().createSpanTermQueryBuilders(randomIntBetween(1, 6));
-        for (SpanTermQueryBuilder clause : spanTermQueries) {
-            queryBuilder.clause(clause);
+        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder(spanTermQueries[0]);
+        for (int i = 1; i < spanTermQueries.length; i++) {
+            queryBuilder.clause(spanTermQueries[i]);
         }
         return queryBuilder;
     }
@@ -54,24 +54,20 @@ public class SpanOrQueryBuilderTests extends AbstractQueryTestCase<SpanOrQueryBu
     }
 
     @Test
-    public void testValidate() {
-        SpanOrQueryBuilder queryBuilder = new SpanOrQueryBuilder();
-        assertValidate(queryBuilder, 1); // empty clause list
-
-        int totalExpectedErrors = 0;
-        int clauses = randomIntBetween(1, 10);
-        for (int i = 0; i < clauses; i++) {
-            if (randomBoolean()) {
-                if (randomBoolean()) {
-                    queryBuilder.clause(new SpanTermQueryBuilder("", "test"));
-                } else {
-                    queryBuilder.clause(null);
-                }
-                totalExpectedErrors++;
-            } else {
-                queryBuilder.clause(new SpanTermQueryBuilder("name", "value"));
-            }
+    public void testIllegalArguments() {
+        try {
+            new SpanOrQueryBuilder(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        assertValidate(queryBuilder, totalExpectedErrors);
+
+        try {
+            SpanOrQueryBuilder spanOrBuilder = new SpanOrQueryBuilder(SpanTermQueryBuilder.PROTOTYPE);
+            spanOrBuilder.clause(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanWithinQueryBuilderTests.java
@@ -41,31 +41,19 @@ public class SpanWithinQueryBuilderTests extends AbstractQueryTestCase<SpanWithi
     }
 
     @Test
-    public void testValidate() {
-        int totalExpectedErrors = 0;
-        SpanQueryBuilder bigSpanQueryBuilder;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                bigSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
-            } else {
-                bigSpanQueryBuilder = null;
-            }
-            totalExpectedErrors++;
-        } else {
-            bigSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
+    public void testIllegalArguments() {
+        try {
+            new SpanWithinQueryBuilder(null, SpanTermQueryBuilder.PROTOTYPE);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        SpanQueryBuilder littleSpanQueryBuilder;
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                littleSpanQueryBuilder = new SpanTermQueryBuilder("", "test");
-            } else {
-                littleSpanQueryBuilder = null;
-            }
-            totalExpectedErrors++;
-        } else {
-            littleSpanQueryBuilder = new SpanTermQueryBuilder("name", "value");
+
+        try {
+            new SpanWithinQueryBuilder(SpanTermQueryBuilder.PROTOTYPE, null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
-        SpanWithinQueryBuilder queryBuilder = new SpanWithinQueryBuilder(bigSpanQueryBuilder, littleSpanQueryBuilder);
-        assertValidate(queryBuilder, totalExpectedErrors);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/TemplateQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TemplateQueryBuilderTests.java
@@ -31,8 +31,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
-
 public class TemplateQueryBuilderTests extends AbstractQueryTestCase<TemplateQueryBuilder> {
 
     /**
@@ -61,9 +59,13 @@ public class TemplateQueryBuilderTests extends AbstractQueryTestCase<TemplateQue
     }
 
     @Test
-    public void testValidate() {
-        TemplateQueryBuilder templateQueryBuilder = new TemplateQueryBuilder(null);
-        assertThat(templateQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegalArgument() {
+        try {
+            new TemplateQueryBuilder(null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
@@ -49,8 +49,12 @@ public class TypeQueryBuilderTests extends AbstractQueryTestCase<TypeQueryBuilde
     }
 
     @Test
-    public void testValidate() {
-        TypeQueryBuilder typeQueryBuilder = new TypeQueryBuilder((String) null);
-        assertThat(typeQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegalArgument() {
+        try {
+            new TypeQueryBuilder((String) null);
+            fail("cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQueryBuilder> {
 
@@ -53,18 +52,24 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
     }
 
     @Test
-    public void testValidate() {
-        WildcardQueryBuilder wildcardQueryBuilder = new WildcardQueryBuilder("", "text");
-        assertThat(wildcardQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegalArguments() {
+        try {
+            if (randomBoolean()) {
+                new WildcardQueryBuilder(null, "text");
+            } else {
+                new WildcardQueryBuilder("", "text");
+            }
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
 
-        wildcardQueryBuilder = new WildcardQueryBuilder("field", null);
-        assertThat(wildcardQueryBuilder.validate().validationErrors().size(), is(1));
-
-        wildcardQueryBuilder = new WildcardQueryBuilder(null, null);
-        assertThat(wildcardQueryBuilder.validate().validationErrors().size(), is(2));
-
-        wildcardQueryBuilder = new WildcardQueryBuilder("field", "text");
-        assertNull(wildcardQueryBuilder.validate());
+        try {
+            new WildcardQueryBuilder("field", null);
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 
     @Test

--- a/core/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.junit.Test;
@@ -27,7 +29,6 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQueryBuilder> {
 
@@ -68,11 +69,38 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
     }
 
     @Test
-    public void testValidate() {
-        WrapperQueryBuilder wrapperQueryBuilder = new WrapperQueryBuilder((byte[]) null);
-        assertThat(wrapperQueryBuilder.validate().validationErrors().size(), is(1));
+    public void testIllegalArgument() {
+        try {
+            if (randomBoolean()) {
+                new WrapperQueryBuilder((byte[]) null);
+            } else {
+                new WrapperQueryBuilder(new byte[0]);
+            }
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
 
-        wrapperQueryBuilder = new WrapperQueryBuilder("");
-        assertThat(wrapperQueryBuilder.validate().validationErrors().size(), is(1));
+        try {
+            if (randomBoolean()) {
+                new WrapperQueryBuilder((String) null);
+            } else {
+                new WrapperQueryBuilder("");
+            }
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            if (randomBoolean()) {
+                new WrapperQueryBuilder((BytesReference) null);
+            } else {
+                new WrapperQueryBuilder(new BytesArray(new byte[0]));
+            }
+            fail("cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -1556,12 +1556,11 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "test", "4").setSource("description", "foo"));
 
         SearchResponse searchResponse = client().prepareSearch("test")
-                .setQuery(spanOrQuery().clause(spanTermQuery("description", "bar"))).get();
+                .setQuery(spanOrQuery(spanTermQuery("description", "bar"))).get();
         assertHitCount(searchResponse, 1l);
 
         searchResponse = client().prepareSearch("test").setQuery(
-                spanNearQuery(3)
-                        .clause(spanTermQuery("description", "foo"))
+                spanNearQuery(spanTermQuery("description", "foo"), 3)
                         .clause(spanTermQuery("description", "other"))).get();
         assertHitCount(searchResponse, 3l);
     }
@@ -1577,24 +1576,24 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
-                .setQuery(spanOrQuery().clause(spanMultiTermQueryBuilder(fuzzyQuery("description", "fop")))).get();
+                .setQuery(spanOrQuery(spanMultiTermQueryBuilder(fuzzyQuery("description", "fop")))).get();
         assertHitCount(response, 4);
 
         response = client().prepareSearch("test")
-                .setQuery(spanOrQuery().clause(spanMultiTermQueryBuilder(prefixQuery("description", "fo")))).get();
+                .setQuery(spanOrQuery(spanMultiTermQueryBuilder(prefixQuery("description", "fo")))).get();
         assertHitCount(response, 4);
 
         response = client().prepareSearch("test")
-                .setQuery(spanOrQuery().clause(spanMultiTermQueryBuilder(wildcardQuery("description", "oth*")))).get();
+                .setQuery(spanOrQuery(spanMultiTermQueryBuilder(wildcardQuery("description", "oth*")))).get();
         assertHitCount(response, 3);
 
         response = client().prepareSearch("test")
-                .setQuery(spanOrQuery().clause(spanMultiTermQueryBuilder(QueryBuilders.rangeQuery("description").from("ffa").to("foo"))))
+                .setQuery(spanOrQuery(spanMultiTermQueryBuilder(QueryBuilders.rangeQuery("description").from("ffa").to("foo"))))
                 .execute().actionGet();
         assertHitCount(response, 3);
 
         response = client().prepareSearch("test")
-                .setQuery(spanOrQuery().clause(spanMultiTermQueryBuilder(regexpQuery("description", "fo{2}")))).get();
+                .setQuery(spanOrQuery(spanMultiTermQueryBuilder(regexpQuery("description", "fo{2}")))).get();
         assertHitCount(response, 3);
     }
 
@@ -1607,20 +1606,17 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
-                .setQuery(spanNotQuery(spanNearQuery(1)
-                        .clause(QueryBuilders.spanTermQuery("description", "quick"))
+                .setQuery(spanNotQuery(spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                         .clause(QueryBuilders.spanTermQuery("description", "fox")), spanTermQuery("description", "brown"))).get();
         assertHitCount(searchResponse, 1l);
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(spanNotQuery(spanNearQuery(1)
-                        .clause(QueryBuilders.spanTermQuery("description", "quick"))
+                .setQuery(spanNotQuery(spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                         .clause(QueryBuilders.spanTermQuery("description", "fox")), spanTermQuery("description", "sleeping")).dist(5)).get();
         assertHitCount(searchResponse, 1l);
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(spanNotQuery(spanNearQuery(1)
-                        .clause(QueryBuilders.spanTermQuery("description", "quick"))
+                .setQuery(spanNotQuery(spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                         .clause(QueryBuilders.spanTermQuery("description", "fox")), spanTermQuery("description", "jumped")).pre(1).post(1)).get();
         assertHitCount(searchResponse, 1l);
     }

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -31,10 +31,16 @@ Removed setters for mandatory big/little inner span queries. Both arguments now 
 to be supplied at construction time already and have to be non-null. Updated
 static factory methods in QueryBuilders accordingly.
 
+==== SpanOrQueryBuilder
+
+Making sure that query contains at least one clause by making initial clause mandatory
+in constructor.
+
 ==== SpanNearQueryBuilder
 
-Removed setter for mandatory slop parameter, needs to be set in constructor now.
-Updated the static factory methods in QueryBuilders accordingly.
+Removed setter for mandatory slop parameter, needs to be set in constructor now. Also
+making sure that query contains at least one clause by making initial clause mandatory
+in constructor. Updated the static factory methods in QueryBuilders accordingly.
 
 ==== SpanNotQueryBuilder
 


### PR DESCRIPTION
This PR is the second batch in moving the query validation we started
to collect in the validate() method to the corresponding setters
and constructors.
