### PR TITLE
Add methods for variable-length encoding integral arrays

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -460,11 +460,29 @@ public abstract class StreamInput extends InputStream {
         return values;
     }
 
+    public int[] readVIntArray() throws IOException {
+        int length = readVInt();
+        int[] values = new int[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = readVInt();
+        }
+        return values;
+    }
+
     public long[] readLongArray() throws IOException {
         int length = readVInt();
         long[] values = new long[length];
         for (int i = 0; i < length; i++) {
             values[i] = readLong();
+        }
+        return values;
+    }
+
+    public long[] readVLongArray() throws IOException {
+        int length = readVInt();
+        long[] values = new long[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = readVLong();
         }
         return values;
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -438,10 +438,24 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
+    public void writeVIntArray(int[] values) throws IOException {
+        writeVInt(values.length);
+        for (int value : values) {
+            writeVInt(value);
+        }
+    }
+
     public void writeLongArray(long[] values) throws IOException {
         writeVInt(values.length);
         for (long value : values) {
             writeLong(value);
+        }
+    }
+
+    public void writeVLongArray(long[] values) throws IOException {
+        writeVInt(values.length);
+        for (long value : values) {
+            writeVLong(value);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -276,8 +276,12 @@ public class BytesStreamsTests extends ESTestCase {
         out.writeDouble(2.2);
         int[] intArray = {1, 2, 3};
         out.writeGenericValue(intArray);
+        int[] vIntArray = {4, 5, 6};
+        out.writeVIntArray(vIntArray);
         long[] longArray = {1, 2, 3};
         out.writeGenericValue(longArray);
+        long[] vLongArray = {4, 5, 6};
+        out.writeVLongArray(vLongArray);
         float[] floatArray = {1.1f, 2.2f, 3.3f};
         out.writeGenericValue(floatArray);
         double[] doubleArray = {1.1, 2.2, 3.3};
@@ -296,7 +300,9 @@ public class BytesStreamsTests extends ESTestCase {
         assertThat((double)in.readFloat(), closeTo(1.1, 0.0001));
         assertThat(in.readDouble(), closeTo(2.2, 0.0001));
         assertThat(in.readGenericValue(), equalTo((Object) intArray));
+        assertThat(in.readVIntArray(), equalTo(vIntArray));
         assertThat(in.readGenericValue(), equalTo((Object)longArray));
+        assertThat(in.readVLongArray(), equalTo(vLongArray));
         assertThat(in.readGenericValue(), equalTo((Object)floatArray));
         assertThat(in.readGenericValue(), equalTo((Object)doubleArray));
         assertThat(in.readString(), equalTo("hello"));


### PR DESCRIPTION
This commit adds methods to serialize the elements of int and long
arrays using variable-length encodings. This can be useful for
serializing int and long arrays containing mostly non-negative “not
large” values in a compressed form.
