### PR TITLE
Remove ScriptEngineService.execute.

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
@@ -94,11 +94,6 @@ public class NativeScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
-        return executable(compiledScript, vars).run();
-    }
-
-    @Override
     public void close() {
     }
 

--- a/core/src/main/java/org/elasticsearch/script/ScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptEngineService.java
@@ -42,8 +42,6 @@ public interface ScriptEngineService extends Closeable {
 
     SearchScript search(CompiledScript compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars);
 
-    Object execute(CompiledScript compiledScript, Map<String, Object> vars);
-
     /**
      * Handler method called when a script is removed from the Guava cache.
      *

--- a/core/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.script.mustache;
 
 import com.github.mustachejava.Mustache;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -34,7 +33,6 @@ import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.util.Collections;
 import java.util.Map;
@@ -86,29 +84,6 @@ public class MustacheScriptEngineService extends AbstractComponent implements Sc
     public Object compile(String template) {
         /** Factory to generate Mustache objects from. */
         return (new JsonEscapingMustacheFactory()).compile(new FastStringReader(template), "query-template");
-    }
-
-    /**
-     * Execute a compiled template object (as retrieved from the compile method)
-     * and fill potential place holders with the variables given.
-     *
-     * @param template
-     *            compiled template object.
-     * @param vars
-     *            map of variables to use during substitution.
-     *
-     * @return the processed string with all given variables substitued.
-     * */
-    @Override
-    public Object execute(CompiledScript template, Map<String, Object> vars) {
-        BytesStreamOutput result = new BytesStreamOutput();
-        try (UTF8StreamWriter writer = utf8StreamWriter().setOutput(result)) {
-            ((Mustache) template.compiled()).execute(writer, vars);
-        } catch (Exception e) {
-            logger.error("Error executing " + template, e);
-            throw new ScriptException("Error executing " + template, e);
-        }
-        return result.bytes();
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/core/src/test/java/org/elasticsearch/script/MockScriptEngine.java
@@ -104,11 +104,6 @@ public class MockScriptEngine implements ScriptEngineService {
     }
 
     @Override
-    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
-        return null;
-    }
-
-    @Override
     public void scriptRemoved(@Nullable CompiledScript script) {
     }
 

--- a/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
@@ -286,11 +286,6 @@ public class ScriptModesTests extends ESTestCase {
         }
 
         @Override
-        public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
-            return null;
-        }
-
-        @Override
         public void close() {
 
         }

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -497,11 +497,6 @@ public class ScriptServiceTests extends ESTestCase {
         }
 
         @Override
-        public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
-            return null;
-        }
-
-        @Override
         public void close() {
 
         }

--- a/core/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
@@ -54,7 +54,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
                     + "\"negative\": {\"term\": {\"body\": {\"value\": \"solr\"}" + "}}, \"negative_boost\": {{boost_val}} } }}";
             Map<String, Object> vars = new HashMap<>();
             vars.put("boost_val", "0.3");
-            BytesReference o = (BytesReference) qe.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "", "mustache", qe.compile(template)), vars);
+            BytesReference o = (BytesReference) qe.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "", "mustache", qe.compile(template)), vars).run();
             assertEquals("GET _search {\"query\": {\"boosting\": {\"positive\": {\"match\": {\"body\": \"gift\"}},"
                     + "\"negative\": {\"term\": {\"body\": {\"value\": \"solr\"}}}, \"negative_boost\": 0.3 } }}",
                     new String(o.toBytes(), Charset.forName("UTF-8")));
@@ -65,7 +65,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
             Map<String, Object> vars = new HashMap<>();
             vars.put("boost_val", "0.3");
             vars.put("body_val", "\"quick brown\"");
-            BytesReference o = (BytesReference) qe.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "", "mustache", qe.compile(template)), vars);
+            BytesReference o = (BytesReference) qe.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "", "mustache", qe.compile(template)), vars).run();
             assertEquals("GET _search {\"query\": {\"boosting\": {\"positive\": {\"match\": {\"body\": \"gift\"}},"
                     + "\"negative\": {\"term\": {\"body\": {\"value\": \"\\\"quick brown\\\"\"}}}, \"negative_boost\": 0.3 } }}",
                     new String(o.toBytes(), Charset.forName("UTF-8")));

