### PR TITLE
Fork lucene PatternTokenizer to not reuse a StringBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzer.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzer.java
@@ -24,7 +24,6 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.StopFilter;
-import org.apache.lucene.analysis.pattern.PatternTokenizer;
 import org.apache.lucene.analysis.util.CharArraySet;
 
 import java.util.regex.Pattern;

--- a/core/src/main/java/org/elasticsearch/index/analysis/PatternTokenizer.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PatternTokenizer.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.util.AttributeFactory;
+
+/**
+ * This tokenizer uses regex pattern matching to construct distinct tokens
+ * for the input stream.  It takes two arguments:  "pattern" and "group".
+ * <ul>
+ * <li>"pattern" is the regular expression.</li>
+ * <li>"group" says which group to extract into tokens.</li>
+ *  </ul>
+ * <p>
+ * group=-1 (the default) is equivalent to "split".  In this case, the tokens will
+ * be equivalent to the output from (without empty tokens):
+ * {@link String#split(java.lang.String)}
+ * </p>
+ * <p>
+ * Using group &gt;= 0 selects the matching group as the token.  For example, if you have:<br>
+ * <pre>
+ *  pattern = \'([^\']+)\'
+ *  group = 0
+ *  input = aaa 'bbb' 'ccc'
+ *</pre>
+ * the output will be two tokens: 'bbb' and 'ccc' (including the ' marks).  With the same input
+ * but using group=1, the output would be: bbb and ccc (no ' marks)
+ * <p>NOTE: This Tokenizer does not output tokens that are of zero length.</p>
+ *
+ * <b>This is a modified org.apache.lucene.analysis.pattern.PatternTokenizer that does not reuse
+ * a StringBuilder.</b>
+ *
+ * @see Pattern
+ */
+public final class PatternTokenizer extends Tokenizer {
+
+  private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+  private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+
+  private String str = "";
+  private int index;
+  
+  private final int group;
+  private final Matcher matcher;
+
+  /** creates a new PatternTokenizer returning tokens from group (-1 for split functionality) */
+  public PatternTokenizer(Pattern pattern, int group) {
+    this(DEFAULT_TOKEN_ATTRIBUTE_FACTORY, pattern, group);
+  }
+
+  /** creates a new PatternTokenizer returning tokens from group (-1 for split functionality) */
+  public PatternTokenizer(AttributeFactory factory, Pattern pattern, int group) {
+    super(factory);
+    this.group = group;
+
+    // Use "" instead of str so don't consume chars
+    // (fillBuffer) from the input on throwing IAE below:
+    matcher = pattern.matcher("");
+
+    // confusingly group count depends ENTIRELY on the pattern but is only accessible via matcher
+    if (group >= 0 && group > matcher.groupCount()) {
+      throw new IllegalArgumentException("invalid group specified: pattern only has: " + matcher.groupCount() + " capturing groups");
+    }
+  }
+
+  @Override
+  public boolean incrementToken() {
+    if (index >= str.length()) return false;
+    clearAttributes();
+    if (group >= 0) {
+    
+      // match a specific group
+      while (matcher.find()) {
+        index = matcher.start(group);
+        final int endIndex = matcher.end(group);
+        if (index == endIndex) continue;       
+        termAtt.setEmpty().append(str, index, endIndex);
+        offsetAtt.setOffset(correctOffset(index), correctOffset(endIndex));
+        return true;
+      }
+      
+      index = Integer.MAX_VALUE; // mark exhausted
+      return false;
+      
+    } else {
+    
+      // String.split() functionality
+      while (matcher.find()) {
+        if (matcher.start() - index > 0) {
+          // found a non-zero-length token
+          termAtt.setEmpty().append(str, index, matcher.start());
+          offsetAtt.setOffset(correctOffset(index), correctOffset(matcher.start()));
+          index = matcher.end();
+          return true;
+        }
+        
+        index = matcher.end();
+      }
+      
+      if (str.length() - index == 0) {
+        index = Integer.MAX_VALUE; // mark exhausted
+        return false;
+      }
+      
+      termAtt.setEmpty().append(str, index, str.length());
+      offsetAtt.setOffset(correctOffset(index), correctOffset(str.length()));
+      index = Integer.MAX_VALUE; // mark exhausted
+      return true;
+    }
+  }
+
+  @Override
+  public void end() throws IOException {
+    super.end();
+    final int ofs = correctOffset(str.length());
+    offsetAtt.setOffset(ofs, ofs);
+  }
+
+  @Override
+  public void reset() throws IOException {
+    super.reset();
+    fillBuffer(input);
+    matcher.reset(str);
+    index = 0;
+  }
+  
+  final char[] buffer = new char[8192];
+  private void fillBuffer(Reader input) throws IOException {
+    int len;
+    StringBuilder sb = new StringBuilder();
+    while ((len = input.read(buffer)) > 0) {
+      sb.append(buffer, 0, len);
+    }
+    str = sb.toString();
+  }
+}

