### PR TITLE
Discovery-ec2 plugin should check `discovery.type`

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java
@@ -21,8 +21,6 @@ package org.elasticsearch.discovery.ec2;
 
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.settings.ClusterDynamicSettings;
-import org.elasticsearch.cluster.settings.DynamicSettings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoverySettings;
@@ -37,6 +35,8 @@ import org.elasticsearch.transport.TransportService;
  *
  */
 public class Ec2Discovery extends ZenDiscovery {
+
+    public static final String EC2 = "ec2";
 
     @Inject
     public Ec2Discovery(Settings settings, ClusterName clusterName, ThreadPool threadPool, TransportService transportService,

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -23,6 +23,9 @@ import org.elasticsearch.cloud.aws.AwsEc2ServiceImpl;
 import org.elasticsearch.cloud.aws.Ec2Module;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.discovery.ec2.AwsEc2UnicastHostsProvider;
 import org.elasticsearch.discovery.ec2.Ec2Discovery;
@@ -55,6 +58,13 @@ public class Ec2DiscoveryPlugin extends Plugin {
         });
     }
 
+    private final Settings settings;
+    protected final ESLogger logger = Loggers.getLogger(Ec2DiscoveryPlugin.class);
+
+    public Ec2DiscoveryPlugin(Settings settings) {
+        this.settings = settings;
+    }
+
     @Override
     public String name() {
         return "discovery-ec2";
@@ -80,7 +90,9 @@ public class Ec2DiscoveryPlugin extends Plugin {
     }
 
     public void onModule(DiscoveryModule discoveryModule) {
-        discoveryModule.addDiscoveryType("ec2", Ec2Discovery.class);
-        discoveryModule.addUnicastHostProvider(AwsEc2UnicastHostsProvider.class);
+        if (Ec2Module.isEc2DiscoveryActive(settings, logger)) {
+            discoveryModule.addDiscoveryType("ec2", Ec2Discovery.class);
+            discoveryModule.addUnicastHostProvider(AwsEc2UnicastHostsProvider.class);
+        }
     }
 }

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoverySettingsTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoverySettingsTests.java
@@ -17,31 +17,28 @@
  * under the License.
  */
 
-package org.elasticsearch.cloud.aws;
+package org.elasticsearch.discovery.ec2;
 
-import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.cloud.aws.Ec2Module;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.discovery.ec2.Ec2Discovery;
+import org.elasticsearch.test.ESTestCase;
 
-public class Ec2Module extends AbstractModule {
+import static org.hamcrest.Matchers.is;
 
-    @Override
-    protected void configure() {
-        bind(AwsEc2Service.class).to(AwsEc2ServiceImpl.class).asEagerSingleton();
+public class Ec2DiscoverySettingsTests extends ESTestCase {
+
+    public void testDiscoveryReady() {
+        Settings settings = Settings.builder()
+                .put("discovery.type", "ec2")
+                .build();
+        boolean discoveryReady = Ec2Module.isEc2DiscoveryActive(settings, logger);
+        assertThat(discoveryReady, is(true));
     }
 
-    /**
-     * Check if discovery is meant to start
-     * @return true if we can start discovery features
-     */
-    public static boolean isEc2DiscoveryActive(Settings settings, ESLogger logger) {
-        // User set discovery.type: ec2
-        if (!Ec2Discovery.EC2.equalsIgnoreCase(settings.get("discovery.type"))) {
-            logger.trace("discovery.type not set to {}", Ec2Discovery.EC2);
-            return false;
-        }
-
-        return true;
+    public void testDiscoveryNotReady() {
+        Settings settings = Settings.EMPTY;
+        boolean discoveryReady = Ec2Module.isEc2DiscoveryActive(settings, logger);
+        assertThat(discoveryReady, is(false));
     }
+
 }


### PR DESCRIPTION
As done in #13809 and in Azure, we should check that `discovery.type` is set to `ec2` before starting services.

Closes #13581
