### PR TITLE
LoggingRunnable.run should catch and log all errors, not just Exception?

### DIFF
--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -511,8 +511,8 @@ public class ThreadPool extends AbstractComponent {
         public void run() {
             try {
                 runnable.run();
-            } catch (Exception e) {
-                logger.warn("failed to run {}", e, runnable.toString());
+            } catch (Throwable t) {
+                logger.warn("failed to run {}", t, runnable.toString());
             }
         }
 


### PR DESCRIPTION
Still digging on https://github.com/elastic/elasticsearch/issues/13487 ... and I think it's unlikely this is the cause ...

`ThreadPool.scheduleWithFixedDelay` wraps the incoming command with a `LoggingRunnable` which runs the command, but catching, suppressing and logging any exceptions.  This is important because the JDK's `ScheduledThreadPoolExecutor.schedulWithFixedDelay` will stop executing the task if an unhandled exception is hit.

But it only catches `Exception` ... I think maybe it should instead catch `Throwable`, so that e.g. `AssertionError` is also logged?

It's remotely possible this test failure is happening because some bad exception (subclassing Error) was hit and the thread is no longer checking for inactive indices ... but then I think the JDK would have sent that exception to stderr, so this is probably not it.
