### PR TITLE
[test] remove index= from catch: /regex/ in date math tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_date_math_index_names.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/80_date_math_index_names.yaml
@@ -2,6 +2,6 @@
 "Missing index with catch":
 
   - do:
-      catch:   /index=logstash-\d{4}\.\d{2}\.\d{2}/
+      catch:   /logstash-\d{4}\.\d{2}\.\d{2}/
       search:
         index: <logstash-{now/M}>


### PR DESCRIPTION
This breaks on some clients and is not required for the actual test

Should be back-ported to `2.x` and `2.0`
