### PR TITLE
Don't log multi-megabyte guice exceptions.

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/StartupError.java
@@ -97,7 +97,11 @@ final class StartupError extends RuntimeException {
                 linesWritten++;
             }
         }
-        s.println("Refer to the log for complete error details.");
+        // if its a guice exception, the whole thing really will not be in the log, its megabytes.
+        // refer to the hack in bootstrap, where we don't log it
+        if (originalCause instanceof CreationException == false) {
+            s.println("Refer to the log for complete error details.");
+        }
     }
     
     /** 


### PR DESCRIPTION
Instead just log the same thing we print to the startup console for that case (magic logic),
it sucks to do this, but guice exceptions are too much.

All other non-guice exceptions will still be fully logged.

cc: @drewr 
