### PR TITLE
Query refactoring: last //norelease addressed

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -156,10 +156,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
         return queryBuilder;
     }
 
-    //norelease make this abstract once all builders implement doReadFrom themselves
-    protected QB doReadFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract QB doReadFrom(StreamInput in) throws IOException;
 
     @Override
     public final void writeTo(StreamOutput out) throws IOException {
@@ -168,10 +165,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
         out.writeOptionalString(queryName);
     }
 
-    //norelease make this abstract once all builders implement doWriteTo themselves
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract void doWriteTo(StreamOutput out) throws IOException;
 
     protected final QueryValidationException addValidationError(String validationError, QueryValidationException validationException) {
         return QueryValidationException.addValidationError(getName(), validationError, validationException);
@@ -195,20 +189,14 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
     /**
      * Indicates whether some other {@link QueryBuilder} object of the same type is "equal to" this one.
      */
-    //norelease to be made abstract once all queries are refactored
-    protected boolean doEquals(QB other) {
-        return super.equals(other);
-    }
+    protected abstract boolean doEquals(QB other);
 
     @Override
     public final int hashCode() {
         return Objects.hash(getClass(), queryName, boost, doHashCode());
     }
 
-    //norelease to be made abstract once all queries are refactored
-    protected int doHashCode() {
-        return super.hashCode();
-    }
+    protected abstract int doHashCode();
 
     /**
      * This helper method checks if the object passed in is a string, if so it
@@ -274,21 +262,5 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder> exte
             queries.add(in.readQuery());
         }
         return queries;
-    }
-
-    protected final void writeOptionalQuery(StreamOutput out, QueryBuilder query) throws IOException {
-        if (query == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeQuery(query);
-        }
-    }
-
-    protected final QueryBuilder readOptionalQuery(StreamInput in) throws IOException {
-        if (in.readBoolean()) {
-            return in.readQuery();
-        }
-        return null;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilder.java
@@ -20,11 +20,8 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.client.Requests;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -49,14 +46,6 @@ public interface QueryBuilder<QB extends QueryBuilder> extends NamedWriteable<QB
      * @return the {@link Query} or <tt>null</tt> if this query should be ignored upstream
      */
     Query toFilter(QueryShardContext context) throws IOException;
-
-    /**
-     * Returns a {@link org.elasticsearch.common.bytes.BytesReference}
-     * containing the {@link ToXContent} output in binary format.
-     * Builds the request based on the default {@link XContentType}, either {@link Requests#CONTENT_TYPE} or provided as a constructor argument
-     */
-    //norelease once we move to serializing queries over the wire in Streamable format, this method shouldn't be needed anymore
-    BytesReference buildAsBytes();
 
     /**
      * Sets the arbitrary name to be assigned to the query (see named queries).

--- a/core/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -44,9 +44,9 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
             case 0:
                 return new WrapperQueryBuilder(wrappedQuery.toString());
             case 1:
-                return new WrapperQueryBuilder(wrappedQuery.buildAsBytes().toBytes());
+                return new WrapperQueryBuilder(((AbstractQueryBuilder<?>)wrappedQuery).buildAsBytes().toBytes());
             case 2:
-                return new WrapperQueryBuilder(wrappedQuery.buildAsBytes());
+                return new WrapperQueryBuilder(((AbstractQueryBuilder<?>)wrappedQuery).buildAsBytes());
             default:
                 throw new UnsupportedOperationException();
         }

--- a/core/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryParserPlugin.java
+++ b/core/src/test/java/org/elasticsearch/index/query/plugin/DummyQueryParserPlugin.java
@@ -23,6 +23,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Weight;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.*;
@@ -58,6 +60,26 @@ public class DummyQueryParserPlugin extends Plugin {
         @Override
         protected Query doToQuery(QueryShardContext context) throws IOException {
             return new DummyQuery(context.isFilter());
+        }
+
+        @Override
+        protected DummyQueryBuilder doReadFrom(StreamInput in) throws IOException {
+            return null;
+        }
+
+        @Override
+        protected void doWriteTo(StreamOutput out) throws IOException {
+
+        }
+
+        @Override
+        protected boolean doEquals(DummyQueryBuilder other) {
+            return false;
+        }
+
+        @Override
+        protected int doHashCode() {
+            return 0;
         }
 
         @Override


### PR DESCRIPTION
Some methods had default implementation while queries were going to be refactored, now that they are all refactored all those methods can be made abstract.
