### PR TITLE
Docu typo: Fixed parameter value

### DIFF
--- a/docs/reference/modules/gateway/local.asciidoc
+++ b/docs/reference/modules/gateway/local.asciidoc
@@ -46,7 +46,7 @@ The import of dangling indices can be controlled with the
 
     Import dangling indices into the cluster (default).
 
-`close`::
+`closed`::
 
     Import dangling indices into the cluster state, but leave them closed.
 


### PR DESCRIPTION
Parameter "auto_import_dangled" accepts 'closed' not 'close'
