### PR TITLE
Update to forbidden-apis 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -833,7 +833,7 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>1.8</version>
+                    <version>2.0</version>
 
                     <executions>
                         <execution>


### PR DESCRIPTION
This is just to update to forbidden-apis 2.0. I know the gradle build is coming, but it is still good to update.

New features:
This is the major 2.0 release of the forbidden-apis plugin. The main new
feature is native support for the [Gradle](https://gradle.org/) build system (minimum requirement is Gradle 2.3).
But also Apache Ant and Apache Maven build systems got improved support: Ant can now load signatures from
arbitrary resources by using a new XML element `<signatures></signatures>` that may contain
any valid ANT resource, e.g., ivy's cache-filesets or plain URLs. Apache Maven now supports
to load signatures files as artifacts from your repository or Maven Central (new `signaturesArtifacts`
Mojo property).

It also adds missing java.time API signatures to the famous "unsafe" bundled signatures.

There was one change in Maven: the default lifecycle phase is now "verify", but this has no effect on ES, because it explicitely declares lifecycle phases.
