### PR TITLE
fix numerical issue in function score query

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -225,7 +225,8 @@ public class FiltersFunctionScoreQuery extends Query {
             }
 
             FiltersFunctionFactorScorer scorer = (FiltersFunctionFactorScorer)scorer(context);
-            scorer.advance(doc);
+            int actualDoc = scorer.advance(doc);
+            assert (actualDoc == doc);
             double score = scorer.computeScore(doc, subQueryExpl.getValue());
             Explanation factorExplanation = Explanation.match(
                     CombineFunction.toFloat(score),

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -207,19 +207,11 @@ public class FiltersFunctionScoreQuery extends Query {
             }
             // First: Gather explanations for all filters
             List<Explanation> filterExplanations = new ArrayList<>();
-            float weightSum = 0;
             for (int i = 0; i < filterFunctions.length; ++i) {
-                FilterFunction filterFunction = filterFunctions[i];
-
-                if (filterFunction.function instanceof WeightFactorFunction) {
-                    weightSum += ((WeightFactorFunction) filterFunction.function).getWeight();
-                } else {
-                    weightSum++;
-                }
-
                 Bits docSet = Lucene.asSequentialAccessBits(context.reader().maxDoc(),
                         filterWeights[i].scorer(context));
                 if (docSet.get(doc)) {
+                    FilterFunction filterFunction = filterFunctions[i];
                     Explanation functionExplanation = filterFunction.function.getLeafScoreFunction(context).explainScore(doc, subQueryExpl);
                     double factor = functionExplanation.getValue();
                     float sc = CombineFunction.toFloat(factor);
@@ -232,44 +224,11 @@ public class FiltersFunctionScoreQuery extends Query {
                 return subQueryExpl;
             }
 
-            // Second: Compute the factor that would have been computed by the
-            // filters
-            double factor = 1.0;
-            switch (scoreMode) {
-            case FIRST:
-                factor = filterExplanations.get(0).getValue();
-                break;
-            case MAX:
-                factor = Double.NEGATIVE_INFINITY;
-                for (Explanation filterExplanation : filterExplanations) {
-                    factor = Math.max(filterExplanation.getValue(), factor);
-                }
-                break;
-            case MIN:
-                factor = Double.POSITIVE_INFINITY;
-                for (Explanation filterExplanation : filterExplanations) {
-                    factor = Math.min(filterExplanation.getValue(), factor);
-                }
-                break;
-            case MULTIPLY:
-                for (Explanation filterExplanation : filterExplanations) {
-                    factor *= filterExplanation.getValue();
-                }
-                break;
-            default:
-                double totalFactor = 0.0f;
-                for (Explanation filterExplanation : filterExplanations) {
-                    totalFactor += filterExplanation.getValue();
-                }
-                if (weightSum != 0) {
-                    factor = totalFactor;
-                    if (scoreMode == ScoreMode.AVG) {
-                        factor /= weightSum;
-                    }
-                }
-            }
+            FiltersFunctionFactorScorer scorer = (FiltersFunctionFactorScorer)scorer(context);
+            scorer.advance(doc);
+            double score = scorer.computeScore(doc, subQueryExpl.getValue());
             Explanation factorExplanation = Explanation.match(
-                    CombineFunction.toFloat(factor),
+                    CombineFunction.toFloat(score),
                     "function score, score mode [" + scoreMode.toString().toLowerCase(Locale.ROOT) + "]",
                     filterExplanations);
             return combineFunction.explain(subQueryExpl, factorExplanation, maxBoost);
@@ -296,11 +255,16 @@ public class FiltersFunctionScoreQuery extends Query {
         @Override
         public float innerScore() throws IOException {
             int docId = scorer.docID();
-            double factor = 1.0f;
             // Even if the weight is created with needsScores=false, it might
             // be costly to call score(), so we explicitly check if scores
             // are needed
             float subQueryScore = needsScores ? scorer.score() : 0f;
+            double factor = computeScore(docId, subQueryScore);
+            return scoreCombiner.combine(subQueryScore, factor, maxBoost);
+        }
+
+        protected double computeScore(int docId, float subQueryScore) {
+            double factor = 1d;
             switch(scoreMode) {
                 case FIRST:
                     for (int i = 0; i < filterFunctions.length; i++) {
@@ -360,7 +324,7 @@ public class FiltersFunctionScoreQuery extends Query {
                     }
                     break;
             }
-            return scoreCombiner.combine(subQueryScore, factor, maxBoost);
+            return factor;
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FiltersFunctionScoreQuery.java
@@ -341,14 +341,14 @@ public class FiltersFunctionScoreQuery extends Query {
                     break;
                 default: // Avg / Total
                     double totalFactor = 0.0f;
-                    float weightSum = 0;
+                    double weightSum = 0;
                     for (int i = 0; i < filterFunctions.length; i++) {
                         if (docSets[i].get(docId)) {
                             totalFactor += functions[i].score(docId, subQueryScore);
                             if (filterFunctions[i].function instanceof WeightFactorFunction) {
-                                weightSum+= ((WeightFactorFunction)filterFunctions[i].function).getWeight();
+                                weightSum += ((WeightFactorFunction) filterFunctions[i].function).getWeight();
                             } else {
-                                weightSum++;
+                                weightSum += 1.0;
                             }
                         }
                     }

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
@@ -48,6 +48,7 @@ import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class FunctionScoreTests extends ESTestCase {
@@ -396,17 +397,25 @@ public class FunctionScoreTests extends ESTestCase {
     }
 
     private static float[] randomFloats(int size) {
-        float[] weights = new float[size];
-        for (int i = 0; i < weights.length; i++) {
-            weights[i] = randomFloat() * (randomBoolean() ? 1.0f : -1.0f) * randomInt(100) + 1.e-5f;
+        float[] values = new float[size];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = randomFloat() * (randomBoolean() ? 1.0f : -1.0f) * randomInt(100) + 1.e-5f;
         }
-        return weights;
+        return values;
+    }
+
+    private static double[] randomDoubles(int size) {
+        double[] values = new double[size];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = randomDouble() * (randomBoolean() ? 1.0d : -1.0d) * randomInt(100) + 1.e-5d;
+        }
+        return values;
     }
 
     private static class ScoreFunctionStub extends ScoreFunction {
-        private float score;
+        private double score;
 
-        ScoreFunctionStub(float score) {
+        ScoreFunctionStub(double score) {
             super(CombineFunction.REPLACE);
             this.score = score;
         }
@@ -441,7 +450,7 @@ public class FunctionScoreTests extends ESTestCase {
     public void simpleWeightedFunctionsTest() throws IOException, ExecutionException, InterruptedException {
         int numFunctions = randomIntBetween(1, 3);
         float[] weights = randomFloats(numFunctions);
-        float[] scores = randomFloats(numFunctions);
+        double[] scores = randomDoubles(numFunctions);
         ScoreFunctionStub[] scoreFunctionStubs = new ScoreFunctionStub[numFunctions];
         for (int i = 0; i < numFunctions; i++) {
             scoreFunctionStubs[i] = new ScoreFunctionStub(scores[i]);
@@ -463,7 +472,7 @@ public class FunctionScoreTests extends ESTestCase {
         for (int i = 0; i < weights.length; i++) {
             score *= weights[i] * scores[i];
         }
-        assertThat(scoreWithWeight / score, closeTo(1, 1.e-5d));
+        assertThat(scoreWithWeight / (float) score, is(1f));
 
         filtersFunctionScoreQueryWithWeights = getFiltersFunctionScoreQuery(
                 FiltersFunctionScoreQuery.ScoreMode.SUM
@@ -477,7 +486,7 @@ public class FunctionScoreTests extends ESTestCase {
         for (int i = 0; i < weights.length; i++) {
             sum += weights[i] * scores[i];
         }
-        assertThat(scoreWithWeight / sum, closeTo(1, 1.e-5d));
+        assertThat(scoreWithWeight / (float) sum, is(1f));
 
         filtersFunctionScoreQueryWithWeights = getFiltersFunctionScoreQuery(
                 FiltersFunctionScoreQuery.ScoreMode.AVG
@@ -493,7 +502,7 @@ public class FunctionScoreTests extends ESTestCase {
             norm += weights[i];
             sum += weights[i] * scores[i];
         }
-        assertThat(scoreWithWeight * norm / sum, closeTo(1, 1.e-5d));
+        assertThat(scoreWithWeight / (float) (sum / norm), is(1f));
 
         filtersFunctionScoreQueryWithWeights = getFiltersFunctionScoreQuery(
                 FiltersFunctionScoreQuery.ScoreMode.MIN
@@ -507,7 +516,7 @@ public class FunctionScoreTests extends ESTestCase {
         for (int i = 0; i < weights.length; i++) {
             min = Math.min(min, weights[i] * scores[i]);
         }
-        assertThat(scoreWithWeight / min, closeTo(1, 1.e-5d));
+        assertThat(scoreWithWeight / (float) min, is(1f));
 
         filtersFunctionScoreQueryWithWeights = getFiltersFunctionScoreQuery(
                 FiltersFunctionScoreQuery.ScoreMode.MAX
@@ -521,7 +530,7 @@ public class FunctionScoreTests extends ESTestCase {
         for (int i = 0; i < weights.length; i++) {
             max = Math.max(max, weights[i] * scores[i]);
         }
-        assertThat(scoreWithWeight / max, closeTo(1, 1.e-5d));
+        assertThat(scoreWithWeight / (float) max, is(1f));
     }
 
     @Test


### PR DESCRIPTION
we should sum the weights as double to not lose precision. also,
the tests should simulate exactly what function score does and then test
for equality of scores.

Also, while at it I changed the same thing for explain. 
FiltersFunctionScoreQuery sums up scores and weights and scores as double but when
we explain we cannot get the double scores from the explanation of score
functions. as a result we cannot compute the exact score from the explanations
of the functions alone.
this commit makes the explanation more accurate but also causes the score to be
computed one additional time.
