### PR TITLE
Make ElasticsearchException ids for 2.0 consistent with master

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -48,7 +48,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     private static final String RESOURCE_HEADER_TYPE_KEY = "es.resource.type";
     private static final String RESOURCE_HEADER_ID_KEY = "es.resource.id";
 
-    private static final Constructor<? extends ElasticsearchException>[] ID_TO_SUPPLIER;
+    static final Map<Integer, Constructor<? extends ElasticsearchException>> ID_TO_SUPPLIER;
     private static final Map<Class<? extends ElasticsearchException>, Integer> CLASS_TO_ID;
     private final Map<String, List<String>> headers = new HashMap<>();
 
@@ -232,7 +232,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     }
 
     public static ElasticsearchException readException(StreamInput input, int id) throws IOException {
-        Constructor<? extends ElasticsearchException> elasticsearchException = ID_TO_SUPPLIER[id];
+        Constructor<? extends ElasticsearchException> elasticsearchException = ID_TO_SUPPLIER.get(id);
         if (elasticsearchException == null) {
             throw new IllegalStateException("unknown exception for id: " + id);
         }
@@ -506,108 +506,106 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         exceptions.put(org.elasticsearch.snapshots.SnapshotRestoreException.class, 39);
         exceptions.put(org.elasticsearch.index.query.QueryParsingException.class, 40);
         exceptions.put(org.elasticsearch.index.shard.IndexShardClosedException.class, 41);
-        exceptions.put(org.elasticsearch.script.expression.ExpressionScriptCompilationException.class, 42);
-        exceptions.put(org.elasticsearch.indices.recovery.RecoverFilesRecoveryException.class, 43);
-        exceptions.put(org.elasticsearch.index.translog.TruncatedTranslogException.class, 44);
-        exceptions.put(org.elasticsearch.indices.recovery.RecoveryFailedException.class, 45);
-        exceptions.put(org.elasticsearch.index.shard.IndexShardRelocatedException.class, 46);
-        exceptions.put(org.elasticsearch.transport.NodeShouldNotConnectException.class, 47);
-        exceptions.put(org.elasticsearch.indices.IndexTemplateAlreadyExistsException.class, 48);
-        exceptions.put(org.elasticsearch.index.translog.TranslogCorruptedException.class, 49);
-        exceptions.put(org.elasticsearch.cluster.block.ClusterBlockException.class, 50);
-        exceptions.put(org.elasticsearch.search.fetch.FetchPhaseExecutionException.class, 51);
-        exceptions.put(org.elasticsearch.index.IndexShardAlreadyExistsException.class, 52);
-        exceptions.put(org.elasticsearch.index.engine.VersionConflictEngineException.class, 53);
-        exceptions.put(org.elasticsearch.index.engine.EngineException.class, 54);
-        exceptions.put(org.elasticsearch.index.engine.DocumentAlreadyExistsException.class, 55);
-        exceptions.put(org.elasticsearch.action.NoSuchNodeException.class, 56);
-        exceptions.put(org.elasticsearch.common.settings.SettingsException.class, 57);
-        exceptions.put(org.elasticsearch.indices.IndexTemplateMissingException.class, 58);
-        exceptions.put(org.elasticsearch.transport.SendRequestTransportException.class, 59);
-        exceptions.put(org.elasticsearch.common.util.concurrent.EsRejectedExecutionException.class, 60);
-        exceptions.put(org.elasticsearch.common.lucene.Lucene.EarlyTerminationException.class, 61);
-        exceptions.put(org.elasticsearch.cluster.routing.RoutingValidationException.class, 62);
-        exceptions.put(org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper.class, 63);
-        exceptions.put(org.elasticsearch.indices.AliasFilterParsingException.class, 64);
-        exceptions.put(org.elasticsearch.index.engine.DeleteByQueryFailedEngineException.class, 65);
-        exceptions.put(org.elasticsearch.gateway.GatewayException.class, 66);
-        exceptions.put(org.elasticsearch.index.shard.IndexShardNotRecoveringException.class, 67);
-        exceptions.put(org.elasticsearch.http.HttpException.class, 68);
-        exceptions.put(org.elasticsearch.ElasticsearchException.class, 69);
-        exceptions.put(org.elasticsearch.snapshots.SnapshotMissingException.class, 70);
-        exceptions.put(org.elasticsearch.action.PrimaryMissingActionException.class, 71);
-        exceptions.put(org.elasticsearch.action.FailedNodeException.class, 72);
-        exceptions.put(org.elasticsearch.search.SearchParseException.class, 73);
-        exceptions.put(org.elasticsearch.snapshots.ConcurrentSnapshotExecutionException.class, 74);
-        exceptions.put(org.elasticsearch.common.blobstore.BlobStoreException.class, 75);
-        exceptions.put(org.elasticsearch.cluster.IncompatibleClusterStateVersionException.class, 76);
-        exceptions.put(org.elasticsearch.index.engine.RecoveryEngineException.class, 77);
-        exceptions.put(org.elasticsearch.common.util.concurrent.UncategorizedExecutionException.class, 78);
-        exceptions.put(org.elasticsearch.action.TimestampParsingException.class, 79);
-        exceptions.put(org.elasticsearch.action.RoutingMissingException.class, 80);
-        exceptions.put(org.elasticsearch.index.engine.IndexFailedEngineException.class, 81);
-        exceptions.put(org.elasticsearch.index.snapshots.IndexShardRestoreFailedException.class, 82);
-        exceptions.put(org.elasticsearch.repositories.RepositoryException.class, 83);
-        exceptions.put(org.elasticsearch.transport.ReceiveTimeoutTransportException.class, 84);
-        exceptions.put(org.elasticsearch.transport.NodeDisconnectedException.class, 85);
-        exceptions.put(org.elasticsearch.index.AlreadyExpiredException.class, 86);
-        exceptions.put(org.elasticsearch.search.aggregations.AggregationExecutionException.class, 87);
-        exceptions.put(org.elasticsearch.index.mapper.MergeMappingException.class, 88);
-        exceptions.put(org.elasticsearch.indices.InvalidIndexTemplateException.class, 89);
-        exceptions.put(org.elasticsearch.percolator.PercolateException.class, 90);
-        exceptions.put(org.elasticsearch.index.engine.RefreshFailedEngineException.class, 91);
-        exceptions.put(org.elasticsearch.search.aggregations.AggregationInitializationException.class, 92);
-        exceptions.put(org.elasticsearch.indices.recovery.DelayRecoveryException.class, 93);
-        exceptions.put(org.elasticsearch.search.warmer.IndexWarmerMissingException.class, 94);
-        exceptions.put(org.elasticsearch.client.transport.NoNodeAvailableException.class, 95);
-        exceptions.put(org.elasticsearch.script.groovy.GroovyScriptCompilationException.class, 96);
-        exceptions.put(org.elasticsearch.snapshots.InvalidSnapshotNameException.class, 97);
-        exceptions.put(org.elasticsearch.index.shard.IllegalIndexShardStateException.class, 98);
-        exceptions.put(org.elasticsearch.index.snapshots.IndexShardSnapshotException.class, 99);
-        exceptions.put(org.elasticsearch.index.shard.IndexShardNotStartedException.class, 100);
-        exceptions.put(org.elasticsearch.action.search.SearchPhaseExecutionException.class, 101);
-        exceptions.put(org.elasticsearch.transport.ActionNotFoundTransportException.class, 102);
-        exceptions.put(org.elasticsearch.transport.TransportSerializationException.class, 103);
-        exceptions.put(org.elasticsearch.transport.RemoteTransportException.class, 104);
-        exceptions.put(org.elasticsearch.index.engine.EngineCreationFailureException.class, 105);
-        exceptions.put(org.elasticsearch.cluster.routing.RoutingException.class, 106);
-        exceptions.put(org.elasticsearch.index.shard.IndexShardRecoveryException.class, 107);
-        exceptions.put(org.elasticsearch.repositories.RepositoryMissingException.class, 108);
-        exceptions.put(org.elasticsearch.script.expression.ExpressionScriptExecutionException.class, 109);
-        exceptions.put(org.elasticsearch.index.percolator.PercolatorException.class, 110);
-        exceptions.put(org.elasticsearch.index.engine.DocumentSourceMissingException.class, 111);
-        exceptions.put(org.elasticsearch.index.engine.FlushNotAllowedEngineException.class, 112);
-        exceptions.put(org.elasticsearch.common.settings.NoClassSettingsException.class, 113);
-        exceptions.put(org.elasticsearch.transport.BindTransportException.class, 114);
-        exceptions.put(org.elasticsearch.rest.action.admin.indices.alias.delete.AliasesNotFoundException.class, 115);
-        exceptions.put(org.elasticsearch.index.shard.IndexShardRecoveringException.class, 116);
-        exceptions.put(org.elasticsearch.index.translog.TranslogException.class, 117);
-        exceptions.put(org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException.class, 118);
-        exceptions.put(org.elasticsearch.action.support.replication.TransportReplicationAction.RetryOnPrimaryException.class, 119);
-        exceptions.put(org.elasticsearch.ElasticsearchTimeoutException.class, 120);
-        exceptions.put(org.elasticsearch.search.query.QueryPhaseExecutionException.class, 121);
-        exceptions.put(org.elasticsearch.repositories.RepositoryVerificationException.class, 122);
-        exceptions.put(org.elasticsearch.search.aggregations.InvalidAggregationPathException.class, 123);
-        exceptions.put(org.elasticsearch.script.groovy.GroovyScriptExecutionException.class, 124);
-        exceptions.put(org.elasticsearch.indices.IndexAlreadyExistsException.class, 125);
-        exceptions.put(org.elasticsearch.script.Script.ScriptParseException.class, 126);
-        exceptions.put(org.elasticsearch.transport.netty.SizeHeaderFrameDecoder.HttpOnTransportException.class, 127);
-        exceptions.put(org.elasticsearch.index.mapper.MapperParsingException.class, 128);
-        exceptions.put(org.elasticsearch.search.SearchContextException.class, 129);
-        exceptions.put(org.elasticsearch.search.builder.SearchSourceBuilderException.class, 130);
-        exceptions.put(org.elasticsearch.index.engine.EngineClosedException.class, 131);
-        exceptions.put(org.elasticsearch.action.NoShardAvailableActionException.class, 132);
-        exceptions.put(org.elasticsearch.action.UnavailableShardsException.class, 133);
-        exceptions.put(org.elasticsearch.index.engine.FlushFailedEngineException.class, 134);
-        exceptions.put(org.elasticsearch.common.breaker.CircuitBreakingException.class, 135);
-        exceptions.put(org.elasticsearch.transport.NodeNotConnectedException.class, 136);
-        exceptions.put(org.elasticsearch.index.mapper.StrictDynamicMappingException.class, 137);
-        exceptions.put(org.elasticsearch.action.support.replication.TransportReplicationAction.RetryOnReplicaException.class, 138);
-        exceptions.put(org.elasticsearch.indices.TypeMissingException.class, 139);
+        exceptions.put(org.elasticsearch.indices.recovery.RecoverFilesRecoveryException.class, 42);
+        exceptions.put(org.elasticsearch.index.translog.TruncatedTranslogException.class, 43);
+        exceptions.put(org.elasticsearch.indices.recovery.RecoveryFailedException.class, 44);
+        exceptions.put(org.elasticsearch.index.shard.IndexShardRelocatedException.class, 45);
+        exceptions.put(org.elasticsearch.transport.NodeShouldNotConnectException.class, 46);
+        exceptions.put(org.elasticsearch.indices.IndexTemplateAlreadyExistsException.class, 47);
+        exceptions.put(org.elasticsearch.index.translog.TranslogCorruptedException.class, 48);
+        exceptions.put(org.elasticsearch.cluster.block.ClusterBlockException.class, 49);
+        exceptions.put(org.elasticsearch.search.fetch.FetchPhaseExecutionException.class, 50);
+        exceptions.put(org.elasticsearch.index.IndexShardAlreadyExistsException.class, 51);
+        exceptions.put(org.elasticsearch.index.engine.VersionConflictEngineException.class, 52);
+        exceptions.put(org.elasticsearch.index.engine.EngineException.class, 53);
+        exceptions.put(org.elasticsearch.index.engine.DocumentAlreadyExistsException.class, 54);
+        exceptions.put(org.elasticsearch.action.NoSuchNodeException.class, 55);
+        exceptions.put(org.elasticsearch.common.settings.SettingsException.class, 56);
+        exceptions.put(org.elasticsearch.indices.IndexTemplateMissingException.class, 57);
+        exceptions.put(org.elasticsearch.transport.SendRequestTransportException.class, 58);
+        exceptions.put(org.elasticsearch.common.util.concurrent.EsRejectedExecutionException.class, 59);
+        exceptions.put(org.elasticsearch.common.lucene.Lucene.EarlyTerminationException.class, 60);
+        exceptions.put(org.elasticsearch.cluster.routing.RoutingValidationException.class, 61);
+        exceptions.put(org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper.class, 62);
+        exceptions.put(org.elasticsearch.indices.AliasFilterParsingException.class, 63);
+        exceptions.put(org.elasticsearch.index.engine.DeleteByQueryFailedEngineException.class, 64);
+        exceptions.put(org.elasticsearch.gateway.GatewayException.class, 65);
+        exceptions.put(org.elasticsearch.index.shard.IndexShardNotRecoveringException.class, 66);
+        exceptions.put(org.elasticsearch.http.HttpException.class, 67);
+        exceptions.put(org.elasticsearch.ElasticsearchException.class, 68);
+        exceptions.put(org.elasticsearch.snapshots.SnapshotMissingException.class, 69);
+        exceptions.put(org.elasticsearch.action.PrimaryMissingActionException.class, 70);
+        exceptions.put(org.elasticsearch.action.FailedNodeException.class, 71);
+        exceptions.put(org.elasticsearch.search.SearchParseException.class, 72);
+        exceptions.put(org.elasticsearch.snapshots.ConcurrentSnapshotExecutionException.class, 73);
+        exceptions.put(org.elasticsearch.common.blobstore.BlobStoreException.class, 74);
+        exceptions.put(org.elasticsearch.cluster.IncompatibleClusterStateVersionException.class, 75);
+        exceptions.put(org.elasticsearch.index.engine.RecoveryEngineException.class, 76);
+        exceptions.put(org.elasticsearch.common.util.concurrent.UncategorizedExecutionException.class, 77);
+        exceptions.put(org.elasticsearch.action.TimestampParsingException.class, 78);
+        exceptions.put(org.elasticsearch.action.RoutingMissingException.class, 79);
+        exceptions.put(org.elasticsearch.index.engine.IndexFailedEngineException.class, 80);
+        exceptions.put(org.elasticsearch.index.snapshots.IndexShardRestoreFailedException.class, 81);
+        exceptions.put(org.elasticsearch.repositories.RepositoryException.class, 82);
+        exceptions.put(org.elasticsearch.transport.ReceiveTimeoutTransportException.class, 83);
+        exceptions.put(org.elasticsearch.transport.NodeDisconnectedException.class, 84);
+        exceptions.put(org.elasticsearch.index.AlreadyExpiredException.class, 85);
+        exceptions.put(org.elasticsearch.search.aggregations.AggregationExecutionException.class, 86);
+        exceptions.put(org.elasticsearch.index.mapper.MergeMappingException.class, 87);
+        exceptions.put(org.elasticsearch.indices.InvalidIndexTemplateException.class, 88);
+        exceptions.put(org.elasticsearch.percolator.PercolateException.class, 89);
+        exceptions.put(org.elasticsearch.index.engine.RefreshFailedEngineException.class, 90);
+        exceptions.put(org.elasticsearch.search.aggregations.AggregationInitializationException.class, 91);
+        exceptions.put(org.elasticsearch.indices.recovery.DelayRecoveryException.class, 92);
+        exceptions.put(org.elasticsearch.search.warmer.IndexWarmerMissingException.class, 93);
+        exceptions.put(org.elasticsearch.client.transport.NoNodeAvailableException.class, 94);
+        exceptions.put(org.elasticsearch.script.groovy.GroovyScriptCompilationException.class, 95);
+        exceptions.put(org.elasticsearch.snapshots.InvalidSnapshotNameException.class, 96);
+        exceptions.put(org.elasticsearch.index.shard.IllegalIndexShardStateException.class, 97);
+        exceptions.put(org.elasticsearch.index.snapshots.IndexShardSnapshotException.class, 98);
+        exceptions.put(org.elasticsearch.index.shard.IndexShardNotStartedException.class, 99);
+        exceptions.put(org.elasticsearch.action.search.SearchPhaseExecutionException.class, 100);
+        exceptions.put(org.elasticsearch.transport.ActionNotFoundTransportException.class, 101);
+        exceptions.put(org.elasticsearch.transport.TransportSerializationException.class, 102);
+        exceptions.put(org.elasticsearch.transport.RemoteTransportException.class, 103);
+        exceptions.put(org.elasticsearch.index.engine.EngineCreationFailureException.class, 104);
+        exceptions.put(org.elasticsearch.cluster.routing.RoutingException.class, 105);
+        exceptions.put(org.elasticsearch.index.shard.IndexShardRecoveryException.class, 106);
+        exceptions.put(org.elasticsearch.repositories.RepositoryMissingException.class, 107);
+        exceptions.put(org.elasticsearch.index.percolator.PercolatorException.class, 108);
+        exceptions.put(org.elasticsearch.index.engine.DocumentSourceMissingException.class, 109);
+        exceptions.put(org.elasticsearch.index.engine.FlushNotAllowedEngineException.class, 110);
+        exceptions.put(org.elasticsearch.common.settings.NoClassSettingsException.class, 111);
+        exceptions.put(org.elasticsearch.transport.BindTransportException.class, 112);
+        exceptions.put(org.elasticsearch.rest.action.admin.indices.alias.delete.AliasesNotFoundException.class, 113);
+        exceptions.put(org.elasticsearch.index.shard.IndexShardRecoveringException.class, 114);
+        exceptions.put(org.elasticsearch.index.translog.TranslogException.class, 115);
+        exceptions.put(org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException.class, 116);
+        exceptions.put(org.elasticsearch.action.support.replication.TransportReplicationAction.RetryOnPrimaryException.class, 117);
+        exceptions.put(org.elasticsearch.ElasticsearchTimeoutException.class, 118);
+        exceptions.put(org.elasticsearch.search.query.QueryPhaseExecutionException.class, 119);
+        exceptions.put(org.elasticsearch.repositories.RepositoryVerificationException.class, 120);
+        exceptions.put(org.elasticsearch.search.aggregations.InvalidAggregationPathException.class, 121);
+        exceptions.put(org.elasticsearch.script.groovy.GroovyScriptExecutionException.class, 122);
+        exceptions.put(org.elasticsearch.indices.IndexAlreadyExistsException.class, 123);
+        exceptions.put(org.elasticsearch.script.Script.ScriptParseException.class, 124);
+        exceptions.put(org.elasticsearch.transport.netty.SizeHeaderFrameDecoder.HttpOnTransportException.class, 125);
+        exceptions.put(org.elasticsearch.index.mapper.MapperParsingException.class, 126);
+        exceptions.put(org.elasticsearch.search.SearchContextException.class, 127);
+        exceptions.put(org.elasticsearch.search.builder.SearchSourceBuilderException.class, 128);
+        exceptions.put(org.elasticsearch.index.engine.EngineClosedException.class, 129);
+        exceptions.put(org.elasticsearch.action.NoShardAvailableActionException.class, 130);
+        exceptions.put(org.elasticsearch.action.UnavailableShardsException.class, 131);
+        exceptions.put(org.elasticsearch.index.engine.FlushFailedEngineException.class, 132);
+        exceptions.put(org.elasticsearch.common.breaker.CircuitBreakingException.class, 133);
+        exceptions.put(org.elasticsearch.transport.NodeNotConnectedException.class, 134);
+        exceptions.put(org.elasticsearch.index.mapper.StrictDynamicMappingException.class, 135);
+        exceptions.put(org.elasticsearch.action.support.replication.TransportReplicationAction.RetryOnReplicaException.class, 136);
+        exceptions.put(org.elasticsearch.indices.TypeMissingException.class, 137);
+        exceptions.put(org.elasticsearch.script.expression.ExpressionScriptCompilationException.class, 138);
+        exceptions.put(org.elasticsearch.script.expression.ExpressionScriptExecutionException.class, 139);
 
-        final int maxOrd = 139;
-        assert exceptions.size() == maxOrd + 1;
-        Constructor<? extends ElasticsearchException>[] idToSupplier = new Constructor[maxOrd + 1];
+        Map<Integer, Constructor<? extends ElasticsearchException>> idToSupplier = new HashMap<>();
         for (Map.Entry<Class<? extends ElasticsearchException>, Integer> e : exceptions.entrySet()) {
             try {
                 Constructor<? extends ElasticsearchException> constructor = e.getKey().getDeclaredConstructor(StreamInput.class);
@@ -615,21 +613,16 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                     throw new IllegalStateException(e.getKey().getName() + " has not StreamInput ctor");
                 }
                 assert e.getValue().intValue() >= 0;
-                if (idToSupplier[e.getValue().intValue()] != null) {
+                if (idToSupplier.get(e.getValue().intValue()) != null) {
                     throw new IllegalStateException("ordinal [" + e.getValue().intValue()  +"] is used more than once");
                 }
-                idToSupplier[e.getValue().intValue()] = constructor;
+                idToSupplier.put(e.getValue().intValue(), constructor);
             } catch (NoSuchMethodException t) {
                 throw new RuntimeException("failed to register [" + e.getKey().getName() + "] exception must have a public StreamInput ctor", t);
             }
         }
-        for (int i = 0; i < idToSupplier.length; i++) {
-            if (idToSupplier[i] == null) {
-                throw new IllegalStateException("missing exception for ordinal [" + i + "]");
-            }
-        }
 
-        ID_TO_SUPPLIER = idToSupplier;
+        ID_TO_SUPPLIER = Collections.unmodifiableMap(idToSupplier);
         CLASS_TO_ID = Collections.unmodifiableMap(exceptions);
     }
 

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.TimestampParsingException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.bootstrap.Elasticsearch;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -71,6 +72,7 @@ import org.elasticsearch.transport.ActionTransportException;
 import org.elasticsearch.transport.ConnectTransportException;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.net.URISyntaxException;
 import java.nio.file.FileVisitResult;
