### PR TITLE
Add stack traces to logged exceptions where missing

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -520,7 +520,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
 
         private void handleBlockException(ClusterBlockException blockException) {
             if (blockException.retryable()) {
-                logger.trace("cluster is blocked ({}), scheduling a retry", blockException.getMessage());
+                logger.trace("cluster is blocked, scheduling a retry", blockException);
                 retry(blockException);
             } else {
                 finishAsFailed(blockException);

--- a/core/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
@@ -307,7 +308,7 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
             @Override
             public void onFailure(Throwable e) {
                 if (e instanceof ReceiveTimeoutTransportException) {
-                    logger.error("NodeStatsAction timed out for ClusterInfoUpdateJob (reason [{}])", e.getMessage());
+                    logger.error("NodeStatsAction timed out for ClusterInfoUpdateJob", e);
                 } else {
                     if (e instanceof ClusterBlockException) {
                         if (logger.isTraceEnabled()) {
@@ -337,7 +338,7 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
             @Override
             public void onFailure(Throwable e) {
                 if (e instanceof ReceiveTimeoutTransportException) {
-                    logger.error("IndicesStatsAction timed out for ClusterInfoUpdateJob (reason [{}])", e.getMessage());
+                    logger.error("IndicesStatsAction timed out for ClusterInfoUpdateJob", e);
                 } else {
                     if (e instanceof ClusterBlockException) {
                         if (logger.isTraceEnabled()) {

--- a/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -299,7 +299,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
                         if (logger.isTraceEnabled()) {
                             logger.trace("failed to execute bulk", e);
                         } else {
-                            logger.warn("failed to execute bulk: [{}]", e.getMessage());
+                            logger.warn("failed to execute bulk: ", e);
                         }
                     }
                 });


### PR DESCRIPTION
Switches to .stackTrace(...) for logging statements. Eliminates another 11 calls to .getMessage()

(So much for the trivial/obvious changes.)

Relates to #10021 
