### PR TITLE
Query refactoring: function_score

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -27,6 +27,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.support.ToXContentToBytes;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.unit.DistanceUnit.Distance;
@@ -34,7 +35,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 
 import java.io.IOException;
@@ -43,7 +43,7 @@ import java.util.*;
 /**
  * Basic class for building GeoJSON shapes like Polygons, Linestrings, etc 
  */
-public abstract class ShapeBuilder implements ToXContent {
+public abstract class ShapeBuilder extends ToXContentToBytes {
 
     protected static final ESLogger LOGGER = ESLoggerFactory.getLogger(ShapeBuilder.class.getName());
 
@@ -208,16 +208,6 @@ public abstract class ShapeBuilder implements ToXContent {
      * @return a new {@link EnvelopeBuilder}
      */
     public static EnvelopeBuilder newEnvelope(Orientation orientation) { return new EnvelopeBuilder(orientation); }
-
-    @Override
-    public String toString() {
-        try {
-            XContentBuilder xcontent = JsonXContent.contentBuilder();
-            return toXContent(xcontent, EMPTY_PARAMS).prettyPrint().string();
-        } catch (IOException e) {
-            return super.toString();
-        }
-    }
 
     /**
      * Create a new Shape from this builder. Since calling this method could change the

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.text.StringAndBytesText;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -584,6 +585,13 @@ public abstract class StreamInput extends InputStream {
      */
     public QueryBuilder readQuery() throws IOException {
         return readNamedWriteable(QueryBuilder.class);
+    }
+
+    /**
+     * Reads a {@link org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder} from the current stream
+     */
+    public ScoreFunctionBuilder<?> readScoreFunction() throws IOException {
+        return readNamedWriteable(ScoreFunctionBuilder.class);
     }
 
     public static StreamInput wrap(BytesReference reference) {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.joda.time.ReadableInstant;
 
 import java.io.EOFException;
@@ -587,5 +588,12 @@ public abstract class StreamOutput extends OutputStream {
      */
     public void writeQuery(QueryBuilder queryBuilder) throws IOException {
         writeNamedWriteable(queryBuilder);
+    }
+
+    /**
+     * Writes a {@link ScoreFunctionBuilder} to the current stream
+     */
+    public void writeScoreFunction(ScoreFunctionBuilder<?> scoreFunctionBuilder) throws IOException {
+        writeNamedWriteable(scoreFunctionBuilder);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -22,11 +22,16 @@ package org.elasticsearch.common.lucene.search.function;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 
+import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * A function_score function that multiplies the score with the value of a
@@ -45,7 +50,7 @@ public class FieldValueFactorFunction extends ScoreFunction {
 
     public FieldValueFactorFunction(String field, float boostFactor, Modifier modifierType, Double missing,
             IndexNumericFieldData indexFieldData) {
-        super(CombineFunction.MULT);
+        super(CombineFunction.MULTIPLY);
         this.field = field;
         this.boostFactor = boostFactor;
         this.modifier = modifierType;
@@ -103,11 +108,19 @@ public class FieldValueFactorFunction extends ScoreFunction {
         return false;
     }
 
+    @Override
+    protected boolean doEquals(ScoreFunction other) {
+        FieldValueFactorFunction fieldValueFactorFunction = (FieldValueFactorFunction) other;
+        return this.boostFactor == fieldValueFactorFunction.boostFactor &&
+                Objects.equals(this.field, fieldValueFactorFunction.field) &&
+                Objects.equals(this.modifier, fieldValueFactorFunction.modifier);
+    }
+
     /**
      * The Type class encapsulates the modification types that can be applied
      * to the score/value product.
      */
-    public enum Modifier {
+    public enum Modifier implements Writeable<Modifier> {
         NONE {
             @Override
             public double apply(double n) {
@@ -172,8 +185,30 @@ public class FieldValueFactorFunction extends ScoreFunction {
         public abstract double apply(double n);
 
         @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(this.ordinal());
+        }
+
+        public static Modifier readModifierFrom(StreamInput in) throws IOException {
+            return Modifier.NONE.readFrom(in);
+        }
+
+        @Override
+        public Modifier readFrom(StreamInput in) throws IOException {
+            int ordinal = in.readVInt();
+            if (ordinal < 0 || ordinal >= values().length) {
+                throw new IOException("Unknown Modifier ordinal [" + ordinal + "]");
+            }
+            return values()[ordinal];
+        }
+
+        @Override
         public String toString() {
             return super.toString().toLowerCase(Locale.ROOT);
+        }
+
+        public static Modifier fromString(String modifier) {
+            return valueOf(modifier.toUpperCase(Locale.ROOT));
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.ToStringUtils;
 
 import java.io.IOException;
@@ -35,31 +34,27 @@ import java.util.Set;
  */
 public class FunctionScoreQuery extends Query {
 
+    public static final float DEFAULT_MAX_BOOST = Float.MAX_VALUE;
+
     Query subQuery;
     final ScoreFunction function;
-    float maxBoost = Float.MAX_VALUE;
-    CombineFunction combineFunction;
-    private Float minScore = null;
+    final float maxBoost;
+    final CombineFunction combineFunction;
+    private Float minScore;
 
-    public FunctionScoreQuery(Query subQuery, ScoreFunction function, Float minScore) {
+    public FunctionScoreQuery(Query subQuery, ScoreFunction function, Float minScore, CombineFunction combineFunction, float maxBoost) {
         this.subQuery = subQuery;
         this.function = function;
-        this.combineFunction = function == null? CombineFunction.MULT : function.getDefaultScoreCombiner();
+        this.combineFunction = combineFunction;
         this.minScore = minScore;
+        this.maxBoost = maxBoost;
     }
 
     public FunctionScoreQuery(Query subQuery, ScoreFunction function) {
         this.subQuery = subQuery;
         this.function = function;
         this.combineFunction = function.getDefaultScoreCombiner();
-    }
-
-    public void setCombineFunction(CombineFunction combineFunction) {
-        this.combineFunction = combineFunction;
-    }
-    
-    public void setMaxBoost(float maxBoost) {
-        this.maxBoost = maxBoost;
+        this.maxBoost = DEFAULT_MAX_BOOST;
     }
 
     public float getMaxBoost() {
@@ -193,15 +188,20 @@ public class FunctionScoreQuery extends Query {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass())
+        if (this == o) {
+            return true;
+        }
+        if (super.equals(o) == false) {
             return false;
+        }
         FunctionScoreQuery other = (FunctionScoreQuery) o;
-        return this.getBoost() == other.getBoost() && this.subQuery.equals(other.subQuery) && (this.function != null ? this.function.equals(other.function) : other.function == null)
-                && this.maxBoost == other.maxBoost;
+        return Objects.equals(this.subQuery, other.subQuery) && Objects.equals(this.function, other.function)
+                && Objects.equals(this.combineFunction, other.combineFunction)
+                && Objects.equals(this.minScore, other.minScore) && this.maxBoost == other.maxBoost;
     }
 
     @Override
     public int hashCode() {
-        return subQuery.hashCode() + 31 * Objects.hashCode(function) ^ Float.floatToIntBits(getBoost());
+        return Objects.hash(super.hashCode(), subQuery.hashCode(), function, combineFunction, minScore, maxBoost);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
@@ -38,7 +38,7 @@ public class RandomScoreFunction extends ScoreFunction {
      * Default constructor. Only useful for constructing as a placeholder, but should not be used for actual scoring.
      */
     public RandomScoreFunction() {
-        super(CombineFunction.MULT);
+        super(CombineFunction.MULTIPLY);
         uidFieldData = null;
     }
 
@@ -50,7 +50,7 @@ public class RandomScoreFunction extends ScoreFunction {
      * @param uidFieldData The field data for _uid to use for generating consistent random values for the same id
      */
     public RandomScoreFunction(int seed, int salt, IndexFieldData<?> uidFieldData) {
-        super(CombineFunction.MULT);
+        super(CombineFunction.MULTIPLY);
         this.originalSeed = seed;
         this.saltedSeed = seed ^ salt;
         this.uidFieldData = uidFieldData;
@@ -84,5 +84,12 @@ public class RandomScoreFunction extends ScoreFunction {
     @Override
     public boolean needsScores() {
         return false;
+    }
+
+    @Override
+    protected boolean doEquals(ScoreFunction other) {
+        RandomScoreFunction randomScoreFunction = (RandomScoreFunction) other;
+        return this.originalSeed == randomScoreFunction.originalSeed &&
+                this.saltedSeed == randomScoreFunction.saltedSeed;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.lucene.search.function;
 import org.apache.lucene.index.LeafReaderContext;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  *
@@ -46,4 +47,23 @@ public abstract class ScoreFunction {
      * @return {@code true} if scores are needed.
      */
     public abstract boolean needsScores();
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ScoreFunction other = (ScoreFunction) obj;
+        return Objects.equals(scoreCombiner, other.scoreCombiner) &&
+                doEquals(other);
+    }
+
+    /**
+     * Indicates whether some other {@link ScoreFunction} object of the same type is "equal to" this one.
+     */
+    protected abstract boolean doEquals(ScoreFunction other);
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class ScriptScoreFunction extends ScoreFunction {
 
@@ -136,4 +137,9 @@ public class ScriptScoreFunction extends ScoreFunction {
         return "script" + sScript.toString();
     }
 
+    @Override
+    protected boolean doEquals(ScoreFunction other) {
+        ScriptScoreFunction scriptScoreFunction = (ScriptScoreFunction) other;
+        return Objects.equals(this.sScript, scriptScoreFunction.sScript);
+    }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
@@ -23,18 +23,19 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  *
  */
 public class WeightFactorFunction extends ScoreFunction {
 
-    private static final ScoreFunction SCORE_ONE = new ScoreOne(CombineFunction.MULT);
+    private static final ScoreFunction SCORE_ONE = new ScoreOne(CombineFunction.MULTIPLY);
     private final ScoreFunction scoreFunction;
     private float weight = 1.0f;
 
     public WeightFactorFunction(float weight, ScoreFunction scoreFunction) {
-        super(CombineFunction.MULT);
+        super(CombineFunction.MULTIPLY);
         if (scoreFunction == null) {
             this.scoreFunction = SCORE_ONE;
         } else {
@@ -44,7 +45,7 @@ public class WeightFactorFunction extends ScoreFunction {
     }
 
     public WeightFactorFunction(float weight) {
-        super(CombineFunction.MULT);
+        super(CombineFunction.MULTIPLY);
         this.scoreFunction = SCORE_ONE;
         this.weight = weight;
     }
@@ -81,6 +82,17 @@ public class WeightFactorFunction extends ScoreFunction {
         return weight;
     }
 
+    public ScoreFunction getScoreFunction() {
+        return scoreFunction;
+    }
+
+    @Override
+    protected boolean doEquals(ScoreFunction other) {
+        WeightFactorFunction weightFactorFunction = (WeightFactorFunction) other;
+        return this.weight == weightFactorFunction.weight &&
+                Objects.equals(this.scoreFunction, weightFactorFunction.scoreFunction);
+    }
+
     private static class ScoreOne extends ScoreFunction {
 
         protected ScoreOne(CombineFunction scoreCombiner) {
@@ -105,6 +117,11 @@ public class WeightFactorFunction extends ScoreFunction {
         @Override
         public boolean needsScores() {
             return false;
+        }
+
+        @Override
+        protected boolean doEquals(ScoreFunction other) {
+            return true;
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -118,11 +118,10 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
         if (shape != null) {
             XContentBuilder builder = XContentFactory.jsonBuilder();
             shape.toXContent(builder, EMPTY_PARAMS);
-            BytesReference bytes = builder.bytes();
-            if (bytes.length() == 0) {
+            this.shapeBytes = shape.buildAsBytes(XContentType.JSON);
+            if (this.shapeBytes.length() == 0) {
                 throw new IllegalArgumentException("shape must not be empty");
             }
-            this.shapeBytes = bytes;
         } else {
             throw new IllegalArgumentException("shape must not be null");
         }

--- a/core/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IndexQueryParserService.java
@@ -96,8 +96,7 @@ public class IndexQueryParserService extends AbstractIndexComponent {
     private final boolean queryStringAllowLeadingWildcard;
     private final ParseFieldMatcher parseFieldMatcher;
     private final boolean defaultAllowUnmappedFields;
-
-    private Client client;
+    private final Client client;
 
     @Inject
     public IndexQueryParserService(Index index, @IndexSettings Settings indexSettings, Settings settings,

--- a/core/src/main/java/org/elasticsearch/index/query/Operator.java
+++ b/core/src/main/java/org/elasticsearch/index/query/Operator.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.CollectionUtils;
 
 import java.io.IOException;
+import java.util.Locale;
 
 public enum Operator implements Writeable<Operator> {
     OR, AND;
@@ -56,7 +57,11 @@ public enum Operator implements Writeable<Operator> {
 
     @Override
     public Operator readFrom(StreamInput in) throws IOException {
-        return Operator.values()[in.readVInt()];
+        int ordinal = in.readVInt();
+        if (ordinal < 0 || ordinal >= values().length) {
+            throw new IOException("Unknown Operator ordinal [" + ordinal + "]");
+        }
+        return values()[ordinal];
     }
 
     public static Operator readOperatorFrom(StreamInput in) throws IOException {
@@ -69,15 +74,10 @@ public enum Operator implements Writeable<Operator> {
     }
 
     public static Operator fromString(String op) {
-        for (Operator operator : Operator.values()) {
-            if (operator.name().equalsIgnoreCase(op)) {
-                return operator;
-            }
-        }
-        throw Operator.newOperatorException(op);
+        return valueOf(op.toUpperCase(Locale.ROOT));
     }
 
     private static IllegalArgumentException newOperatorException(String op) {
-        return new IllegalArgumentException("operator needs to be either " + CollectionUtils.arrayAsArrayList(Operator.values()) + ", but not [" + op + "]");
+        return new IllegalArgumentException("operator needs to be either " + CollectionUtils.arrayAsArrayList(values()) + ", but not [" + op + "]");
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -372,19 +372,34 @@ public abstract class QueryBuilders {
     }
 
     /**
-     * A query that allows to define a custom scoring function.
+     * A function_score query with no functions.
      *
      * @param queryBuilder The query to custom score
+     * @return the function score query
      */
     public static FunctionScoreQueryBuilder functionScoreQuery(QueryBuilder queryBuilder) {
         return new FunctionScoreQueryBuilder(queryBuilder);
     }
 
     /**
-     * A query that allows to define a custom scoring function.
+     * A query that allows to define a custom scoring function
+     *
+     * @param queryBuilder The query to custom score
+     * @param filterFunctionBuilders the filters and functions to execute
+     * @return the function score query
      */
-    public static FunctionScoreQueryBuilder functionScoreQuery() {
-        return new FunctionScoreQueryBuilder();
+    public static FunctionScoreQueryBuilder functionScoreQuery(QueryBuilder queryBuilder, FunctionScoreQueryBuilder.FilterFunctionBuilder[] filterFunctionBuilders) {
+        return new FunctionScoreQueryBuilder(queryBuilder, filterFunctionBuilders);
+    }
+
+    /**
+     * A query that allows to define a custom scoring function
+     *
+     * @param filterFunctionBuilders the filters and functions to execute
+     * @return the function score query
+     */
+    public static FunctionScoreQueryBuilder functionScoreQuery(FunctionScoreQueryBuilder.FilterFunctionBuilder[] filterFunctionBuilders) {
+        return new FunctionScoreQueryBuilder(filterFunctionBuilders);
     }
 
     /**
@@ -403,7 +418,7 @@ public abstract class QueryBuilders {
      * @param function     The function builder used to custom score
      */
     public static FunctionScoreQueryBuilder functionScoreQuery(QueryBuilder queryBuilder, ScoreFunctionBuilder function) {
-        return (new FunctionScoreQueryBuilder(queryBuilder)).add(function);
+        return (new FunctionScoreQueryBuilder(queryBuilder, function));
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -110,7 +110,9 @@ public class QueryShardContext {
     }
 
     public void parseFieldMatcher(ParseFieldMatcher parseFieldMatcher) {
+        //norelease ParseFieldMatcher is currently duplicated, this should be cleaned up
         this.parseFieldMatcher = parseFieldMatcher;
+        this.parseContext.parseFieldMatcher(parseFieldMatcher);
     }
 
     public ParseFieldMatcher parseFieldMatcher() {
@@ -119,7 +121,7 @@ public class QueryShardContext {
 
     public void reset() {
         allowUnmappedFields = indexQueryParser.defaultAllowUnmappedFields();
-        this.parseFieldMatcher = ParseFieldMatcher.EMPTY;
+        this.parseFieldMatcher(ParseFieldMatcher.EMPTY);
         this.lookup = null;
         this.namedQueries.clear();
         this.nestedScope = new NestedScope();

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunction.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunction.java
@@ -32,9 +32,9 @@ import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionParse
 
 public interface DecayFunction {
 
-    public double evaluate(double value, double scale);
+    double evaluate(double value, double scale);
 
-    public Explanation explainFunction(String valueString, double value, double scale);
+    Explanation explainFunction(String valueString, double value, double scale);
 
     /**
      * The final scale parameter is computed from the scale parameter given by
@@ -49,6 +49,5 @@ public interface DecayFunction {
      *            the value which decay function should take once the distance
      *            reaches this scale
      * */
-    public double processScale(double scale, double decay);
-
+    double processScale(double scale, double decay);
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -19,73 +19,515 @@
 
 package org.elasticsearch.index.query.functionscore;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.common.lucene.search.function.LeafScoreFunction;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.*;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.core.DateFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
-import java.util.Locale;
+import java.util.Objects;
 
-public abstract class DecayFunctionBuilder extends ScoreFunctionBuilder {
+public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder> extends ScoreFunctionBuilder<DFB> {
 
     protected static final String ORIGIN = "origin";
     protected static final String SCALE = "scale";
     protected static final String DECAY = "decay";
     protected static final String OFFSET = "offset";
 
-    private String fieldName;
-    private Object origin;
-    private Object scale;
-    private double decay = -1;
-    private Object offset;
-    private MultiValueMode multiValueMode = null;
+    public static double DEFAULT_DECAY = 0.5;
+    public static MultiValueMode DEFAULT_MULTI_VALUE_MODE = MultiValueMode.MIN;
 
-    public DecayFunctionBuilder(String fieldName, Object origin, Object scale) {
-        this.fieldName = fieldName;
-        this.origin = origin;
-        this.scale = scale;
+    private final String fieldName;
+    //parsing of origin, scale, offset and decay depends on the field type, delayed to the data node that has the mapping for it
+    private final BytesReference functionBytes;
+    private MultiValueMode multiValueMode = DEFAULT_MULTI_VALUE_MODE;
+
+    protected DecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset) {
+        this(fieldName, origin, scale, offset, DEFAULT_DECAY);
     }
 
-    public DecayFunctionBuilder setDecay(double decay) {
-        if (decay <= 0 || decay >= 1.0) {
-            throw new IllegalStateException("scale weight parameter must be in range 0..1!");
+    protected DecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, double decay) {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("decay function: field name must not be null");
         }
-        this.decay = decay;
-        return this;
+        if (scale == null) {
+            throw new IllegalArgumentException("decay function: scale must not be null");
+        }
+        if (decay <= 0 || decay >= 1.0) {
+            throw new IllegalStateException("decay function: decay must be in range 0..1!");
+        }
+        this.fieldName = fieldName;
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            builder.startObject();
+            if (origin != null) {
+                builder.field(ORIGIN, origin);
+            }
+            builder.field(SCALE, scale);
+            if (offset != null) {
+                builder.field(OFFSET, offset);
+            }
+            builder.field(DECAY, decay);
+            builder.endObject();
+            this.functionBytes = builder.bytes();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("unable to build inner function object",e);
+        }
     }
 
-    public DecayFunctionBuilder setOffset(Object offset) {
-        this.offset = offset;
-        return this;
+    protected DecayFunctionBuilder(String fieldName, BytesReference functionBytes) {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("decay function: field name must not be null");
+        }
+        if (functionBytes == null) {
+            throw new IllegalArgumentException("decay function: function must not be null");
+        }
+        this.fieldName = fieldName;
+        this.functionBytes = functionBytes;
+    }
+
+    public String getFieldName() {
+        return this.fieldName;
+    }
+
+    public BytesReference getFunctionBytes() {
+        return this.functionBytes;
     }
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(getName());
-        builder.startObject(fieldName);
-        if (origin != null) {
-            builder.field(ORIGIN, origin);
-        }
-        builder.field(SCALE, scale);
-        if (decay > 0) {
-            builder.field(DECAY, decay);
-        }
-        if (offset != null) {
-            builder.field(OFFSET, offset);
-        }
-        builder.endObject();
-        if (multiValueMode != null) {
-            builder.field(DecayFunctionParser.MULTI_VALUE_MODE.getPreferredName(), multiValueMode.name());
-        }
+        builder.field(fieldName);
+        XContentParser parser = XContentFactory.xContent(functionBytes).createParser(functionBytes);
+        builder.copyCurrentStructure(parser);
+        builder.field(DecayFunctionParser.MULTI_VALUE_MODE.getPreferredName(), multiValueMode.name());
         builder.endObject();
     }
 
     public ScoreFunctionBuilder setMultiValueMode(MultiValueMode multiValueMode) {
+        if (multiValueMode == null) {
+            throw new IllegalArgumentException("decay function: multi_value_mode must not be null");
+        }
         this.multiValueMode = multiValueMode;
         return this;
     }
 
-    public ScoreFunctionBuilder setMultiValueMode(String multiValueMode) {
-        this.multiValueMode = MultiValueMode.fromString(multiValueMode.toUpperCase(Locale.ROOT));
-        return this;
+    public MultiValueMode getMultiValueMode() {
+        return this.multiValueMode;
+    }
+
+    @Override
+    protected DFB doReadFrom(StreamInput in) throws IOException {
+        DFB decayFunctionBuilder = createFunctionBuilder(in.readString(), in.readBytesReference());
+        decayFunctionBuilder.setMultiValueMode(MultiValueMode.readMultiValueModeFrom(in));
+        return decayFunctionBuilder;
+    }
+
+    protected abstract DFB createFunctionBuilder(String fieldName, BytesReference functionBytes);
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeBytesReference(functionBytes);
+        multiValueMode.writeTo(out);
+    }
+
+    @Override
+    protected boolean doEquals(DFB functionBuilder) {
+        return Objects.equals(this.fieldName, functionBuilder.getFieldName()) &&
+                Objects.equals(this.functionBytes, functionBuilder.getFunctionBytes()) &&
+                Objects.equals(this.multiValueMode, functionBuilder.getMultiValueMode());
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(this.fieldName, this.functionBytes, this.multiValueMode);
+    }
+
+    @Override
+    protected ScoreFunction doToFunction(QueryShardContext context) throws IOException {
+        XContentParser parser = XContentFactory.xContent(functionBytes).createParser(functionBytes);
+        return parseVariable(fieldName, parser, context, multiValueMode);
+    }
+
+    /**
+     * Override this function if you want to produce your own scorer.
+     * */
+    protected abstract DecayFunction getDecayFunction();
+
+    private AbstractDistanceScoreFunction parseVariable(String fieldName, XContentParser parser, QueryShardContext context, MultiValueMode mode) throws IOException {
+        //the field must exist, else we cannot read the value for the doc later
+        MappedFieldType fieldType = context.fieldMapper(fieldName);
+        if (fieldType == null) {
+            throw new ParsingException(parser.getTokenLocation(), "unknown field [{}]", fieldName);
+        }
+
+        // dates and time need special handling
+        parser.nextToken();
+        if (fieldType instanceof DateFieldMapper.DateFieldType) {
+            return parseDateVariable(parser, context, (DateFieldMapper.DateFieldType) fieldType, mode);
+        } else if (fieldType instanceof GeoPointFieldMapper.GeoPointFieldType) {
+            return parseGeoVariable(parser, context, (GeoPointFieldMapper.GeoPointFieldType) fieldType, mode);
+        } else if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
+            return parseNumberVariable(parser, context, (NumberFieldMapper.NumberFieldType) fieldType, mode);
+        } else {
+            throw new ParsingException(parser.getTokenLocation(), "field [{}] is of type [{}], but only numeric types are supported.", fieldName, fieldType);
+        }
+    }
+
+    private AbstractDistanceScoreFunction parseNumberVariable(XContentParser parser, QueryShardContext context,
+                                                              NumberFieldMapper.NumberFieldType fieldType, MultiValueMode mode) throws IOException {
+        XContentParser.Token token;
+        String parameterName = null;
+        double scale = 0;
+        double origin = 0;
+        double decay = 0.5;
+        double offset = 0.0d;
+        boolean scaleFound = false;
+        boolean refFound = false;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                parameterName = parser.currentName();
+            } else if (DecayFunctionBuilder.SCALE.equals(parameterName)) {
+                scale = parser.doubleValue();
+                scaleFound = true;
+            } else if (DecayFunctionBuilder.DECAY.equals(parameterName)) {
+                decay = parser.doubleValue();
+            } else if (DecayFunctionBuilder.ORIGIN.equals(parameterName)) {
+                origin = parser.doubleValue();
+                refFound = true;
+            } else if (DecayFunctionBuilder.OFFSET.equals(parameterName)) {
+                offset = parser.doubleValue();
+            } else {
+                throw new ElasticsearchParseException("parameter [{}] not supported!", parameterName);
+            }
+        }
+        if (!scaleFound || !refFound) {
+            throw new ElasticsearchParseException("both [{}] and [{}] must be set for numeric fields.", DecayFunctionBuilder.SCALE, DecayFunctionBuilder.ORIGIN);
+        }
+        IndexNumericFieldData numericFieldData = context.getForField(fieldType);
+        return new NumericFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), numericFieldData, mode);
+    }
+
+    private AbstractDistanceScoreFunction parseGeoVariable(XContentParser parser, QueryShardContext context,
+                                                           GeoPointFieldMapper.GeoPointFieldType fieldType, MultiValueMode mode) throws IOException {
+        XContentParser.Token token;
+        String parameterName = null;
+        GeoPoint origin = new GeoPoint();
+        String scaleString = null;
+        String offsetString = "0km";
+        double decay = 0.5;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                parameterName = parser.currentName();
+            } else if (DecayFunctionBuilder.SCALE.equals(parameterName)) {
+                scaleString = parser.text();
+            } else if (DecayFunctionBuilder.ORIGIN.equals(parameterName)) {
+                origin = GeoUtils.parseGeoPoint(parser);
+            } else if (DecayFunctionBuilder.DECAY.equals(parameterName)) {
+                decay = parser.doubleValue();
+            } else if (DecayFunctionBuilder.OFFSET.equals(parameterName)) {
+                offsetString = parser.text();
+            } else {
+                throw new ElasticsearchParseException("parameter [{}] not supported!", parameterName);
+            }
+        }
+        if (origin == null || scaleString == null) {
+            throw new ElasticsearchParseException("[{}] and [{}] must be set for geo fields.", DecayFunctionBuilder.ORIGIN, DecayFunctionBuilder.SCALE);
+        }
+        double scale = DistanceUnit.DEFAULT.parse(scaleString, DistanceUnit.DEFAULT);
+        double offset = DistanceUnit.DEFAULT.parse(offsetString, DistanceUnit.DEFAULT);
+        IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
+        return new GeoFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), indexFieldData, mode);
+
+    }
+
+    private AbstractDistanceScoreFunction parseDateVariable(XContentParser parser, QueryShardContext context,
+                                                            DateFieldMapper.DateFieldType dateFieldType, MultiValueMode mode) throws IOException {
+        XContentParser.Token token;
+        String parameterName = null;
+        String scaleString = null;
+        String originString = null;
+        String offsetString = "0d";
+        double decay = 0.5;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                parameterName = parser.currentName();
+            } else if (DecayFunctionBuilder.SCALE.equals(parameterName)) {
+                scaleString = parser.text();
+            } else if (DecayFunctionBuilder.ORIGIN.equals(parameterName)) {
+                originString = parser.text();
+            } else if (DecayFunctionBuilder.DECAY.equals(parameterName)) {
+                decay = parser.doubleValue();
+            } else if (DecayFunctionBuilder.OFFSET.equals(parameterName)) {
+                offsetString = parser.text();
+            } else {
+                throw new ElasticsearchParseException("parameter [{}] not supported!", parameterName);
+            }
+        }
+        long origin;
+        if (originString == null) {
+            origin = context.nowInMillis();
+        } else {
+            origin = dateFieldType.parseToMilliseconds(originString, false, null, null);
+        }
+
+        if (scaleString == null) {
+            throw new ElasticsearchParseException("[{}] must be set for date fields.", DecayFunctionBuilder.SCALE);
+        }
+        TimeValue val = TimeValue.parseTimeValue(scaleString, TimeValue.timeValueHours(24), DecayFunctionParser.class.getSimpleName() + ".scale");
+        double scale = val.getMillis();
+        val = TimeValue.parseTimeValue(offsetString, TimeValue.timeValueHours(24), DecayFunctionParser.class.getSimpleName() + ".offset");
+        double offset = val.getMillis();
+        IndexNumericFieldData numericFieldData = context.getForField(dateFieldType);
+        return new NumericFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), numericFieldData, mode);
+    }
+
+    static class GeoFieldDataScoreFunction extends AbstractDistanceScoreFunction {
+
+        private final GeoPoint origin;
+        private final IndexGeoPointFieldData fieldData;
+
+        private static final GeoDistance distFunction = GeoDistance.DEFAULT;
+
+        public GeoFieldDataScoreFunction(GeoPoint origin, double scale, double decay, double offset, DecayFunction func,
+                                         IndexGeoPointFieldData fieldData, MultiValueMode mode) {
+            super(scale, decay, offset, func, mode);
+            this.origin = origin;
+            this.fieldData = fieldData;
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
+        }
+
+        @Override
+        protected NumericDoubleValues distance(LeafReaderContext context) {
+            final MultiGeoPointValues geoPointValues = fieldData.load(context).getGeoPointValues();
+            return mode.select(new MultiValueMode.UnsortedNumericDoubleValues() {
+                @Override
+                public int count() {
+                    return geoPointValues.count();
+                }
+
+                @Override
+                public void setDocument(int docId) {
+                    geoPointValues.setDocument(docId);
+                }
+
+                @Override
+                public double valueAt(int index) {
+                    GeoPoint other = geoPointValues.valueAt(index);
+                    return Math.max(0.0d, distFunction.calculate(origin.lat(), origin.lon(), other.lat(), other.lon(), DistanceUnit.METERS) - offset);
+                }
+            }, 0.0);
+        }
+
+        @Override
+        protected String getDistanceString(LeafReaderContext ctx, int docId) {
+            StringBuilder values = new StringBuilder(mode.name());
+            values.append(" of: [");
+            final MultiGeoPointValues geoPointValues = fieldData.load(ctx).getGeoPointValues();
+            geoPointValues.setDocument(docId);
+            final int num = geoPointValues.count();
+            if (num > 0) {
+                for (int i = 0; i < num; i++) {
+                    GeoPoint value = geoPointValues.valueAt(i);
+                    values.append("Math.max(arcDistance(");
+                    values.append(value).append("(=doc value),").append(origin).append("(=origin)) - ").append(offset).append("(=offset), 0)");
+                    if (i != num - 1) {
+                        values.append(", ");
+                    }
+                }
+            } else {
+                values.append("0.0");
+            }
+            values.append("]");
+            return values.toString();
+        }
+
+        @Override
+        protected String getFieldName() {
+            return fieldData.getFieldNames().fullName();
+        }
+
+        @Override
+        protected boolean doEquals(ScoreFunction other) {
+            GeoFieldDataScoreFunction geoFieldDataScoreFunction = (GeoFieldDataScoreFunction) other;
+            return super.doEquals(other) &&
+                    Objects.equals(this.origin, geoFieldDataScoreFunction.origin);
+        }
+    }
+
+    static class NumericFieldDataScoreFunction extends AbstractDistanceScoreFunction {
+
+        private final IndexNumericFieldData fieldData;
+        private final double origin;
+
+        public NumericFieldDataScoreFunction(double origin, double scale, double decay, double offset, DecayFunction func,
+                                             IndexNumericFieldData fieldData, MultiValueMode mode) {
+            super(scale, decay, offset, func, mode);
+            this.fieldData = fieldData;
+            this.origin = origin;
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
+        }
+
+        @Override
+        protected NumericDoubleValues distance(LeafReaderContext context) {
+            final SortedNumericDoubleValues doubleValues = fieldData.load(context).getDoubleValues();
+            return mode.select(new MultiValueMode.UnsortedNumericDoubleValues() {
+                @Override
+                public int count() {
+                    return doubleValues.count();
+                }
+
+                @Override
+                public void setDocument(int docId) {
+                    doubleValues.setDocument(docId);
+                }
+
+                @Override
+                public double valueAt(int index) {
+                    return Math.max(0.0d, Math.abs(doubleValues.valueAt(index) - origin) - offset);
+                }
+            }, 0.0);
+        }
+
+        @Override
+        protected String getDistanceString(LeafReaderContext ctx, int docId) {
+
+            StringBuilder values = new StringBuilder(mode.name());
+            values.append("[");
+            final SortedNumericDoubleValues doubleValues = fieldData.load(ctx).getDoubleValues();
+            doubleValues.setDocument(docId);
+            final int num = doubleValues.count();
+            if (num > 0) {
+                for (int i = 0; i < num; i++) {
+                    double value = doubleValues.valueAt(i);
+                    values.append("Math.max(Math.abs(");
+                    values.append(value).append("(=doc value) - ").append(origin).append("(=origin))) - ").append(offset).append("(=offset), 0)");
+                    if (i != num - 1) {
+                        values.append(", ");
+                    }
+                }
+            } else {
+                values.append("0.0");
+            }
+            values.append("]");
+            return values.toString();
+
+        }
+
+        @Override
+        protected String getFieldName() {
+            return fieldData.getFieldNames().fullName();
+        }
+
+        @Override
+        protected boolean doEquals(ScoreFunction other) {
+            NumericFieldDataScoreFunction numericFieldDataScoreFunction = (NumericFieldDataScoreFunction) other;
+            if (super.doEquals(other) == false) {
+                return false;
+            }
+            return Objects.equals(this.origin, numericFieldDataScoreFunction.origin);
+        }
+    }
+
+    /**
+     * This is the base class for scoring a single field.
+     *
+     * */
+    public static abstract class AbstractDistanceScoreFunction extends ScoreFunction {
+
+        private final double scale;
+        protected final double offset;
+        private final DecayFunction func;
+        protected final MultiValueMode mode;
+
+        public AbstractDistanceScoreFunction(double userSuppiedScale, double decay, double offset, DecayFunction func, MultiValueMode mode) {
+            super(CombineFunction.MULTIPLY);
+            this.mode = mode;
+            if (userSuppiedScale <= 0.0) {
+                throw new IllegalArgumentException(FunctionScoreQueryBuilder.NAME + " : scale must be > 0.0.");
+            }
+            if (decay <= 0.0 || decay >= 1.0) {
+                throw new IllegalArgumentException(FunctionScoreQueryBuilder.NAME
+                        + " : decay must be in the range [0..1].");
+            }
+            this.scale = func.processScale(userSuppiedScale, decay);
+            this.func = func;
+            if (offset < 0.0d) {
+                throw new IllegalArgumentException(FunctionScoreQueryBuilder.NAME + " : offset must be > 0.0");
+            }
+            this.offset = offset;
+        }
+
+        /**
+         * This function computes the distance from a defined origin. Since
+         * the value of the document is read from the index, it cannot be
+         * guaranteed that the value actually exists. If it does not, we assume
+         * the user handles this case in the query and return 0.
+         * */
+        protected abstract NumericDoubleValues distance(LeafReaderContext context);
+
+        @Override
+        public final LeafScoreFunction getLeafScoreFunction(final LeafReaderContext ctx) {
+            final NumericDoubleValues distance = distance(ctx);
+            return new LeafScoreFunction() {
+
+                @Override
+                public double score(int docId, float subQueryScore) {
+                    return func.evaluate(distance.get(docId), scale);
+                }
+
+                @Override
+                public Explanation explainScore(int docId, Explanation subQueryScore) throws IOException {
+                    return Explanation.match(
+                            CombineFunction.toFloat(score(docId, subQueryScore.getValue())),
+                            "Function for field " + getFieldName() + ":",
+                            func.explainFunction(getDistanceString(ctx, docId), distance.get(docId), scale));
+                }
+            };
+        }
+
+        protected abstract String getDistanceString(LeafReaderContext ctx, int docId);
+
+        protected abstract String getFieldName();
+
+        @Override
+        protected boolean doEquals(ScoreFunction other) {
+            AbstractDistanceScoreFunction distanceScoreFunction = (AbstractDistanceScoreFunction) other;
+            return Objects.equals(this.scale, distanceScoreFunction.scale) &&
+                    Objects.equals(this.offset, distanceScoreFunction.offset) &&
+                    Objects.equals(this.mode, distanceScoreFunction.mode) &&
+                    Objects.equals(this.func, distanceScoreFunction.func) &&
+                    Objects.equals(this.getFieldName(), distanceScoreFunction.getFieldName());
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -19,39 +19,20 @@
 
 package org.elasticsearch.index.query.functionscore;
 
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.Explanation;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.geo.GeoDistance;
-import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.lucene.search.function.CombineFunction;
-import org.elasticsearch.common.lucene.search.function.LeafScoreFunction;
-import org.elasticsearch.common.lucene.search.function.ScoreFunction;
-import org.elasticsearch.common.unit.DistanceUnit;
-import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
-import org.elasticsearch.index.fielddata.MultiGeoPointValues;
-import org.elasticsearch.index.fielddata.NumericDoubleValues;
-import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.core.DateFieldMapper;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper;
-import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionParser;
 import org.elasticsearch.search.MultiValueMode;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.Locale;
 
 /**
  * This class provides the basic functionality needed for adding a decay
@@ -65,8 +46,9 @@ import java.util.Locale;
  *      "fieldname1" : {
  *          "origin" = "someValue",
  *          "scale" = "someValue"
- *      }
- *
+ *      },
+ *      "multi_value_mode" : "min"
+ * }
  * </code>
  * </pre>
  *
@@ -84,23 +66,24 @@ import java.util.Locale;
  * parameters origin and scale.
  * <p>
  * To write a new scoring function, create a new class that inherits from this
- * one and implement the getDistanceFunction(). Furthermore, to create a builder,
- * override the getName() in {@link DecayFunctionBuilder}.
+ * one and implements {@link #getBuilderPrototype()} and {@link #getNames()}.
+ * Also create its corresponding {@link DecayFunctionBuilder}. The latter needs to
+ * implement {@link DecayFunctionBuilder#doReadFrom(StreamInput)} and
+ * {@link DecayFunctionBuilder#doWriteTo(StreamOutput)} for serialization purposes,
+ * {@link DecayFunctionBuilder#doEquals(DecayFunctionBuilder)} and
+ * {@link DecayFunctionBuilder#doHashCode()} for equality checks,
+ * {@link DecayFunctionBuilder#getName()} that returns the name of the function and
+ * {@link DecayFunctionBuilder#getDecayFunction()} which returns the corresponding lucene function.
  * <p>
  * See {@link GaussDecayFunctionBuilder} and {@link GaussDecayFunctionParser}
  * for an example. The parser furthermore needs to be registered in the
  * {@link org.elasticsearch.search.SearchModule SearchModule}.
  *
- * **/
+ */
 
-public abstract class DecayFunctionParser implements ScoreFunctionParser {
+public abstract class DecayFunctionParser<DFB extends DecayFunctionBuilder<DFB>> implements ScoreFunctionParser<DFB> {
 
     public static final ParseField MULTI_VALUE_MODE = new ParseField("multi_value_mode");
-
-    /**
-     * Override this function if you want to produce your own scorer.
-     * */
-    public abstract DecayFunction getDecayFunction();
 
     /**
      * Parses bodies of the kind
@@ -109,371 +92,40 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
      * <code>
      * {
      *      "fieldname1" : {
-     *          "origin" = "someValue",
-     *          "scale" = "someValue"
-     *      }
-     *
+     *          "origin" : "someValue",
+     *          "scale" : "someValue"
+     *      },
+     *      "multi_value_mode" : "min"
      * }
      * </code>
      * </pre>
-     *
-     * */
+     */
     @Override
-    public ScoreFunction parse(QueryShardContext context, XContentParser parser) throws IOException, ParsingException {
+    public DFB fromXContent(QueryParseContext context, XContentParser parser) throws IOException, ParsingException {
         String currentFieldName;
         XContentParser.Token token;
-        AbstractDistanceScoreFunction scoreFunction;
-        String multiValueMode = "MIN";
-        XContentBuilder variableContent = XContentFactory.jsonBuilder();
+        MultiValueMode multiValueMode = DecayFunctionBuilder.DEFAULT_MULTI_VALUE_MODE;
         String fieldName = null;
+        BytesReference functionBytes = null;
         while ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME) {
             currentFieldName = parser.currentName();
             token = parser.nextToken();
             if (token == XContentParser.Token.START_OBJECT) {
-                variableContent.copyCurrentStructure(parser);
                 fieldName = currentFieldName;
+                XContentBuilder builder = XContentFactory.jsonBuilder();
+                builder.copyCurrentStructure(parser);
+                functionBytes = builder.bytes();
             } else if (context.parseFieldMatcher().match(currentFieldName, MULTI_VALUE_MODE)) {
-                multiValueMode = parser.text();
+                multiValueMode = MultiValueMode.fromString(parser.text());
             } else {
-                throw new ElasticsearchParseException("malformed score function score parameters.");
+                throw new ParsingException(parser.getTokenLocation(), "malformed score function score parameters.");
             }
         }
-        if (fieldName == null) {
-            throw new ElasticsearchParseException("malformed score function score parameters.");
+        if (fieldName == null || functionBytes == null) {
+            throw new ParsingException(parser.getTokenLocation(), "malformed score function score parameters.");
         }
-        XContentParser variableParser = XContentFactory.xContent(variableContent.string()).createParser(variableContent.string());
-        scoreFunction = parseVariable(fieldName, variableParser, context, MultiValueMode.fromString(multiValueMode.toUpperCase(Locale.ROOT)));
-        return scoreFunction;
+        DFB functionBuilder = getBuilderPrototype().createFunctionBuilder(fieldName, functionBytes);
+        functionBuilder.setMultiValueMode(multiValueMode);
+        return functionBuilder;
     }
-
-    // parses origin and scale parameter for field "fieldName"
-    private AbstractDistanceScoreFunction parseVariable(String fieldName, XContentParser parser, QueryShardContext context, MultiValueMode mode) throws IOException {
-
-        // now, the field must exist, else we cannot read the value for
-        // the doc later
-        MappedFieldType fieldType = context.fieldMapper(fieldName);
-        if (fieldType == null) {
-            throw new ParsingException(context.parseContext().parser().getTokenLocation(), "unknown field [{}]", fieldName);
-        }
-
-        // dates and time need special handling
-        parser.nextToken();
-        if (fieldType instanceof DateFieldMapper.DateFieldType) {
-            return parseDateVariable(fieldName, parser, context, (DateFieldMapper.DateFieldType) fieldType, mode);
-        } else if (fieldType instanceof GeoPointFieldMapper.GeoPointFieldType) {
-            return parseGeoVariable(fieldName, parser, context, (GeoPointFieldMapper.GeoPointFieldType) fieldType, mode);
-        } else if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
-            return parseNumberVariable(fieldName, parser, context, (NumberFieldMapper.NumberFieldType) fieldType, mode);
-        } else {
-            throw new ParsingException(context.parseContext().parser().getTokenLocation(), "field [{}] is of type [{}], but only numeric types are supported.", fieldName, fieldType);
-        }
-    }
-
-    private AbstractDistanceScoreFunction parseNumberVariable(String fieldName, XContentParser parser, QueryShardContext context,
-            NumberFieldMapper.NumberFieldType fieldType, MultiValueMode mode) throws IOException {
-        XContentParser.Token token;
-        String parameterName = null;
-        double scale = 0;
-        double origin = 0;
-        double decay = 0.5;
-        double offset = 0.0d;
-        boolean scaleFound = false;
-        boolean refFound = false;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                parameterName = parser.currentName();
-            } else if (parameterName.equals(DecayFunctionBuilder.SCALE)) {
-                scale = parser.doubleValue();
-                scaleFound = true;
-            } else if (parameterName.equals(DecayFunctionBuilder.DECAY)) {
-                decay = parser.doubleValue();
-            } else if (parameterName.equals(DecayFunctionBuilder.ORIGIN)) {
-                origin = parser.doubleValue();
-                refFound = true;
-            } else if (parameterName.equals(DecayFunctionBuilder.OFFSET)) {
-                offset = parser.doubleValue();
-            } else {
-                throw new ElasticsearchParseException("parameter [{}] not supported!", parameterName);
-            }
-        }
-        if (!scaleFound || !refFound) {
-            throw new ElasticsearchParseException("both [{}] and [{}] must be set for numeric fields.", DecayFunctionBuilder.SCALE, DecayFunctionBuilder.ORIGIN);
-        }
-        IndexNumericFieldData numericFieldData = context.getForField(fieldType);
-        return new NumericFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), numericFieldData, mode);
-    }
-
-    private AbstractDistanceScoreFunction parseGeoVariable(String fieldName, XContentParser parser, QueryShardContext context,
-            GeoPointFieldMapper.GeoPointFieldType fieldType, MultiValueMode mode) throws IOException {
-        XContentParser.Token token;
-        String parameterName = null;
-        GeoPoint origin = new GeoPoint();
-        String scaleString = null;
-        String offsetString = "0km";
-        double decay = 0.5;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                parameterName = parser.currentName();
-            } else if (parameterName.equals(DecayFunctionBuilder.SCALE)) {
-                scaleString = parser.text();
-            } else if (parameterName.equals(DecayFunctionBuilder.ORIGIN)) {
-                origin = GeoUtils.parseGeoPoint(parser);
-            } else if (parameterName.equals(DecayFunctionBuilder.DECAY)) {
-                decay = parser.doubleValue();
-            } else if (parameterName.equals(DecayFunctionBuilder.OFFSET)) {
-                offsetString = parser.text();
-            } else {
-                throw new ElasticsearchParseException("parameter [{}] not supported!", parameterName);
-            }
-        }
-        if (origin == null || scaleString == null) {
-            throw new ElasticsearchParseException("[{}] and [{}] must be set for geo fields.", DecayFunctionBuilder.ORIGIN, DecayFunctionBuilder.SCALE);
-        }
-        double scale = DistanceUnit.DEFAULT.parse(scaleString, DistanceUnit.DEFAULT);
-        double offset = DistanceUnit.DEFAULT.parse(offsetString, DistanceUnit.DEFAULT);
-        IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
-        return new GeoFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), indexFieldData, mode);
-
-    }
-
-    private AbstractDistanceScoreFunction parseDateVariable(String fieldName, XContentParser parser, QueryShardContext context,
-            DateFieldMapper.DateFieldType dateFieldType, MultiValueMode mode) throws IOException {
-        XContentParser.Token token;
-        String parameterName = null;
-        String scaleString = null;
-        String originString = null;
-        String offsetString = "0d";
-        double decay = 0.5;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                parameterName = parser.currentName();
-            } else if (parameterName.equals(DecayFunctionBuilder.SCALE)) {
-                scaleString = parser.text();
-            } else if (parameterName.equals(DecayFunctionBuilder.ORIGIN)) {
-                originString = parser.text();
-            } else if (parameterName.equals(DecayFunctionBuilder.DECAY)) {
-                decay = parser.doubleValue();
-            } else if (parameterName.equals(DecayFunctionBuilder.OFFSET)) {
-                offsetString = parser.text();
-            } else {
-                throw new ElasticsearchParseException("parameter [{}] not supported!", parameterName);
-            }
-        }
-        long origin = SearchContext.current().nowInMillis();
-        if (originString != null) {
-            origin = dateFieldType.parseToMilliseconds(originString, false, null, null);
-        }
-
-        if (scaleString == null) {
-            throw new ElasticsearchParseException("[{}] must be set for date fields.", DecayFunctionBuilder.SCALE);
-        }
-        TimeValue val = TimeValue.parseTimeValue(scaleString, TimeValue.timeValueHours(24), getClass().getSimpleName() + ".scale");
-        double scale = val.getMillis();
-        val = TimeValue.parseTimeValue(offsetString, TimeValue.timeValueHours(24), getClass().getSimpleName() + ".offset");
-        double offset = val.getMillis();
-        IndexNumericFieldData numericFieldData = context.getForField(dateFieldType);
-        return new NumericFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), numericFieldData, mode);
-    }
-
-    static class GeoFieldDataScoreFunction extends AbstractDistanceScoreFunction {
-
-        private final GeoPoint origin;
-        private final IndexGeoPointFieldData fieldData;
-
-        private static final GeoDistance distFunction = GeoDistance.DEFAULT;
-
-        public GeoFieldDataScoreFunction(GeoPoint origin, double scale, double decay, double offset, DecayFunction func,
-                IndexGeoPointFieldData fieldData, MultiValueMode mode) {
-            super(scale, decay, offset, func, mode);
-            this.origin = origin;
-            this.fieldData = fieldData;
-        }
-
-        @Override
-        public boolean needsScores() {
-            return false;
-        }
-
-        @Override
-        protected NumericDoubleValues distance(LeafReaderContext context) {
-            final MultiGeoPointValues geoPointValues = fieldData.load(context).getGeoPointValues();
-            return mode.select(new MultiValueMode.UnsortedNumericDoubleValues() {
-                @Override
-                public int count() {
-                    return geoPointValues.count();
-                }
-
-                @Override
-                public void setDocument(int docId) {
-                    geoPointValues.setDocument(docId);
-                }
-
-                @Override
-                public double valueAt(int index) {
-                    GeoPoint other = geoPointValues.valueAt(index);
-                    return Math.max(0.0d, distFunction.calculate(origin.lat(), origin.lon(), other.lat(), other.lon(), DistanceUnit.METERS) - offset);
-                }
-            }, 0.0);
-        }
-
-        @Override
-        protected String getDistanceString(LeafReaderContext ctx, int docId) {
-            StringBuilder values = new StringBuilder(mode.name());
-            values.append(" of: [");
-            final MultiGeoPointValues geoPointValues = fieldData.load(ctx).getGeoPointValues();
-            geoPointValues.setDocument(docId);
-            final int num = geoPointValues.count();
-            if (num > 0) {
-                for (int i = 0; i < num; i++) {
-                    GeoPoint value = geoPointValues.valueAt(i);
-                    values.append("Math.max(arcDistance(");
-                    values.append(value).append("(=doc value),").append(origin).append("(=origin)) - ").append(offset).append("(=offset), 0)");
-                    if (i != num - 1) {
-                        values.append(", ");
-                    }
-                }
-            } else {
-                values.append("0.0");
-            }
-            values.append("]");
-            return values.toString();
-        }
-
-        @Override
-        protected String getFieldName() {
-            return fieldData.getFieldNames().fullName();
-        }
-    }
-
-    static class NumericFieldDataScoreFunction extends AbstractDistanceScoreFunction {
-
-        private final IndexNumericFieldData fieldData;
-        private final double origin;
-
-        public NumericFieldDataScoreFunction(double origin, double scale, double decay, double offset, DecayFunction func,
-                IndexNumericFieldData fieldData, MultiValueMode mode) {
-            super(scale, decay, offset, func, mode);
-            this.fieldData = fieldData;
-            this.origin = origin;
-        }
-
-        @Override
-        public boolean needsScores() {
-            return false;
-        }
-
-        @Override
-        protected NumericDoubleValues distance(LeafReaderContext context) {
-            final SortedNumericDoubleValues doubleValues = fieldData.load(context).getDoubleValues();
-            return mode.select(new MultiValueMode.UnsortedNumericDoubleValues() {
-                @Override
-                public int count() {
-                    return doubleValues.count();
-                }
-
-                @Override
-                public void setDocument(int docId) {
-                    doubleValues.setDocument(docId);
-                }
-
-                @Override
-                public double valueAt(int index) {
-                    return Math.max(0.0d, Math.abs(doubleValues.valueAt(index) - origin) - offset);
-                }
-            }, 0.0);
-        }
-
-        @Override
-        protected String getDistanceString(LeafReaderContext ctx, int docId) {
-
-            StringBuilder values = new StringBuilder(mode.name());
-            values.append("[");
-            final SortedNumericDoubleValues doubleValues = fieldData.load(ctx).getDoubleValues();
-            doubleValues.setDocument(docId);
-            final int num = doubleValues.count();
-            if (num > 0) {
-                for (int i = 0; i < num; i++) {
-                    double value = doubleValues.valueAt(i);
-                    values.append("Math.max(Math.abs(");
-                    values.append(value).append("(=doc value) - ").append(origin).append("(=origin))) - ").append(offset).append("(=offset), 0)");
-                    if (i != num - 1) {
-                        values.append(", ");
-                    }
-                }
-            } else {
-                values.append("0.0");
-            }
-            values.append("]");
-            return values.toString();
-
-        }
-
-        @Override
-        protected String getFieldName() {
-            return fieldData.getFieldNames().fullName();
-        }
-    }
-
-    /**
-     * This is the base class for scoring a single field.
-     *
-     * */
-    public static abstract class AbstractDistanceScoreFunction extends ScoreFunction {
-
-        private final double scale;
-        protected final double offset;
-        private final DecayFunction func;
-        protected final MultiValueMode mode;
-
-        public AbstractDistanceScoreFunction(double userSuppiedScale, double decay, double offset, DecayFunction func, MultiValueMode mode) {
-            super(CombineFunction.MULT);
-            this.mode = mode;
-            if (userSuppiedScale <= 0.0) {
-                throw new IllegalArgumentException(FunctionScoreQueryParser.NAME + " : scale must be > 0.0.");
-            }
-            if (decay <= 0.0 || decay >= 1.0) {
-                throw new IllegalArgumentException(FunctionScoreQueryParser.NAME
-                        + " : decay must be in the range [0..1].");
-            }
-            this.scale = func.processScale(userSuppiedScale, decay);
-            this.func = func;
-            if (offset < 0.0d) {
-                throw new IllegalArgumentException(FunctionScoreQueryParser.NAME + " : offset must be > 0.0");
-            }
-            this.offset = offset;
-        }
-
-        /**
-         * This function computes the distance from a defined origin. Since
-         * the value of the document is read from the index, it cannot be
-         * guaranteed that the value actually exists. If it does not, we assume
-         * the user handles this case in the query and return 0.
-         * */
-        protected abstract NumericDoubleValues distance(LeafReaderContext context);
-
-        @Override
-        public final LeafScoreFunction getLeafScoreFunction(final LeafReaderContext ctx) {
-            final NumericDoubleValues distance = distance(ctx);
-            return new LeafScoreFunction() {
-
-                @Override
-                public double score(int docId, float subQueryScore) {
-                    return func.evaluate(distance.get(docId), scale);
-                }
-
-                @Override
-                public Explanation explainScore(int docId, Explanation subQueryScore) throws IOException {
-                    return Explanation.match(
-                            CombineFunction.toFloat(score(docId, subQueryScore.getValue())),
-                            "Function for field " + getFieldName() + ":",
-                            func.explainFunction(getDistanceString(ctx, docId), distance.get(docId), scale));
-                }
-            };
-        }
-
-        protected abstract String getDistanceString(LeafReaderContext ctx, int docId);
-
-        protected abstract String getFieldName();
-    }
-
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -19,13 +19,24 @@
 
 package org.elasticsearch.index.query.functionscore;
 
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery;
+import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.*;
+import org.elasticsearch.index.query.functionscore.random.RandomScoreFunctionBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Objects;
 
 /**
  * A query that uses a filters with a script associated with them to compute the
@@ -33,139 +44,169 @@ import java.util.ArrayList;
  */
 public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScoreQueryBuilder> {
 
-    private final QueryBuilder queryBuilder;
+    public static final String NAME = "function_score";
 
-    private Float maxBoost;
+    public static final CombineFunction DEFAULT_BOOST_MODE = CombineFunction.MULTIPLY;
+    public static final FiltersFunctionScoreQuery.ScoreMode DEFAULT_SCORE_MODE = FiltersFunctionScoreQuery.ScoreMode.MULTIPLY;
 
-    private String scoreMode;
+    private final QueryBuilder<?> query;
 
-    private String boostMode;
+    private float maxBoost = FunctionScoreQuery.DEFAULT_MAX_BOOST;
 
-    private ArrayList<QueryBuilder> filters = new ArrayList<>();
-    private ArrayList<ScoreFunctionBuilder> scoreFunctions = new ArrayList<>();
+    private FiltersFunctionScoreQuery.ScoreMode scoreMode = DEFAULT_SCORE_MODE;
+
+    private CombineFunction boostMode;
+
     private Float minScore = null;
 
-    static final FunctionScoreQueryBuilder PROTOTYPE = new FunctionScoreQueryBuilder();
+    private final FilterFunctionBuilder[] filterFunctionBuilders;
 
     /**
-     * Creates a function_score query that executes on documents that match query a query.
-     * Query and filter will be wrapped into a filtered_query.
+     * Creates a function_score query without functions
      *
-     * @param queryBuilder the query that defines which documents the function_score query will be executed on.
+     * @param query the query that needs to be custom scored
      */
-    public FunctionScoreQueryBuilder(QueryBuilder queryBuilder) {
-        this.queryBuilder = queryBuilder;
-    }
-
-    public FunctionScoreQueryBuilder() {
-        this.queryBuilder = null;
+    public FunctionScoreQueryBuilder(QueryBuilder<?> query) {
+        this(query, new FilterFunctionBuilder[0]);
     }
 
     /**
-     * Creates a function_score query that will execute the function scoreFunctionBuilder on all documents.
+     * Creates a function_score query that executes the provided filters and functions on all documents
+     *
+     * @param filterFunctionBuilders the filters and functions
+     */
+    public FunctionScoreQueryBuilder(FilterFunctionBuilder[] filterFunctionBuilders) {
+        this(new MatchAllQueryBuilder(), filterFunctionBuilders);
+    }
+
+    /**
+     * Creates a function_score query that will execute the function provided on all documents
      *
      * @param scoreFunctionBuilder score function that is executed
      */
     public FunctionScoreQueryBuilder(ScoreFunctionBuilder scoreFunctionBuilder) {
-        if (scoreFunctionBuilder == null) {
-            throw new IllegalArgumentException("function_score: function must not be null");
-        }
-        queryBuilder = null;
-        this.filters.add(null);
-        this.scoreFunctions.add(scoreFunctionBuilder);
+        this(new MatchAllQueryBuilder(), new FilterFunctionBuilder[]{new FilterFunctionBuilder(scoreFunctionBuilder)});
     }
 
     /**
-     * Adds a score function that will will execute the function scoreFunctionBuilder on all documents matching the filter.
+     * Creates a function_score query that will execute the function provided in the context of the provided query
      *
-     * @param filter the filter that defines which documents the function_score query will be executed on.
+     * @param query the query to custom score
      * @param scoreFunctionBuilder score function that is executed
      */
-    public FunctionScoreQueryBuilder add(QueryBuilder filter, ScoreFunctionBuilder scoreFunctionBuilder) {
-        if (scoreFunctionBuilder == null) {
-            throw new IllegalArgumentException("function_score: function must not be null");
-        }
-        this.filters.add(filter);
-        this.scoreFunctions.add(scoreFunctionBuilder);
-        return this;
+    public FunctionScoreQueryBuilder(QueryBuilder<?> query, ScoreFunctionBuilder scoreFunctionBuilder) {
+        this(query, new FilterFunctionBuilder[]{new FilterFunctionBuilder(scoreFunctionBuilder)});
     }
 
     /**
-     * Adds a score function that will will execute the function scoreFunctionBuilder on all documents.
+     * Creates a function_score query that executes the provided filters and functions on documents that match a query.
      *
-     * @param scoreFunctionBuilder score function that is executed
+     * @param query the query that defines which documents the function_score query will be executed on.
+     * @param filterFunctionBuilders the filters and functions
      */
-    public FunctionScoreQueryBuilder add(ScoreFunctionBuilder scoreFunctionBuilder) {
-        if (scoreFunctionBuilder == null) {
-            throw new IllegalArgumentException("function_score: function must not be null");
+    public FunctionScoreQueryBuilder(QueryBuilder<?> query, FilterFunctionBuilder[] filterFunctionBuilders) {
+        if (query == null) {
+            throw new IllegalArgumentException("function_score: query must not be null");
         }
-        this.filters.add(null);
-        this.scoreFunctions.add(scoreFunctionBuilder);
-        return this;
+        if (filterFunctionBuilders == null) {
+            throw new IllegalArgumentException("function_score: filters and functions array must not be null");
+        }
+        for (FilterFunctionBuilder filterFunctionBuilder : filterFunctionBuilders) {
+            if (filterFunctionBuilder == null) {
+                throw new IllegalArgumentException("function_score: each filter and function must not be null");
+            }
+        }
+        this.query = query;
+        this.filterFunctionBuilders = filterFunctionBuilders;
+    }
+
+    /**
+     * Returns the query that defines which documents the function_score query will be executed on.
+     */
+    public QueryBuilder<?> query() {
+        return this.query;
+    }
+
+    /**
+     * Returns the filters and functions
+     */
+    public FilterFunctionBuilder[] filterFunctionBuilders() {
+        return this.filterFunctionBuilders;
     }
 
     /**
      * Score mode defines how results of individual score functions will be aggregated.
-     * Can be first, avg, max, sum, min, multiply
+     * @see org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery.ScoreMode
      */
-    public FunctionScoreQueryBuilder scoreMode(String scoreMode) {
+    public FunctionScoreQueryBuilder scoreMode(FiltersFunctionScoreQuery.ScoreMode scoreMode) {
+        if (scoreMode == null) {
+            throw new IllegalArgumentException("[" + NAME + "]  requires 'score_mode' field");
+        }
         this.scoreMode = scoreMode;
         return this;
     }
 
     /**
-     * Score mode defines how the combined result of score functions will influence the final score together with the sub query score.
-     * Can be replace, avg, max, sum, min, multiply
+     * Returns the score mode, meaning how results of individual score functions will be aggregated.
+     * @see org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery.ScoreMode
      */
-    public FunctionScoreQueryBuilder boostMode(String boostMode) {
-        this.boostMode = boostMode;
-        return this;
+    public FiltersFunctionScoreQuery.ScoreMode scoreMode() {
+        return this.scoreMode;
     }
 
     /**
-     * Score mode defines how the combined result of score functions will influence the final score together with the sub query score.
+     * Boost mode defines how the combined result of score functions will influence the final score together with the sub query score.
+     * @see CombineFunction
      */
     public FunctionScoreQueryBuilder boostMode(CombineFunction combineFunction) {
-        this.boostMode = combineFunction.getName();
+        if (combineFunction == null) {
+            throw new IllegalArgumentException("[" + NAME + "]  requires 'boost_mode' field");
+        }
+        this.boostMode = combineFunction;
         return this;
     }
 
     /**
-     * Tha maximum boost that will be applied by function score.
+     * Returns the boost mode, meaning how the combined result of score functions will influence the final score together with the sub query score.
+     * @see CombineFunction
+     */
+    public CombineFunction boostMode() {
+        return this.boostMode;
+    }
+
+    /**
+     * Sets the maximum boost that will be applied by function score.
      */
     public FunctionScoreQueryBuilder maxBoost(float maxBoost) {
         this.maxBoost = maxBoost;
         return this;
     }
 
+    /**
+     * Returns the maximum boost that will be applied by function score.
+     */
+    public float maxBoost() {
+        return this.maxBoost;
+    }
+
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(FunctionScoreQueryParser.NAME);
-        if (queryBuilder != null) {
+        builder.startObject(NAME);
+        if (query != null) {
             builder.field("query");
-            queryBuilder.toXContent(builder, params);
+            query.toXContent(builder, params);
         }
         builder.startArray("functions");
-        for (int i = 0; i < filters.size(); i++) {
-            builder.startObject();
-            if (filters.get(i) != null) {
-                builder.field("filter");
-                filters.get(i).toXContent(builder, params);
-            }
-            scoreFunctions.get(i).toXContent(builder, params);
-            builder.endObject();
+        for (FilterFunctionBuilder filterFunctionBuilder : filterFunctionBuilders) {
+            filterFunctionBuilder.toXContent(builder, params);
         }
         builder.endArray();
 
-        if (scoreMode != null) {
-            builder.field("score_mode", scoreMode);
-        }
+        builder.field("score_mode", scoreMode.name().toLowerCase(Locale.ROOT));
         if (boostMode != null) {
-            builder.field("boost_mode", boostMode);
+            builder.field("boost_mode", boostMode.name().toLowerCase(Locale.ROOT));
         }
-        if (maxBoost != null) {
-            builder.field("max_boost", maxBoost);
-        }
+        builder.field("max_boost", maxBoost);
         if (minScore != null) {
             builder.field("min_score", minScore);
         }
@@ -178,8 +219,175 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
         return this;
     }
 
+    public Float getMinScore() {
+        return this.minScore;
+    }
+
     @Override
     public String getWriteableName() {
-        return FunctionScoreQueryParser.NAME;
+        return FunctionScoreQueryBuilder.NAME;
+    }
+
+    @Override
+    protected boolean doEquals(FunctionScoreQueryBuilder other) {
+        return Objects.equals(this.query, other.query) &&
+                Arrays.equals(this.filterFunctionBuilders, other.filterFunctionBuilders) &&
+                Objects.equals(this.boostMode, other.boostMode) &&
+                Objects.equals(this.scoreMode, other.scoreMode) &&
+                Objects.equals(this.minScore, other.minScore) &&
+                Objects.equals(this.maxBoost, other.maxBoost);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(this.query, Arrays.hashCode(this.filterFunctionBuilders), this.boostMode, this.scoreMode, this.minScore, this.maxBoost);
+    }
+
+    @Override
+    protected FunctionScoreQueryBuilder doReadFrom(StreamInput in) throws IOException {
+        QueryBuilder<?> query = in.readQuery();
+        int size = in.readVInt();
+        FilterFunctionBuilder[] filterFunctionBuilders = new FilterFunctionBuilder[size];
+        for (int i = 0; i < size; i++) {
+            filterFunctionBuilders[i] = FilterFunctionBuilder.PROTOTYPE.readFrom(in);
+        }
+        FunctionScoreQueryBuilder functionScoreQueryBuilder = new FunctionScoreQueryBuilder(query, filterFunctionBuilders);
+        functionScoreQueryBuilder.maxBoost(in.readFloat());
+        if (in.readBoolean()) {
+            functionScoreQueryBuilder.setMinScore(in.readFloat());
+        }
+        if (in.readBoolean()) {
+            functionScoreQueryBuilder.boostMode(CombineFunction.readCombineFunctionFrom(in));
+        }
+        functionScoreQueryBuilder.scoreMode(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in));
+        return functionScoreQueryBuilder;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeQuery(query);
+        out.writeVInt(filterFunctionBuilders.length);
+        for (FilterFunctionBuilder filterFunctionBuilder : filterFunctionBuilders) {
+            filterFunctionBuilder.writeTo(out);
+        }
+        out.writeFloat(maxBoost);
+        if (minScore == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeFloat(minScore);
+        }
+        if (boostMode == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            boostMode.writeTo(out);
+        }
+        scoreMode.writeTo(out);
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        FiltersFunctionScoreQuery.FilterFunction[] filterFunctions = new FiltersFunctionScoreQuery.FilterFunction[filterFunctionBuilders.length];
+        int i = 0;
+        for (FilterFunctionBuilder filterFunctionBuilder : filterFunctionBuilders) {
+            Query filter = filterFunctionBuilder.getFilter().toQuery(context);
+            ScoreFunction scoreFunction = filterFunctionBuilder.getScoreFunction().toFunction(context);
+            filterFunctions[i++] = new FiltersFunctionScoreQuery.FilterFunction(filter, scoreFunction);
+        }
+
+        Query query = this.query.toQuery(context);
+        if (query == null) {
+            query = new MatchAllDocsQuery();
+        }
+
+        // handle cases where only one score function and no filter was provided. In this case we create a FunctionScoreQuery.
+        if (filterFunctions.length == 0 || filterFunctions.length == 1 && (this.filterFunctionBuilders[0].getFilter().getName().equals(MatchAllQueryBuilder.NAME))) {
+            ScoreFunction function = filterFunctions.length == 0 ? null : filterFunctions[0].function;
+            CombineFunction combineFunction = this.boostMode;
+            if (combineFunction == null) {
+                if (function != null) {
+                    combineFunction = function.getDefaultScoreCombiner();
+                } else {
+                    combineFunction = DEFAULT_BOOST_MODE;
+                }
+            }
+            return new FunctionScoreQuery(query, function, minScore, combineFunction, maxBoost);
+        }
+        // in all other cases we create a FiltersFunctionScoreQuery
+        return new FiltersFunctionScoreQuery(query, scoreMode, filterFunctions, maxBoost, minScore, boostMode == null ? DEFAULT_BOOST_MODE : boostMode);
+    }
+
+    /**
+     * Function to be associated with an optional filter, meaning it will be executed only for the documents
+     * that match the given filter.
+     */
+    public static class FilterFunctionBuilder implements ToXContent, Writeable<FilterFunctionBuilder> {
+        private static final FilterFunctionBuilder PROTOTYPE = new FilterFunctionBuilder(EmptyQueryBuilder.PROTOTYPE, new RandomScoreFunctionBuilder());
+
+        private final QueryBuilder<?> filter;
+        private final ScoreFunctionBuilder scoreFunction;
+
+        public FilterFunctionBuilder(ScoreFunctionBuilder scoreFunctionBuilder) {
+            this(new MatchAllQueryBuilder(), scoreFunctionBuilder);
+        }
+
+        public FilterFunctionBuilder(QueryBuilder<?> filter, ScoreFunctionBuilder scoreFunction) {
+            if (filter == null) {
+                throw new IllegalArgumentException("function_score: filter must not be null");
+            }
+            if (scoreFunction == null) {
+                throw new IllegalArgumentException("function_score: function must not be null");
+            }
+            this.filter = filter;
+            this.scoreFunction = scoreFunction;
+        }
+
+        public QueryBuilder<?> getFilter() {
+            return filter;
+        }
+
+        public ScoreFunctionBuilder<?> getScoreFunction() {
+            return scoreFunction;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("filter");
+            filter.toXContent(builder, params);
+            scoreFunction.toXContent(builder, params);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(filter, scoreFunction);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            FilterFunctionBuilder that = (FilterFunctionBuilder) obj;
+            return Objects.equals(this.filter, that.filter) &&
+                    Objects.equals(this.scoreFunction, that.scoreFunction);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeQuery(filter);
+            out.writeScoreFunction(scoreFunction);
+        }
+
+        @Override
+        public FilterFunctionBuilder readFrom(StreamInput in) throws IOException {
+            return new FilterFunctionBuilder(in.readQuery(), in.readScoreFunction());
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilders.java
@@ -29,29 +29,41 @@ import org.elasticsearch.index.query.functionscore.weight.WeightBuilder;
 import org.elasticsearch.script.Script;
 
 public class ScoreFunctionBuilders {
-   
+
     public static ExponentialDecayFunctionBuilder exponentialDecayFunction(String fieldName, Object origin, Object scale) {
-        return new ExponentialDecayFunctionBuilder(fieldName, origin, scale);
+        return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, null);
     }
-    
-    public static ExponentialDecayFunctionBuilder exponentialDecayFunction(String fieldName, Object scale) {
-        return new ExponentialDecayFunctionBuilder(fieldName, null, scale);
+
+    public static ExponentialDecayFunctionBuilder exponentialDecayFunction(String fieldName, Object origin, Object scale, Object offset) {
+        return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, offset);
     }
-    
+
+    public static ExponentialDecayFunctionBuilder exponentialDecayFunction(String fieldName, Object origin, Object scale, Object offset, double decay) {
+        return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, offset, decay);
+    }
+
     public static GaussDecayFunctionBuilder gaussDecayFunction(String fieldName, Object origin, Object scale) {
-        return new GaussDecayFunctionBuilder(fieldName, origin, scale);
+        return new GaussDecayFunctionBuilder(fieldName, origin, scale, null);
     }
-    
-    public static GaussDecayFunctionBuilder gaussDecayFunction(String fieldName, Object scale) {
-        return new GaussDecayFunctionBuilder(fieldName, null, scale);
+
+    public static GaussDecayFunctionBuilder gaussDecayFunction(String fieldName, Object origin, Object scale, Object offset) {
+        return new GaussDecayFunctionBuilder(fieldName, origin, scale, offset);
     }
-    
+
+    public static GaussDecayFunctionBuilder gaussDecayFunction(String fieldName, Object origin, Object scale, Object offset, double decay) {
+        return new GaussDecayFunctionBuilder(fieldName, origin, scale, offset, decay);
+    }
+
     public static LinearDecayFunctionBuilder linearDecayFunction(String fieldName, Object origin, Object scale) {
-        return new LinearDecayFunctionBuilder(fieldName, origin, scale);
+        return new LinearDecayFunctionBuilder(fieldName, origin, scale, null);
     }
-    
-    public static LinearDecayFunctionBuilder linearDecayFunction(String fieldName, Object scale) {
-        return new LinearDecayFunctionBuilder(fieldName, null, scale);
+
+    public static LinearDecayFunctionBuilder linearDecayFunction(String fieldName, Object origin, Object scale, Object offset) {
+        return new LinearDecayFunctionBuilder(fieldName, origin, scale, offset);
+    }
+
+    public static LinearDecayFunctionBuilder linearDecayFunction(String fieldName, Object origin, Object scale, Object offset, double decay) {
+        return new LinearDecayFunctionBuilder(fieldName, origin, scale, offset, decay);
     }
 
     public static ScriptScoreFunctionBuilder scriptFunction(Script script) {

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/ScoreFunctionParser.java
@@ -19,16 +19,17 @@
 
 package org.elasticsearch.index.query.functionscore;
 
-import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.index.query.QueryParseContext;
 
 import java.io.IOException;
 
-public interface ScoreFunctionParser {
+public interface ScoreFunctionParser<FB extends ScoreFunctionBuilder<FB>> {
 
-    ScoreFunction parse(QueryShardContext context, XContentParser parser) throws IOException, ParsingException;
+    FB fromXContent(QueryParseContext context, XContentParser parser) throws IOException, ParsingException;
+
+    FB getBuilderPrototype();
 
     /**
      * Returns the name of the function, for example "linear", "gauss" etc. This
@@ -36,5 +37,4 @@ public interface ScoreFunctionParser {
      * {@link FunctionScoreQueryParser}.
      * */
     String[] getNames();
-
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/exp/ExponentialDecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/exp/ExponentialDecayFunctionBuilder.java
@@ -20,12 +20,30 @@
 package org.elasticsearch.index.query.functionscore.exp;
 
 
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.query.functionscore.DecayFunction;
 import org.elasticsearch.index.query.functionscore.DecayFunctionBuilder;
 
-public class ExponentialDecayFunctionBuilder extends DecayFunctionBuilder {
+public class ExponentialDecayFunctionBuilder extends DecayFunctionBuilder<ExponentialDecayFunctionBuilder> {
 
-    public ExponentialDecayFunctionBuilder(String fieldName, Object origin, Object scale) {
-        super(fieldName, origin, scale);
+    private static final DecayFunction EXP_DECAY_FUNCTION = new ExponentialDecayScoreFunction();
+
+    public ExponentialDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset) {
+        super(fieldName, origin, scale, offset);
+    }
+
+    public ExponentialDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, double decay) {
+        super(fieldName, origin, scale, offset, decay);
+    }
+
+    private ExponentialDecayFunctionBuilder(String fieldName, BytesReference functionBytes) {
+        super(fieldName, functionBytes);
+    }
+
+    @Override
+    protected ExponentialDecayFunctionBuilder createFunctionBuilder(String fieldName, BytesReference functionBytes) {
+        return new ExponentialDecayFunctionBuilder(fieldName, functionBytes);
     }
 
     @Override
@@ -33,4 +51,41 @@ public class ExponentialDecayFunctionBuilder extends DecayFunctionBuilder {
         return ExponentialDecayFunctionParser.NAMES[0];
     }
 
+    @Override
+    public DecayFunction getDecayFunction() {
+        return EXP_DECAY_FUNCTION;
+    }
+
+    private static final class ExponentialDecayScoreFunction implements DecayFunction {
+
+        @Override
+        public double evaluate(double value, double scale) {
+            return Math.exp(scale * value);
+        }
+
+        @Override
+        public Explanation explainFunction(String valueExpl, double value, double scale) {
+            return Explanation.match(
+                    (float) evaluate(value, scale),
+                    "exp(- " + valueExpl + " * " + -1 * scale + ")");
+        }
+
+        @Override
+        public double processScale(double scale, double decay) {
+            return Math.log(decay) / scale;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.getClass().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (super.equals(obj)) {
+                return true;
+            }
+            return obj != null && getClass() != obj.getClass();
+        }
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/exp/ExponentialDecayFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/exp/ExponentialDecayFunctionParser.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.index.query.functionscore.exp;
 
-import org.apache.lucene.search.Explanation;
-import org.elasticsearch.index.query.functionscore.DecayFunction;
 import org.elasticsearch.index.query.functionscore.DecayFunctionParser;
 
-public class ExponentialDecayFunctionParser extends DecayFunctionParser {
+public class ExponentialDecayFunctionParser extends DecayFunctionParser<ExponentialDecayFunctionBuilder> {
+
+    private static final ExponentialDecayFunctionBuilder PROTOTYPE = new ExponentialDecayFunctionBuilder("", "", "", "");
 
     public static final String[] NAMES = { "exp" };
 
@@ -32,31 +32,8 @@ public class ExponentialDecayFunctionParser extends DecayFunctionParser {
         return NAMES;
     }
 
-    static final DecayFunction decayFunction = new ExponentialDecayScoreFunction();
-
     @Override
-    public DecayFunction getDecayFunction() {
-        return decayFunction;
-    }
-
-    final static class ExponentialDecayScoreFunction implements DecayFunction {
-
-        @Override
-        public double evaluate(double value, double scale) {
-            return Math.exp(scale * value);
-        }
-
-        @Override
-        public Explanation explainFunction(String valueExpl, double value, double scale) {
-            return Explanation.match(
-                    (float) evaluate(value, scale),
-                    "exp(- " + valueExpl + " * " + -1 * scale + ")");
-        }
-
-        @Override
-        public double processScale(double scale, double decay) {
-            return Math.log(decay) / scale;
-        }
-
+    public ExponentialDecayFunctionBuilder getBuilderPrototype() {
+        return PROTOTYPE;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/fieldvaluefactor/FieldValueFactorFunctionBuilder.java
@@ -19,24 +19,39 @@
 
 package org.elasticsearch.index.query.functionscore.fieldvaluefactor;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * Builder to construct {@code field_value_factor} functions for a function
  * score query.
  */
-public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder {
-    private String field = null;
-    private Float factor = null;
-    private Double missing = null;
-    private FieldValueFactorFunction.Modifier modifier = null;
+public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder<FieldValueFactorFunctionBuilder> {
+
+    public static final FieldValueFactorFunction.Modifier DEFAULT_MODIFIER = FieldValueFactorFunction.Modifier.NONE;
+    public static final float DEFAULT_FACTOR = 1;
+
+    private final String field;
+    private float factor = DEFAULT_FACTOR;
+    private Double missing;
+    private FieldValueFactorFunction.Modifier modifier = DEFAULT_MODIFIER;
 
     public FieldValueFactorFunctionBuilder(String fieldName) {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("field_value_factor: field must not be null");
+        }
         this.field = fieldName;
     }
 
@@ -45,9 +60,17 @@ public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder {
         return FieldValueFactorFunctionParser.NAMES[0];
     }
 
+    public String fieldName() {
+        return this.field;
+    }
+
     public FieldValueFactorFunctionBuilder factor(float boostFactor) {
         this.factor = boostFactor;
         return this;
+    }
+
+    public float factor() {
+        return this.factor;
     }
 
     /**
@@ -58,29 +81,82 @@ public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder {
         return this;
     }
 
+    public Double missing() {
+        return this.missing;
+    }
+
     public FieldValueFactorFunctionBuilder modifier(FieldValueFactorFunction.Modifier modifier) {
+        if (modifier == null) {
+            throw new IllegalArgumentException("field_value_factor: modifier must not be null");
+        }
         this.modifier = modifier;
         return this;
+    }
+
+    public FieldValueFactorFunction.Modifier modifier() {
+        return this.modifier;
     }
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(getName());
-        if (field != null) {
-            builder.field("field", field);
-        }
-
-        if (factor != null) {
-            builder.field("factor", factor);
-        }
-
+        builder.field("field", field);
+        builder.field("factor", factor);
         if (missing != null) {
             builder.field("missing", missing);
         }
-
-        if (modifier != null) {
-            builder.field("modifier", modifier.toString().toLowerCase(Locale.ROOT));
-        }
+        builder.field("modifier", modifier.name().toLowerCase(Locale.ROOT));
         builder.endObject();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(field);
+        out.writeFloat(factor);
+        if (missing == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeDouble(missing);
+        }
+        modifier.writeTo(out);
+    }
+
+    @Override
+    protected FieldValueFactorFunctionBuilder doReadFrom(StreamInput in) throws IOException {
+        FieldValueFactorFunctionBuilder functionBuilder = new FieldValueFactorFunctionBuilder(in.readString());
+        functionBuilder.factor = in.readFloat();
+        if (in.readBoolean()) {
+            functionBuilder.missing = in.readDouble();
+        }
+        functionBuilder.modifier = FieldValueFactorFunction.Modifier.readModifierFrom(in);
+        return functionBuilder;
+    }
+
+    @Override
+    protected boolean doEquals(FieldValueFactorFunctionBuilder functionBuilder) {
+        return Objects.equals(this.field, functionBuilder.field) &&
+                Objects.equals(this.factor, functionBuilder.factor) &&
+                Objects.equals(this.missing, functionBuilder.missing) &&
+                Objects.equals(this.modifier, functionBuilder.modifier);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(this.field, this.factor, this.missing, this.modifier);
+    }
+
+    @Override
+    protected ScoreFunction doToFunction(QueryShardContext context) {
+        MappedFieldType fieldType = context.mapperService().smartNameFieldType(field);
+        IndexNumericFieldData fieldData = null;
+        if (fieldType == null) {
+            if(missing == null) {
+                throw new ElasticsearchException("Unable to find a field mapper for field [" + field + "]. No 'missing' value defined.");
+            }
+        } else {
+            fieldData = context.getForField(fieldType);
+        }
+        return new FieldValueFactorFunction(field, factor, modifier, missing, fieldData);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/gauss/GaussDecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/gauss/GaussDecayFunctionBuilder.java
@@ -20,12 +20,30 @@
 package org.elasticsearch.index.query.functionscore.gauss;
 
 
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.query.functionscore.DecayFunction;
 import org.elasticsearch.index.query.functionscore.DecayFunctionBuilder;
 
-public class GaussDecayFunctionBuilder extends DecayFunctionBuilder {
+public class GaussDecayFunctionBuilder extends DecayFunctionBuilder<GaussDecayFunctionBuilder> {
 
-    public GaussDecayFunctionBuilder(String fieldName, Object origin, Object scale) {
-        super(fieldName, origin, scale);
+    private static final DecayFunction GAUSS_DECAY_FUNCTION = new GaussScoreFunction();
+
+    public GaussDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset) {
+        super(fieldName, origin, scale, offset);
+    }
+
+    public GaussDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, double decay) {
+        super(fieldName, origin, scale, offset, decay);
+    }
+
+    private GaussDecayFunctionBuilder(String fieldName, BytesReference functionBytes) {
+        super(fieldName, functionBytes);
+    }
+
+    @Override
+    protected GaussDecayFunctionBuilder createFunctionBuilder(String fieldName, BytesReference functionBytes) {
+        return new GaussDecayFunctionBuilder(fieldName, functionBytes);
     }
 
     @Override
@@ -33,4 +51,43 @@ public class GaussDecayFunctionBuilder extends DecayFunctionBuilder {
         return GaussDecayFunctionParser.NAMES[0];
     }
 
+    @Override
+    public DecayFunction getDecayFunction() {
+        return GAUSS_DECAY_FUNCTION;
+    }
+
+    private static final class GaussScoreFunction implements DecayFunction {
+
+        @Override
+        public double evaluate(double value, double scale) {
+            // note that we already computed scale^2 in processScale() so we do
+            // not need to square it here.
+            return Math.exp(0.5 * Math.pow(value, 2.0) / scale);
+        }
+
+        @Override
+        public Explanation explainFunction(String valueExpl, double value, double scale) {
+            return Explanation.match(
+                    (float) evaluate(value, scale),
+                    "exp(-0.5*pow(" + valueExpl + ",2.0)/" + -1 * scale + ")");
+        }
+
+        @Override
+        public double processScale(double scale, double decay) {
+            return 0.5 * Math.pow(scale, 2.0) / Math.log(decay);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.getClass().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (super.equals(obj)) {
+                return true;
+            }
+            return obj != null && getClass() != obj.getClass();
+        }
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/gauss/GaussDecayFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/gauss/GaussDecayFunctionParser.java
@@ -19,45 +19,21 @@
 
 package org.elasticsearch.index.query.functionscore.gauss;
 
-import org.apache.lucene.search.Explanation;
-import org.elasticsearch.index.query.functionscore.DecayFunction;
 import org.elasticsearch.index.query.functionscore.DecayFunctionParser;
 
-public class GaussDecayFunctionParser extends DecayFunctionParser {
+public class GaussDecayFunctionParser extends DecayFunctionParser<GaussDecayFunctionBuilder> {
 
-    static final DecayFunction decayFunction = new GaussScoreFunction();
+    private static final GaussDecayFunctionBuilder PROTOTYPE = new GaussDecayFunctionBuilder("", "", "", "");
+
     public static final String[] NAMES = { "gauss" };
-
-    @Override
-    public DecayFunction getDecayFunction() {
-        return decayFunction;
-    }
-
-    final static class GaussScoreFunction implements DecayFunction {
-
-        @Override
-        public double evaluate(double value, double scale) {
-            // note that we already computed scale^2 in processScale() so we do
-            // not need to square it here.
-            return Math.exp(0.5 * Math.pow(value, 2.0) / scale);
-        }
-
-        @Override
-        public Explanation explainFunction(String valueExpl, double value, double scale) {
-            return Explanation.match(
-                    (float) evaluate(value, scale),
-                    "exp(-0.5*pow(" + valueExpl + ",2.0)/" + -1 * scale + ")");
-        }
-
-        @Override
-        public double processScale(double scale, double decay) {
-            return 0.5 * Math.pow(scale, 2.0) / Math.log(decay);
-        }
-    }
 
     @Override
     public String[] getNames() {
         return NAMES;
     }
 
+    @Override
+    public GaussDecayFunctionBuilder getBuilderPrototype() {
+        return PROTOTYPE;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/lin/LinearDecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/lin/LinearDecayFunctionBuilder.java
@@ -19,12 +19,25 @@
 
 package org.elasticsearch.index.query.functionscore.lin;
 
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.query.functionscore.DecayFunction;
 import org.elasticsearch.index.query.functionscore.DecayFunctionBuilder;
 
-public class LinearDecayFunctionBuilder extends DecayFunctionBuilder {
+public class LinearDecayFunctionBuilder extends DecayFunctionBuilder<LinearDecayFunctionBuilder> {
 
-    public LinearDecayFunctionBuilder(String fieldName, Object origin, Object scale) {
-        super(fieldName, origin, scale);
+    private static final DecayFunction LINEAR_DECAY_FUNCTION = new LinearDecayScoreFunction();
+
+    public LinearDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset) {
+        super(fieldName, origin, scale, offset);
+    }
+
+    public LinearDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, double decay) {
+        super(fieldName, origin, scale, offset, decay);
+    }
+
+    private LinearDecayFunctionBuilder(String fieldName, BytesReference functionBytes) {
+        super(fieldName, functionBytes);
     }
 
     @Override
@@ -32,4 +45,46 @@ public class LinearDecayFunctionBuilder extends DecayFunctionBuilder {
         return LinearDecayFunctionParser.NAMES[0];
     }
 
+    @Override
+    protected LinearDecayFunctionBuilder createFunctionBuilder(String fieldName, BytesReference functionBytes) {
+        return new LinearDecayFunctionBuilder(fieldName, functionBytes);
+    }
+
+    @Override
+    public DecayFunction getDecayFunction() {
+        return LINEAR_DECAY_FUNCTION;
+    }
+
+    private static final class LinearDecayScoreFunction implements DecayFunction {
+
+        @Override
+        public double evaluate(double value, double scale) {
+            return Math.max(0.0, (scale - value) / scale);
+        }
+
+        @Override
+        public Explanation explainFunction(String valueExpl, double value, double scale) {
+            return Explanation.match(
+                    (float) evaluate(value, scale),
+                    "max(0.0, ((" + scale + " - " + valueExpl + ")/" + scale + ")");
+        }
+
+        @Override
+        public double processScale(double scale, double decay) {
+            return scale / (1.0 - decay);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.getClass().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (super.equals(obj)) {
+                return true;
+            }
+            return obj != null && getClass() != obj.getClass();
+        }
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/lin/LinearDecayFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/lin/LinearDecayFunctionParser.java
@@ -19,44 +19,21 @@
 
 package org.elasticsearch.index.query.functionscore.lin;
 
-import org.apache.lucene.search.Explanation;
-import org.elasticsearch.index.query.functionscore.DecayFunction;
 import org.elasticsearch.index.query.functionscore.DecayFunctionParser;
 
-public class LinearDecayFunctionParser extends DecayFunctionParser {
+public class LinearDecayFunctionParser extends DecayFunctionParser<LinearDecayFunctionBuilder> {
 
     public static final String[] NAMES = { "linear" };
+
+    private static final LinearDecayFunctionBuilder PROTOTYPE = new LinearDecayFunctionBuilder("", "", "", "");
 
     @Override
     public String[] getNames() {
         return NAMES;
     }
 
-    static final DecayFunction decayFunction = new LinearDecayScoreFunction();
-
     @Override
-    public DecayFunction getDecayFunction() {
-        return decayFunction;
-    }
-
-    final static class LinearDecayScoreFunction implements DecayFunction {
-
-        @Override
-        public double evaluate(double value, double scale) { 
-            return Math.max(0.0, (scale - value) / scale);
-        }
-
-        @Override
-        public Explanation explainFunction(String valueExpl, double value, double scale) {
-            return Explanation.match(
-                    (float) evaluate(value, scale),
-                    "max(0.0, ((" + scale + " - " + valueExpl + ")/" + scale + ")");
-        }
-
-        @Override
-        public double processScale(double scale, double decay) {
-            return scale / (1.0 - decay);
-        }
-
+    public LinearDecayFunctionBuilder getBuilderPrototype() {
+        return PROTOTYPE;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionBuilder.java
@@ -18,17 +18,27 @@
  */
 package org.elasticsearch.index.query.functionscore.random;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.function.RandomScoreFunction;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A function that computes a random score for the matched documents
  */
-public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder {
+public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScoreFunctionBuilder> {
 
-    private Object seed = null;
+    private Integer seed;
 
     public RandomScoreFunctionBuilder() {
     }
@@ -54,7 +64,7 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder {
      * @see #seed(int)
      */
     public RandomScoreFunctionBuilder seed(long seed) {
-        this.seed = seed;
+        this.seed = hash(seed);
         return this;
     }
 
@@ -63,19 +73,64 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder {
      * @see #seed(int)
      */
     public RandomScoreFunctionBuilder seed(String seed) {
-        this.seed = seed;
+        if (seed == null) {
+            throw new IllegalArgumentException("random_score function: seed must not be null");
+        }
+        this.seed = seed.hashCode();
         return this;
+    }
+
+    public Integer getSeed() {
+        return seed;
     }
 
     @Override
     public void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(getName());
-        if (seed instanceof Number) {
-            builder.field("seed", ((Number)seed).longValue());
-        } else if (seed != null) {
-            builder.field("seed", seed.toString());
+        if (seed != null) {
+            builder.field("seed", seed);
         }
         builder.endObject();
     }
 
+    @Override
+    protected RandomScoreFunctionBuilder doReadFrom(StreamInput in) throws IOException {
+        RandomScoreFunctionBuilder randomScoreFunctionBuilder = new RandomScoreFunctionBuilder();
+        randomScoreFunctionBuilder.seed = in.readInt();
+        return randomScoreFunctionBuilder;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeInt(seed);
+    }
+
+    @Override
+    protected boolean doEquals(RandomScoreFunctionBuilder functionBuilder) {
+        return Objects.equals(this.seed, functionBuilder.seed);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(this.seed);
+    }
+
+    @Override
+    protected ScoreFunction doToFunction(QueryShardContext context) {
+        final MappedFieldType fieldType = context.mapperService().smartNameFieldType("_uid");
+        if (fieldType == null) {
+            // mapper could be null if we are on a shard with no docs yet, so this won't actually be used
+            return new RandomScoreFunction();
+        }
+        //TODO find a way to not get the shard_id from the current search context? make it available in QueryShardContext?
+        //this currently causes NPE in FunctionScoreQueryBuilderTests#testToQuery
+        final ShardId shardId = SearchContext.current().indexShard().shardId();
+        final int salt = (context.index().name().hashCode() << 10) | shardId.id();
+        final IndexFieldData<?> uidFieldData = context.getForField(fieldType);
+        return new RandomScoreFunction(this.seed == null ? hash(context.nowInMillis()) : seed, salt, uidFieldData);
+    }
+
+    private static int hash(long value) {
+        return (int) (value ^ (value >>> 32));
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionParser.java
@@ -22,23 +22,18 @@ package org.elasticsearch.index.query.functionscore.random;
 
 
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.lucene.search.function.RandomScoreFunction;
-import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 
-public class RandomScoreFunctionParser implements ScoreFunctionParser {
+public class RandomScoreFunctionParser implements ScoreFunctionParser<RandomScoreFunctionBuilder> {
 
     public static String[] NAMES = { "random_score", "randomScore" };
+
+    private static RandomScoreFunctionBuilder PROTOTYPE = new RandomScoreFunctionBuilder();
 
     @Inject
     public RandomScoreFunctionParser() {
@@ -50,10 +45,8 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
     }
 
     @Override
-    public ScoreFunction parse(QueryShardContext context, XContentParser parser) throws IOException, ParsingException {
-        QueryParseContext parseContext = context.parseContext();
-        int seed = -1;
-
+    public RandomScoreFunctionBuilder fromXContent(QueryParseContext parseContext, XContentParser parser) throws IOException, ParsingException {
+        RandomScoreFunctionBuilder randomScoreFunctionBuilder = new RandomScoreFunctionBuilder();
         String currentFieldName = null;
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -63,15 +56,15 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
                 if ("seed".equals(currentFieldName)) {
                     if (token == XContentParser.Token.VALUE_NUMBER) {
                         if (parser.numberType() == XContentParser.NumberType.INT) {
-                            seed = parser.intValue();
+                            randomScoreFunctionBuilder.seed(parser.intValue());
                         } else if (parser.numberType() == XContentParser.NumberType.LONG) {
-                            seed = hash(parser.longValue());
+                            randomScoreFunctionBuilder.seed(parser.longValue());
                         } else {
                             throw new ParsingException(parser.getTokenLocation(), "random_score seed must be an int, long or string, not '"
                                     + token.toString() + "'");
                         }
                     } else if (token == XContentParser.Token.VALUE_STRING) {
-                        seed = parser.text().hashCode();
+                        randomScoreFunctionBuilder.seed(parser.text());
                     } else {
                         throw new ParsingException(parser.getTokenLocation(), "random_score seed must be an int/long or string, not '"
                                 + token.toString() + "'");
@@ -81,24 +74,11 @@ public class RandomScoreFunctionParser implements ScoreFunctionParser {
                 }
             }
         }
-
-        final MappedFieldType fieldType = SearchContext.current().mapperService().smartNameFieldType("_uid");
-        if (fieldType == null) {
-            // mapper could be null if we are on a shard with no docs yet, so this won't actually be used
-            return new RandomScoreFunction();
-        }
-
-        if (seed == -1) {
-            seed = hash(context.nowInMillis());
-        }
-        final ShardId shardId = SearchContext.current().indexShard().shardId();
-        final int salt = (shardId.index().name().hashCode() << 10) | shardId.id();
-        final IndexFieldData<?> uidFieldData = SearchContext.current().fieldData().getForField(fieldType);
-
-        return new RandomScoreFunction(seed, salt, uidFieldData);
+        return randomScoreFunctionBuilder;
     }
 
-    private static final int hash(long value) {
-        return (int) (value ^ (value >>> 32));
+    @Override
+    public RandomScoreFunctionBuilder getBuilderPrototype() {
+        return PROTOTYPE;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/script/ScriptScoreFunctionBuilder.java
@@ -19,20 +19,27 @@
 
 package org.elasticsearch.index.query.functionscore.script;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
+import org.elasticsearch.common.lucene.search.function.ScriptScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.Script.ScriptField;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.SearchScript;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Objects;
 
 /**
  * A function that uses a script to compute or influence the score of documents
  * that match with the inner query or filter.
  */
-public class ScriptScoreFunctionBuilder extends ScoreFunctionBuilder {
+public class ScriptScoreFunctionBuilder extends ScoreFunctionBuilder<ScriptScoreFunctionBuilder> {
 
     private final Script script;
 
@@ -41,6 +48,10 @@ public class ScriptScoreFunctionBuilder extends ScoreFunctionBuilder {
             throw new IllegalArgumentException("script must not be null");
         }
         this.script = script;
+    }
+
+    public Script getScript() {
+        return this.script;
     }
 
     @Override
@@ -53,5 +64,35 @@ public class ScriptScoreFunctionBuilder extends ScoreFunctionBuilder {
     @Override
     public String getName() {
         return ScriptScoreFunctionParser.NAMES[0];
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        script.writeTo(out);
+    }
+
+    @Override
+    protected ScriptScoreFunctionBuilder doReadFrom(StreamInput in) throws IOException {
+        return new ScriptScoreFunctionBuilder(Script.readScript(in));
+    }
+
+    @Override
+    protected boolean doEquals(ScriptScoreFunctionBuilder functionBuilder) {
+        return Objects.equals(this.script, functionBuilder.script);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(this.script);
+    }
+
+    @Override
+    protected ScoreFunction doToFunction(QueryShardContext context) {
+        try {
+            SearchScript searchScript = context.scriptService().search(context.lookup(), script, ScriptContext.Standard.SEARCH);
+            return new ScriptScoreFunction(script, searchScript);
+        } catch (Exception e) {
+            throw new QueryShardException(context, "script_score: the script could not be loaded", e);
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/weight/WeightBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/weight/WeightBuilder.java
@@ -19,8 +19,11 @@
 
 package org.elasticsearch.index.query.functionscore.weight;
 
-import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 
 import java.io.IOException;
@@ -28,7 +31,7 @@ import java.io.IOException;
 /**
  * A query that multiplies the weight to the score.
  */
-public class WeightBuilder extends ScoreFunctionBuilder {
+public class WeightBuilder extends ScoreFunctionBuilder<WeightBuilder> {
 
     @Override
     public String getName() {
@@ -37,5 +40,31 @@ public class WeightBuilder extends ScoreFunctionBuilder {
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+
+    }
+
+    @Override
+    protected WeightBuilder doReadFrom(StreamInput in) throws IOException {
+        return new WeightBuilder();
+    }
+
+    @Override
+    protected boolean doEquals(WeightBuilder functionBuilder) {
+        return true;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return 0;
+    }
+
+    @Override
+    protected ScoreFunction doToFunction(QueryShardContext context) throws IOException {
+        //nothing to do here, weight will be applied by the parent class, no score function
+        return null;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -66,11 +66,7 @@ import org.elasticsearch.search.aggregations.bucket.significant.UnmappedSignific
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristicParser;
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristicParserMapper;
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristicStreams;
-import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.TermsParser;
-import org.elasticsearch.search.aggregations.bucket.terms.UnmappedTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.*;
 import org.elasticsearch.search.aggregations.metrics.avg.AvgParser;
 import org.elasticsearch.search.aggregations.metrics.avg.InternalAvg;
 import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityParser;
@@ -150,7 +146,8 @@ import org.elasticsearch.search.query.QueryPhase;
 import org.elasticsearch.search.suggest.Suggester;
 import org.elasticsearch.search.suggest.Suggesters;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  *
@@ -254,7 +251,7 @@ public class SearchModule extends AbstractModule {
         for (Class<? extends ScoreFunctionParser> clazz : functionScoreParsers) {
             parserMapBinder.addBinding().to(clazz);
         }
-        bind(ScoreFunctionParserMapper.class);
+        bind(ScoreFunctionParserMapper.class).asEagerSingleton();
     }
 
     protected void configureHighlighters() {

--- a/core/src/test/java/org/elasticsearch/index/query/CombineFunctionTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/CombineFunctionTests.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class CombineFunctionTests extends ESTestCase {
+
+    public void testValidOrdinals() {
+        assertThat(CombineFunction.MULTIPLY.ordinal(), equalTo(0));
+        assertThat(CombineFunction.REPLACE.ordinal(), equalTo(1));
+        assertThat(CombineFunction.SUM.ordinal(), equalTo(2));
+        assertThat(CombineFunction.AVG.ordinal(), equalTo(3));
+        assertThat(CombineFunction.MIN.ordinal(), equalTo(4));
+        assertThat(CombineFunction.MAX.ordinal(), equalTo(5));
+    }
+
+    public void testWriteTo() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            CombineFunction.MULTIPLY.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(0));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            CombineFunction.REPLACE.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(1));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            CombineFunction.SUM.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(2));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            CombineFunction.AVG.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(3));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            CombineFunction.MIN.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(4));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            CombineFunction.MAX.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(5));
+            }
+        }
+    }
+
+    public void testReadFrom() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(0);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.MULTIPLY));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(1);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.REPLACE));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(2);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.SUM));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(3);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.AVG));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(4);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.MIN));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(5);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(CombineFunction.readCombineFunctionFrom(in), equalTo(CombineFunction.MAX));
+            }
+        }
+    }
+
+    public void testFromString() {
+        assertThat(CombineFunction.fromString("multiply"), equalTo(CombineFunction.MULTIPLY));
+        assertThat(CombineFunction.fromString("replace"), equalTo(CombineFunction.REPLACE));
+        assertThat(CombineFunction.fromString("sum"), equalTo(CombineFunction.SUM));
+        assertThat(CombineFunction.fromString("avg"), equalTo(CombineFunction.AVG));
+        assertThat(CombineFunction.fromString("min"), equalTo(CombineFunction.MIN));
+        assertThat(CombineFunction.fromString("max"), equalTo(CombineFunction.MAX));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -135,6 +135,7 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
      */
     @Override
     public void testToQuery() throws IOException {
+        //TODO figure out why this test might take up to 10 seconds once in a while
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         super.testToQuery();
     }

--- a/core/src/test/java/org/elasticsearch/index/query/OperatorTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/OperatorTests.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.BooleanClause;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class OperatorTests extends ESTestCase {
+
+    public void testValidOrdinals() {
+        assertThat(Operator.OR.ordinal(), equalTo(0));
+        assertThat(Operator.AND.ordinal(), equalTo(1));
+    }
+
+    public void testWriteTo() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            Operator.OR.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(0));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            Operator.AND.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(1));
+            }
+        }
+    }
+
+    public void testReadFrom() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(0);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(Operator.readOperatorFrom(in), equalTo(Operator.OR));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(1);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(Operator.readOperatorFrom(in), equalTo(Operator.AND));
+            }
+        }
+    }
+
+    public void testToBooleanClauseOccur() {
+        assertThat(Operator.AND.toBooleanClauseOccur(), equalTo(BooleanClause.Occur.MUST));
+        assertThat(Operator.OR.toBooleanClauseOccur(), equalTo(BooleanClause.Occur.SHOULD));
+    }
+
+    public void testToQueryParserOperator() {
+        assertThat(Operator.AND.toQueryParserOperator(), equalTo(QueryParser.Operator.AND));
+        assertThat(Operator.OR.toQueryParserOperator(), equalTo(QueryParser.Operator.OR));
+    }
+
+    public void testFromString() {
+        assertThat(Operator.fromString("and"), equalTo(Operator.AND));
+        assertThat(Operator.fromString("AND"), equalTo(Operator.AND));
+        assertThat(Operator.fromString("AnD"), equalTo(Operator.AND));
+        assertThat(Operator.fromString("or"), equalTo(Operator.OR));
+        assertThat(Operator.fromString("OR"), equalTo(Operator.OR));
+        assertThat(Operator.fromString("Or"), equalTo(Operator.OR));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/ScoreModeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ScoreModeTests.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ScoreModeTests extends ESTestCase {
+
+    public void testValidOrdinals() {
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.FIRST.ordinal(), equalTo(0));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.AVG.ordinal(), equalTo(1));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.MAX.ordinal(), equalTo(2));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.SUM.ordinal(), equalTo(3));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.MIN.ordinal(), equalTo(4));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.MULTIPLY.ordinal(), equalTo(5));
+    }
+
+    public void testWriteTo() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FiltersFunctionScoreQuery.ScoreMode.FIRST.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(0));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FiltersFunctionScoreQuery.ScoreMode.AVG.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(1));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FiltersFunctionScoreQuery.ScoreMode.MAX.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(2));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FiltersFunctionScoreQuery.ScoreMode.SUM.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(3));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FiltersFunctionScoreQuery.ScoreMode.MIN.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(4));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FiltersFunctionScoreQuery.ScoreMode.MULTIPLY.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(5));
+            }
+        }
+    }
+
+    public void testReadFrom() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(0);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.FIRST));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(1);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.AVG));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(2);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MAX));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(3);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.SUM));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(4);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MIN));
+            }
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(5);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FiltersFunctionScoreQuery.ScoreMode.readScoreModeFrom(in), equalTo(FiltersFunctionScoreQuery.ScoreMode.MULTIPLY));
+            }
+        }
+    }
+
+    public void testFromString() {
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.fromString("first"), equalTo(FiltersFunctionScoreQuery.ScoreMode.FIRST));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.fromString("avg"), equalTo(FiltersFunctionScoreQuery.ScoreMode.AVG));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.fromString("max"), equalTo(FiltersFunctionScoreQuery.ScoreMode.MAX));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.fromString("sum"), equalTo(FiltersFunctionScoreQuery.ScoreMode.SUM));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.fromString("min"), equalTo(FiltersFunctionScoreQuery.ScoreMode.MIN));
+        assertThat(FiltersFunctionScoreQuery.ScoreMode.fromString("multiply"), equalTo(FiltersFunctionScoreQuery.ScoreMode.MULTIPLY));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.script.expression.ExpressionScriptEngineService;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
         } else {
             script = "5 * 2 > 2";
         }
