### PR TITLE
Deprecates defaultRescoreWindowSize

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -795,11 +795,18 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
-     * Sets the rescore window for all rescorers that don't specify a window when added.
+     * Sets the rescore window for all rescorers that don't specify a window
+     * when added.
      *
-     * @param window rescore window
+     * @param window
+     *            rescore window
      * @return this for chaining
+     *
+     * @deprecated use
+     *             {@link #addRescorer(org.elasticsearch.search.rescore.RescoreBuilder.Rescorer, int)}
+     *             instead.
      */
+    @Deprecated
     public SearchRequestBuilder setRescoreWindow(int window) {
         sourceBuilder().defaultRescoreWindowSize(window);
         return this;

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.builder;
 
 import com.carrotsearch.hppc.ObjectFloatHashMap;
 import com.google.common.base.Charsets;
+
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.ToXContentToBytes;
@@ -417,7 +418,10 @@ public class SearchSourceBuilder extends ToXContentToBytes {
 
     /**
      * Set the rescore window size for rescores that don't specify their window.
+     * 
+     * @deprecated use {@link RescoreBuilder#windowSize(int)} instead.
      */
+    @Deprecated
     public SearchSourceBuilder defaultRescoreWindowSize(int defaultRescoreWindowSize) {
         this.defaultRescoreWindowSize = defaultRescoreWindowSize;
         return this;


### PR DESCRIPTION
The window size should be set on each rescorer individually. This method will be removed in 3.0
