### PR TITLE
Tests: fix test by making copy of geopoints in assertLuceneQuery

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -66,8 +66,9 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         if (GeoValidationMethod.isCoerce(queryBuilder.getValidationMethod())) {
             for (int i = 0; i < queryBuilderPoints.size(); i++) {
                 GeoPoint queryBuilderPoint = queryBuilderPoints.get(i);
-                GeoUtils.normalizePoint(queryBuilderPoint, true, true);
-                assertThat(queryPoints[i], equalTo(queryBuilderPoint));
+                GeoPoint pointCopy = new GeoPoint(queryBuilderPoint);
+                GeoUtils.normalizePoint(pointCopy, true, true);
+                assertThat(queryPoints[i], equalTo(pointCopy));
             }
         } else {
             for (int i = 0; i < queryBuilderPoints.size(); i++) {


### PR DESCRIPTION
This avoids modifying the point in a query builder shell during assertions in `doAssertLuceneQuery'