-        return new ScriptQueryBuilder(new Script(script, ScriptType.INLINE, "expression", params));
+        return new ScriptQueryBuilder(new Script(script, ScriptType.INLINE, ExpressionScriptEngineService.NAME, params));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -20,41 +20,14 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
-import org.apache.lucene.index.Fields;
-import org.apache.lucene.index.MultiFields;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.index.Terms;
-import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.index.*;
 import org.apache.lucene.index.memory.MemoryIndex;
 import org.apache.lucene.queries.BoostingQuery;
 import org.apache.lucene.queries.ExtendedCommonTermsQuery;
 import org.apache.lucene.queries.TermsQuery;
-import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.*;
 import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.BoostQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.DisjunctionMaxQuery;
-import org.apache.lucene.search.FuzzyQuery;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.MultiTermQuery;
-import org.apache.lucene.search.NumericRangeQuery;
-import org.apache.lucene.search.PrefixQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
-import org.apache.lucene.search.RegexpQuery;
-import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TermRangeQuery;
-import org.apache.lucene.search.WildcardQuery;
-import org.apache.lucene.search.spans.FieldMaskingSpanQuery;
-import org.apache.lucene.search.spans.SpanContainingQuery;
-import org.apache.lucene.search.spans.SpanFirstQuery;
-import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
-import org.apache.lucene.search.spans.SpanNearQuery;
-import org.apache.lucene.search.spans.SpanNotQuery;
-import org.apache.lucene.search.spans.SpanOrQuery;
-import org.apache.lucene.search.spans.SpanTermQuery;
-import org.apache.lucene.search.spans.SpanWithinQuery;
+import org.apache.lucene.search.spans.*;
 import org.apache.lucene.spatial.prefix.IntersectsPrefixTreeFilter;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -69,8 +42,6 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.search.MoreLikeThisQuery;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
