### PR TITLE
Remove ScriptEngineService.unwrap.

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/NativeScriptEngineService.java
@@ -99,11 +99,6 @@ public class NativeScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public Object unwrap(Object value) {
-        return value;
-    }
-
-    @Override
     public void close() {
     }
 

--- a/core/src/main/java/org/elasticsearch/script/ScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptEngineService.java
@@ -44,8 +44,6 @@ public interface ScriptEngineService extends Closeable {
 
     Object execute(CompiledScript compiledScript, Map<String, Object> vars);
 
-    Object unwrap(Object value);
-
     /**
      * Handler method called when a script is removed from the Guava cache.
      *

--- a/core/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/core/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -139,11 +139,6 @@ public class MustacheScriptEngineService extends AbstractComponent implements Sc
     }
 
     @Override
-    public Object unwrap(Object value) {
-        return value;
-    }
-
-    @Override
     public void close() {
         // Nothing to do here
     }

--- a/core/src/test/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/core/src/test/java/org/elasticsearch/script/MockScriptEngine.java
@@ -109,11 +109,6 @@ public class MockScriptEngine implements ScriptEngineService {
     }
 
     @Override
-    public Object unwrap(Object value) {
-        return null;
-    }
-
-    @Override
     public void scriptRemoved(@Nullable CompiledScript script) {
     }
 

--- a/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
@@ -291,11 +291,6 @@ public class ScriptModesTests extends ESTestCase {
         }
 
         @Override
-        public Object unwrap(Object value) {
-            return null;
-        }
-
-        @Override
         public void close() {
 
         }

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -502,11 +502,6 @@ public class ScriptServiceTests extends ESTestCase {
         }
 
         @Override
-        public Object unwrap(Object value) {
-            return null;
-        }
-
-        @Override
         public void close() {
 
         }

--- a/plugins/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
+++ b/plugins/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngineService.java
@@ -243,11 +243,6 @@ public class ExpressionScriptEngineService extends AbstractComponent implements 
     }
 
     @Override
-    public Object unwrap(Object value) {
-        return value;
-    }
-
-    @Override
     public void close() {}
 
     @Override

--- a/plugins/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/plugins/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -38,7 +38,6 @@ import org.codehaus.groovy.control.customizers.CompilationCustomizer;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.bootstrap.BootstrapInfo;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.hash.MessageDigests;
@@ -257,11 +256,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
         } catch (Exception e) {
             throw new ScriptException("failed to execute " + compiledScript, e);
         }
-    }
-
-    @Override
-    public Object unwrap(Object value) {
-        return value;
     }
 
     public static final class GroovyScript implements ExecutableScript, LeafSearchScript {

--- a/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineService.java
+++ b/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineService.java
@@ -198,11 +198,6 @@ public class JavaScriptScriptEngineService extends AbstractComponent implements 
         }
     }
 
-    @Override
-    public Object unwrap(Object value) {
-        return ScriptValueConverter.unwrapValue(value);
-    }
-
     private String generateScriptName() {
         return "Script" + counter.incrementAndGet() + ".js";
     }

--- a/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineTests.java
+++ b/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptEngineTests.java
@@ -97,9 +97,10 @@ public class JavaScriptScriptEngineTests extends ESTestCase {
         ctx.put("obj1", obj1);
         vars.put("ctx", ctx);
 
-        se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testJavaScriptObjectMapInter", "js",
+        ExecutableScript executable = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testJavaScriptObjectMapInter", "js",
                 se.compile("ctx.obj2 = {}; ctx.obj2.prop2 = 'value2'; ctx.obj1.prop1 = 'uvalue1'")), vars);
-        ctx = (Map<String, Object>) se.unwrap(vars.get("ctx"));
+        executable.run();
+        ctx = (Map<String, Object>) executable.unwrap(vars.get("ctx"));
         assertThat(ctx.containsKey("obj1"), equalTo(true));
         assertThat((String) ((Map<String, Object>) ctx.get("obj1")).get("prop1"), equalTo("uvalue1"));
         assertThat(ctx.containsKey("obj2"), equalTo(true));

--- a/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
+++ b/plugins/lang-python/src/main/java/org/elasticsearch/script/python/PythonScriptEngineService.java
@@ -137,11 +137,6 @@ public class PythonScriptEngineService extends AbstractComponent implements Scri
     }
 
     @Override
-    public Object unwrap(Object value) {
-        return unwrapValue(value);
-    }
-
-    @Override
     public void close() {
         interp.cleanup();
     }

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonScriptEngineTests.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonScriptEngineTests.java
@@ -89,9 +89,10 @@ public class PythonScriptEngineTests extends ESTestCase {
         ctx.put("obj1", obj1);
         vars.put("ctx", ctx);
 
-        se.execute(new CompiledScript(ScriptService.ScriptType.INLINE, "testObjectInterMap", "python",
+        ExecutableScript executable = se.executable(new CompiledScript(ScriptService.ScriptType.INLINE, "testObjectInterMap", "python",
                 se.compile("ctx['obj2'] = { 'prop2' : 'value2' }; ctx['obj1']['prop1'] = 'uvalue1'")), vars);
-        ctx = (Map<String, Object>) se.unwrap(vars.get("ctx"));
+        executable.run();
+        ctx = (Map<String, Object>) executable.unwrap(vars.get("ctx"));
         assertThat(ctx.containsKey("obj1"), equalTo(true));
         assertThat((String) ((Map<String, Object>) ctx.get("obj1")).get("prop1"), equalTo("uvalue1"));
         assertThat(ctx.containsKey("obj2"), equalTo(true));


### PR DESCRIPTION
The ability to unwrap script values is already exposed via ExecutableScript.unwrap.
