### PR TITLE
Fix more issues with plugin unit tests and allow running from IDE.

### DIFF
--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -118,6 +118,10 @@ public class BootstrapForTesting {
                 // if its an insecure plugin, we use a wrapper policy impl to try
                 // to simulate what happens with a real distribution
                 String artifact = System.getProperty("tests.artifact");
+                // in case we are running from the IDE:
+                if (artifact == null || System.getProperty("tests.maven") == null) {
+                    artifact = PathUtils.get(System.getProperty("user.dir")).toAbsolutePath().getFileName().toString();
+                }
                 String insecurePluginProp = Security.INSECURE_PLUGINS.get(artifact);
                 if (insecurePluginProp != null) {
                     policy = new MockPluginPolicy(perms, insecurePluginProp);
@@ -131,10 +135,11 @@ public class BootstrapForTesting {
                 if (insecurePluginProp != null) {
                     // initialize the plugin class, in case it has one-time hacks (unit tests often won't do this)
                     String clazz = System.getProperty("tests.plugin.classname");
-                    if (clazz == null) {
-                        throw new IllegalStateException("plugin classname is needed for insecure plugin unit tests");
+                    if (clazz != null) {
+                        Class.forName(clazz);
+                    } else if (System.getProperty("tests.maven") != null) {
+                        throw new IllegalStateException("plugin classname is needed for insecure plugin unit tests: something wrong with build");
                     }
-                    Class.forName(clazz);
                 }
             } catch (Exception e) {
                 throw new RuntimeException("unable to install test security manager", e);


### PR DESCRIPTION
This is the more sheisty business along the same lines as
https://github.com/elastic/elasticsearch/pull/13638

1 hour total adding the real functionality, days of wasted time
on simulated fake functionality to satisfy our crazy test framework...

I debugged on the problematic jenkins machine and I think issues are
from parsing the classpath and URL normalization etc (trailing slashes
vs not, etc in URLs). So I simplifed the code, to remove this completely,
inverting the logic so we just use an exclusion list instead of inclusion one.

I also allow tests for these plugins to run from the IDE (works at least for eclipse) too.
At least for eclipse this is even less realistic as it piles all the code (src and test)
into a single codebase, but it means you can _use it_ and you just have to run mvn verify
before pushing as always. And as always... best effort.
