### PR TITLE
Disable doclint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1261,10 +1261,14 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                     <version>2.0.0</version>
                 </plugin>
                 <plugin>
-                    <!-- We just declare which plugin version to use. Each project can have then its own settings -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.3</version>
+                    <configuration>
+                        <!-- Doclint defaults to very strict. While it'd be great to have wonderful Javadocs we
+                             prefer working Javadocs over total failure. -->
+                        <additionalparam>-Xdoclint:none</additionalparam>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->


### PR DESCRIPTION
Java 8's javadoc defaults to very strict linting. It is very `-Wall -Werr`
style. And Elasticsearch's Javadocs do not pass and it'd be a huge and not
super useful effort to get them to pass the linting. So this disables it.

Closes #13336