-import org.elasticsearch.common.lucene.search.function.WeightFactorFunction;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -81,11 +52,9 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
-import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 import org.elasticsearch.index.search.geo.GeoPolygonQuery;
 import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxQuery;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -99,43 +68,11 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.boostingQuery;
-import static org.elasticsearch.index.query.QueryBuilders.commonTermsQuery;
-import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
-import static org.elasticsearch.index.query.QueryBuilders.disMaxQuery;
-import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
-import static org.elasticsearch.index.query.QueryBuilders.fuzzyQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.index.query.QueryBuilders.moreLikeThisQuery;
-import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
-import static org.elasticsearch.index.query.QueryBuilders.notQuery;
-import static org.elasticsearch.index.query.QueryBuilders.prefixQuery;
-import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
-import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
-import static org.elasticsearch.index.query.QueryBuilders.regexpQuery;
-import static org.elasticsearch.index.query.QueryBuilders.spanContainingQuery;
-import static org.elasticsearch.index.query.QueryBuilders.spanFirstQuery;
-import static org.elasticsearch.index.query.QueryBuilders.spanNearQuery;
-import static org.elasticsearch.index.query.QueryBuilders.spanNotQuery;
-import static org.elasticsearch.index.query.QueryBuilders.spanOrQuery;
-import static org.elasticsearch.index.query.QueryBuilders.spanTermQuery;
-import static org.elasticsearch.index.query.QueryBuilders.spanWithinQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
-import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
+import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.StreamsUtils.copyToBytesFromClasspath;
 import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBooleanSubQuery;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.*;
 
 public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
 
