### PR TITLE
move render search template methods to cluster admin client

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -77,6 +77,9 @@ import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksRequest;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksRequestBuilder;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
+import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateRequest;
+import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateRequestBuilder;
+import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateResponse;
 
 /**
  * Administrative actions/operations against indices.
@@ -423,4 +426,25 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      */
     SnapshotsStatusRequestBuilder prepareSnapshotStatus();
 
+
+    /**
+     * Return the rendered search request for a given search template.
+     *
+     * @param request The request
+     * @return The result future
+     */
+    ActionFuture<RenderSearchTemplateResponse> renderSearchTemplate(RenderSearchTemplateRequest request);
+
+    /**
+     * Return the rendered search request for a given search template.
+     *
+     * @param request  The request
+     * @param listener A listener to be notified of the result
+     */
+    void renderSearchTemplate(RenderSearchTemplateRequest request, ActionListener<RenderSearchTemplateResponse> listener);
+
+    /**
+     * Return the rendered search request for a given search template.
+     */
+    RenderSearchTemplateRequestBuilder prepareRenderSearchTemplate();
 }

--- a/core/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -105,9 +105,6 @@ import org.elasticsearch.action.admin.indices.upgrade.post.UpgradeResponse;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequestBuilder;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
-import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateRequest;
-import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateRequestBuilder;
-import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateResponse;
 import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerRequest;
 import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerRequestBuilder;
 import org.elasticsearch.action.admin.indices.warmer.delete.DeleteWarmerResponse;
