### PR TITLE
ByteSizeValue.equals should normalize units

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -250,10 +250,11 @@ public class ByteSizeValue implements Streamable {
 
         ByteSizeValue sizeValue = (ByteSizeValue) o;
 
-        if (size != sizeValue.size) return false;
-        if (sizeUnit != sizeValue.sizeUnit) return false;
-
-        return true;
+        if (sizeUnit == sizeValue.sizeUnit) {
+            return size == sizeValue.size;
+        } else {
+            return bytes() == sizeValue.bytes();
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -245,16 +245,16 @@ public class ByteSizeValue implements Streamable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ByteSizeValue sizeValue = (ByteSizeValue) o;
 
-        if (sizeUnit == sizeValue.sizeUnit) {
-            return size == sizeValue.size;
-        } else {
-            return bytes() == sizeValue.bytes();
-        }
+        return bytes() == sizeValue.bytes();
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -57,6 +57,13 @@ public class ByteSizeValueTests extends ESTestCase {
         assertThat(ByteSizeUnit.PB.toPB(10), is(new ByteSizeValue(10, ByteSizeUnit.PB).pb()));
     }
 
+    public void testEquality() {
+        String[] equalValues = new String[]{"2GB", "2048MB", "2097152KB", "2147483684B"};
+        ByteSizeValue value1 = ByteSizeValue.parseBytesSizeValue(randomFrom(equalValues), "equalTest");
+        ByteSizeValue value2 = ByteSizeValue.parseBytesSizeValue(randomFrom(equalValues), "equalTest");
+        assertThat(value1, equalTo(value2));
+    }
+
     @Test
     public void testToString() {
         assertThat("10b", is(new ByteSizeValue(10, ByteSizeUnit.BYTES).toString()));


### PR DESCRIPTION
currently ByteSizeValue.parse("1GB") is not equal to ByteSizeValue.parse("1024MB")
