### PR TITLE
Plugin script to set proper plugin config dir attributes

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -36,9 +36,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.PosixFileAttributeView;
-import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.*;
 import java.util.*;
 import java.util.stream.StreamSupport;
 import java.util.zip.ZipEntry;
@@ -255,7 +253,7 @@ public class PluginManager {
                 copyBinDirectory(sourcePluginBinDirectory, destPluginBinDirectory, pluginHandle.name, terminal);
             } catch (IOException e) {
                 // rollback and remove potentially before installed leftovers
-                terminal.printError("Error copying bin directory [%s] to [%s], cleaning up, reason: %s", sourcePluginBinDirectory, destPluginBinDirectory, e.getMessage());
+                terminal.printError("Error copying bin directory [%s] to [%s], cleaning up, reason: %s", sourcePluginBinDirectory, destPluginBinDirectory, ExceptionsHelper.detailedMessage(e));
                 tryToDeletePath(terminal, extractLocation, pluginHandle.binDir(environment));
                 throw e;
             }
@@ -274,13 +272,67 @@ public class PluginManager {
             try {
                 terminal.println(VERBOSE, "Found config, moving to %s", destConfigDirectory.toAbsolutePath());
                 moveFilesWithoutOverwriting(sourceConfigDirectory, destConfigDirectory, ".new");
+
+                if (Environment.getFileStore(destConfigDirectory).supportsFileAttributeView(PosixFileAttributeView.class)) {
+                    //We copy owner, group and permissions from the parent ES_CONFIG directory, assuming they were properly set depending
+                    // on how es was installed in the first place: can be root:elasticsearch (750) if es was installed from rpm/deb packages
+                    // or most likely elasticsearch:elasticsearch if installed from tar/zip. As for permissions we don't rely on umask.
+                    PosixFileAttributes parentDirAttributes = Files.getFileAttributeView(destConfigDirectory.getParent(), PosixFileAttributeView.class).readAttributes();
+                    //for files though, we make sure not to copy execute permissions from the parent dir and leave them untouched
+                    Set<PosixFilePermission> baseFilePermissions = new HashSet<>();
+                    for (PosixFilePermission posixFilePermission : parentDirAttributes.permissions()) {
+                        switch (posixFilePermission) {
+                            case OWNER_EXECUTE:
+                            case GROUP_EXECUTE:
+                            case OTHERS_EXECUTE:
+                                break;
+                            default:
+                                baseFilePermissions.add(posixFilePermission);
+                        }
+                    }
+                    Files.walkFileTree(destConfigDirectory, new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                            if (attrs.isRegularFile()) {
+                                Set<PosixFilePermission> newFilePermissions = new HashSet<>(baseFilePermissions);
+                                Set<PosixFilePermission> currentFilePermissions = Files.getPosixFilePermissions(file);
+                                for (PosixFilePermission posixFilePermission : currentFilePermissions) {
+                                    switch (posixFilePermission) {
+                                        case OWNER_EXECUTE:
+                                        case GROUP_EXECUTE:
+                                        case OTHERS_EXECUTE:
+                                            newFilePermissions.add(posixFilePermission);
+                                    }
+                                }
+                                setPosixFileAttributes(file, parentDirAttributes.owner(), parentDirAttributes.group(), newFilePermissions);
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+
+                        @Override
+                        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                            setPosixFileAttributes(dir, parentDirAttributes.owner(), parentDirAttributes.group(), parentDirAttributes.permissions());
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+                } else {
+                    terminal.println(VERBOSE, "Skipping posix permissions - filestore doesn't support posix permission");
+                }
+
                 terminal.println(VERBOSE, "Installed %s into %s", pluginHandle.name, destConfigDirectory.toAbsolutePath());
             } catch (IOException e) {
-                terminal.printError("Error copying config directory [%s] to [%s], cleaning up, reason: %s", sourceConfigDirectory, destConfigDirectory, e.getMessage());
+                terminal.printError("Error copying config directory [%s] to [%s], cleaning up, reason: %s", sourceConfigDirectory, destConfigDirectory, ExceptionsHelper.detailedMessage(e));
                 tryToDeletePath(terminal, extractLocation, destPluginBinDirectory, destConfigDirectory);
                 throw e;
             }
         }
+    }
+
+    private static void setPosixFileAttributes(Path path, UserPrincipal owner, GroupPrincipal group, Set<PosixFilePermission> permissions) throws IOException {
+        PosixFileAttributeView fileAttributeView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+        fileAttributeView.setOwner(owner);
+        fileAttributeView.setGroup(group);
+        fileAttributeView.setPermissions(permissions);
     }
 
     private void tryToDeletePath(Terminal terminal, Path ... paths) {

--- a/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/scripts/packaging_test_utils.bash
@@ -164,7 +164,7 @@ assert_file() {
     fi
 
     if [ "x$user" != "x" ]; then
-        realuser=$(ls -ld "$file" | awk '{print $3}')
+        realuser=$(find "$file" -maxdepth 0 -printf "%u")
         [ "$realuser" = "$user" ]
     fi
 


### PR DESCRIPTION
Depending on how elasticsearch is installed, we have two scenarios to take into account that relate to user, group and permissions assigned to the config directory:

1) deb/rpm package: /etc/elasticsearch is root:elasticsearch 750 and the plugin script is run from root user
2) tar/zip archive: es config dir is most likely elasticsearch:elasticsearch and the plugin script is run from elasticsearch user

When the plugin script copies over the plugin config dir within the es config dir, it should take care of setting the proper user, group and permissions, which vary depending on how elasticsearch was installed in the first place. Should be root:elasticsearch 750 if installed from a package, or elasticsearch:elasticsearch if installed from an archive.

This commit makes sure that the plugin script looks at user, group and permissions of the config dir and copies them over to the plugin config subdirectory, whatever they are, so that they get properly setup depending on how elasticsearch was installed in the first place.

Relates to #11016
