### PR TITLE
Remove and forbid use of com.google.common.net.InetAddresses

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -334,11 +334,13 @@
                         <!-- Guice -->
                         <exclude>src/main/java/org/elasticsearch/common/inject/**</exclude>
                         <exclude>src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java</exclude>
+                        <exclude>src/main/java/org/elasticsearch/common/network/InetAddresses.java</exclude>
                         <exclude>src/main/java/org/apache/lucene/**/X*.java</exclude>
                         <!-- t-digest -->
                         <exclude>src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/TDigestState.java</exclude>
                         <!-- netty pipelining -->
                         <exclude>src/main/java/org/elasticsearch/http/netty/pipelining/**</exclude>
+                        <exclude>src/test/java/org/elasticsearch/common/network/InetAddressesTests.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/core/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/core/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.common.network;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Locale;
+
+public class InetAddresses {
+    private static int IPV4_PART_COUNT = 4;
+    private static int IPV6_PART_COUNT = 8;
+
+    public static boolean isInetAddress(String ipString) {
+        return ipStringToBytes(ipString) != null;
+    }
+
+    private static byte[] ipStringToBytes(String ipString) {
+        // Make a first pass to categorize the characters in this string.
+        boolean hasColon = false;
+        boolean hasDot = false;
+        for (int i = 0; i < ipString.length(); i++) {
+            char c = ipString.charAt(i);
+            if (c == '.') {
+                hasDot = true;
+            } else if (c == ':') {
+                if (hasDot) {
+                    return null;  // Colons must not appear after dots.
+                }
+                hasColon = true;
+            } else if (Character.digit(c, 16) == -1) {
+                return null;  // Everything else must be a decimal or hex digit.
+            }
+        }
+
+        // Now decide which address family to parse.
+        if (hasColon) {
+            if (hasDot) {
+                ipString = convertDottedQuadToHex(ipString);
+                if (ipString == null) {
+                    return null;
+                }
+            }
+            return textToNumericFormatV6(ipString);
+        } else if (hasDot) {
+            return textToNumericFormatV4(ipString);
+        }
+        return null;
+    }
+
+    private static String convertDottedQuadToHex(String ipString) {
+        int lastColon = ipString.lastIndexOf(':');
+        String initialPart = ipString.substring(0, lastColon + 1);
+        String dottedQuad = ipString.substring(lastColon + 1);
+        byte[] quad = textToNumericFormatV4(dottedQuad);
+        if (quad == null) {
+            return null;
+        }
+        String penultimate = Integer.toHexString(((quad[0] & 0xff) << 8) | (quad[1] & 0xff));
+        String ultimate = Integer.toHexString(((quad[2] & 0xff) << 8) | (quad[3] & 0xff));
+        return initialPart + penultimate + ":" + ultimate;
+    }
+
+    private static byte[] textToNumericFormatV4(String ipString) {
+        String[] address = ipString.split("\\.", IPV4_PART_COUNT + 1);
+        if (address.length != IPV4_PART_COUNT) {
+            return null;
+        }
+
+        byte[] bytes = new byte[IPV4_PART_COUNT];
+        try {
+            for (int i = 0; i < bytes.length; i++) {
+                bytes[i] = parseOctet(address[i]);
+            }
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+
+        return bytes;
+    }
+
+    private static byte parseOctet(String ipPart) {
+        // Note: we already verified that this string contains only hex digits.
+        int octet = Integer.parseInt(ipPart);
+        // Disallow leading zeroes, because no clear standard exists on
+        // whether these should be interpreted as decimal or octal.
+        if (octet > 255 || (ipPart.startsWith("0") && ipPart.length() > 1)) {
+            throw new NumberFormatException();
+        }
+        return (byte) octet;
+    }
+
+    private static byte[] textToNumericFormatV6(String ipString) {
+        // An address can have [2..8] colons, and N colons make N+1 parts.
+        String[] parts = ipString.split(":", IPV6_PART_COUNT + 2);
+        if (parts.length < 3 || parts.length > IPV6_PART_COUNT + 1) {
+            return null;
+        }
+
+        // Disregarding the endpoints, find "::" with nothing in between.
+        // This indicates that a run of zeroes has been skipped.
+        int skipIndex = -1;
+        for (int i = 1; i < parts.length - 1; i++) {
+            if (parts[i].length() == 0) {
+                if (skipIndex >= 0) {
+                    return null;  // Can't have more than one ::
+                }
+                skipIndex = i;
+            }
+        }
+
+        int partsHi;  // Number of parts to copy from above/before the "::"
+        int partsLo;  // Number of parts to copy from below/after the "::"
+        if (skipIndex >= 0) {
+            // If we found a "::", then check if it also covers the endpoints.
+            partsHi = skipIndex;
+            partsLo = parts.length - skipIndex - 1;
+            if (parts[0].length() == 0 && --partsHi != 0) {
+                return null;  // ^: requires ^::
+            }
+            if (parts[parts.length - 1].length() == 0 && --partsLo != 0) {
+                return null;  // :$ requires ::$
+            }
+        } else {
+            // Otherwise, allocate the entire address to partsHi.  The endpoints
+            // could still be empty, but parseHextet() will check for that.
+            partsHi = parts.length;
+            partsLo = 0;
+        }
+
+        // If we found a ::, then we must have skipped at least one part.
+        // Otherwise, we must have exactly the right number of parts.
+        int partsSkipped = IPV6_PART_COUNT - (partsHi + partsLo);
+        if (!(skipIndex >= 0 ? partsSkipped >= 1 : partsSkipped == 0)) {
+            return null;
+        }
+
+        // Now parse the hextets into a byte array.
+        ByteBuffer rawBytes = ByteBuffer.allocate(2 * IPV6_PART_COUNT);
+        try {
+            for (int i = 0; i < partsHi; i++) {
+                rawBytes.putShort(parseHextet(parts[i]));
+            }
+            for (int i = 0; i < partsSkipped; i++) {
+                rawBytes.putShort((short) 0);
+            }
+            for (int i = partsLo; i > 0; i--) {
+                rawBytes.putShort(parseHextet(parts[parts.length - i]));
+            }
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+        return rawBytes.array();
+    }
+
+    private static short parseHextet(String ipPart) {
+        // Note: we already verified that this string contains only hex digits.
+        int hextet = Integer.parseInt(ipPart, 16);
+        if (hextet > 0xffff) {
+            throw new NumberFormatException();
+        }
+        return (short) hextet;
+    }
+
+    /**
+     * Returns the string representation of an {@link InetAddress} suitable
+     * for inclusion in a URI.
+     *
+     * <p>For IPv4 addresses, this is identical to
+     * {@link InetAddress#getHostAddress()}, but for IPv6 addresses it
+     * compresses zeroes and surrounds the text with square brackets; for example
+     * {@code "[2001:db8::1]"}.
+     *
+     * <p>Per section 3.2.2 of
+     * <a target="_parent"
+     *    href="http://tools.ietf.org/html/rfc3986#section-3.2.2"
+     *  >http://tools.ietf.org/html/rfc3986</a>,
+     * a URI containing an IPv6 string literal is of the form
+     * {@code "http://[2001:db8::1]:8888/index.html"}.
+     *
+     * <p>Use of either {@link InetAddresses#toAddrString},
+     * {@link InetAddress#getHostAddress()}, or this method is recommended over
+     * {@link InetAddress#toString()} when an IP address string literal is
+     * desired.  This is because {@link InetAddress#toString()} prints the
+     * hostname and the IP address string joined by a "/".
+     *
+     * @param ip {@link InetAddress} to be converted to URI string literal
+     * @return {@code String} containing URI-safe string literal
+     */
+    public static String toUriString(InetAddress ip) {
+        if (ip instanceof Inet6Address) {
+            return "[" + toAddrString(ip) + "]";
+        }
+        return toAddrString(ip);
+    }
+
+    /**
+     * Returns the string representation of an {@link InetAddress}.
+     *
+     * <p>For IPv4 addresses, this is identical to
+     * {@link InetAddress#getHostAddress()}, but for IPv6 addresses, the output
+     * follows <a href="http://tools.ietf.org/html/rfc5952">RFC 5952</a>
+     * section 4.  The main difference is that this method uses "::" for zero
+     * compression, while Java's version uses the uncompressed form.
+     *
+     * <p>This method uses hexadecimal for all IPv6 addresses, including
+     * IPv4-mapped IPv6 addresses such as "::c000:201".  The output does not
+     * include a Scope ID.
+     *
+     * @param ip {@link InetAddress} to be converted to an address string
+     * @return {@code String} containing the text-formatted IP address
+     * @since 10.0
+     */
+    public static String toAddrString(InetAddress ip) {
+        if (ip == null) {
+            throw new NullPointerException("ip");
+        }
+        if (ip instanceof Inet4Address) {
+            // For IPv4, Java's formatting is good enough.
+            byte[] bytes = ip.getAddress();
+            return (bytes[0] & 0xff) + "." + (bytes[1] & 0xff) + "." + (bytes[2] & 0xff) + "." + (bytes[3] & 0xff);
+        }
+        if (!(ip instanceof Inet6Address)) {
+            throw new IllegalArgumentException("ip");
+        }
+        byte[] bytes = ip.getAddress();
+        int[] hextets = new int[IPV6_PART_COUNT];
+        for (int i = 0; i < hextets.length; i++) {
+            hextets[i] =  (bytes[2 * i] & 255) << 8 | bytes[2 * i + 1] & 255;
+        }
+        compressLongestRunOfZeroes(hextets);
+        return hextetsToIPv6String(hextets);
+    }
+
+    /**
+     * Identify and mark the longest run of zeroes in an IPv6 address.
+     *
+     * <p>Only runs of two or more hextets are considered.  In case of a tie, the
+     * leftmost run wins.  If a qualifying run is found, its hextets are replaced
+     * by the sentinel value -1.
+     *
+     * @param hextets {@code int[]} mutable array of eight 16-bit hextets
+     */
+    private static void compressLongestRunOfZeroes(int[] hextets) {
+        int bestRunStart = -1;
+        int bestRunLength = -1;
+        int runStart = -1;
+        for (int i = 0; i < hextets.length + 1; i++) {
+            if (i < hextets.length && hextets[i] == 0) {
+                if (runStart < 0) {
+                    runStart = i;
+                }
+            } else if (runStart >= 0) {
+                int runLength = i - runStart;
+                if (runLength > bestRunLength) {
+                    bestRunStart = runStart;
+                    bestRunLength = runLength;
+                }
+                runStart = -1;
+            }
+        }
+        if (bestRunLength >= 2) {
+            Arrays.fill(hextets, bestRunStart, bestRunStart + bestRunLength, -1);
+        }
+    }
+
+    /**
+     * Convert a list of hextets into a human-readable IPv6 address.
+     *
+     * <p>In order for "::" compression to work, the input should contain negative
+     * sentinel values in place of the elided zeroes.
+     *
+     * @param hextets {@code int[]} array of eight 16-bit hextets, or -1s
+     */
+    private static String hextetsToIPv6String(int[] hextets) {
+    /*
+     * While scanning the array, handle these state transitions:
+     *   start->num => "num"     start->gap => "::"
+     *   num->num   => ":num"    num->gap   => "::"
+     *   gap->num   => "num"     gap->gap   => ""
+     */
+        StringBuilder buf = new StringBuilder(39);
+        boolean lastWasNumber = false;
+        for (int i = 0; i < hextets.length; i++) {
+            boolean thisIsNumber = hextets[i] >= 0;
+            if (thisIsNumber) {
+                if (lastWasNumber) {
+                    buf.append(':');
+                }
+                buf.append(Integer.toHexString(hextets[i]));
+            } else {
+                if (i == 0 || lastWasNumber) {
+                    buf.append("::");
+                }
+            }
+            lastWasNumber = thisIsNumber;
+        }
+        return buf.toString();
+    }
+
+    /**
+     * Returns the {@link InetAddress} having the given string representation.
+     *
+     * <p>This deliberately avoids all nameservice lookups (e.g. no DNS).
+     *
+     * @param ipString {@code String} containing an IPv4 or IPv6 string literal, e.g.
+     *     {@code "192.168.0.1"} or {@code "2001:db8::1"}
+     * @return {@link InetAddress} representing the argument
+     * @throws IllegalArgumentException if the argument is not a valid IP string literal
+     */
+    public static InetAddress forString(String ipString) {
+        byte[] addr = ipStringToBytes(ipString);
+
+        // The argument was malformed, i.e. not an IP string literal.
+        if (addr == null) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "'%s' is not an IP string literal.", ipString));
+        }
+
+        return bytesToInetAddress(addr);
+    }
+
+    /**
+     * Convert a byte array into an InetAddress.
+     *
+     * {@link InetAddress#getByAddress} is documented as throwing a checked
+     * exception "if IP address is of illegal length."  We replace it with
+     * an unchecked exception, for use by callers who already know that addr
+     * is an array of length 4 or 16.
+     *
+     * @param addr the raw 4-byte or 16-byte IP address in big-endian order
+     * @return an InetAddress object created from the raw IP address
+     */
+    private static InetAddress bytesToInetAddress(byte[] addr) {
+        try {
+            return InetAddress.getByAddress(addr);
+        } catch (UnknownHostException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.common.network;
 
-import com.google.common.net.InetAddresses;
-
 import org.elasticsearch.common.SuppressForbidden;
 
 import java.net.Inet6Address;

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.mapper.ip;
 
-import com.google.common.net.InetAddresses;
 import org.apache.lucene.analysis.NumericTokenStream;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
@@ -29,6 +28,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;

--- a/core/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
+++ b/core/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.common.network;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class InetAddressesTests extends ESTestCase {
+    public void testForStringBogusInput() {
+        String[] bogusInputs = {
+                "",
+                "016.016.016.016",
+                "016.016.016",
+                "016.016",
+                "016",
+                "000.000.000.000",
+                "000",
+                "0x0a.0x0a.0x0a.0x0a",
+                "0x0a.0x0a.0x0a",
+                "0x0a.0x0a",
+                "0x0a",
+                "42.42.42.42.42",
+                "42.42.42",
+                "42.42",
+                "42",
+                "42..42.42",
+                "42..42.42.42",
+                "42.42.42.42.",
+                "42.42.42.42...",
+                ".42.42.42.42",
+                "...42.42.42.42",
+                "42.42.42.-0",
+                "42.42.42.+0",
+                ".",
+                "...",
+                "bogus",
+                "bogus.com",
+                "192.168.0.1.com",
+                "12345.67899.-54321.-98765",
+                "257.0.0.0",
+                "42.42.42.-42",
+                "3ffe::1.net",
+                "3ffe::1::1",
+                "1::2::3::4:5",
+                "::7:6:5:4:3:2:",  // should end with ":0"
+                ":6:5:4:3:2:1::",  // should begin with "0:"
+                "2001::db:::1",
+                "FEDC:9878",
+                "+1.+2.+3.4",
+                "1.2.3.4e0",
+                "::7:6:5:4:3:2:1:0",  // too many parts
+                "7:6:5:4:3:2:1:0::",  // too many parts
+                "9:8:7:6:5:4:3::2:1",  // too many parts
+                "0:1:2:3::4:5:6:7",  // :: must remove at least one 0.
+                "3ffe:0:0:0:0:0:0:0:1",  // too many parts (9 instead of 8)
+                "3ffe::10000",  // hextet exceeds 16 bits
+                "3ffe::goog",
+                "3ffe::-0",
+                "3ffe::+0",
+                "3ffe::-1",
+                ":",
+                ":::",
+                "::1.2.3",
+                "::1.2.3.4.5",
+                "::1.2.3.4:",
+                "1.2.3.4::",
+                "2001:db8::1:",
+                ":2001:db8::1",
+                ":1:2:3:4:5:6:7",
+                "1:2:3:4:5:6:7:",
+                ":1:2:3:4:5:6:"
+        };
+
+        for (int i = 0; i < bogusInputs.length; i++) {
+            try {
+                InetAddresses.forString(bogusInputs[i]);
+                fail("IllegalArgumentException expected for '" + bogusInputs[i] + "'");
+            } catch (IllegalArgumentException expected) {
+                // expected behavior
+            }
+            assertFalse(InetAddresses.isInetAddress(bogusInputs[i]));
+        }
+    }
+
+    public void test3ff31() {
+        try {
+            InetAddresses.forString("3ffe:::1");
+            fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException expected) {
+            // expected behavior
+        }
+        assertFalse(InetAddresses.isInetAddress("016.016.016.016"));
+    }
+
+    public void testForStringIPv4Input() throws UnknownHostException {
+        String ipStr = "192.168.0.1";
+        InetAddress ipv4Addr = null;
+        // Shouldn't hit DNS, because it's an IP string literal.
+        ipv4Addr = InetAddress.getByName(ipStr);
+        assertEquals(ipv4Addr, InetAddresses.forString(ipStr));
+        assertTrue(InetAddresses.isInetAddress(ipStr));
+    }
+
+    public void testForStringIPv6Input() throws UnknownHostException {
+        String ipStr = "3ffe::1";
+        InetAddress ipv6Addr = null;
+        // Shouldn't hit DNS, because it's an IP string literal.
+        ipv6Addr = InetAddress.getByName(ipStr);
+        assertEquals(ipv6Addr, InetAddresses.forString(ipStr));
+        assertTrue(InetAddresses.isInetAddress(ipStr));
+    }
+
+    public void testForStringIPv6EightColons() throws UnknownHostException {
+        String[] eightColons = {
+                "::7:6:5:4:3:2:1",
+                "::7:6:5:4:3:2:0",
+                "7:6:5:4:3:2:1::",
+                "0:6:5:4:3:2:1::",
+        };
+
+        for (int i = 0; i < eightColons.length; i++) {
+            InetAddress ipv6Addr = null;
+            // Shouldn't hit DNS, because it's an IP string literal.
+            ipv6Addr = InetAddress.getByName(eightColons[i]);
+            assertEquals(ipv6Addr, InetAddresses.forString(eightColons[i]));
+            assertTrue(InetAddresses.isInetAddress(eightColons[i]));
+        }
+    }
+
+    public void testConvertDottedQuadToHex() throws UnknownHostException {
+        String[] ipStrings = {"7::0.128.0.127", "7::0.128.0.128",
+                "7::128.128.0.127", "7::0.128.128.127"};
+
+        for (String ipString : ipStrings) {
+            // Shouldn't hit DNS, because it's an IP string literal.
+            InetAddress ipv6Addr = InetAddress.getByName(ipString);
+            assertEquals(ipv6Addr, InetAddresses.forString(ipString));
+            assertTrue(InetAddresses.isInetAddress(ipString));
+        }
+    }
+
+    public void testToAddrStringIPv4() {
+        // Don't need to test IPv4 much; it just calls getHostAddress().
+        assertEquals("1.2.3.4",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("1.2.3.4")));
+    }
+
+    public void testToAddrStringIPv6() {
+        assertEquals("1:2:3:4:5:6:7:8",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("1:2:3:4:5:6:7:8")));
+        assertEquals("2001:0:0:4::8",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("2001:0:0:4:0:0:0:8")));
+        assertEquals("2001::4:5:6:7:8",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("2001:0:0:4:5:6:7:8")));
+        assertEquals("2001:0:3:4:5:6:7:8",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("2001:0:3:4:5:6:7:8")));
+        assertEquals("0:0:3::ffff",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("0:0:3:0:0:0:0:ffff")));
+        assertEquals("::4:0:0:0:ffff",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("0:0:0:4:0:0:0:ffff")));
+        assertEquals("::5:0:0:ffff",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("0:0:0:0:5:0:0:ffff")));
+        assertEquals("1::4:0:0:7:8",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("1:0:0:4:0:0:7:8")));
+        assertEquals("::",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("0:0:0:0:0:0:0:0")));
+        assertEquals("::1",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("0:0:0:0:0:0:0:1")));
+        assertEquals("2001:658:22a:cafe::",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("2001:0658:022a:cafe::")));
+        assertEquals("::102:304",
+                InetAddresses.toAddrString(
+                        InetAddresses.forString("::1.2.3.4")));
+    }
+
+    public void testToUriStringIPv4() {
+        String ipStr = "1.2.3.4";
+        InetAddress ip = InetAddresses.forString(ipStr);
+        assertEquals("1.2.3.4", InetAddresses.toUriString(ip));
+    }
+
+    public void testToUriStringIPv6() {
+        // Unfortunately the InetAddress.toString() method for IPv6 addresses
+        // does not collapse contiguous shorts of zeroes with the :: abbreviation.
+        String ipStr = "3ffe::1";
+        InetAddress ip = InetAddresses.forString(ipStr);
+        assertEquals("[3ffe::1]", InetAddresses.toUriString(ip));
+    }
+}

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -134,6 +134,7 @@ com.google.common.hash.HashCode
 com.google.common.hash.HashFunction
 com.google.common.hash.Hashing
 com.google.common.collect.Iterators
+com.google.common.net.InetAddresses
 
 @defaultMessage Do not violate java's access system
 java.lang.reflect.AccessibleObject#setAccessible(boolean)


### PR DESCRIPTION
This commit removes and now forbids all uses of
com.google.common.net.InetAddresses across the codebase. This is one of
the few remaining steps in the eventual removal of Guava as a
dependency.

Relates #13224
