### PR TITLE
Add missing REST spec for `detect_noop`

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -82,6 +82,10 @@
           "type": "enum",
           "options": ["internal", "force"],
           "description": "Specific version type"
+        },
+        "detect_noop": {
+          "type": "boolean",
+          "description": "Specifying as true will cause Elasticsearch to check if there are changes and, if there aren’t, turn the update request into a noop."
         }
       }
     },


### PR DESCRIPTION
Hi,
Looks like there is missing spec for [detect_noop](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html?q=update%20a#_literal_detect_noop_literal) parameter.

Reported https://github.com/elastic/elasticsearch-net/issues/1587
