### PR TITLE
Build: Ensure dependency convergence using mvn plugin

### DIFF
--- a/plugins/analysis-phonetic/pom.xml
+++ b/plugins/analysis-phonetic/pom.xml
@@ -26,6 +26,17 @@
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-phonetic</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,17 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <executions>
                         <execution>
+                            <id>enforce-dependencies</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <dependencyConvergence/>
+                                </rules>
+                            </configuration>
+                        </execution>
+                        <execution>
                             <id>enforce-versions</id>
                             <goals>
                                 <goal>enforce</goal>


### PR DESCRIPTION
This adds the dependency convergence part of the already used
enforcer plugin to the build.

If two artifacts depend on different versions of another artifact
this plugin barfs before the build. The phonetic plugin had this problem
with the `commons-codec` dependency.
