### PR TITLE
Denormalize cluster state output with 'keyed' parameter

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -404,11 +404,11 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
 
         // nodes
         if (metrics.contains(Metric.NODES)) {
-            builder.startObject("nodes");
+            builder.startKeyedObjects("nodes", params);
             for (DiscoveryNode node : nodes) {
                 node.toXContent(builder, params);
             }
-            builder.endObject();
+            builder.endKeyedObjects(params);
         }
 
         // meta data
@@ -447,9 +447,9 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
             }
             builder.endObject();
 
-            builder.startObject("indices");
+            builder.startKeyedObjects("indices", params);
             for (IndexMetaData indexMetaData : metaData()) {
-                builder.startObject(indexMetaData.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startKeyedObject("index", indexMetaData.index(), XContentBuilder.FieldCaseConversion.NONE, params);
 
                 builder.field("state", indexMetaData.getState().toString().toLowerCase(Locale.ENGLISH));
 
@@ -478,9 +478,9 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
                 }
                 builder.endArray();
 
-                builder.endObject();
+                builder.endKeyedObject(params);
             }
-            builder.endObject();
+            builder.endKeyedObjects(params);
 
             for (ObjectObjectCursor<String, MetaData.Custom> cursor : metaData.customs()) {
                 builder.startObject(cursor.key);
@@ -494,7 +494,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
         // routing table
         if (metrics.contains(Metric.ROUTING_TABLE)) {
             builder.startObject("routing_table");
-            builder.startObject("indices");
+            builder.startKeyedObjects("indices", params);
             for (IndexRoutingTable indexRoutingTable : routingTable()) {
                 builder.startObject(indexRoutingTable.index(), XContentBuilder.FieldCaseConversion.NONE);
                 builder.startObject("shards");
@@ -506,9 +506,9 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
                     builder.endArray();
                 }
                 builder.endObject();
-                builder.endObject();
+                builder.endKeyedObject(params);
             }
-            builder.endObject();
+            builder.endKeyedObjects(params);
             builder.endObject();
         }
 
@@ -521,15 +521,15 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
             }
             builder.endArray();
 
