### PR TITLE
Update to randomizedtesting 2.1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,7 @@
         <lucene.version>5.4.0</lucene.version>
         <lucene.snapshot.revision>1702855</lucene.snapshot.revision>
         <lucene.maven.version>5.4.0-snapshot-${lucene.snapshot.revision}</lucene.maven.version>
-        <!-- we are using a snapshot of randomizedtesting with this PR:
-             https://github.com/randomizedtesting/randomizedtesting/pull/202
-             This allows us to only give the test-framework jars dangerous permissions and not
-             all of our code/test code. It is temporary while Dawid is on vacation. -->
-        <testframework.snapshot.revision>pr202</testframework.snapshot.revision>
-        <testframework.version>2.2.0-snapshot-${testframework.snapshot.revision}</testframework.version>
+        <testframework.version>2.1.17</testframework.version>
         <jackson.version>2.5.3</jackson.version>
         <slf4j.version>1.6.2</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
@@ -151,18 +146,7 @@
             <id>Lucene snapshots</id>
             <url>https://download.elasticsearch.org/lucenesnapshots/${lucene.snapshot.revision}</url>
         </repository>
-        <repository>
-            <id>Randomized Runner snapshot</id>
-            <url>https://download.elasticsearch.org/lucenesnapshots/rr-${testframework.snapshot.revision}</url>
-        </repository>
     </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>Randomized Runner snapshot</id>
-            <url>https://download.elasticsearch.org/lucenesnapshots/rr-${testframework.snapshot.revision}</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
See changes: https://github.com/randomizedtesting/randomizedtesting/releases/tag/release%2F2.1.17

We can move off our snapshot copy now.
