### PR TITLE
Use a system property to locate JAVA_HOME

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -53,8 +53,7 @@ class BuildPlugin implements Plugin<Project> {
     /** Returns a closure of common configuration shared by unit and integration tests. */
     static Closure commonTestConfig(Project project) {
         return {
-            // TODO: don't use JAVA_HOME env var, but instead sysprop set by java?
-            jvm System.getenv('JAVA_HOME') + File.separator + 'bin' + File.separator + 'java'
+            jvm System.getProperty("java.home") + File.separator + 'bin' + File.separator + 'java'
             parallelism System.getProperty('tests.jvms', 'auto')
 
             // TODO: why are we not passing maxmemory to junit4?


### PR DESCRIPTION
It's more reliable than environment variable.
