### PR TITLE
Workaround JDK-8056984

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -435,7 +435,9 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      * Allows to override boost assertions for queries that don't have the default behaviour
      */
     protected void assertBoost(QB queryBuilder, Query query) throws IOException {
-        assertThat(query.getBoost(), equalTo(queryBuilder.boost()));
+        // workaround https://bugs.openjdk.java.net/browse/JDK-8056984
+        float boost = queryBuilder.boost();
+        assertThat(query.getBoost(), equalTo(boost));
     }
 
     /**


### PR DESCRIPTION
This commit works around JDK bug [JDK-8056984](https://bugs.openjdk.java.net/browse/JDK-8056984) in the`javac` compiler.
This bug is impacting CI compilations on JDK 8u25.