@@ -937,8 +874,6 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         }
     }
 
-
-
     @Test
     public void testInQuery() throws IOException {
         IndexQueryParserService queryParser = queryParser();
@@ -1014,26 +949,6 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         assertThat(parsedQuery, instanceOf(ConstantScoreQuery.class));
         ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) parsedQuery;
         assertThat(getTerm(constantScoreQuery.getQuery()), equalTo(new Term("name.last", "banon")));
-    }
-
-    @Test
-    public void testCustomWeightFactorQueryBuilder_withFunctionScore() throws IOException {
-        IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(functionScoreQuery(termQuery("name.last", "banon"), ScoreFunctionBuilders.weightFactorFunction(1.3f))).query();
-        assertThat(parsedQuery, instanceOf(FunctionScoreQuery.class));
-        FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) parsedQuery;
-        assertThat(((TermQuery) functionScoreQuery.getSubQuery()).getTerm(), equalTo(new Term("name.last", "banon")));
-        assertThat((double) ((WeightFactorFunction) functionScoreQuery.getFunction()).getWeight(), closeTo(1.3, 0.001));
-    }
-
-    @Test
-    public void testCustomWeightFactorQueryBuilder_withFunctionScoreWithoutQueryGiven() throws IOException {
-        IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(functionScoreQuery(ScoreFunctionBuilders.weightFactorFunction(1.3f))).query();
-        assertThat(parsedQuery, instanceOf(FunctionScoreQuery.class));
-        FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) parsedQuery;
-        assertThat(functionScoreQuery.getSubQuery() instanceof MatchAllDocsQuery, equalTo(true));
-        assertThat((double) ((WeightFactorFunction) functionScoreQuery.getFunction()).getWeight(), closeTo(1.3, 0.001));
     }
 
     @Test
