### PR TITLE
Remove ClusterSerivce and IndexSettingsService dependency from IndexShard

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/settings/IndexSettingsService.java
+++ b/core/src/main/java/org/elasticsearch/index/settings/IndexSettingsService.java
@@ -73,6 +73,12 @@ public class IndexSettingsService extends AbstractIndexComponent {
         this.listeners.remove(listener);
     }
 
+    /**
+     * Returns <code>true</code> iff the given listener is already registered otherwise <code>false</code>
+     */
+    public boolean isRegistered(Listener listener) {
+        return listeners.contains(listener);
+    }
     public interface Listener {
         void onRefreshSettings(Settings settings);
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.aliases.IndexAliasesService;
 import org.elasticsearch.index.cache.IndexCache;
@@ -34,6 +35,7 @@ import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.query.IndexQueryParserService;
+import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.Store;
@@ -54,7 +56,7 @@ import java.io.IOException;
 public final class ShadowIndexShard extends IndexShard {
 
     @Inject
-    public ShadowIndexShard(ShardId shardId, IndexSettingsService indexSettingsService,
+    public ShadowIndexShard(ShardId shardId, @IndexSettings Settings indexSettings,
                             IndicesLifecycle indicesLifecycle, Store store,
                             ThreadPool threadPool, MapperService mapperService,
                             IndexQueryParserService queryParserService, IndexCache indexCache,
@@ -62,14 +64,14 @@ public final class ShadowIndexShard extends IndexShard {
                             CodecService codecService, TermVectorsService termVectorsService, IndexFieldDataService indexFieldDataService,
                             @Nullable IndicesWarmer warmer,
                             SimilarityService similarityService,
-                            EngineFactory factory, ClusterService clusterService,
+                            EngineFactory factory,
                             ShardPath path, BigArrays bigArrays, IndexSearcherWrappingService wrappingService) throws IOException {
-        super(shardId, indexSettingsService, indicesLifecycle, store,
+        super(shardId, indexSettings, indicesLifecycle, store,
                 threadPool, mapperService, queryParserService, indexCache, indexAliasesService,
                 indicesQueryCache, codecService,
                 termVectorsService, indexFieldDataService,
                 warmer, similarityService,
-                factory, clusterService, path, bigArrays, wrappingService);
+                factory, path, bigArrays, wrappingService);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -677,14 +677,15 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                 try {
                     final boolean success;
                     final IndexShard shard = indexService.shard(shardId);
+                    final DiscoveryNode localNode = clusterService.localNode();
                     if (restoreSource == null) {
                         // recover from filesystem store
-                        success = shard.recoverFromStore(shardRouting);
+                        success = shard.recoverFromStore(shardRouting, localNode);
                     } else {
                         // restore
                         final IndexShardRepository indexShardRepository = repositoriesService.indexShardRepository(restoreSource.snapshotId().getRepository());
                         try {
-                            success = shard.restoreFromRepository(shardRouting, indexShardRepository);
+                            success = shard.restoreFromRepository(shardRouting, indexShardRepository, localNode);
                         } catch (Throwable t) {
                             if (Lucene.isCorruptionException(t)) {
                                 restoreService.failRestore(restoreSource.snapshotId(), shard.shardId());

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -131,7 +131,8 @@ public class RecoveryTarget extends AbstractComponent {
 
     public void startRecovery(final IndexShard indexShard, final RecoveryState.Type recoveryType, final DiscoveryNode sourceNode, final RecoveryListener listener) {
         try {
-            indexShard.recovering("from " + sourceNode, recoveryType, sourceNode);
+            RecoveryState recoveryState = new RecoveryState(indexShard.shardId(), indexShard.routingEntry().primary(), recoveryType, sourceNode, clusterService.localNode());
+            indexShard.recovering("from " + sourceNode, recoveryState);
         } catch (IllegalIndexShardStateException e) {
             // that's fine, since we might be called concurrently, just ignore this, we are already recovering
             logger.debug("{} ignore recovery. already in recovering process, {}", indexShard.shardId(), e.getMessage());

--- a/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetaDataIndexUpgradeService;
 import org.elasticsearch.cluster.metadata.RepositoriesMetaData;
 import org.elasticsearch.cluster.metadata.SnapshotId;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RestoreSource;
@@ -115,7 +116,7 @@ import static org.elasticsearch.common.util.set.Sets.newHashSet;
  * method.
  * <p>
  * Individual shards are getting restored as part of normal recovery process in
- * {@link IndexShard#restoreFromRepository(ShardRouting, IndexShardRepository)}
+ * {@link IndexShard#restoreFromRepository(ShardRouting, IndexShardRepository, DiscoveryNode)} )}
  * method, which detects that shard should be restored from snapshot rather than recovered from gateway by looking
  * at the {@link org.elasticsearch.cluster.routing.ShardRouting#restoreSource()} property.
  * <p>


### PR DESCRIPTION
We have two unneeded heavy dependencies on IndexShard that are unneeded and only cause
trouble if you try to mock index shard. This commit removes IndexSettingsService as well as
ClusterSerivce from IndexShard to simplify future mocking and construction.
