### PR TITLE
Query Refactoring: moving validation to setters and constructors

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -114,13 +114,6 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
         return context.indexQueryParserService().indicesQueriesRegistry().queryParsers().get(getName()).parse(context);
     }
 
-    @Override
-    public QueryValidationException validate() {
-        // default impl does not validate, subclasses should override.
-        //norelease to be possibly made abstract once all queries support validation
-        return null;
-    }
-
     /**
      * Returns the query name for the query.
      */
@@ -265,27 +258,6 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
             }
         }
         return queries;
-    }
-
-    protected QueryValidationException validateInnerQueries(List<QueryBuilder> queryBuilders, QueryValidationException initialValidationException) {
-        QueryValidationException validationException = initialValidationException;
-        for (QueryBuilder queryBuilder : queryBuilders) {
-            validationException = validateInnerQuery(queryBuilder, validationException);
-        }
-        return validationException;
-    }
-
-    protected QueryValidationException validateInnerQuery(QueryBuilder queryBuilder, QueryValidationException initialValidationException) {
-        QueryValidationException validationException = initialValidationException;
-        if (queryBuilder != null) {
-            QueryValidationException queryValidationException = queryBuilder.validate();
-            if (queryValidationException != null) {
-                validationException = QueryValidationException.addValidationErrors(queryValidationException.validationErrors(), validationException);
-            }
-        } else {
-            validationException = addValidationError("inner query cannot be null", validationException);
-        }
-        return validationException;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/EmptyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/EmptyQueryBuilder.java
@@ -78,13 +78,6 @@ public class EmptyQueryBuilder extends ToXContentToBytes implements QueryBuilder
         return null;
     }
 
-
-    @Override
-    public QueryValidationException validate() {
-        // nothing to validate
-        return null;
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
     }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
@@ -76,7 +75,6 @@ public class GeoDistanceRangeQueryParser extends BaseQueryParser<GeoDistanceRang
         String queryName = null;
         String currentFieldName = null;
         GeoPoint point = null;
-        String geohash = null;
         String fieldName = null;
         Object vFrom = null;
         Object vTo = null;
@@ -173,7 +171,7 @@ public class GeoDistanceRangeQueryParser extends BaseQueryParser<GeoDistanceRang
                     point.resetLon(parser.doubleValue());
                     fieldName = currentFieldName.substring(0, currentFieldName.length() - GeoPointFieldMapper.Names.LON_SUFFIX.length());
                 } else if (currentFieldName.endsWith(GeoPointFieldMapper.Names.GEOHASH_SUFFIX)) {
-                    geohash = parser.text();
+                    point = GeoPoint.fromGeohash(parser.text());
                     fieldName = currentFieldName.substring(0, currentFieldName.length() - GeoPointFieldMapper.Names.GEOHASH_SUFFIX.length());
                 } else if (parseContext.parseFieldMatcher().match(currentFieldName, NAME_FIELD)) {
                     queryName = parser.text();
@@ -195,8 +193,7 @@ public class GeoDistanceRangeQueryParser extends BaseQueryParser<GeoDistanceRang
             }
         }
 
-        GeoDistanceRangeQueryBuilder queryBuilder = new GeoDistanceRangeQueryBuilder(fieldName);
-
+        GeoDistanceRangeQueryBuilder queryBuilder = new GeoDistanceRangeQueryBuilder(fieldName, point);
         if (boost != null) {
             queryBuilder.boost(boost);
         }
@@ -205,20 +202,12 @@ public class GeoDistanceRangeQueryParser extends BaseQueryParser<GeoDistanceRang
             queryBuilder.queryName(queryName);
         }
 
-        if (point != null) {
-            queryBuilder.point(point.lat(), point.lon());
-        }
-
-        if (geohash != null) {
-            queryBuilder.geohash(geohash);
-        }
-
         if (vFrom != null) {
-            queryBuilder.from(vFrom);
+            queryBuilder.from(vFrom.toString());
         }
 
         if (vTo != null) {
-            queryBuilder.to(vTo);
+            queryBuilder.to(vTo.toString());
         }
 
         if (includeUpper != null) {

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -943,7 +943,6 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         }
     }
 
