### PR TITLE
Remove and forbid use of com.google.common.collect.Iterators

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndexShardSegments.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndexShardSegments.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.action.admin.indices.segments;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.index.shard.ShardId;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 public class IndexShardSegments implements Iterable<ShardSegments> {
@@ -49,6 +49,6 @@ public class IndexShardSegments implements Iterable<ShardSegments> {
 
     @Override
     public Iterator<ShardSegments> iterator() {
-        return Iterators.forArray(shards);
+        return Arrays.stream(shards).iterator();
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexShardStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexShardStats.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -57,7 +57,7 @@ public class IndexShardStats implements Iterable<ShardStats>, Streamable {
 
     @Override
     public Iterator<ShardStats> iterator() {
-        return Iterators.forArray(shards);
+        return Arrays.stream(shards).iterator();
     }
 
     private CommonStats total = null;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/IndexShardUpgradeStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/IndexShardUpgradeStatus.java
@@ -19,9 +19,9 @@
 
 package org.elasticsearch.action.admin.indices.upgrade.get;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.index.shard.ShardId;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 public class IndexShardUpgradeStatus implements Iterable<ShardUpgradeStatus> {
@@ -49,7 +49,7 @@ public class IndexShardUpgradeStatus implements Iterable<ShardUpgradeStatus> {
 
     @Override
     public Iterator<ShardUpgradeStatus> iterator() {
-        return Iterators.forArray(shards);
+        return Arrays.stream(shards).iterator();
     }
 
     public long getTotalBytes() {

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.action.bulk;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -95,7 +95,7 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
 
     @Override
     public Iterator<BulkItemResponse> iterator() {
-        return Iterators.forArray(responses);
+        return Arrays.stream(responses).iterator();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.get;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -27,6 +26,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -37,10 +37,7 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements Iterable<MultiGetRequest.Item>, CompositeIndicesRequest, RealtimeRequest {
 
@@ -498,7 +495,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
 
     @Override
     public Iterator<Item> iterator() {
-        return Iterators.unmodifiableIterator(items.iterator());
+        return Collections.unmodifiableCollection(items).iterator();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.action.get;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -31,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Iterator;
 
 public class MultiGetResponse extends ActionResponse implements Iterable<MultiGetItemResponse>, ToXContent {
@@ -126,7 +124,7 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
 
     @Override
     public Iterator<MultiGetItemResponse> iterator() {
-        return Iterators.forArray(responses);
+        return Arrays.stream(responses).iterator();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/percolate/MultiPercolateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/MultiPercolateResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.percolate;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Nullable;
@@ -30,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -52,7 +52,7 @@ public class MultiPercolateResponse extends ActionResponse implements Iterable<M
 
     @Override
     public Iterator<Item> iterator() {
-        return Iterators.forArray(items);
+        return Arrays.stream(items).iterator();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.search;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Nullable;
@@ -32,7 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -122,7 +121,7 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
 
     @Override
     public Iterator<Item> iterator() {
-        return Iterators.forArray(items);
+        return Arrays.stream(items).iterator();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequest.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.action.termvectors;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.*;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -74,7 +74,7 @@ public class MultiTermVectorsRequest extends ActionRequest<MultiTermVectorsReque
 
     @Override
     public Iterator<TermVectorsRequest> iterator() {
-        return Iterators.unmodifiableIterator(requests.iterator());
+        return Collections.unmodifiableCollection(requests).iterator();
     }
 
     public boolean isEmpty() {

--- a/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.termvectors;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -30,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 
 public class MultiTermVectorsResponse extends ActionResponse implements Iterable<MultiTermVectorsItemResponse>, ToXContent {
@@ -120,7 +120,7 @@ public class MultiTermVectorsResponse extends ActionResponse implements Iterable
 
     @Override
     public Iterator<MultiTermVectorsItemResponse> iterator() {
-        return Iterators.forArray(responses);
+        return Arrays.stream(responses).iterator();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -19,13 +19,10 @@
 
 package org.elasticsearch.cluster.routing;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.collect.Iterators;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * A {@link RoutingNode} represents a cluster node associated with a single {@link DiscoveryNode} including all shards
@@ -51,7 +48,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
 
     @Override
     public Iterator<ShardRouting> iterator() {
-        return Iterators.unmodifiableIterator(shards.iterator());
+        return Collections.unmodifiableCollection(shards).iterator();
     }
 
     Iterator<ShardRouting> mutableIterator() {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -21,13 +21,13 @@ package org.elasticsearch.cluster.routing;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.google.common.collect.Iterators;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.*;
@@ -144,7 +144,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     @Override
     public Iterator<RoutingNode> iterator() {
-        return Iterators.unmodifiableIterator(nodesToShards.values().iterator());
+        return Collections.unmodifiableCollection(nodesToShards.values()).iterator();
     }
 
     public RoutingTable routingTable() {

--- a/core/src/main/java/org/elasticsearch/common/collect/Iterators.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/Iterators.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.collect;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class Iterators {
+    public static <T> Iterator<T> concat(Iterator<? extends T>... iterators) {
+        if (iterators == null) {
+            throw new NullPointerException("iterators");
+        }
+
+        return new ConcatenatedIterator<>(iterators);
+    }
+
+    static class ConcatenatedIterator<T> implements Iterator<T> {
+        private final Iterator<? extends T>[] iterators;
+        private int index = 0;
+
+        public ConcatenatedIterator(Iterator<? extends T>... iterators) {
+            if (iterators == null) {
+                throw new NullPointerException("iterators");
+            }
+            for (int i = 0; i < iterators.length; i++) {
+                if (iterators[i] == null) {
+                    throw new NullPointerException("iterators[" + i  + "]");
+                }
+            }
+            this.iterators = iterators;
+        }
+
+        @Override
+        public boolean hasNext() {
+            boolean hasNext = false;
+            while (index < iterators.length && !(hasNext = iterators[index].hasNext())) {
+                index++;
+            }
+
+            return hasNext;
+        }
+
+        @Override
+        public T next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return iterators[index].next();
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
@@ -19,9 +19,8 @@
 
 package org.elasticsearch.common.io;
 
-import com.google.common.collect.Iterators;
-
 import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.logging.ESLogger;
 
 import java.io.BufferedReader;
@@ -35,6 +34,7 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.StreamSupport;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.FileVisitResult.SKIP_SUBTREE;
@@ -328,7 +328,7 @@ public final class FileSystemUtils {
      */
     public static Path[] files(Path from, DirectoryStream.Filter<Path> filter) throws IOException {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(from, filter)) {
-            return Iterators.toArray(stream.iterator(), Path.class);
+            return toArray(stream);
         }
     }
 
@@ -337,7 +337,7 @@ public final class FileSystemUtils {
      */
     public static Path[] files(Path directory) throws IOException {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory)) {
-            return Iterators.toArray(stream.iterator(), Path.class);
+            return toArray(stream);
         }
     }
 
@@ -346,8 +346,12 @@ public final class FileSystemUtils {
      */
     public static Path[] files(Path directory, String glob) throws IOException {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory, glob)) {
-            return Iterators.toArray(stream.iterator(), Path.class);
+            return toArray(stream);
         }
+    }
+
+    private static Path[] toArray(DirectoryStream<Path> stream) {
+        return StreamSupport.stream(stream.spliterator(), false).toArray(length -> new Path[length]);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -23,15 +23,12 @@ import com.carrotsearch.hppc.DoubleArrayList;
 import com.carrotsearch.hppc.FloatArrayList;
 import com.carrotsearch.hppc.LongArrayList;
 import com.carrotsearch.hppc.ObjectArrayList;
-import com.google.common.collect.Iterators;
 import org.apache.lucene.util.*;
 
 import java.util.*;
 
 /** Collections-related utility methods. */
-public enum CollectionUtils {
-    CollectionUtils;
-
+public class CollectionUtils {
     public static void sort(LongArrayList list) {
         sort(list.buffer, list.size());
     }
@@ -364,13 +361,6 @@ public enum CollectionUtils {
         }
         return uniqueCount;
 
-    }
-
-    /**
-     * Combines multiple iterators into a single iterator.
-     */
-    public static <T> Iterator<T> concat(Iterator<? extends T>... iterators) {
-        return Iterators.<T>concat(iterators);
     }
 
     public static <E> ArrayList<E> iterableAsArrayList(Iterable<? extends E> elements) {

--- a/core/src/main/java/org/elasticsearch/index/codec/postingsformat/Elasticsearch090PostingsFormat.java
+++ b/core/src/main/java/org/elasticsearch/index/codec/postingsformat/Elasticsearch090PostingsFormat.java
@@ -18,22 +18,17 @@
  */
 package org.elasticsearch.index.codec.postingsformat;
 
-import com.google.common.collect.Iterators;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat;
-import org.apache.lucene.index.Fields;
-import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.BloomFilter;
-import org.elasticsearch.index.codec.postingsformat.BloomFilterPostingsFormat.BloomFilteredFieldsConsumer;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.function.Predicate;
 
 /**

--- a/core/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.engine;
 
-import com.google.common.collect.Iterators;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
 import org.elasticsearch.common.Nullable;
@@ -32,7 +31,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 public class Segment implements Streamable {

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterators;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
@@ -39,6 +38,7 @@ import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -72,6 +72,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
@@ -184,13 +185,13 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
      */
     public Iterable<DocumentMapper> docMappers(final boolean includingDefaultMapping) {
         return () -> {
-            final Iterator<DocumentMapper> iterator;
+            final Collection<DocumentMapper> documentMappers;
             if (includingDefaultMapping) {
-                iterator = mappers.values().iterator();
+                documentMappers = mappers.values();
             } else {
-                iterator = mappers.values().stream().filter(mapper -> !DEFAULT_MAPPING.equals(mapper.type())).iterator();
+                documentMappers = mappers.values().stream().filter(mapper -> !DEFAULT_MAPPING.equals(mapper.type())).collect(Collectors.toList());
             }
-            return Iterators.unmodifiableIterator(iterator);
+            return Collections.unmodifiableCollection(documentMappers).iterator();
         };
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.mapper.geo;
 
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.google.common.collect.Iterators;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.util.BytesRef;
@@ -30,6 +29,7 @@ import org.apache.lucene.util.XGeoHashUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
@@ -39,14 +39,7 @@ import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MergeMappingException;
-import org.elasticsearch.index.mapper.MergeResult;
-import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper.CustomNumericDocValuesField;
@@ -54,18 +47,10 @@ import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
-import static org.elasticsearch.index.mapper.MapperBuilders.doubleField;
-import static org.elasticsearch.index.mapper.MapperBuilders.geoPointField;
-import static org.elasticsearch.index.mapper.MapperBuilders.stringField;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
+import static org.elasticsearch.index.mapper.MapperBuilders.*;
+import static org.elasticsearch.index.mapper.core.TypeParsers.*;
 
 /**
  * Parsing: We handle:

--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.monitor.fs;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -235,7 +235,7 @@ public class FsInfo implements Iterable<FsInfo.Path>, Streamable, ToXContent {
 
     @Override
     public Iterator<Path> iterator() {
-        return Iterators.forArray(paths);
+        return Arrays.stream(paths).iterator();
     }
 
     public static FsInfo readFsInfo(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.monitor.jvm;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -32,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import java.io.IOException;
 import java.lang.management.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -378,7 +378,7 @@ public class JvmStats implements Streamable, ToXContent {
 
         @Override
         public Iterator<GarbageCollector> iterator() {
-            return Iterators.forArray(collectors);
+            return Arrays.stream(collectors).iterator();
         }
     }
 
@@ -546,7 +546,7 @@ public class JvmStats implements Streamable, ToXContent {
 
         @Override
         public Iterator<MemoryPool> iterator() {
-            return Iterators.forArray(pools);
+            return Arrays.stream(pools).iterator();
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.plugins;
 
-import com.google.common.collect.Iterators;
-
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchCorruptionException;
@@ -30,6 +28,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.JarHell;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.cli.Terminal;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.http.client.HttpDownloadHelper;
 import org.elasticsearch.common.io.FileSystemUtils;
@@ -56,6 +55,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -437,7 +437,7 @@ public class PluginManager {
         }
 
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(environment.pluginsFile())) {
-            return Iterators.toArray(stream.iterator(), Path.class);
+            return StreamSupport.stream(stream.spliterator(), false).toArray(length -> new Path[length]);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHits.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchHits.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.internal;
 
 import com.carrotsearch.hppc.IntObjectHashMap;
-import com.google.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -30,6 +29,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchShardTarget;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -156,7 +156,7 @@ public class InternalSearchHits implements SearchHits {
 
     @Override
     public Iterator<SearchHit> iterator() {
-        return Iterators.forArray(hits());
+        return Arrays.stream(hits()).iterator();
     }
 
     public InternalSearchHit[] internalHits() {

--- a/core/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.collect;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.*;
+
+public class IteratorsTests extends ESTestCase {
+    public void testConcatentation() {
+        List<Integer> threeTwoOne = Arrays.asList(3, 2, 1);
+        List<Integer> fourFiveSix = Arrays.asList(4, 5, 6);
+        Iterator<Integer> concat = Iterators.concat(threeTwoOne.iterator(), fourFiveSix.iterator());
+        assertContainsInOrder(concat, 3, 2, 1, 4, 5, 6);
+    }
+
+    public void testNoConcatenation() {
+        Iterator<Integer> iterator = Iterators.<Integer>concat();
+        assertEmptyIterator(iterator);
+    }
+
+    public void testEmptyConcatenation() {
+        Iterator<Integer> iterator = Iterators.<Integer>concat(empty());
+        assertEmptyIterator(iterator);
+    }
+
+    public void testMultipleEmptyConcatenation() {
+        Iterator<Integer> iterator = Iterators.concat(empty(), empty());
+        assertEmptyIterator(iterator);
+    }
+
+    public void testSingleton() {
+        int value = randomInt();
+        assertSingleton(value, singletonIterator(value));
+    }
+
+    public void testEmptyBeforeSingleton() {
+        int value = randomInt();
+        assertSingleton(value, empty(), singletonIterator(value));
+    }
+
+
+    public void testEmptyAfterSingleton() {
+        int value = randomInt();
+        assertSingleton(value, singletonIterator(value), empty());
+    }
+
+    public void testRandomSingleton() {
+        int numberOfIterators = randomIntBetween(1, 1000);
+        int singletonIndex = randomIntBetween(0, numberOfIterators - 1);
+        int value = randomInt();
+        Iterator<Integer>[] iterators = new Iterator[numberOfIterators];
+        for (int i = 0; i < numberOfIterators; i++) {
+            iterators[i] = i != singletonIndex ? empty() : singletonIterator(value);
+        }
+        assertSingleton(value, iterators);
+    }
+
+    public void testRandomIterators() {
+        int numberOfIterators = randomIntBetween(1, 1000);
+        Iterator<Integer>[] iterators = new Iterator[numberOfIterators];
+        List<Integer> values = new ArrayList<>();
+        for (int i = 0; i < numberOfIterators; i++) {
+            int numberOfValues = randomIntBetween(0, 256);
+            List<Integer> theseValues = new ArrayList<>();
+            for (int j = 0; j < numberOfValues; j++) {
+                int value = randomInt();
+                values.add(value);
+                theseValues.add(value);
+            }
+            iterators[i] = theseValues.iterator();
+        }
+        assertContainsInOrder(Iterators.concat(iterators), values.toArray(new Integer[values.size()]));
+    }
+
+    public void testTwoEntries() {
+        int first = randomInt();
+        int second = randomInt();
+        Iterator<Integer> concat = Iterators.concat(singletonIterator(first), empty(), empty(), singletonIterator(second));
+        assertContainsInOrder(concat, first, second);
+    }
+
+    public void testNull() {
+        try {
+            Iterators.concat((Iterator<?>)null);
+            fail("expected " + NullPointerException.class.getSimpleName());
+        } catch (NullPointerException e) {
+
+        }
+    }
+
+    public void testNullIterator() {
+        try {
+            Iterators.concat(singletonIterator(1), empty(), null, empty(), singletonIterator(2));
+            fail("expected " + NullPointerException.class.getSimpleName());
+        } catch (NullPointerException e) {
+
+        }
+    }
+
+    private <T> Iterator<T> singletonIterator(T value) {
+        return Collections.singleton(value).iterator();
+    }
+
+    private <T> void assertSingleton(T value, Iterator<T>... iterators) {
+        Iterator<T> concat = Iterators.concat(iterators);
+        assertContainsInOrder(concat, value);
+    }
+
+    private <T> Iterator<T> empty() {
+        return new Iterator<T>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public T next() {
+                throw new NoSuchElementException();
+            }
+        };
+    }
+
+    private <T> void assertContainsInOrder(Iterator<T> iterator, T... values) {
+        for (T value : values) {
+            assertTrue(iterator.hasNext());
+            assertEquals(value, iterator.next());
+        }
+        assertNoSuchElementException(iterator);
+    }
+
+    private <T> void assertEmptyIterator(Iterator<T> iterator) {
+        assertFalse(iterator.hasNext());
+        assertNoSuchElementException(iterator);
+    }
+
+    private <T> void assertNoSuchElementException(Iterator<T> iterator) {
+        try {
+            iterator.next();
+            fail("expected " + NoSuchElementException.class.getSimpleName());
+        } catch (NoSuchElementException e) {
+
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.gateway;
 
-import com.google.common.collect.Iterators;
-
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
@@ -33,6 +31,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -59,6 +58,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -535,7 +535,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
 
     public Path[] content(String glob, Path dir) throws IOException {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir, glob)) {
-            return Iterators.toArray(stream.iterator(), Path.class);
+            return StreamSupport.stream(stream.spliterator(), false).toArray(length -> new Path[length]);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/codec/postingformat/Elasticsearch090RWPostingsFormat.java
+++ b/core/src/test/java/org/elasticsearch/index/codec/postingformat/Elasticsearch090RWPostingsFormat.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.codec.postingformat;
 
-import com.google.common.collect.Iterators;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.index.Fields;
@@ -32,6 +31,7 @@ import org.elasticsearch.index.codec.postingsformat.Elasticsearch090PostingsForm
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.StreamSupport;
 
@@ -61,7 +61,7 @@ public class Elasticsearch090RWPostingsFormat extends Elasticsearch090PostingsFo
                 maskedFields = new FilterLeafReader.FilterFields(fields) {
                     @Override
                     public Iterator<String> iterator() {
-                        return Iterators.singletonIterator(UidFieldMapper.NAME);
+                        return Collections.singleton(UidFieldMapper.NAME).iterator();
                     }
                 };
                 // only go through bloom for the UID field

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import com.google.common.collect.Iterators;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
@@ -30,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.StreamSupport;
 
 public class FieldTypeLookupTests extends ESTestCase {
 
@@ -61,7 +59,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertNull(lookup.get("bar"));
         assertEquals(f.fieldType(), lookup2.getByIndexName("bar"));
         assertNull(lookup.getByIndexName("foo"));
-        assertEquals(1, Iterators.size(lookup2.iterator()));
+        assertEquals(1, size(lookup2.iterator()));
     }
 
     public void testAddExistingField() {
@@ -76,7 +74,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertSame(f.fieldType(), f2.fieldType());
         assertSame(f.fieldType(), lookup2.get("foo"));
         assertSame(f.fieldType(), lookup2.getByIndexName("foo"));
-        assertEquals(1, Iterators.size(lookup2.iterator()));
+        assertEquals(1, size(lookup2.iterator()));
     }
 
     public void testAddExistingIndexName() {
@@ -92,7 +90,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertSame(f.fieldType(), lookup2.get("foo"));
         assertSame(f.fieldType(), lookup2.get("bar"));
         assertSame(f.fieldType(), lookup2.getByIndexName("foo"));
-        assertEquals(2, Iterators.size(lookup2.iterator()));
+        assertEquals(2, size(lookup2.iterator()));
     }
 
     public void testAddExistingFullName() {
@@ -108,7 +106,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertSame(f.fieldType(), lookup2.get("foo"));
         assertSame(f.fieldType(), lookup2.getByIndexName("foo"));
         assertSame(f.fieldType(), lookup2.getByIndexName("bar"));
-        assertEquals(1, Iterators.size(lookup2.iterator()));
+        assertEquals(1, size(lookup2.iterator()));
     }
 
     public void testAddExistingBridgeName() {
@@ -285,5 +283,17 @@ public class FieldTypeLookupTests extends ESTestCase {
         protected String contentType() { return null; }
         @Override
         protected void parseCreateField(ParseContext context, List list) throws IOException {}
+    }
+
+    private int size(Iterator<MappedFieldType> iterator) {
+        if (iterator == null) {
+            throw new NullPointerException("iterator");
+        }
+        int count = 0;
+        while (iterator.hasNext()) {
+            count++;
+            iterator.next();
+        }
+        return count;
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.index.mapper.externalvalues;
 
-import com.google.common.collect.Iterators;
 import com.spatial4j.core.shape.Point;
 import org.apache.lucene.document.Field;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.settings.Settings;

--- a/core/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.test;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-import com.google.common.collect.Iterators;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -31,11 +30,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Random;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
@@ -247,7 +242,7 @@ public class CompositeTestCluster extends TestCluster {
 
     @Override
     public synchronized Iterator<Client> iterator() {
-        return Iterators.singletonIterator(client());
+        return Collections.singleton(client()).iterator();
     }
 
     /**

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -133,6 +133,7 @@ com.google.common.io.Resources
 com.google.common.hash.HashCode
 com.google.common.hash.HashFunction
 com.google.common.hash.Hashing
+com.google.common.collect.Iterators
 
 @defaultMessage Do not violate java's access system
 java.lang.reflect.AccessibleObject#setAccessible(boolean)


### PR DESCRIPTION
This commit removes and now forbids all uses of
com.google.common.collect.Iterators across the codebase. This is one of
the final steps in the eventual removal of Guava as a dependency.

Relates #13224
