### PR TITLE
Verify Checksum once it has been fully written to fail as soon as possible

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1292,6 +1292,9 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                 final int index = Math.toIntExact(writtenBytes - checksumPosition);
                 if (index < footerChecksum.length) {
                     footerChecksum[index] = b;
+                    if (index == footerChecksum.length-1) {
+                        verify();// we have recorded the entire checksum
+                    }
                 } else {
                     verify(); // fail if we write more than expected
                     throw new AssertionError("write past EOF expected length: " + metadata.length() + " writtenBytes: " + writtenBytes);

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -674,7 +674,6 @@ public class RecoverySourceHandler {
                     try (final OutputStream outputStream = outputStreamFactory.apply(md);
                          final IndexInput indexInput = store.directory().openInput(md.name(), IOContext.READONCE)) {
                         Streams.copy(new InputStreamIndexInput(indexInput, md.length()), outputStream);
-                        Store.verify(indexInput);
                     }
                     return null;
                 });


### PR DESCRIPTION
Today we are relying on calling Store.verify on the closed stream to validate the
checksum. This is still necessary to catch file truncation but for an actually corrupted
file or checksum we can fail early and check the checksum against the actual metadata
once it's been fully written to the VerifyingIndexOutput.

This failure is fixed with this PR:

```
http://build-us-00.elastic.co/job/es_core_master_strong/5179/testReport/junit/org.elasticsearch.indices.recovery/RecoverySourceHandlerTests/testHandleCorruptedIndexOnSendSendFiles/
```
