### PR TITLE
"now" is not affected by "time_zone" in range queries

### DIFF
--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -116,6 +116,4 @@ accepts it), or it can be specified as the `time_zone` parameter:
 }
 --------------------------------------------------
 <1> This date will be converted to `2014-12-31T23:00:00 UTC`.
-<2> `now` is not affected by the `time_zone` parameter (dates should be stored as UTC).
-
-
+<2> `now` is not affected by the `time_zone` parameter (dates must be stored as UTC).

--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -109,12 +109,13 @@ accepts it), or it can be specified as the `time_zone` parameter:
     "range" : {
         "timestamp" : {
             "gte": "2015-01-01 00:00:00", <1>
-            "lte": "now",
+            "lte": "now", <2>
             "time_zone": "+01:00"
         }
     }
 }
 --------------------------------------------------
 <1> This date will be converted to `2014-12-31T23:00:00 UTC`.
+<2> `now` is not affected by the `time_zone` parameter (dates should be stored as UTC).
 
 


### PR DESCRIPTION
As discussed in #13607, `now` ignores the `time_zone` parameter in range queries. This PR adds this to docs.

I decided to not throw an exception for this case because this can be still useful when there are two dates provided and one of them isn't `now`. Is this enough or we should:

(a) Throw an exception every time there is a `now` with `time_zone` even when there is another date parameter (e.g the example in the docs).
(b) Throw an exception if the only date provided is `now`.
(c) The same as (b) but instead of throwing an exception, just log it (warning?).

Closes #13607.
