### PR TITLE
Avoid deadlocks in Cache#computeIfAbsent

### DIFF
--- a/core/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/core/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -394,12 +394,12 @@ public class CacheTests extends ESTestCase {
     // randomly replace some entries, increasing the weight by 1 for each replacement, then count that the cache size
     // is correct
     public void testReplaceRecomputesSize() {
-        class Key {
-            private int key;
+        class Value {
+            private String value;
             private long weight;
 
-            public Key(int key, long weight) {
-                this.key = key;
+            public Value(String value, long weight) {
+                this.value = value;
                 this.weight = weight;
             }
 
@@ -408,20 +408,20 @@ public class CacheTests extends ESTestCase {
                 if (this == o) return true;
                 if (o == null || getClass() != o.getClass()) return false;
 
-                Key key1 = (Key) o;
+                Value that = (Value) o;
 
-                return key == key1.key;
+                return value == that.value;
 
             }
 
             @Override
             public int hashCode() {
-                return key;
+                return value.hashCode();
             }
         }
-        Cache<Key, String> cache = CacheBuilder.<Key, String>builder().weigher((k, s) -> k.weight).build();
+        Cache<Integer, Value> cache = CacheBuilder.<Integer, Value>builder().weigher((k, s) -> s.weight).build();
         for (int i = 0; i < numberOfEntries; i++) {
-            cache.put(new Key(i, 1), Integer.toString(i));
+            cache.put(i, new Value(Integer.toString(i), 1));
         }
         assertEquals(numberOfEntries, cache.count());
         assertEquals(numberOfEntries, cache.weight());
@@ -429,7 +429,7 @@ public class CacheTests extends ESTestCase {
         for (int i = 0; i < numberOfEntries; i++) {
             if (rarely()) {
                 replaced++;
-                cache.put(new Key(i, 2), Integer.toString(i));
+                cache.put(i, new Value(Integer.toString(i), 2));
             }
         }
         assertEquals(numberOfEntries, cache.count());


### PR DESCRIPTION
This commit changes the behavior of Cache#computeIfAbsent to not invoke
load for a key under the segment lock. Instead, the synchronization
mechanism to ensure that load is invoked at most once per key is
through the use of a future. Under the segment lock, we put a future in
the cache and through this ensure that load is invoked at most once per
key. This will not lead to the same deadlock situation as before
because a dependent key load on the same thread can not be triggered
while the segment lock is held.

Closes #14090
