### PR TITLE
fix access denied for shard deletion with WindowsFS

### DIFF
--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
@@ -152,29 +152,23 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
     }
 
     protected void assertIndexDirectoryDeleted(final String nodeName, final String indexName) throws Exception {
-        assertBusy(new Runnable() {
-                       @Override
-                       public void run() {
-                           logger.info("checking if index directory exists...");
-                           assertFalse("Expecting index directory of " + indexName + " to be deleted from node " + nodeName, indexDirectoryExists(nodeName, indexName));
-                       }
-                   }
+        assertBusy(() -> {
+            logger.info("checking if index directory exists...");
+            assertFalse("Expecting index directory of " + indexName + " to be deleted from node " + nodeName, indexDirectoryExists(nodeName, indexName));
+        }
         );
     }
 
     protected void assertIndexInMetaState(final String nodeName, final String indexName) throws Exception {
-        assertBusy(new Runnable() {
-                       @Override
-                       public void run() {
-                           logger.info("checking if meta state exists...");
-                           try {
-                               assertTrue("Expecting meta state of index " + indexName + " to be on node " + nodeName, getIndicesMetaDataOnNode(nodeName).containsKey(indexName));
-                           } catch (Throwable t) {
-                               logger.info("failed to load meta state", t);
-                               fail("could not load meta state");
-                           }
-                       }
-                   }
+        assertBusy(() -> {
+            logger.info("checking if meta state exists...");
+            try {
+                assertTrue("Expecting meta state of index " + indexName + " to be on node " + nodeName, getIndicesMetaDataOnNode(nodeName).containsKey(indexName));
+            } catch (Throwable t) {
+                logger.info("failed to load meta state", t);
+                fail("could not load meta state");
+            }
+        }
         );
     }
 

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
@@ -155,13 +155,8 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
         assertBusy(new Runnable() {
                        @Override
                        public void run() {
-                           logger.info("checking if meta state exists...");
-                           try {
-                               assertFalse("Expecting index directory of " + indexName + " to be deleted from node " + nodeName, indexDirectoryExists(nodeName, indexName));
-                           } catch (Exception e) {
-                               logger.info("failed to check for data director of index {} on node {}", indexName, nodeName);
-                               fail("could not check if data directory still exists");
-                           }
+                           logger.info("checking if index directory exists...");
+                           assertFalse("Expecting index directory of " + indexName + " to be deleted from node " + nodeName, indexDirectoryExists(nodeName, indexName));
                        }
                    }
         );
@@ -184,7 +179,7 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
     }
 
 
-    private boolean indexDirectoryExists(String nodeName, String indexName) throws Exception {
+    private boolean indexDirectoryExists(String nodeName, String indexName) {
         NodeEnvironment nodeEnv = ((InternalTestCluster) cluster()).getInstance(NodeEnvironment.class, nodeName);
         for (Path path : nodeEnv.indexPaths(new Index(indexName))) {
             if (Files.exists(path)) {


### PR DESCRIPTION
We randomly use the WindowsFS mock file system to simulate that
windows does not delete files if they are opened by some other
process and instead gives you java.io.IOException: access denied.
In the tests we also check if the shard was deleted while it is
being deleted. This check loads the mata data of the index
and therefore might hold on to a file while the node
is trying to delete it and deletion will fail then.

Instead we should just check if the directory was removed.

closes #13758
