### PR TITLE
Completion Suggester: Add doc-values based payload support

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/core/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -143,7 +143,7 @@ public class TransportSuggestAction extends TransportBroadcastAction<SuggestRequ
                     throw new IllegalArgumentException("suggest content missing");
                 }
                 final SuggestionSearchContext context = suggestPhase.parseElement().parseInternal(parser, indexService.mapperService(),
-                        indexService.queryParserService(), request.shardId().getIndex(), request.shardId().id());
+                        indexService.queryParserService(), indexService.fieldData(), request.shardId().getIndex(), request.shardId().id());
                 final Suggest result = suggestPhase.execute(context, searcher.searcher());
                 return new ShardSuggestResponse(request.shardId(), result);
             }

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestContextParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestContextParser.java
@@ -21,10 +21,11 @@ package org.elasticsearch.search.suggest;
 import java.io.IOException;
 
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 
 public interface SuggestContextParser {
-    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException;
+    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService, IndexFieldDataService indexFieldDataService) throws IOException;
 
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestParseElement.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.suggest;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.search.SearchParseElement;
@@ -47,11 +48,11 @@ public final class SuggestParseElement implements SearchParseElement {
 
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
-        SuggestionSearchContext suggestionSearchContext = parseInternal(parser, context.mapperService(), context.queryParserService(), context.shardTarget().index(), context.shardTarget().shardId());
+        SuggestionSearchContext suggestionSearchContext = parseInternal(parser, context.mapperService(), context.queryParserService(), context.fieldData(), context.shardTarget().index(), context.shardTarget().shardId());
         context.suggest(suggestionSearchContext);
     }
 
