### PR TITLE
Test that Jayatana is ignored

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,10 @@ Vagrant.configure(2) do |config|
   end
   config.vm.define "vivid" do |config|
     config.vm.box = "ubuntu/vivid64"
-    ubuntu_common config
+    ubuntu_common config, extra: <<-SHELL
+      # Install Jayatana so we can work around it being present.
+      [ -f /usr/share/java/jayatanaag.jar ] || install jayatana
+    SHELL
   end
   # Wheezy's backports don't contain Openjdk 8 and the backflips required to
   # get the sun jdk on there just aren't worth it. We have jessie for testing
@@ -116,11 +119,11 @@ SOURCE_PROMPT
   end
 end
 
-def ubuntu_common(config)
-  deb_common config, 'apt-add-repository -y ppa:openjdk-r/ppa > /dev/null 2>&1', 'openjdk-r-*'
+def ubuntu_common(config, extra: '')
+  deb_common config, 'apt-add-repository -y ppa:openjdk-r/ppa > /dev/null 2>&1', 'openjdk-r-*', extra: extra
 end
 
-def deb_common(config, add_openjdk_repository_command, openjdk_list)
+def deb_common(config, add_openjdk_repository_command, openjdk_list, extra: '')
   # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
   config.vm.provision "fix-no-tty", type: "shell" do |s|
       s.privileged = false
@@ -137,6 +140,7 @@ def deb_common(config, add_openjdk_repository_command, openjdk_list)
         (echo "Importing java-8 ppa" &&
           #{add_openjdk_repository_command} &&
           apt-get update)
+      #{extra}
 SHELL
   )
 end

--- a/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
@@ -243,8 +243,14 @@ start_elasticsearch_service() {
         # su and the Elasticsearch init script work together to break bats.
         # sudo isolates bats enough from the init script so everything continues
         # to tick along
-        sudo -u elasticsearch /tmp/elasticsearch/bin/elasticsearch -d \
-            -p /tmp/elasticsearch/elasticsearch.pid
+        sudo -u elasticsearch bash <<BASH
+# If jayatana is installed then we try to use it. Elasticsearch should ignore it even when we try.
+# If it doesn't ignore it then Elasticsearch will fail to start because of security errors.
+# This line is attempting to emulate the on login behavior of /usr/share/upstart/sessions/jayatana.conf
+[ -f /usr/share/java/jayatanaag.jar ] && export JAVA_TOOL_OPTIONS="-javaagent:/usr/share/java/jayatanaag.jar"
+# And now we can start Elasticsearch normally, in the background (-d) and with a pidfile (-p).
+/tmp/elasticsearch/bin/elasticsearch -d -p /tmp/elasticsearch/elasticsearch.pid
+BASH
     elif is_systemd; then
         run systemctl daemon-reload
         [ "$status" -eq 0 ]


### PR DESCRIPTION
Installs javatana in vivid, emulates its on-login actions when starting
elasticsearch and verifies that elasticsearch turns off javatana.

Relates to #13813
