### PR TITLE
Query Refactoring: Move MLT validation to constructor

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
@@ -158,7 +158,7 @@ public class MoreLikeThisQuery extends Query {
         if (this.unlikeText != null || this.unlikeFields != null) {
             handleUnlike(mlt, this.unlikeText, this.unlikeFields);
         }
-        
+
         return createQuery(mlt);
     }
 
@@ -182,7 +182,7 @@ public class MoreLikeThisQuery extends Query {
 
         BooleanQuery bq = bqBuilder.build();
         bq.setBoost(getBoost());
-        return bq;    
+        return bq;
     }
 
     private void handleUnlike(XMoreLikeThis mlt, String[] unlikeText, Fields[] unlikeFields) throws IOException {
@@ -257,8 +257,8 @@ public class MoreLikeThisQuery extends Query {
         this.unlikeFields = unlikeFields;
     }
 
-    public void setUnlikeText(List<String> unlikeText) {
-        this.unlikeText = unlikeText.toArray(Strings.EMPTY_ARRAY);
+    public void setUnlikeText(String[] unlikeText) {
+        this.unlikeText = unlikeText;
     }
 
     public String[] getMoreLikeFields() {

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryParser.java
@@ -187,11 +187,15 @@ public class MoreLikeThisQueryParser extends BaseQueryParser<MoreLikeThisQueryBu
             throw new ParsingException(parser.getTokenLocation(), "more_like_this requires 'fields' to be non-empty");
         }
 
-        MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = new MoreLikeThisQueryBuilder(fields)
-                .like(likeTexts.toArray(new String[likeTexts.size()]))
-                .unlike(unlikeTexts.toArray(new String[unlikeTexts.size()]))
-                .like(likeItems.toArray(new Item[likeItems.size()]))
-                .unlike(unlikeItems.toArray(new Item[unlikeItems.size()]))
+        String[] fieldsArray = fields == null ? null : fields.toArray(new String[fields.size()]);
+        String[] likeTextsArray = likeTexts.isEmpty() ? null : likeTexts.toArray(new String[likeTexts.size()]);
+        String[] unlikeTextsArray = unlikeTexts.isEmpty() ? null : unlikeTexts.toArray(new String[unlikeTexts.size()]);
+        Item[] likeItemsArray = likeItems.isEmpty() ? null : likeItems.toArray(new Item[likeItems.size()]);
+        Item[] unlikeItemsArray = unlikeItems.isEmpty() ? null : unlikeItems.toArray(new Item[unlikeItems.size()]);
+
+        MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = new MoreLikeThisQueryBuilder(fieldsArray, likeTextsArray, likeItemsArray)
+                .unlike(unlikeTextsArray)
+                .unlike(unlikeItemsArray)
                 .maxQueryTerms(maxQueryTerms)
                 .minTermFreq(minTermFreq)
                 .minDocFreq(minDocFreq)

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.index.query.MoreLikeThisQueryBuilder.Item;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.search.MatchQuery;
@@ -422,21 +423,43 @@ public abstract class QueryBuilders {
     }
 
     /**
-     * A more like this query that finds documents that are "like" the provided {@link MoreLikeThisQueryBuilder#likeText(String)}
+     * A more like this query that finds documents that are "like" the provided texts or documents
      * which is checked against the fields the query is constructed with.
      *
-     * @param fields The fields to run the query against
+     * @param fields the field names that will be used when generating the 'More Like This' query.
+     * @param likeTexts the text to use when generating the 'More Like This' query.
+     * @param likeItems the documents to use when generating the 'More Like This' query.
      */
-    public static MoreLikeThisQueryBuilder moreLikeThisQuery(String... fields) {
-        return new MoreLikeThisQueryBuilder(fields);
+    public static MoreLikeThisQueryBuilder moreLikeThisQuery(String[] fields, String[] likeTexts, Item[] likeItems) {
+        return new MoreLikeThisQueryBuilder(fields, likeTexts, likeItems);
     }
 
     /**
-     * A more like this query that finds documents that are "like" the provided {@link MoreLikeThisQueryBuilder#likeText(String)}
+     * A more like this query that finds documents that are "like" the provided texts or documents
      * which is checked against the "_all" field.
+     * @param likeTexts the text to use when generating the 'More Like This' query.
+     * @param likeItems the documents to use when generating the 'More Like This' query.
      */
-    public static MoreLikeThisQueryBuilder moreLikeThisQuery() {
-        return new MoreLikeThisQueryBuilder();
+    public static MoreLikeThisQueryBuilder moreLikeThisQuery(String[] likeTexts, Item[] likeItems) {
+        return moreLikeThisQuery(null, likeTexts, likeItems);
+    }
+
+    /**
+     * A more like this query that finds documents that are "like" the provided texts
+     * which is checked against the "_all" field.
+     * @param likeTexts the text to use when generating the 'More Like This' query.
+     */
+    public static MoreLikeThisQueryBuilder moreLikeThisQuery(String[] likeTexts) {
+        return moreLikeThisQuery(null, likeTexts, null);
+    }
+
+    /**
+     * A more like this query that finds documents that are "like" the provided documents
+     * which is checked against the "_all" field.
+     * @param likeItems the documents to use when generating the 'More Like This' query.
+     */
+    public static MoreLikeThisQueryBuilder moreLikeThisQuery(Item[] likeItems) {
+        return moreLikeThisQuery(null, null, likeItems);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -1231,7 +1231,7 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
     @Test
     public void testMoreLikeThisBuilder() throws Exception {
         IndexQueryParserService queryParser = queryParser();
-        Query parsedQuery = queryParser.parse(moreLikeThisQuery("name.first", "name.last").likeText("something").minTermFreq(1).maxQueryTerms(12)).query();
+        Query parsedQuery = queryParser.parse(moreLikeThisQuery(new String[] {"name.first", "name.last"}, new String[] {"something"}, null).minTermFreq(1).maxQueryTerms(12)).query();
         assertThat(parsedQuery, instanceOf(MoreLikeThisQuery.class));
         MoreLikeThisQuery mltQuery = (MoreLikeThisQuery) parsedQuery;
         assertThat(mltQuery.getMoreLikeFields()[0], equalTo("name.first"));

--- a/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
+++ b/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
@@ -229,8 +229,8 @@ public class ContextAndHeaderTransportIT extends ESIntegTestCase {
                 .get();
         transportClient().admin().indices().prepareRefresh(lookupIndex, queryIndex).get();
 
-        MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = QueryBuilders.moreLikeThisQuery("name")
-                .like(new Item(lookupIndex, "type", "1"))
+        MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = QueryBuilders.moreLikeThisQuery(new String[] {"name"}, null,
+                new Item[] {new Item(lookupIndex, "type", "1")})
                 .minTermFreq(1)
                 .minDocFreq(1);
 

--- a/core/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.validate;
 
 import java.nio.charset.StandardCharsets;
-
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.client.Client;
@@ -28,6 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.query.MoreLikeThisQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -250,10 +250,10 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
                 containsString("field:jumps^0.75"), true);
 
         // more like this queries
-        assertExplanation(QueryBuilders.moreLikeThisQuery("field").ids("1")
+        assertExplanation(QueryBuilders.moreLikeThisQuery(new String[] { "field" }, null, MoreLikeThisQueryBuilder.ids("1"))
                         .include(true).minTermFreq(1).minDocFreq(1).maxQueryTerms(2),
                 containsString("field:huge field:pidgin"), true);
-        assertExplanation(QueryBuilders.moreLikeThisQuery("field").like("the huge pidgin")
+        assertExplanation(QueryBuilders.moreLikeThisQuery(new String[] { "field" }, new String[] {"the huge pidgin"}, null)
                         .minTermFreq(1).minDocFreq(1).maxQueryTerms(2),
                 containsString("field:huge field:pidgin"), true);
     }

--- a/docs/reference/migration/migrate_query_refactoring.asciidoc
+++ b/docs/reference/migration/migrate_query_refactoring.asciidoc
@@ -109,8 +109,11 @@ Also reusing new Operator enum.
 Removed `MoreLikeThisQueryBuilder.Item#id(String id)`, `Item#doc(BytesReference doc)`,
 `Item#doc(XContentBuilder doc)`. Use provided constructors instead.
 
-Removed `MoreLikeThisQueryBuilder#addLike` and `addUnlike` in favor to using the `like`
-and `unlike` methods.
+Removed `MoreLikeThisQueryBuilder#addLike` in favor of texts and/or items beeing provided
+at construction time. Using arrays there instead of lists now.
+
+Removed `MoreLikeThisQueryBuilder#addUnlike` in favor to using the `unlike` methods
+which take arrays as arguments now rather than the lists used before. 
 
 The deprecated `docs(Item... docs)`, `ignoreLike(Item... docs)`,
 `ignoreLike(String... likeText)`, `addItem(Item... likeItems)` have been removed.


### PR DESCRIPTION
The current MoreLikeThisQueryBuilder validation checks for existence of at least one `like` text or item. This is hard to check in setters, so this PR tries to change the construction of the query so that we can do these checks already at construction time.

Relates to #10217