@@ -1894,15 +1809,6 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         assertTrue(ectQuery.isCoordDisabled());
     }
 
-    @Test(expected = ParsingException.class)
-    public void assureMalformedThrowsException() throws IOException {
-        IndexQueryParserService queryParser;
-        queryParser = queryParser();
-        String query;
-        query = copyToStringFromClasspath("/org/elasticsearch/index/query/faulty-function-score-query.json");
-        Query parsedQuery = queryParser.parse(query).query();
-    }
-
     @Test
     public void testFilterParsing() throws IOException {
         IndexQueryParserService queryParser;
@@ -1995,75 +1901,6 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         String query = jsonBuilder().startObject().startObject("bool").endObject().endObject().string();
         Query parsedQuery = queryParser.parse(query).query();
         assertThat(parsedQuery, instanceOf(MatchAllDocsQuery.class));
-    }
-
-    @Test
-    public void testProperErrorMessageWhenTwoFunctionsDefinedInQueryBody() throws IOException {
-        IndexQueryParserService queryParser = queryParser();
-        String query = copyToStringFromClasspath("/org/elasticsearch/index/query/function-score-query-causing-NPE.json");
-        try {
-            queryParser.parse(query).query();
-            fail("FunctionScoreQueryParser should throw an exception here because two functions in body are not allowed.");
-        } catch (ParsingException e) {
-            assertThat(e.getDetailedMessage(), containsString("use [functions] array if you want to define several functions."));
-        }
-    }
-
-    @Test
-    public void testWeight1fStillProducesWeighFunction() throws IOException {
-        IndexQueryParserService queryParser = queryParser();
-        String queryString = jsonBuilder().startObject()
-                .startObject("function_score")
-                .startArray("functions")
-                .startObject()
-                .startObject("field_value_factor")
-                .field("field", "popularity")
-                .endObject()
-                .field("weight", 1.0)
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject().string();
-        IndexService indexService = createIndex("testidx", client().admin().indices().prepareCreate("testidx")
-                .addMapping("doc",jsonBuilder().startObject()
-                        .startObject("properties")
-                        .startObject("popularity").field("type", "float").endObject()
-                        .endObject()
-                        .endObject()));
-        SearchContext.setCurrent(createSearchContext(indexService));
-        Query query = queryParser.parse(queryString).query();
-        assertThat(query, instanceOf(FunctionScoreQuery.class));
-        assertThat(((FunctionScoreQuery) query).getFunction(), instanceOf(WeightFactorFunction.class));
-        SearchContext.removeCurrent();
-    }
-
-    @Test
-    public void testProperErrorMessagesForMisplacedWeightsAndFunctions() throws IOException {
-        IndexQueryParserService queryParser = queryParser();
-        String query = jsonBuilder().startObject().startObject("function_score")
-                .startArray("functions")
-                .startObject().startObject("script_score").field("script", "3").endObject().endObject()
-                .endArray()
-                .field("weight", 2)
-                .endObject().endObject().string();
-        try {
-            queryParser.parse(query).query();
-            fail("Expect exception here because array of functions and one weight in body is not allowed.");
-        } catch (ParsingException e) {
-            assertThat(e.getDetailedMessage(), containsString("you can either define [functions] array or a single function, not both. already found [functions] array, now encountering [weight]."));
-        }
-        query = jsonBuilder().startObject().startObject("function_score")
-                .field("weight", 2)
-                .startArray("functions")
-                .startObject().endObject()
-                .endArray()
-                .endObject().endObject().string();
-        try {
-            queryParser.parse(query).query();
-            fail("Expect exception here because array of functions and one weight in body is not allowed.");
-        } catch (ParsingException e) {
-            assertThat(e.getDetailedMessage(), containsString("you can either define [functions] array or a single function, not both. already found [weight], now encountering [functions]."));
-        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionModifierTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionModifierTests.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.functionscore;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class FieldValueFactorFunctionModifierTests extends ESTestCase {
+
+    public void testValidOrdinals() {
+        assertThat(FieldValueFactorFunction.Modifier.NONE.ordinal(), equalTo(0));
+        assertThat(FieldValueFactorFunction.Modifier.LOG.ordinal(), equalTo(1));
+        assertThat(FieldValueFactorFunction.Modifier.LOG1P.ordinal(), equalTo(2));
+        assertThat(FieldValueFactorFunction.Modifier.LOG2P.ordinal(), equalTo(3));
+        assertThat(FieldValueFactorFunction.Modifier.LN.ordinal(), equalTo(4));
+        assertThat(FieldValueFactorFunction.Modifier.LN1P.ordinal(), equalTo(5));
+        assertThat(FieldValueFactorFunction.Modifier.LN2P.ordinal(), equalTo(6));
+        assertThat(FieldValueFactorFunction.Modifier.SQUARE.ordinal(), equalTo(7));
+        assertThat(FieldValueFactorFunction.Modifier.SQRT.ordinal(), equalTo(8));
+        assertThat(FieldValueFactorFunction.Modifier.RECIPROCAL.ordinal(), equalTo(9));
+    }
+
+    public void testWriteTo() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.NONE.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(0));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.LOG.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(1));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.LOG1P.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(2));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.LOG2P.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(3));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.LN.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(4));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.LN1P.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(5));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.LN2P.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(6));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.SQUARE.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(7));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.SQRT.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(8));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            FieldValueFactorFunction.Modifier.RECIPROCAL.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(9));
+            }
+        }
+    }
+
+    public void testReadFrom() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(0);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.NONE));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(1);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.LOG));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(2);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.LOG1P));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(3);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.LOG2P));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(4);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.LN));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(5);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.LN1P));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(6);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.LN2P));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(7);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.SQUARE));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(8);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.SQRT));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(9);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(FieldValueFactorFunction.Modifier.readModifierFrom(in), equalTo(FieldValueFactorFunction.Modifier.RECIPROCAL));
+            }
+        }
+    }
+
+    public void testFromString() {
+        assertThat(FieldValueFactorFunction.Modifier.fromString("none"), equalTo(FieldValueFactorFunction.Modifier.NONE));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("log"), equalTo(FieldValueFactorFunction.Modifier.LOG));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("log1p"), equalTo(FieldValueFactorFunction.Modifier.LOG1P));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("log2p"), equalTo(FieldValueFactorFunction.Modifier.LOG2P));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("ln"), equalTo(FieldValueFactorFunction.Modifier.LN));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("ln1p"), equalTo(FieldValueFactorFunction.Modifier.LN1P));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("ln2p"), equalTo(FieldValueFactorFunction.Modifier.LN2P));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("square"), equalTo(FieldValueFactorFunction.Modifier.SQUARE));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("sqrt"), equalTo(FieldValueFactorFunction.Modifier.SQRT));
+        assertThat(FieldValueFactorFunction.Modifier.fromString("reciprocal"), equalTo(FieldValueFactorFunction.Modifier.RECIPROCAL));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -1,0 +1,603 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.functionscore;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.lucene.search.function.*;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.*;
+import org.elasticsearch.index.query.functionscore.exp.ExponentialDecayFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.fieldvaluefactor.FieldValueFactorFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.lin.LinearDecayFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.random.RandomScoreFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.script.ScriptScoreFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.weight.WeightBuilder;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.expression.ExpressionScriptEngineService;
+import org.elasticsearch.search.MultiValueMode;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
+import static org.hamcrest.Matchers.*;
+
+public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<FunctionScoreQueryBuilder> {
+
+    @Override
+    protected FunctionScoreQueryBuilder doCreateTestQueryBuilder() {
+        FunctionScoreQueryBuilder functionScoreQueryBuilder;
+        switch(randomIntBetween(0, 3)) {
+            case 0:
+                int numFunctions = randomIntBetween(0, 3);
+                FunctionScoreQueryBuilder.FilterFunctionBuilder[] filterFunctionBuilders = new FunctionScoreQueryBuilder.FilterFunctionBuilder[numFunctions];
+                for (int i = 0; i < numFunctions; i++) {
+                    filterFunctionBuilders[i] = new FunctionScoreQueryBuilder.FilterFunctionBuilder(RandomQueryBuilder.createQuery(random()), randomScoreFunction());
+                }
+                if (randomBoolean()) {
+                    functionScoreQueryBuilder = new FunctionScoreQueryBuilder(RandomQueryBuilder.createQuery(random()), filterFunctionBuilders);
+                } else {
+                    functionScoreQueryBuilder = new FunctionScoreQueryBuilder(filterFunctionBuilders);
+                }
+                break;
+            case 1:
+                functionScoreQueryBuilder = new FunctionScoreQueryBuilder(randomScoreFunction());
+                break;
+            case 2:
+                functionScoreQueryBuilder = new FunctionScoreQueryBuilder(RandomQueryBuilder.createQuery(random()), randomScoreFunction());
+                break;
+            case 3:
+                functionScoreQueryBuilder = new FunctionScoreQueryBuilder(RandomQueryBuilder.createQuery(random()));
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+
+        if (randomBoolean()) {
+            functionScoreQueryBuilder.boostMode(randomFrom(CombineFunction.values()));
+        }
+        if (randomBoolean()) {
+            functionScoreQueryBuilder.scoreMode(randomFrom(FiltersFunctionScoreQuery.ScoreMode.values()));
+        }
+        if (randomBoolean()) {
+            functionScoreQueryBuilder.maxBoost(randomFloat());
+        }
+        if (randomBoolean()) {
+            functionScoreQueryBuilder.setMinScore(randomFloat());
+        }
+        return functionScoreQueryBuilder;
+    }
+
+    private static ScoreFunctionBuilder randomScoreFunction() {
+        if (randomBoolean()) {
+            return new WeightBuilder().setWeight(randomFloat());
+        }
+        ScoreFunctionBuilder functionBuilder;
+        //TODO random score function is temporarily disabled, it causes NPE in testToQuery when trying to access the shardId through SearchContext
+        switch (randomIntBetween(0, 2)) {
+            case 0:
+                DecayFunctionBuilder decayFunctionBuilder;
+                Float offset = randomBoolean() ? null : randomFloat();
+                double decay = randomDouble();
+                switch(randomIntBetween(0, 2)) {
+                    case 0:
+                        decayFunctionBuilder = new GaussDecayFunctionBuilder(INT_FIELD_NAME, randomFloat(), randomFloat(), offset, decay);
+                        break;
+                    case 1:
+                        decayFunctionBuilder = new ExponentialDecayFunctionBuilder(INT_FIELD_NAME, randomFloat(), randomFloat(), offset, decay);
+                        break;
+                    case 2:
+                        decayFunctionBuilder = new LinearDecayFunctionBuilder(INT_FIELD_NAME, randomFloat(), randomFloat(), offset, decay);
+                        break;
+                    default:
+                        throw new UnsupportedOperationException();
+                }
+                if (randomBoolean()) {
+                    decayFunctionBuilder.setMultiValueMode(randomFrom(MultiValueMode.values()));
+                }
+                functionBuilder = decayFunctionBuilder;
+                break;
+            case 1:
+                FieldValueFactorFunctionBuilder fieldValueFactorFunctionBuilder = new FieldValueFactorFunctionBuilder(INT_FIELD_NAME);
+                if (randomBoolean()) {
+                    fieldValueFactorFunctionBuilder.factor(randomFloat());
+                }
+                if (randomBoolean()) {
+                    fieldValueFactorFunctionBuilder.missing(randomDouble());
+                }
+                if (randomBoolean()) {
+                    fieldValueFactorFunctionBuilder.modifier(randomFrom(FieldValueFactorFunction.Modifier.values()));
+                }
+                functionBuilder = fieldValueFactorFunctionBuilder;
+                break;
+            case 2:
+                String script;
+                Map<String, Object> params = null;
+                if (randomBoolean()) {
+                    script = "5 * 2 > param";
+                    params = new HashMap<>();
+                    params.put("param", 1);
+                } else {
+                    script = "5 * 2 > 2";
+                }
+                functionBuilder = new ScriptScoreFunctionBuilder(new Script(script, ScriptService.ScriptType.INLINE, ExpressionScriptEngineService.NAME, params));
+                break;
+            case 3:
+                RandomScoreFunctionBuilder randomScoreFunctionBuilder = new RandomScoreFunctionBuilder();
+                if (randomBoolean()) {
+                    randomScoreFunctionBuilder.seed(randomLong());
+                } else if(randomBoolean()) {
+                    randomScoreFunctionBuilder.seed(randomInt());
+                } else {
+                    randomScoreFunctionBuilder.seed(randomAsciiOfLengthBetween(1, 10));
+                }
+                functionBuilder = randomScoreFunctionBuilder;
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+        if (randomBoolean()) {
+            functionBuilder.setWeight(randomFloat());
+        }
+        return functionBuilder;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(FunctionScoreQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        assertThat(query, either(instanceOf(FunctionScoreQuery.class)).or(instanceOf(FiltersFunctionScoreQuery.class)));
+    }
+
+    /**
+     * Overridden here to ensure the test is only run if at least one type is
+     * present in the mappings. Functions require the field to be
+     * explicitly mapped
+     */
+    @Override
+    public void testToQuery() throws IOException {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        super.testToQuery();
+    }
+
+    @Test
+    public void testIllegalArguments() {
+        try {
+            new FunctionScoreQueryBuilder((QueryBuilder<?>)null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder((ScoreFunctionBuilder)null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder((FunctionScoreQueryBuilder.FilterFunctionBuilder[])null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder(null, ScoreFunctionBuilders.randomFunction(123));
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder(new MatchAllQueryBuilder(), (ScoreFunctionBuilder)null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder(new MatchAllQueryBuilder(), (FunctionScoreQueryBuilder.FilterFunctionBuilder[])null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder(null, new FunctionScoreQueryBuilder.FilterFunctionBuilder[0]);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder(QueryBuilders.matchAllQuery(), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{null});
+            fail("content of array must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder.FilterFunctionBuilder(null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder.FilterFunctionBuilder(null, ScoreFunctionBuilders.randomFunction(123));
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder.FilterFunctionBuilder(new MatchAllQueryBuilder(), null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder(new MatchAllQueryBuilder()).scoreMode(null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FunctionScoreQueryBuilder(new MatchAllQueryBuilder()).boostMode(null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+    }
+
+    @Test
+    public void testParseFunctionsArray() throws IOException {
+        String functionScoreQuery = "{\n" +
+                    "    \"function_score\":{\n" +
+                    "        \"query\":{\n" +
+                    "            \"term\":{\n" +
+                    "                \"field1\":\"value1\"\n" +
+                    "            }\n" +
+                    "        },\n" +
+                    "        \"functions\":  [\n" +
+                    "            {\n" +
+                    "                \"random_score\":  {\n" +
+                    "                    \"seed\":123456\n" +
+                    "                },\n" +
+                    "                \"weight\": 3,\n" +
+                    "                \"filter\": {\n" +
+                    "                    \"term\":{\n" +
+                    "                        \"field2\":\"value2\"\n" +
+                    "                    }\n" +
+                    "                }\n" +
+                    "            },\n" +
+                    "            {\n" +
+                    "                \"filter\": {\n" +
+                    "                    \"term\":{\n" +
+                    "                        \"field3\":\"value3\"\n" +
+                    "                    }\n" +
+                    "                },\n" +
+                    "                \"weight\": 9\n" +
+                    "            },\n" +
+                    "            {\n" +
+                    "                \"gauss\":  {\n" +
+                    "                    \"field_name\":  {\n" +
+                    "                        \"origin\":0.5,\n" +
+                    "                        \"scale\":0.6\n" +
+                    "                    }\n" +
+                    "                }\n" +
+                    "            }\n" +
+                    "        ],\n" +
+                    "        \"boost\" : 3,\n" +
+                    "        \"score_mode\" : \"avg\",\n" +
+                    "        \"boost_mode\" : \"replace\",\n" +
+                    "        \"max_boost\" : 10\n" +
+                    "    }\n" +
+                    "}";
+
+        QueryBuilder<?> queryBuilder = parseQuery(functionScoreQuery);
+        //given that we copy part of the decay functions as bytes, we test that fromXContent and toXContent both work no matter what the initial format was
+        for (int i = 0; i <= XContentType.values().length; i++) {
+            assertThat(queryBuilder, instanceOf(FunctionScoreQueryBuilder.class));
+            FunctionScoreQueryBuilder functionScoreQueryBuilder = (FunctionScoreQueryBuilder) queryBuilder;
+            assertThat(functionScoreQueryBuilder.query(), instanceOf(TermQueryBuilder.class));
+            TermQueryBuilder termQueryBuilder = (TermQueryBuilder) functionScoreQueryBuilder.query();
+            assertThat(termQueryBuilder.fieldName(), equalTo("field1"));
+            assertThat(termQueryBuilder.value(), equalTo("value1"));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders().length, equalTo(3));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[0].getFilter(), instanceOf(TermQueryBuilder.class));
+            termQueryBuilder = (TermQueryBuilder) functionScoreQueryBuilder.filterFunctionBuilders()[0].getFilter();
+            assertThat(termQueryBuilder.fieldName(), equalTo("field2"));
+            assertThat(termQueryBuilder.value(), equalTo("value2"));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[1].getFilter(), instanceOf(TermQueryBuilder.class));
+            termQueryBuilder = (TermQueryBuilder) functionScoreQueryBuilder.filterFunctionBuilders()[1].getFilter();
+            assertThat(termQueryBuilder.fieldName(), equalTo("field3"));
+            assertThat(termQueryBuilder.value(), equalTo("value3"));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[2].getFilter(), instanceOf(MatchAllQueryBuilder.class));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[0].getScoreFunction(), instanceOf(RandomScoreFunctionBuilder.class));
+            RandomScoreFunctionBuilder randomScoreFunctionBuilder = (RandomScoreFunctionBuilder) functionScoreQueryBuilder.filterFunctionBuilders()[0].getScoreFunction();
+            assertThat(randomScoreFunctionBuilder.getSeed(), equalTo(123456));
+            assertThat(randomScoreFunctionBuilder.getWeight(), equalTo(3f));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[1].getScoreFunction(), instanceOf(WeightBuilder.class));
+            WeightBuilder weightBuilder = (WeightBuilder) functionScoreQueryBuilder.filterFunctionBuilders()[1].getScoreFunction();
+            assertThat(weightBuilder.getWeight(), equalTo(9f));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[2].getScoreFunction(), instanceOf(GaussDecayFunctionBuilder.class));
+            GaussDecayFunctionBuilder gaussDecayFunctionBuilder = (GaussDecayFunctionBuilder) functionScoreQueryBuilder.filterFunctionBuilders()[2].getScoreFunction();
+            assertThat(gaussDecayFunctionBuilder.getFieldName(), equalTo("field_name"));
+            assertThat(functionScoreQueryBuilder.boost(), equalTo(3f));
+            assertThat(functionScoreQueryBuilder.scoreMode(), equalTo(FiltersFunctionScoreQuery.ScoreMode.AVG));
+            assertThat(functionScoreQueryBuilder.boostMode(), equalTo(CombineFunction.REPLACE));
+            assertThat(functionScoreQueryBuilder.maxBoost(), equalTo(10f));
+
+            if (i < XContentType.values().length) {
+                queryBuilder = parseQuery(((AbstractQueryBuilder)queryBuilder).buildAsBytes(XContentType.values()[i]));
+            }
+        }
+    }
+
+    @Test
+    public void testParseSingleFunction() throws IOException {
+        String functionScoreQuery = "{\n" +
+                "    \"function_score\":{\n" +
+                "        \"query\":{\n" +
+                "            \"term\":{\n" +
+                "                \"field1\":\"value1\"\n" +
+                "            }\n" +
+                "        },\n" +
+                "        \"gauss\":  {\n" +
+                "            \"field_name\":  {\n" +
+                "                \"origin\":0.5,\n" +
+                "                \"scale\":0.6\n" +
+                "            }\n" +
+                "         },\n" +
+                "        \"boost\" : 3,\n" +
+                "        \"score_mode\" : \"avg\",\n" +
+                "        \"boost_mode\" : \"replace\",\n" +
+                "        \"max_boost\" : 10\n" +
+                "    }\n" +
+                "}";
+
+        QueryBuilder<?> queryBuilder = parseQuery(functionScoreQuery);
+        //given that we copy part of the decay functions as bytes, we test that fromXContent and toXContent both work no matter what the initial format was
+        for (int i = 0; i <= XContentType.values().length; i++) {
+            assertThat(queryBuilder, instanceOf(FunctionScoreQueryBuilder.class));
+            FunctionScoreQueryBuilder functionScoreQueryBuilder = (FunctionScoreQueryBuilder) queryBuilder;
+            assertThat(functionScoreQueryBuilder.query(), instanceOf(TermQueryBuilder.class));
+            TermQueryBuilder termQueryBuilder = (TermQueryBuilder) functionScoreQueryBuilder.query();
+            assertThat(termQueryBuilder.fieldName(), equalTo("field1"));
+            assertThat(termQueryBuilder.value(), equalTo("value1"));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders().length, equalTo(1));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[0].getFilter(), instanceOf(MatchAllQueryBuilder.class));
+            assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[0].getScoreFunction(), instanceOf(GaussDecayFunctionBuilder.class));
+            GaussDecayFunctionBuilder gaussDecayFunctionBuilder = (GaussDecayFunctionBuilder) functionScoreQueryBuilder.filterFunctionBuilders()[0].getScoreFunction();
+            assertThat(gaussDecayFunctionBuilder.getFieldName(), equalTo("field_name"));
+            assertThat(gaussDecayFunctionBuilder.getWeight(), nullValue());
+            assertThat(functionScoreQueryBuilder.boost(), equalTo(3f));
+            assertThat(functionScoreQueryBuilder.scoreMode(), equalTo(FiltersFunctionScoreQuery.ScoreMode.AVG));
+            assertThat(functionScoreQueryBuilder.boostMode(), equalTo(CombineFunction.REPLACE));
+            assertThat(functionScoreQueryBuilder.maxBoost(), equalTo(10f));
+
+            if (i < XContentType.values().length) {
+                queryBuilder = parseQuery(((AbstractQueryBuilder)queryBuilder).buildAsBytes(XContentType.values()[i]));
+            }
+        }
+    }
+
+    @Test
+    public void testProperErrorMessageWhenTwoFunctionsDefinedInQueryBody() throws IOException {
+        //without a functions array, we support only a single function, weight can't be associated with the function either.
+        String functionScoreQuery = "{\n" +
+                "    \"function_score\": {\n" +
+                "      \"script_score\": {\n" +
+                "        \"script\": \"_index['text']['foo'].tf()\"\n" +
+                "      },\n" +
+                "      \"weight\": 2\n" +
+                "    }\n" +
+                "}";
+        try {
+            parseQuery(functionScoreQuery);
+            fail("parsing should have failed");
+        } catch(ParsingException e) {
+            assertThat(e.getMessage(), containsString("use [functions] array if you want to define several functions."));
+        }
+    }
+
+    @Test
+    public void testProperErrorMessageWhenTwoFunctionsDefinedInFunctionsArray() throws IOException {
+        String functionScoreQuery = "{\n" +
+                "    \"function_score\":{\n" +
+                "        \"functions\":  [\n" +
+                "            {\n" +
+                "                \"random_score\":  {\n" +
+                "                    \"seed\":123456\n" +
+                "                },\n" +
+                "                \"weight\": 3,\n" +
+                "                \"script_score\": {\n" +
+                "                    \"script\": \"_index['text']['foo'].tf()\"\n" +
+                "                },\n" +
+                "                \"filter\": {\n" +
+                "                    \"term\":{\n" +
+                "                        \"field2\":\"value2\"\n" +
+                "                    }\n" +
+                "                }\n" +
+                "            }\n" +
+                "        ]\n" +
+                "    }\n" +
+                "}";
+
+        try {
+            parseQuery(functionScoreQuery);
+            fail("parsing should have failed");
+        } catch(ParsingException e) {
+            assertThat(e.getMessage(), containsString("failed to parse function_score functions. already found [random_score], now encountering [script_score]."));
+        }
+    }
+
+    @Test
+    public void testProperErrorMessageWhenMissingFunction() throws IOException {
+        String functionScoreQuery = "{\n" +
+                "    \"function_score\":{\n" +
+                "        \"functions\":  [\n" +
+                "            {\n" +
+                "                \"filter\": {\n" +
+                "                    \"term\":{\n" +
+                "                        \"field2\":\"value2\"\n" +
+                "                    }\n" +
+                "                }\n" +
+                "            }\n" +
+                "        ]\n" +
+                "    }\n" +
+                "}";
+        try {
+            parseQuery(functionScoreQuery);
+            fail("parsing should have failed");
+        } catch(ParsingException e) {
+            assertThat(e.getMessage(), containsString("an entry in functions list is missing a function."));
+        }
+    }
+
+    @Test
+    public void testWeight1fStillProducesWeightFunction() throws IOException {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        String queryString = jsonBuilder().startObject()
+                .startObject("function_score")
+                .startArray("functions")
+                .startObject()
+                .startObject("field_value_factor")
+                .field("field", INT_FIELD_NAME)
+                .endObject()
+                .field("weight", 1.0)
+                .endObject()
+                .endArray()
+                .endObject()
+                .endObject().string();
+        QueryBuilder<?> query = parseQuery(queryString);
+        assertThat(query, instanceOf(FunctionScoreQueryBuilder.class));
+        FunctionScoreQueryBuilder functionScoreQueryBuilder = (FunctionScoreQueryBuilder) query;
+        assertThat(functionScoreQueryBuilder.filterFunctionBuilders()[0].getScoreFunction(), instanceOf(FieldValueFactorFunctionBuilder.class));
+        FieldValueFactorFunctionBuilder fieldValueFactorFunctionBuilder = (FieldValueFactorFunctionBuilder) functionScoreQueryBuilder.filterFunctionBuilders()[0].getScoreFunction();
+        assertThat(fieldValueFactorFunctionBuilder.fieldName(), equalTo(INT_FIELD_NAME));
+        assertThat(fieldValueFactorFunctionBuilder.factor(), equalTo(FieldValueFactorFunctionBuilder.DEFAULT_FACTOR));
+        assertThat(fieldValueFactorFunctionBuilder.modifier(), equalTo(FieldValueFactorFunctionBuilder.DEFAULT_MODIFIER));
+        assertThat(fieldValueFactorFunctionBuilder.getWeight(), equalTo(1f));
+        assertThat(fieldValueFactorFunctionBuilder.missing(), nullValue());
+
+        Query luceneQuery = query.toQuery(createShardContext());
+        assertThat(luceneQuery, instanceOf(FunctionScoreQuery.class));
+        FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) luceneQuery;
+        assertThat(functionScoreQuery.getFunction(), instanceOf(WeightFactorFunction.class));
+        WeightFactorFunction weightFactorFunction = (WeightFactorFunction) functionScoreQuery.getFunction();
+        assertThat(weightFactorFunction.getWeight(), equalTo(1.0f));
+        assertThat(weightFactorFunction.getScoreFunction(), instanceOf(FieldValueFactorFunction.class));
+    }
+
+    @Test
+    public void testProperErrorMessagesForMisplacedWeightsAndFunctions() throws IOException {
+        String query = jsonBuilder().startObject().startObject("function_score")
+                .startArray("functions")
+                .startObject().startObject("script_score").field("script", "3").endObject().endObject()
+                .endArray()
+                .field("weight", 2)
+                .endObject().endObject().string();
+        try {
+            parseQuery(query);
+            fail("Expect exception here because array of functions and one weight in body is not allowed.");
+        } catch (ParsingException e) {
+            assertThat(e.getMessage(), containsString("you can either define [functions] array or a single function, not both. already found [functions] array, now encountering [weight]."));
+        }
+        query = jsonBuilder().startObject().startObject("function_score")
+                .field("weight", 2)
+                .startArray("functions")
+                .startObject().endObject()
+                .endArray()
+                .endObject().endObject().string();
+        try {
+            parseQuery(query);
+            fail("Expect exception here because array of functions and one weight in body is not allowed.");
+        } catch (ParsingException e) {
+            assertThat(e.getMessage(), containsString("you can either define [functions] array or a single function, not both. already found [weight], now encountering [functions]."));
+        }
+    }
+
+    @Test(expected = JsonParseException.class)
+    public void ensureMalformedThrowsException() throws IOException {
+        parseQuery(copyToStringFromClasspath("/org/elasticsearch/index/query/faulty-function-score-query.json"));
+    }
+
+    @Test
+    public void testCustomWeightFactorQueryBuilder_withFunctionScore() throws IOException {
+        Query parsedQuery = parseQuery(functionScoreQuery(termQuery("name.last", "banon"), ScoreFunctionBuilders.weightFactorFunction(1.3f)).buildAsBytes()).toQuery(createShardContext());
+        assertThat(parsedQuery, instanceOf(FunctionScoreQuery.class));
+        FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) parsedQuery;
+        assertThat(((TermQuery) functionScoreQuery.getSubQuery()).getTerm(), equalTo(new Term("name.last", "banon")));
+        assertThat((double) ((WeightFactorFunction) functionScoreQuery.getFunction()).getWeight(), closeTo(1.3, 0.001));
+    }
+
+    @Test
+    public void testCustomWeightFactorQueryBuilder_withFunctionScoreWithoutQueryGiven() throws IOException {
+        Query parsedQuery = parseQuery(functionScoreQuery(ScoreFunctionBuilders.weightFactorFunction(1.3f)).buildAsBytes()).toQuery(createShardContext());
+        assertThat(parsedQuery, instanceOf(FunctionScoreQuery.class));
+        FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) parsedQuery;
+        assertThat(functionScoreQuery.getSubQuery() instanceof MatchAllDocsQuery, equalTo(true));
+        assertThat((double) ((WeightFactorFunction) functionScoreQuery.getFunction()).getWeight(), closeTo(1.3, 0.001));
+    }
+
+    @Test
+    public void testFieldValueFactorFactorArray() throws IOException {
+        // don't permit an array of factors
+        String querySource = "{" +
+                "\"query\": {" +
+                "  \"function_score\": {" +
+                "    \"query\": {" +
+                "      \"match\": {\"name\": \"foo\"}" +
+                "      }," +
+                "      \"functions\": [" +
+                "        {" +
+                "          \"field_value_factor\": {" +
+                "            \"field\": \"test\"," +
+                "            \"factor\": [1.2,2]" +
+                "          }" +
+                "        }" +
+                "      ]" +
+                "    }" +
+                "  }" +
+                "}";
+        try {
+            parseQuery(querySource);
+            fail("parsing should have failed");
+        } catch(ParsingException e) {
+            assertThat(e.getMessage(), containsString("[field_value_factor] field 'factor' does not support lists or objects"));
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.functionscore;
+
+import org.elasticsearch.index.query.functionscore.exp.ExponentialDecayFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.fieldvaluefactor.FieldValueFactorFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.lin.LinearDecayFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.random.RandomScoreFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.script.ScriptScoreFunctionBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+public class ScoreFunctionBuilderTests extends ESTestCase {
+
+    public void testIllegalArguments() {
+        try {
+            new RandomScoreFunctionBuilder().seed(null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new ScriptScoreFunctionBuilder(null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FieldValueFactorFunctionBuilder(null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new FieldValueFactorFunctionBuilder("").modifier(null);
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new GaussDecayFunctionBuilder(null, "", "", "");
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new GaussDecayFunctionBuilder("", "", null, "");
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new GaussDecayFunctionBuilder("", "", null, "", randomIntBetween(1, 100));
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new GaussDecayFunctionBuilder("", "", null, "", randomIntBetween(-100, -1));
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new LinearDecayFunctionBuilder(null, "", "", "");
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new LinearDecayFunctionBuilder("", "", null, "");
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new LinearDecayFunctionBuilder("", "", null, "", randomIntBetween(1, 100));
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new LinearDecayFunctionBuilder("", "", null, "", randomIntBetween(-100, -1));
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new ExponentialDecayFunctionBuilder(null, "", "", "");
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new ExponentialDecayFunctionBuilder("", "", null, "");
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new ExponentialDecayFunctionBuilder("", "", null, "", randomIntBetween(1, 100));
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+        try {
+            new ExponentialDecayFunctionBuilder("", "", null, "", randomIntBetween(-100, -1));
+            fail("must not be null");
+        } catch(IllegalArgumentException e) {
+            //all good
+        }
+
+    }
+}

--- a/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
@@ -45,9 +45,8 @@ import org.elasticsearch.index.percolator.PercolatorException;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryShardException;
-import org.elasticsearch.index.query.support.QueryInnerHits;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.index.query.functionscore.weight.WeightBuilder;
+import org.elasticsearch.index.query.support.QueryInnerHits;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.highlight.HighlightBuilder;
@@ -1421,7 +1420,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setSize(5)
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "The quick brown fox jumps over the lazy dog").endObject()))
                 .setHighlightBuilder(new HighlightBuilder().field("field1"))
-                .setPercolateQuery(functionScoreQuery(matchAllQuery()).add(new WeightBuilder().setWeight(5.5f)))
+                .setPercolateQuery(functionScoreQuery(new WeightBuilder().setWeight(5.5f)))
                 .setScore(true)
                 .execute().actionGet();
         assertNoFailures(response);
@@ -1453,7 +1452,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setSize(5)
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "The quick brown fox jumps over the lazy dog").endObject()))
                 .setHighlightBuilder(new HighlightBuilder().field("field1"))
-                .setPercolateQuery(functionScoreQuery(matchAllQuery()).add(new WeightBuilder().setWeight(5.5f)))
+                .setPercolateQuery(functionScoreQuery(new WeightBuilder().setWeight(5.5f)))
                 .setSortByScore(true)
                 .execute().actionGet();
         assertMatchCount(response, 5l);
@@ -1485,7 +1484,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setSize(5)
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "The quick brown fox jumps over the lazy dog").endObject()))
                 .setHighlightBuilder(new HighlightBuilder().field("field1").highlightQuery(QueryBuilders.matchQuery("field1", "jumps")))
