### PR TITLE
Ensure more specific analyzer is used independent of the mapping order

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -160,6 +160,9 @@ public class TypeParsers {
     }
 
     public static void parseField(AbstractFieldMapper.Builder builder, String name, Map<String, Object> fieldNode, Mapper.TypeParser.ParserContext parserContext) {
+        NamedAnalyzer theAnalyzer = null;
+        NamedAnalyzer searchAnalyzer = null;
+        NamedAnalyzer indexAnalyzer = null;
         for (Map.Entry<String, Object> entry : fieldNode.entrySet()) {
             final String propName = Strings.toUnderscoreCase(entry.getKey());
             final Object propNode = entry.getValue();
@@ -212,20 +215,19 @@ public class TypeParsers {
                 if (analyzer == null) {
                     throw new MapperParsingException("Analyzer [" + propNode.toString() + "] not found for field [" + name + "]");
                 }
-                builder.indexAnalyzer(analyzer);
-                builder.searchAnalyzer(analyzer);
+                theAnalyzer = analyzer;
             } else if (propName.equals("index_analyzer")) {
                 NamedAnalyzer analyzer = parserContext.analysisService().analyzer(propNode.toString());
                 if (analyzer == null) {
                     throw new MapperParsingException("Analyzer [" + propNode.toString() + "] not found for field [" + name + "]");
                 }
-                builder.indexAnalyzer(analyzer);
+                indexAnalyzer = analyzer;
             } else if (propName.equals("search_analyzer")) {
                 NamedAnalyzer analyzer = parserContext.analysisService().analyzer(propNode.toString());
                 if (analyzer == null) {
                     throw new MapperParsingException("Analyzer [" + propNode.toString() + "] not found for field [" + name + "]");
                 }
-                builder.searchAnalyzer(analyzer);
+                searchAnalyzer = analyzer;
             } else if (propName.equals("include_in_all")) {
                 builder.includeInAll(nodeBooleanValue(propNode));
             } else if (propName.equals("postings_format")) {
@@ -242,6 +244,16 @@ public class TypeParsers {
             } else if (propName.equals("copy_to")) {
                 parseCopyFields(propNode, builder);
             }
+        }
+        if (indexAnalyzer != null) {
+            builder.indexAnalyzer(indexAnalyzer);
+        } else if (theAnalyzer != null) {
+            builder.indexAnalyzer(theAnalyzer);
+        }
+        if (searchAnalyzer != null) {
+            builder.searchAnalyzer(searchAnalyzer);
+        } else if (theAnalyzer != null) {
+            builder.searchAnalyzer(theAnalyzer);
         }
     }
 

--- a/src/test/java/org/elasticsearch/index/mapper/FieldMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/FieldMapperTests.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.core.StringFieldMapper;
+import org.elasticsearch.index.mapper.core.TypeParsers;
+import org.elasticsearch.test.ElasticsearchSingleNodeTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ */
+public class FieldMapperTests extends ElasticsearchSingleNodeTest {
+
+    public void testRandomAnalyzerOrder() {
+        IndexService test = createIndex("test");
+        MapperService mapperService = test.mapperService();
+        DocumentMapperParser documentMapperParser = mapperService.documentMapperParser();
+        Mapper.TypeParser.ParserContext parserContext = documentMapperParser.parserContext();
+        StringFieldMapper.Builder builder = new StringFieldMapper.Builder("test");
+        Map<String, Object> map = new HashMap<>();
+        int numValues = randomIntBetween(0, 10);
+        for (int i = 0; i < numValues; i++) {
+            map.put("random_key_" + i, "" + i);
+        }
+        final boolean hasAnalyzer = randomBoolean();
+        if (hasAnalyzer) {
+            map.put("analyzer", "whitespace");
+        }
+        final boolean hasIndexAnalyzer = randomBoolean();
+        if (hasIndexAnalyzer) {
+            map.put("index_analyzer", "stop");
+        }
+        final boolean hasSearchAnalyzer = randomBoolean();
+        if (hasSearchAnalyzer) {
+            map.put("search_analyzer", "simple");
+        }
+
+        TypeParsers.parseField(builder, "Test", map, parserContext);
+        StringFieldMapper build = builder.build(new Mapper.BuilderContext(ImmutableSettings.EMPTY, new ContentPath()));
+        NamedAnalyzer index = (NamedAnalyzer) build.indexAnalyzer();
+        NamedAnalyzer search = (NamedAnalyzer) build.searchAnalyzer();
+        if (hasSearchAnalyzer) {
+            assertEquals(search.name(), "simple");
+        }
+        if (hasIndexAnalyzer) {
+            assertEquals(index.name(), "stop");
+        }
+        if (hasAnalyzer && hasIndexAnalyzer == false) {
+            assertEquals(index.name(), "whitespace");
+        }
+        if (hasAnalyzer && hasSearchAnalyzer == false) {
+            assertEquals(search.name(), "whitespace");
+        }
+    }
+
+    public void testAnalyzerOrderAllSet() {
+        IndexService test = createIndex("test");
+        MapperService mapperService = test.mapperService();
+        DocumentMapperParser documentMapperParser = mapperService.documentMapperParser();
+        Mapper.TypeParser.ParserContext parserContext = documentMapperParser.parserContext();
+        StringFieldMapper.Builder builder = new StringFieldMapper.Builder("test");
+        Map<String, Object> map = new HashMap<>();
+        map.put("analyzer", "whitespace");
+        map.put("index_analyzer", "stop");
+        map.put("search_analyzer", "simple");
+
+        TypeParsers.parseField(builder, "Test", map, parserContext);
+        StringFieldMapper build = builder.build(new Mapper.BuilderContext(ImmutableSettings.EMPTY, new ContentPath()));
+        NamedAnalyzer index = (NamedAnalyzer) build.indexAnalyzer();
+        NamedAnalyzer search = (NamedAnalyzer) build.searchAnalyzer();
+        assertEquals(search.name(), "simple");
+        assertEquals(index.name(), "stop");
+    }
+
+    public void testAnalyzerOrderUseDefaultForIndex() {
+        IndexService test = createIndex("test");
+        MapperService mapperService = test.mapperService();
+        DocumentMapperParser documentMapperParser = mapperService.documentMapperParser();
+        Mapper.TypeParser.ParserContext parserContext = documentMapperParser.parserContext();
+        StringFieldMapper.Builder builder = new StringFieldMapper.Builder("test");
+        Map<String, Object> map = new HashMap<>();
+        int numValues = randomIntBetween(0, 10);
+        for (int i = 0; i < numValues; i++) {
+            map.put("random_key_" + i, "" + i);
+        }
+        map.put("analyzer", "whitespace");
+        map.put("search_analyzer", "simple");
+
+        TypeParsers.parseField(builder, "Test", map, parserContext);
+        StringFieldMapper build = builder.build(new Mapper.BuilderContext(ImmutableSettings.EMPTY, new ContentPath()));
+        NamedAnalyzer index = (NamedAnalyzer) build.indexAnalyzer();
+        NamedAnalyzer search = (NamedAnalyzer) build.searchAnalyzer();
+        assertEquals(search.name(), "simple");
+        assertEquals(index.name(), "whitespace");
+    }
+
+    public void testAnalyzerOrderUseDefaultForSearch() {
+        IndexService test = createIndex("test");
+        MapperService mapperService = test.mapperService();
+        DocumentMapperParser documentMapperParser = mapperService.documentMapperParser();
+        Mapper.TypeParser.ParserContext parserContext = documentMapperParser.parserContext();
+        StringFieldMapper.Builder builder = new StringFieldMapper.Builder("test");
+        Map<String, Object> map = new HashMap<>();
+        int numValues = randomIntBetween(0, 10);
+        for (int i = 0; i < numValues; i++) {
+            map.put("random_key_" + i, "" + i);
+        }
+        map.put("analyzer", "whitespace");
+        map.put("index_analyzer", "simple");
+
+        TypeParsers.parseField(builder, "Test", map, parserContext);
+        StringFieldMapper build = builder.build(new Mapper.BuilderContext(ImmutableSettings.EMPTY, new ContentPath()));
+        NamedAnalyzer index = (NamedAnalyzer) build.indexAnalyzer();
+        NamedAnalyzer search = (NamedAnalyzer) build.searchAnalyzer();
+        assertEquals(search.name(), "whitespace");
+        assertEquals(index.name(), "simple");
+    }
+
+    public void testAnalyzerOrder() {
+        IndexService test = createIndex("test");
+        MapperService mapperService = test.mapperService();
+        DocumentMapperParser documentMapperParser = mapperService.documentMapperParser();
+        Mapper.TypeParser.ParserContext parserContext = documentMapperParser.parserContext();
+        StringFieldMapper.Builder builder = new StringFieldMapper.Builder("test");
+        Map<String, Object> map = new HashMap<>();
+        int numValues = randomIntBetween(0, 10);
+        for (int i = 0; i < numValues; i++) {
+            map.put("random_key_" + i, "" + i);
+        }
+        map.put("analyzer", "whitespace");
+
+        TypeParsers.parseField(builder, "Test", map, parserContext);
+        StringFieldMapper build = builder.build(new Mapper.BuilderContext(ImmutableSettings.EMPTY, new ContentPath()));
+        NamedAnalyzer index = (NamedAnalyzer) build.indexAnalyzer();
+        NamedAnalyzer search = (NamedAnalyzer) build.searchAnalyzer();
+        assertEquals(search.name(), "whitespace");
+        assertEquals(index.name(), "whitespace");
+    }
+}


### PR DESCRIPTION
Today in the 1.x series `search_analyzer` or `index_analyzer` will be
overwritten by `analyzer` dependent on the hash map interation order. if
the `analyzer` key comes last all previously set analzyers are lost.
This commit removes the ambigutiy such that `search_analyzer` is always used
if specified.

Closes #14023 

Note: This PR is against branch `1.7` and this issue is already fixed in `2.x` and `master`
