### PR TITLE
Ensure XContent is consistent across platforms

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.common.xcontent.json;
 
 import com.fasterxml.jackson.core.io.SerializedString;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.*;
 
@@ -34,6 +36,8 @@ public class JsonXContentGenerator implements XContentGenerator {
 
     protected final BaseJsonGenerator generator;
     private boolean writeLineFeedAtEnd;
+    private static final SerializedString LF = new SerializedString("\n");
+    private  static final DefaultPrettyPrinter.Indenter INDENTER = new DefaultIndenter("  ", LF.getValue());
 
     public JsonXContentGenerator(BaseJsonGenerator generator) {
         this.generator = generator;
@@ -45,8 +49,8 @@ public class JsonXContentGenerator implements XContentGenerator {
     }
 
     @Override
-    public void usePrettyPrint() {
-        generator.useDefaultPrettyPrinter();
+    public final void usePrettyPrint() {
+        generator.setPrettyPrinter(new DefaultPrettyPrinter().withObjectIndenter(INDENTER));
     }
 
     @Override
@@ -326,6 +330,4 @@ public class JsonXContentGenerator implements XContentGenerator {
         }
         generator.close();
     }
-
-    private static final SerializedString LF = new SerializedString("\n");
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -331,4 +331,24 @@ public class XContentBuilderTests extends ESTestCase {
         assertThat(pathBuilder.string(), equalTo(stringBuilder.string()));
     }
 
+    public void testIndentIsPlatformIndependent() throws IOException {
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint();
+        builder.startObject().field("test","foo").startObject("foo").field("foobar", "boom").endObject().endObject();
+        String string = builder.string();
+        assertEquals("{\n" +
+                "  \"test\" : \"foo\",\n" +
+                "  \"foo\" : {\n" +
+                "    \"foobar\" : \"boom\"\n" +
+                "  }\n" +
+                "}", string);
+
+        builder = XContentFactory.contentBuilder(XContentType.YAML).prettyPrint();
+        builder.startObject().field("test","foo").startObject("foo").field("foobar", "boom").endObject().endObject();
+        string = builder.string();
+        assertEquals("---\n" +
+                "test: \"foo\"\n" +
+                "foo:\n" +
+                "  foobar: \"boom\"\n", string);
+    }
+
 }

--- a/core/src/test/java/org/elasticsearch/index/query/HasChildQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasChildQueryBuilderTests.java
@@ -196,7 +196,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         // now assert that we actually generate the same JSON
         XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
         queryBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        assertEquals(query, builder.string().replaceAll("\\r\\n", "\n")); // jackson uses system linefeed - will fail on windows otherwise
+        assertEquals(query, builder.string());
     }
 
 }


### PR DESCRIPTION
Today we generate XContent with platform dependent linefeeds. This
commit makes the pretty-printed json etc. consistent with \n across all
platforms.
