### PR TITLE
Block process execution with seccomp on linux/amd64

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -91,6 +91,8 @@ final class Bootstrap {
             }
         }
         
+        Natives.trySeccomp();
+        
         // mlockall if requested
         if (mlockAll) {
             if (Constants.WINDOWS) {

--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -79,7 +79,7 @@ final class Bootstrap {
     }
     
     /** initialize native resources */
-    public static void initializeNatives(boolean mlockAll, boolean ctrlHandler) {
+    public static void initializeNatives(boolean mlockAll, boolean seccomp, boolean ctrlHandler) {
         final ESLogger logger = Loggers.getLogger(Bootstrap.class);
         
         // check if the user is running as root, and bail
@@ -91,7 +91,10 @@ final class Bootstrap {
             }
         }
         
-        Natives.trySeccomp();
+        // enable secure computing mode
+        if (seccomp) {
+            Natives.trySeccomp();
+        }
         
         // mlockall if requested
         if (mlockAll) {
@@ -136,7 +139,8 @@ final class Bootstrap {
 
     private void setup(boolean addShutdownHook, Settings settings, Environment environment) throws Exception {
         initializeNatives(settings.getAsBoolean("bootstrap.mlockall", false),
-                settings.getAsBoolean("bootstrap.ctrlhandler", true));
+                          settings.getAsBoolean("bootstrap.seccomp", true),
+                          settings.getAsBoolean("bootstrap.ctrlhandler", true));
 
         // initialize probes before the security manager is installed
         initializeProbes();

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
@@ -43,4 +43,11 @@ public final class BootstrapInfo {
     public static boolean isMemoryLocked() {
         return Natives.isMemoryLocked();
     }
+    
+    /**
+     * Returns true if secure computing mode is enabled (linux/amd64 only)
+     */
+    public static boolean isSeccompInstalled() {
+        return Natives.isSeccompInstalled();
+    }
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
@@ -179,7 +179,10 @@ class JNANatives {
                 LOCAL_SECCOMP = true;
             } catch (Exception e) {
                 // this is likely to happen unless the kernel is newish, its a best effort at the moment
-                // so unfortunately, we hide the stacktrace for now...
+                // so we log stacktrace at debug for now...
+                if (logger.isDebugEnabled()) {
+                    logger.debug("unable to install seccomp filter", e);
+                }
                 logger.warn("unable to install seccomp filter: " + e.getMessage());
             }
         }

--- a/core/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
@@ -41,6 +41,8 @@ class JNANatives {
 
     // Set to true, in case native mlockall call was successful
     static boolean LOCAL_MLOCKALL = false;
+    // Set to true, in case native seccomp call was successful
+    static boolean LOCAL_SECCOMP = false;
 
     static void tryMlockall() {
         int errno = Integer.MIN_VALUE;
@@ -170,4 +172,16 @@ class JNANatives {
         }
     }
 
+    static void trySeccomp() {
+        if (Constants.LINUX && "amd64".equals(Constants.OS_ARCH)) {
+            try {
+                Seccomp.installFilter();
+                LOCAL_SECCOMP = true;
+            } catch (Exception e) {
+                // this is likely to happen unless the kernel is newish, its a best effort at the moment
+                // so unfortunately, we hide the stacktrace for now...
+                logger.warn("unable to install seccomp filter: " + e.getMessage());
+            }
+        }
+    }
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -88,4 +88,19 @@ final class Natives {
         }
         return JNANatives.LOCAL_MLOCKALL;
     }
+    
+    static void trySeccomp() {
+        if (!JNA_AVAILABLE) {
+            logger.warn("cannot install seccomp filters because JNA is not available");
+            return;
+        }
+        JNANatives.trySeccomp();
+    }
+    
+    static boolean isSeccompInstalled() {
+        if (!JNA_AVAILABLE) {
+            return false;
+        }
+        return JNANatives.LOCAL_SECCOMP;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
@@ -191,6 +191,7 @@ final class Seccomp {
     /** try to install our filters */
     static void installFilter() {
         // first be defensive: we can give nice errors this way, at the very least.
+        // also, some of these security features get backported to old versions, checking kernel version here is a big no-no! 
         boolean supported = Constants.LINUX && "amd64".equals(Constants.OS_ARCH);
         if (supported == false) {
             throw new IllegalStateException("bug: should not be trying to initialize seccomp for an unsupported architecture");

--- a/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /** 
- * installs system call filter, to block some dangerous system calls like execve
+ * installs system call filter, to block some dangerous system calls like fork,execve
  * only supported on linux/amd64
  * not an example of how to write code!!!
  */
@@ -50,11 +50,10 @@ final class Seccomp {
     
     // TODO: support new seccomp(2) syscall, to specify SECCOMP_FILTER_FLAG_TSYNC
     
-    static final int PR_SET_NO_NEW_PRIVS = 38;  // since Linux 3.5
-    static final int PR_SET_SECCOMP = 22;       // since Linux 2.6.23
-    static final int SECCOMP_MODE_FILTER = 2;   // since Linux Linux 3.5
+    static final int PR_SET_NO_NEW_PRIVS = 38;   // since Linux 3.5
+    static final int PR_SET_SECCOMP      = 22;   // since Linux 2.6.23
+    static final int SECCOMP_MODE_FILTER =  2;   // since Linux Linux 3.5
     static native int prctl(int option, long arg2, long arg3, long arg4, long arg5);
-    static native int prctl(int option, long arg2, SockFProg arg3, long arg4, long arg5);
     
     /** corresponds to struct sock_filter */
     static final class SockFilter {
@@ -98,12 +97,14 @@ final class Seccomp {
     
     // BPF "macros" and constants
     static final int BPF_LD  = 0x00;
-    static final int BPF_JMP = 0x05;
-    static final int BPF_RET = 0x06;
     static final int BPF_W   = 0x00;
     static final int BPF_ABS = 0x20;
+    static final int BPF_JMP = 0x05;
     static final int BPF_JEQ = 0x10;
-    static final int BPF_K   = 0x0;
+    static final int BPF_JGE = 0x30;
+    static final int BPF_JGT = 0x20;
+    static final int BPF_RET = 0x06;
+    static final int BPF_K   = 0x00;
     
     static SockFilter BPF_STMT(int code, int k) {
         return new SockFilter((short) code, (byte) 0, (byte) 0, k);
@@ -119,12 +120,19 @@ final class Seccomp {
     static final int SECCOMP_RET_ALLOW = 0x7FFF0000;
     static final int EACCES = 0xD;
     
+    static final int SECCOMP_DATA_NR_OFFSET   = 0x00;
     static final int SECCOMP_DATA_ARCH_OFFSET = 0x04;
-    static final int SECCOMP_DATA_NR_OFFSET   = 0x0;
     
-    // TODO: probably block some more syscalls, including clone/fork/vfork to get a better exception message maybe
-    static final int SYSCALL_EXECVE = 59;
-    
+    // currently this range is blocked (inclusive):
+    // execve is really the only one needed but why let someone fork a 30G heap?
+    // ...
+    // 57: fork
+    // 58: vfork
+    // 59: execve
+    // ...
+    static final int BLACKLIST_START = 57;
+    static final int BLACKLIST_END   = 59;
+
     /** try to install our filters */
     static void installFilter() {
         // first set PR_SET_NO_NEW_PRIVS, needed to be able to set a seccomp filter as ordinary user
@@ -133,17 +141,20 @@ final class Seccomp {
         }
         
         SockFilter insns[] = {
-          BPF_STMT(BPF_LD  + BPF_W   + BPF_ABS, SECCOMP_DATA_ARCH_OFFSET),
-          BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K,   AUDIT_ARCH_X86_64, 0, 3),
-          BPF_STMT(BPF_LD  + BPF_W   + BPF_ABS, SECCOMP_DATA_NR_OFFSET),
-          BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K,   SYSCALL_EXECVE, 0, 1),
-          BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ERRNO | (EACCES & SECCOMP_RET_DATA)),
-          BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW)      
+          /* 1 */ BPF_STMT(BPF_LD  + BPF_W   + BPF_ABS, SECCOMP_DATA_ARCH_OFFSET),               // if (arch != amd64) goto fail;
+          /* 2 */ BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K,   AUDIT_ARCH_X86_64, 0, 3),                //
+          /* 3 */ BPF_STMT(BPF_LD  + BPF_W   + BPF_ABS, SECCOMP_DATA_NR_OFFSET),                 // if (syscall < BLACKLIST_START) goto pass;
+          /* 4 */ BPF_JUMP(BPF_JMP + BPF_JGE + BPF_K,   BLACKLIST_START, 0, 2),                  //
+          /* 5 */ BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K,   BLACKLIST_END, 1, 0),                    // if (syscall > BLACKLIST_END) goto pass;
+          /* 6 */ BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ERRNO | (EACCES & SECCOMP_RET_DATA)),    // fail: return EACCES;
+          /* 7 */ BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW)                                   // pass: return OK;
         };
         
         SockFProg prog = new SockFProg(insns);
+        prog.write();
+        long pointer = Pointer.nativeValue(prog.getPointer());
 
-        if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, prog, 0, 0) < 0) {
+        if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, pointer, 0, 0) < 0) {
             throw new UnsupportedOperationException("prctl(PR_SET_SECCOMP): " + JNACLibrary.strerror(Native.getLastError()));
         }
     }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
@@ -185,6 +185,8 @@ final class Seccomp {
     // ...
     static final int BLACKLIST_START = 57;
     static final int BLACKLIST_END   = 59;
+    
+    // TODO: execveat()? its less of a risk since the jvm does not use it...
 
     /** try to install our filters */
     static void installFilter() {

--- a/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.List;
 
@@ -73,12 +74,13 @@ final class Seccomp {
     /** corresponds to struct sock_fprog */
     public static final class SockFProg extends Structure implements Structure.ByReference {
         public short   len;           // number of filters
-        public Pointer filter;       // filters
+        public Pointer filter;        // filters
         
         public SockFProg(SockFilter filters[]) {
             len = (short) filters.length;
             Memory filter = new Memory(len * 8);
             ByteBuffer bbuf = filter.getByteBuffer(0, len * 8);
+            bbuf.order(ByteOrder.nativeOrder()); // little endian
             for (SockFilter f : filters) {
                 bbuf.putShort(f.code);
                 bbuf.put(f.jt);

--- a/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+/** 
+ * installs system call filter, to block some dangerous system calls like execve
+ * only supported on linux/amd64
+ * not an example of how to write code!!!
+ */
+final class Seccomp {
+    private static final ESLogger logger = Loggers.getLogger(Seccomp.class);
+
+    static {
+        try {
+            Native.register("c");
+        } catch (UnsatisfiedLinkError e) {
+            logger.warn("unable to link C library. native methods (seccomp) will be disabled.", e);
+        }
+    }
+    
+    // TODO: support new seccomp(2) syscall, to specify SECCOMP_FILTER_FLAG_TSYNC
+    
+    static final int PR_SET_NO_NEW_PRIVS = 38;  // since Linux 3.5
+    static final int PR_SET_SECCOMP = 22;       // since Linux 2.6.23
+    static final int SECCOMP_MODE_FILTER = 2;   // since Linux Linux 3.5
+    static native int prctl(int option, long arg2, long arg3, long arg4, long arg5);
+    static native int prctl(int option, long arg2, SockFProg arg3, long arg4, long arg5);
+    
+    /** corresponds to struct sock_filter */
+    static final class SockFilter {
+        short code; // insn
+        byte jt;    // number of insn to jump if true
+        byte jf;    // number of insn to jump if false
+        int k;      // additional data
+
+        SockFilter(short code, byte jt, byte jf, int k) {
+            this.code = code;
+            this.jt = jt;
+            this.jf = jf;
+            this.k = k;
+        }
+    }
+    
+    /** corresponds to struct sock_fprog */
+    public static final class SockFProg extends Structure implements Structure.ByReference {
+        public short   len;           // number of filters
+        public Pointer filter;       // filters
+        
+        public SockFProg(SockFilter filters[]) {
+            len = (short) filters.length;
+            Memory filter = new Memory(len * 8);
+            ByteBuffer bbuf = filter.getByteBuffer(0, len * 8);
+            for (SockFilter f : filters) {
+                bbuf.putShort(f.code);
+                bbuf.put(f.jt);
+                bbuf.put(f.jf);
+                bbuf.putInt(f.k);
+            }
+            this.filter = filter;
+        }
+        
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList(new String[] { "len", "filter" });
+        }
+    }
+    
+    // BPF "macros" and constants
+    static final int BPF_LD  = 0x00;
+    static final int BPF_JMP = 0x05;
+    static final int BPF_RET = 0x06;
+    static final int BPF_W   = 0x00;
+    static final int BPF_ABS = 0x20;
+    static final int BPF_JEQ = 0x10;
+    static final int BPF_K   = 0x0;
+    
+    static SockFilter BPF_STMT(int code, int k) {
+        return new SockFilter((short) code, (byte) 0, (byte) 0, k);
+    }
+    
+    static SockFilter BPF_JUMP(int code, int k, int jt, int jf) {
+        return new SockFilter((short) code, (byte) jt, (byte) jf, k);
+    }
+    
+    static final int AUDIT_ARCH_X86_64 = 0xC000003E;
+    static final int SECCOMP_RET_ERRNO = 0x00050000;
+    static final int SECCOMP_RET_DATA  = 0x0000FFFF;
+    static final int SECCOMP_RET_ALLOW = 0x7FFF0000;
+    static final int EACCES = 0xD;
+    
+    static final int SECCOMP_DATA_ARCH_OFFSET = 0x04;
+    static final int SECCOMP_DATA_NR_OFFSET   = 0x0;
+    
+    // TODO: probably block some more syscalls, including clone/fork/vfork to get a better exception message maybe
+    static final int SYSCALL_EXECVE = 59;
+    
+    /** try to install our filters */
+    static void installFilter() {
+        // first set PR_SET_NO_NEW_PRIVS, needed to be able to set a seccomp filter as ordinary user
+        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0) {
+            throw new UnsupportedOperationException("prctl(PR_SET_NO_NEW_PRIVS): " + JNACLibrary.strerror(Native.getLastError()));
+        }
+        
+        SockFilter insns[] = {
+          BPF_STMT(BPF_LD  + BPF_W   + BPF_ABS, SECCOMP_DATA_ARCH_OFFSET),
+          BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K,   AUDIT_ARCH_X86_64, 0, 3),
+          BPF_STMT(BPF_LD  + BPF_W   + BPF_ABS, SECCOMP_DATA_NR_OFFSET),
+          BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K,   SYSCALL_EXECVE, 0, 1),
+          BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ERRNO | (EACCES & SECCOMP_RET_DATA)),
+          BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW)      
+        };
+        
+        SockFProg prog = new SockFProg(insns);
+
+        if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, prog, 0, 0) < 0) {
+            throw new UnsupportedOperationException("prctl(PR_SET_SECCOMP): " + JNACLibrary.strerror(Native.getLastError()));
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
@@ -221,6 +221,7 @@ final class Seccomp {
             switch (errno) {
                 case EFAULT: break; // available
                 case EINVAL: throw new UnsupportedOperationException("seccomp unavailable: CONFIG_SECCOMP_FILTER not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed");
+                default: throw new UnsupportedOperationException("prctl(PR_SET_SECCOMP): " + JNACLibrary.strerror(Native.getLastError()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Seccomp.java
@@ -206,7 +206,7 @@ final class Seccomp {
             int errno = Native.getLastError();
             switch (errno) {
                 case ENOSYS: throw new UnsupportedOperationException("seccomp unavailable: requires kernel 3.5+ with CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER compiled in");
-                default: throw new UnsupportedOperationException("prctl(PR_GET_NO_NEW_PRIVS): " + JNACLibrary.strerror(Native.getLastError()));
+                default: throw new UnsupportedOperationException("prctl(PR_GET_NO_NEW_PRIVS): " + JNACLibrary.strerror(errno));
             }
         }
         // check for SECCOMP
@@ -214,7 +214,7 @@ final class Seccomp {
             int errno = Native.getLastError();
             switch (errno) {
                 case EINVAL: throw new UnsupportedOperationException("seccomp unavailable: CONFIG_SECCOMP not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed");
-                default: throw new UnsupportedOperationException("prctl(PR_GET_SECCOMP): " + JNACLibrary.strerror(Native.getLastError()));
+                default: throw new UnsupportedOperationException("prctl(PR_GET_SECCOMP): " + JNACLibrary.strerror(errno));
             }
         }
         // check for SECCOMP_MODE_FILTER
@@ -223,7 +223,7 @@ final class Seccomp {
             switch (errno) {
                 case EFAULT: break; // available
                 case EINVAL: throw new UnsupportedOperationException("seccomp unavailable: CONFIG_SECCOMP_FILTER not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed");
-                default: throw new UnsupportedOperationException("prctl(PR_SET_SECCOMP): " + JNACLibrary.strerror(Native.getLastError()));
+                default: throw new UnsupportedOperationException("prctl(PR_SET_SECCOMP): " + JNACLibrary.strerror(errno));
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -52,7 +52,7 @@ public class BootstrapForTesting {
 
     static {
         // just like bootstrap, initialize natives, then SM
-        Bootstrap.initializeNatives(true, true);
+        Bootstrap.initializeNatives(true, true, true);
 
         // initialize probes
         Bootstrap.initializeProbes();

--- a/core/src/test/java/org/elasticsearch/bootstrap/SeccompTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/SeccompTests.java
@@ -50,7 +50,6 @@ public class SeccompTests extends ESTestCase {
                     at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
                     ... 
             */
-            // if we improve the chain to block fork()/vfork(), maybe something else
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/bootstrap/SeccompTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/SeccompTests.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class SeccompTests extends ESTestCase {
+    
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        assumeTrue("requires seccomp filter installation", Natives.isSeccompInstalled());
+        // otherwise security manager will block the execution, no fun
+        assumeTrue("cannot test with security manager enabled", System.getSecurityManager() == null);
+    }
+    
+    public void testNoExecution() throws Exception {
+        try {
+            Runtime.getRuntime().exec("ls");
+            fail("should not have been able to execute!");
+        } catch (Exception expected) {
+            // we can't guarantee how its converted, currently its an IOException, like this:
+            /*
+            java.io.IOException: Cannot run program "ls": error=13, Permission denied
+                    at __randomizedtesting.SeedInfo.seed([65E6C4BED11899E:FC6E1CA6AA2DB634]:0)
+                    at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
+                    at java.lang.Runtime.exec(Runtime.java:620)
+                    ...
+                  Caused by: java.io.IOException: error=13, Permission denied
+                    at java.lang.UNIXProcess.forkAndExec(Native Method)
+                    at java.lang.UNIXProcess.<init>(UNIXProcess.java:248)
+                    at java.lang.ProcessImpl.start(ProcessImpl.java:134)
+                    at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
+                    ... 
+            */
+            // if we improve the chain to block fork()/vfork(), maybe something else
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/bootstrap/SeccompTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/SeccompTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.bootstrap;
 
 import org.elasticsearch.test.ESTestCase;
 
+/** Simple tests seccomp filter is working. */
 public class SeccompTests extends ESTestCase {
     
     @Override
@@ -51,5 +52,22 @@ public class SeccompTests extends ESTestCase {
                     ... 
             */
         }
+    }
+    
+    // make sure thread inherits this too (its documented that way)
+    public void testNoExecutionFromThread() throws Exception {
+        Thread t = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    Runtime.getRuntime().exec("ls");
+                    fail("should not have been able to execute!");
+                } catch (Exception expected) {
+                    // ok
+                }
+            }
+        };
+        t.start();
+        t.join();
     }
 }


### PR DESCRIPTION
On newer linux kernels, we can use prctl/seccomp to lock down the process and prevent the worst of the worst, like execution. This is used by e.g. chrome/firefox sandbox and so on.

This is just another level of security, java's security manager is not perfect, and there are often bugs in java itself, so it would good to have another level of defense.

See https://en.wikipedia.org/wiki/Seccomp for more information

This PR blocks execve(), fork(), and vfork(), returning EACCES instead, so even with security manager disabled, process execution is still prevented. 

```
            java.io.IOException: Cannot run program "ls": error=13, Permission denied
                    at __randomizedtesting.SeedInfo.seed([65E6C4BED11899E:FC6E1CA6AA2DB634]:0)
                    at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
                    at java.lang.Runtime.exec(Runtime.java:620)
                    ...
                  Caused by: java.io.IOException: error=13, Permission denied
                    at java.lang.UNIXProcess.forkAndExec(Native Method)
                    at java.lang.UNIXProcess.<init>(UNIXProcess.java:248)
                    at java.lang.ProcessImpl.start(ProcessImpl.java:134)
                    at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
```
