### PR TITLE
Added link to Swagger for Elasticsearch

### DIFF
--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -298,6 +298,7 @@ deprecated[1.5.0,Rivers have been deprecated.  See https://www.elastic.co/blog/d
 * https://github.com/polyfractal/elasticsearch-segmentspy[SegmentSpy Plugin] (by Zachary Tong)
 * https://github.com/xyu/elasticsearch-whatson[Whatson Plugin] (by Xiao Yu)
 * https://github.com/lmenezes/elasticsearch-kopf[Kopf Plugin] (by lmenezes)
+* https://github.com/timschlechter/swagger-for-elasticsearch[Swagger for Elasticsearch] (by Tim Schlechter)
 
 [float]
 [[repository-plugins]]


### PR DESCRIPTION
I wrote this plugin a couple of months ago and have been using it since. I received some messages from people using it and finding it actually useful to discover the API's. Is it suitable to add it to this page?

The plugin supports Swagger 1.2 docs for Elasticsearch 0.90 and up
