### PR TITLE
Switch geo validation to enum

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoValidationMethod.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoValidationMethod.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.CollectionUtils;
+
+import java.io.IOException;
+
+/**
+ * This enum is used to determine how to deal with invalid geo coordinates in geo related
+ * queries:
+ * 
+ *  On STRICT validation invalid coordinates cause an exception to be thrown.
+ *  On IGNORE_MALFORMED invalid coordinates are being accepted.
+ *  On COERCE invalid coordinates are being corrected to the most likely valid coordinate.
+ * */
+public enum GeoValidationMethod implements Writeable<GeoValidationMethod>{
+    COERCE, IGNORE_MALFORMED, STRICT;
+
+    public static final GeoValidationMethod DEFAULT = STRICT;
+    public static final boolean DEFAULT_LENIENT_PARSING = (DEFAULT != STRICT);
+    private static final GeoValidationMethod PROTOTYPE = DEFAULT;
+
+    @Override
+    public GeoValidationMethod readFrom(StreamInput in) throws IOException {
+        return GeoValidationMethod.values()[in.readVInt()];
+    }
+
+    public static GeoValidationMethod readGeoValidationMethodFrom(StreamInput in) throws IOException {
+        return PROTOTYPE.readFrom(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(this.ordinal());
+    }
+
+    public static GeoValidationMethod fromString(String op) {
+        for (GeoValidationMethod method : GeoValidationMethod.values()) {
+            if (method.name().equalsIgnoreCase(op)) {
+                return method;
+            }
+        }
+        throw new IllegalArgumentException("operator needs to be either " + CollectionUtils.arrayAsArrayList(GeoValidationMethod.values())
+                + ", but not [" + op + "]");
+    }
+    
+    /** Returns whether or not to skip bounding box validation. */
+    public static boolean isIgnoreMalformed(GeoValidationMethod method) {
+        return (method == GeoValidationMethod.IGNORE_MALFORMED || method == GeoValidationMethod.COERCE);
+    }
+
+    /** Returns whether or not to try and fix broken/wrapping bounding boxes. */
+    public static boolean isCoerce(GeoValidationMethod method) {
+        return method == GeoValidationMethod.COERCE;
+    }
+
+    /** Returns validation method corresponding to given coerce and ignoreMalformed values. */
+    public static GeoValidationMethod infer(boolean coerce, boolean ignoreMalformed) {
+        if (coerce) {
+            return GeoValidationMethod.COERCE;
+        } else if (ignoreMalformed) {
+            return GeoValidationMethod.IGNORE_MALFORMED;
+        } else {
+            return GeoValidationMethod.STRICT;
+        }
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -59,11 +59,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         qb.point(new GeoPoint(p.getY(), p.getX()));
 
         if (randomBoolean()) {
-            qb.coerce(randomBoolean());
-        }
-
-        if (randomBoolean()) {
-            qb.ignoreMalformed(randomBoolean());
+            qb.setValidationMethod(randomFrom(GeoValidationMethod.values()));
         }
 
         if (randomBoolean()) {

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceRangeQueryTests.java
@@ -96,10 +96,7 @@ public class GeoDistanceRangeQueryTests extends AbstractQueryTestCase<GeoDistanc
             builder.optimizeBbox(randomFrom("none", "memory", "indexed"));
         }
         if (randomBoolean()) {
-            builder.coerce(randomBoolean());
-        }
-        if (randomBoolean()) {
-            builder.ignoreMalformed(randomBoolean());
+            builder.setValidationMethod(randomFrom(GeoValidationMethod.values()));
         }
         return builder;
     }

--- a/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -49,8 +49,9 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
     protected GeoPolygonQueryBuilder doCreateTestQueryBuilder() {
         List<GeoPoint> polygon = randomPolygon(randomIntBetween(4, 50));
         GeoPolygonQueryBuilder builder = new GeoPolygonQueryBuilder(GEO_POINT_FIELD_NAME, polygon);
-        builder.coerce(randomBoolean());
-        builder.ignoreMalformed(randomBoolean());
+        if (randomBoolean()) {
+            builder.setValidationMethod(randomFrom(GeoValidationMethod.values()));
+        }
         return builder;
     }
 
@@ -62,7 +63,7 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         List<GeoPoint> queryBuilderPoints = queryBuilder.points();
         GeoPoint[] queryPoints = geoQuery.points();
         assertThat(queryPoints.length, equalTo(queryBuilderPoints.size()));
-        if (queryBuilder.coerce()) {
+        if (GeoValidationMethod.isCoerce(queryBuilder.getValidationMethod())) {
             for (int i = 0; i < queryBuilderPoints.size(); i++) {
                 GeoPoint queryBuilderPoint = queryBuilderPoints.get(i);
                 GeoUtils.normalizePoint(queryBuilderPoint, true, true);

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoBoundingBoxIT.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoBoundingBoxIT.java
@@ -22,12 +22,12 @@ package org.elasticsearch.search.geo;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.GeoValidationMethod;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -289,43 +289,43 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(
-                        geoBoundingBoxQuery("location").coerce(true).setCorners(50, -180, -50, 180)
+                        geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, -180, -50, 180)
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
         searchResponse = client().prepareSearch()
                 .setQuery(
-                        geoBoundingBoxQuery("location").coerce(true).setCorners(50, -180, -50, 180).type("indexed")
+                        geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, -180, -50, 180).type("indexed")
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
         searchResponse = client().prepareSearch()
                 .setQuery(
-                        geoBoundingBoxQuery("location").coerce(true).setCorners(90, -180, -90, 180)
+                        geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, -180, -90, 180)
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
         searchResponse = client().prepareSearch()
                 .setQuery(
-                        geoBoundingBoxQuery("location").coerce(true).setCorners(90, -180, -90, 180).type("indexed")
+                        geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, -180, -90, 180).type("indexed")
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
 
         searchResponse = client().prepareSearch()
                 .setQuery(
-                        geoBoundingBoxQuery("location").coerce(true).setCorners(50, 0, -50, 360)
+                        geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, 0, -50, 360)
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
         searchResponse = client().prepareSearch()
                 .setQuery(
-                        geoBoundingBoxQuery("location").coerce(true).setCorners(50, 0, -50, 360).type("indexed")
+                        geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, 0, -50, 360).type("indexed")
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
         searchResponse = client().prepareSearch()
                 .setQuery(
-                        geoBoundingBoxQuery("location").coerce(true).setCorners(90, 0, -90, 360)
+                        geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360)
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
         searchResponse = client().prepareSearch()
                 .setQuery(
-                        geoBoundingBoxQuery("location").coerce(true).setCorners(90, 0, -90, 360).type("indexed")
+                        geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360).type("indexed")
                 ).execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
     }


### PR DESCRIPTION
Relates to #13608:

This switches handling coerce and ignore_malformed parameters to an enum to better reflect their relationship.

@cbuescher / @nknize / @colings86 can either of you have a look please whether those changes make sense and are in line with the issue above before I move on to the other geo queries.
