### PR TITLE
First cleanup of the WIP commit

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/Data.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/Data.java
@@ -23,6 +23,9 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 
 import java.util.Map;
 
+/**
+ * Represents the data and meta data (like id and type) of a single document that is going to be indexed.
+ */
 public final class Data {
 
     private final String index;

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/Processor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/Processor.java
@@ -20,15 +20,45 @@
 
 package org.elasticsearch.ingest;
 
+import java.util.Map;
+
+/**
+ * An processor implementation may modify the data belonging to a document.
+ * If and what exactly is modified is upto the implementation.
+ */
 public interface Processor {
 
+    /**
+     * Introspect and potentially modify the incoming data.
+     */
     void execute(Data data);
 
-    String type();
-
+    /**
+     * A builder to contruct a processor to be used in a pipeline.
+     */
     interface Builder {
 
+        /**
+         * A general way to set processor related settings based on the config map.
+         */
+        void fromMap(Map<String, Object> config);
+
+        /**
+         * Builds the processor based on previous set settings.
+         */
         Processor build();
+
+        /**
+         * A factory that creates a processor builder when processor instances for pipelines are being created.
+         */
+        interface Factory {
+
+            /**
+             * Creates the builder.
+             */
+            Builder create();
+
+        }
 
     }
 

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/SimpleProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/SimpleProcessor.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 public final class SimpleProcessor implements Processor {
 
+    public static final String TYPE = "simple";
+
     private final String path;
     private final String expectedValue;
 
@@ -44,11 +46,6 @@ public final class SimpleProcessor implements Processor {
                 data.addField(addField, addFieldValue);
             }
         }
-    }
-
-    @Override
-    public String type() {
-        return "logging";
     }
 
     public static class Builder implements Processor.Builder {
@@ -85,6 +82,15 @@ public final class SimpleProcessor implements Processor {
         public Processor build() {
             return new SimpleProcessor(path, value, addField, addFieldValue);
         }
+
+        public static class Factory implements Processor.Builder.Factory {
+
+            @Override
+            public Processor.Builder create() {
+                return new Builder();
+            }
+        }
+
     }
 
 }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestPlugin.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestPlugin.java
@@ -27,13 +27,14 @@ import org.elasticsearch.plugin.ingest.transport.IngestActionFilter;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.action.RestActionModule;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
 public class IngestPlugin extends Plugin {
 
     public static final String INGEST_CONTEXT_KEY = "__ingest__";
-    public static final String INGEST_HTTP_PARAM = "ingest";
+    public static final String INGEST_PARAM = "ingest";
 
     @Override
     public String name() {
@@ -52,14 +53,11 @@ public class IngestPlugin extends Plugin {
 
     @Override
     public Collection<Class<? extends LifecycleComponent>> nodeServices() {
-        return Collections.singletonList(PipelineStore.class);
+        return Arrays.asList(PipelineStore.class, PipelineConfigDocReader.class);
     }
 
     public void onModule(ActionModule module) {
         module.registerFilter(IngestActionFilter.class);
-    }
-
-    public void onModule(RestActionModule module) {
     }
 
 }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineConfigDocReader.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineConfigDocReader.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+public class PipelineConfigDocReader extends AbstractLifecycleComponent {
+
+    private volatile Client client;
+    private final Injector injector;
+    private final TimeValue scrollTimeout;
+
+    @Inject
+    public PipelineConfigDocReader(Settings settings, Injector injector) {
+        super(settings);
+        this.injector = injector;
+        this.scrollTimeout = settings.getAsTime("ingest.pipeline.store.scroll.timeout", TimeValue.timeValueSeconds(30));
+    }
+
+    @Override
+    protected void doStart() {
+        client = injector.getInstance(Client.class);
+    }
+
+    @Override
+    protected void doStop() {
+        client.close();
+    }
+
+    @Override
+    protected void doClose() {
+    }
+
+    public Iterable<SearchHit> readAll() {
+        // TODO: the search should be replaced with an ingest API when it is available
+        SearchResponse searchResponse = client.prepareSearch(PipelineStore.INDEX)
+                .setVersion(true)
+                .setScroll(scrollTimeout)
+                .addSort("_doc", SortOrder.ASC)
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                .get();
+
+        if (searchResponse.getHits().getTotalHits() == 0) {
+            return Collections.emptyList();
+        }
+        logger.debug("reading [{}] pipeline documents", searchResponse.getHits().totalHits());
+        return new Iterable<SearchHit>() {
+            @Override
+            public Iterator<SearchHit> iterator() {
+                return new SearchScrollIterator(searchResponse);
+            }
+        };
+    }
+
+    class SearchScrollIterator implements Iterator<SearchHit> {
+
+        private SearchResponse searchResponse;
+
+        private int currentIndex;
+        private SearchHit[] currentHits;
+
+        SearchScrollIterator(SearchResponse searchResponse) {
+            this.searchResponse = searchResponse;
+            this.currentHits = searchResponse.getHits().getHits();
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (currentIndex < currentHits.length) {
+                return true;
+            } else {
+                if (searchResponse == null) {
+                    return false;
+                }
+
+                searchResponse = client.prepareSearchScroll(searchResponse.getScrollId())
+                        .setScroll(scrollTimeout)
+                        .get();
+                if (searchResponse.getHits().getHits().length == 0) {
+                    searchResponse = null;
+                    return false;
+                } else {
+                    currentHits = searchResponse.getHits().getHits();
+                    currentIndex = 0;
+                    return true;
+                }
+            }
+        }
+
+        @Override
+        public SearchHit next() {
+            SearchHit hit = currentHits[currentIndex++];
+            if (logger.isTraceEnabled()) {
+                logger.trace("reading pipeline document [{}] with source [{}]", hit.getId(), hit.sourceAsString());
+            }
+            return hit;
+        }
+    }
+
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/rest/IngestRestFilter.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/rest/IngestRestFilter.java
@@ -34,7 +34,7 @@ public class IngestRestFilter extends RestFilter {
 
     @Override
     public void process(RestRequest request, RestChannel channel, RestFilterChain filterChain) throws Exception {
-        request.putInContext(INGEST_CONTEXT_KEY, request.param(INGEST_HTTP_PARAM));
+        request.putInContext(INGEST_CONTEXT_KEY, request.param(INGEST_PARAM));
         filterChain.continueProcessing(request, channel);
     }
 }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilter.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilter.java
@@ -49,7 +49,7 @@ public class IngestActionFilter extends ActionFilter.Simple {
     protected boolean apply(String action, ActionRequest request, ActionListener listener) {
         String pipelineId = request.getFromContext(IngestPlugin.INGEST_CONTEXT_KEY);
         if (pipelineId == null) {
-            pipelineId = request.getHeader(IngestPlugin.INGEST_HTTP_PARAM);
+            pipelineId = request.getHeader(IngestPlugin.INGEST_PARAM);
             if (pipelineId == null) {
                 return true;
             }
@@ -73,6 +73,7 @@ public class IngestActionFilter extends ActionFilter.Simple {
         return true;
     }
 
+    // TODO: this should be delegated to a PipelineExecutor service that executes on a different thread (pipeline TP)
     void processIndexRequest(IndexRequest indexRequest, Pipeline pipeline) {
         Map<String, Object> sourceAsMap = indexRequest.sourceAsMap();
         Data data = new Data(indexRequest.index(), indexRequest.type(), indexRequest.id(), sourceAsMap);

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineConfigDocReaderTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineConfigDocReaderTests.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class PipelineConfigDocReaderTests extends ESSingleNodeTestCase {
+
+    public void testReadAll() {
+        PipelineConfigDocReader reader = new PipelineConfigDocReader(Settings.EMPTY, node().injector());
+        reader.start();
+
+        createIndex(PipelineStore.INDEX);
+        int numDocs = scaledRandomIntBetween(32, 128);
+        for (int i = 0; i < numDocs; i++) {
+            client().prepareIndex(PipelineStore.INDEX, PipelineStore.TYPE, Integer.toString(i))
+                    .setSource("field", "value" + i)
+                    .get();
+        }
+        client().admin().indices().prepareRefresh().get();
+
+        int i = 0;
+        for (SearchHit hit : reader.readAll()) {
+            assertThat(hit.getId(), equalTo(Integer.toString(i)));
+            assertThat(hit.getVersion(), equalTo(1l));
+            assertThat(hit.getSource().get("field"), equalTo("value" + i));
+            i++;
+        }
+        assertThat(i, equalTo(numDocs));
+    }
+
+}

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreTests.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest;
+
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.text.StringText;
+import org.elasticsearch.ingest.SimpleProcessor;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.internal.InternalSearchHit;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PipelineStoreTests extends ESTestCase {
+
+    private PipelineStore store;
+    private ThreadPool threadPool;
+    private PipelineConfigDocReader docReader;
+
+    @Before
+    public void init() {
+        threadPool = new ThreadPool("test");
+        ClusterService clusterService = mock(ClusterService.class);
+        docReader = mock(PipelineConfigDocReader.class);
+        store = new PipelineStore(Settings.EMPTY, threadPool, clusterService, docReader, Collections.singletonMap(SimpleProcessor.TYPE, new SimpleProcessor.Builder.Factory()));
+        store.start();
+    }
+
+    @After
+    public void cleanup() {
+        store.stop();
+        threadPool.shutdown();
+    }
+
+
+    public void testUpdatePipeline() {
+        List<SearchHit> hits = new ArrayList<>();
+        hits.add(new InternalSearchHit(0, "1", new StringText("type"), Collections.emptyMap())
+                .sourceRef(new BytesArray("{\"name\": \"_name1\", \"description\": \"_description1\"}"))
+        );
+
+        when(docReader.readAll()).thenReturn(hits);
+        assertThat(store.get("1"), nullValue());
+
+        store.updatePipelines();
+        assertThat(store.get("1").getId(), equalTo("_name1"));
+        assertThat(store.get("1").getDescription(), equalTo("_description1"));
+
+        hits.add(new InternalSearchHit(0, "2", new StringText("type"), Collections.emptyMap())
+                        .sourceRef(new BytesArray("{\"name\": \"_name2\", \"description\": \"_description2\"}"))
+        );
+        store.updatePipelines();
+        assertThat(store.get("1").getId(), equalTo("_name1"));
+        assertThat(store.get("1").getDescription(), equalTo("_description1"));
+        assertThat(store.get("2").getId(), equalTo("_name2"));
+        assertThat(store.get("2").getDescription(), equalTo("_description2"));
+    }
+
+    public void testPipelineUpdater() throws Exception {
+        List<SearchHit> hits = new ArrayList<>();
+        hits.add(new InternalSearchHit(0, "1", new StringText("type"), Collections.emptyMap())
+                        .sourceRef(new BytesArray("{\"name\": \"_name1\", \"description\": \"_description1\"}"))
+        );
+        when(docReader.readAll()).thenReturn(hits);
+        assertThat(store.get("1"), nullValue());
+
+        store.startUpdateWorker();
+        assertBusy(() -> {
+            assertThat(store.get("1"), notNullValue());
+            assertThat(store.get("1").getId(), equalTo("_name1"));
+            assertThat(store.get("1").getDescription(), equalTo("_description1"));
+        });
+
+        hits.add(new InternalSearchHit(0, "2", new StringText("type"), Collections.emptyMap())
+                        .sourceRef(new BytesArray("{\"name\": \"_name2\", \"description\": \"_description2\"}"))
+        );
+        assertBusy(() -> {
+            assertThat(store.get("1"), notNullValue());
+            assertThat(store.get("1").getId(), equalTo("_name1"));
+            assertThat(store.get("1").getDescription(), equalTo("_description1"));
+            assertThat(store.get("2"), notNullValue());
+            assertThat(store.get("2").getId(), equalTo("_name2"));
+            assertThat(store.get("2").getDescription(), equalTo("_description2"));
+        });
+    }
+
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -47,6 +47,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>securemock</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Provided dependencies by elasticsearch itself  -->
         <dependency>


### PR DESCRIPTION
1. only update pipeline if the content has been changed
2. split the actual fetching of pipeline docs from the pipeline store to make unit testing easier
3. replaced hardcoded processor lookups with simple map registry