-    @Override
     public QueryValidationException validate() {
         QueryValidationException validationException = null;
         if (likeTexts.isEmpty() && likeItems.isEmpty()) {

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -31,13 +31,6 @@ import java.io.IOException;
 public interface QueryBuilder<QB extends QueryBuilder> extends NamedWriteable<QB>, ToXContent {
 
     /**
-     * Validate the query.
-     * @return a {@link QueryValidationException} containing error messages, {@code null} if query is valid.
-     * e.g. if fields that are needed to create the lucene query are missing.
-     */
-    QueryValidationException validate();
-
-    /**
      * Converts this QueryBuilder to a lucene {@link Query}.
      * Returns <tt>null</tt> if this query should be ignored in the context of
      * parent queries.

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -27,12 +27,14 @@ import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.search.MatchQuery;
+import org.elasticsearch.indices.cache.query.terms.TermsLookup;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.Template;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -579,8 +581,8 @@ public abstract class QueryBuilders {
     /**
      * A terms query that can extract the terms from another doc in an index.
      */
-    public static TermsQueryBuilder termsLookupQuery(String name) {
-        return new TermsQueryBuilder(name);
+    public static TermsQueryBuilder termsLookupQuery(String name, TermsLookup termsLookup) {
+        return new TermsQueryBuilder(name, termsLookup);
     }
 
     /**
@@ -606,9 +608,31 @@ public abstract class QueryBuilders {
      * A filter to filter based on a specific range from a specific geo location / point.
      *
      * @param name The location field name.
+     * @param point The point
      */
-    public static GeoDistanceRangeQueryBuilder geoDistanceRangeQuery(String name) {
-        return new GeoDistanceRangeQueryBuilder(name);
+    public static GeoDistanceRangeQueryBuilder geoDistanceRangeQuery(String name, GeoPoint point) {
+        return new GeoDistanceRangeQueryBuilder(name, point);
+    }
+
+    /**
+     * A filter to filter based on a specific range from a specific geo location / point.
+     *
+     * @param name The location field name.
+     * @param point The point as geohash
+     */
+    public static GeoDistanceRangeQueryBuilder geoDistanceRangeQuery(String name, String geohash) {
+        return new GeoDistanceRangeQueryBuilder(name, geohash);
+    }
+
+    /**
+     * A filter to filter based on a specific range from a specific geo location / point.
+     *
+     * @param name The location field name.
+     * @param lat The points latitude
+     * @param lon The points longitude
+     */
+    public static GeoDistanceRangeQueryBuilder geoDistanceRangeQuery(String name, double lat, double lon) {
+        return new GeoDistanceRangeQueryBuilder(name, lat, lon);
     }
 
     /**
@@ -618,17 +642,6 @@ public abstract class QueryBuilders {
      */
     public static GeoBoundingBoxQueryBuilder geoBoundingBoxQuery(String name) {
         return new GeoBoundingBoxQueryBuilder(name);
-    }
-
-    /**
-     * A filter based on a bounding box defined by geohash. The field this filter is applied to
-     * must have <code>{&quot;type&quot;:&quot;geo_point&quot;, &quot;geohash&quot;:true}</code>
-     * to work.
-     *
-     * @param name The geo point field name.
-     */
-    public static GeohashCellQuery.Builder geoHashCellQuery(String name) {
-        return new GeohashCellQuery.Builder(name);
     }
 
     /**
@@ -673,8 +686,8 @@ public abstract class QueryBuilders {
      *
      * @param name The location field name.
      */
-    public static GeoPolygonQueryBuilder geoPolygonQuery(String name) {
-        return new GeoPolygonQueryBuilder(name);
+    public static GeoPolygonQueryBuilder geoPolygonQuery(String name, List<GeoPoint> points) {
+        return new GeoPolygonQueryBuilder(name, points);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryParser.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.indices.cache.query.terms.TermsLookup;
 
@@ -77,7 +76,7 @@ public class TermsQueryParser extends BaseQueryParser {
                 values = parseValues(parseContext, parser);
             } else if (token == XContentParser.Token.START_OBJECT) {
                 fieldName = currentFieldName;
-                termsLookup = parseTermsLookup(parseContext, parser);
+                termsLookup = TermsLookup.parseTermsLookup(parseContext, parser);
             } else if (token.isValue()) {
                 if (parseContext.parseFieldMatcher().match(currentFieldName, EXECUTION_FIELD)) {
                     // ignore
@@ -117,42 +116,6 @@ public class TermsQueryParser extends BaseQueryParser {
             values.add(value);
         }
         return values;
-    }
-
-    private static TermsLookup parseTermsLookup(QueryParseContext parseContext, XContentParser parser) throws IOException {
-        TermsLookup termsLookup = new TermsLookup();
-        XContentParser.Token token;
-        String currentFieldName = null;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else if (token.isValue()) {
-                if ("index".equals(currentFieldName)) {
-                    termsLookup.index(parser.textOrNull());
-                } else if ("type".equals(currentFieldName)) {
-                    termsLookup.type(parser.text());
-                } else if ("id".equals(currentFieldName)) {
-                    termsLookup.id(parser.text());
-                } else if ("routing".equals(currentFieldName)) {
-                    termsLookup.routing(parser.textOrNull());
-                } else if ("path".equals(currentFieldName)) {
-                    termsLookup.path(parser.text());
-                } else {
-                    throw new ParsingException(parseContext, "[terms] query does not support [" + currentFieldName
-                            + "] within lookup element");
-                }
-            }
-        }
-        if (termsLookup.type() == null) {
-            throw new ParsingException(parseContext, "[terms] query lookup element requires specifying the type");
-        }
-        if (termsLookup.id() == null) {
-            throw new ParsingException(parseContext, "[terms] query lookup element requires specifying the id");
-        }
-        if (termsLookup.path() == null) {
-            throw new ParsingException(parseContext, "[terms] query lookup element requires specifying the path");
-        }
-        return termsLookup;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalValuesMapperIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalValuesMapperIntegrationIT.java
@@ -66,7 +66,7 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
         assertThat(response.getHits().totalHits(), equalTo((long) 1));
 
         response = client().prepareSearch("test-idx")
-                .setPostFilter(QueryBuilders.geoDistanceRangeQuery("field.point").point(42.0, 51.0).to("1km"))
+                .setPostFilter(QueryBuilders.geoDistanceRangeQuery("field.point", 42.0, 51.0).to("1km"))
                 .execute().actionGet();
 
         assertThat(response.getHits().totalHits(), equalTo((long) 1));

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -480,16 +480,6 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         return createShardContext().parseContext();
     }
 
-    protected static void assertValidate(QueryBuilder queryBuilder, int totalExpectedErrors) {
-        QueryValidationException queryValidationException = queryBuilder.validate();
-        if (totalExpectedErrors > 0) {
-            assertThat(queryValidationException, notNullValue());
-            assertThat(queryValidationException.validationErrors().size(), equalTo(totalExpectedErrors));
-        } else {
-            assertThat(queryValidationException, nullValue());
-        }
-    }
-
     /**
      * create a random value for either {@link AbstractQueryTestCase#BOOLEAN_FIELD_NAME}, {@link AbstractQueryTestCase#INT_FIELD_NAME},
      * {@link AbstractQueryTestCase#DOUBLE_FIELD_NAME}, {@link AbstractQueryTestCase#STRING_FIELD_NAME} or

--- a/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/DisMaxQueryBuilderTests.java
@@ -89,7 +89,6 @@ public class DisMaxQueryBuilderTests extends AbstractQueryTestCase<DisMaxQueryBu
     public void testNoInnerQueries() throws IOException {
         DisMaxQueryBuilder disMaxBuilder = new DisMaxQueryBuilder();
         assertNull(disMaxBuilder.toQuery(createShardContext()));
-        assertNull(disMaxBuilder.validate());
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -116,14 +116,14 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
 
         try {
             query.distance("1", null);
-            fail("must not be null");
+            fail("unit must not be null");
         } catch (IllegalArgumentException ex) {
             // expected
         }
 
         try {
             query.distance(1, null);
-            fail("must not be null");
+            fail("unit must not be null");
         } catch (IllegalArgumentException ex) {
             // expected
         }

--- a/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -39,33 +39,13 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.notNullValue;
 
 public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygonQueryBuilder> {
 
     @Override
     protected GeoPolygonQueryBuilder doCreateTestQueryBuilder() {
-        GeoPolygonQueryBuilder builder;
         List<GeoPoint> polygon = randomPolygon(randomIntBetween(4, 50));
-        if (randomBoolean()) {
-            builder = new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, polygon);
-        } else {
-            builder = new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME);
-            for (GeoPoint point : polygon) {
-                int method = randomInt(2);
-                switch (method) {
-                case 0:
-                    builder.addPoint(point);
-                    break;
-                case 1:
-                    builder.addPoint(point.geohash());
-                    break;
-                case 2:
-                    builder.addPoint(point.lat(), point.lon());
-                    break;
-                }
-            }
-        }
+        GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, polygon);
         builder.coerce(randomBoolean());
         builder.ignoreMalformed(randomBoolean());
         return builder;
@@ -123,45 +103,34 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullFieldName() {
-        new GeoPolygonQueryBuilder(null);
+        new GeoPolygonQueryBuilder(null, randomPolygon(5));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testEmptyPolygon() {
-        GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME);
-        QueryValidationException exception = builder.validate();
-        assertThat(exception, notNullValue());
-        assertThat(exception.validationErrors(), notNullValue());
-        assertThat(exception.validationErrors().size(), equalTo(1));
-        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoPolygonQueryBuilder.NAME
-                + "] no points defined for geo_polygon query"));
+        if (randomBoolean()) {
+            new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, new ArrayList<GeoPoint>());
+        } else {
+            new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, null);
+        }
     }
 
-    @Test
+    @Test(expected=IllegalArgumentException.class)
     public void testInvalidClosedPolygon() {
-        GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME);
-        builder.addPoint(new GeoPoint(0, 90));
-        builder.addPoint(new GeoPoint(90, 90));
-        builder.addPoint(new GeoPoint(0, 90));
-        QueryValidationException exception = builder.validate();
-        assertThat(exception, notNullValue());
-        assertThat(exception.validationErrors(), notNullValue());
-        assertThat(exception.validationErrors().size(), equalTo(1));
-        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoPolygonQueryBuilder.NAME
-                + "] too few points defined for geo_polygon query"));
+        List<GeoPoint> points = new ArrayList<>();
+        points.add(new GeoPoint(0, 90));
+        points.add(new GeoPoint(90, 90));
+        points.add(new GeoPoint(0, 90));
+        new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, points);
+
     }
 
-    @Test
+    @Test(expected=IllegalArgumentException.class)
     public void testInvalidOpenPolygon() {
-        GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME);
-        builder.addPoint(new GeoPoint(0, 90));
-        builder.addPoint(new GeoPoint(90, 90));
-        QueryValidationException exception = builder.validate();
-        assertThat(exception, notNullValue());
-        assertThat(exception.validationErrors(), notNullValue());
-        assertThat(exception.validationErrors().size(), equalTo(1));
-        assertThat(exception.validationErrors().get(0), equalTo("[" + GeoPolygonQueryBuilder.NAME
-                + "] too few points defined for geo_polygon query"));
+        List<GeoPoint> points = new ArrayList<>();
+        points.add(new GeoPoint(0, 90));
+        points.add(new GeoPoint(90, 90));
+        new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, points);
     }
 
     public void testDeprecatedXContent() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -149,13 +149,9 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
     public void testNoShape() throws IOException {
         try {
             GeoShapeQueryBuilder builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, (ShapeBuilder) null);
-            QueryValidationException exception = builder.validate();
-            assertThat(exception, notNullValue());
-            assertThat(exception.validationErrors(), notNullValue());
-            assertThat(exception.validationErrors().size(), equalTo(1));
-            assertThat(exception.validationErrors().get(0), equalTo("[" + GeoShapeQueryBuilder.NAME + "] No Shape defined"));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            fail("exception expected");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
     }
 
@@ -170,18 +166,14 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
     }
 
     @Test
-    public void testNoRelation() {
+    public void testNoRelation() throws IOException {
         ShapeBuilder shape = RandomShapeGenerator.createShapeWithin(getRandom(), null);
         try {
             GeoShapeQueryBuilder builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
             builder.relation(null);
-            QueryValidationException exception = builder.validate();
-            assertThat(exception, notNullValue());
-            assertThat(exception.validationErrors(), notNullValue());
-            assertThat(exception.validationErrors().size(), equalTo(1));
-            assertThat(exception.validationErrors().get(0), equalTo("[" + GeoShapeQueryBuilder.NAME + "] No Shape Relation defined"));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            fail("relation cannot be null");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/indices/cache/query/terms/TermsLookupTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/cache/query/terms/TermsLookupTests.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.cache.query.terms;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TermsLookupTests extends ESTestCase {
+
+    @Test
+    public void testTermsLookup() {
+        String index = randomAsciiOfLengthBetween(1, 10);
+        String type = randomAsciiOfLengthBetween(1, 10);
+        String id = randomAsciiOfLengthBetween(1, 10);
+        String path = randomAsciiOfLengthBetween(1, 10);
+        String routing = randomAsciiOfLengthBetween(1, 10);
+        TermsLookup termsLookup = new TermsLookup(index, type, id, path);
+        termsLookup.routing(routing);
+        assertEquals(index, termsLookup.index());
+        assertEquals(type, termsLookup.type());
+        assertEquals(id, termsLookup.id());
+        assertEquals(path, termsLookup.path());
+        assertEquals(routing, termsLookup.routing());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testIllegalArguments() {
+        String type = randomAsciiOfLength(5);
+        String id = randomAsciiOfLength(5);
+        String path = randomAsciiOfLength(5);
+        switch (randomIntBetween(0, 2)) {
+        case 0:
+            type = null; break;
+        case 1:
+            id = null; break;
+        case 2:
+            path = null; break;
+        }
+        new TermsLookup(null, type, id, path);
+    }
+
+    @Test
+    public void testSerialization() throws IOException {
+        TermsLookup termsLookup = randomTermsLookup();
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            termsLookup.writeTo(output);
+            try (StreamInput in = StreamInput.wrap(output.bytes())) {
+                TermsLookup deserializedLookup = TermsLookup.readTermsLookupFrom(in);
+                assertEquals(deserializedLookup, termsLookup);
+                assertEquals(deserializedLookup.hashCode(), termsLookup.hashCode());
+                assertNotSame(deserializedLookup, termsLookup);
+            }
+        }
+    }
+
+    public static TermsLookup randomTermsLookup() {
+        return new TermsLookup(
+                randomBoolean() ? randomAsciiOfLength(10) : null,
+                randomAsciiOfLength(10),
+                randomAsciiOfLength(10),
+                randomAsciiOfLength(10).replace('.', '_')
+        ).routing(randomBoolean() ? randomAsciiOfLength(10) : null);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoDistanceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoDistanceIT.java
@@ -171,7 +171,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         }
 
         searchResponse = client().prepareSearch() // from NY
-                .setQuery(geoDistanceRangeQuery("location").from("1.0km").to("2.0km").point(40.7143528, -74.0059731))
+                .setQuery(geoDistanceRangeQuery("location", 40.7143528, -74.0059731).from("1.0km").to("2.0km"))
                 .execute().actionGet();
         assertHitCount(searchResponse, 2);
         assertThat(searchResponse.getHits().hits().length, equalTo(2));
@@ -179,7 +179,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             assertThat(hit.id(), anyOf(equalTo("4"), equalTo("5")));
         }
         searchResponse = client().prepareSearch() // from NY
-                .setQuery(geoDistanceRangeQuery("location").from("1.0km").to("2.0km").point(40.7143528, -74.0059731).optimizeBbox("indexed"))
+                .setQuery(geoDistanceRangeQuery("location", 40.7143528, -74.0059731).from("1.0km").to("2.0km").optimizeBbox("indexed"))
                 .execute().actionGet();
         assertHitCount(searchResponse, 2);
         assertThat(searchResponse.getHits().hits().length, equalTo(2));
@@ -188,13 +188,13 @@ public class GeoDistanceIT extends ESIntegTestCase {
         }
 
         searchResponse = client().prepareSearch() // from NY
-                .setQuery(geoDistanceRangeQuery("location").to("2.0km").point(40.7143528, -74.0059731))
+                .setQuery(geoDistanceRangeQuery("location", 40.7143528, -74.0059731).to("2.0km"))
                 .execute().actionGet();
         assertHitCount(searchResponse, 4);
         assertThat(searchResponse.getHits().hits().length, equalTo(4));
 
         searchResponse = client().prepareSearch() // from NY
-                .setQuery(geoDistanceRangeQuery("location").from("2.0km").point(40.7143528, -74.0059731))
+                .setQuery(geoDistanceRangeQuery("location", 40.7143528, -74.0059731).from("2.0km"))
                 .execute().actionGet();
         assertHitCount(searchResponse, 3);
         assertThat(searchResponse.getHits().hits().length, equalTo(3));

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoPolygonIT.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoPolygonIT.java
@@ -20,11 +20,15 @@
 package org.elasticsearch.search.geo;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
@@ -49,7 +53,7 @@ public class GeoPolygonIT extends ESIntegTestCase {
         indexRandom(true, client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("name", "New York")
                 .startObject("location").field("lat", 40.714).field("lon", -74.006).endObject()
-                .endObject()), 
+                .endObject()),
         // to NY: 5.286 km
         client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject()
                 .field("name", "Times Square")
@@ -85,14 +89,14 @@ public class GeoPolygonIT extends ESIntegTestCase {
 
     @Test
     public void simplePolygonTest() throws Exception {
-
+        List<GeoPoint> points = new ArrayList<>();
+        points.add(new GeoPoint(40.7, -74.0));
+        points.add(new GeoPoint(40.7, -74.1));
+        points.add(new GeoPoint(40.8, -74.1));
+        points.add(new GeoPoint(40.8, -74.0));
+        points.add(new GeoPoint(40.7, -74.0));
         SearchResponse searchResponse = client().prepareSearch("test") // from NY
-                .setQuery(boolQuery().must(geoPolygonQuery("location")
-                        .addPoint(40.7, -74.0)
-                        .addPoint(40.7, -74.1)
-                        .addPoint(40.8, -74.1)
-                        .addPoint(40.8, -74.0)
-                        .addPoint(40.7, -74.0)))
+                .setQuery(boolQuery().must(geoPolygonQuery("location", points)))
                 .execute().actionGet();
         assertHitCount(searchResponse, 4);
         assertThat(searchResponse.getHits().hits().length, equalTo(4));
@@ -103,13 +107,13 @@ public class GeoPolygonIT extends ESIntegTestCase {
 
     @Test
     public void simpleUnclosedPolygon() throws Exception {
+        List<GeoPoint> points = new ArrayList<>();
+        points.add(new GeoPoint(40.7, -74.0));
+        points.add(new GeoPoint(40.7, -74.1));
+        points.add(new GeoPoint(40.8, -74.1));
+        points.add(new GeoPoint(40.8, -74.0));
         SearchResponse searchResponse = client().prepareSearch("test") // from NY
-                .setQuery(boolQuery().must(geoPolygonQuery("location")
-                        .addPoint(40.7, -74.0)
-                        .addPoint(40.7, -74.1)
-                        .addPoint(40.8, -74.1)
-                        .addPoint(40.8, -74.0)))
-                .execute().actionGet();
+                .setQuery(boolQuery().must(geoPolygonQuery("location", points))).execute().actionGet();
         assertHitCount(searchResponse, 4);
         assertThat(searchResponse.getHits().hits().length, equalTo(4));
         for (SearchHit hit : searchResponse.getHits()) {

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.query.*;
 import org.elasticsearch.index.search.MatchQuery.Type;
 import org.elasticsearch.index.search.MatchQuery;
+import org.elasticsearch.indices.cache.query.terms.TermsLookup;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.SearchHit;
@@ -1231,63 +1232,54 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type", "4").setSource("term", "4") );
 
         SearchResponse searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("term").lookupIndex("lookup").lookupType("type").lookupId("1").lookupPath("terms")
-                ).get();
+                .setQuery(termsLookupQuery("term" , new TermsLookup("lookup", "type", "1", "terms"))).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "1", "3");
 
         // same as above, just on the _id...
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("_id").lookupIndex("lookup").lookupType("type").lookupId("1").lookupPath("terms")
+                .setQuery(termsLookupQuery("_id", new TermsLookup("lookup", "type", "1", "terms"))
                 ).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "1", "3");
 
         // another search with same parameters...
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("term").lookupIndex("lookup").lookupType("type").lookupId("1").lookupPath("terms")
-                ).get();
+                .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "type", "1", "terms"))).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "1", "3");
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("term").lookupIndex("lookup").lookupType("type").lookupId("2").lookupPath("terms")
-                ).get();
+                .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "type", "2", "terms"))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("term").lookupIndex("lookup").lookupType("type").lookupId("3").lookupPath("terms")
-                ).get();
+                .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "type", "3", "terms"))).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "2", "4");
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("term").lookupIndex("lookup").lookupType("type").lookupId("4").lookupPath("terms")
-                ).get();
+                .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "type", "4", "terms"))).get();
         assertHitCount(searchResponse, 0l);
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("term").lookupIndex("lookup2").lookupType("type").lookupId("1").lookupPath("arr.term")
-                ).get();
+                .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "type", "1", "arr.term"))).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "1", "3");
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("term").lookupIndex("lookup2").lookupType("type").lookupId("2").lookupPath("arr.term")
-                ).get();
+                .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "type", "2", "arr.term"))).get();
         assertHitCount(searchResponse, 1l);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("term").lookupIndex("lookup2").lookupType("type").lookupId("3").lookupPath("arr.term")
-                ).get();
+                .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "type", "3", "arr.term"))).get();
         assertHitCount(searchResponse, 2l);
         assertSearchHits(searchResponse, "2", "4");
 
         searchResponse = client().prepareSearch("test")
-                .setQuery(termsLookupQuery("not_exists").lookupIndex("lookup2").lookupType("type").lookupId("3").lookupPath("arr.term")
-                ).get();
+                .setQuery(termsLookupQuery("not_exists", new TermsLookup("lookup2", "type", "3", "arr.term"))).get();
         assertHitCount(searchResponse, 0l);
     }
 

--- a/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
+++ b/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
@@ -55,10 +55,10 @@ import org.elasticsearch.index.query.MoreLikeThisQueryBuilder;
 import org.elasticsearch.index.query.MoreLikeThisQueryBuilder.Item;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.indices.cache.query.terms.TermsLookup;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.script.Template;
 import org.elasticsearch.script.groovy.GroovyScriptEngineService;
@@ -161,7 +161,7 @@ public class ContextAndHeaderTransportIT extends ESIntegTestCase {
                 .setSource(jsonBuilder().startObject().field("username", "foo").endObject()).get();
         transportClient().admin().indices().prepareRefresh(queryIndex, lookupIndex).get();
 
-        TermsQueryBuilder termsLookupFilterBuilder = QueryBuilders.termsLookupQuery("username").lookupIndex(lookupIndex).lookupType("type").lookupId("1").lookupPath("followers");
+        TermsQueryBuilder termsLookupFilterBuilder = QueryBuilders.termsLookupQuery("username", new TermsLookup(lookupIndex, "type", "1", "followers"));
         BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery()).must(termsLookupFilterBuilder);
 
         SearchResponse searchResponse = transportClient()

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -111,9 +111,22 @@ The deprecated `docs(Item... docs)`, `ignoreLike(Item... docs)`,
 Removing individual setters for lon() and lat() values, both values should be set together
  using point(lon, lat).
 
+==== GeoDistanceRangeQueryBuilder
+
+Removing setters for to(Object ...) and from(Object ...) in favour of the only two allowed input
+arguments (String, Number). Removing setter for center point (point(), geohash()) because parameter 
+is mandatory and should already be set in constructor. 
+Also removing setters for lt(), lte(), gt(), gte() since they can all be replaced by equivallent 
+calls to to/from() and inludeLower()/includeUpper().
+
+==== GeoPolygonQueryBuilder
+
+Require shell of polygon already to be specified in constructor instead of adding it pointwise.
+This enables validation, but makes it necessary to remove the addPoint() methods. 
+
 ==== MultiMatchQueryBuilder
 
-Moving MultiMatchQueryBuilder.ZeroTermsQuery enum to MatchQuery..ZeroTermsQuery.
+Moving MultiMatchQueryBuilder.ZeroTermsQuery enum to MatchQuery.ZeroTermsQuery.
 Also reusing new Operator enum.
 
 Removed ability to pass in boost value using `field(String field)` method in form e.g. `field^2`.
@@ -124,3 +137,11 @@ Use the `field(String, float)` method instead.
 The two individual setters for existence() and nullValue() were removed in favour of
 optional constructor settings in order to better capture and validate their interdependent
 settings at construction time.
+
+==== TermsQueryBuilder
+
+Remove the setter for `termsLookup()`, making it only possible to either use a TermsLookUp object or
+individual values at constrution time. Also moving individual settings for the TermsLookUp (lookupIndex,
+lookupType, lookupId, lookupPath) to the separate TermsLookUp class, using construtor only and moving
+checks for validation there.
+


### PR DESCRIPTION
Moving validation from validate() to constructors and setters for the following query builders:
- GeoDistanceQueryBuilder
- GeoDistanceRangeQueryBuilder
- GeoPolygonQueryBuilder
- GeoShapeQueryBuilder
- GeohashCellQuery
- TermsQueryBuilder
