### PR TITLE
Deprecate locale parameters in query_string and simple_query_string

### DIFF
--- a/core/src/main/java/org/apache/lucene/queryparser/classic/QueryParserSettings.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/QueryParserSettings.java
@@ -287,10 +287,18 @@ public class QueryParserSettings {
         this.useDisMax = useDisMax;
     }
 
+    /**
+     * @deprecated properly configure the analysis chain instead
+     */
+    @Deprecated
     public void locale(Locale locale) {
         this.locale = locale;
     }
 
+    /**
+     * @deprecated properly configure the analysis chain instead
+     */
+    @Deprecated
     public Locale locale() {
         return this.locale;
     }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -328,6 +328,10 @@ public class QueryStringQueryBuilder extends QueryBuilder implements BoostableQu
         return this;
     }
 
+    /**
+     * @deprecated properly configure the analysis chain instead
+     */
+    @Deprecated
     public QueryStringQueryBuilder locale(Locale locale) {
         this.locale = locale;
         return this;

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
@@ -50,6 +50,7 @@ public class QueryStringQueryParser implements QueryParser {
 
     public static final String NAME = "query_string";
     private static final ParseField FUZZINESS = Fuzziness.FIELD.withDeprecation("fuzzy_min_sim");
+    private static final ParseField LOCALE_FIELD = new ParseField("locale").withAllDeprecated("properly configure the analysis chain instead");
 
     private final boolean defaultAnalyzeWildcard;
     private final boolean defaultAllowLeadingWildcard;
@@ -193,7 +194,7 @@ public class QueryStringQueryParser implements QueryParser {
                     qpSettings.quoteFieldSuffix(parser.textOrNull());
                 } else if ("lenient".equalsIgnoreCase(currentFieldName)) {
                     qpSettings.lenient(parser.booleanValue());
-                } else if ("locale".equals(currentFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, LOCALE_FIELD)) {
                     String localeStr = parser.text();
                     qpSettings.locale(LocaleUtils.parse(localeStr));
                 } else if ("time_zone".equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -134,11 +133,19 @@ public class SimpleQueryStringBuilder extends QueryBuilder implements BoostableQ
         return this;
     }
 
+    /**
+     * @deprecated properly configure the analysis chain instead
+     */
+    @Deprecated
     public SimpleQueryStringBuilder locale(Locale locale) {
         this.locale = locale;
         return this;
     }
 
+    /**
+     * @deprecated properly configure the analysis chain instead
+     */
+    @Deprecated
     public SimpleQueryStringBuilder lenient(boolean lenient) {
         this.lenient = lenient;
         return this;

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringParser.java
@@ -23,6 +23,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -71,6 +72,8 @@ import java.util.Map;
 public class SimpleQueryStringParser implements QueryParser {
 
     public static final String NAME = "simple_query_string";
+
+    private static final ParseField LOCALE_FIELD = new ParseField("locale").withAllDeprecated("properly configure the analysis chain instead");
 
     @Inject
     public SimpleQueryStringParser() {
@@ -170,7 +173,7 @@ public class SimpleQueryStringParser implements QueryParser {
                             flags = SimpleQueryStringFlag.ALL.value();
                         }
                     }
-                } else if ("locale".equals(currentFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, LOCALE_FIELD)) {
                     String localeStr = parser.text();
                     Locale locale = LocaleUtils.parse(localeStr);
                     sqsSettings.locale(locale);

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -77,7 +77,7 @@ both>>.
 providing text to a numeric field) to be ignored.
 
 |`locale` | Locale that should be used for string conversions.
-Defaults to `ROOT`.
+Defaults to `ROOT`. deprecated[2.1.0,Properly configure the analysis chain instead]
 
 |`time_zone` | Time Zone to be applied to any range query related to dates. See also
 http://www.joda.org/joda-time/apidocs/org/joda/time/DateTimeZone.html[JODA timezone].

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -50,7 +50,7 @@ some analyzers will be not able to provide a meaningful results
 based just on the prefix of a term. Defaults to `false`.
 
 |`locale` | Locale that should be used for string conversions.
-Defaults to `ROOT`.
+Defaults to `ROOT`. deprecated[2.1.0,Properly configure the analysis chain instead]
 
 |`lenient` | If set to `true` will cause format based failures
 (like providing text to a numeric field) to be ignored.


### PR DESCRIPTION
The configured analysis chain should be used instead.

Relates to #13229
