### PR TITLE
Exposed hit/miss counters on filter cache

### DIFF
--- a/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/FilterCacheStats.java
@@ -35,18 +35,24 @@ public class FilterCacheStats implements Streamable, ToXContent {
 
     long memorySize;
     long evictions;
+    long hitCount;
+    long missCount;
 
     public FilterCacheStats() {
     }
 
-    public FilterCacheStats(long memorySize, long evictions) {
+    public FilterCacheStats(long memorySize, long evictions, long hitCount, long missCount) {
         this.memorySize = memorySize;
         this.evictions = evictions;
+        this.hitCount = hitCount;
+        this.missCount = missCount;
     }
 
     public void add(FilterCacheStats stats) {
         this.memorySize += stats.memorySize;
         this.evictions += stats.evictions;
+        this.hitCount += stats.hitCount;
+        this.missCount += stats.missCount;
     }
 
     public long getMemorySizeInBytes() {
@@ -61,6 +67,14 @@ public class FilterCacheStats implements Streamable, ToXContent {
         return this.evictions;
     }
 
+    public long getHitCount() {
+        return this.hitCount;
+    }
+
+    public long getMissCount() {
+        return this.missCount;
+    }
+
     public static FilterCacheStats readFilterCacheStats(StreamInput in) throws IOException {
         FilterCacheStats stats = new FilterCacheStats();
         stats.readFrom(in);
@@ -71,12 +85,16 @@ public class FilterCacheStats implements Streamable, ToXContent {
     public void readFrom(StreamInput in) throws IOException {
         memorySize = in.readVLong();
         evictions = in.readVLong();
+        hitCount = in.readVLong();
+        missCount = in.readVLong();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(memorySize);
         out.writeVLong(evictions);
+        out.writeVLong(hitCount);
+        out.writeVLong(missCount);
     }
 
     @Override
@@ -84,6 +102,8 @@ public class FilterCacheStats implements Streamable, ToXContent {
         builder.startObject(Fields.FILTER_CACHE);
         builder.byteSizeField(Fields.MEMORY_SIZE_IN_BYTES, Fields.MEMORY_SIZE, memorySize);
         builder.field(Fields.EVICTIONS, getEvictions());
+        builder.field(Fields.HIT_COUNT, getHitCount());
+        builder.field(Fields.MISS_COUNT, getMissCount());
         builder.endObject();
         return builder;
     }
@@ -93,5 +113,7 @@ public class FilterCacheStats implements Streamable, ToXContent {
         static final XContentBuilderString MEMORY_SIZE = new XContentBuilderString("memory_size");
         static final XContentBuilderString MEMORY_SIZE_IN_BYTES = new XContentBuilderString("memory_size_in_bytes");
         static final XContentBuilderString EVICTIONS = new XContentBuilderString("evictions");
+        static final XContentBuilderString HIT_COUNT = new XContentBuilderString("hit_count");
+        static final XContentBuilderString MISS_COUNT = new XContentBuilderString("miss_count");
     }
 }

--- a/src/main/java/org/elasticsearch/index/cache/filter/ShardFilterCache.java
+++ b/src/main/java/org/elasticsearch/index/cache/filter/ShardFilterCache.java
@@ -37,6 +37,8 @@ public class ShardFilterCache extends AbstractIndexShardComponent implements Rem
 
     final CounterMetric evictionsMetric = new CounterMetric();
     final CounterMetric totalMetric = new CounterMetric();
+    final CounterMetric hitCount = new CounterMetric();
+    final CounterMetric missCount = new CounterMetric();
 
     @Inject
     public ShardFilterCache(ShardId shardId, @IndexSettings Settings indexSettings) {
@@ -44,11 +46,17 @@ public class ShardFilterCache extends AbstractIndexShardComponent implements Rem
     }
 
     public FilterCacheStats stats() {
-        return new FilterCacheStats(totalMetric.count(), evictionsMetric.count());
+        return new FilterCacheStats(totalMetric.count(), evictionsMetric.count(), hitCount.count(), missCount.count());
     }
 
     public void onCached(long sizeInBytes) {
         totalMetric.inc(sizeInBytes);
+    }
+
+    public void onHit() { hitCount.inc(); }
+
+    public void onMiss() {
+        missCount.inc();
     }
 
     @Override


### PR DESCRIPTION
Quick and dirty exposing of hit/miss counters on the filter caches. Comments/suggestions are welcome.
