### PR TITLE
Remove unused clear(IndexReader) method from IndexFieldData

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -107,12 +107,10 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
      */
     void clear();
 
-    void clear(IndexReader reader);
-
     // we need this extended source we we have custom comparators to reuse our field data
     // in this case, we need to reduce type that will be used when search results are reduced
     // on another node (we don't have the custom source them...)
-    public abstract class XFieldComparatorSource extends FieldComparatorSource {
+    abstract class XFieldComparatorSource extends FieldComparatorSource {
 
         /**
          * Simple wrapper class around a filter that matches parent documents

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataCache.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataCache.java
@@ -45,8 +45,6 @@ public interface IndexFieldDataCache {
      */
     void clear(String fieldName);
 
-    void clear(IndexReader reader);
-
     interface Listener {
 
         /**
@@ -79,10 +77,6 @@ public interface IndexFieldDataCache {
 
         @Override
         public void clear(String fieldName) {
-        }
-
-        @Override
-        public void clear(IndexReader reader) {
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -89,11 +89,6 @@ public abstract class GlobalOrdinalsIndexFieldData extends AbstractIndexComponen
     }
 
     @Override
-    public void clear(IndexReader reader) {
-        // no need to clear, because this is cached and cleared in AbstractBytesIndexFieldData
-    }
-
-    @Override
     public long ramBytesUsed() {
         return memorySizeInBytes;
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexFieldData.java
@@ -65,11 +65,6 @@ public abstract class AbstractIndexFieldData<FD extends AtomicFieldData> extends
     }
 
     @Override
-    public void clear(IndexReader reader) {
-        cache.clear(reader);
-    }
-
-    @Override
     public FD load(LeafReaderContext context) {
         if (context.reader().getFieldInfos().fieldInfo(fieldNames.indexName()) == null) {
             // If the field doesn't exist, then don't bother with loading and adding an empty instance to the field data cache

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
@@ -112,10 +112,6 @@ public class IndexIndexFieldData extends AbstractIndexOrdinalsFieldData {
     }
 
     @Override
-    public void clear(IndexReader reader) {
-    }
-
-    @Override
     public final AtomicOrdinalsFieldData load(LeafReaderContext context) {
         return atomicFieldData;
     }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/ParentChildIndexFieldData.java
@@ -332,11 +332,6 @@ public class ParentChildIndexFieldData extends AbstractIndexFieldData<AtomicPare
         }
 
         @Override
-        public void clear(IndexReader reader) {
-            ParentChildIndexFieldData.this.clear(reader);
-        }
-
-        @Override
         public Index index() {
             return ParentChildIndexFieldData.this.index();
         }

--- a/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -227,12 +227,6 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
             // soon as possible
             cache.refresh();
         }
-
-        @Override
-        public void clear(IndexReader indexReader) {
-            cache.invalidate(new Key(this, indexReader.getCoreCacheKey(), null));
-            // don't call cache.cleanUp here as it would have bad performance implications
-        }
     }
 
     public static class Key {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/NoOrdinalsStringFieldDataTests.java
@@ -70,11 +70,6 @@ public class NoOrdinalsStringFieldDataTests extends PagedBytesStringFieldDataTes
                 in.clear();
             }
 
-            @Override
-            public void clear(IndexReader reader) {
-                in.clear(reader);
-            }
-
         };
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
@@ -129,11 +129,6 @@ public class FunctionScoreTests extends ESTestCase {
         }
 
         @Override
-        public void clear(IndexReader reader) {
-            throw new UnsupportedOperationException(UNSUPPORTED);
-        }
-
-        @Override
         public Index index() {
             throw new UnsupportedOperationException(UNSUPPORTED);
         }
@@ -224,11 +219,6 @@ public class FunctionScoreTests extends ESTestCase {
 
         @Override
         public void clear() {
-            throw new UnsupportedOperationException(UNSUPPORTED);
-        }
-
-        @Override
-        public void clear(IndexReader reader) {
             throw new UnsupportedOperationException(UNSUPPORTED);
         }
 


### PR DESCRIPTION
This method is unused can can simply be removed. It's rather confusing
instead since it's another way of invalidating a cache entry but not through
the close listener.
