### PR TITLE
Record all bytes of the checksum in VerifyingIndexOutput

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -208,11 +208,6 @@ public class StoreTests extends ESTestCase {
                     verifyingOutput.writeByte(checksumBytes.bytes[i]);
                 }
             }
-            if (randomBoolean()) {
-               appendRandomData(verifyingOutput);
-            } else {
-                Store.verify(verifyingOutput);
-            }
             fail("should be a corrupted index");
         } catch (CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
             // ok


### PR DESCRIPTION
The fix in #13848 has an off by one issue where the first byte of the checksum
was never written. Unfortunately most tests shadowed the problem and the first
byte of the checksum seems to be very likely a 0 which causes only very rare
failures.

Relates to #13896
Relates to #13848
