### PR TITLE
Allow tests to run from eclipse on windows

### DIFF
--- a/core/src/test/java/org/elasticsearch/bootstrap/JarHellTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/JarHellTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.bootstrap;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -334,5 +335,23 @@ public class JarHellTests extends ESTestCase {
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("should not contain empty elements"));
         }
+    }
+
+    /**
+     * Make sure a "bogus" windows classpath element is accepted, java's classpath parsing accepts it,
+     * therefore eclipse OSGI code does it :)
+     */
+    public void testCrazyEclipseClassPathWindows() throws Exception {
+        assumeTrue("test is designed for windows-like systems only", ";".equals(System.getProperty("path.separator")));
+        assumeTrue("test is designed for windows-like systems only", "\\".equals(System.getProperty("file.separator")));
+
+        URL expected[] = {
+            PathUtils.get("c:\\element1").toUri().toURL(),
+            PathUtils.get("c:\\element2").toUri().toURL(),
+            PathUtils.get("c:\\element3").toUri().toURL(),
+            PathUtils.get("c:\\element 4").toUri().toURL(),
+        };
+        URL actual[] = JarHell.parseClassPath("c:\\element1;c:\\element2;/c:/element3;/c:/element 4");
+        assertArrayEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Eclipse appends "invalid"-looking classpath entries when running tests, see the last two entries in this example:

```
<other stuff>;C:\Users\dweiss\.m2\repository\commons-logging\commons-logging\1.1.3\commons-logging-1.1.3.jar;C:\Users\dweiss\.m2\repository\commons-codec\commons-codec\1.6\commons-codec-1.6.jar;/C:/Tools/eclipse/Luna/configuration/org.eclipse.osgi/633/0/.cp/;/C:/Tools/eclipse/Luna/configuration/org.eclipse.osgi/632/0/.cp/
```

It is easy to discard this as "invalid stuff eclipse is doing" but java accepts classpath entries like this (it is not clear this is intentional), therefore things like eclipse do it.

Currently anyone trying to run tests from eclipse on windows will get an exception from jarhell with root cause like `java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Tools/eclipse/Luna/configuration/org.eclipse.osgi/633/0/.cp/`

Unfortunately 2.0 is affected, @dweiss discovered this while doing some plugin development with the RC. 