-                .setPercolateQuery(functionScoreQuery(matchAllQuery()).add(new WeightBuilder().setWeight(5.5f)))
+                .setPercolateQuery(functionScoreQuery(new WeightBuilder().setWeight(5.5f)))
                 .setSortByScore(true)
                 .execute().actionGet();
         assertMatchCount(response, 5l);
@@ -1522,7 +1521,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setSize(5)
                 .setGetRequest(Requests.getRequest("test").type("type").id("1"))
                 .setHighlightBuilder(new HighlightBuilder().field("field1"))
-                .setPercolateQuery(functionScoreQuery(matchAllQuery()).add(new WeightBuilder().setWeight(5.5f)))
+                .setPercolateQuery(functionScoreQuery(new WeightBuilder().setWeight(5.5f)))
                 .setSortByScore(true)
                 .execute().actionGet();
         assertMatchCount(response, 5l);

--- a/core/src/test/java/org/elasticsearch/script/GroovyScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/script/GroovyScriptIT.java
@@ -104,9 +104,7 @@ public class GroovyScriptIT extends ESIntegTestCase {
         refresh();
 
         // doc[] access
-        SearchResponse resp = client().prepareSearch("test").setQuery(functionScoreQuery(matchAllQuery())
-.add(
-                                scriptFunction(new Script("doc['bar'].value", ScriptType.INLINE, "groovy", null)))
+        SearchResponse resp = client().prepareSearch("test").setQuery(functionScoreQuery(scriptFunction(new Script("doc['bar'].value", ScriptType.INLINE, "groovy", null)))
             .boostMode(CombineFunction.REPLACE)).get();
 
         assertNoFailures(resp);
@@ -120,8 +118,8 @@ public class GroovyScriptIT extends ESIntegTestCase {
         refresh();
 
         // _score can be accessed
-        SearchResponse resp = client().prepareSearch("test").setQuery(functionScoreQuery(matchQuery("foo", "dog"))
-            .add(scriptFunction(new Script("_score", ScriptType.INLINE, "groovy", null)))
+        SearchResponse resp = client().prepareSearch("test").setQuery(functionScoreQuery(matchQuery("foo", "dog"),
+                scriptFunction(new Script("_score", ScriptType.INLINE, "groovy", null)))
             .boostMode(CombineFunction.REPLACE)).get();
         assertNoFailures(resp);
         assertSearchHits(resp, "3", "1");
@@ -132,7 +130,7 @@ public class GroovyScriptIT extends ESIntegTestCase {
         resp = client()
                 .prepareSearch("test")
                 .setQuery(
-                        functionScoreQuery(matchQuery("foo", "dog")).add(
+                        functionScoreQuery(matchQuery("foo", "dog"),
                                 scriptFunction(new Script("_score > 0.0 ? _score : 0", ScriptType.INLINE, "groovy", null))).boostMode(
                                 CombineFunction.REPLACE)).get();
         assertNoFailures(resp);

--- a/core/src/test/java/org/elasticsearch/script/expression/ExpressionScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/script/expression/ExpressionScriptIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -106,7 +107,7 @@ public class ExpressionScriptIT extends ESIntegTestCase {
                 client().prepareIndex("test", "doc", "3").setSource("text", "hello hello goodebye"));
         ScoreFunctionBuilder score = ScoreFunctionBuilders.scriptFunction(new Script("1 / _score", ScriptType.INLINE, "expression", null));
         SearchRequestBuilder req = client().prepareSearch().setIndices("test");
-        req.setQuery(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("text", "hello"), score).boostMode("replace"));
+        req.setQuery(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("text", "hello"), score).boostMode(CombineFunction.REPLACE));
         req.setSearchType(SearchType.DFS_QUERY_THEN_FETCH); // make sure DF is consistent
         SearchResponse rsp = req.get();
         assertSearchResponse(rsp);

--- a/core/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
@@ -24,6 +24,8 @@ import org.apache.lucene.index.*;
 import org.apache.lucene.util.BitDocIdSet;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -32,6 +34,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class MultiValueModeTests extends ESTestCase {
 
@@ -732,5 +736,95 @@ public class MultiValueModeTests extends ESTestCase {
                 }
             }
         }
+    }
+
+    public void testValidOrdinals() {
+        assertThat(MultiValueMode.SUM.ordinal(), equalTo(0));
+        assertThat(MultiValueMode.AVG.ordinal(), equalTo(1));
+        assertThat(MultiValueMode.MEDIAN.ordinal(), equalTo(2));
+        assertThat(MultiValueMode.MIN.ordinal(), equalTo(3));
+        assertThat(MultiValueMode.MAX.ordinal(), equalTo(4));
+    }
+
+    public void testWriteTo() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            MultiValueMode.SUM.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(0));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            MultiValueMode.AVG.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(1));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            MultiValueMode.MEDIAN.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(2));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            MultiValueMode.MIN.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(3));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            MultiValueMode.MAX.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(in.readVInt(), equalTo(4));
+            }
+        }
+    }
+
+    public void testReadFrom() throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(0);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(MultiValueMode.readMultiValueModeFrom(in), equalTo(MultiValueMode.SUM));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(1);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(MultiValueMode.readMultiValueModeFrom(in), equalTo(MultiValueMode.AVG));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(2);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(MultiValueMode.readMultiValueModeFrom(in), equalTo(MultiValueMode.MEDIAN));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(3);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(MultiValueMode.readMultiValueModeFrom(in), equalTo(MultiValueMode.MIN));
+            }
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(4);
+            try (StreamInput in = StreamInput.wrap(out.bytes())) {
+                assertThat(MultiValueMode.readMultiValueModeFrom(in), equalTo(MultiValueMode.MAX));
+            }
+        }
+    }
+
+    public void testFromString() {
+        assertThat(MultiValueMode.fromString("sum"), equalTo(MultiValueMode.SUM));
+        assertThat(MultiValueMode.fromString("avg"), equalTo(MultiValueMode.AVG));
+        assertThat(MultiValueMode.fromString("median"), equalTo(MultiValueMode.MEDIAN));
+        assertThat(MultiValueMode.fromString("min"), equalTo(MultiValueMode.MIN));
+        assertThat(MultiValueMode.fromString("max"), equalTo(MultiValueMode.MAX));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DoubleTermsIT.java
@@ -1201,8 +1201,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
                 .prepareSearch("idx")
                 .setTypes("type")
                 .setQuery(
-                        functionScoreQuery(matchAllQuery()).add(
-                                ScoreFunctionBuilders.scriptFunction(new Script("doc['" + SINGLE_VALUED_FIELD_NAME + "'].value"))))
+                        functionScoreQuery(ScoreFunctionBuilders.scriptFunction(new Script("doc['" + SINGLE_VALUED_FIELD_NAME + "'].value"))))
                 .addAggregation(
                         terms("terms").collectMode(randomFrom(SubAggCollectionMode.values())).script(
                                 new Script("ceil(_score.doubleValue()/3)"))).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
