### PR TITLE
Removes wheezy from script testing docs

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -397,10 +397,10 @@ fedora-22 with:
 mvn -Dtests.vagrant -pl qa/vagrant verify -DboxesToTest=fedora-22
 --------------------------------------------
 
-or run wheezy and trusty:
+or run jessie and trusty:
 
 ------------------------------------------------------------------
-mvn -Dtests.vagrant -pl qa/vagrant verify -DboxesToTest='wheezy, trusty'
+mvn -Dtests.vagrant -pl qa/vagrant verify -DboxesToTest='jessie, trusty'
 ------------------------------------------------------------------
 
 or run all the boxes:
@@ -440,7 +440,6 @@ These are the linux flavors the Vagrantfile currently supports:
 * precise aka Ubuntu 12.04
 * trusty aka Ubuntu 14.04
 * vivid aka Ubuntun 15.04
-* wheezy aka Debian 7, the current debian oldstable distribution
 * jessie aka Debian 8, the current debina stable distribution
 * centos-6
 * centos-7


### PR DESCRIPTION
Wheezy was removed from the Vagrantfile and its not used in script testing anymore.
The reason it was removed is commented in the [Vagrantfile](https://github.com/elastic/elasticsearch/blob/master/Vagrantfile#L37).
