### PR TITLE
Added link to Swagger for Elasticsearch

### DIFF
--- a/docs/plugins/management.asciidoc
+++ b/docs/plugins/management.asciidoc
@@ -37,6 +37,7 @@ A number of plugins have been contributed by our community:
 * https://github.com/andrewvc/elastic-hammer[Hammer Plugin] (by Andrew Cholakian)
 * https://github.com/polyfractal/elasticsearch-inquisitor[Inquisitor Plugin] (by Zachary Tong)
 * https://github.com/lmenezes/elasticsearch-kopf[Kopf Plugin] (by lmenezes)
+* https://github.com/timschlechter/swagger-for-elasticsearch[Swagger for Elasticsearch] (by Tim Schlechter)
 
 These community plugins appear to have been abandoned:
 


### PR DESCRIPTION
This PR is a follow up of #14093

> I wrote this plugin a couple of months ago and have been using it since. I received some messages from people using it and finding it actually useful to discover the API's. Is it suitable to add it to this page?
> 
> The plugin supports Swagger 1.2 docs for Elasticsearch 0.90 and up
