### PR TITLE
Workaround JDK-8056014

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/inject/util/Modules.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/util/Modules.java
@@ -135,7 +135,8 @@ public final class Modules {
         private final Set<Module> baseModules;
 
         private RealOverriddenModuleBuilder(Iterable<? extends Module> baseModules) {
-            this.baseModules = unmodifiableSet(newHashSet(baseModules));
+            HashSet<? extends Module> modules = newHashSet(baseModules);
+            this.baseModules = unmodifiableSet(modules);
         }
 
         @Override


### PR DESCRIPTION
This commit works around JDK bug [JDK-8056014](https://bugs.openjdk.java.net/browse/JDK-8056014) in the `javac` compiler.
This bug is impacting CI compilations on JDK 8u11 and 8u25.
