### PR TITLE
Packaging: change permissions/ownership of config dir

### DIFF
--- a/distribution/deb/pom.xml
+++ b/distribution/deb/pom.xml
@@ -120,6 +120,19 @@
                                         <group>root</group>
                                     </mapper>
                                 </data>
+                                <!-- create the conf dir manually so it gets proper permissions -->
+                                <data>
+                                    <type>template</type>
+                                    <paths>
+                                        <path>${packaging.elasticsearch.conf.dir}</path>
+                                    </paths>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <filemode>750</filemode>
+                                        <user>root</user>
+                                        <group>elasticsearch</group>
+                                    </mapper>
+                                </data>
                                 <!-- Add configuration files -->
                                 <data>
                                     <src>${project.basedir}/../src/main/resources/config</src>
@@ -128,8 +141,9 @@
                                     <mapper>
                                         <type>perm</type>
                                         <prefix>${packaging.elasticsearch.conf.dir}</prefix>
+                                        <filemode>750</filemode>
                                         <user>root</user>
-                                        <group>root</group>
+                                        <group>elasticsearch</group>
                                     </mapper>
                                 </data>
                                 <data>
@@ -137,6 +151,12 @@
                                     <paths>
                                         <path>${packaging.elasticsearch.conf.dir}/scripts</path>
                                     </paths>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <filemode>750</filemode>
+                                        <user>root</user>
+                                        <group>elasticsearch</group>
+                                    </mapper>
                                 </data>
                                 <!-- Add environment vars file -->
                                 <data>

--- a/distribution/rpm/pom.xml
+++ b/distribution/rpm/pom.xml
@@ -142,10 +142,14 @@
                                  that creates the conf.dir.-->
                             <directory>${packaging.elasticsearch.conf.dir}</directory>
                             <configuration>noreplace</configuration>
+                            <groupname>elasticsearch</groupname>
+                            <filemode>750</filemode>
                         </mapping>
                         <mapping>
                             <directory>${packaging.elasticsearch.conf.dir}/</directory>
                             <configuration>noreplace</configuration>
+                            <groupname>elasticsearch</groupname>
+                            <filemode>750</filemode>
                             <sources>
                                 <source>
                                     <location>${project.basedir}/../src/main/resources/config/</location>
@@ -158,6 +162,8 @@
                         <mapping>
                             <directory>${packaging.elasticsearch.conf.dir}/scripts</directory>
                             <configuration>noreplace</configuration>
+                            <groupname>elasticsearch</groupname>
+                            <filemode>750</filemode>
                         </mapping>
                         <!-- Add environment vars file -->
                         <mapping>

--- a/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/os_package.bash
@@ -72,38 +72,39 @@ verify_package_installation() {
 
     getent group elasticsearch
 
-    assert_file "$ESHOME" d root 755
-    assert_file "$ESHOME/bin" d root 755
-    assert_file "$ESHOME/lib" d root 755
-    assert_file "$ESCONFIG" d root 755
-    assert_file "$ESCONFIG/elasticsearch.yml" f root 644
-    assert_file "$ESCONFIG/logging.yml" f root 644
-    assert_file "$ESDATA" d elasticsearch 755
-    assert_file "$ESLOG" d elasticsearch 755
-    assert_file "$ESPLUGINS" d elasticsearch 755
-    assert_file "$ESPIDDIR" d elasticsearch 755
-    assert_file "$ESHOME/NOTICE.txt" f root 644
-    assert_file "$ESHOME/README.textile" f root 644
+    assert_file "$ESHOME" d root root 755
+    assert_file "$ESHOME/bin" d root root 755
+    assert_file "$ESHOME/lib" d root root 755
+    assert_file "$ESCONFIG" d root elasticsearch 750
+    assert_file "$ESCONFIG/elasticsearch.yml" f root elasticsearch 750
+    assert_file "$ESCONFIG/logging.yml" f root elasticsearch 750
+    assert_file "$ESSCRIPTS" d root elasticsearch 750
+    assert_file "$ESDATA" d elasticsearch elasticsearch 755
+    assert_file "$ESLOG" d elasticsearch elasticsearch 755
+    assert_file "$ESPLUGINS" d elasticsearch elasticsearch 755
+    assert_file "$ESPIDDIR" d elasticsearch elasticsearch 755
+    assert_file "$ESHOME/NOTICE.txt" f root root 644
+    assert_file "$ESHOME/README.textile" f root root 644
 
     if is_dpkg; then
         # Env file
-        assert_file "/etc/default/elasticsearch" f root 644
+        assert_file "/etc/default/elasticsearch" f root root 644
 
         # Doc files
-        assert_file "/usr/share/doc/elasticsearch" d root 755
-        assert_file "/usr/share/doc/elasticsearch/copyright" f root 644
+        assert_file "/usr/share/doc/elasticsearch" d root root 755
+        assert_file "/usr/share/doc/elasticsearch/copyright" f root root 644
     fi
 
     if is_rpm; then
         # Env file
-        assert_file "/etc/sysconfig/elasticsearch" f root 644
+        assert_file "/etc/sysconfig/elasticsearch" f root root 644
         # License file
-        assert_file "/usr/share/elasticsearch/LICENSE.txt" f root 644
+        assert_file "/usr/share/elasticsearch/LICENSE.txt" f root root 644
     fi
 
     if is_systemd; then
-        assert_file "/usr/lib/systemd/system/elasticsearch.service" f root 644
-        assert_file "/usr/lib/tmpfiles.d/elasticsearch.conf" f root 644
-        assert_file "/usr/lib/sysctl.d/elasticsearch.conf" f root 644
+        assert_file "/usr/lib/systemd/system/elasticsearch.service" f root root 644
+        assert_file "/usr/lib/tmpfiles.d/elasticsearch.conf" f root root 644
+        assert_file "/usr/lib/sysctl.d/elasticsearch.conf" f root root 644
     fi
 }

--- a/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
@@ -150,7 +150,8 @@ assert_file() {
     local file="$1"
     local type=$2
     local user=$3
-    local privileges=$4
+    local group=$4
+    local privileges=$5
 
     assert_file_exist "$file"
 
@@ -165,6 +166,11 @@ assert_file() {
     if [ "x$user" != "x" ]; then
         realuser=$(ls -ld "$file" | awk '{print $3}')
         [ "$realuser" = "$user" ]
+    fi
+
+    if [ "x$group" != "x" ]; then
+        realgroup=$(find "$file" -maxdepth 0 -printf "%g")
+        [ "$realgroup" = "$group" ]
     fi
 
     if [ "x$privileges" != "x" ]; then


### PR DESCRIPTION
When generating the rpm and dep package we now set proper group (elasticsearch) and permissions (750) to the conf dir (default /etc/elasticsearch). Same for the scripts subdirectory.

Expanded the assert_file bash function to also optionally check the group of files, so we can actually test that the group was set correctly.

Relates to #11016