@@ -52,6 +52,7 @@ import static org.elasticsearch.action.search.SearchType.DFS_QUERY_AND_FETCH;
 import static org.elasticsearch.action.search.SearchType.DFS_QUERY_THEN_FETCH;
 import static org.elasticsearch.action.search.SearchType.QUERY_AND_FETCH;
 import static org.elasticsearch.action.search.SearchType.QUERY_THEN_FETCH;
+
 import static org.elasticsearch.client.Requests.createIndexRequest;
 import static org.elasticsearch.client.Requests.searchRequest;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
@@ -427,8 +428,8 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         logger.info("Start Testing failed multi search with a wrong query");
 
         MultiSearchResponse response = client().prepareMultiSearch()
-                // Add function score with a bogus score mode
-                .add(client().prepareSearch("test").setQuery(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("nid", 1)).scoreMode("foobar")))
+                // Add geo distance range query against a field that doesn't exist (should be a geo point for the query to work)
+                .add(client().prepareSearch("test").setQuery(QueryBuilders.geoDistanceRangeQuery("non_existing_field", 1, 1).from(10).to(15)))
                 .add(client().prepareSearch("test").setQuery(QueryBuilders.termQuery("nid", 2)))
                 .add(client().prepareSearch("test").setQuery(QueryBuilders.matchAllQuery()))
                 .execute().actionGet();
@@ -444,7 +445,6 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         logger.info("Done Testing failed search");
     }
 
-
     @Test
     public void testFailedMultiSearchWithWrongQuery_withFunctionScore() throws Exception {
         prepareData();
@@ -453,7 +453,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
         MultiSearchResponse response = client().prepareMultiSearch()
                 // Add custom score query with bogus script
-                .add(client().prepareSearch("test").setQuery(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("nid", 1)).add(new ScriptScoreFunctionBuilder(new Script("foo", ScriptService.ScriptType.INLINE, "bar", null)))))
+                .add(client().prepareSearch("test").setQuery(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("nid", 1), new ScriptScoreFunctionBuilder(new Script("foo", ScriptService.ScriptType.INLINE, "bar", null)))))
                 .add(client().prepareSearch("test").setQuery(QueryBuilders.termQuery("nid", 2)))
                 .add(client().prepareSearch("test").setQuery(QueryBuilders.matchAllQuery()))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -24,14 +24,10 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.script.AbstractDoubleSearchScript;
-import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.ExplainableSearchScript;
-import org.elasticsearch.script.NativeScriptFactory;
-import org.elasticsearch.script.Script;
+import org.elasticsearch.script.*;
 import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -49,7 +45,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.client.Requests.searchRequest;
-import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -79,9 +74,9 @@ public class ExplainableScriptIT extends ESIntegTestCase {
         ensureYellow();
         SearchResponse response = client().search(searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource().explain(true).query(
-                                functionScoreQuery(termQuery("text", "text")).add(
+                                functionScoreQuery(termQuery("text", "text"),
                                         scriptFunction(new Script("native_explainable_script", ScriptType.INLINE, "native", null)))
-                                        .boostMode("replace")))).actionGet();
+                                        .boostMode(CombineFunction.REPLACE)))).actionGet();
 
         ElasticsearchAssertions.assertNoFailures(response);
         SearchHits hits = response.getHits();

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreBackwardCompatibilityIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.test.ESBackcompatTestCase;
 import org.junit.Test;
@@ -110,11 +111,12 @@ public class FunctionScoreBackwardCompatibilityIT extends ESBackcompatTestCase {
         SearchResponse response = client().search(
                 searchRequest().source(
                         searchSource().query(
-                                functionScoreQuery(termQuery("text", "value"))
-                                        .add(gaussDecayFunction("loc", new GeoPoint(10, 20), "1000km"))
-                                        .add(scriptFunction(new Script("_index['text']['value'].tf()")))
-                                        .add(termQuery("text", "boosted"), weightFactorFunction(5))
-                        ))).actionGet();
+                                functionScoreQuery(termQuery("text", "value"), new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(gaussDecayFunction("loc", new GeoPoint(10, 20), "1000km")),
+                                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("_index['text']['value'].tf()"))),
+                                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(termQuery("text", "boosted"), weightFactorFunction(5))
+                                        }
+                                )))).actionGet();
         assertSearchResponse(response);
         assertOrderedSearchHits(response, ids);
     }

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.functionscore;
 
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -126,34 +125,5 @@ public class FunctionScoreFieldValueIT extends ESIntegTestCase {
             // This is fine, the query will throw an exception if executed
             // locally, instead of just having failures
         }
-
-        // don't permit an array of factors
-        try {
-          String querySource = "{" +
-            "\"query\": {" +
-            "  \"function_score\": {" +
-            "    \"query\": {" +
-            "      \"match\": {\"name\": \"foo\"}" +
-            "      }," +
-            "      \"functions\": [" +
-            "        {" +
-            "          \"field_value_factor\": {" +
-            "            \"field\": \"test\"," +
-            "            \"factor\": [1.2,2]" +
-            "          }" +
-            "        }" +
-            "      ]" +
-            "    }" +
-            "  }" +
-            "}";
-          response = client().prepareSearch("test")
-          .setSource(new BytesArray(querySource))
-                  .get();
-          assertFailures(response);
-        } catch (SearchPhaseExecutionException e) {
-          // This is fine, the query will throw an exception if executed
-          // locally, instead of just having failures
-        }
-
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
@@ -25,8 +25,11 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.weight.WeightBuilder;
@@ -90,21 +93,25 @@ public class FunctionScoreIT extends ESIntegTestCase {
         SearchResponse response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource().explain(true).query(
-                                functionScoreQuery(termQuery("test", "value")).add(gaussDecayFunction("num", 5, 5)).add(exponentialDecayFunction("num", 5, 5)).add(linearDecayFunction("num", 5, 5))))).get();
+                                functionScoreQuery(termQuery("test", "value"), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(gaussDecayFunction("num", 5, 5)),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(exponentialDecayFunction("num", 5, 5)),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(linearDecayFunction("num", 5, 5))
+                                })))).get();
         String explanation = response.getHits().getAt(0).explanation().toString();
 
         checkQueryExplanationAppearsOnlyOnce(explanation);
         response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource().explain(true).query(
-                                functionScoreQuery(termQuery("test", "value")).add(fieldValueFactorFunction("num"))))).get();
+                                functionScoreQuery(termQuery("test", "value"), fieldValueFactorFunction("num"))))).get();
         explanation = response.getHits().getAt(0).explanation().toString();
         checkQueryExplanationAppearsOnlyOnce(explanation);
 
         response = client().search(
                 searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
                         searchSource().explain(true).query(
-                                functionScoreQuery(termQuery("test", "value")).add(randomFunction(10))))).get();
+                                functionScoreQuery(termQuery("test", "value"), randomFunction(10))))).get();
         explanation = response.getHits().getAt(0).explanation().toString();
 
         checkQueryExplanationAppearsOnlyOnce(explanation);
@@ -171,11 +178,11 @@ public class FunctionScoreIT extends ESIntegTestCase {
         SearchResponse responseWithWeights = client().search(
                 searchRequest().source(
                         searchSource().query(
-                                functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")))
-                                        .add(gaussDecayFunction(GEO_POINT_FIELD, new GeoPoint(10, 20), "1000km"))
-                                        .add(fieldValueFactorFunction(DOUBLE_FIELD).modifier(FieldValueFactorFunction.Modifier.LN).setWeight(2))
-                                        .add(scriptFunction(new Script("_index['" + TEXT_FIELD + "']['value'].tf()")).setWeight(3)))
-                                .explain(true))).actionGet();
+                                functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(gaussDecayFunction(GEO_POINT_FIELD, new GeoPoint(10, 20), "1000km")),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction(DOUBLE_FIELD).modifier(FieldValueFactorFunction.Modifier.LN).setWeight(2)),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("_index['" + TEXT_FIELD + "']['value'].tf()")).setWeight(3))
+                                })).explain(true))).actionGet();
 
         assertThat(
                 responseWithWeights.getHits().getAt(0).getExplanation().toString(),
@@ -183,7 +190,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
         responseWithWeights = client().search(
                 searchRequest().source(
                         searchSource().query(
-                                functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value"))).add(weightFactorFunction(4.0f)))
+                                functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")), weightFactorFunction(4.0f)))
                                 .explain(true))).actionGet();
         assertThat(
                 responseWithWeights.getHits().getAt(0).getExplanation().toString(),
@@ -203,19 +210,19 @@ public class FunctionScoreIT extends ESIntegTestCase {
         SearchResponse response = client().search(
                 searchRequest().source(
                         searchSource().query(
-                                functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")))
-                                        .add(gaussDecayFunction(GEO_POINT_FIELD, new GeoPoint(10, 20), "1000km"))
-                                        .add(fieldValueFactorFunction(DOUBLE_FIELD).modifier(FieldValueFactorFunction.Modifier.LN))
-                                        .add(scriptFunction(new Script("_index['" + TEXT_FIELD + "']['value'].tf()")))))).actionGet();
+                                functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(gaussDecayFunction(GEO_POINT_FIELD, new GeoPoint(10, 20), "1000km")),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction(DOUBLE_FIELD).modifier(FieldValueFactorFunction.Modifier.LN)),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("_index['" + TEXT_FIELD + "']['value'].tf()")))
+                                })))).actionGet();
         SearchResponse responseWithWeights = client().search(
                 searchRequest().source(
                         searchSource().query(
-                                functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")))
-                                        .add(gaussDecayFunction(GEO_POINT_FIELD, new GeoPoint(10, 20), "1000km").setWeight(2))
-                                        .add(fieldValueFactorFunction(DOUBLE_FIELD).modifier(FieldValueFactorFunction.Modifier.LN)
-                                                .setWeight(2))
-                                        .add(scriptFunction(new Script("_index['" + TEXT_FIELD + "']['value'].tf()")).setWeight(2)))))
-                .actionGet();
+                                functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(gaussDecayFunction(GEO_POINT_FIELD, new GeoPoint(10, 20), "1000km").setWeight(2)),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction(DOUBLE_FIELD).modifier(FieldValueFactorFunction.Modifier.LN).setWeight(2)),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("_index['" + TEXT_FIELD + "']['value'].tf()")).setWeight(2))
+                                })))).actionGet();
 
         assertSearchResponse(response);
         assertThat(response.getHits().getAt(0).getScore(), is(1.0f));
@@ -235,14 +242,16 @@ public class FunctionScoreIT extends ESIntegTestCase {
         ScoreFunctionBuilder[] scoreFunctionBuilders = getScoreFunctionBuilders();
         float[] weights = createRandomWeights(scoreFunctionBuilders.length);
         float[] scores = getScores(scoreFunctionBuilders);
-
-        String scoreMode = getRandomScoreMode();
-        FunctionScoreQueryBuilder withWeights = functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value"))).scoreMode(scoreMode);
         int weightscounter = 0;
+        FunctionScoreQueryBuilder.FilterFunctionBuilder[] filterFunctionBuilders = new FunctionScoreQueryBuilder.FilterFunctionBuilder[scoreFunctionBuilders.length];
         for (ScoreFunctionBuilder builder : scoreFunctionBuilders) {
-            withWeights.add(builder.setWeight(weights[weightscounter]));
+            filterFunctionBuilders[weightscounter] = new FunctionScoreQueryBuilder.FilterFunctionBuilder(builder.setWeight(weights[weightscounter]));
             weightscounter++;
         }
+        FiltersFunctionScoreQuery.ScoreMode scoreMode = randomFrom(FiltersFunctionScoreQuery.ScoreMode.AVG, FiltersFunctionScoreQuery.ScoreMode.SUM,
+                FiltersFunctionScoreQuery.ScoreMode.MIN, FiltersFunctionScoreQuery.ScoreMode.MAX, FiltersFunctionScoreQuery.ScoreMode.MULTIPLY);
+        FunctionScoreQueryBuilder withWeights = functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")), filterFunctionBuilders).scoreMode(scoreMode);
+
         SearchResponse responseWithWeights = client().search(
                 searchRequest().source(searchSource().query(withWeights))
         ).actionGet();
@@ -251,38 +260,48 @@ public class FunctionScoreIT extends ESIntegTestCase {
         assertThat((float) expectedScore / responseWithWeights.getHits().getAt(0).getScore(), is(1.0f));
     }
 
-    protected double computeExpectedScore(float[] weights, float[] scores, String scoreMode) {
-        double expectedScore = 0.0;
-        if ("multiply".equals(scoreMode)) {
-            expectedScore = 1.0;
-        }
-        if ("max".equals(scoreMode)) {
-            expectedScore = Float.MAX_VALUE * -1.0;
-        }
-        if ("min".equals(scoreMode)) {
-            expectedScore = Float.MAX_VALUE;
+    protected double computeExpectedScore(float[] weights, float[] scores, FiltersFunctionScoreQuery.ScoreMode scoreMode) {
+        double expectedScore;
+        switch(scoreMode) {
+            case MULTIPLY:
+                expectedScore = 1.0;
+                break;
+            case MAX:
+                expectedScore = Float.MAX_VALUE * -1.0;
+                break;
+            case MIN:
+                expectedScore = Float.MAX_VALUE;
+                break;
+            default:
+                expectedScore = 0.0;
+                break;
         }
 
         float weightSum = 0;
-
         for (int i = 0; i < weights.length; i++) {
             double functionScore = (double) weights[i] * scores[i];
             weightSum += weights[i];
-
-            if ("avg".equals(scoreMode)) {
-                expectedScore += functionScore;
-            } else if ("max".equals(scoreMode)) {
-                expectedScore = Math.max(functionScore, expectedScore);
-            } else if ("min".equals(scoreMode)) {
-                expectedScore = Math.min(functionScore, expectedScore);
-            } else if ("sum".equals(scoreMode)) {
-                expectedScore += functionScore;
-            } else if ("multiply".equals(scoreMode)) {
-                expectedScore *= functionScore;
+            switch(scoreMode) {
+                case AVG:
+                    expectedScore += functionScore;
+                    break;
+                case MAX:
+                    expectedScore = Math.max(functionScore, expectedScore);
+                    break;
+                case MIN:
+                    expectedScore = Math.min(functionScore, expectedScore);
+                    break;
+                case SUM:
+                    expectedScore += functionScore;
+                    break;
+                case MULTIPLY:
+                    expectedScore *= functionScore;
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
             }
-
         }
-        if ("avg".equals(scoreMode)) {
+        if (scoreMode == FiltersFunctionScoreQuery.ScoreMode.AVG) {
             expectedScore /= weightSum;
         }
         return expectedScore;
@@ -309,8 +328,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
         ScoreFunctionBuilder scoreFunctionBuilder = scoreFunctionBuilders[randomInt(3)];
         float[] weights = createRandomWeights(1);
         float[] scores = getScores(scoreFunctionBuilder);
-        FunctionScoreQueryBuilder withWeights = functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")));
-        withWeights.add(scoreFunctionBuilder.setWeight(weights[0]));
+        FunctionScoreQueryBuilder withWeights = functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")), scoreFunctionBuilder.setWeight(weights[0]));
 
         SearchResponse responseWithWeights = client().search(
                 searchRequest().source(searchSource().query(withWeights))
@@ -320,11 +338,6 @@ public class FunctionScoreIT extends ESIntegTestCase {
 
     }
 
-    private String getRandomScoreMode() {
-        String[] scoreModes = {"avg", "sum", "min", "max", "multiply"};
-        return scoreModes[randomInt(scoreModes.length - 1)];
-    }
-
     private float[] getScores(ScoreFunctionBuilder... scoreFunctionBuilders) {
         float[] scores = new float[scoreFunctionBuilders.length];
         int scorecounter = 0;
@@ -332,8 +345,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
             SearchResponse response = client().search(
                     searchRequest().source(
                             searchSource().query(
-                                    functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")))
-                                            .add(builder)
+                                    functionScoreQuery(constantScoreQuery(termQuery(TEXT_FIELD, "value")), builder)
                             ))).actionGet();
             scores[scorecounter] = response.getHits().getAt(0).getScore();
             scorecounter++;
@@ -397,12 +409,12 @@ public class FunctionScoreIT extends ESIntegTestCase {
         assertSearchResponse(response);
         assertThat(response.getHits().getAt(0).score(), equalTo(2.0f));
         response = client().search(
-                searchRequest().source(searchSource().query(functionScoreQuery().add(new WeightBuilder().setWeight(2.0f))))
+                searchRequest().source(searchSource().query(functionScoreQuery(new WeightBuilder().setWeight(2.0f))))
         ).actionGet();
         assertSearchResponse(response);
         assertThat(response.getHits().getAt(0).score(), equalTo(2.0f));
         response = client().search(
-                searchRequest().source(searchSource().query(functionScoreQuery().add(weightFactorFunction(2.0f))))
+                searchRequest().source(searchSource().query(functionScoreQuery(weightFactorFunction(2.0f))))
         ).actionGet();
         assertSearchResponse(response);
         assertThat(response.getHits().getAt(0).score(), equalTo(2.0f));
@@ -419,10 +431,10 @@ public class FunctionScoreIT extends ESIntegTestCase {
                         searchSource().query(
                                 functionScoreQuery(
                                         functionScoreQuery(
-functionScoreQuery().add(scriptFunction(new Script("1")))).add(
-                                                scriptFunction(new Script("_score.doubleValue()")))).add(
+                                                functionScoreQuery(scriptFunction(new Script("1"))),
+                                                scriptFunction(new Script("_score.doubleValue()"))),
                                         scriptFunction(new Script("_score.doubleValue()"))
-                                        )
+                                )
                         )
                 )
         ).actionGet();
@@ -438,7 +450,7 @@ functionScoreQuery().add(scriptFunction(new Script("1")))).add(
         refresh();
         SearchResponse response = client().search(
                 searchRequest().source(
-                        searchSource().query(functionScoreQuery().add(scriptFunction(new Script("_score.doubleValue()")))).aggregation(
+                        searchSource().query(functionScoreQuery(scriptFunction(new Script("_score.doubleValue()")))).aggregation(
                                 terms("score_agg").script(new Script("_score.doubleValue()")))
                 )
         ).actionGet();
@@ -457,7 +469,7 @@ functionScoreQuery().add(scriptFunction(new Script("1")))).add(
         SearchResponse searchResponse = client().search(
                 searchRequest().source(
                         searchSource().query(
-                                functionScoreQuery().add(scriptFunction(new Script(Float.toString(score)))).setMinScore(minScore)))
+                                functionScoreQuery(scriptFunction(new Script(Float.toString(score)))).setMinScore(minScore)))
         ).actionGet();
         if (score < minScore) {
             assertThat(searchResponse.getHits().getTotalHits(), is(0l));
@@ -466,11 +478,11 @@ functionScoreQuery().add(scriptFunction(new Script("1")))).add(
         }
 
         searchResponse = client().search(
-                searchRequest().source(searchSource().query(functionScoreQuery()
-.add(scriptFunction(new Script(Float.toString(score))))
-                                        .add(scriptFunction(new Script(Float.toString(score))))
-                        .scoreMode("avg").setMinScore(minScore)))
-        ).actionGet();
+                searchRequest().source(searchSource().query(functionScoreQuery(new MatchAllQueryBuilder(), new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script(Float.toString(score)))),
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script(Float.toString(score))))
+                        }).scoreMode(FiltersFunctionScoreQuery.ScoreMode.AVG).setMinScore(minScore)))
+                ).actionGet();
         if (score < minScore) {
             assertThat(searchResponse.getHits().getTotalHits(), is(0l));
         } else {
@@ -499,16 +511,15 @@ functionScoreQuery().add(scriptFunction(new Script("1")))).add(
         }
 
         SearchResponse searchResponse = client().search(
-                searchRequest().source(searchSource().query(functionScoreQuery()
-                        .add(scriptFunction(script))
+                searchRequest().source(searchSource().query(functionScoreQuery(scriptFunction(script))
                         .setMinScore(minScore)).size(numDocs))).actionGet();
         assertMinScoreSearchResponses(numDocs, searchResponse, numMatchingDocs);
 
         searchResponse = client().search(
-                searchRequest().source(searchSource().query(functionScoreQuery()
-                        .add(scriptFunction(script))
-                        .add(scriptFunction(script))
-                        .scoreMode("avg").setMinScore(minScore)).size(numDocs))).actionGet();
+                searchRequest().source(searchSource().query(functionScoreQuery(new MatchAllQueryBuilder(), new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)),
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script))
+                }).scoreMode(FiltersFunctionScoreQuery.ScoreMode.AVG).setMinScore(minScore)).size(numDocs))).actionGet();
         assertMinScoreSearchResponses(numDocs, searchResponse, numMatchingDocs);
     }
 