--- a/core/src/main/java/org/elasticsearch/index/analysis/PatternTokenizerFactory.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PatternTokenizerFactory.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.pattern.PatternTokenizer;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.regex.Regex;

--- a/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenizers.java
+++ b/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenizers.java
@@ -28,7 +28,6 @@ import org.apache.lucene.analysis.ngram.NGramTokenizer;
 import org.apache.lucene.analysis.ngram.Lucene43EdgeNGramTokenizer;
 import org.apache.lucene.analysis.ngram.Lucene43NGramTokenizer;
 import org.apache.lucene.analysis.path.PathHierarchyTokenizer;
-import org.apache.lucene.analysis.pattern.PatternTokenizer;
 import org.apache.lucene.analysis.standard.ClassicTokenizer;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizer;
@@ -37,6 +36,7 @@ import org.apache.lucene.analysis.standard.std40.UAX29URLEmailTokenizer40;
 import org.apache.lucene.analysis.th.ThaiTokenizer;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.index.analysis.PatternTokenizer;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 

--- a/core/src/test/java/org/elasticsearch/index/analysis/PatternTokenizerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/PatternTokenizerTests.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.index.analysis;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.BaseTokenStreamTestCase;
+import org.apache.lucene.analysis.CharFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.charfilter.MappingCharFilter;
+import org.apache.lucene.analysis.charfilter.NormalizeCharMap;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+public class PatternTokenizerTests extends BaseTokenStreamTestCase
+{
+  @Test
+  public void testSplitting() throws Exception 
+  {
+    String qpattern = "\\'([^\\']+)\\'"; // get stuff between "'"
+    String[][] tests = {
+      // group  pattern        input                    output
+      { "-1",   "--",          "aaa--bbb--ccc",         "aaa bbb ccc" },
+      { "-1",   ":",           "aaa:bbb:ccc",           "aaa bbb ccc" },
+      { "-1",   "\\p{Space}",  "aaa   bbb \t\tccc  ",   "aaa bbb ccc" },
+      { "-1",   ":",           "boo:and:foo",           "boo and foo" },
+      { "-1",   "o",           "boo:and:foo",           "b :and:f" },
+      { "0",    ":",           "boo:and:foo",           ": :" },
+      { "0",    qpattern,      "aaa 'bbb' 'ccc'",       "'bbb' 'ccc'" },
+      { "1",    qpattern,      "aaa 'bbb' 'ccc'",       "bbb ccc" }
+    };
+    
+    for( String[] test : tests ) {     
+      TokenStream stream = new PatternTokenizer(newAttributeFactory(), Pattern.compile(test[1]), Integer.parseInt(test[0]));
+      ((Tokenizer)stream).setReader(new StringReader(test[2]));
+      String out = tsToString( stream );
+      // System.out.println( test[2] + " ==> " + out );
+
+      assertEquals("pattern: "+test[1]+" with input: "+test[2], test[3], out );
+      
+      // Make sure it is the same as if we called 'split'
+      // test disabled, as we remove empty tokens
+      /*if( "-1".equals( test[0] ) ) {
+        String[] split = test[2].split( test[1] );
+        stream = tokenizer.create( new StringReader( test[2] ) );
+        int i=0;
+        for( Token t = stream.next(); null != t; t = stream.next() ) 
+        {
+          assertEquals( "split: "+test[1] + " "+i, split[i++], new String(t.termBuffer(), 0, t.termLength()) );
+        }
+      }*/
+    } 
+  }
+
+  @Test
+  public void testOffsetCorrection() throws Exception {
+    final String INPUT = "G&uuml;nther G&uuml;nther is here";
+
+    // create MappingCharFilter
+    List<String> mappingRules = new ArrayList<>();
+    mappingRules.add( "\"&uuml;\" => \"ü\"" );
+    NormalizeCharMap.Builder builder = new NormalizeCharMap.Builder();
+    builder.add("&uuml;", "ü");
+    NormalizeCharMap normMap = builder.build();
+    CharFilter charStream = new MappingCharFilter( normMap, new StringReader( INPUT ) );
+
+    // create PatternTokenizer
+    Tokenizer stream = new PatternTokenizer(newAttributeFactory(), Pattern.compile("[,;/\\s]+"), -1);
+    stream.setReader(charStream);
+    assertTokenStreamContents(stream,
+        new String[] { "Günther", "Günther", "is", "here" },
+        new int[] { 0, 13, 26, 29 },
+        new int[] { 12, 25, 28, 33 },
+        INPUT.length());
+    
+    charStream = new MappingCharFilter( normMap, new StringReader( INPUT ) );
+    stream = new PatternTokenizer(newAttributeFactory(), Pattern.compile("Günther"), 0);
+    stream.setReader(charStream);
+    assertTokenStreamContents(stream,
+        new String[] { "Günther", "Günther" },
+        new int[] { 0, 13 },
+        new int[] { 12, 25 },
+        INPUT.length());
+  }
+  
+  /** 
+   * TODO: rewrite tests not to use string comparison.
+   */
+  private static String tsToString(TokenStream in) throws IOException {
+    StringBuilder out = new StringBuilder();
+    CharTermAttribute termAtt = in.addAttribute(CharTermAttribute.class);
+    // extra safety to enforce, that the state is not preserved and also
+    // assign bogus values
+    in.clearAttributes();
+    termAtt.setEmpty().append("bogusTerm");
+    in.reset();
+    while (in.incrementToken()) {
+      if (out.length() > 0)
+        out.append(' ');
+      out.append(termAtt.toString());
+      in.clearAttributes();
+      termAtt.setEmpty().append("bogusTerm");
+    }
+
+    in.close();
+    return out.toString();
+  }
+  
+  /** blast some random strings through the analyzer */
+  @Test
+  public void testRandomStrings() throws Exception {
+    Analyzer a = new Analyzer() {
+      @Override
+      protected TokenStreamComponents createComponents(String fieldName) {
+        Tokenizer tokenizer = new PatternTokenizer(newAttributeFactory(), Pattern.compile("a"), -1);
+        return new TokenStreamComponents(tokenizer);
+      }    
+    };
+    checkRandomData(random(), a, 1000*RANDOM_MULTIPLIER);
+    a.close();
+    
+    Analyzer b = new Analyzer() {
+      @Override
+      protected TokenStreamComponents createComponents(String fieldName) {
+        Tokenizer tokenizer = new PatternTokenizer(newAttributeFactory(), Pattern.compile("a"), 0);
+        return new TokenStreamComponents(tokenizer);
+      }    
+    };
+    checkRandomData(random(), b, 1000*RANDOM_MULTIPLIER);
+    b.close();
+  }
+}


### PR DESCRIPTION
To resolve https://github.com/elastic/elasticsearch/issues/13721. Doesn't seem anyone's looked at that, though.

PatternTokenizer and tests are based off Lucene 5.3.0.
