### PR TITLE
Remove and ban ImmutableMap#entrySet

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -42,9 +42,8 @@ import java.util.Map;
  * Node information (static, does not change over time).
  */
 public class NodeInfo extends BaseNodeResponse {
-
     @Nullable
-    private ImmutableMap<String, String> serviceAttributes;
+    private Map<String, String> serviceAttributes;
 
     private Version version;
     private Build build;
@@ -119,7 +118,7 @@ public class NodeInfo extends BaseNodeResponse {
      * The service attributes of the node.
      */
     @Nullable
-    public ImmutableMap<String, String> getServiceAttributes() {
+    public Map<String, String> getServiceAttributes() {
         return this.serviceAttributes;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -157,7 +157,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
                         // We should have information about this shard from the shard:
                         TransportNodesSnapshotsStatus.NodeSnapshotStatus nodeStatus = nodeSnapshotStatusMap.get(status.nodeId());
                         if (nodeStatus != null) {
-                            ImmutableMap<ShardId, SnapshotIndexShardStatus> shardStatues = nodeStatus.status().get(entry.snapshotId());
+                            Map<ShardId, SnapshotIndexShardStatus> shardStatues = nodeStatus.status().get(entry.snapshotId());
                             if (shardStatues != null) {
                                 SnapshotIndexShardStatus shardStatus = shardStatues.get(shardEntry.getKey());
                                 if (shardStatus != null) {
@@ -204,7 +204,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
                     Snapshot snapshot = snapshotsService.snapshot(snapshotId);
                     List<SnapshotIndexShardStatus> shardStatusBuilder = new ArrayList<>();
                     if (snapshot.state().completed()) {
-                        ImmutableMap<ShardId, IndexShardSnapshotStatus> shardStatues = snapshotsService.snapshotShards(snapshotId);
+                        Map<ShardId, IndexShardSnapshotStatus> shardStatues = snapshotsService.snapshotShards(snapshotId);
                         for (ImmutableMap.Entry<ShardId, IndexShardSnapshotStatus> shardStatus : shardStatues.entrySet()) {
                             shardStatusBuilder.add(new SnapshotIndexShardStatus(shardStatus.getKey(), shardStatus.getValue()));
                         }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.mapping.get;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -31,14 +32,17 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.mapper.Mapper;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
 
 /** Response object for {@link GetFieldMappingsRequest} API */
 public class GetFieldMappingsResponse extends ActionResponse implements ToXContent {
 
-    private ImmutableMap<String, ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>>> mappings = ImmutableMap.of();
+    private Map<String, Map<String, Map<String, FieldMappingMetaData>>> mappings = ImmutableMap.of();
 
-    GetFieldMappingsResponse(ImmutableMap<String, ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>>> mappings) {
+    GetFieldMappingsResponse(Map<String, Map<String, Map<String, FieldMappingMetaData>>> mappings) {
         this.mappings = mappings;
     }
 
@@ -46,7 +50,7 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
     }
 
     /** returns the retrieved field mapping. The return map keys are index, type, field (as specified in the request). */
-    public ImmutableMap<String, ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>>> mappings() {
+    public Map<String, Map<String, Map<String, FieldMappingMetaData>>> mappings() {
         return mappings;
     }
 
@@ -57,11 +61,11 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
      * @return FieldMappingMetaData for the requested field or null if not found.
      */
     public FieldMappingMetaData fieldMappings(String index, String type, String field) {
-        ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>> indexMapping = mappings.get(index);
+        Map<String, Map<String, FieldMappingMetaData>> indexMapping = mappings.get(index);
         if (indexMapping == null) {
             return null;
         }
-        ImmutableMap<String, FieldMappingMetaData> typeMapping = indexMapping.get(type);
+        Map<String, FieldMappingMetaData> typeMapping = indexMapping.get(type);
         if (typeMapping == null) {
             return null;
         }
@@ -70,10 +74,10 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        for (Map.Entry<String, ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>>> indexEntry : mappings.entrySet()) {
+        for (Map.Entry<String, Map<String, Map<String, FieldMappingMetaData>>> indexEntry : mappings.entrySet()) {
             builder.startObject(indexEntry.getKey(), XContentBuilder.FieldCaseConversion.NONE);
             builder.startObject("mappings");
-            for (Map.Entry<String, ImmutableMap<String, FieldMappingMetaData>> typeEntry : indexEntry.getValue().entrySet()) {
+            for (Map.Entry<String, Map<String, FieldMappingMetaData>> typeEntry : indexEntry.getValue().entrySet()) {
                 builder.startObject(typeEntry.getKey(), XContentBuilder.FieldCaseConversion.NONE);
                 for (Map.Entry<String, FieldMappingMetaData> fieldEntry : typeEntry.getValue().entrySet()) {
                     builder.startObject(fieldEntry.getKey());
@@ -128,33 +132,33 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         int size = in.readVInt();
-        ImmutableMap.Builder<String, ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>>> indexMapBuilder = ImmutableMap.builder();
+        Map<String, Map<String, Map<String, FieldMappingMetaData>>> indexMapBuilder = new HashMap<>(size);
         for (int i = 0; i < size; i++) {
             String index = in.readString();
             int typesSize = in.readVInt();
-            ImmutableMap.Builder<String, ImmutableMap<String, FieldMappingMetaData>> typeMapBuilder = ImmutableMap.builder();
+            Map<String, Map<String, FieldMappingMetaData>> typeMapBuilder = new HashMap<>(typesSize);
             for (int j = 0; j < typesSize; j++) {
                 String type = in.readString();
-                ImmutableMap.Builder<String, FieldMappingMetaData> fieldMapBuilder = ImmutableMap.builder();
                 int fieldSize = in.readVInt();
+                Map<String, FieldMappingMetaData> fieldMapBuilder = new HashMap<>(fieldSize);
                 for (int k = 0; k < fieldSize; k++) {
                     fieldMapBuilder.put(in.readString(), new FieldMappingMetaData(in.readString(), in.readBytesReference()));
                 }
-                typeMapBuilder.put(type, fieldMapBuilder.build());
+                typeMapBuilder.put(type, unmodifiableMap(fieldMapBuilder));
             }
-            indexMapBuilder.put(index, typeMapBuilder.build());
+            indexMapBuilder.put(index, unmodifiableMap(typeMapBuilder));
         }
-        mappings = indexMapBuilder.build();
+        mappings = unmodifiableMap(indexMapBuilder);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeVInt(mappings.size());
-        for (Map.Entry<String, ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>>> indexEntry : mappings.entrySet()) {
+        for (Map.Entry<String, Map<String, Map<String, FieldMappingMetaData>>> indexEntry : mappings.entrySet()) {
             out.writeString(indexEntry.getKey());
             out.writeVInt(indexEntry.getValue().size());
-            for (Map.Entry<String, ImmutableMap<String, FieldMappingMetaData>> typeEntry : indexEntry.getValue().entrySet()) {
+            for (Map.Entry<String, Map<String, FieldMappingMetaData>> typeEntry : indexEntry.getValue().entrySet()) {
                 out.writeString(typeEntry.getKey());
                 out.writeVInt(typeEntry.getValue().size());
                 for (Map.Entry<String, FieldMappingMetaData> fieldEntry : typeEntry.getValue().entrySet()) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.indices.mapping.get;
 
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -32,6 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -88,7 +88,7 @@ public class TransportGetFieldMappingsAction extends HandledTransportAction<GetF
     }
 
     private GetFieldMappingsResponse merge(AtomicReferenceArray<Object> indexResponses) {
-        MapBuilder<String, ImmutableMap<String, ImmutableMap<String, GetFieldMappingsResponse.FieldMappingMetaData>>> mergedResponses = MapBuilder.newMapBuilder();
+        MapBuilder<String, Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetaData>>> mergedResponses = MapBuilder.newMapBuilder();
         for (int i = 0; i < indexResponses.length(); i++) {
             Object element = indexResponses.get(i);
             if (element instanceof GetFieldMappingsResponse) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.mapping.get;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
 import org.elasticsearch.action.support.ActionFilters;
@@ -52,6 +53,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.util.CollectionUtils.newLinkedList;
@@ -105,7 +107,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
             }
         }
 
-        MapBuilder<String, ImmutableMap<String, FieldMappingMetaData>> typeMappings = new MapBuilder<>();
+        MapBuilder<String, Map<String, FieldMappingMetaData>> typeMappings = new MapBuilder<>();
         for (String type : typeIntersection) {
             DocumentMapper documentMapper = indexService.mapperService().documentMapper(type);
             ImmutableMap<String, FieldMappingMetaData> fieldMapping = findFieldMappingsByType(documentMapper, request);

--- a/core/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
@@ -112,7 +112,7 @@ public class RestoreInProgress extends AbstractDiffable<Custom> implements Custo
     public static class Entry {
         private final State state;
         private final SnapshotId snapshotId;
-        private final ImmutableMap<ShardId, ShardRestoreStatus> shards;
+        private final Map<ShardId, ShardRestoreStatus> shards;
         private final List<String> indices;
 
         /**
@@ -148,7 +148,7 @@ public class RestoreInProgress extends AbstractDiffable<Custom> implements Custo
          *
          * @return list of shards
          */
-        public ImmutableMap<ShardId, ShardRestoreStatus> shards() {
+        public Map<ShardId, ShardRestoreStatus> shards() {
             return this.shards;
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.unmodifiableMap;
+
 /**
  * Meta data about snapshots that are currently executing
  */
@@ -67,12 +69,12 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
         private final State state;
         private final SnapshotId snapshotId;
         private final boolean includeGlobalState;
-        private final ImmutableMap<ShardId, ShardSnapshotStatus> shards;
+        private final Map<ShardId, ShardSnapshotStatus> shards;
         private final List<String> indices;
-        private final ImmutableMap<String, List<ShardId>> waitingIndices;
+        private final Map<String, List<ShardId>> waitingIndices;
         private final long startTime;
 
-        public Entry(SnapshotId snapshotId, boolean includeGlobalState, State state, List<String> indices, long startTime, ImmutableMap<ShardId, ShardSnapshotStatus> shards) {
+        public Entry(SnapshotId snapshotId, boolean includeGlobalState, State state, List<String> indices, long startTime, Map<ShardId, ShardSnapshotStatus> shards) {
             this.state = state;
             this.snapshotId = snapshotId;
             this.includeGlobalState = includeGlobalState;
@@ -82,16 +84,16 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
                 this.shards = ImmutableMap.of();
                 this.waitingIndices = ImmutableMap.of();
             } else {
-                this.shards = shards;
+                this.shards = unmodifiableMap(shards);
                 this.waitingIndices = findWaitingIndices(shards);
             }
         }
 
-        public Entry(Entry entry, State state, ImmutableMap<ShardId, ShardSnapshotStatus> shards) {
+        public Entry(Entry entry, State state, Map<ShardId, ShardSnapshotStatus> shards) {
             this(entry.snapshotId, entry.includeGlobalState, state, entry.indices, entry.startTime, shards);
         }
 
-        public Entry(Entry entry, ImmutableMap<ShardId, ShardSnapshotStatus> shards) {
+        public Entry(Entry entry, Map<ShardId, ShardSnapshotStatus> shards) {
             this(entry, entry.state, shards);
         }
 
@@ -99,7 +101,7 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
             return this.snapshotId;
         }
 
-        public ImmutableMap<ShardId, ShardSnapshotStatus> shards() {
+        public Map<ShardId, ShardSnapshotStatus> shards() {
             return this.shards;
         }
 
@@ -111,7 +113,7 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
             return indices;
         }
 
-        public ImmutableMap<String, List<ShardId>> waitingIndices() {
+        public Map<String, List<ShardId>> waitingIndices() {
             return waitingIndices;
         }
 
@@ -153,7 +155,7 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
             return result;
         }
 
-        private ImmutableMap<String, List<ShardId>> findWaitingIndices(ImmutableMap<ShardId, ShardSnapshotStatus> shards) {
+        private ImmutableMap<String, List<ShardId>> findWaitingIndices(Map<ShardId, ShardSnapshotStatus> shards) {
             Map<String, List<ShardId>> waitingIndicesMap = new HashMap<>();
             for (ImmutableMap.Entry<ShardId, ShardSnapshotStatus> entry : shards.entrySet()) {
                 if (entry.getValue().state() == State.WAITING) {

--- a/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -45,11 +45,11 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
 
     private final ImmutableSet<ClusterBlock> global;
 
-    private final ImmutableMap<String, ImmutableSet<ClusterBlock>> indicesBlocks;
+    private final Map<String, ImmutableSet<ClusterBlock>> indicesBlocks;
 
     private final ImmutableLevelHolder[] levelHolders;
 
-    ClusterBlocks(ImmutableSet<ClusterBlock> global, ImmutableMap<String, ImmutableSet<ClusterBlock>> indicesBlocks) {
+    ClusterBlocks(ImmutableSet<ClusterBlock> global, Map<String, ImmutableSet<ClusterBlock>> indicesBlocks) {
         this.global = global;
         this.indicesBlocks = indicesBlocks;
 
@@ -83,7 +83,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
         return global;
     }
 
-    public ImmutableMap<String, ImmutableSet<ClusterBlock>> indices() {
+    public Map<String, ImmutableSet<ClusterBlock>> indices() {
         return indicesBlocks;
     }
 
@@ -91,7 +91,7 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
         return levelHolders[level.id()].global();
     }
 
-    public ImmutableMap<String, ImmutableSet<ClusterBlock>> indices(ClusterBlockLevel level) {
+    public Map<String, ImmutableSet<ClusterBlock>> indices(ClusterBlockLevel level) {
         return levelHolders[level.id()].indices();
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -100,7 +100,7 @@ public class DiscoveryNode implements Streamable, ToXContent {
     private String hostName;
     private String hostAddress;
     private TransportAddress address;
-    private ImmutableMap<String, String> attributes;
+    private Map<String, String> attributes;
     private Version version = Version.CURRENT;
 
     DiscoveryNode() {
@@ -120,7 +120,7 @@ public class DiscoveryNode implements Streamable, ToXContent {
      * @param version the version of the node.
      */
     public DiscoveryNode(String nodeId, TransportAddress address, Version version) {
-        this("", nodeId, address, ImmutableMap.<String, String>of(), version);
+        this("", nodeId, address, Collections.emptyMap(), version);
     }
 
     /**
@@ -230,14 +230,14 @@ public class DiscoveryNode implements Streamable, ToXContent {
     /**
      * The node attributes.
      */
-    public ImmutableMap<String, String> attributes() {
+    public Map<String, String> attributes() {
         return this.attributes;
     }
 
     /**
      * The node attributes.
      */
-    public ImmutableMap<String, String> getAttributes() {
+    public Map<String, String> getAttributes() {
         return attributes();
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.routing;
 
 import com.carrotsearch.hppc.IntSet;
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.Diffable;
 import org.elasticsearch.cluster.DiffableUtils;
@@ -32,8 +33,15 @@ import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.index.IndexNotFoundException;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
+
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * Represents a global cluster-wide routing table for all indices including the
@@ -50,11 +58,11 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
     private final long version;
 
     // index to IndexRoutingTable map
-    private final ImmutableMap<String, IndexRoutingTable> indicesRouting;
+    private final Map<String, IndexRoutingTable> indicesRouting;
 
     RoutingTable(long version, Map<String, IndexRoutingTable> indicesRouting) {
         this.version = version;
-        this.indicesRouting = ImmutableMap.copyOf(indicesRouting);
+        this.indicesRouting = unmodifiableMap(indicesRouting);
     }
 
     /**
@@ -304,7 +312,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
 
         private final long version;
 
-        private final Diff<ImmutableMap<String, IndexRoutingTable>> indicesRouting;
+        private final Diff<Map<String, IndexRoutingTable>> indicesRouting;
 
         public RoutingTableDiff(RoutingTable before, RoutingTable after) {
             version = after.version;
@@ -313,7 +321,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
 
         public RoutingTableDiff(StreamInput in) throws IOException {
             version = in.readLong();
-            indicesRouting = DiffableUtils.readImmutableMapDiff(in, IndexRoutingTable.PROTO);
+            indicesRouting = DiffableUtils.readJdkMapDiff(in, IndexRoutingTable.PROTO);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/PrivateElementsImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/PrivateElementsImpl.java
@@ -51,7 +51,7 @@ public final class PrivateElementsImpl implements PrivateElements {
     /**
      * lazily instantiated
      */
-    private ImmutableMap<Key<?>, Object> exposedKeysToSources;
+    private Map<Key<?>, Object> exposedKeysToSources;
     private Injector injector;
 
     public PrivateElementsImpl(Object source) {

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -49,8 +49,8 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
     public static final BlobStoreIndexShardSnapshots PROTO = new BlobStoreIndexShardSnapshots();
 
     private final List<SnapshotFiles> shardSnapshots;
-    private final ImmutableMap<String, FileInfo> files;
-    private final ImmutableMap<String, List<FileInfo>> physicalFiles;
+    private final Map<String, FileInfo> files;
+    private final Map<String, List<FileInfo>> physicalFiles;
 
     public BlobStoreIndexShardSnapshots(List<SnapshotFiles> shardSnapshots) {
         this.shardSnapshots = Collections.unmodifiableList(new ArrayList<>(shardSnapshots));
@@ -108,8 +108,8 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
 
     private BlobStoreIndexShardSnapshots() {
         shardSnapshots = Collections.emptyList();
-        files = ImmutableMap.of();
-        physicalFiles = ImmutableMap.of();
+        files = Collections.emptyMap();
+        physicalFiles = Collections.emptyMap();
     }
 
 

--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -737,7 +737,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
         public static final MetadataSnapshot EMPTY = new MetadataSnapshot();
 
-        private final ImmutableMap<String, String> commitUserData;
+        private final Map<String, String> commitUserData;
 
         private final long numDocs;
 

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/DeadlockAnalyzer.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/DeadlockAnalyzer.java
@@ -70,7 +70,7 @@ public class DeadlockAnalyzer {
     }
 
 
-    private Set<LinkedHashSet<ThreadInfo>> calculateCycles(ImmutableMap<Long, ThreadInfo> threadInfoMap) {
+    private Set<LinkedHashSet<ThreadInfo>> calculateCycles(Map<Long, ThreadInfo> threadInfoMap) {
         Set<LinkedHashSet<ThreadInfo>> cycles = new HashSet<>();
         for (Map.Entry<Long, ThreadInfo> entry : threadInfoMap.entrySet()) {
             LinkedHashSet<ThreadInfo> cycle = new LinkedHashSet<>();

--- a/core/src/main/java/org/elasticsearch/node/service/NodeService.java
+++ b/core/src/main/java/org/elasticsearch/node/service/NodeService.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.node.service;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
@@ -41,6 +42,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  */
@@ -101,7 +103,7 @@ public class NodeService extends AbstractComponent {
     /**
      * Attributes different services in the node can add to be reported as part of the node info (for example).
      */
-    public ImmutableMap<String, String> attributes() {
+    public Map<String, String> attributes() {
         return this.serviceAttributes;
     }
 

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -58,7 +58,7 @@ public class RepositoriesService extends AbstractComponent implements ClusterSta
 
     private final VerifyNodeRepositoryAction verifyAction;
 
-    private volatile ImmutableMap<String, RepositoryHolder> repositories = ImmutableMap.of();
+    private volatile Map<String, RepositoryHolder> repositories = ImmutableMap.of();
 
     @Inject
     public RepositoriesService(Settings settings, ClusterService clusterService, TransportService transportService, RepositoryTypesRegistry typesRegistry, Injector injector) {

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.admin.indices.mapping.get;
 
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
@@ -29,7 +28,13 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
 
 import java.io.IOException;
@@ -64,11 +69,9 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
         getMappingsRequest.indicesOptions(IndicesOptions.fromRequest(request, getMappingsRequest.indicesOptions()));
         getMappingsRequest.local(request.paramAsBoolean("local", getMappingsRequest.local()));
         client.admin().indices().getFieldMappings(getMappingsRequest, new RestBuilderListener<GetFieldMappingsResponse>(channel) {
-
-            @SuppressWarnings("unchecked")
             @Override
             public RestResponse buildResponse(GetFieldMappingsResponse response, XContentBuilder builder) throws Exception {
-                ImmutableMap<String, ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>>> mappingsByIndex = response.mappings();
+                Map<String, Map<String, Map<String, FieldMappingMetaData>>> mappingsByIndex = response.mappings();
 
                 boolean isPossibleSingleFieldRequest = indices.length == 1 && types.length == 1 && fields.length == 1;
                 if (isPossibleSingleFieldRequest && isFieldMappingMissingField(mappingsByIndex)) {
@@ -91,13 +94,13 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
      * Helper method to find out if the only included fieldmapping metadata is typed NULL, which means
      * that type and index exist, but the field did not
      */
-    private boolean isFieldMappingMissingField(ImmutableMap<String, ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>>> mappingsByIndex) throws IOException {
+    private boolean isFieldMappingMissingField(Map<String, Map<String, Map<String, FieldMappingMetaData>>> mappingsByIndex) throws IOException {
         if (mappingsByIndex.size() != 1) {
             return false;
         }
 
-        for (ImmutableMap<String, ImmutableMap<String, FieldMappingMetaData>> value : mappingsByIndex.values()) {
-            for (ImmutableMap<String, FieldMappingMetaData> fieldValue : value.values()) {
+        for (Map<String, Map<String, FieldMappingMetaData>> value : mappingsByIndex.values()) {
+            for (Map<String, FieldMappingMetaData> fieldValue : value.values()) {
                 for (Map.Entry<String, FieldMappingMetaData> fieldMappingMetaDataEntry : fieldValue.entrySet()) {
                     if (fieldMappingMetaDataEntry.getValue().isNull()) {
                         return true;

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
@@ -18,7 +18,6 @@
  */
 
 package org.elasticsearch.rest.action.cat;
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -34,10 +33,15 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
+
+import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -107,7 +111,7 @@ public class RestNodeAttrsAction extends AbstractCatAction {
 
         for (DiscoveryNode node : nodes) {
             NodeInfo info = nodesInfo.getNodesMap().get(node.id());
-            ImmutableMap<String, String> attrs = node.getAttributes();
+            Map<String, String> attrs = node.getAttributes();
             for(String att : attrs.keySet()) {
                 table.startRow();
                 table.addCell(node.name());

--- a/core/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
@@ -79,7 +79,7 @@ public class MatchedQueriesFetchSubPhase implements FetchSubPhase {
         hitContext.hit().matchedQueries(matchedQueries.toArray(new String[matchedQueries.size()]));
     }
 
-    private void addMatchedQueries(HitContext hitContext, ImmutableMap<String, Query> namedQueries, List<String> matchedQueries) throws IOException {
+    private void addMatchedQueries(HitContext hitContext, Map<String, Query> namedQueries, List<String> matchedQueries) throws IOException {
         for (Map.Entry<String, Query> entry : namedQueries.entrySet()) {
             String name = entry.getKey();
             Query filter = entry.getValue();

--- a/core/src/main/java/org/elasticsearch/search/lookup/LeafSearchLookup.java
+++ b/core/src/main/java/org/elasticsearch/search/lookup/LeafSearchLookup.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.search.lookup;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.apache.lucene.index.LeafReaderContext;
 
+import java.util.HashMap;
 import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * Per-segment version of {@link SearchLookup}.
@@ -35,7 +36,7 @@ public class LeafSearchLookup {
     final SourceLookup sourceLookup;
     final LeafFieldsLookup fieldsLookup;
     final LeafIndexLookup indexLookup;
-    final ImmutableMap<String, Object> asMap;
+    final Map<String, Object> asMap;
 
     public LeafSearchLookup(LeafReaderContext ctx, LeafDocLookup docMap, SourceLookup sourceLookup,
             LeafFieldsLookup fieldsLookup, LeafIndexLookup indexLookup, Map<String, Object> topLevelMap) {
@@ -45,17 +46,17 @@ public class LeafSearchLookup {
         this.fieldsLookup = fieldsLookup;
         this.indexLookup = indexLookup;
 
-        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
-        builder.putAll(topLevelMap);
-        builder.put("doc", docMap);
-        builder.put("_doc", docMap);
-        builder.put("_source", sourceLookup);
-        builder.put("_fields", fieldsLookup);
-        builder.put("_index", indexLookup);
-        asMap = builder.build();
+        Map<String, Object> asMap = new HashMap<>(topLevelMap.size() + 5);
+        asMap.putAll(topLevelMap);
+        asMap.put("doc", docMap);
+        asMap.put("_doc", docMap);
+        asMap.put("_source", sourceLookup);
+        asMap.put("_fields", fieldsLookup);
+        asMap.put("_index", indexLookup);
+        this.asMap = unmodifiableMap(asMap);
     }
 
-    public ImmutableMap<String, Object> asMap() {
+    public Map<String, Object> asMap() {
         return this.asMap;
     }
 

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -91,7 +91,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent<SnapshotSh
 
     private final Condition shutdownCondition = shutdownLock.newCondition();
 
-    private volatile ImmutableMap<SnapshotId, SnapshotShards> shardSnapshots = ImmutableMap.of();
+    private volatile Map<SnapshotId, SnapshotShards> shardSnapshots = ImmutableMap.of();
 
     private final BlockingQueue<UpdateIndexShardSnapshotStatusRequest> updatedSnapshotStateQueue = ConcurrentCollections.newBlockingQueue();
 
@@ -368,7 +368,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent<SnapshotSh
             if (snapshot.state() == SnapshotsInProgress.State.STARTED || snapshot.state() == SnapshotsInProgress.State.ABORTED) {
                 Map<ShardId, IndexShardSnapshotStatus> localShards = currentSnapshotShards(snapshot.snapshotId());
                 if (localShards != null) {
-                    ImmutableMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> masterShards = snapshot.shards();
+                    Map<ShardId, SnapshotsInProgress.ShardSnapshotStatus> masterShards = snapshot.shards();
                     for(Map.Entry<ShardId, IndexShardSnapshotStatus> localShard : localShards.entrySet()) {
                         ShardId shardId = localShard.getKey();
                         IndexShardSnapshotStatus localShardStatus = localShard.getValue();

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -596,7 +596,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
                         for (final SnapshotsInProgress.Entry snapshot : snapshots.entries()) {
                             SnapshotsInProgress.Entry updatedSnapshot = snapshot;
                             if (snapshot.state() == State.STARTED) {
-                                ImmutableMap<ShardId, ShardSnapshotStatus> shards = processWaitingShards(snapshot.shards(), routingTable);
+                                Map<ShardId, ShardSnapshotStatus> shards = processWaitingShards(snapshot.shards(), routingTable);
                                 if (shards != null) {
                                     changed = true;
                                     if (!snapshot.state().completed() && completed(shards.values())) {
@@ -625,7 +625,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
         }
     }
 
-    private ImmutableMap<ShardId, ShardSnapshotStatus> processWaitingShards(ImmutableMap<ShardId, ShardSnapshotStatus> snapshotShards, RoutingTable routingTable) {
+    private Map<ShardId, ShardSnapshotStatus> processWaitingShards(Map<ShardId, ShardSnapshotStatus> snapshotShards, RoutingTable routingTable) {
         boolean snapshotChanged = false;
         ImmutableMap.Builder<ShardId, ShardSnapshotStatus> shards = ImmutableMap.builder();
         for (ImmutableMap.Entry<ShardId, ShardSnapshotStatus> shardEntry : snapshotShards.entrySet()) {
@@ -716,10 +716,10 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
      * @param shards list of shard statuses
      * @return list of failed and closed indices
      */
-    private Tuple<Set<String>, Set<String>> indicesWithMissingShards(ImmutableMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards, MetaData metaData) {
+    private Tuple<Set<String>, Set<String>> indicesWithMissingShards(Map<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards, MetaData metaData) {
         Set<String> missing = new HashSet<>();
         Set<String> closed = new HashSet<>();
-        for (ImmutableMap.Entry<ShardId, SnapshotsInProgress.ShardSnapshotStatus> entry : shards.entrySet()) {
+        for (Map.Entry<ShardId, SnapshotsInProgress.ShardSnapshotStatus> entry : shards.entrySet()) {
             if (entry.getValue().state() == State.MISSING) {
                 if (metaData.hasIndex(entry.getKey().getIndex()) && metaData.index(entry.getKey().getIndex()).getState() == IndexMetaData.State.CLOSE) {
                     closed.add(entry.getKey().getIndex());
@@ -864,7 +864,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
                 } else {
                     // This snapshot is currently running - stopping shards first
                     waitForSnapshot = true;
-                    ImmutableMap<ShardId, ShardSnapshotStatus> shards;
+                    Map<ShardId, ShardSnapshotStatus> shards;
                     if (snapshot.state() == State.STARTED && snapshot.shards() != null) {
                         // snapshot is currently running - stop started shards
                         ImmutableMap.Builder<ShardId, ShardSnapshotStatus> shardsBuilder = ImmutableMap.builder();

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -91,7 +91,7 @@ public class ThreadPool extends AbstractComponent {
 
     private volatile ImmutableMap<String, ExecutorHolder> executors;
 
-    private final ImmutableMap<String, Settings> defaultExecutorTypeSettings;
+    private final Map<String, Settings> defaultExecutorTypeSettings;
 
     private final Queue<ExecutorHolder> retiredExecutors = new ConcurrentLinkedQueue<>();
 

--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -67,7 +67,7 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
     protected final Transport transport;
     protected final ThreadPool threadPool;
 
-    volatile ImmutableMap<String, RequestHandlerRegistry> requestHandlers = ImmutableMap.of();
+    volatile Map<String, RequestHandlerRegistry> requestHandlers = Collections.emptyMap();
     final Object requestHandlerMutex = new Object();
 
     final ConcurrentMapLong<RequestHolder> clientHandlers = ConcurrentCollections.newConcurrentMapLongWithAggressiveConcurrency();

--- a/core/src/test/java/org/elasticsearch/benchmark/common/recycler/RecyclerBenchmark.java
+++ b/core/src/test/java/org/elasticsearch/benchmark/common/recycler/RecyclerBenchmark.java
@@ -19,17 +19,22 @@
 
 package org.elasticsearch.benchmark.common.recycler;
 
-import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.common.recycler.AbstractRecyclerC;
 import org.elasticsearch.common.recycler.Recycler;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.elasticsearch.common.recycler.Recyclers.*;
+import static org.elasticsearch.common.recycler.Recyclers.concurrent;
+import static org.elasticsearch.common.recycler.Recyclers.concurrentDeque;
+import static org.elasticsearch.common.recycler.Recyclers.deque;
+import static org.elasticsearch.common.recycler.Recyclers.dequeFactory;
+import static org.elasticsearch.common.recycler.Recyclers.locked;
+import static org.elasticsearch.common.recycler.Recyclers.none;
 
 /** Benchmark that tries to measure the overhead of object recycling depending on concurrent access. */
 public class RecyclerBenchmark {
@@ -89,11 +94,11 @@ public class RecyclerBenchmark {
             }
         };
 
-        final ImmutableMap<String, Recycler<Object>> recyclers = ImmutableMap.<String, Recycler<Object>>builder()
-                .put("none", none(c))
-                .put("concurrent-queue", concurrentDeque(c, limit))
-                .put("locked", locked(deque(c, limit)))
-                .put("concurrent", concurrent(dequeFactory(c, limit), Runtime.getRuntime().availableProcessors())).build();
+        Map<String, Recycler<Object>> recyclers = new HashMap<>();
+        recyclers.put("none", none(c));
+        recyclers.put("concurrent-queue", concurrentDeque(c, limit));
+        recyclers.put("locked", locked(deque(c, limit)));
+        recyclers.put("concurrent", concurrent(dequeFactory(c, limit), Runtime.getRuntime().availableProcessors()));
 
         // warmup
         final long start = System.nanoTime();

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -41,7 +41,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class DiffableTests extends ESTestCase {
 
     @Test
-    public void testImmutableMapDiff() throws IOException {
+    public void testJdkMapDiff() throws IOException {
         ImmutableMap.Builder<String, TestDiffable> builder = ImmutableMap.builder();
         builder.put("foo", new TestDiffable("1"));
         builder.put("bar", new TestDiffable("2"));
@@ -57,7 +57,7 @@ public class DiffableTests extends ESTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
         diff.writeTo(out);
         StreamInput in = StreamInput.wrap(out.bytes());
-        ImmutableMap<String, TestDiffable> serialized = DiffableUtils.readImmutableMapDiff(in, TestDiffable.PROTO).apply(before);
+        Map<String, TestDiffable> serialized = DiffableUtils.readJdkMapDiff(in, TestDiffable.PROTO).apply(before);
         assertThat(serialized.size(), equalTo(3));
         assertThat(serialized.get("foo").value(), equalTo("1"));
         assertThat(serialized.get("baz").value(), equalTo("4"));

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -127,6 +127,7 @@ com.google.common.collect.HashMultimap
 com.google.common.collect.FluentIterable
 com.google.common.io.Files
 com.google.common.primitives.Ints
+com.google.common.collect.ImmutableMap#entrySet()
 
 @defaultMessage Do not violate java's access system
 java.lang.reflect.AccessibleObject#setAccessible(boolean)


### PR DESCRIPTION
Banning `ImmutableSet` outright is too much to do all at once - this starts
the process by banning `ImmutableMap#entrySet` - one of the more common ways
that `ImmutableSet`s come up. It then starts to remove calls to
`ImmutableMap#entrySet` by changing declarations from `ImmutableMap` to `Map`.

Unfortunately this process is like pulling on a long, windy string and one
declaration change requires another which requires 5 more which in turn
require another few. So there are lots of scattered changes to do this.

As such, to keep these commits manageable they only remove `ImmutableMap` from
the signatures that are needed for `entrySet` and make no effort to stop using
`ImmutableMap` internally. Removing the usages of `ImmutableMap` complicates
immutability guarantees and should be done separately.