--- a/plugins/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/plugins/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -237,12 +237,6 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
     }
 
     @Override
-    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
-        ExpressionExecutableScript expressionExecutableScript = new ExpressionExecutableScript(compiledScript, vars);
-        return expressionExecutableScript.run();
-    }
-
-    @Override
     public void close() {}
 
     @Override

--- a/plugins/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/plugins/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -244,20 +244,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
         };
     }
 
-    @Override
-    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
-        try {
-            Map<String, Object> allVars = new HashMap<>();
-            if (vars != null) {
-                allVars.putAll(vars);
-            }
-            Script scriptObject = createScript(compiledScript.compiled(), allVars);
-            return scriptObject.run();
-        } catch (Exception e) {
-            throw new ScriptException("failed to execute " + compiledScript, e);
-        }
-    }
-
     public static final class GroovyScript implements ExecutableScript, LeafSearchScript {
 
         private final CompiledScript compiledScript;

--- a/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineService.java
+++ b/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineService.java
@@ -178,26 +178,6 @@ public class JavaScriptScriptEngineService extends AbstractComponent implements 
         }
     }
 
-    @Override
-    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
-        Context ctx = Context.enter();
-        ctx.setWrapFactory(wrapFactory);
-        try {
-            Script script = (Script) compiledScript.compiled();
-            Scriptable scope = ctx.newObject(globalScope);
-            scope.setPrototype(globalScope);
-            scope.setParentScope(null);
-
-            for (Map.Entry<String, Object> entry : vars.entrySet()) {
-                ScriptableObject.putProperty(scope, entry.getKey(), entry.getValue());
-            }
-            Object ret = script.exec(ctx, scope);
-            return ScriptValueConverter.unwrapValue(ret);
-        } finally {
-            Context.exit();
-        }
-    }
-
     private String generateScriptName() {
         return "Script" + counter.incrementAndGet() + ".js";
     }

--- a/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineTests.java
+++ b/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineTests.java
@@ -57,7 +57,7 @@ public class JavaScriptScriptEngineTests extends ESTestCase {
     @Test
     public void testSimpleEquation() {
         Map<String, Object> vars = new HashMap<String, Object>();
-        Object o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testSimpleEquation", "js", se.compile("1 + 2")), vars);
+        Object o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testSimpleEquation", "js", se.compile("1 + 2")), vars).run();
         assertThat(((Number) o).intValue(), equalTo(3));
     }
 
@@ -68,21 +68,21 @@ public class JavaScriptScriptEngineTests extends ESTestCase {
         Map<String, Object> obj2 = MapBuilder.<String, Object>newMapBuilder().put("prop2", "value2").map();
         Map<String, Object> obj1 = MapBuilder.<String, Object>newMapBuilder().put("prop1", "value1").put("obj2", obj2).put("l", Arrays.asList("2", "1")).map();
         vars.put("obj1", obj1);
-        Object o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testMapAccess", "js", se.compile("obj1")), vars);
+        Object o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testMapAccess", "js", se.compile("obj1")), vars).run();
         assertThat(o, instanceOf(Map.class));
         obj1 = (Map<String, Object>) o;
         assertThat((String) obj1.get("prop1"), equalTo("value1"));
         assertThat((String) ((Map<String, Object>) obj1.get("obj2")).get("prop2"), equalTo("value2"));
 
-        o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testMapAccess", "js", se.compile("obj1.l[0]")), vars);
+        o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testMapAccess", "js", se.compile("obj1.l[0]")), vars).run();
         assertThat(((String) o), equalTo("2"));
     }
 
     @Test
     public void testJavaScriptObjectToMap() {
         Map<String, Object> vars = new HashMap<String, Object>();
-        Object o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testJavaScriptObjectToMap", "js",
-                se.compile("var obj1 = {}; obj1.prop1 = 'value1'; obj1.obj2 = {}; obj1.obj2.prop2 = 'value2'; obj1")), vars);
+        Object o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testJavaScriptObjectToMap", "js",
+                se.compile("var obj1 = {}; obj1.prop1 = 'value1'; obj1.obj2 = {}; obj1.obj2.prop2 = 'value2'; obj1")), vars).run();
         Map obj1 = (Map) o;
         assertThat((String) obj1.get("prop1"), equalTo("value1"));
         assertThat((String) ((Map<String, Object>) obj1.get("obj2")).get("prop2"), equalTo("value2"));
