### PR TITLE
Remove UpdateTests' dependency on groovy.

### DIFF
--- a/plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/package-info.java
+++ b/plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/package-info.java
@@ -80,7 +80,6 @@
   renamed:    core/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/TDigestPercentilesTests.java
   renamed:    core/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/TopHitsTests.java
   renamed:    core/src/test/java/org/elasticsearch/index/mapper/TransformOnIndexMapperIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/TransformOnIndexMapperTests.java
-  renamed:    core/src/test/java/org/elasticsearch/update/UpdateIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/UpdateTests.java
   renamed:    core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ValueCountTests.java
   renamed:    core/src/main/java/org/elasticsearch/script/groovy/GroovyScriptCompilationException.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovyRestIT.java
   renamed:    core/src/test/java/org/elasticsearch/script/GroovyScriptIT.java -> plugins/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovyScriptTests.java


### PR DESCRIPTION
These tests had to be moved to lang-groovy when groovy has been made a plugin.
I refactored them a bit to use mock plugins instead so that groovy is not
necessary anymore and they can come back to core.