@@ -531,15 +542,12 @@ functionScoreQuery().add(scriptFunction(new Script("1")))).add(
 
         // make sure that min_score works if functions is empty, see https://github.com/elastic/elasticsearch/issues/10253
         float termQueryScore = 0.19178301f;
-        testMinScoreApplied("sum", termQueryScore);
-        testMinScoreApplied("avg", termQueryScore);
-        testMinScoreApplied("max", termQueryScore);
-        testMinScoreApplied("min", termQueryScore);
-        testMinScoreApplied("multiply", termQueryScore);
-        testMinScoreApplied("replace", termQueryScore);
+        for (CombineFunction combineFunction : CombineFunction.values()) {
+            testMinScoreApplied(combineFunction, termQueryScore);
+        }
     }
 
-    protected void testMinScoreApplied(String boostMode, float expectedScore) throws InterruptedException, ExecutionException {
+    protected void testMinScoreApplied(CombineFunction boostMode, float expectedScore) throws InterruptedException, ExecutionException {
         SearchResponse response = client().search(
                 searchRequest().source(
                         searchSource().explain(true).query(

--- a/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScorePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/FunctionScorePluginIT.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.Priority;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.query.functionscore.DecayFunction;
 import org.elasticsearch.index.query.functionscore.DecayFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.DecayFunctionParser;
@@ -41,7 +41,6 @@ import java.util.Collection;
 
 import static org.elasticsearch.client.Requests.indexRequest;
 import static org.elasticsearch.client.Requests.searchRequest;
-import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -82,7 +81,7 @@ public class FunctionScorePluginIT extends ESIntegTestCase {
         DecayFunctionBuilder gfb = new CustomDistanceScoreBuilder("num1", "2013-05-28", "+1d");
 
         ActionFuture<SearchResponse> response = client().search(searchRequest().searchType(SearchType.QUERY_THEN_FETCH).source(
-                searchSource().explain(false).query(functionScoreQuery(termQuery("test", "value")).add(gfb))));
+                searchSource().explain(false).query(functionScoreQuery(termQuery("test", "value"), gfb))));
 
         SearchResponse sr = response.actionGet();
         ElasticsearchAssertions.assertNoFailures(sr);
@@ -109,10 +108,11 @@ public class FunctionScorePluginIT extends ESIntegTestCase {
         public void onModule(SearchModule scoreModule) {
             scoreModule.registerFunctionScoreParser(FunctionScorePluginIT.CustomDistanceScoreParser.class);
         }
-
     }
 
-    public static class CustomDistanceScoreParser extends DecayFunctionParser {
+    public static class CustomDistanceScoreParser extends DecayFunctionParser<CustomDistanceScoreBuilder> {
+
+        private static final CustomDistanceScoreBuilder PROTOTYPE = new CustomDistanceScoreBuilder("", "", "");
 
         public static final String[] NAMES = { "linear_mult", "linearMult" };
 
@@ -121,20 +121,46 @@ public class FunctionScorePluginIT extends ESIntegTestCase {
             return NAMES;
         }
 
-        static final DecayFunction decayFunction = new LinearMultScoreFunction();
+        @Override
+        public CustomDistanceScoreBuilder getBuilderPrototype() {
+            return PROTOTYPE;
+        }
+    }
+
+    public static class CustomDistanceScoreBuilder extends DecayFunctionBuilder<CustomDistanceScoreBuilder> {
+
+        public CustomDistanceScoreBuilder(String fieldName, Object origin, Object scale) {
+            super(fieldName, origin, scale, null);
+        }
+
+        private CustomDistanceScoreBuilder(String fieldName, BytesReference functionBytes) {
+            super(fieldName, functionBytes);
+        }
+
+        @Override
+        protected CustomDistanceScoreBuilder createFunctionBuilder(String fieldName, BytesReference functionBytes) {
+            return new CustomDistanceScoreBuilder(fieldName, functionBytes);
+        }
+
+        @Override
+        public String getName() {
+            return CustomDistanceScoreParser.NAMES[0];
+        }
 
         @Override
         public DecayFunction getDecayFunction() {
             return decayFunction;
         }
 
-        static class LinearMultScoreFunction implements DecayFunction {
+        private static final DecayFunction decayFunction = new LinearMultScoreFunction();
+
+        private static class LinearMultScoreFunction implements DecayFunction {
             LinearMultScoreFunction() {
             }
 
             @Override
             public double evaluate(double value, double scale) {
-                
+
                 return value;
             }
 
@@ -148,18 +174,5 @@ public class FunctionScorePluginIT extends ESIntegTestCase {
                 return userGivenScale;
             }
         }
-    }
-
-    public class CustomDistanceScoreBuilder extends DecayFunctionBuilder {
-
-        public CustomDistanceScoreBuilder(String fieldName, Object origin, Object scale) {
-            super(fieldName, origin, scale);
-        }
-
-        @Override
-        public String getName() {
-            return CustomDistanceScoreParser.NAMES[0];
-        }
-
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionIT.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.functionscore;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.random.RandomScoreFunctionBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService.ScriptType;
@@ -104,7 +105,7 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
 
     public void testScoreAccessWithinScript() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type", "body", "type=string", "index",
-                "type=" + randomFrom(new String[] { "short", "float", "long", "integer", "double" })));
+                "type=" + randomFrom("short", "float", "long", "integer", "double")));
         ensureYellow();
 
         int docCount = randomIntBetween(100, 200);
@@ -120,9 +121,10 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         SearchResponse resp = client()
                 .prepareSearch("test")
                 .setQuery(
-                        functionScoreQuery(matchQuery("body", "foo")).add(fieldValueFactorFunction("index").factor(2)).add(
-                                scriptFunction(new Script("log(doc['index'].value + (factor * _score))", ScriptType.INLINE, null, params))))
-                .get();
+                        functionScoreQuery(matchQuery("body", "foo"), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("log(doc['index'].value + (factor * _score))", ScriptType.INLINE, null, params)))
+                        })).get();
         assertNoFailures(resp);
         SearchHit firstHit = resp.getHits().getAt(0);
         assertThat(firstHit.getScore(), greaterThan(1f));
@@ -131,9 +133,10 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         resp = client()
                 .prepareSearch("test")
                 .setQuery(
-                        functionScoreQuery(matchQuery("body", "foo")).add(fieldValueFactorFunction("index").factor(2)).add(
-                                scriptFunction(new Script("log(doc['index'].value + (factor * _score.intValue()))", ScriptType.INLINE,
-                                        null, params)))).get();
+                        functionScoreQuery(matchQuery("body", "foo"), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("log(doc['index'].value + (factor * _score.intValue()))", ScriptType.INLINE, null, params)))
+                        })).get();
         assertNoFailures(resp);
         firstHit = resp.getHits().getAt(0);
         assertThat(firstHit.getScore(), greaterThan(1f));
@@ -142,9 +145,10 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         resp = client()
                 .prepareSearch("test")
                 .setQuery(
-                        functionScoreQuery(matchQuery("body", "foo")).add(fieldValueFactorFunction("index").factor(2)).add(
-                                scriptFunction(new Script("log(doc['index'].value + (factor * _score.longValue()))", ScriptType.INLINE,
-                                        null, params)))).get();
+                        functionScoreQuery(matchQuery("body", "foo"), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("log(doc['index'].value + (factor * _score.longValue()))", ScriptType.INLINE, null, params)))
+                        })).get();
         assertNoFailures(resp);
         firstHit = resp.getHits().getAt(0);
         assertThat(firstHit.getScore(), greaterThan(1f));
@@ -153,9 +157,11 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         resp = client()
                 .prepareSearch("test")
                 .setQuery(
-                        functionScoreQuery(matchQuery("body", "foo")).add(fieldValueFactorFunction("index").factor(2)).add(
-                                scriptFunction(new Script("log(doc['index'].value + (factor * _score.floatValue()))", ScriptType.INLINE,
-                                        null, params)))).get();
+                        functionScoreQuery(matchQuery("body", "foo"), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                                new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("log(doc['index'].value + (factor * _score.floatValue()))",
+                                        ScriptType.INLINE, null, params)))
+                        })).get();
         assertNoFailures(resp);
         firstHit = resp.getHits().getAt(0);
         assertThat(firstHit.getScore(), greaterThan(1f));
@@ -164,9 +170,11 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         resp = client()
                 .prepareSearch("test")
                 .setQuery(
-                        functionScoreQuery(matchQuery("body", "foo")).add(fieldValueFactorFunction("index").factor(2)).add(
-                                scriptFunction(new Script("log(doc['index'].value + (factor * _score.doubleValue()))", ScriptType.INLINE,
-                                        null, params)))).get();
+                        functionScoreQuery(matchQuery("body", "foo"), new FunctionScoreQueryBuilder.FilterFunctionBuilder[]{
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(new Script("log(doc['index'].value + (factor * _score.doubleValue()))",
+                                                ScriptType.INLINE, null, params)))
+                                })).get();
         assertNoFailures(resp);
         firstHit = resp.getHits().getAt(0);
         assertThat(firstHit.getScore(), greaterThan(1f));

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescorerIT.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescorerIT.java
@@ -28,11 +28,10 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
-import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
@@ -46,22 +45,11 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFourthHit;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThirdHit;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasScore;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
+import static org.hamcrest.Matchers.*;
 
 /**
  *
@@ -84,9 +72,9 @@ public class QueryRescorerIT extends ESIntegTestCase {
             SearchResponse searchResponse = client().prepareSearch()
                     .setQuery(QueryBuilders.matchAllQuery())
                     .setRescorer(RescoreBuilder.queryRescorer(
-                            QueryBuilders.functionScoreQuery(QueryBuilders.matchAllQuery())
-                                    .boostMode("replace").add(ScoreFunctionBuilders.weightFactorFunction(100))).setQueryWeight(0.0f).setRescoreQueryWeight(1.0f))
-                    .setRescoreWindow(1).setSize(randomIntBetween(2,10)).execute().actionGet();
+                            QueryBuilders.functionScoreQuery(QueryBuilders.matchAllQuery(),
+                                    ScoreFunctionBuilders.weightFactorFunction(100)).boostMode(CombineFunction.REPLACE)).setQueryWeight(0.0f).setRescoreQueryWeight(1.0f))
+                    .setRescoreWindow(1).setSize(randomIntBetween(2, 10)).execute().actionGet();
             assertSearchResponse(searchResponse);
             assertFirstHit(searchResponse, hasScore(100.f));
             int numDocsWith100AsAScore = 0;
@@ -599,15 +587,12 @@ public class QueryRescorerIT extends ESIntegTestCase {
                         .queryRescorer(
                                 QueryBuilders.boolQuery()
                                         .disableCoord(true)
-                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[0]))
-                                                .boostMode(CombineFunction.REPLACE)
-                                                .add(ScoreFunctionBuilders.scriptFunction(new Script("5.0f"))))
-                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[1]))
-                                                .boostMode(CombineFunction.REPLACE)
-                                                .add(ScoreFunctionBuilders.scriptFunction(new Script("7.0f"))))
-                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[3]))
-                                                .boostMode(CombineFunction.REPLACE)
-                                                .add(ScoreFunctionBuilders.scriptFunction(new Script("0.0f")))))
+                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[0]),
+                                                ScoreFunctionBuilders.scriptFunction(new Script("5.0f"))).boostMode(CombineFunction.REPLACE))
+                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[1]),
+                                                ScoreFunctionBuilders.scriptFunction(new Script("7.0f"))).boostMode(CombineFunction.REPLACE))
+                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[3]),
+                                                ScoreFunctionBuilders.scriptFunction(new Script("0.0f"))).boostMode(CombineFunction.REPLACE)))
                         .setQueryWeight(primaryWeight)
                         .setRescoreQueryWeight(secondaryWeight);
 
@@ -620,22 +605,18 @@ public class QueryRescorerIT extends ESIntegTestCase {
                         .setPreference("test") // ensure we hit the same shards for tie-breaking
                         .setQuery(QueryBuilders.boolQuery()
                                 .disableCoord(true)
-                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[0]))
-                                                .boostMode(CombineFunction.REPLACE)
-                                                .add(ScoreFunctionBuilders.scriptFunction(new Script("2.0f"))))
-                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[1]))
-                                                .boostMode(CombineFunction.REPLACE)
-                                                .add(ScoreFunctionBuilders.scriptFunction(new Script("3.0f"))))
-                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[2]))
-                                                .boostMode(CombineFunction.REPLACE)
-                                                .add(ScoreFunctionBuilders.scriptFunction(new Script("5.0f"))))
-                                        .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[3]))
-                                                .boostMode(CombineFunction.REPLACE)
-                                                .add(ScoreFunctionBuilders.scriptFunction(new Script("0.2f")))))
-                        .setFrom(0)
-                        .setSize(10)
-                        .setRescorer(rescoreQuery)
-                        .setRescoreWindow(50).execute().actionGet();
+                                .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[0]),
+                                        ScoreFunctionBuilders.scriptFunction(new Script("2.0f"))).boostMode(CombineFunction.REPLACE))
+                                .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[1]),
+                                        ScoreFunctionBuilders.scriptFunction(new Script("3.0f"))).boostMode(CombineFunction.REPLACE))
+                                .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[2]),
+                                        ScoreFunctionBuilders.scriptFunction(new Script("5.0f"))).boostMode(CombineFunction.REPLACE))
+                                .should(QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", intToEnglish[3]),
+                                        ScoreFunctionBuilders.scriptFunction(new Script("0.2f"))).boostMode(CombineFunction.REPLACE)))
+                                .setFrom(0)
+                                .setSize(10)
+                                .setRescorer(rescoreQuery)
+                                .setRescoreWindow(50).execute().actionGet();
 
                 assertHitCount(rescored, 4);
 
@@ -688,12 +669,11 @@ public class QueryRescorerIT extends ESIntegTestCase {
     public void testMultipleRescores() throws Exception {
         int numDocs = indexRandomNumbers("keyword", 1, true);
         QueryRescorer eightIsGreat = RescoreBuilder.queryRescorer(
-                QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", English.intToEnglish(8))).boostMode(CombineFunction.REPLACE)
-.add(ScoreFunctionBuilders.scriptFunction(new Script("1000.0f")))).setScoreMode(
-                "total");
+                QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", English.intToEnglish(8)),
+                        ScoreFunctionBuilders.scriptFunction(new Script("1000.0f"))).boostMode(CombineFunction.REPLACE)).setScoreMode("total");
         QueryRescorer sevenIsBetter = RescoreBuilder.queryRescorer(
-                QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", English.intToEnglish(7))).boostMode(CombineFunction.REPLACE)
-.add(ScoreFunctionBuilders.scriptFunction(new Script("10000.0f"))))
+                QueryBuilders.functionScoreQuery(QueryBuilders.termQuery("field1", English.intToEnglish(7)),
+                        ScoreFunctionBuilders.scriptFunction(new Script("10000.0f"))).boostMode(CombineFunction.REPLACE))
                 .setScoreMode("total");
 
         // First set the rescore window large enough that both rescores take effect
@@ -710,11 +690,11 @@ public class QueryRescorerIT extends ESIntegTestCase {
 
         // Now use one rescore to drag the number we're looking for into the window of another
         QueryRescorer ninetyIsGood = RescoreBuilder.queryRescorer(
-                QueryBuilders.functionScoreQuery(QueryBuilders.queryStringQuery("*ninety*")).boostMode(CombineFunction.REPLACE)
-                        .add(ScoreFunctionBuilders.scriptFunction(new Script("1000.0f")))).setScoreMode("total");
+                QueryBuilders.functionScoreQuery(QueryBuilders.queryStringQuery("*ninety*"), ScoreFunctionBuilders.scriptFunction(new Script("1000.0f")))
+                        .boostMode(CombineFunction.REPLACE)).setScoreMode("total");
         QueryRescorer oneToo = RescoreBuilder.queryRescorer(
-                QueryBuilders.functionScoreQuery(QueryBuilders.queryStringQuery("*one*")).boostMode(CombineFunction.REPLACE)
-                        .add(ScoreFunctionBuilders.scriptFunction(new Script("1000.0f")))).setScoreMode("total");
+                QueryBuilders.functionScoreQuery(QueryBuilders.queryStringQuery("*one*"), ScoreFunctionBuilders.scriptFunction(new Script("1000.0f")))
+                        .boostMode(CombineFunction.REPLACE)).setScoreMode("total");
         request.clearRescorers().addRescorer(ninetyIsGood).addRescorer(oneToo, 10);
         response = request.setSize(2).get();
         assertFirstHit(response, hasId("91"));

--- a/core/src/test/resources/org/elasticsearch/index/query/function-score-query-causing-NPE.json
+++ b/core/src/test/resources/org/elasticsearch/index/query/function-score-query-causing-NPE.json
@@ -1,9 +1,0 @@
-{
-    "function_score": {
-      "script_score": {
-        "script": "_index['text']['foo'].tf()"
-      },
-      "weight": 2
-    }
-}
-

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -10,13 +10,22 @@ Plugins implementing custom queries need to implement the `fromXContent(QueryPar
 `QueryParser` subclass rather than `parse`. This method will take care of parsing the query from `XContent` format
 into an intermediate query representation that can be streamed between the nodes in binary format, effectively the
 query object used in the java api. Also, the query parser needs to implement the `getBuilderPrototype` method that
-returns a prototype of the streamable query, which allows to deserialize an incoming query by calling
+returns a prototype of the `NamedWriteable` query, which allows to deserialize an incoming query by calling
 `readFrom(StreamInput)` against it, which will create a new object, see usages of `Writeable`. The `QueryParser`
 also needs to declare the generic type of the query that it supports and it's able to parse.
 The query object can then transform itself into a lucene query through the new `toQuery(QueryShardContext)` method,
-which returns a lucene query to be executed on the data node. The query implementation also needs to implement the
-`validate` method that allows to validate the content of the query, no matter whether it came in through the java api
-directly or through the REST layer.
+which returns a lucene query to be executed on the data node.
+
+Similarly, plugins implementing custom score functions need to implement the `fromXContent(QueryParseContext)`
+method in their `ScoreFunctionParser` subclass rather than `parse`. This method will take care of parsing
+the function from `XContent` format into an intermediate function representation that can be streamed between
+the nodes in binary format, effectively the function object used in the java api. Also, the query parser needs
+to implement the `getBuilderPrototype` method that returns a prototype of the `NamedWriteable` function, which
+allows to deserialize an incoming function by calling `readFrom(StreamInput)` against it, which will create a
+new object, see usages of `Writeable`. The `ScoreFunctionParser` also needs to declare the generic type of the
+function that it supports and it's able to parse. The function object can then transform itself into a lucene
+function through the new `toFunction(QueryShardContext)` method, which returns a lucene function to be executed
+on the data node.
 
 === Java-API
 
@@ -144,4 +153,15 @@ Remove the setter for `termsLookup()`, making it only possible to either use a T
 individual values at constrution time. Also moving individual settings for the TermsLookUp (lookupIndex,
 lookupType, lookupId, lookupPath) to the separate TermsLookUp class, using construtor only and moving
 checks for validation there.
+
+==== FunctionScoreQueryBuilder
+
+`add` methods have been removed, all filters and functions must be provided as constructor arguments by
+creating an array of `FunctionScoreQueryBuilder.FilterFunctionBuilder` objects, containing one element
+for each filter/function pair.
+
+`scoreMode` and `boostMode` can only be provided using corresponding enum members instead
+of string values: see `FilterFunctionScoreQuery.ScoreMode` and `CombineFunction`.
+
+`CombineFunction.MULT` has been renamed to `MULTIPLY`.
 


### PR DESCRIPTION
Refactor the function_score query so it can be parsed on the coordinating node, split parse into fromXContent and toQuery, make the builder writeable.

Found an issue with script_score function in tests, given that it accesses the shardId through SearchContext, but that's something that we don't have available and I am not sure how to make available. Added a TODO there, left out script_score from testing for now.

Simplified code around enums (boost mode and score mode), we now rely on enums for serialization and naming.

This change is breaking for the java api as it modifies FunctionScoreQueryBuilder, removes all the add method from it. Also breaking for plugins that implement custom score functions, see the migrate guide for more info.