@@ -131,22 +131,22 @@ public class JavaScriptScriptEngineTests extends ESTestCase {
         Map<String, Object> obj1 = MapBuilder.<String, Object>newMapBuilder().put("prop1", "value1").put("obj2", obj2).map();
         vars.put("l", Arrays.asList("1", "2", "3", obj1));
 
-        Object o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessInScript", "js",
-                se.compile("l.length")), vars);
+        Object o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessInScript", "js",
+                se.compile("l.length")), vars).run();
         assertThat(((Number) o).intValue(), equalTo(4));
 
-        o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessInScript", "js",
-                se.compile("l[0]")), vars);
+        o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessInScript", "js",
+                se.compile("l[0]")), vars).run();
         assertThat(((String) o), equalTo("1"));
 
-        o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessInScript", "js",
-                se.compile("l[3]")), vars);
+        o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessInScript", "js",
+                se.compile("l[3]")), vars).run();
         obj1 = (Map<String, Object>) o;
         assertThat((String) obj1.get("prop1"), equalTo("value1"));
         assertThat((String) ((Map<String, Object>) obj1.get("obj2")).get("prop2"), equalTo("value2"));
 
-        o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessInScript", "js",
-                se.compile("l[3].prop1")), vars);
+        o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessInScript", "js",
+                se.compile("l[3].prop1")), vars).run();
         assertThat(((String) o), equalTo("value1"));
     }
 

--- a/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptMultiThreadedTests.java
+++ b/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptMultiThreadedTests.java
@@ -149,7 +149,7 @@ public class JavaScriptScriptMultiThreadedTests extends ESTestCase {
                             long addition = x + y;
                             runtimeVars.put("x", x);
                             runtimeVars.put("y", y);
-                            long result = ((Number) se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testExecutableNoRuntimeParams", "js", compiled), runtimeVars)).longValue();
+                            long result = ((Number) se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testExecutableNoRuntimeParams", "js", compiled), runtimeVars).run()).longValue();
                             assertThat(result, equalTo(addition));
                         }
                     } catch (Throwable t) {

--- a/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptSecurityTests.java
+++ b/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptSecurityTests.java
@@ -50,7 +50,7 @@ public class JavaScriptSecurityTests extends ESTestCase {
     /** runs a script */
     private void doTest(String script) {
         Map<String, Object> vars = new HashMap<String, Object>();
-        se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "test", "js", se.compile(script)), vars);
+        se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "test", "js", se.compile(script)), vars).run();
     }
     
     /** asserts that a script runs without exception */

