### PR TITLE
Update version incompatibility message for plugin manager

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -114,7 +114,8 @@ public class PluginInfo implements Streamable, ToXContent {
             }
             Version esVersion = Version.fromString(esVersionString);
             if (esVersion.equals(Version.CURRENT) == false) {
-                throw new IllegalArgumentException("Elasticsearch version [" + esVersionString + "] is too old for plugin [" + name + "]");
+                throw new IllegalArgumentException("Plugin [" + name + "] is incompatible with Elasticsearch [" + Version.CURRENT.toString() +
+                        "]. Was designed for version [" + esVersionString + "]");
             }
             String javaVersionString = props.getProperty("java.version");
             if (javaVersionString == null) {

--- a/core/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
@@ -221,7 +221,7 @@ public class PluginInfoTests extends ESTestCase {
             PluginInfo.readFromProperties(pluginDir);
             fail("expected old elasticsearch version exception");
         } catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("Elasticsearch version [1.7.0] is too old"));
+            assertTrue(e.getMessage().contains("Was designed for version [1.7.0]"));
         }
     }
 


### PR DESCRIPTION
When the plugin manager does not find in `plugin-descriptor.properties` the exact same elasticsearch version it was built on
as the current elasticsearch version, it fails with a message like:

```
ERROR: Elasticsearch version [2.0.0-beta1] is too old for plugin [elasticsearch-mapper-attachments]
```

Actually, the message should be:

```
Plugin [elasticsearch-mapper-attachments] is incompatible with Elasticsearch [2.0.0.beta2]. Was designed for version [2.0.0.beta1].
```

The opposite is true. If you try to install a version of a plugin which was built with a newer version of elasticsearch, it will fail the same way:

```
Plugin [elasticsearch-mapper-attachments] is incompatible with Elasticsearch [2.0.0.beta1]. Was designed for version [2.0.0.beta2].
```