-            builder.startObject("nodes");
+            builder.startKeyedObjects("nodes", params);
             for (RoutingNode routingNode : getRoutingNodes()) {
-                builder.startArray(routingNode.nodeId() == null ? "null" : routingNode.nodeId(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startKeyedArray("id", routingNode.nodeId() == null ? "null" : routingNode.nodeId(), "shards", XContentBuilder.FieldCaseConversion.NONE, params);
                 for (ShardRouting shardRouting : routingNode) {
                     shardRouting.toXContent(builder, params);
                 }
-                builder.endArray();
+                builder.endKeyedArray(params);
             }
-            builder.endObject();
+            builder.endKeyedObjects(params);
 
             builder.endObject();
         }

--- a/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
+++ b/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
@@ -102,7 +102,12 @@ public class ClusterBlock implements Streamable, ToXContent {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(Integer.toString(id));
+        if (builder.useNamesAsKeys(params)) {
+            builder.startObject(Integer.toString(id));
+        } else {
+            builder.startObject();
+            builder.field("id", Integer.toString(id));
+        }
         builder.field("description", description);
         builder.field("retryable", retryable);
         if (disableStatePersistence) {

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -357,7 +357,7 @@ public class DiscoveryNode implements Streamable, ToXContent {
         for (int i = 0; i < size; i++) {
             attributes.put(in.readString().intern(), in.readString().intern());
         }
-        this.attributes = attributes.build();
+        attributes = builder.build();
         version = Version.readVersion(in);
     }
 
@@ -414,7 +414,7 @@ public class DiscoveryNode implements Streamable, ToXContent {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(id(), XContentBuilder.FieldCaseConversion.NONE);
+        builder.startKeyedObject("id", id(), XContentBuilder.FieldCaseConversion.NONE, params);
         builder.field("name", name());
         builder.field("transport_address", address().toString());
 
@@ -424,7 +424,7 @@ public class DiscoveryNode implements Streamable, ToXContent {
         }
         builder.endObject();
 
-        builder.endObject();
+        builder.endKeyedObject(params);
         return builder;
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -357,7 +357,7 @@ public class DiscoveryNode implements Streamable, ToXContent {
         for (int i = 0; i < size; i++) {
             attributes.put(in.readString().intern(), in.readString().intern());
         }
-        attributes = builder.build();
+        this.attributes = attributes.build();
         version = Version.readVersion(in);
     }
 
@@ -414,7 +414,12 @@ public class DiscoveryNode implements Streamable, ToXContent {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startKeyedObject("id", id(), XContentBuilder.FieldCaseConversion.NONE, params);
+        if (builder.useNamesAsKeys(params)) {
+            builder.startObject(id(), XContentBuilder.FieldCaseConversion.NONE);
+        } else {
+            builder.startObject();
+            builder.field("id", id(), XContentBuilder.FieldCaseConversion.NONE);
+        }
         builder.field("name", name());
         builder.field("transport_address", address().toString());
 
@@ -424,7 +429,7 @@ public class DiscoveryNode implements Streamable, ToXContent {
         }
         builder.endObject();
 
-        builder.endKeyedObject(params);
+        builder.endObject();
         return builder;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -250,6 +250,61 @@ public final class XContentBuilder implements BytesStream, Releasable {
         return this;
     }
 
+    private boolean isKeyed(ToXContent.Params params) {
+        return params.paramAsBoolean("keyed", true);
+    }
+
+    public XContentBuilder startKeyedObjects(String name, ToXContent.Params params) throws IOException {
+        if (isKeyed(params)) {
+            startObject(name);
+        } else {
+            startArray(name);
+        }
+        return this;
+    }
+
+    public XContentBuilder endKeyedObjects(ToXContent.Params params) throws IOException {
+        if (isKeyed(params)) {
+            endObject();
+        } else {
+            endArray();
+        }
+        return this;
+    }
+
+    public XContentBuilder startKeyedObject(String key, String value, FieldCaseConversion conversion, ToXContent.Params params) throws IOException {
+        if (isKeyed(params)) {
+            startObject(value, conversion);
+        } else {
+            startObject();
+            field(key, value, conversion);
+        }
+        return this;
+    }
+
+    public XContentBuilder endKeyedObject(ToXContent.Params params) throws IOException {
+        endObject();
+        return this;
+    }
+
+    public XContentBuilder startKeyedArray(String key, String value, String array, FieldCaseConversion conversion, ToXContent.Params params) throws IOException {
+        if (isKeyed(params)) {
+            startArray(value, conversion);
+        } else {
+            startKeyedObject(key, value, conversion, params);
+            startArray(array);
+        }
+        return this;
+    }
+
+    public XContentBuilder endKeyedArray(ToXContent.Params params) throws IOException {
+        endArray();
+        if (isKeyed(params) == false) {
+            endKeyedObject(params);
+        }
+        return this;
+    }
+
     public XContentBuilder field(XContentBuilderString name) throws IOException {
         if (fieldCaseConversion == FieldCaseConversion.UNDERSCORE) {
             generator.writeFieldName(name.underscore());

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -19,11 +19,29 @@
 package org.elasticsearch.cluster;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ClusterStateTests extends ESTestCase {
@@ -49,5 +67,377 @@ public class ClusterStateTests extends ESTestCase {
         // state from the same master compare by version
         assertThat(withMaster1a.supersedes(withMaster1b), equalTo(withMaster1a.version() > withMaster1b.version()));
 
+    }
+
+    public void testToXContent() throws IOException {
+        ClusterState clusterState = newClusterState();
+        assertNotNull(clusterState);
+
+        ShardRouting testShard0 = clusterState.getRoutingTable().getIndicesRouting().get("test").shard(0).primaryShard();
+        assertNotNull(testShard0);
+
+        ShardRouting testShard1 = clusterState.getRoutingTable().getIndicesRouting().get("test").shard(1).primaryShard();
+        assertNotNull(testShard1);
+
+        for (ToXContent.Params params : Arrays.asList(ToXContent.EMPTY_PARAMS, toParams("keyed", Boolean.TRUE.toString()))) {
+            assertEquals("{\n" +
+                    "  \"version\" : 0,\n" +
+                    "  \"state_uuid\" : \"_dummy_state_uuid_\",\n" +
+                    "  \"master_node\" : \"_dummy_node_id_\",\n" +
+                    "  \"blocks\" : {\n" +
+                    // by default, global cluster blocks are placed as objects named with the block's id
+                    "    \"global\" : {\n" +
+                    "      \"2\" : {\n" +
+                    "        \"description\" : \"no master\",\n" +
+                    "        \"retryable\" : true,\n" +
+                    "        \"disable_state_persistence\" : true,\n" +
+                    "        \"levels\" : [ \"read\", \"write\", \"metadata_read\", \"metadata_write\" ]\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    // by default, index blocks are placed as objects named with the index's name
+                    "    \"indices\" : {\n" +
+                    "      \"test\" : {\n" +
+                    // and then each block is placed as an object named with the block's id
+                    "        \"8\" : {\n" +
+                    "          \"description\" : \"index write (api)\",\n" +
+                    "          \"retryable\" : false,\n" +
+                    "          \"levels\" : [ \"write\" ]\n" +
+                    "        },\n" +
+                    "        \"9\" : {\n" +
+                    "          \"description\" : \"index metadata (api)\",\n" +
+                    "          \"retryable\" : false,\n" +
+                    "          \"levels\" : [ \"metadata_read\", \"metadata_write\" ]\n" +
+                    "        }\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    // by default, nodes are placed as objects named with the node's id
+                    "  \"nodes\" : {\n" +
+                    "    \"_dummy_node_id_\" : {\n" +
+                    "      \"name\" : \"_dummy_node_\",\n" +
+                    "      \"transport_address\" : \"_dummy_addr_\",\n" +
+                    "      \"attributes\" : { }\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"metadata\" : {\n" +
+                    "    \"cluster_uuid\" : \"_dummy_cluster_uuid_\",\n" +
+                    // by default, templates are placed as objects named with the template's name
+                    "    \"templates\" : {\n" +
+                    "      \"foo\" : {\n" +
+                    "        \"template\" : \"bar\",\n" +
+                    "        \"order\" : 1,\n" +
+                    "        \"settings\" : {\n" +
+                    "          \"setting2\" : \"value2\",\n" +
+                    "          \"setting1\" : \"value1\"\n" +
+                    "        },\n" +
+                    "        \"mappings\" : { }\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    // by default, indices are placed as objects named with the index's name
+                    "    \"indices\" : {\n" +
+                    "      \"test\" : {\n" +
+                    "        \"state\" : \"open\",\n" +
+                    "        \"settings\" : {\n" +
+                    "          \"index\" : {\n" +
+                    "            \"creation_date\" : \"1\",\n" +
+                    "            \"number_of_shards\" : \"2\",\n" +
+                    "            \"number_of_replicas\" : \"0\",\n" +
+                    "            \"version\" : {\n" +
+                    "              \"created\" : \"1070099\"\n" +
+                    "            }\n" +
+                    "          }\n" +
+                    "        },\n" +
+                    "        \"mappings\" : { },\n" +
+                    "        \"aliases\" : [ ]\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"routing_table\" : {\n" +
+                    // same as above
+                    "    \"indices\" : {\n" +
+                    "      \"test\" : {\n" +
+                    "        \"shards\" : {\n" +
+                    "          \"1\" : [ {\n" +
+                    "            \"state\" : \"STARTED\",\n" +
+                    "            \"primary\" : true,\n" +
+                    "            \"node\" : \"_dummy_node_id_\",\n" +
+                    "            \"relocating_node\" : null,\n" +
+                    "            \"shard\" : 1,\n" +
+                    "            \"index\" : \"test\",\n" +
+                    "            \"version\" : 1,\n" +
+                    "            \"allocation_id\" : {\n" +
+                    "              \"id\" : \"" + testShard1.allocationId().getId() + "\"\n" +
+                    "            }\n" +
+                    "          } ],\n" +
+                    "          \"0\" : [ {\n" +
+                    "            \"state\" : \"STARTED\",\n" +
+                    "            \"primary\" : true,\n" +
+                    "            \"node\" : \"_dummy_node_id_\",\n" +
+                    "            \"relocating_node\" : null,\n" +
+                    "            \"shard\" : 0,\n" +
+                    "            \"index\" : \"test\",\n" +
+                    "            \"version\" : 1,\n" +
+                    "            \"allocation_id\" : {\n" +
+                    "              \"id\" : \"" + testShard0.allocationId().getId() + "\"\n" +
+                    "            }\n" +
+                    "          } ]\n" +
+                    "        }\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"routing_nodes\" : {\n" +
+                    "    \"unassigned\" : [ ],\n" +
+                    // by default, nodes are placed as objects named with the node's id
+                    "    \"nodes\" : {\n" +
+                    "      \"_dummy_node_id_\" : [ {\n" +
+                    "        \"state\" : \"STARTED\",\n" +
+                    "        \"primary\" : true,\n" +
+                    "        \"node\" : \"_dummy_node_id_\",\n" +
+                    "        \"relocating_node\" : null,\n" +
+                    "        \"shard\" : 1,\n" +
+                    "        \"index\" : \"test\",\n" +
+                    "        \"version\" : 1,\n" +
+                    "        \"allocation_id\" : {\n" +
+                    "          \"id\" : \"" + testShard1.allocationId().getId() + "\"\n" +
+                    "        }\n" +
+                    "      }, {\n" +
+                    "        \"state\" : \"STARTED\",\n" +
+                    "        \"primary\" : true,\n" +
+                    "        \"node\" : \"_dummy_node_id_\",\n" +
+                    "        \"relocating_node\" : null,\n" +
+                    "        \"shard\" : 0,\n" +
+                    "        \"index\" : \"test\",\n" +
+                    "        \"version\" : 1,\n" +
+                    "        \"allocation_id\" : {\n" +
+                    "          \"id\" : \"" + testShard0.allocationId().getId() + "\"\n" +
+                    "        }\n" +
+                    "      } ]\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}", buildClusterState(clusterState, params));
+        }
+    }
+
+    public void testToXContentWithKeyedSetToFalse() throws IOException {
+        ClusterState clusterState = newClusterState();
+        assertNotNull(clusterState);
+
+        ShardRouting testShard0 = clusterState.getRoutingTable().getIndicesRouting().get("test").shard(0).primaryShard();
+        assertNotNull(testShard0);
+
+        ShardRouting testShard1 = clusterState.getRoutingTable().getIndicesRouting().get("test").shard(1).primaryShard();
+        assertNotNull(testShard1);
+
+        assertEquals("{\n" +
+                "  \"version\" : 0,\n" +
+                "  \"state_uuid\" : \"_dummy_state_uuid_\",\n" +
+                "  \"master_node\" : \"_dummy_node_id_\",\n" +
+                "  \"blocks\" : {\n" +
+                // with keyed=false, the global cluster blocks are placed in an array of blocks,
+                // each block id is moved to a sub field "id"
+                "    \"global\" : [ {\n" +
+                "      \"id\" : \"2\",\n" +
+                "      \"description\" : \"no master\",\n" +
+                "      \"retryable\" : true,\n" +
+                "      \"disable_state_persistence\" : true,\n" +
+                "      \"levels\" : [ \"read\", \"write\", \"metadata_read\", \"metadata_write\" ]\n" +
+                "    } ],\n" +
+                "    \"indices\" : [ {\n" +
+                "      \"index\" : \"test\",\n" +
+                "      \"blocks\" : [ {\n" +
+                "        \"id\" : \"8\",\n" +
+                "        \"description\" : \"index write (api)\",\n" +
+                "        \"retryable\" : false,\n" +
+                "        \"levels\" : [ \"write\" ]\n" +
+                "      }, {\n" +
+                "        \"id\" : \"9\",\n" +
+                "        \"description\" : \"index metadata (api)\",\n" +
+                "        \"retryable\" : false,\n" +
+                "        \"levels\" : [ \"metadata_read\", \"metadata_write\" ]\n" +
+                "      } ]\n" +
+                "    } ]\n" +
+                "  },\n" +
+                // with keyed=false, the nodes are placed in an array,
+                // each node id is moved to a sub field "id"
+                "  \"nodes\" : [ {\n" +
+                "    \"id\" : \"_dummy_node_id_\",\n" +
+                "    \"name\" : \"_dummy_node_\",\n" +
+                "    \"transport_address\" : \"_dummy_addr_\",\n" +
+                "    \"attributes\" : { }\n" +
+                "  } ],\n" +
+                "  \"metadata\" : {\n" +
+                "    \"cluster_uuid\" : \"_dummy_cluster_uuid_\",\n" +
+                // with keyed=false, the templates are placed in an array,
+                // each template name is moved to a sub field "name"
+                "    \"templates\" : [ {\n" +
+                "      \"name\" : \"foo\",\n" +
+                "      \"template\" : \"bar\",\n" +
+                "      \"order\" : 1,\n" +
+                "      \"settings\" : {\n" +
+                "        \"setting2\" : \"value2\",\n" +
+                "        \"setting1\" : \"value1\"\n" +
+                "      },\n" +
+                "      \"mappings\" : { }\n" +
+                "    } ],\n" +
+                // with keyed=false, the indices are placed in an array,
+                // each index name is moved to a sub field "index"
+                "    \"indices\" : [ {\n" +
+                "      \"index\" : \"test\",\n" +
+                "      \"state\" : \"open\",\n" +
+                "      \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "          \"creation_date\" : \"1\",\n" +
+                "          \"number_of_shards\" : \"2\",\n" +
+                "          \"number_of_replicas\" : \"0\",\n" +
+                "          \"version\" : {\n" +
+                "            \"created\" : \"1070099\"\n" +
+                "          }\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"mappings\" : { },\n" +
+                "      \"aliases\" : [ ]\n" +
+                "    } ]\n" +
+                "  },\n" +
+                "  \"routing_table\" : {\n" +
+                // with keyed=false, the indices are placed in an array,
+                // each index name is moved to a sub field "index"
+                "    \"indices\" : [ {\n" +
+                "      \"index\" : \"test\",\n" +
+                // with keyed=false, the shards are placed in an array,
+                // each shard id is moved to a sub field "id"
+                "      \"shards\" : [ {\n" +
+                "        \"id\" : \"1\",\n" +
+                // same as above
+                "        \"shards\" : [ {\n" +
+                "          \"state\" : \"STARTED\",\n" +
+                "          \"primary\" : true,\n" +
+                "          \"node\" : \"_dummy_node_id_\",\n" +
+                "          \"relocating_node\" : null,\n" +
+                "          \"shard\" : 1,\n" +
+                "          \"index\" : \"test\",\n" +
+                "          \"version\" : 1,\n" +
+                "          \"allocation_id\" : {\n" +
+                "            \"id\" : \"" + testShard1.allocationId().getId() + "\"\n" +
+                "          }\n" +
+                "        } ]\n" +
+                "      }, {\n" +
+                "        \"id\" : \"0\",\n" +
+                "        \"shards\" : [ {\n" +
+                "          \"state\" : \"STARTED\",\n" +
+                "          \"primary\" : true,\n" +
+                "          \"node\" : \"_dummy_node_id_\",\n" +
+                "          \"relocating_node\" : null,\n" +
+                "          \"shard\" : 0,\n" +
+                "          \"index\" : \"test\",\n" +
+                "          \"version\" : 1,\n" +
+                "          \"allocation_id\" : {\n" +
+                "            \"id\" : \"" + testShard0.allocationId().getId() + "\"\n" +
+                "          }\n" +
+                "        } ]\n" +
+                "      } ]\n" +
+                "    } ]\n" +
+                "  },\n" +
+                "  \"routing_nodes\" : {\n" +
+                "    \"unassigned\" : [ ],\n" +
+                // with keyed=false, the nodes are placed in an array,
+                // each node id is moved to a sub field "id"
+                "    \"nodes\" : [ {\n" +
+                "      \"id\" : \"_dummy_node_id_\",\n" +
+                "      \"shards\" : [ {\n" +
+                "        \"state\" : \"STARTED\",\n" +
+                "        \"primary\" : true,\n" +
+                "        \"node\" : \"_dummy_node_id_\",\n" +
+                "        \"relocating_node\" : null,\n" +
+                "        \"shard\" : 1,\n" +
+                "        \"index\" : \"test\",\n" +
+                "        \"version\" : 1,\n" +
+                "        \"allocation_id\" : {\n" +
+                "          \"id\" : \"" + testShard1.allocationId().getId() + "\"\n" +
+                "        }\n" +
+                "      }, {\n" +
+                "        \"state\" : \"STARTED\",\n" +
+                "        \"primary\" : true,\n" +
+                "        \"node\" : \"_dummy_node_id_\",\n" +
+                "        \"relocating_node\" : null,\n" +
+                "        \"shard\" : 0,\n" +
+                "        \"index\" : \"test\",\n" +
+                "        \"version\" : 1,\n" +
+                "        \"allocation_id\" : {\n" +
+                "          \"id\" : \"" + testShard0.allocationId().getId() + "\"\n" +
+                "        }\n" +
+                "      } ]\n" +
+                "    } ]\n" +
+                "  }\n" +
+                "}", buildClusterState(clusterState, toParams("keyed", Boolean.FALSE.toString())));
+    }
+
+    /**
+     * Creates a fake ClusterState instance
+     *
+     * @return a fake ClusterState instance
+     */
+    private ClusterState newClusterState() {
+        DiscoveryNode node = new DiscoveryNode("_dummy_node_", "_dummy_node_id_", DummyTransportAddress.INSTANCE, emptyMap(), Version.CURRENT);
+        DiscoveryNodes nodes = DiscoveryNodes.builder().put(node).build();
+
+        MetaData metaData = MetaData.builder()
+                .clusterUUID("_dummy_cluster_uuid_")
+                .put(IndexMetaData.builder("test")
+                        .settings(settings(Version.V_1_7_0))
+                        .creationDate(1l)
+                        .numberOfShards(2)
+                        .numberOfReplicas(0))
+                .put(IndexTemplateMetaData.builder("foo")
+                                .template("bar")
+                                .order(1)
+                                .settings(settingsBuilder()
+                                                .put("setting1", "value1")
+                                                .put("setting2", "value2")
+                                )
+                ).build();
+
+        RoutingTable routingTable = RoutingTable.builder()
+                .add(IndexRoutingTable.builder("test")
+                                .addIndexShard(new IndexShardRoutingTable.Builder(new ShardId("test", 0))
+                                        .addShard(TestShardRouting.newShardRouting("test", 0, "_dummy_node_id_", null, null, true, ShardRoutingState.STARTED, 1))
+                                        .build())
+                                .addIndexShard(new IndexShardRoutingTable.Builder(new ShardId("test", 1))
+                                                .addShard(TestShardRouting.newShardRouting("test", 1, "_dummy_node_id_", null, null, true, ShardRoutingState.STARTED, 1))
+                                                .build()
+                                )
+                )
+                .build();
+
+        ClusterBlocks blocks = ClusterBlocks.builder()
+                .addGlobalBlock(DiscoverySettings.NO_MASTER_BLOCK_ALL)
+                .addIndexBlock("test", IndexMetaData.INDEX_METADATA_BLOCK)
+                .addIndexBlock("test", IndexMetaData.INDEX_WRITE_BLOCK)
+                .build();
+
+        return ClusterState.builder(ClusterName.DEFAULT)
+                .stateUUID("_dummy_state_uuid_")
+                .version(0)
+                .nodes(DiscoveryNodes.builder(nodes)
+                        .masterNodeId(node.id()))
+                .blocks(blocks)
+                .metaData(metaData)
+                .routingTable(routingTable)
+                .build();
+    }
+
+    private String buildClusterState(ClusterState clusterState, ToXContent.Params params) throws IOException {
+        assertNotNull(clusterState);
+        try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint()) {
+            builder.startObject();
+            clusterState.toXContent(builder, params);
+            builder.endObject();
+            return builder.string().trim();
+        }
+    }
+
+    private ToXContent.Params toParams(String key, String value) {
+        Map<String, String> params = new HashMap<>();
+        params.put(key, value);
+        return new ToXContent.MapParams(params);
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.node;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+public class DiscoveryNodeTests extends ESTestCase {
+
+    public void testToXContent() throws IOException {
+        for (ToXContent.Params params : Arrays.asList(null, ToXContent.EMPTY_PARAMS, toParams("keyed", Boolean.TRUE.toString()))) {
+            assertEquals("{\n" +
+                    "  \"nodes\" : {\n" +
+                    "    \"_dummy_id0_\" : {\n" +
+                    "      \"name\" : \"_dummy_name0_\",\n" +
+                    "      \"transport_address\" : \"_dummy_addr_\",\n" +
+                    "      \"attributes\" : { }\n" +
+                    "    },\n" +
+                    "    \"_dummy_id1_\" : {\n" +
+                    "      \"name\" : \"_dummy_name1_\",\n" +
+                    "      \"transport_address\" : \"_dummy_addr_\",\n" +
+                    "      \"attributes\" : { }\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}", buildNodes(params));
+        }
+    }
+
+    public void testToXContentWithKeyedSetToFalse() throws IOException {
+        // With keyed=false parameter, the nodes ids are moved to a sub field "id"
+        assertEquals("{\n" +
+                "  \"nodes\" : [ {\n" +
+                "    \"id\" : \"_dummy_id0_\",\n" +
+                "    \"name\" : \"_dummy_name0_\",\n" +
+                "    \"transport_address\" : \"_dummy_addr_\",\n" +
+                "    \"attributes\" : { }\n" +
+                "  }, {\n" +
+                "    \"id\" : \"_dummy_id1_\",\n" +
+                "    \"name\" : \"_dummy_name1_\",\n" +
+                "    \"transport_address\" : \"_dummy_addr_\",\n" +
+                "    \"attributes\" : { }\n" +
+                "  } ]\n" +
+                "}", buildNodes(toParams("keyed", Boolean.FALSE.toString())));
+    }
+
+    private String buildNodes(ToXContent.Params params) throws IOException {
+        try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint()) {
+            builder.startObject();
+            builder.start("nodes", params);
+            for (int i = 0; i < 2; i++) {
+                String name = "_dummy_name" + String.valueOf(i) + "_";
+                String id = "_dummy_id" + String.valueOf(i) + "_";
+                DiscoveryNode node = new DiscoveryNode(name, id, DummyTransportAddress.INSTANCE, emptyMap(), Version.CURRENT);
+                node.toXContent(builder, params);
+            }
+            builder.end(params);
+            builder.endObject();
+            return builder.string().trim();
+        }
+    }
+
+    private ToXContent.Params toParams(String key, String value) {
+        Map<String, String> params = new HashMap<>();
+        params.put(key, value);
+        return new ToXContent.MapParams(params);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common.xcontent.builder;
 
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.FastCharArrayWriter;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -31,6 +30,7 @@ import org.elasticsearch.common.xcontent.XContentGenerator;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -53,6 +53,7 @@ import static org.hamcrest.Matchers.equalTo;
  *
  */
 public class XContentBuilderTests extends ESTestCase {
+    
     public void testPrettyWithLfAtEnd() throws Exception {
         FastCharArrayWriter writer = new FastCharArrayWriter();
         XContentGenerator generator = XContentFactory.xContent(XContentType.JSON).createGenerator(writer);
@@ -347,4 +348,53 @@ public class XContentBuilderTests extends ESTestCase {
                 "}", string.trim());
     }
 
+    private String buildSampleKeyedObject(ToXContent.Params params) throws IOException {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        builder.startObject()
+                    .startKeyedObjects("ids", params)
+                        .startKeyedObject("id", "A9rCgJ0nQnGS5cPCQ5VOKA", XContentBuilder.FieldCaseConversion.NONE, params)
+                            .field("test", "value")
+                        .endKeyedObject(params)
+                    .endKeyedObjects(params)
+                .endObject();
+        return builder.string();
+    }
+
+    private String buildSampleKeyedArray(ToXContent.Params params) throws IOException {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        builder.startObject()
+                    .startKeyedObjects("names", params)
+                        .startKeyedArray("name", "4uT7lJ2GRBuQI7Nq6odX5A", "numbers", XContentBuilder.FieldCaseConversion.NONE, params)
+                            .value(0)
+                            .value(1)
+                        .endKeyedArray(params)
+                        .startKeyedArray("name", "jvJMRG0_TKCShW_keZw1Dw", "numbers", XContentBuilder.FieldCaseConversion.NONE, params)
+                            .value(2)
+                            .value(3)
+                        .endKeyedArray(params)
+                    .endKeyedObjects(params)
+                .endObject();
+        return builder.string();
+    }
+
+    @Test
+    public void testKeyedParameter() throws IOException {
+        // Test with default value for keyed parameter
+        assertThat(buildSampleKeyedObject(ToXContent.EMPTY_PARAMS), equalTo("{\"ids\":{\"A9rCgJ0nQnGS5cPCQ5VOKA\":{\"test\":\"value\"}}}"));
+        assertThat(buildSampleKeyedArray(ToXContent.EMPTY_PARAMS), equalTo("{\"names\":{\"4uT7lJ2GRBuQI7Nq6odX5A\":[0,1],\"jvJMRG0_TKCShW_keZw1Dw\":[2,3]}}"));
+
+        // Test with keyed=true
+        Map<String, String> keyed = new HashMap<>();
+        keyed.put("keyed", Boolean.TRUE.toString());
+        ToXContent.Params params = new ToXContent.MapParams(keyed);
+        assertThat(buildSampleKeyedObject(params), equalTo("{\"ids\":{\"A9rCgJ0nQnGS5cPCQ5VOKA\":{\"test\":\"value\"}}}"));
+        assertThat(buildSampleKeyedArray(params), equalTo("{\"names\":{\"4uT7lJ2GRBuQI7Nq6odX5A\":[0,1],\"jvJMRG0_TKCShW_keZw1Dw\":[2,3]}}"));
+
+        // Test with keyed=false
+        keyed = new HashMap<>();
+        keyed.put("keyed", Boolean.FALSE.toString());
+        params = new ToXContent.MapParams(keyed);
+        assertThat(buildSampleKeyedObject(params), equalTo("{\"ids\":[{\"id\":\"A9rCgJ0nQnGS5cPCQ5VOKA\",\"test\":\"value\"}]}"));
+        assertThat(buildSampleKeyedArray(params), equalTo("{\"names\":[{\"name\":\"4uT7lJ2GRBuQI7Nq6odX5A\",\"numbers\":[0,1]},{\"name\":\"jvJMRG0_TKCShW_keZw1Dw\",\"numbers\":[2,3]}]}"));
+    }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -46,6 +46,10 @@
           "options" : ["open","closed","none","all"],
           "default" : "open",
           "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        },
+        "keyed": {
+          "type" : "boolean",
+          "description" : "Whether nodes and indices information are keyed by id (default: true) or denormalized in a sub field"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/40_keyed_parameter.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/40_keyed_parameter.yaml
@@ -1,0 +1,34 @@
+setup:
+  - do:
+      index:
+        index: testidx
+        type:  testtype
+        id:    testing_document
+        body:
+            "text" : "The quick brown fox is brown."
+  - do:
+      indices.refresh: {}
+
+---
+"Cluster state with keyed parameter set to true":
+  - do:
+      cluster.state:
+        keyed: true
+
+  - set: {master_node: node_id}
+
+  - is_true: nodes.$node_id
+  - is_true: metadata.indices.testidx
+  - is_true: routing_table.indices.testidx
+
+---
+"Cluster state with keyed parameter set to false":
+  - do:
+      cluster.state:
+        keyed: false
+
+  - set: {master_node: node_id}
+
+  - is_true: nodes.0.id
+  - match: {metadata.indices.0.index: "testidx"}
+  - match: {routing_table.indices.0.index: "testidx"}


### PR DESCRIPTION
This pull request adds the `keyed` parameter to the Cluster State API. When set to `false`, this parameter will denormalize some information (like `nodes` or `indices` fields) so that they are no more keyed by node id or index name but encapsulated in an object with a node id or index name sub field.

Here is an example (truncated for brevity) when `keyed=true` (the default behavior):

``` json
{
  "cluster_name" : "Idea",
  "nodes" : {
    "KoOu7TkgSz6oXRwGs21m2Q" : {
      "name" : "Battlestar",
    }
  },
  "metadata" : {
    "indices" : {
      "my_index" : {
        "state" : "open"
      },
      "my_other_index" : {
        "state" : "open"
      }
  }
}
```

and when `keyed=false`:

``` json
{
  "cluster_name" : "Idea",
 "nodes" : [ {
    "id" : "KoOu7TkgSz6oXRwGs21m2Q",
    "name" : "Battlestar"
  } ],
 "metadata" : {
    "indices" : [ {
      "index" : "my_index",
      "state" : "open"
    },{
      "index" : "my_other_index",
      "state" : "open"
  }]
}
```