--- a/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/SimpleBench.java
+++ b/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/SimpleBench.java
@@ -43,14 +43,14 @@ public class SimpleBench {
         for (int i = 0; i < 1000; i++) {
             vars.put("x", i);
             vars.put("y", i + 1);
-            se.execute(compiledScript, vars);
+            se.executable(compiledScript, vars).run();
         }
 
         final long ITER = 100000;
 
         StopWatch stopWatch = new StopWatch().start();
         for (long i = 0; i < ITER; i++) {
-            se.execute(compiledScript, vars);
+            se.executable(compiledScript, vars).run();
         }
         System.out.println("Execute Took: " + stopWatch.stop().lastTaskTime());
 

--- a/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
+++ b/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
@@ -125,18 +125,6 @@ public class PythonScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public Object execute(CompiledScript compiledScript, Map<String, Object> vars) {
-        PyObject pyVars = Py.java2py(vars);
-        interp.setLocals(pyVars);
-        // eval the script with reduced privileges
-        PyObject ret = evalRestricted((PyCode) compiledScript.compiled());
-        if (ret == null) {
-            return null;
-        }
-        return ret.__tojava__(Object.class);
-    }
-
-    @Override
     public void close() {
         interp.cleanup();
     }

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonScriptEngineTests.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonScriptEngineTests.java
@@ -59,7 +59,7 @@ public class PythonScriptEngineTests extends ESTestCase {
     @Test
     public void testSimpleEquation() {
         Map<String, Object> vars = new HashMap<String, Object>();
-        Object o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testSimpleEquation", "python", se.compile("1 + 2")), vars);
+        Object o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testSimpleEquation", "python", se.compile("1 + 2")), vars).run();
         assertThat(((Number) o).intValue(), equalTo(3));
     }
 
@@ -70,13 +70,13 @@ public class PythonScriptEngineTests extends ESTestCase {
         Map<String, Object> obj2 = MapBuilder.<String, Object>newMapBuilder().put("prop2", "value2").map();
         Map<String, Object> obj1 = MapBuilder.<String, Object>newMapBuilder().put("prop1", "value1").put("obj2", obj2).put("l", Arrays.asList("2", "1")).map();
         vars.put("obj1", obj1);
-        Object o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testMapAccess", "python", se.compile("obj1")), vars);
+        Object o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testMapAccess", "python", se.compile("obj1")), vars).run();
         assertThat(o, instanceOf(Map.class));
         obj1 = (Map<String, Object>) o;
         assertThat((String) obj1.get("prop1"), equalTo("value1"));
         assertThat((String) ((Map<String, Object>) obj1.get("obj2")).get("prop2"), equalTo("value2"));
 
-        o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testMapAccess", "python", se.compile("obj1['l'][0]")), vars);
+        o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testMapAccess", "python", se.compile("obj1['l'][0]")), vars).run();
         assertThat(((String) o), equalTo("2"));
     }
 
@@ -110,15 +110,15 @@ public class PythonScriptEngineTests extends ESTestCase {
 //        Object o = se.execute(se.compile("l.length"), vars);
 //        assertThat(((Number) o).intValue(), equalTo(4));
 
-        Object o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessListInScript", "python", se.compile("l[0]")), vars);
+        Object o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessListInScript", "python", se.compile("l[0]")), vars).run();
         assertThat(((String) o), equalTo("1"));
 
-        o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessListInScript", "python", se.compile("l[3]")), vars);
+        o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessListInScript", "python", se.compile("l[3]")), vars).run();
         obj1 = (Map<String, Object>) o;
         assertThat((String) obj1.get("prop1"), equalTo("value1"));
         assertThat((String) ((Map<String, Object>) obj1.get("obj2")).get("prop2"), equalTo("value2"));
 
-        o = se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessListInScript", "python", se.compile("l[3]['prop1']")), vars);
+        o = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testAccessListInScript", "python", se.compile("l[3]['prop1']")), vars).run();
         assertThat(((String) o), equalTo("value1"));
     }
 

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonScriptMultiThreadedTests.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonScriptMultiThreadedTests.java
@@ -158,7 +158,7 @@ public class PythonScriptMultiThreadedTests extends ESTestCase {
                             long addition = x + y;
                             runtimeVars.put("x", x);
                             runtimeVars.put("y", y);
-                            long result = ((Number) se.execute(compiledScript, runtimeVars)).longValue();
+                            long result = ((Number) se.executable(compiledScript, runtimeVars).run()).longValue();
                             assertThat(result, equalTo(addition));
                         }
                     } catch (Throwable t) {

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonSecurityTests.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonSecurityTests.java
@@ -53,7 +53,7 @@ public class PythonSecurityTests extends ESTestCase {
     /** runs a script */
     private void doTest(String script) {
         Map<String, Object> vars = new HashMap<String, Object>();
-        se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "test", "python", se.compile(script)), vars);
+        se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "test", "python", se.compile(script)), vars).run();
     }
     
     /** asserts that a script runs without exception */

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/SimpleBench.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/SimpleBench.java
@@ -44,14 +44,14 @@ public class SimpleBench {
         for (int i = 0; i < 1000; i++) {
             vars.put("x", i);
             vars.put("y", i + 1);
-            se.execute(compiledScript, vars);
+            se.executable(compiledScript, vars).run();
         }
 
         final long ITER = 100000;
 
         StopWatch stopWatch = new StopWatch().start();
         for (long i = 0; i < ITER; i++) {
-            se.execute(compiledScript, vars);
+            se.executable(compiledScript, vars).run();
         }
         System.out.println("Execute Took: " + stopWatch.stop().lastTaskTime());
 


### PR DESCRIPTION
This methods was only used in tests and can be replaced by calling
`ScriptEngineService.executable(compiledScript, vars).run()` instead.
