### PR TITLE
HEAD support for the _search/exists api

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/exists/RestExistsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/exists/RestExistsAction.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
- * Action for /_search/exists endpoint
+ * Action for /_search/exists endpoint.
  */
 public class RestExistsAction extends BaseRestHandler {
 
@@ -65,9 +65,11 @@ public class RestExistsAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(ExistsResponse response, XContentBuilder builder) throws Exception {
                 RestStatus status = response.exists() ? OK : NOT_FOUND;
-                builder.startObject();
-                builder.field("exists", response.exists());
-                builder.endObject();
+                if (request.method() != RestRequest.Method.HEAD) {
+                    builder.startObject();
+                    builder.field("exists", response.exists());
+                    builder.endObject();
+                }
                 return new BytesRestResponse(status, builder);
             }
         });

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.search.sort.SortOrder;
 
 import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.search.suggest.SuggestBuilders.termSuggestion;
 
@@ -71,10 +72,13 @@ public class RestSearchAction extends BaseRestHandler {
         RestExistsAction restExistsAction = new RestExistsAction(settings, controller, client);
         controller.registerHandler(GET, "/_search/exists", restExistsAction);
         controller.registerHandler(POST, "/_search/exists", restExistsAction);
+        controller.registerHandler(HEAD, "/_search/exists", restExistsAction);
         controller.registerHandler(GET, "/{index}/_search/exists", restExistsAction);
         controller.registerHandler(POST, "/{index}/_search/exists", restExistsAction);
+        controller.registerHandler(HEAD, "/{index}/_search/exists", restExistsAction);
         controller.registerHandler(GET, "/{index}/{type}/_search/exists", restExistsAction);
         controller.registerHandler(POST, "/{index}/{type}/_search/exists", restExistsAction);
+        controller.registerHandler(HEAD, "/{index}/{type}/_search/exists", restExistsAction);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/test/rest/client/RestResponse.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/client/RestResponse.java
@@ -86,10 +86,8 @@ public class RestResponse {
         JsonPath jsonPath = parsedResponse();
 
         if (jsonPath == null) {
-            //special case: api that don't support body (e.g. exists) return true if 200, false if 404, even if no body
-            //is_true: '' means the response had no body but the client returned true (caused by 200)
-            //is_false: '' means the response had no body but the client returned false (caused by 404)
-            if ("".equals(path) && !response.supportsBody()) {
+            //special case: apis that don't send a body always return true if 200, false if 404, even if no body
+            if (!response.supportsBody()) {
                 return !response.isError();
             }
             return null;
@@ -98,9 +96,16 @@ public class RestResponse {
         return jsonPath.evaluate(path, stash);
     }
 
+    /**
+     * Was this request over a method that supports a body?
+     */
+    public boolean supportsBody() {
+        return response.supportsBody();
+    }
+
     private boolean isJson() {
         String contentType = response.getHeaders().get("Content-Type");
-        return contentType != null && contentType.contains("application/json");
+        return response.supportsBody() && contentType != null && contentType.contains("application/json");
     }
 
     private JsonPath parsedResponse() throws IOException {

--- a/core/src/test/java/org/elasticsearch/test/rest/section/DoSection.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/section/DoSection.java
@@ -87,7 +87,9 @@ public class DoSection implements ExecutableSection {
 
         try {
             RestResponse restResponse = executionContext.callApi(apiCallSection.getApi(), apiCallSection.getParams(), apiCallSection.getBodies());
-            if (Strings.hasLength(catchParam)) {
+            // We ignore "missing" catch params on HEAD requests in favor of asserting them with "is_false: ''"-style assertions
+            boolean ignoreCatchParam = "missing".equals(catchParam) && !restResponse.supportsBody();
+            if (Strings.hasLength(catchParam) && !ignoreCatchParam) {
                 String catchStatusCode;
                 if (catches.containsKey(catchParam)) {
                     catchStatusCode = catches.get(catchParam).v1();

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_exists.json
@@ -1,7 +1,7 @@
 {
   "search_exists": {
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html",
-    "methods": ["POST", "GET"],
+    "methods": ["POST", "GET", "HEAD"],
     "url": {
       "path": "/_search/exists",
       "paths": ["/_search/exists", "/{index}/_search/exists", "/{index}/{type}/_search/exists"],
@@ -71,6 +71,10 @@
         "lowercase_expanded_terms": {
           "type" : "boolean",
           "description" : "Specify whether query terms should be lowercased"
+        },
+        "source": {
+          "type": "string",
+          "description": "source of the search query if the search query isn't included in the body"
         }
       }
     },


### PR DESCRIPTION
Registers the `_search/exists` api to receive HEAD requests. If it gets one
then it won't output the JSON response but will still do everything else.

Adds magic to the rest tests to ignore `catch: missing` for HEAD requests.
This behavior is checked instead with `- is_false: anystring`. This setup
makes the rest tests for `search/_exists` work for HEAD requests.

Also forces the request body over the source URL parameter for all HEAD
requests.

Closes #11204
