### PR TITLE
Remove and forbid use of com.google.common.collect.ImmutableCollection

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/similarity/Similarities.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/Similarities.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.index.similarity;
 
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.DefaultSimilarity;
 import org.elasticsearch.common.collect.MapBuilder;
+
+import java.util.Collection;
 
 /**
  * Cache of pre-defined Similarities
@@ -49,7 +50,7 @@ public class Similarities {
      *
      * @return Pre-defined SimilarityProvider Factories
      */
-    public static ImmutableCollection<PreBuiltSimilarityProvider.Factory> listFactories() {
+    public static Collection<PreBuiltSimilarityProvider.Factory> listFactories() {
         return PRE_BUILT_SIMILARITIES.values();
     }
 }

--- a/core/src/main/java/org/elasticsearch/script/ScriptContextRegistry.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptContextRegistry.java
@@ -19,14 +19,9 @@
 
 package org.elasticsearch.script;
 
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Collections.unmodifiableSet;
 
@@ -58,7 +53,7 @@ public final class ScriptContextRegistry {
     /**
      * @return a list that contains all the supported {@link ScriptContext}s, both standard ones and registered via plugins
      */
-    ImmutableCollection<ScriptContext> scriptContexts() {
+    Collection<ScriptContext> scriptContexts() {
         return scriptContexts.values();
     }
 


### PR DESCRIPTION
This commit removes and now forbids all uses of
com.google.common.collect.ImmutableCollection across the codebase. This
is one of the final steps in the eventual removal of Guava as a
dependency.

Relates #13224