-    public SuggestionSearchContext parseInternal(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService, String index, int shardId) throws IOException {
+    public SuggestionSearchContext parseInternal(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService, IndexFieldDataService fieldDataService, String index, int shardId) throws IOException {
         SuggestionSearchContext suggestionSearchContext = new SuggestionSearchContext();
 
         BytesRef globalText = null;
@@ -99,7 +100,7 @@ public final class SuggestParseElement implements SearchParseElement {
                         if (contextParser instanceof CompletionSuggestParser) {
                             ((CompletionSuggestParser) contextParser).setOldCompletionSuggester(((CompletionSuggester) suggesters.get("completion_old")));
                         }
-                        suggestionContext = contextParser.parse(parser, mapperService, queryParserService);
+                        suggestionContext = contextParser.parse(parser, mapperService, queryParserService, fieldDataService);
                     }
                 }
                 if (suggestionContext != null) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -45,6 +45,7 @@ public class CompletionSuggestionBuilder extends SuggestBuilder.SuggestionBuilde
     private FuzzyOptionsBuilder fuzzyOptionsBuilder;
     private RegexOptionsBuilder regexOptionsBuilder;
     private List<QueryContexts> queryContextsList;
+    private String[] payloadFields;
 
     public CompletionSuggestionBuilder(String name) {
         super(name, "completion");
@@ -257,6 +258,15 @@ public class CompletionSuggestionBuilder extends SuggestBuilder.SuggestionBuilde
     }
 
     /**
+     * Sets the fields to be returned as suggestion payload.
+     * Note: Only doc values enabled fields are supported
+     */
+    public CompletionSuggestionBuilder payload(String... fields) {
+        this.payloadFields = fields;
+        return this;
+    }
+
+    /**
      * Sets query contexts for a category context
      * @param name of the category context to execute on
      * @param queryContexts a list of {@link CategoryQueryContext}
@@ -289,6 +299,13 @@ public class CompletionSuggestionBuilder extends SuggestBuilder.SuggestionBuilde
 
     @Override
     protected XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException {
+        if (payloadFields != null) {
+            builder.startArray("payload");
+            for (String field : payloadFields) {
+                builder.value(field);
+            }
+            builder.endArray();
+        }
         if (fuzzyOptionsBuilder != null) {
             fuzzyOptionsBuilder.toXContent(builder, params);
         }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -18,12 +18,15 @@
  */
 package org.elasticsearch.search.suggest.completion;
 
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.core.CompletionFieldMapper;
 import org.elasticsearch.search.suggest.Suggester;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import org.elasticsearch.search.suggest.completion.context.ContextMapping;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -34,16 +37,19 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
     private CompletionSuggestionBuilder.FuzzyOptionsBuilder fuzzyOptionsBuilder;
     private CompletionSuggestionBuilder.RegexOptionsBuilder regexOptionsBuilder;
     private Map<String, ContextMapping.QueryContexts> queryContexts;
+    private MapperService mapperService;
+    private IndexFieldDataService fieldData;
+    private Set<String> payloadFields;
 
     CompletionSuggestionContext(Suggester suggester) {
         super(suggester);
     }
 
-    CompletionFieldMapper.CompletionFieldType fieldType() {
+    CompletionFieldMapper.CompletionFieldType getFieldType() {
         return this.fieldType;
     }
 
-    void fieldType(CompletionFieldMapper.CompletionFieldType fieldType) {
+    void setFieldType(CompletionFieldMapper.CompletionFieldType fieldType) {
         this.fieldType = fieldType;
     }
 
@@ -69,5 +75,29 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
 
     Map<String, ContextMapping.QueryContexts> getQueryContexts() {
         return queryContexts;
+    }
+
+    void setMapperService(MapperService mapperService) {
+        this.mapperService = mapperService;
+    }
+
+    MapperService getMapperService() {
+        return mapperService;
+    }
+
+    void setFieldData(IndexFieldDataService fieldData) {
+        this.fieldData = fieldData;
+    }
+
+    IndexFieldDataService getFieldData() {
+        return fieldData;
+    }
+
+   void setPayloadFields(Set<String> fields) {
+        this.payloadFields = fields;
+    }
+
+    Set<String> getPayloadFields() {
+        return payloadFields;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestParser.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.analysis.ShingleTokenFilterFactory;
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
@@ -48,7 +49,7 @@ public final class PhraseSuggestParser implements SuggestContextParser {
     }
 
     @Override
-    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException {
+    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService, IndexFieldDataService indexFieldDataService) throws IOException {
         PhraseSuggestionContext suggestion = new PhraseSuggestionContext(suggester);
         suggestion.setQueryParserService(queryParserService);
         XContentParser.Token token;

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestParser.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestParser.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.suggest.term;
 
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 import org.elasticsearch.search.suggest.DirectSpellcheckerSettings;
@@ -38,7 +39,7 @@ public final class TermSuggestParser implements SuggestContextParser {
     }
 
     @Override
-    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException {
+    public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService, IndexFieldDataService indexFieldDataService) throws IOException {
         XContentParser.Token token;
         String fieldName = null;
         TermSuggestionContext suggestion = new TermSuggestionContext(suggester);

--- a/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggester.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggester.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IndexQueryParserService;
 
@@ -59,7 +60,7 @@ public class CustomSuggester extends Suggester<CustomSuggester.CustomSuggestions
     public SuggestContextParser getContextParser() {
         return new SuggestContextParser() {
             @Override
-            public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService) throws IOException {
+            public SuggestionSearchContext.SuggestionContext parse(XContentParser parser, MapperService mapperService, IndexQueryParserService queryParserService, IndexFieldDataService indexFieldDataService) throws IOException {
                 Map<String, Object> options = parser.map();
                 CustomSuggestionsContext suggestionContext = new CustomSuggestionsContext(CustomSuggester.this, options);
                 suggestionContext.setField((String) options.get("field"));

--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -109,7 +109,9 @@ a weight with suggestion(s).
 ==== Querying
 
 Suggesting works as usual, except that you have to specify the suggest
-type as `completion`.
+type as `completion`. Suggestions are near real-time, which means
+new suggestions can be made visible by <<indices-refresh,refresh>> and
+documents once deleted are never shown.
 
 [source,js]
 --------------------------------------------------
@@ -144,17 +146,74 @@ POST music/_suggest?pretty
 The configured weight for a suggestion is returned as `score`.
 The `text` field uses the `input` of your indexed suggestion.
 
-The basic completion suggester query supports the following two parameters:
+Suggestions are document oriented, you can specify fields to be
+returned as part of suggestion payload. All field types (`string`,
+`numeric`, `date`, etc) are supported.
+
+For example, if you index a "title" field along with the suggestion
+as follows:
+
+[source,js]
+--------------------------------------------------
+POST music/song
+{
+    "suggest" : "Nirvana",
+    "title" : "Nevermind"
+}
+--------------------------------------------------
+
+You can get the "title" as part of the suggestion
+payload by specifying it as a `payload`:
+
+[source,js]
+--------------------------------------------------
+POST music/_suggest?pretty
+{
+    "song-suggest" : {
+        "prefix" : "n",
+        "completion" : {
+            "field" : "suggest"
+            "payload" : [ "title" ] <1>
+        }
+    }
+}
+
+{
+  "_shards" : {
+    "total" : 5,
+    "successful" : 5,
+    "failed" : 0
+  },
+  "song-suggest" : [ {
+    "text" : "n",
+    "offset" : 0,
+    "length" : 1,
+    "options" : [ {
+      "text" : "Nirvana",
+      "score" : 34.0,
+      "payload" : {
+        "title" : [ "Nevermind" ]
+      }
+    } ]
+  } ]
+}
+--------------------------------------------------
+<1> The fields to be returned as part of each suggestion payload.
+
+The basic completion suggester query supports the following parameters:
 
 `field`:: The name of the field on which to run the query (required).
 `size`::  The number of suggestions to return (defaults to `5`).
+`payload`::  The name of the field or field name array to be returned
+             as payload (defaults to no fields).
 
 NOTE: The completion suggester considers all documents in the index.
 See <<suggester-context>> for an explanation of how to query a subset of
 documents instead.
 
-NOTE: It will be possible to return the associated documents
-with each suggestion in the future (TODO).
+NOTE: Specifying `payload` fields will incur additional search performance
+hit. The `payload` fields are retrieved eagerly (single pass) for top
+suggestions at the shard level using field data or from doc values.
 
 [[fuzzy]]
 ==== Fuzzy queries

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/20_completion.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/20_completion.yaml
@@ -22,6 +22,11 @@ setup:
                      "type" : "completion"
                   "suggest_5b":
                      "type" : "completion"
+                  "suggest_6":
+                     "type" : "completion"
+                  "count":
+                    "type" : "integer"
+                    "doc_values" : "true"
 
 ---
 "Simple suggestion should work":
@@ -227,3 +232,52 @@ setup:
   - length: { result: 1  }
   - length: { result.0.options: 1  }
   - match:  { result.0.options.0.text: "baz" }
+
+---
+"Suggestions with payload fields should work":
+
+  - do:
+      index:
+        index: test
+        type:  test
+        id:    1
+        body:
+          suggest_6:
+            input: "bar"
+            weight: 2
+          title: "title_bar"
+          count: 2
+
+  - do:
+      index:
+        index: test
+        type:  test
+        id:    2
+        body:
+          suggest_6:
+            input: "baz"
+            weight: 3
+          title: "title_baz"
+          count: 3
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      suggest:
+        body:
+          result:
+            text: "b"
+            completion:
+              field: suggest_6
+              payload: [ title, count ]
+
+  - length: { result: 1  }
+  - length: { result.0.options: 2  }
+  - match:  { result.0.options.0.text: "baz" }
+  - match:  { result.0.options.0.payload.title: ["title_baz"] }
+  - match:  { result.0.options.0.payload.count: [3] }
+  - match:  { result.0.options.1.text: "bar" }
+  - match:  { result.0.options.1.payload.title: ["title_bar"] }
+  - match:  { result.0.options.1.payload.count: [2] }
+


### PR DESCRIPTION
Note: the PR is against `feature/completion_suggester_v2` branch

Followup of https://github.com/elastic/elasticsearch/pull/13576#issuecomment-140695698. The PR enables returning any doc values enabled fields as suggestion payload.

One can specify fields to be returned as part of the suggestion payload at query time, using the 
`payload` option:

``` bash
POST music/_suggest 
{
  "song-suggest" : {
    "prefix" : "nev",
    "completion" : {
      "field" : "song_suggest"
      "payload" : [ "title" ]
    }
  }
}
```

The specified payload field values will be returned as part of the suggestion `payload`:

``` bash
{
  "song-suggest": [
    {
      "text": "nev",
      "offset": 0,
      "length": 4,
      "options" : [ {
        "text" : "Nirvana",
        "score" : 34.0,
        "payload" : {
          "title" : [ "Nevermind" ]
        }
      } ]
    }
  ]
}
```

Now suggestion `payload` are not part of the completion (FST) index, as was the case before. Payload fields are fetched for the top N completions per shard hence specifying payload fields will incur additional search performance hit. 
