### PR TITLE
Update to maven-assembly-plugin 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
+                    <version>2.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- [https://issues.apache.org/jira/browse/MASSEMBLY-780](MASSEMBLY-780): Snappy supported

Unsure if we want to push it in 2.0 as well.
