### PR TITLE
Deprecate _search/exists in favour of regular _search with size 0 and terminate_after 1

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/exists/ExistsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/exists/ExistsRequest.java
@@ -38,6 +38,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
+/**
+ * @deprecated use {@link org.elasticsearch.action.search.SearchRequest} instead and set `size` to `0` and `terminate_after` to `1`
+ */
+@Deprecated
 public class ExistsRequest extends BroadcastRequest<ExistsRequest> {
 
     public static final float DEFAULT_MIN_SCORE = -1f;

--- a/core/src/main/java/org/elasticsearch/action/exists/ExistsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/exists/ExistsRequestBuilder.java
@@ -24,6 +24,10 @@ import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.query.QueryBuilder;
 
+/**
+ * @deprecated use {@link org.elasticsearch.action.search.SearchRequestBuilder} instead and set `size` to `0` and `terminate_after` to `1`
+ */
+@Deprecated
 public class ExistsRequestBuilder extends BroadcastOperationRequestBuilder<ExistsRequest, ExistsResponse, ExistsRequestBuilder> {
 
     private QuerySourceBuilder sourceBuilder;

--- a/core/src/main/java/org/elasticsearch/action/exists/ExistsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/exists/ExistsResponse.java
@@ -27,6 +27,10 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * @deprecated use {@link org.elasticsearch.action.search.SearchRequest} instead and set `size` to `0` and `terminate_after` to `1`
+ */
+@Deprecated
 public class ExistsResponse extends BroadcastResponse {
 
     private boolean exists = false;

--- a/core/src/main/java/org/elasticsearch/client/Client.java
+++ b/core/src/main/java/org/elasticsearch/client/Client.java
@@ -371,8 +371,9 @@ public interface Client extends ElasticsearchClient, Releasable {
      *
      * @param request The exists request
      * @return The result future
-     * @see Requests#existsRequest(String...)
+     * @deprecated use {@link #search(SearchRequest)} instead and set `size` to `0` and `terminate_after` to `1`
      */
+    @Deprecated
     ActionFuture<ExistsResponse> exists(ExistsRequest request);
 
     /**
@@ -380,13 +381,16 @@ public interface Client extends ElasticsearchClient, Releasable {
      *
      * @param request The exists request
      * @param listener A listener to be notified of the result
-     * @see Requests#existsRequest(String...)
+     * @deprecated use {@link #search(SearchRequest, ActionListener)} instead and set `size` to `0` and `terminate_after` to `1`
      */
+    @Deprecated
     void exists(ExistsRequest request, ActionListener<ExistsResponse> listener);
 
     /**
      * Checks existence of any documents matching a specific query.
+     * @deprecated use {@link #prepareSearch(String...)} instead and set `size` to `0` and `terminate_after` to `1`
      */
+    @Deprecated
     ExistsRequestBuilder prepareExists(String... indices);
 
     /**

--- a/core/src/main/java/org/elasticsearch/client/Requests.java
+++ b/core/src/main/java/org/elasticsearch/client/Requests.java
@@ -144,8 +144,9 @@ public class Requests {
      *
      * @param indices The indices to count matched documents against a query. Use <tt>null</tt> or <tt>_all</tt> to execute against all indices
      * @return The exists request
-     * @see org.elasticsearch.client.Client#exists(org.elasticsearch.action.exists.ExistsRequest)
+     * @deprecated use {@link org.elasticsearch.action.search.SearchRequest} instead and set `size` to `0` and `terminate_after` to `1`
      */
+    @Deprecated
     public static ExistsRequest existsRequest(String... indices) {
         return new ExistsRequest(indices);
     }

--- a/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -637,16 +637,19 @@ public abstract class AbstractClient extends AbstractComponent implements Client
 
     @Override
     public ActionFuture<ExistsResponse> exists(final ExistsRequest request) {
+        deprecationLogger.deprecated("search exists api is deprecated and will be removed in the next major version, use search with size set to 0 and terminate_after set to 1 instead");
         return execute(ExistsAction.INSTANCE, request);
     }
 
     @Override
     public void exists(final ExistsRequest request, final ActionListener<ExistsResponse> listener) {
+        deprecationLogger.deprecated("search exists api is deprecated and will be removed in the next major version, use search with size set to 0 and terminate_after set to 1 instead");
         execute(ExistsAction.INSTANCE, request, listener);
     }
 
     @Override
     public ExistsRequestBuilder prepareExists(String... indices) {
+        deprecationLogger.deprecated("search exists api is deprecated and will be removed in the next major version, use search with size set to 0 and terminate_after set to 1 instead");
         return new ExistsRequestBuilder(this, ExistsAction.INSTANCE).setIndices(indices);
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/exists/RestExistsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/exists/RestExistsAction.java
@@ -37,7 +37,9 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  * Action for /_search/exists endpoint
+ * @deprecated use {@link org.elasticsearch.rest.action.search.RestSearchAction} instead and set `size` to `0` and `terminate_after` to `1`
  */
+@Deprecated
 public class RestExistsAction extends BaseRestHandler {
 
     public RestExistsAction(Settings settings, RestController controller, Client client) {

--- a/docs/reference/search/exists.asciidoc
+++ b/docs/reference/search/exists.asciidoc
@@ -1,6 +1,8 @@
 [[search-exists]]
 == Search Exists API
 
+deprecated[2.1.0, use regular `_search` with `size` set to `0` and `terminate_after` set to `1` instead]
+
 The exists API allows to easily determine if any
 matching documents exist for a provided query. It can be executed across one or more indices
 and across one or more types. The query can either be provided using a


### PR DESCRIPTION
Deprecate `_search/exists` in favour of regular `_search` with `size` set to  `0` and `terminate_after` set to `1`.

Relates to #13682
