### PR TITLE
Ensure all resoruces are closed on Node#close()

### DIFF
--- a/core/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
+++ b/core/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
@@ -29,13 +29,14 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Locale;
 
 import static org.elasticsearch.common.recycler.Recyclers.*;
 
 /** A recycler of fixed-size pages. */
-public class PageCacheRecycler extends AbstractComponent {
+public class PageCacheRecycler extends AbstractComponent implements Closeable {
 
     public static final String TYPE = "recycler.page.type";
     public static final String LIMIT_HEAP = "recycler.page.limit.heap";

--- a/core/src/main/java/org/elasticsearch/client/Client.java
+++ b/core/src/main/java/org/elasticsearch/client/Client.java
@@ -69,6 +69,8 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.Settings;
 
+import java.io.Closeable;
+
 /**
  * A client provides a one stop interface for performing actions/operations against the cluster.
  * <p/>
@@ -82,7 +84,7 @@ import org.elasticsearch.common.settings.Settings;
  * @see org.elasticsearch.node.Node#client()
  * @see org.elasticsearch.client.transport.TransportClient
  */
-public interface Client extends ElasticsearchClient, Releasable {
+public interface Client extends ElasticsearchClient, Releasable, Closeable {
 
     String CLIENT_TYPE_SETTING = "client.type";
 

--- a/core/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
+++ b/core/src/main/java/org/elasticsearch/common/component/AbstractLifecycleComponent.java
@@ -21,13 +21,14 @@ package org.elasticsearch.common.component;
 
 import org.elasticsearch.common.settings.Settings;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  *
  */
-public abstract class AbstractLifecycleComponent<T> extends AbstractComponent implements LifecycleComponent<T> {
+public abstract class AbstractLifecycleComponent<T> extends AbstractComponent implements LifecycleComponent<T>, Closeable {
 
     protected final Lifecycle lifecycle = new Lifecycle();
 

--- a/core/src/main/java/org/elasticsearch/common/component/LifecycleComponent.java
+++ b/core/src/main/java/org/elasticsearch/common/component/LifecycleComponent.java
@@ -27,7 +27,7 @@ import java.io.Closeable;
 /**
  *
  */
-public interface LifecycleComponent<T> extends Releasable {
+public interface LifecycleComponent<T> extends Releasable, Closeable {
 
     Lifecycle.State lifecycleState();
 

--- a/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -41,12 +41,13 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  */
-public class IndicesFieldDataCache extends AbstractComponent implements RemovalListener<IndicesFieldDataCache.Key, Accountable> {
+public class IndicesFieldDataCache extends AbstractComponent implements RemovalListener<IndicesFieldDataCache.Key, Accountable>, Closeable {
 
     public static final String FIELDDATA_CLEAN_INTERVAL_SETTING = "indices.fielddata.cache.cleanup_interval";
     public static final String FIELDDATA_CACHE_CONCURRENCY_LEVEL = "indices.fielddata.cache.concurrency_level";

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.node;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.Build;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
@@ -94,10 +96,9 @@ import org.elasticsearch.tribe.TribeService;
 import org.elasticsearch.watcher.ResourceWatcherModule;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
@@ -329,87 +330,93 @@ public class Node implements Releasable {
         if (!lifecycle.moveToClosed()) {
             return;
         }
+        List<Closeable> toClose = new ArrayList<>();
 
         ESLogger logger = Loggers.getLogger(Node.class, settings.get("name"));
         logger.info("closing ...");
 
         StopWatch stopWatch = new StopWatch("node_close");
-        stopWatch.start("tribe");
-        injector.getInstance(TribeService.class).close();
-        stopWatch.stop().start("http");
+        toClose.add(() -> stopWatch.start("tribe"));
+        toClose.add(injector.getInstance(TribeService.class));
         if (settings.getAsBoolean("http.enabled", true)) {
-            injector.getInstance(HttpServer.class).close();
+            toClose.add(() -> stopWatch.stop().start("http"));
+            toClose.add(injector.getInstance(HttpServer.class));
         }
-        stopWatch.stop().start("snapshot_service");
-        injector.getInstance(SnapshotsService.class).close();
-        injector.getInstance(SnapshotShardsService.class).close();
-        stopWatch.stop().start("client");
-        Releasables.close(injector.getInstance(Client.class));
-        stopWatch.stop().start("indices_cluster");
-        injector.getInstance(IndicesClusterStateService.class).close();
-        stopWatch.stop().start("indices");
-        injector.getInstance(IndexingMemoryController.class).close();
-        injector.getInstance(IndicesTTLService.class).close();
-        injector.getInstance(IndicesService.class).close();
+        toClose.add(() -> stopWatch.stop().start("snapshot_service"));
+
+        toClose.add(injector.getInstance(SnapshotsService.class));
+        toClose.add(injector.getInstance(SnapshotShardsService.class));
+        toClose.add(() -> stopWatch.stop().start("client"));
+        toClose.add(injector.getInstance(Client.class));
+        toClose.add(() -> stopWatch.stop().start("indices_cluster"));
+        toClose.add(injector.getInstance(IndicesClusterStateService.class));
+        toClose.add(() -> stopWatch.stop().start("indices"));
+        toClose.add(injector.getInstance(IndexingMemoryController.class));
+        toClose.add(injector.getInstance(IndicesTTLService.class));
+        toClose.add(injector.getInstance(IndicesService.class));
         // close filter/fielddata caches after indices
-        injector.getInstance(IndicesQueryCache.class).close();
-        injector.getInstance(IndicesFieldDataCache.class).close();
-        injector.getInstance(IndicesStore.class).close();
-        stopWatch.stop().start("routing");
-        injector.getInstance(RoutingService.class).close();
-        stopWatch.stop().start("cluster");
-        injector.getInstance(ClusterService.class).close();
-        stopWatch.stop().start("discovery");
-        injector.getInstance(DiscoveryService.class).close();
-        stopWatch.stop().start("monitor");
-        injector.getInstance(MonitorService.class).close();
-        stopWatch.stop().start("gateway");
-        injector.getInstance(GatewayService.class).close();
-        stopWatch.stop().start("search");
-        injector.getInstance(SearchService.class).close();
-        stopWatch.stop().start("rest");
-        injector.getInstance(RestController.class).close();
-        stopWatch.stop().start("transport");
-        injector.getInstance(TransportService.class).close();
-        stopWatch.stop().start("percolator_service");
-        injector.getInstance(PercolatorService.class).close();
+        toClose.add(injector.getInstance(IndicesQueryCache.class));
+        toClose.add(injector.getInstance(IndicesFieldDataCache.class));
+        toClose.add(injector.getInstance(IndicesStore.class));
+        toClose.add(() -> stopWatch.stop().start("routing"));
+        toClose.add(injector.getInstance(RoutingService.class));
+        toClose.add(() -> stopWatch.stop().start("cluster"));
+        toClose.add(injector.getInstance(ClusterService.class));
+        toClose.add(() -> stopWatch.stop().start("discovery"));
+        toClose.add(injector.getInstance(DiscoveryService.class));
+        toClose.add(() -> stopWatch.stop().start("monitor"));
+        toClose.add(injector.getInstance(MonitorService.class));
+        toClose.add(() -> stopWatch.stop().start("gateway"));
+        toClose.add(injector.getInstance(GatewayService.class));
+        toClose.add(() -> stopWatch.stop().start("search"));
+        toClose.add(injector.getInstance(SearchService.class));
+        toClose.add(() -> stopWatch.stop().start("rest"));
+        toClose.add(injector.getInstance(RestController.class));
+        toClose.add(() -> stopWatch.stop().start("transport"));
+        toClose.add(injector.getInstance(TransportService.class));
+        toClose.add(() -> stopWatch.stop().start("percolator_service"));
+        toClose.add(injector.getInstance(PercolatorService.class));
 
         for (Class<? extends LifecycleComponent> plugin : pluginsService.nodeServices()) {
-            stopWatch.stop().start("plugin(" + plugin.getName() + ")");
-            injector.getInstance(plugin).close();
+            toClose.add(() -> stopWatch.stop().start("plugin(" + plugin.getName() + ")"));
+            toClose.add(injector.getInstance(plugin));
         }
 
-        stopWatch.stop().start("script");
-        try {
-            injector.getInstance(ScriptService.class).close();
-        } catch(IOException e) {
-            logger.warn("ScriptService close failed", e);
-        }
-
-        stopWatch.stop().start("thread_pool");
+        toClose.add(() -> stopWatch.stop().start("script"));
+        toClose.add(injector.getInstance(ScriptService.class));
         // TODO this should really use ThreadPool.terminate()
-        injector.getInstance(ThreadPool.class).shutdown();
-        try {
-            injector.getInstance(ThreadPool.class).awaitTermination(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            // ignore
-        }
-        stopWatch.stop().start("thread_pool_force_shutdown");
-        try {
-            injector.getInstance(ThreadPool.class).shutdownNow();
-        } catch (Exception e) {
-            // ignore
-        }
-        stopWatch.stop();
+        toClose.add(() -> {
+            stopWatch.stop().start("thread_pool");
+            injector.getInstance(ThreadPool.class).shutdown();
+            try {
+                injector.getInstance(ThreadPool.class).awaitTermination(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                // ignore
+            } finally {
+                stopWatch.stop().start("thread_pool_force_shutdown");
+                try {
+                    injector.getInstance(ThreadPool.class).shutdownNow();
+                } catch (Exception e) {
+                    // ignore
+                }
+            }
+        });
 
+        toClose.add(() -> stopWatch.stop());
         if (logger.isTraceEnabled()) {
             logger.trace("Close times for each service:\n{}", stopWatch.prettyPrint());
         }
 
-        injector.getInstance(NodeEnvironment.class).close();
-        injector.getInstance(PageCacheRecycler.class).close();
+        toClose.add(injector.getInstance(NodeEnvironment.class));
+        toClose.add(injector.getInstance(PageCacheRecycler.class));
+        try {
+            IOUtils.close(toClose);
+        } catch (IOException ex) {
+            throw new ElasticsearchException("close failed ", ex);
+        } finally {
+            logger.info("closed");
+        }
 
-        logger.info("closed");
     }
 
 

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -88,13 +88,13 @@ import org.elasticsearch.search.aggregations.AggregationPhase;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.SiblingPipelineAggregator;
 import org.elasticsearch.search.highlight.HighlightField;
 import org.elasticsearch.search.highlight.HighlightPhase;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortParseElement;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,7 +107,7 @@ import static org.elasticsearch.percolator.QueryCollector.count;
 import static org.elasticsearch.percolator.QueryCollector.match;
 import static org.elasticsearch.percolator.QueryCollector.matchAndScore;
 
-public class PercolatorService extends AbstractComponent {
+public class PercolatorService extends AbstractComponent implements Closeable {
 
     public final static float NO_SCORE = Float.NEGATIVE_INFINITY;
     public final static String TYPE_NAME = ".percolator";


### PR DESCRIPTION
We are leaking all kinds of resources if something during Node#close() barfs.
This commit cuts over to a list of closeables to release resources that
also closed remaining services if one or more services fail to close.

Closes #13685
