### PR TITLE
Added correct generic type parameter on ScriptedMetricBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricBuilder.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * Builder for the {@link ScriptedMetric} aggregation.
  */
-public class ScriptedMetricBuilder extends MetricsAggregationBuilder {
+public class ScriptedMetricBuilder extends MetricsAggregationBuilder<ScriptedMetricBuilder> {
 
     private Script initScript = null;
     private Script mapScript = null;


### PR DESCRIPTION
Make ScriptedMetricBuilder class declaration consistent with all other Builder declarations

Closes https://github.com/elastic/elasticsearch/issues/13986
