### PR TITLE
More helpful error message on parameter order

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCLIParser.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCLIParser.java
@@ -128,7 +128,13 @@ final class BootstrapCLIParser extends CliTool {
             while (iterator.hasNext()) {
                 String arg = iterator.next();
                 if (!arg.startsWith("--")) {
-                    throw new IllegalArgumentException("Parameter [" + arg + "]does not start with --");
+                    if (arg.startsWith("-D") || arg.startsWith("-d") || arg.startsWith("-p")) {
+                        throw new IllegalArgumentException(
+                                "Parameter [" + arg + "] starting with \"-D\", \"-d\" or \"-p\" must be before any parameters starting with --"
+                        );
+                    } else {
+                        throw new IllegalArgumentException("Parameter [" + arg + "]does not start with --");
+                    }
                 }
                 // if there is no = sign, we have to get the next argu
                 arg = arg.replace("--", "");

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCliParserTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCliParserTests.java
@@ -220,6 +220,16 @@ public class BootstrapCliParserTests extends CliToolTestCase {
 
     }
 
+    public void testThatHelpfulErrorMessageIsGivenWhenParametersAreOutOfOrder() throws Exception {
+        BootstrapCLIParser parser = new BootstrapCLIParser(terminal);
+        try {
+            parser.parse("start", new String[]{"--foo=bar", "-Dbaz=qux"});
+            fail("expected IllegalArgumentException for out-of-order parameters");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("must appear before any parameters starting with --"));
+        }
+    }
+
     private void registerProperties(String ... systemProperties) {
         propertiesToClear.addAll(Arrays.asList(systemProperties));
     }


### PR DESCRIPTION
This commit addresses a confusing error message that arises when a
property parameter (e.g. -D) is after a double-dash parameter. The
current error message reports to the user that the parameter does not
start with “--". Adding the second dash as the error message suggests
causes the parameter to be silently ignored. This is confusing for the
user. With this commit, the user is now informed that the parameter
order is violated.

Relates e27ede48ce6f275f80e8b59bc6dc7ad2849c64fc
