### PR TITLE
Adds disk used by indices to _cat/allocation

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -68,7 +69,7 @@ public class RestAllocationAction extends AbstractCatAction {
             @Override
             public void processResponse(final ClusterStateResponse state) {
                 NodesStatsRequest statsRequest = new NodesStatsRequest(nodes);
-                statsRequest.clear().fs(true);
+                statsRequest.clear().fs(true).indices(new CommonStatsFlags(CommonStatsFlags.Flag.Store));
 
                 client.admin().cluster().nodesStats(statsRequest, new RestResponseListener<NodesStatsResponse>(channel) {
                     @Override
@@ -87,6 +88,7 @@ public class RestAllocationAction extends AbstractCatAction {
         final Table table = new Table();
         table.startHeaders();
         table.addCell("shards", "alias:s;text-align:right;desc:number of shards on node");
+        table.addCell("disk.indices", "alias:di,diskIndices;text-align:right;desc:disk used by ES indices");
         table.addCell("disk.used", "alias:du,diskUsed;text-align:right;desc:disk used (total, not just ES)");
         table.addCell("disk.avail", "alias:da,diskAvail;text-align:right;desc:disk available");
         table.addCell("disk.total", "alias:dt,diskTotal;text-align:right;desc:total capacity of all volumes");
@@ -132,6 +134,7 @@ public class RestAllocationAction extends AbstractCatAction {
 
             table.startRow();
             table.addCell(shardCount);
+            table.addCell(nodeStats.getIndices().getStore().getSize());
             table.addCell(used < 0 ? null : new ByteSizeValue(used));
             table.addCell(avail.bytes() < 0 ? null : avail);
             table.addCell(total.bytes() < 0 ? null : total);
@@ -146,6 +149,7 @@ public class RestAllocationAction extends AbstractCatAction {
         if (allocs.containsKey(UNASSIGNED)) {
             table.startRow();
             table.addCell(allocs.get(UNASSIGNED));
+            table.addCell(null);
             table.addCell(null);
             table.addCell(null);
             table.addCell(null);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.allocation/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.allocation/10_basic.yaml
@@ -6,14 +6,15 @@
 
   - match:
       $body: |
-               /^  shards           .+   \n
-                   disk.used        .+   \n
-                   disk.avail       .+   \n
-                   disk.total       .+   \n
-                   disk.percent     .+   \n
-                   host             .+   \n
-                   ip               .+   \n
-                   node             .+   \n
+               /^  shards            .+   \n
+                   disk.indices      .+   \n
+                   disk.used         .+   \n
+                   disk.avail        .+   \n
+                   disk.total        .+   \n
+                   disk.percent      .+   \n
+                   host              .+   \n
+                   ip                .+   \n
+                   node              .+   \n
                $/
 
 ---
@@ -26,6 +27,7 @@
       $body: |
             /^
               ( 0                      \s+
+                0b                     \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
                 (\d+(\.\d+)?[kmgt]b    \s+)?  #no value from client nodes
                 (\d+(\.\d+)?[kmgt]b    \s+)?  #no value from client nodes
@@ -56,6 +58,7 @@
             /^
               ( \s*                          #allow leading spaces to account for right-justified text
                 \d+                    \s+
+                \d+(\.\d+)?b           \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
                 (\d+(\.\d+)?[kmgt]b   \s+)  #always should return value since we filter out non data nodes by default
                 (\d+(\.\d+)?[kmgt]b   \s+)  #always should return value since we filter out non data nodes by default
@@ -84,6 +87,7 @@
       $body: |
             /^
               ( 0                      \s+
+                0b                     \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
                 (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
                 (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
@@ -117,6 +121,7 @@
              /^
                ( \s*                          #allow leading spaces to account for right-justified text
                  \d+                    \s+
+                 \d+(\.\d+)?b           \s+
                  \d+(\.\d+)?[kmgt]?b    \s+
                  (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
                  (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
@@ -144,6 +149,7 @@
 
       $body: |
            /^  shards                  \s+
+               disk.indices            \s+
                disk.used               \s+
                disk.avail              \s+
                disk.total              \s+
@@ -155,6 +161,7 @@
 
               ( \s*                          #allow leading spaces to account for right-justified text
                 0                      \s+
+                0b                     \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
                 (\d+(\.\d+)?[kmgt]b   \s+)  #always should return value since we filter out non data nodes by default
                 (\d+(\.\d+)?[kmgt]b   \s+)  #always should return value since we filter out non data nodes by default
@@ -214,6 +221,7 @@
       $body: |
             /^
               ( 0                   \s+
+                0                   \s+
                 \d+                 \s+
                 (\d+                 \s+)  #always should return value since we filter out non data nodes by default
                 (\d+                 \s+)  #always should return value since we filter out non data nodes by default


### PR DESCRIPTION
This PR adds a column to _cat/allocation with the disk space used by ES indices in the node.

Closes #13529 
