### PR TITLE
Tests: Avoid unicode strings in alternative query builder tests

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
@@ -550,7 +551,13 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         Object value;
         switch (fieldName) {
             case STRING_FIELD_NAME:
-                value = rarely() ? randomUnicodeOfLength(10) : randomAsciiOfLengthBetween(1, 10); // unicode in 10% cases
+                if (rarely()) {
+                    // unicode in 10% cases
+                    JsonStringEncoder encoder = JsonStringEncoder.getInstance();
+                    value = new String(encoder.quoteAsString(randomUnicodeOfLength(10)));
+                } else {
+                    value = randomAsciiOfLengthBetween(1, 10);
+                }
                 break;
             case INT_FIELD_NAME:
                 value = randomIntBetween(0, 10);

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
@@ -97,12 +97,19 @@ public abstract class AbstractTermQueryTestCase<QB extends BaseTermQueryBuilder<
     protected Map<String, QB> getAlternateVersions() {
         HashMap<String, QB> alternateVersions = new HashMap<>();
         QB tempQuery = createTestQueryBuilder();
-        QB testQuery = createQueryBuilder(tempQuery.fieldName(), tempQuery.value());
-        boolean isString = testQuery.value() instanceof String;
-        String value = (isString ? "\"" : "") + testQuery.value() + (isString ? "\"" : "");
+        String fieldName = tempQuery.fieldName();
+        Object value = tempQuery.value();
+        boolean isString = value instanceof String;
+        // random builder rarely generates unicode string, which ca cause problems in contentString below
+        // if not escaped, so we simply default to ascii strings for this special case
+        if (isString) {
+            value = randomAsciiOfLengthBetween(1, 10);
+        }
+        QB testQuery = createQueryBuilder(fieldName, value);
+        String valueInQuery = (isString ? "\"" : "") + testQuery.value() + (isString ? "\"" : "");
         String contentString = "{\n" +
                 "    \"" + testQuery.getName() + "\" : {\n" +
-                "        \"" + testQuery.fieldName() + "\" : " + value + "\n" +
+                "        \"" + testQuery.fieldName() + "\" : " + valueInQuery + "\n" +
                 "    }\n" +
                 "}";
         alternateVersions.put(contentString, testQuery);


### PR DESCRIPTION
When testing alternative versions of the json syntax for the term queries (SpanTermQueryBuilder and TermQueryBuilder) we don't go trough the doXContent json rendering, so having a unicode value creates problems for the parser later, causing those tests to fail rarely. Since Unicode values are generally tested elsewhere, I suggest we make sure we always have ascii here.
