### PR TITLE
Add Intellij support for plugins with extra permissions.

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
@@ -54,6 +54,6 @@ public final class BootstrapInfo {
      * that require additional privileges as a workaround.
      */
     public static Set<String> getInsecurePluginList() {
-        return Collections.unmodifiableSet(Security.INSECURE_PLUGINS.keySet());
+        return Collections.unmodifiableSet(Security.SPECIAL_PLUGINS.keySet());
     }
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.bootstrap;
 
-import java.util.Collections;
-import java.util.Set;
-
 /** 
  * Exposes system startup information 
  */
@@ -45,15 +42,5 @@ public final class BootstrapInfo {
      */
     public static boolean isMemoryLocked() {
         return Natives.isMemoryLocked();
-    }
-
-    /**
-     * Returns set of insecure plugins.
-     * <p>
-     * These are plugins with unresolved issues in third-party libraries,
-     * that require additional privileges as a workaround.
-     */
-    public static Set<String> getInsecurePluginList() {
-        return Collections.unmodifiableSet(Security.SPECIAL_PLUGINS.keySet());
     }
 }

--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -37,22 +37,22 @@ grant codeBase "${es.security.jar.lucene.core}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-//// Insecure plugin permissions:
-//// These are dangerous permissions due to problems in third-party library code
-//// We try our best to contain and protect the issues, but ultimately warn the user
-//// when installing these plugins that it can introduce a security risk
+//// Special plugin permissions:
+//// These are dangerous permissions only needed by special plugins that we don't
+//// want to grant in general. Some may be due to problems in third-party library code,
+//// others may just be more obscure integrations.
 
-grant codeBase "${es.security.insecure.plugin.repository-s3}" {
+grant codeBase "${es.security.plugin.repository-s3}" {
   // needed because of problems in aws-sdk
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-grant codeBase "${es.security.insecure.plugin.discovery-ec2}" {
+grant codeBase "${es.security.plugin.discovery-ec2}" {
   // needed because of problems in aws-sdk
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-grant codeBase "${es.security.insecure.plugin.cloud-gce}" {
+grant codeBase "${es.security.plugin.cloud-gce}" {
   // needed because of problems in cloud-gce
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -114,6 +114,11 @@ public class BootstrapForTesting {
                     // in case we get fancy and use the -integration goals later:
                     perms.add(new FilePermission(coverageDir.resolve("jacoco-it.exec").toString(), "read,write"));
                 }
+                // intellij hack: intellij test runner wants setIO and will
+                // screw up all test logging without it!
+                if (System.getProperty("tests.maven") == null) {
+                    perms.add(new RuntimePermission("setIO"));
+                }
 
                 final Policy policy;
                 // if its a plugin with special permissions, we use a wrapper policy impl to try

--- a/pom.xml
+++ b/pom.xml
@@ -664,9 +664,8 @@
                             <tests.cluster>${tests.cluster}</tests.cluster>
                             <tests.iters>${tests.iters}</tests.iters>
                             <tests.project>${project.groupId}:${project.artifactId}</tests.project>
-                            <!-- these two are needed for insecure plugins, remove if possible! -->
+                            <!-- needed to know which project we are in for plugin permissions -->
                             <tests.artifact>${project.artifactId}</tests.artifact>
-                            <tests.plugin.classname>${elasticsearch.plugin.classname}</tests.plugin.classname>
                             <tests.maxfailures>${tests.maxfailures}</tests.maxfailures>
                             <tests.failfast>${tests.failfast}</tests.failfast>
                             <tests.class>${tests.class}</tests.class>


### PR DESCRIPTION
graduate this from a hack for insecure plugins to something we can
live with for per-module/plugin permissions, it now works reasonably
in unit tests and with Intellij and Eclipse IDEs.

remove security warnings: we will deal with these issues in a secure
way, if we cannot, then the plugin shouldn't be in our core codebase.

separately, fix test logging when running under intellij.
