### PR TITLE
Add options for indices.get feature

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -13,7 +13,8 @@
         },
         "feature":{
           "type":"list",
-          "description":"A comma-separated list of features"
+          "description":"A comma-separated list of features",
+          "options": ["_settings", "_mappings", "_warmers", "_aliases"]
         }
       },
       "params":{


### PR DESCRIPTION
As described here https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html?q=get%20index#_filtering_index_information
