### PR TITLE
Add response into ClearScrollResponse

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/ClearScrollResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ClearScrollResponse.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.StatusToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -69,6 +69,8 @@ public class ClearScrollResponse extends ActionResponse implements StatusToXCont
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(Fields.SUCCEEDED, succeeded);
+        builder.field(Fields.NUMFREED, numFreed);
         return builder;
     }
 
@@ -85,4 +87,10 @@ public class ClearScrollResponse extends ActionResponse implements StatusToXCont
         out.writeBoolean(succeeded);
         out.writeVInt(numFreed);
     }
+
+    static final class Fields {
+        static final XContentBuilderString SUCCEEDED = new XContentBuilderString("succeeded");
+        static final XContentBuilderString NUMFREED = new XContentBuilderString("num_freed");
+    }
+
 }


### PR DESCRIPTION
When deleting an individual scroll ID, ES does produce a 200 in the
header if successful and a 404 if the scroll ID wasn't found, but
returns empty response body. 

It would be more user friendly to provide
some information on whether the scroll deletion is successful.

closes #13817
