### PR TITLE
Fix indices.get_field_mapping rest tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yaml
@@ -18,7 +18,7 @@ setup:
 
   - do:
       indices.get_field_mapping:
-        field: text
+        fields: text
 
   - match: {test_index.mappings.test_type.text.mapping.text.type:     string}
 
@@ -27,7 +27,7 @@ setup:
   - do:
       indices.get_field_mapping:
         index: test_index
-        field: text
+        fields: text
 
   - match: {test_index.mappings.test_type.text.mapping.text.type:     string}
 
@@ -38,7 +38,7 @@ setup:
       indices.get_field_mapping:
         index: test_index
         type: test_type
-        field: text
+        fields: text
 
   - match: {test_index.mappings.test_type.text.mapping.text.type:     string}
 
@@ -49,7 +49,7 @@ setup:
       indices.get_field_mapping:
         index: test_index
         type: test_type
-        field: [ text , text1 ]
+        fields: [ text , text1 ]
 
   - match: {test_index.mappings.test_type.text.mapping.text.type:     string}
   - is_false: test_index.mappings.test_type.text1
@@ -61,19 +61,19 @@ setup:
       indices.get_field_mapping:
         index: test_index
         type: test_type
-        field: text
+        fields: text
         include_defaults: true
 
   - match: {test_index.mappings.test_type.text.mapping.text.type:     string}
   - match: {test_index.mappings.test_type.text.mapping.text.analyzer: default}
 
 ---
-"Get field mapping should work without index specifying type and field": 
+"Get field mapping should work without index specifying type and fields":
 
   - do:
       indices.get_field_mapping:
         type: test_type
-        field: text
+        fields: text
 
   - match: {test_index.mappings.test_type.text.mapping.text.type:     string}
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yaml
@@ -19,6 +19,6 @@
       indices.get_field_mapping:
         index: test_index
         type: test_type
-        field: not_existent
+        fields: not_existent
   
   - match: { '': {}}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/30_missing_type.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/30_missing_type.yaml
@@ -20,5 +20,5 @@
       indices.get_field_mapping:
         index: test_index
         type: not_test_type
-        field: text
+        fields: text
   

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/40_missing_index.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/40_missing_index.yaml
@@ -6,6 +6,6 @@
       indices.get_field_mapping:
         index: test_index
         type: type
-        field: field
+        fields: field
 
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yaml
@@ -49,7 +49,7 @@ setup:
 
   - do:
       indices.get_field_mapping:
-        field: "*"
+        fields: "*"
 
   - match: {test_index.mappings.test_type.t1.full_name:     t1     }
   - match: {test_index.mappings.test_type.t2.full_name:     t2     }
@@ -63,7 +63,7 @@ setup:
   - do:
       indices.get_field_mapping:
         index: test_index
-        field: "t*"
+        fields: "t*"
 
   - match:  {test_index.mappings.test_type.t1.full_name:     t1       }
   - match:  {test_index.mappings.test_type.t2.full_name:     t2       }
@@ -75,7 +75,7 @@ setup:
   - do:
       indices.get_field_mapping:
         index: test_index
-        field: "*t1"
+        fields: "*t1"
   - match:  {test_index.mappings.test_type.t1.full_name:        t1       }
   - match:  {test_index.mappings.test_type.obj\.t1.full_name:   obj.t1   }
   - match:  {test_index.mappings.test_type.obj\.i_t1.full_name: obj.i_t1 }
@@ -87,7 +87,7 @@ setup:
   - do:
       indices.get_field_mapping:
         index: test_index
-        field: "obj.i_*"
+        fields: "obj.i_*"
   - match:  {test_index.mappings.test_type.obj\.i_t1.full_name: obj.i_t1 }
   - match:  {test_index.mappings.test_type.obj\.i_t3.full_name: obj.i_t3 }
   - length: {test_index.mappings.test_type: 2}
@@ -99,7 +99,7 @@ setup:
       indices.get_field_mapping:
         index: _all
         type: _all
-        field: "t*"
+        fields: "t*"
   - match:  {test_index.mappings.test_type.t1.full_name: t1 }
   - match:  {test_index.mappings.test_type.t2.full_name: t2 }
   - length: {test_index.mappings.test_type: 2}
@@ -114,7 +114,7 @@ setup:
       indices.get_field_mapping:
         index: '*'
         type: '*'
-        field: "t*"
+        fields: "t*"
   - match:  {test_index.mappings.test_type.t1.full_name: t1 }
   - match:  {test_index.mappings.test_type.t2.full_name: t2 }
   - length: {test_index.mappings.test_type: 2}
@@ -129,7 +129,7 @@ setup:
       indices.get_field_mapping:
         index: 'test_index,test_index_2'
         type: 'test_type,test_type_2'
-        field: "t*"
+        fields: "t*"
   - match:  {test_index.mappings.test_type.t1.full_name: t1 }
   - match:  {test_index.mappings.test_type.t2.full_name: t2 }
   - length: {test_index.mappings.test_type: 2}


### PR DESCRIPTION
After `field` has been renamed to `fields` in #13902
