### PR TITLE
Nuke ES_CLASSPATH appending, JarHell fail on empty classpath elements

### DIFF
--- a/core/src/test/java/org/elasticsearch/bootstrap/JarHellTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/JarHellTests.java
@@ -275,4 +275,64 @@ public class JarHellTests extends ESTestCase {
             }
         }
     }
+
+    // classpath testing is system specific, so we just write separate tests for *nix and windows cases
+
+    /**
+     * Parse a simple classpath with two elements on unix
+     */
+    public void testParseClassPathUnix() throws Exception {
+        assumeTrue("test is designed for unix-like systems only", ":".equals(System.getProperty("path.separator")));
+        assumeTrue("test is designed for unix-like systems only", "/".equals(System.getProperty("file.separator")));
+
+        Path element1 = createTempDir();
+        Path element2 = createTempDir();
+
+        URL expected[] = { element1.toUri().toURL(), element2.toUri().toURL() };
+        assertArrayEquals(expected, JarHell.parseClassPath(element1.toString() + ":" + element2.toString()));
+    }
+
+    /**
+     * Make sure an old unix classpath with an empty element (implicitly CWD: i'm looking at you 1.x ES scripts) fails
+     */
+    public void testEmptyClassPathUnix() throws Exception {
+        assumeTrue("test is designed for unix-like systems only", ":".equals(System.getProperty("path.separator")));
+        assumeTrue("test is designed for unix-like systems only", "/".equals(System.getProperty("file.separator")));
+
+        try {
+            JarHell.parseClassPath(":/element1:/element2");
+            fail("should have hit exception");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("should not contain empty elements"));
+        }
+    }
+
+    /**
+     * Parse a simple classpath with two elements on windows
+     */
+    public void testParseClassPathWindows() throws Exception {
+        assumeTrue("test is designed for windows-like systems only", ";".equals(System.getProperty("path.separator")));
+        assumeTrue("test is designed for windows-like systems only", "\\".equals(System.getProperty("file.separator")));
+
+        Path element1 = createTempDir();
+        Path element2 = createTempDir();
+
+        URL expected[] = { element1.toUri().toURL(), element2.toUri().toURL() };
+        assertArrayEquals(expected, JarHell.parseClassPath(element1.toString() + ";" + element2.toString()));
+    }
+
+    /**
+     * Make sure an old windows classpath with an empty element (implicitly CWD: i'm looking at you 1.x ES scripts) fails
+     */
+    public void testEmptyClassPathWindows() throws Exception {
+        assumeTrue("test is designed for windows-like systems only", ";".equals(System.getProperty("path.separator")));
+        assumeTrue("test is designed for windows-like systems only", "\\".equals(System.getProperty("file.separator")));
+
+        try {
+            JarHell.parseClassPath(";c:\\element1;c:\\element2");
+            fail("should have hit exception");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("should not contain empty elements"));
+        }
+    }
 }

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -91,10 +91,13 @@ set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
 REM Use our provided JNA always versus the system one
 set JAVA_OPTS=%JAVA_OPTS% -Djna.nosys=true
 
-set CORE_CLASSPATH=%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*
+REM check in case a user was using this mechanism
 if "%ES_CLASSPATH%" == "" (
-set ES_CLASSPATH=%CORE_CLASSPATH%
+set ES_CLASSPATH=%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*
 ) else (
-set ES_CLASSPATH=%ES_CLASSPATH%;%CORE_CLASSPATH%
+ECHO Error: Don't modify the classpath with ES_CLASSPATH. Best is to add 1>&2
+ECHO additional elements via the plugin mechanism, or if code must really be 1>&2
+ECHO added to the main classpath, add jars to lib\ (unsupported). 1>&2
+EXIT /B 1
 )
 set ES_PARAMS=-Delasticsearch -Des-foreground=yes -Des.path.home="%ES_HOME%"

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -95,9 +95,9 @@ REM check in case a user was using this mechanism
 if "%ES_CLASSPATH%" == "" (
 set ES_CLASSPATH=%ES_HOME%/lib/${project.build.finalName}.jar;%ES_HOME%/lib/*
 ) else (
-ECHO Error: Don't modify the classpath with ES_CLASSPATH. Best is to add 1>&2
+ECHO Error: Don't modify the classpath with ES_CLASSPATH, Best is to add 1>&2
 ECHO additional elements via the plugin mechanism, or if code must really be 1>&2
-ECHO added to the main classpath, add jars to lib\ (unsupported). 1>&2
+ECHO added to the main classpath, add jars to lib\, unsupported 1>&2
 EXIT /B 1
 )
 set ES_PARAMS=-Delasticsearch -Des-foreground=yes -Des.path.home="%ES_HOME%"

--- a/distribution/src/main/resources/bin/elasticsearch.in.sh
+++ b/distribution/src/main/resources/bin/elasticsearch.in.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 
-CORE_CLASSPATH="$ES_HOME/lib/${project.build.finalName}.jar:$ES_HOME/lib/*"
-
-if [ "x$ES_CLASSPATH" = "x" ]; then
-    ES_CLASSPATH="$CORE_CLASSPATH"
-else
-    ES_CLASSPATH="$ES_CLASSPATH:$CORE_CLASSPATH"
+# check in case a user was using this mechanism
+if [ "x$ES_CLASSPATH" != "x" ]; then
+    cat >&2 << EOF
+Error: Don't modify the classpath with ES_CLASSPATH. Best is to add
+additional elements via the plugin mechanism, or if code must really be
+added to the main classpath, add jars to lib/ (unsupported).
+EOF
+    exit 1
 fi
+
+ES_CLASSPATH="$ES_HOME/lib/${project.build.finalName}.jar:$ES_HOME/lib/*"
 
 if [ "x$ES_MIN_MEM" = "x" ]; then
     ES_MIN_MEM=${packaging.elasticsearch.heap.min}


### PR DESCRIPTION
Old ES 1.x startup scripts were buggy, adding empty classpath elements. But this can be horrible: it means "CWD" to java, and when starting from a service maybe that is /, and now JarHell is scanning your entire computer (like #13864). 

It would be better to just fail hard on a bogus classpath, and hint at the possible cause `(outdated shell script from a previous version?)`

Additionally, users can still override ES_CLASSPATH, which caused the whole bug in the first place for the 1.x scripts, but we should fail on that too. Its not going to work and you will just get a securityexception. Instead we can tell the user how to do it better.

Maybe we want to clean this up for earlier versions (e.g. 2.1 or maybe even 2.0) too, as some of it is "our fault" (the old broken scripts) and possible still "our fault" (maybe packaging is not upgrading them properly?)

Relates to #13864
Closes #13812