@@ -745,27 +742,6 @@ public interface IndicesAdminClient extends ElasticsearchClient {
      * Validate a query for correctness.
      */
     ValidateQueryRequestBuilder prepareValidateQuery(String... indices);
-
-    /**
-     * Return the rendered search request for a given search template.
-     *
-     * @param request The request
-     * @return The result future
-     */
-    ActionFuture<RenderSearchTemplateResponse> renderSearchTemplate(RenderSearchTemplateRequest request);
-
-    /**
-     * Return the rendered search request for a given search template.
-     *
-     * @param request  The request
-     * @param listener A listener to be notified of the result
-     */
-    void renderSearchTemplate(RenderSearchTemplateRequest request, ActionListener<RenderSearchTemplateResponse> listener);
-
-    /**
-     * Return the rendered search request for a given search template.
-     */
-    RenderSearchTemplateRequestBuilder prepareRenderSearchTemplate();
 
     /**
      * Puts an index search warmer to be applies when applicable.

--- a/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -1142,6 +1142,21 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         public SnapshotsStatusRequestBuilder prepareSnapshotStatus() {
             return new SnapshotsStatusRequestBuilder(this, SnapshotsStatusAction.INSTANCE);
         }
+
+        @Override
+        public ActionFuture<RenderSearchTemplateResponse> renderSearchTemplate(final RenderSearchTemplateRequest request) {
+            return execute(RenderSearchTemplateAction.INSTANCE, request);
+        }
+
+        @Override
+        public void renderSearchTemplate(final RenderSearchTemplateRequest request, final ActionListener<RenderSearchTemplateResponse> listener) {
+            execute(RenderSearchTemplateAction.INSTANCE, request, listener);
+        }
+
+        @Override
+        public RenderSearchTemplateRequestBuilder prepareRenderSearchTemplate() {
+            return new RenderSearchTemplateRequestBuilder(this, RenderSearchTemplateAction.INSTANCE);
+        }
     }
 
     static class IndicesAdmin implements IndicesAdminClient {
@@ -1615,21 +1630,6 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         @Override
         public ValidateQueryRequestBuilder prepareValidateQuery(String... indices) {
             return new ValidateQueryRequestBuilder(this, ValidateQueryAction.INSTANCE).setIndices(indices);
-        }
-
-        @Override
-        public ActionFuture<RenderSearchTemplateResponse> renderSearchTemplate(final RenderSearchTemplateRequest request) {
-            return execute(RenderSearchTemplateAction.INSTANCE, request);
-        }
-
-        @Override
-        public void renderSearchTemplate(final RenderSearchTemplateRequest request, final ActionListener<RenderSearchTemplateResponse> listener) {
-            execute(RenderSearchTemplateAction.INSTANCE, request, listener);
-        }
-
-        @Override
-        public RenderSearchTemplateRequestBuilder prepareRenderSearchTemplate() {
-            return new RenderSearchTemplateRequestBuilder(this, RenderSearchTemplateAction.INSTANCE);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/template/RestRenderSearchTemplateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/validate/template/RestRenderSearchTemplateAction.java
@@ -93,7 +93,7 @@ public class RestRenderSearchTemplateAction extends BaseRestHandler {
         }
         renderSearchTemplateRequest = new RenderSearchTemplateRequest();
         renderSearchTemplateRequest.template(template);
-        client.admin().indices().renderSearchTemplate(renderSearchTemplateRequest, new RestBuilderListener<RenderSearchTemplateResponse>(channel) {
+        client.admin().cluster().renderSearchTemplate(renderSearchTemplateRequest, new RestBuilderListener<RenderSearchTemplateResponse>(channel) {
 
             @Override
             public RestResponse buildResponse(RenderSearchTemplateResponse response, XContentBuilder builder) throws Exception {

--- a/core/src/test/java/org/elasticsearch/validate/RenderSearchTemplateIT.java
+++ b/core/src/test/java/org/elasticsearch/validate/RenderSearchTemplateIT.java
@@ -61,7 +61,7 @@ public class RenderSearchTemplateIT extends ESIntegTestCase {
         params.put("value", "bar");
         params.put("size", 20);
         Template template = new Template(TEMPLATE_CONTENTS, ScriptType.INLINE, MustacheScriptEngineService.NAME, XContentType.JSON, params);
-        RenderSearchTemplateResponse response = client().admin().indices().prepareRenderSearchTemplate().template(template).get();
+        RenderSearchTemplateResponse response = client().admin().cluster().prepareRenderSearchTemplate().template(template).get();
         assertThat(response, notNullValue());
         BytesReference source = response.source();
         assertThat(source, notNullValue());
@@ -75,7 +75,7 @@ public class RenderSearchTemplateIT extends ESIntegTestCase {
         params.put("value", "baz");
         params.put("size", 100);
         template = new Template(TEMPLATE_CONTENTS, ScriptType.INLINE, MustacheScriptEngineService.NAME, XContentType.JSON, params);
-        response = client().admin().indices().prepareRenderSearchTemplate().template(template).get();
+        response = client().admin().cluster().prepareRenderSearchTemplate().template(template).get();
         assertThat(response, notNullValue());
         source = response.source();
         assertThat(source, notNullValue());
@@ -91,7 +91,7 @@ public class RenderSearchTemplateIT extends ESIntegTestCase {
         params.put("value", "bar");
         params.put("size", 20);
         Template template = new Template("index_template_1", ScriptType.INDEXED, MustacheScriptEngineService.NAME, XContentType.JSON, params);
-        RenderSearchTemplateResponse response = client().admin().indices().prepareRenderSearchTemplate().template(template).get();
+        RenderSearchTemplateResponse response = client().admin().cluster().prepareRenderSearchTemplate().template(template).get();
         assertThat(response, notNullValue());
         BytesReference source = response.source();
         assertThat(source, notNullValue());
@@ -105,7 +105,7 @@ public class RenderSearchTemplateIT extends ESIntegTestCase {
         params.put("value", "baz");
         params.put("size", 100);
         template = new Template("index_template_1", ScriptType.INDEXED, MustacheScriptEngineService.NAME, XContentType.JSON, params);
-        response = client().admin().indices().prepareRenderSearchTemplate().template(template).get();
+        response = client().admin().cluster().prepareRenderSearchTemplate().template(template).get();
         assertThat(response, notNullValue());
         source = response.source();
         assertThat(source, notNullValue());
@@ -121,7 +121,7 @@ public class RenderSearchTemplateIT extends ESIntegTestCase {
         params.put("value", "bar");
         params.put("size", 20);
         Template template = new Template("file_template_1", ScriptType.FILE, MustacheScriptEngineService.NAME, XContentType.JSON, params);
-        RenderSearchTemplateResponse response = client().admin().indices().prepareRenderSearchTemplate().template(template).get();
+        RenderSearchTemplateResponse response = client().admin().cluster().prepareRenderSearchTemplate().template(template).get();
         assertThat(response, notNullValue());
         BytesReference source = response.source();
         assertThat(source, notNullValue());
@@ -135,7 +135,7 @@ public class RenderSearchTemplateIT extends ESIntegTestCase {
         params.put("value", "baz");
         params.put("size", 100);
         template = new Template("file_template_1", ScriptType.FILE, MustacheScriptEngineService.NAME, XContentType.JSON, params);
-        response = client().admin().indices().prepareRenderSearchTemplate().template(template).get();
+        response = client().admin().cluster().prepareRenderSearchTemplate().template(template).get();
         assertThat(response, notNullValue());
         source = response.source();
         assertThat(source, notNullValue());


### PR DESCRIPTION
In #13971, the RenderSearchTemplateAction was made a cluster level action but the client methods
were not moved from the IndicesAdminClient. This is an inconsistency and this change cleans up the
inconsistency so that the client methods are now part of the ClusterAdminClient since the action is now
considered a cluster level action.
