### PR TITLE
BATS testing: Add SLES-12 to list of tested virtual machines

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -445,12 +445,12 @@ These are the linux flavors the Vagrantfile currently supports:
 * centos-7
 * fedora-22
 * oel-7 aka Oracle Enterprise Linux 7
+* sles-12
 
 We're missing the following from the support matrix because there aren't high
 quality boxes available in vagrant atlas:
 
 * sles-11
-* sles-12
 * opensuse-13
 * oel-6
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,12 @@ Vagrant.configure(2) do |config|
   config.vm.define "opensuse-13" do |config|
     config.vm.box = "chef/opensuse-13"
     config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.2-x86_64_chef-provisionerless.box"
-    suse_common config
+    opensuse_common config
+  end
+  # The SLES boxes are not considered to be highest quality, but seem to be sufficient for a test run
+  config.vm.define "sles-12" do |config|
+    config.vm.box = "idar/sles12"
+    sles_common config
   end
   # Switch the default share for the project root from /vagrant to
   # /elasticsearch because /vagrant is confusing when there is a project inside
@@ -155,12 +160,29 @@ def dnf_common(config)
   end
 end
 
-def suse_common(config)
+def opensuse_common(config)
+  suse_common config, ''
+end
+
+def suse_common(config, extra)
   provision(config,
     update_command: "zypper --non-interactive list-updates",
     update_tracking_file: "/var/cache/zypp/packages/last_update",
     install_command: "zypper --non-interactive --quiet install --no-recommends",
-    java_package: "java-1_8_0-openjdk-devel")
+    java_package: "java-1_8_0-openjdk-devel",
+    extra: extra)
+end
+
+def sles_common(config)
+  extra = <<-SHELL
+    zypper rr systemsmanagement_puppet
+    zypper addrepo -t yast2 http://demeter.uni-regensburg.de/SLES12-x64/DVD1/ dvd1 || true
+    zypper addrepo -t yast2 http://demeter.uni-regensburg.de/SLES12-x64/DVD2/ dvd2 || true
+    zypper addrepo http://download.opensuse.org/repositories/Java:Factory/SLE_12/Java:Factory.repo || true
+    zypper --no-gpg-checks --non-interactive refresh
+    zypper --non-interactive install git-core
+SHELL
+  suse_common config, extra
 end
 
 # Register the main box provisioning script.

--- a/qa/vagrant/pom.xml
+++ b/qa/vagrant/pom.xml
@@ -21,7 +21,7 @@
       <testCommand>sudo bats $BATS/${testScripts}</testCommand>
 
       <allDebBoxes>precise, trusty, vivid, jessie</allDebBoxes>
-      <allRpmBoxes>centos-6, centos-7, oel-7, fedora-22, opensuse-13</allRpmBoxes>
+      <allRpmBoxes>centos-6, centos-7, oel-7, fedora-22, opensuse-13, sles-12</allRpmBoxes>
 
       <defaultDebBoxes>trusty</defaultDebBoxes>
       <defaultRpmBoxes>centos-7</defaultRpmBoxes>


### PR DESCRIPTION
This adds SuSe Linux Enterprise Server 12 to the list of tested VMs.
SLES 12 is using systemd, so that the current RPM works
out of the box.

SLES12 however is already quite old and does not ship with java8, so this
required adding an opensuse repo.
