### PR TITLE
Add ingest CRUD APIs

### DIFF
--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -1,0 +1,74 @@
+[[ingest]]
+== Ingest Plugin
+
+TODO
+
+=== Put pipeline API
+
+The put pipeline api adds pipelines and updates existing pipelines in the cluster.
+
+[source,js]
+--------------------------------------------------
+PUT _ingest/pipeline/my-pipeline-id
+{
+  "description" : "describe pipeline",
+  "processors" : [
+    {
+      "simple" : {
+        // settings
+      }
+    },
+    // other processors
+  ]
+}
+--------------------------------------------------
+// AUTOSENSE
+
+NOTE: Each ingest node updates its processors asynchronously in the background, so it may take a few seconds for all
+      nodes to have the latest version of the pipeline.
+
+=== Get pipeline API
+
+The get pipeline api returns pipelines based on id. This api always returns a local reference of the pipeline.
+
+[source,js]
+--------------------------------------------------
+GET _ingest/pipeline/my-pipeline-id
+--------------------------------------------------
+// AUTOSENSE
+
+Example response:
+
+[source,js]
+--------------------------------------------------
+{
+   "my-pipeline-id": {
+      "_source" : {
+        "description": "describe pipeline",
+        "processors": [
+          {
+            "simple" : {
+              // settings
+            }
+          },
+          // other processors
+        ]
+      },
+      "_version" : 0
+   }
+}
+--------------------------------------------------
+
+For each returned pipeline the source and the version is returned.
+The version is useful for knowing what version of the pipeline the node has.
+Multiple ids can be provided at the same time. Also wildcards are supported.
+
+=== Delete pipeline API
+
+The delete pipeline api deletes pipelines by id.
+
+[source,js]
+--------------------------------------------------
+DELETE _ingest/pipeline/my-pipeline-id
+--------------------------------------------------
+// AUTOSENSE

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -72,16 +72,15 @@ public final class Pipeline {
 
     public final static class Builder {
 
-        private final String name;
+        private final String id;
         private String description;
         private List<Processor> processors = new ArrayList<>();
 
-        public Builder(String name) {
-            this.name = name;
+        public Builder(String id) {
+            this.id = id;
         }
 
-        public Builder(Map<String, Object> config, Map<String, Processor.Builder.Factory> processorRegistry) {
-            name = (String) config.get("name");
+        public void fromMap(Map<String, Object> config, Map<String, Processor.Builder.Factory> processorRegistry) {
             description = (String) config.get("description");
             @SuppressWarnings("unchecked")
             List<Map<String, Map<String, Object>>> processors = (List<Map<String, Map<String, Object>>>) config.get("processors");
@@ -111,7 +110,7 @@ public final class Pipeline {
         }
 
         public Pipeline build() {
-            return new Pipeline(name, description, Collections.unmodifiableList(processors));
+            return new Pipeline(id, description, Collections.unmodifiableList(processors));
         }
     }
 }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestModule.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestModule.java
@@ -21,11 +21,9 @@ package org.elasticsearch.plugin.ingest;
 
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
-import org.elasticsearch.common.inject.multibindings.Multibinder;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.SimpleProcessor;
 import org.elasticsearch.plugin.ingest.rest.IngestRestFilter;
-import org.elasticsearch.plugin.ingest.transport.IngestActionFilter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,7 +37,7 @@ public class IngestModule extends AbstractModule {
         binder().bind(IngestRestFilter.class).asEagerSingleton();
         binder().bind(PipelineExecutionService.class).asEagerSingleton();
         binder().bind(PipelineStore.class).asEagerSingleton();
-        binder().bind(PipelineConfigDocReader.class).asEagerSingleton();
+        binder().bind(PipelineStoreClient.class).asEagerSingleton();
 
         registerProcessor(SimpleProcessor.TYPE, SimpleProcessor.Builder.Factory.class);
 

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/rest/RestDeletePipelineAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/rest/RestDeletePipelineAction.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.rest;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.ingest.transport.delete.DeletePipelineAction;
+import org.elasticsearch.plugin.ingest.transport.delete.DeletePipelineRequest;
+import org.elasticsearch.plugin.ingest.transport.get.GetPipelineAction;
+import org.elasticsearch.plugin.ingest.transport.get.GetPipelineRequest;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.support.RestToXContentListener;
+
+public class RestDeletePipelineAction extends BaseRestHandler {
+
+    @Inject
+    public RestDeletePipelineAction(Settings settings, RestController controller, Client client) {
+        super(settings, controller, client);
+        controller.registerHandler(RestRequest.Method.DELETE, "/_ingest/pipeline/{id}", this);
+    }
+
+    @Override
+    protected void handleRequest(RestRequest restRequest, RestChannel channel, Client client) throws Exception {
+        DeletePipelineRequest request = new DeletePipelineRequest();
+        request.id(restRequest.param("id"));
+        client.execute(DeletePipelineAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/rest/RestGetPipelineAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/rest/RestGetPipelineAction.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.rest;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.ingest.transport.get.GetPipelineAction;
+import org.elasticsearch.plugin.ingest.transport.get.GetPipelineRequest;
+import org.elasticsearch.plugin.ingest.transport.put.PutPipelineAction;
+import org.elasticsearch.plugin.ingest.transport.put.PutPipelineRequest;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
+import org.elasticsearch.rest.action.support.RestToXContentListener;
+
+public class RestGetPipelineAction extends BaseRestHandler {
+
+    @Inject
+    public RestGetPipelineAction(Settings settings, RestController controller, Client client) {
+        super(settings, controller, client);
+        controller.registerHandler(RestRequest.Method.GET, "/_ingest/pipeline/{ids}", this);
+    }
+
+    @Override
+    protected void handleRequest(RestRequest restRequest, RestChannel channel, Client client) throws Exception {
+        GetPipelineRequest request = new GetPipelineRequest();
+        request.ids(Strings.splitStringByCommaToArray(restRequest.param("ids")));
+        client.execute(GetPipelineAction.INSTANCE, request, new RestStatusToXContentListener<>(channel));
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/rest/RestPutPipelineAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/rest/RestPutPipelineAction.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.rest;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.ingest.transport.put.PutPipelineAction;
+import org.elasticsearch.plugin.ingest.transport.put.PutPipelineRequest;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.support.RestToXContentListener;
+
+public class RestPutPipelineAction extends BaseRestHandler {
+
+    @Inject
+    public RestPutPipelineAction(Settings settings, RestController controller, Client client) {
+        super(settings, controller, client);
+        controller.registerHandler(RestRequest.Method.PUT, "/_ingest/pipeline/{id}", this);
+    }
+
+    @Override
+    protected void handleRequest(RestRequest restRequest, RestChannel channel, Client client) throws Exception {
+        PutPipelineRequest request = new PutPipelineRequest();
+        request.id(restRequest.param("id"));
+        if (restRequest.hasContent()) {
+            request.source(restRequest.content());
+        }
+        client.execute(PutPipelineAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineAction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.delete;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class DeletePipelineAction extends Action<DeletePipelineRequest, DeletePipelineResponse, DeletePipelineRequestBuilder> {
+
+    public static final DeletePipelineAction INSTANCE = new DeletePipelineAction();
+    public static final String NAME = "cluster:admin/ingest/pipeline/delete";
+
+    public DeletePipelineAction() {
+        super(NAME);
+    }
+
+    @Override
+    public DeletePipelineRequestBuilder newRequestBuilder(ElasticsearchClient client) {
+        return new DeletePipelineRequestBuilder(client, this);
+    }
+
+    @Override
+    public DeletePipelineResponse newResponse() {
+        return new DeletePipelineResponse();
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineRequest.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.delete;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class DeletePipelineRequest extends ActionRequest {
+
+    private String id;
+
+    public void id(String id) {
+        this.id = id;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (id == null) {
+            validationException = addValidationError("id is missing", validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        id = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(id);
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineRequestBuilder.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineRequestBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.delete;
+
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class DeletePipelineRequestBuilder extends ActionRequestBuilder<DeletePipelineRequest, DeletePipelineResponse, DeletePipelineRequestBuilder> {
+
+    public DeletePipelineRequestBuilder(ElasticsearchClient client, DeletePipelineAction action) {
+        super(client, action, new DeletePipelineRequest());
+    }
+
+    public DeletePipelineRequestBuilder setId(String id) {
+        request.id(id);
+        return this;
+    }
+
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineResponse.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineResponse.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.delete;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.common.xcontent.XContentHelper;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class DeletePipelineResponse extends ActionResponse implements ToXContent {
+
+    private String id;
+    private boolean found;
+
+    DeletePipelineResponse() {
+    }
+
+    public DeletePipelineResponse(String id, boolean found) {
+        this.id = id;
+        this.found = found;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public boolean found() {
+        return found;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        this.id = in.readString();
+        this.found = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(id);
+        out.writeBoolean(found);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(Fields.ID, id);
+        builder.field(Fields.FOUND, found);
+        return builder;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString ID = new XContentBuilderString("_id");
+        static final XContentBuilderString FOUND = new XContentBuilderString("_found");
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineTransportAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/delete/DeletePipelineTransportAction.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.delete;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.delete.TransportDeleteAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.ingest.PipelineStore;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DeletePipelineTransportAction extends HandledTransportAction<DeletePipelineRequest, DeletePipelineResponse> {
+
+    private final TransportDeleteAction deleteAction;
+
+    @Inject
+    public DeletePipelineTransportAction(Settings settings, ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, TransportDeleteAction deleteAction) {
+        super(settings, DeletePipelineAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, DeletePipelineRequest::new);
+        this.deleteAction = deleteAction;
+    }
+
+    @Override
+    protected void doExecute(DeletePipelineRequest request, ActionListener<DeletePipelineResponse> listener) {
+        DeleteRequest deleteRequest = new DeleteRequest();
+        deleteRequest.index(PipelineStore.INDEX);
+        deleteRequest.type(PipelineStore.TYPE);
+        deleteRequest.id(request.id());
+        deleteRequest.refresh(true);
+        deleteAction.execute(deleteRequest, new ActionListener<DeleteResponse>() {
+            @Override
+            public void onResponse(DeleteResponse deleteResponse) {
+                listener.onResponse(new DeletePipelineResponse(deleteResponse.getId(), deleteResponse.isFound()));
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineAction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.get;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class GetPipelineAction extends Action<GetPipelineRequest, GetPipelineResponse, GetPipelineRequestBuilder> {
+
+    public static final GetPipelineAction INSTANCE = new GetPipelineAction();
+    public static final String NAME = "cluster:admin/ingest/pipeline/get";
+
+    public GetPipelineAction() {
+        super(NAME);
+    }
+
+    @Override
+    public GetPipelineRequestBuilder newRequestBuilder(ElasticsearchClient client) {
+        return new GetPipelineRequestBuilder(client, this);
+    }
+
+    @Override
+    public GetPipelineResponse newResponse() {
+        return new GetPipelineResponse();
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineRequest.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.get;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class GetPipelineRequest extends ActionRequest {
+
+    private String[] ids;
+
+    public void ids(String... ids) {
+        this.ids = ids;
+    }
+
+    public String[] ids() {
+        return ids;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (ids == null || ids.length == 0) {
+            validationException = addValidationError("ids is missing", validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        ids = in.readStringArray();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeStringArray(ids);
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineRequestBuilder.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineRequestBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.get;
+
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class GetPipelineRequestBuilder extends ActionRequestBuilder<GetPipelineRequest, GetPipelineResponse, GetPipelineRequestBuilder> {
+
+    public GetPipelineRequestBuilder(ElasticsearchClient client, GetPipelineAction action) {
+        super(client, action, new GetPipelineRequest());
+    }
+
+    public GetPipelineRequestBuilder setIds(String... ids) {
+        request.ids(ids);
+        return this;
+    }
+
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineResponse.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineResponse.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.get;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.StatusToXContent;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GetPipelineResponse extends ActionResponse implements StatusToXContent {
+
+    private Map<String, BytesReference> pipelines;
+    private Map<String, Long> versions;
+
+    public GetPipelineResponse() {
+    }
+
+    public GetPipelineResponse(Map<String, BytesReference> pipelines, Map<String, Long> versions) {
+        this.pipelines = pipelines;
+        this.versions = versions;
+    }
+
+    public Map<String, BytesReference> pipelines() {
+        return pipelines;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        int size = in.readVInt();
+        pipelines = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            pipelines.put(in.readString(), in.readBytesReference());
+        }
+        size = in.readVInt();
+        versions = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            versions.put(in.readString(), in.readVLong());
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeVInt(pipelines.size());
+        for (Map.Entry<String, BytesReference> entry : pipelines.entrySet()) {
+            out.writeString(entry.getKey());
+            out.writeBytesReference(entry.getValue());
+        }
+        out.writeVInt(versions.size());
+        for (Map.Entry<String, Long> entry : versions.entrySet()) {
+            out.writeString(entry.getKey());
+            out.writeVLong(entry.getValue());
+        }
+    }
+
+    public boolean isFound() {
+        return !pipelines.isEmpty();
+    }
+
+    @Override
+    public RestStatus status() {
+        return isFound() ? RestStatus.OK : RestStatus.NOT_FOUND;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        for (Map.Entry<String, BytesReference> entry : pipelines.entrySet()) {
+            builder.startObject(entry.getKey());
+            XContentHelper.writeRawField("_source", entry.getValue(), builder, params);
+            builder.field("_version", versions.get(entry.getKey()));
+            builder.endObject();
+        }
+        return builder;
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineTransportAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/get/GetPipelineTransportAction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.get;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.ingest.PipelineStore;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GetPipelineTransportAction extends HandledTransportAction<GetPipelineRequest, GetPipelineResponse> {
+
+    private final PipelineStore pipelineStore;
+
+    @Inject
+    public GetPipelineTransportAction(Settings settings, ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, PipelineStore pipelineStore) {
+        super(settings, GetPipelineAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, GetPipelineRequest::new);
+        this.pipelineStore = pipelineStore;
+    }
+
+    @Override
+    protected void doExecute(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener) {
+        List<PipelineStore.PipelineReference> references = pipelineStore.getReference(request.ids());
+        Map<String, BytesReference> result = new HashMap<>();
+        Map<String, Long> versions = new HashMap<>();
+        for (PipelineStore.PipelineReference reference : references) {
+            result.put(reference.getPipeline().getId(), reference.getSource());
+            versions.put(reference.getPipeline().getId(), reference.getVersion());
+        }
+        listener.onResponse(new GetPipelineResponse(result, versions));
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineAction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.put;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.ElasticsearchClient;
+
+public class PutPipelineAction extends Action<PutPipelineRequest, PutPipelineResponse, PutPipelineRequestBuilder> {
+
+    public static final PutPipelineAction INSTANCE = new PutPipelineAction();
+    public static final String NAME = "cluster:admin/ingest/pipeline/put";
+
+    public PutPipelineAction() {
+        super(NAME);
+    }
+
+    @Override
+    public PutPipelineRequestBuilder newRequestBuilder(ElasticsearchClient client) {
+        return new PutPipelineRequestBuilder(client, this);
+    }
+
+    @Override
+    public PutPipelineResponse newResponse() {
+        return new PutPipelineResponse();
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineRequest.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.put;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class PutPipelineRequest extends ActionRequest {
+
+    private String id;
+    private BytesReference source;
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (id == null) {
+            validationException = addValidationError("id is missing", validationException);
+        }
+        if (source == null) {
+            validationException = addValidationError("source is missing", validationException);
+        }
+        return validationException;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public void id(String id) {
+        this.id = id;
+    }
+
+    public BytesReference source() {
+        return source;
+    }
+
+    public void source(BytesReference source) {
+        this.source = source;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        id = in.readString();
+        source = in.readBytesReference();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(id);
+        out.writeBytesReference(source);
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineRequestBuilder.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineRequestBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.put;
+
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.bytes.BytesReference;
+
+public class PutPipelineRequestBuilder extends ActionRequestBuilder<PutPipelineRequest, PutPipelineResponse, PutPipelineRequestBuilder> {
+
+    public PutPipelineRequestBuilder(ElasticsearchClient client, PutPipelineAction action) {
+        super(client, action, new PutPipelineRequest());
+    }
+
+    public PutPipelineRequestBuilder setId(String id) {
+        request.id(id);
+        return this;
+    }
+
+    public PutPipelineRequestBuilder setSource(BytesReference source) {
+        request.source(source);
+        return this;
+    }
+
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineResponse.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineResponse.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.put;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+
+public class PutPipelineResponse extends ActionResponse implements ToXContent {
+
+    private String id;
+    private long version;
+
+    public String id() {
+        return id;
+    }
+
+    public PutPipelineResponse id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public long version() {
+        return version;
+    }
+
+    public PutPipelineResponse version(long version) {
+        this.version = version;
+        return this;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(id);
+        out.writeLong(version);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        id = in.readString();
+        version = in.readLong();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(Fields.ID, id);
+        builder.field(Fields.VERSION, version);
+        return builder;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString ID = new XContentBuilderString("_id");
+        static final XContentBuilderString VERSION = new XContentBuilderString("_version");
+    }
+}

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineTransportAction.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/put/PutPipelineTransportAction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.ingest.transport.put;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.index.TransportIndexAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.ingest.PipelineStore;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.function.Supplier;
+
+public class PutPipelineTransportAction extends HandledTransportAction<PutPipelineRequest, PutPipelineResponse> {
+
+    private final TransportIndexAction indexAction;
+
+    @Inject
+    public PutPipelineTransportAction(Settings settings, ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver, TransportIndexAction indexAction) {
+        super(settings, PutPipelineAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, PutPipelineRequest::new);
+        this.indexAction = indexAction;
+    }
+
+    @Override
+    protected void doExecute(PutPipelineRequest request, ActionListener<PutPipelineResponse> listener) {
+        IndexRequest indexRequest = new IndexRequest();
+        indexRequest.index(PipelineStore.INDEX);
+        indexRequest.type(PipelineStore.TYPE);
+        indexRequest.id(request.id());
+        indexRequest.source(request.source());
+        indexRequest.refresh(true);
+        indexAction.execute(indexRequest, new ActionListener<IndexResponse>() {
+            @Override
+            public void onResponse(IndexResponse indexResponse) {
+                PutPipelineResponse response = new PutPipelineResponse();
+                response.id(indexResponse.getId());
+                response.version(indexResponse.getVersion());
+                listener.onResponse(response);
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+}

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreClientTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreClientTests.java
@@ -25,10 +25,10 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class PipelineConfigDocReaderTests extends ESSingleNodeTestCase {
+public class PipelineStoreClientTests extends ESSingleNodeTestCase {
 
     public void testReadAll() {
-        PipelineConfigDocReader reader = new PipelineConfigDocReader(Settings.EMPTY, node().injector());
+        PipelineStoreClient reader = new PipelineStoreClient(Settings.EMPTY, node().injector());
         reader.start();
 
         createIndex(PipelineStore.INDEX);
@@ -41,7 +41,7 @@ public class PipelineConfigDocReaderTests extends ESSingleNodeTestCase {
         client().admin().indices().prepareRefresh().get();
 
         int i = 0;
-        for (SearchHit hit : reader.readAll()) {
+        for (SearchHit hit : reader.readAllPipelines()) {
             assertThat(hit.getId(), equalTo(Integer.toString(i)));
             assertThat(hit.getVersion(), equalTo(1l));
             assertThat(hit.getSource().get("field"), equalTo("value" + i));

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreTests.java
@@ -33,11 +33,13 @@ import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,14 +47,14 @@ public class PipelineStoreTests extends ESTestCase {
 
     private PipelineStore store;
     private ThreadPool threadPool;
-    private PipelineConfigDocReader docReader;
+    private PipelineStoreClient client;
 
     @Before
     public void init() {
         threadPool = new ThreadPool("test");
         ClusterService clusterService = mock(ClusterService.class);
-        docReader = mock(PipelineConfigDocReader.class);
-        store = new PipelineStore(Settings.EMPTY, threadPool, clusterService, docReader, Collections.singletonMap(SimpleProcessor.TYPE, new SimpleProcessor.Builder.Factory()));
+        client = mock(PipelineStoreClient.class);
+        store = new PipelineStore(Settings.EMPTY, threadPool, clusterService, client, Collections.singletonMap(SimpleProcessor.TYPE, new SimpleProcessor.Builder.Factory()));
         store.start();
     }
 
@@ -66,52 +68,110 @@ public class PipelineStoreTests extends ESTestCase {
     public void testUpdatePipeline() {
         List<SearchHit> hits = new ArrayList<>();
         hits.add(new InternalSearchHit(0, "1", new StringText("type"), Collections.emptyMap())
-                .sourceRef(new BytesArray("{\"name\": \"_name1\", \"description\": \"_description1\"}"))
+                .sourceRef(new BytesArray("{\"description\": \"_description1\"}"))
         );
 
-        when(docReader.readAll()).thenReturn(hits);
+        when(client.readAllPipelines()).thenReturn(hits);
+        when(client.existPipeline("1")).thenReturn(true);
         assertThat(store.get("1"), nullValue());
 
         store.updatePipelines();
-        assertThat(store.get("1").getId(), equalTo("_name1"));
+        assertThat(store.get("1").getId(), equalTo("1"));
         assertThat(store.get("1").getDescription(), equalTo("_description1"));
 
+        when(client.existPipeline("2")).thenReturn(true);
         hits.add(new InternalSearchHit(0, "2", new StringText("type"), Collections.emptyMap())
-                        .sourceRef(new BytesArray("{\"name\": \"_name2\", \"description\": \"_description2\"}"))
+                        .sourceRef(new BytesArray("{\"description\": \"_description2\"}"))
         );
         store.updatePipelines();
-        assertThat(store.get("1").getId(), equalTo("_name1"));
+        assertThat(store.get("1").getId(), equalTo("1"));
         assertThat(store.get("1").getDescription(), equalTo("_description1"));
-        assertThat(store.get("2").getId(), equalTo("_name2"));
+        assertThat(store.get("2").getId(), equalTo("2"));
         assertThat(store.get("2").getDescription(), equalTo("_description2"));
+
+        hits.remove(1);
+        when(client.existPipeline("2")).thenReturn(false);
+        store.updatePipelines();
+        assertThat(store.get("1").getId(), equalTo("1"));
+        assertThat(store.get("1").getDescription(), equalTo("_description1"));
+        assertThat(store.get("2"), nullValue());
     }
 
     public void testPipelineUpdater() throws Exception {
         List<SearchHit> hits = new ArrayList<>();
         hits.add(new InternalSearchHit(0, "1", new StringText("type"), Collections.emptyMap())
-                        .sourceRef(new BytesArray("{\"name\": \"_name1\", \"description\": \"_description1\"}"))
+                        .sourceRef(new BytesArray("{\"description\": \"_description1\"}"))
         );
-        when(docReader.readAll()).thenReturn(hits);
+        when(client.readAllPipelines()).thenReturn(hits);
+        when(client.existPipeline(anyString())).thenReturn(true);
         assertThat(store.get("1"), nullValue());
 
         store.startUpdateWorker();
         assertBusy(() -> {
             assertThat(store.get("1"), notNullValue());
-            assertThat(store.get("1").getId(), equalTo("_name1"));
+            assertThat(store.get("1").getId(), equalTo("1"));
             assertThat(store.get("1").getDescription(), equalTo("_description1"));
         });
 
         hits.add(new InternalSearchHit(0, "2", new StringText("type"), Collections.emptyMap())
-                        .sourceRef(new BytesArray("{\"name\": \"_name2\", \"description\": \"_description2\"}"))
+                        .sourceRef(new BytesArray("{\"description\": \"_description2\"}"))
         );
         assertBusy(() -> {
             assertThat(store.get("1"), notNullValue());
-            assertThat(store.get("1").getId(), equalTo("_name1"));
+            assertThat(store.get("1").getId(), equalTo("1"));
             assertThat(store.get("1").getDescription(), equalTo("_description1"));
             assertThat(store.get("2"), notNullValue());
-            assertThat(store.get("2").getId(), equalTo("_name2"));
+            assertThat(store.get("2").getId(), equalTo("2"));
             assertThat(store.get("2").getDescription(), equalTo("_description2"));
         });
+    }
+
+    public void testGetReference() {
+        // fill the store up for the test:
+        List<SearchHit> hits = new ArrayList<>();
+        hits.add(new InternalSearchHit(0, "foo", new StringText("type"), Collections.emptyMap()).sourceRef(new BytesArray("{\"description\": \"_description\"}")));
+        hits.add(new InternalSearchHit(0, "bar", new StringText("type"), Collections.emptyMap()).sourceRef(new BytesArray("{\"description\": \"_description\"}")));
+        hits.add(new InternalSearchHit(0, "foobar", new StringText("type"), Collections.emptyMap()).sourceRef(new BytesArray("{\"description\": \"_description\"}")));
+        when(client.readAllPipelines()).thenReturn(hits);
+        store.updatePipelines();
+
+        List<PipelineStore.PipelineReference> result = store.getReference("foo");
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).getPipeline().getId(), equalTo("foo"));
+
+        result = store.getReference("foo*");
+        // to make sure the order is consistent in the test:
+        Collections.sort(result, new Comparator<PipelineStore.PipelineReference>() {
+            @Override
+            public int compare(PipelineStore.PipelineReference first, PipelineStore.PipelineReference second) {
+                return first.getPipeline().getId().compareTo(second.getPipeline().getId());
+            }
+        });
+        assertThat(result.size(), equalTo(2));
+        assertThat(result.get(0).getPipeline().getId(), equalTo("foo"));
+        assertThat(result.get(1).getPipeline().getId(), equalTo("foobar"));
+
+        result = store.getReference("bar*");
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).getPipeline().getId(), equalTo("bar"));
+
+        result = store.getReference("*");
+        // to make sure the order is consistent in the test:
+        Collections.sort(result, new Comparator<PipelineStore.PipelineReference>() {
+            @Override
+            public int compare(PipelineStore.PipelineReference first, PipelineStore.PipelineReference second) {
+                return first.getPipeline().getId().compareTo(second.getPipeline().getId());
+            }
+        });
+        assertThat(result.size(), equalTo(3));
+        assertThat(result.get(0).getPipeline().getId(), equalTo("bar"));
+        assertThat(result.get(1).getPipeline().getId(), equalTo("foo"));
+        assertThat(result.get(2).getPipeline().getId(), equalTo("foobar"));
+
+        result = store.getReference("foo", "bar");
+        assertThat(result.size(), equalTo(2));
+        assertThat(result.get(0).getPipeline().getId(), equalTo("foo"));
+        assertThat(result.get(1).getPipeline().getId(), equalTo("bar"));
     }
 
 }

--- a/plugins/ingest/src/test/resources/rest-api-spec/api/ingest.delete_pipeline.json
+++ b/plugins/ingest/src/test/resources/rest-api-spec/api/ingest.delete_pipeline.json
@@ -1,0 +1,20 @@
+{
+  "ingest.delete_pipeline": {
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+    "methods": [ "DELETE" ],
+    "url": {
+      "path": "/_ingest/pipeline/{id}",
+      "paths": [ "/_ingest/pipeline/{id}" ],
+      "parts": {
+        "id": {
+          "type" : "string",
+          "description" : "Pipeline ID",
+          "required" : true
+        }
+      },
+      "params": {
+      }
+    },
+    "body": null
+  }
+}

--- a/plugins/ingest/src/test/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/plugins/ingest/src/test/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -1,0 +1,20 @@
+{
+  "ingest.get_pipeline": {
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+    "methods": [ "GET" ],
+    "url": {
+      "path": "/_ingest/pipeline/{ids}",
+      "paths": [ "/_ingest/pipeline/{ids}" ],
+      "parts": {
+        "ids": {
+          "type" : "string",
+          "description" : "Comma separated list of pipeline ids. Wildcards supported",
+          "required" : true
+        }
+      },
+      "params": {
+      }
+    },
+    "body": null
+  }
+}

--- a/plugins/ingest/src/test/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/plugins/ingest/src/test/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -1,0 +1,23 @@
+{
+  "ingest.put_pipeline": {
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+    "methods": [ "PUT" ],
+    "url": {
+      "path": "/_ingest/pipeline/{id}",
+      "paths": [ "/_ingest/pipeline/{id}" ],
+      "parts": {
+        "id": {
+          "type" : "string",
+          "description" : "Pipeline ID",
+          "required" : true
+        }
+      },
+      "params": {
+      }
+    },
+    "body": {
+      "description" : "The ingest definition",
+      "required" : true
+    }    
+  }
+}

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
@@ -1,0 +1,57 @@
+---
+"Test basic pipeline crud":
+  - do:
+      cluster.health:
+          wait_for_status: green
+
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "simple" : {
+                  "path" : "field1",
+                  "value" : "_value",
+                  "add_field" : "field2",
+                  "add_field_value" : "_value"
+                }
+              }
+            ]
+          }
+  - match: { _id: "my_pipeline" }
+
+  # Simulate a Thread.sleep(), because pipeline are updated in the background
+  - do:
+      catch: request_timeout
+      cluster.health:
+        wait_for_nodes: 99
+        timeout: 2s
+  - match: { "timed_out": true }
+
+  - do:
+      ingest.get_pipeline:
+        ids: "my_pipeline"
+  - match: { my_pipeline._source.description: "_description" }
+  - match: { my_pipeline._version: 1 }
+
+  - do:
+      ingest.delete_pipeline:
+        id: "my_pipeline"
+  - match: { _id: "my_pipeline" }
+  - match: { _found: true }
+
+  # Simulate a Thread.sleep(), because pipeline are updated in the background
+  - do:
+      catch: request_timeout
+      cluster.health:
+        wait_for_nodes: 99
+        timeout: 2s
+  - match: { "timed_out": true }
+
+  - do:
+      catch: missing
+      ingest.get_pipeline:
+        ids: "my_pipeline"


### PR DESCRIPTION
Added first version of put, get and delete pipeline APIs.

In order to support deletes the `PipelineStore` needs to also check if all the pipelines it has loaded do still exist.

The documentation is minimal and sits next to all the docs of all other plugins. We may want to move the ingest docs to the plugin itself?
