### PR TITLE
Never wrap searcher for internal engine operations

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -284,6 +284,10 @@ public abstract class Engine implements Closeable {
      * @see Searcher#close()
      */
     public final Searcher acquireSearcher(String source) throws EngineException {
+        return acquireSearcher(source, true);
+    }
+
+    protected final Searcher acquireSearcher(String source, boolean maybeWrap) throws EngineException {
         boolean success = false;
          /* Acquire order here is store -> manager since we need
           * to make sure that the store is not closed before
@@ -296,8 +300,9 @@ public abstract class Engine implements Closeable {
             final IndexSearcher searcher = manager.acquire();
             try {
                 final Searcher retVal = newSearcher(source, searcher, manager);
+                final Searcher wrappedSearcher = maybeWrap ? config().getWrappingService().wrap(engineConfig, retVal) : retVal;
                 success = true;
-                return config().getWrappingService().wrap(engineConfig, retVal);
+                return wrappedSearcher;
             } finally {
                 if (!success) {
                     manager.release(searcher);
@@ -356,7 +361,7 @@ public abstract class Engine implements Closeable {
      */
     public final SegmentsStats segmentsStats() {
         ensureOpen();
-        try (final Searcher searcher = acquireSearcher("segments_stats")) {
+        try (final Searcher searcher = acquireSearcher("segments_stats", false)) {
             SegmentsStats stats = new SegmentsStats();
             for (LeafReaderContext reader : searcher.reader().leaves()) {
                 final SegmentReader segmentReader = segmentReader(reader.reader());
@@ -387,7 +392,7 @@ public abstract class Engine implements Closeable {
         Map<String, Segment> segments = new HashMap<>();
 
         // first, go over and compute the search ones...
-        Searcher searcher = acquireSearcher("segments");
+        Searcher searcher = acquireSearcher("segments", false);
         try {
             for (LeafReaderContext reader : searcher.reader().leaves()) {
                 SegmentCommitInfo info = segmentReader(reader.reader()).getSegmentInfo();

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1023,7 +1023,7 @@ public class InternalEngine extends Engine {
     }
 
     private long loadCurrentVersionFromIndex(Term uid) throws IOException {
-        try (final Searcher searcher = acquireSearcher("load_version")) {
+        try (final Searcher searcher = acquireSearcher("load_version", false)) {
             return Versions.loadVersion(searcher.reader(), uid);
         }
     }


### PR DESCRIPTION
there is no need to wrap the searcher for internal operations like version
checks for indexing. In-fact this can even lead to crazy bugs if the wrapper
filters documents that are updated etc. such that we end up with either duplicated docs
if create is used or we update wrong version under certain conditions.

Note: master doesn't have this particular problem since it wraps searchers on the `IndexShard` level
