### PR TITLE
In cluster health REST spec, {index} can be one or many indices and should be typed to list.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -7,7 +7,7 @@
       "paths": ["/_cluster/health", "/_cluster/health/{index}"],
       "parts": {
         "index": {
-          "type" : "string",
+          "type" : "list",
           "description" : "Limit the information returned to a specific index"
         }
       },


### PR DESCRIPTION
{index} can be one or many indices and should be typed to list.
