### PR TITLE
Get lang-javascript, lang-python, securemock ready for script refactoring

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -163,9 +163,11 @@ final class Security {
     static final Map<String,String> SPECIAL_PLUGINS;
     static {
         Map<String,String> m = new HashMap<>();
-        m.put("repository-s3", "org.elasticsearch.plugin.repository.s3.S3RepositoryPlugin");
-        m.put("discovery-ec2", "org.elasticsearch.plugin.discovery.ec2.Ec2DiscoveryPlugin");
-        m.put("cloud-gce",     "org.elasticsearch.plugin.cloud.gce.CloudGcePlugin");
+        m.put("repository-s3",       "org.elasticsearch.plugin.repository.s3.S3RepositoryPlugin");
+        m.put("discovery-ec2",       "org.elasticsearch.plugin.discovery.ec2.Ec2DiscoveryPlugin");
+        m.put("cloud-gce",           "org.elasticsearch.plugin.cloud.gce.CloudGcePlugin");
+        m.put("lang-javascript",     "org.elasticsearch.plugin.javascript.JavaScriptPlugin");
+        m.put("lang-python",         "org.elasticsearch.plugin.python.PythonPlugin");
         SPECIAL_PLUGINS = Collections.unmodifiableMap(m);
     }
 

--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -57,13 +57,26 @@ grant codeBase "${es.security.plugin.cloud-gce}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
+grant codeBase "${es.security.plugin.lang-javascript}" {
+  // needed to generate runtime classes
+  permission java.lang.RuntimePermission "createClassLoader";
+};
+
+grant codeBase "${es.security.plugin.lang-python}" {
+  // needed to generate runtime classes
+  permission java.lang.RuntimePermission "createClassLoader";
+};
+
 //// test framework permissions.
 //// These are mock objects and test management that we allow test framework libs
 //// to provide on our behalf. But tests themselves cannot do this stuff!
 
 grant codeBase "${es.security.jar.elasticsearch.securemock}" {
+  // needed to access ReflectionFactory (see below)
+  permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
   // needed to support creation of mocks
   permission java.lang.RuntimePermission "reflectionFactoryAccess";
+  // needed for spy interception, etc
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 

--- a/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
+++ b/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.script.python;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 
 import org.apache.lucene.index.LeafReaderContext;
@@ -54,7 +56,13 @@ public class PythonScriptEngineService extends AbstractComponent implements Scri
     public PythonScriptEngineService(Settings settings) {
         super(settings);
 
-        this.interp = PythonInterpreter.threadLocalStateInterpreter(null);
+        // classloader created here
+        this.interp = AccessController.doPrivileged(new PrivilegedAction<PythonInterpreter> () {
+            @Override
+            public PythonInterpreter run() {
+                return PythonInterpreter.threadLocalStateInterpreter(null);
+            }
+        });
     }
 
     @Override
@@ -74,7 +82,13 @@ public class PythonScriptEngineService extends AbstractComponent implements Scri
 
     @Override
     public Object compile(String script) {
-        return interp.compile(script);
+        // classloader created here
+        return AccessController.doPrivileged(new PrivilegedAction<PyCode>() {
+            @Override
+            public PyCode run() {
+                return interp.compile(script);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
I want to refactor scripting engines so we can contain dangerous "God-like" permissions
like createClassloader/sun.reflect. These are used for dynamic class generation (scripts, mocks).
This will mean some refactoring to ES core.

But first lets get the plugins in order first. I removed those permissions globally, and
fixed grants for lang-javascript, lang-python, securemock so that everything works.

lang-javascript needs no code changes, because rhino is properly written :)
lang-python needs accesscontroller blocks. securemock was already working as of 1.1

This is just a baby step, to try to do some of this incrementally! It doesn't yet provide
us anything.
