### PR TITLE
Make sure equivalent geohashCellQueries are equal after toQuery called

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -233,6 +233,7 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
     @Override
     public Query doToQuery(QueryShardContext context) throws IOException {
         Query query = null;
+        String rewrite = this.rewrite;
         if (rewrite == null && context.isFilter()) {
             rewrite = QueryParsers.CONSTANT_SCORE.getPreferredName();
         }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -72,7 +72,10 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
             }
         }
         this.fieldName = fieldName;
-        this.shell = points;
+        this.shell = new ArrayList<>(points);
+        if (!shell.get(shell.size() - 1).equals(shell.get(0))) {
+            shell.add(shell.get(0));
+        }
     }
 
     public String fieldName() {
@@ -97,8 +100,9 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
 
-        if (!shell.get(shell.size() - 1).equals(shell.get(0))) {
-            shell.add(shell.get(0));
+        List<GeoPoint> shell = new ArrayList<GeoPoint>();
+        for (GeoPoint geoPoint : this.shell) {
+            shell.add(new GeoPoint(geoPoint));
         }
 
         final boolean indexCreatedBeforeV2_0 = context.indexVersionCreated().before(Version.V_2_0_0);

--- a/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -197,6 +197,7 @@ public class GeohashCellQuery {
                         fieldName);
             }
 
+            String geohash = this.geohash;
             if (levels != null) {
                 int len = Math.min(levels, geohash.length());
                 geohash = geohash.substring(0, len);

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -41,7 +41,10 @@ import org.elasticsearch.indices.cache.query.terms.TermsLookup;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -267,7 +270,9 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         List<Object> terms;
+        TermsLookup termsLookup = null;
         if (this.termsLookup != null) {
+            termsLookup = new TermsLookup(this.termsLookup);
             if (termsLookup.index() == null) {
                 termsLookup.index(context.index().name());
             }

--- a/core/src/main/java/org/elasticsearch/index/query/support/InnerHitsQueryParserHelper.java
+++ b/core/src/main/java/org/elasticsearch/index/query/support/InnerHitsQueryParserHelper.java
@@ -21,10 +21,6 @@ package org.elasticsearch.index.query.support;
 
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.index.query.QueryShardException;
-import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.search.fetch.fielddata.FieldDataFieldsParseElement;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsSubSearchContext;
 import org.elasticsearch.search.fetch.script.ScriptFieldsParseElement;
@@ -73,7 +69,7 @@ public class InnerHitsQueryParserHelper {
                 }
             }
         } catch (Exception e) {
-            throw new IOException("Failed to parse [_inner_hits]");
+            throw new IOException("Failed to parse [_inner_hits]", e);
         }
         return new InnerHitsSubSearchContext(innerHitName, subSearchContext);
     }

--- a/core/src/main/java/org/elasticsearch/indices/cache/query/terms/TermsLookup.java
+++ b/core/src/main/java/org/elasticsearch/indices/cache/query/terms/TermsLookup.java
@@ -42,6 +42,11 @@ public class TermsLookup implements Writeable<TermsLookup>, ToXContent {
     private final String path;
     private String routing;
 
+    public TermsLookup(TermsLookup copy) {
+        this(copy.index, copy.type, copy.id, copy.path);
+        this.routing = copy.routing;
+    }
+
     public TermsLookup(String index, String type, String id, String path) {
         if (id == null) {
             throw new IllegalArgumentException("[terms] query lookup element requires specifying the id.");

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -19,12 +19,20 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
@@ -98,7 +106,7 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
                 assertThat(booleanQuery.clauses().size(), equalTo(clauses.size()));
                 Iterator<BooleanClause> clauseIterator = clauses.iterator();
                 for (BooleanClause booleanClause : booleanQuery.getClauses()) {
-                    assertThat(booleanClause, equalTo(clauseIterator.next()));
+                    assertThat(booleanClause, instanceOf(clauseIterator.next().getClass()));
                 }
             }
         }

--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -26,7 +26,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<ConstantScoreQueryBuilder> {
 
@@ -46,7 +47,7 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
         } else {
             assertThat(query, instanceOf(ConstantScoreQuery.class));
             ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
-            assertThat(constantScoreQuery.getQuery(), equalTo(innerQuery));
+            assertThat(constantScoreQuery.getQuery(), instanceOf(innerQuery.getClass()));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.spatial4j.core.shape.Point;
+
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -30,7 +31,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDistanceQueryBuilder> {
 
@@ -360,7 +363,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "}\n";
         assertGeoDistanceRangeQuery(query);
     }
-    
+
     private void assertGeoDistanceRangeQuery(String query) throws IOException {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query parsedQuery = parseQuery(query).toQuery(createShardContext());

--- a/core/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -52,7 +52,9 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.index.query.QueryBuilders.moreLikeThisQuery;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLikeThisQueryBuilder> {
 

--- a/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NotQueryBuilderTests.java
@@ -31,7 +31,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 public class NotQueryBuilderTests extends AbstractQueryTestCase<NotQueryBuilder> {
 
@@ -55,7 +57,7 @@ public class NotQueryBuilderTests extends AbstractQueryTestCase<NotQueryBuilder>
             assertThat(booleanQuery.clauses().get(0).getOccur(), equalTo(BooleanClause.Occur.MUST));
             assertThat(booleanQuery.clauses().get(0).getQuery(), instanceOf(MatchAllDocsQuery.class));
             assertThat(booleanQuery.clauses().get(1).getOccur(), equalTo(BooleanClause.Occur.MUST_NOT));
-            assertThat(booleanQuery.clauses().get(1).getQuery(), equalTo(filter));
+            assertThat(booleanQuery.clauses().get(1).getQuery(), instanceOf(filter.getClass()));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoFilterIT.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoFilterIT.java
@@ -23,6 +23,7 @@ import com.spatial4j.core.context.SpatialContext;
 import com.spatial4j.core.distance.DistanceUtils;
 import com.spatial4j.core.exception.InvalidShapeException;
 import com.spatial4j.core.shape.Shape;
+
 import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
 import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.apache.lucene.spatial.query.SpatialArgs;
@@ -43,8 +44,8 @@ import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.GeohashCellQuery;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.BeforeClass;
@@ -65,9 +66,19 @@ import java.util.Random;
 import java.util.zip.GZIPInputStream;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
-import static org.hamcrest.Matchers.*;
+import static org.elasticsearch.index.query.QueryBuilders.geoBoundingBoxQuery;
+import static org.elasticsearch.index.query.QueryBuilders.geoDistanceQuery;
+import static org.elasticsearch.index.query.QueryBuilders.geoHashCellQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
  *


### PR DESCRIPTION
Previous to this change if to equal geohash cell query builders were created and then toQuery was called on one, they would no longer be equal.

This change also adds a test to AbstractQueryTestCase to make sure calling toQuery on any query builder does not affect the query builder's equality