@@ -78,9 +80,7 @@ import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class ExceptionSerializationTests extends ESTestCase {
 
@@ -218,7 +218,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         ex = serialize(new QueryParsingException(null, 1, 2, null, null));
         assertNull(ex.getIndex());
         assertNull(ex.getMessage());
-        assertEquals(ex.getLineNumber(),1);
+        assertEquals(ex.getLineNumber(), 1);
         assertEquals(ex.getColumnNumber(), 2);
     }
 
@@ -621,6 +621,168 @@ public class ExceptionSerializationTests extends ESTestCase {
 
         public UnknownException(String message, Throwable cause) {
             super(message, cause);
+        }
+    }
+
+    public void testIds() {
+        Map<Integer, Class<? extends ElasticsearchException>> ids = new HashMap<>();
+        ids.put(0, org.elasticsearch.index.snapshots.IndexShardSnapshotFailedException.class);
+        ids.put(1, org.elasticsearch.search.dfs.DfsPhaseExecutionException.class);
+        ids.put(2, org.elasticsearch.common.util.CancellableThreads.ExecutionCancelledException.class);
+        ids.put(3, org.elasticsearch.discovery.MasterNotDiscoveredException.class);
+        ids.put(4, org.elasticsearch.ElasticsearchSecurityException.class);
+        ids.put(5, org.elasticsearch.index.snapshots.IndexShardRestoreException.class);
+        ids.put(6, org.elasticsearch.indices.IndexClosedException.class);
+        ids.put(7, org.elasticsearch.http.BindHttpException.class);
+        ids.put(8, org.elasticsearch.action.search.ReduceSearchPhaseException.class);
+        ids.put(9, org.elasticsearch.node.NodeClosedException.class);
+        ids.put(10, org.elasticsearch.index.engine.SnapshotFailedEngineException.class);
+        ids.put(11, org.elasticsearch.index.shard.ShardNotFoundException.class);
+        ids.put(12, org.elasticsearch.transport.ConnectTransportException.class);
+        ids.put(13, org.elasticsearch.transport.NotSerializableTransportException.class);
+        ids.put(14, org.elasticsearch.transport.ResponseHandlerFailureTransportException.class);
+        ids.put(15, org.elasticsearch.indices.IndexCreationException.class);
+        ids.put(16, org.elasticsearch.index.IndexNotFoundException.class);
+        ids.put(17, org.elasticsearch.cluster.routing.IllegalShardRoutingStateException.class);
+        ids.put(18, org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException.class);
+        ids.put(19, org.elasticsearch.ResourceNotFoundException.class);
+        ids.put(20, org.elasticsearch.transport.ActionTransportException.class);
+        ids.put(21, org.elasticsearch.ElasticsearchGenerationException.class);
+        ids.put(22, org.elasticsearch.index.engine.CreateFailedEngineException.class);
+        ids.put(23, org.elasticsearch.index.shard.IndexShardStartedException.class);
+        ids.put(24, org.elasticsearch.search.SearchContextMissingException.class);
+        ids.put(25, org.elasticsearch.script.ScriptException.class);
+        ids.put(26, org.elasticsearch.index.shard.TranslogRecoveryPerformer.BatchOperationException.class);
+        ids.put(27, org.elasticsearch.snapshots.SnapshotCreationException.class);
+        ids.put(28, org.elasticsearch.index.engine.DeleteFailedEngineException.class);
+        ids.put(29, org.elasticsearch.index.engine.DocumentMissingException.class);
+        ids.put(30, org.elasticsearch.snapshots.SnapshotException.class);
+        ids.put(31, org.elasticsearch.indices.InvalidAliasNameException.class);
+        ids.put(32, org.elasticsearch.indices.InvalidIndexNameException.class);
+        ids.put(33, org.elasticsearch.indices.IndexPrimaryShardNotAllocatedException.class);
+        ids.put(34, org.elasticsearch.transport.TransportException.class);
+        ids.put(35, org.elasticsearch.ElasticsearchParseException.class);
+        ids.put(36, org.elasticsearch.search.SearchException.class);
+        ids.put(37, org.elasticsearch.index.mapper.MapperException.class);
+        ids.put(38, org.elasticsearch.indices.InvalidTypeNameException.class);
+        ids.put(39, org.elasticsearch.snapshots.SnapshotRestoreException.class);
+        ids.put(40, org.elasticsearch.index.query.QueryParsingException.class);
+        ids.put(41, org.elasticsearch.index.shard.IndexShardClosedException.class);
+        ids.put(42, org.elasticsearch.indices.recovery.RecoverFilesRecoveryException.class);
+        ids.put(43, org.elasticsearch.index.translog.TruncatedTranslogException.class);
+        ids.put(44, org.elasticsearch.indices.recovery.RecoveryFailedException.class);
+        ids.put(45, org.elasticsearch.index.shard.IndexShardRelocatedException.class);
+        ids.put(46, org.elasticsearch.transport.NodeShouldNotConnectException.class);
+        ids.put(47, org.elasticsearch.indices.IndexTemplateAlreadyExistsException.class);
+        ids.put(48, org.elasticsearch.index.translog.TranslogCorruptedException.class);
+        ids.put(49, org.elasticsearch.cluster.block.ClusterBlockException.class);
+        ids.put(50, org.elasticsearch.search.fetch.FetchPhaseExecutionException.class);
+        ids.put(51, org.elasticsearch.index.IndexShardAlreadyExistsException.class);
+        ids.put(52, org.elasticsearch.index.engine.VersionConflictEngineException.class);
+        ids.put(53, org.elasticsearch.index.engine.EngineException.class);
+        ids.put(54, org.elasticsearch.index.engine.DocumentAlreadyExistsException.class);
+        ids.put(55, org.elasticsearch.action.NoSuchNodeException.class);
+        ids.put(56, org.elasticsearch.common.settings.SettingsException.class);
+        ids.put(57, org.elasticsearch.indices.IndexTemplateMissingException.class);
+        ids.put(58, org.elasticsearch.transport.SendRequestTransportException.class);
+        ids.put(59, org.elasticsearch.common.util.concurrent.EsRejectedExecutionException.class);
+        ids.put(60, org.elasticsearch.common.lucene.Lucene.EarlyTerminationException.class);
+        ids.put(61, org.elasticsearch.cluster.routing.RoutingValidationException.class);
+        ids.put(62, org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper.class);
+        ids.put(63, org.elasticsearch.indices.AliasFilterParsingException.class);
+        ids.put(64, org.elasticsearch.index.engine.DeleteByQueryFailedEngineException.class);
+        ids.put(65, org.elasticsearch.gateway.GatewayException.class);
+        ids.put(66, org.elasticsearch.index.shard.IndexShardNotRecoveringException.class);
+        ids.put(67, org.elasticsearch.http.HttpException.class);
+        ids.put(68, org.elasticsearch.ElasticsearchException.class);
+        ids.put(69, org.elasticsearch.snapshots.SnapshotMissingException.class);
+        ids.put(70, org.elasticsearch.action.PrimaryMissingActionException.class);
+        ids.put(71, org.elasticsearch.action.FailedNodeException.class);
+        ids.put(72, org.elasticsearch.search.SearchParseException.class);
+        ids.put(73, org.elasticsearch.snapshots.ConcurrentSnapshotExecutionException.class);
+        ids.put(74, org.elasticsearch.common.blobstore.BlobStoreException.class);
+        ids.put(75, org.elasticsearch.cluster.IncompatibleClusterStateVersionException.class);
+        ids.put(76, org.elasticsearch.index.engine.RecoveryEngineException.class);
+        ids.put(77, org.elasticsearch.common.util.concurrent.UncategorizedExecutionException.class);
+        ids.put(78, org.elasticsearch.action.TimestampParsingException.class);
+        ids.put(79, org.elasticsearch.action.RoutingMissingException.class);
+        ids.put(80, org.elasticsearch.index.engine.IndexFailedEngineException.class);
+        ids.put(81, org.elasticsearch.index.snapshots.IndexShardRestoreFailedException.class);
+        ids.put(82, org.elasticsearch.repositories.RepositoryException.class);
+        ids.put(83, org.elasticsearch.transport.ReceiveTimeoutTransportException.class);
+        ids.put(84, org.elasticsearch.transport.NodeDisconnectedException.class);
+        ids.put(85, org.elasticsearch.index.AlreadyExpiredException.class);
+        ids.put(86, org.elasticsearch.search.aggregations.AggregationExecutionException.class);
+        ids.put(87, org.elasticsearch.index.mapper.MergeMappingException.class);
+        ids.put(88, org.elasticsearch.indices.InvalidIndexTemplateException.class);
+        ids.put(89, org.elasticsearch.percolator.PercolateException.class);
+        ids.put(90, org.elasticsearch.index.engine.RefreshFailedEngineException.class);
+        ids.put(91, org.elasticsearch.search.aggregations.AggregationInitializationException.class);
+        ids.put(92, org.elasticsearch.indices.recovery.DelayRecoveryException.class);
+        ids.put(93, org.elasticsearch.search.warmer.IndexWarmerMissingException.class);
+        ids.put(94, org.elasticsearch.client.transport.NoNodeAvailableException.class);
+        ids.put(95, org.elasticsearch.script.groovy.GroovyScriptCompilationException.class);
+        ids.put(96, org.elasticsearch.snapshots.InvalidSnapshotNameException.class);
+        ids.put(97, org.elasticsearch.index.shard.IllegalIndexShardStateException.class);
+        ids.put(98, org.elasticsearch.index.snapshots.IndexShardSnapshotException.class);
+        ids.put(99, org.elasticsearch.index.shard.IndexShardNotStartedException.class);
+        ids.put(100, org.elasticsearch.action.search.SearchPhaseExecutionException.class);
+        ids.put(101, org.elasticsearch.transport.ActionNotFoundTransportException.class);
+        ids.put(102, org.elasticsearch.transport.TransportSerializationException.class);
+        ids.put(103, org.elasticsearch.transport.RemoteTransportException.class);
+        ids.put(104, org.elasticsearch.index.engine.EngineCreationFailureException.class);
+        ids.put(105, org.elasticsearch.cluster.routing.RoutingException.class);
+        ids.put(106, org.elasticsearch.index.shard.IndexShardRecoveryException.class);
+        ids.put(107, org.elasticsearch.repositories.RepositoryMissingException.class);
+        ids.put(108, org.elasticsearch.index.percolator.PercolatorException.class);
+        ids.put(109, org.elasticsearch.index.engine.DocumentSourceMissingException.class);
+        ids.put(110, org.elasticsearch.index.engine.FlushNotAllowedEngineException.class);
+        ids.put(111, org.elasticsearch.common.settings.NoClassSettingsException.class);
+        ids.put(112, org.elasticsearch.transport.BindTransportException.class);
+        ids.put(113, org.elasticsearch.rest.action.admin.indices.alias.delete.AliasesNotFoundException.class);
+        ids.put(114, org.elasticsearch.index.shard.IndexShardRecoveringException.class);
+        ids.put(115, org.elasticsearch.index.translog.TranslogException.class);
+        ids.put(116, org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException.class);
+        ids.put(117, org.elasticsearch.action.support.replication.TransportReplicationAction.RetryOnPrimaryException.class);
+        ids.put(118, org.elasticsearch.ElasticsearchTimeoutException.class);
+        ids.put(119, org.elasticsearch.search.query.QueryPhaseExecutionException.class);
+        ids.put(120, org.elasticsearch.repositories.RepositoryVerificationException.class);
+        ids.put(121, org.elasticsearch.search.aggregations.InvalidAggregationPathException.class);
+        ids.put(122, org.elasticsearch.script.groovy.GroovyScriptExecutionException.class);
+        ids.put(123, org.elasticsearch.indices.IndexAlreadyExistsException.class);
+        ids.put(124, org.elasticsearch.script.Script.ScriptParseException.class);
+        ids.put(125, org.elasticsearch.transport.netty.SizeHeaderFrameDecoder.HttpOnTransportException.class);
+        ids.put(126, org.elasticsearch.index.mapper.MapperParsingException.class);
+        ids.put(127, org.elasticsearch.search.SearchContextException.class);
+        ids.put(128, org.elasticsearch.search.builder.SearchSourceBuilderException.class);
+        ids.put(129, org.elasticsearch.index.engine.EngineClosedException.class);
+        ids.put(130, org.elasticsearch.action.NoShardAvailableActionException.class);
+        ids.put(131, org.elasticsearch.action.UnavailableShardsException.class);
+        ids.put(132, org.elasticsearch.index.engine.FlushFailedEngineException.class);
+        ids.put(133, org.elasticsearch.common.breaker.CircuitBreakingException.class);
+        ids.put(134, org.elasticsearch.transport.NodeNotConnectedException.class);
+        ids.put(135, org.elasticsearch.index.mapper.StrictDynamicMappingException.class);
+        ids.put(136, org.elasticsearch.action.support.replication.TransportReplicationAction.RetryOnReplicaException.class);
+        ids.put(137, org.elasticsearch.indices.TypeMissingException.class);
+        ids.put(138, org.elasticsearch.script.expression.ExpressionScriptCompilationException.class);
+        ids.put(139, org.elasticsearch.script.expression.ExpressionScriptExecutionException.class);
+
+        Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
+        for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {
+            if (entry.getValue() != null) {
+                reverse.put(entry.getValue(), entry.getKey());
+            }
+        }
+        
+        for (Map.Entry<Integer, Constructor<? extends ElasticsearchException>> entry : ElasticsearchException.ID_TO_SUPPLIER.entrySet()) {
+            assertNotNull(Integer.toString(entry.getKey()), reverse.get(entry.getValue().getDeclaringClass()));
+            assertEquals(reverse.get(entry.getValue().getDeclaringClass()), entry.getKey());
+        }
+
+        for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {
+            if (entry.getValue() != null) {
+                assertEquals((int) entry.getKey(), ElasticsearchException.getId(entry.getValue()));
+            }
         }
     }
 }


### PR DESCRIPTION
This commit reworks the ElasticsearchException ids so that they are
consistent with master at f40ae25352f842f188ce833406f8aeb500ae64ca.
