### PR TITLE
Rename fields to field to be consistent with other api's

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -4,9 +4,9 @@
     "methods": ["GET"],
     "url": {
       "path": "/_cat/fielddata",
-      "paths": ["/_cat/fielddata", "/_cat/fielddata/{fields}"],
+      "paths": ["/_cat/fielddata", "/_cat/fielddata/{field}"],
       "parts": {
-        "fields": {
+        "field": {
           "type": "list",
           "description": "A comma-separated list of fields to return the fielddata size"
         }


### PR DESCRIPTION
namely indices.get_field_mapping
