### PR TITLE
Make root_cause of field conflicts more obvious

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -324,7 +324,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                             mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent(XContentFactory.jsonBuilder().map(mappings.get(MapperService.DEFAULT_MAPPING)).string()), false, request.updateAllTypes());
                         } catch (Exception e) {
                             removalReason = "failed on parsing default mapping on index creation";
-                            throw new MapperParsingException("mapping [" + MapperService.DEFAULT_MAPPING + "]", e);
+                            throw new MapperParsingException("Failed to parse mapping [{}]: {}", e, MapperService.DEFAULT_MAPPING, e.getMessage());
                         }
                     }
                     for (Map.Entry<String, Map<String, Object>> entry : mappings.entrySet()) {
@@ -336,7 +336,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                             mapperService.merge(entry.getKey(), new CompressedXContent(XContentFactory.jsonBuilder().map(entry.getValue()).string()), true, request.updateAllTypes());
                         } catch (Exception e) {
                             removalReason = "failed on parsing mappings on index creation";
-                            throw new MapperParsingException("mapping [" + entry.getKey() + "]", e);
+                            throw new MapperParsingException("Failed to parse mapping [{}]: {}", e, entry.getKey(), e.getMessage());
                         }
                     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperException.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperException.java
@@ -39,4 +39,8 @@ public class MapperException extends ElasticsearchException {
     public MapperException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public MapperException(String message, Throwable cause, Object... args) {
+        super(message, cause, args);
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperParsingException.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperParsingException.java
@@ -41,6 +41,10 @@ public class MapperParsingException extends MapperException {
         super(message, cause);
     }
 
+    public MapperParsingException(String message, Throwable cause, Object... args) {
+        super(message, cause, args);
+    }
+
     @Override
     public RestStatus status() {
         return RestStatus.BAD_REQUEST;

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/DateBackwardsCompatibilityTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/DateBackwardsCompatibilityTests.java
@@ -40,6 +40,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoSearchHits;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -174,7 +175,8 @@ public class DateBackwardsCompatibilityTests extends ESSingleNodeTestCase {
             createIndex(Version.CURRENT, mapping);
             fail("Expected a MapperParsingException, but did not happen");
         } catch (MapperParsingException e) {
-            assertThat(e.getMessage(), is("mapping [" + type + "]"));
+            assertThat(e.getMessage(), containsString("Failed to parse mapping [" + type + "]"));
+            assertThat(e.getMessage(), containsString("Epoch [epoch_seconds] is not supported as dynamic date format"));
         }
     }
 


### PR DESCRIPTION
Creates a new ElasticsearchException, ConflictingFieldTypesException, that
it then throws on any mapping conflicts.

The error messages for mapping conflicts now look like:

```
{
  "error" : {
    "root_cause" : [ {
      "type" : "mapper_parsing_exception",
      "reason" : "Failed to parse mapping [type_one]: Mapper for [text] conflicts with existing mapping in other types:\n[mapper [text] has different [analyzer], mapper [text] is used by multiple types. Set update_all_types to true to update [search_analyzer] across all types., mapper [text] is used by multiple types. Set update_all_types to true to update [search_quote_analyzer] across all types.]"
    } ],
    "type" : "mapper_parsing_exception",
    "reason" : "Failed to parse mapping [type_one]: Mapper for [text] conflicts with existing mapping in other types:\n[mapper [text] has different [analyzer], mapper [text] is used by multiple types. Set update_all_types to true to update [search_analyzer] across all types., mapper [text] is used by multiple types. Set update_all_types to true to update [search_quote_analyzer] across all types.]",
    "caused_by" : {
      "type" : "illegal_argument_exception",
      "reason" : "Mapper for [text] conflicts with existing mapping in other types:\n[mapper [text] has different [analyzer], mapper [text] is used by multiple types. Set update_all_types to true to update [search_analyzer] across all types., mapper [text] is used by multiple types. Set update_all_types to true to update [search_quote_analyzer] across all types.]"
    }
  },
  "status" : 400
}
```

Closes #12839
