### PR TITLE
Remove Guava as a dependency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -53,7 +53,6 @@ dependencies {
   compile "org.apache.lucene:lucene-spatial:${versions.lucene}"
 
   // utilities
-  compile 'com.google.guava:guava:18.0'
   compile 'commons-cli:commons-cli:1.3.1'
   compile 'com.carrotsearch:hppc:0.7.1'
 
@@ -84,7 +83,7 @@ dependencies {
   compile 'com.vividsolutions:jts:1.13', optional
 
   // templating
-  compile 'com.github.spullara.mustache.java:compiler:0.8.13', optional
+  compile 'com.github.spullara.mustache.java:compiler:0.9.1', optional
 
   // logging
   compile "log4j:log4j:${versions.log4j}", optional

--- a/test-framework/build.gradle
+++ b/test-framework/build.gradle
@@ -16,9 +16,7 @@ dependencies {
   compile(group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3') {
     exclude group: 'org.hamcrest', module: 'hamcrest-core'
   }
-  compile('com.google.jimfs:jimfs:1.0') {
-    exclude group: 'com.google.guava', module: 'guava' // we include our own guava, this conflicts
-  }
+  compile "com.google.jimfs:jimfs:1.0"
   compile "org.apache.httpcomponents:httpclient:${versions.httpclient}"
 }
 


### PR DESCRIPTION
This commit removes Guava as a dependency. Note that Guava will remain
as a test-only dependency (transitively through Jimfs).

Relates #13224
