### PR TITLE
Get field mapping documented fields as field

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -3,8 +3,8 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_mapping/field/{field}",
-      "paths": ["/_mapping/field/{field}", "/{index}/_mapping/field/{field}", "/_mapping/{type}/field/{field}", "/{index}/_mapping/{type}/field/{field}"],
+      "path": "/_mapping/field/{fields}",
+      "paths": ["/_mapping/field/{fields}", "/{index}/_mapping/field/{fields}", "/_mapping/{type}/field/{fields}", "/{index}/_mapping/{type}/field/{fields}"],
       "parts": {
         "index": {
           "type" : "list",
@@ -14,7 +14,7 @@
           "type" : "list",
           "description" : "A comma-separated list of document types"
         },
-        "field": {
+        "fields": {
           "type" : "list",
           "description" : "A comma-separated list of fields",
           "required" : true


### PR DESCRIPTION
This PR brings this spec more inline with other api's and minimizes the known route variables in the API

See: https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetFieldMappingAction.java#L66
