### PR TITLE
Resync Geopoint hashCode/equals method

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -30,8 +30,7 @@ public final class GeoPoint {
 
     private double lat;
     private double lon;
-    private final static double TOLERANCE = XGeoUtils.TOLERANCE;
-    
+
     public GeoPoint() {
     }
 
@@ -126,14 +125,10 @@ public final class GeoPoint {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        final GeoPoint geoPoint = (GeoPoint) o;
-        final double lonCompare = geoPoint.lon - lon;
-        final double latCompare = geoPoint.lat - lat;
+        GeoPoint geoPoint = (GeoPoint) o;
 
-        if ((lonCompare < -TOLERANCE || lonCompare > TOLERANCE)
-                || (latCompare < -TOLERANCE || latCompare > TOLERANCE)) {
-            return false;
-        }
+        if (Double.compare(geoPoint.lat, lat) != 0) return false;
+        if (Double.compare(geoPoint.lon, lon) != 0) return false;
 
         return true;
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/MissingValueIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/MissingValueIT.java
@@ -41,6 +41,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+import static org.hamcrest.Matchers.closeTo;
 
 @ESIntegTestCase.SuiteScopeTestCase
 public class MissingValueIT extends ESIntegTestCase {
@@ -198,7 +199,8 @@ public class MissingValueIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("idx").addAggregation(geoCentroid("centroid").field("location").missing("2,1")).get();
         assertSearchResponse(response);
         GeoCentroid centroid = response.getAggregations().get("centroid");
-        assertEquals(new GeoPoint(1.5, 1.5), centroid.centroid());
+        GeoPoint point = new GeoPoint(1.5, 1.5);
+        assertThat(point.lat(), closeTo(centroid.centroid().lat(), 1E-5));
+        assertThat(point.lon(), closeTo(centroid.centroid().lon(), 1E-5));
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -68,6 +68,7 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
     protected static GeoPoint singleTopLeft, singleBottomRight, multiTopLeft, multiBottomRight, singleCentroid, multiCentroid, unmappedCentroid;
     protected static ObjectIntMap<String> expectedDocCountsForGeoHash = null;
     protected static ObjectObjectMap<String, GeoPoint> expectedCentroidsForGeoHash = null;
+    protected static final double GEOHASH_TOLERANCE = 1E-5D;
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -84,7 +84,8 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
         assertThat(geoCentroid, notNullValue());
         assertThat(geoCentroid.getName(), equalTo(aggName));
         GeoPoint centroid = geoCentroid.centroid();
-        assertThat(centroid, equalTo(singleCentroid));
+        assertThat(centroid.lat(), closeTo(singleCentroid.lat(), GEOHASH_TOLERANCE));
+        assertThat(centroid.lon(), closeTo(singleCentroid.lon(), GEOHASH_TOLERANCE));
     }
 
     @Test
@@ -99,7 +100,8 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
         assertThat(geoCentroid, notNullValue());
         assertThat(geoCentroid.getName(), equalTo(aggName));
         GeoPoint centroid = geoCentroid.centroid();
-        assertThat(centroid, equalTo(singleCentroid));
+        assertThat(centroid.lat(), closeTo(singleCentroid.lat(), GEOHASH_TOLERANCE));
+        assertThat(centroid.lon(), closeTo(singleCentroid.lon(), GEOHASH_TOLERANCE));
     }
 
     @Test
@@ -122,10 +124,12 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
         assertThat(geoCentroid.getName(), equalTo(aggName));
         assertThat((GeoCentroid) global.getProperty(aggName), sameInstance(geoCentroid));
         GeoPoint centroid = geoCentroid.centroid();
-        assertThat(centroid, equalTo(singleCentroid));
-        assertThat((GeoPoint) global.getProperty(aggName + ".value"), equalTo(singleCentroid));
-        assertThat((double) global.getProperty(aggName + ".lat"), closeTo(singleCentroid.lat(), 1e-5));
-        assertThat((double) global.getProperty(aggName + ".lon"), closeTo(singleCentroid.lon(), 1e-5));
+        assertThat(centroid.lat(), closeTo(singleCentroid.lat(), GEOHASH_TOLERANCE));
+        assertThat(centroid.lon(), closeTo(singleCentroid.lon(), GEOHASH_TOLERANCE));
+        assertThat(((GeoPoint) global.getProperty(aggName + ".value")).lat(), closeTo(singleCentroid.lat(), GEOHASH_TOLERANCE));
+        assertThat(((GeoPoint) global.getProperty(aggName + ".value")).lon(), closeTo(singleCentroid.lon(), GEOHASH_TOLERANCE));
+        assertThat((double) global.getProperty(aggName + ".lat"), closeTo(singleCentroid.lat(), GEOHASH_TOLERANCE));
+        assertThat((double) global.getProperty(aggName + ".lon"), closeTo(singleCentroid.lon(), GEOHASH_TOLERANCE));
     }
 
     @Test
@@ -140,7 +144,8 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
         assertThat(geoCentroid, notNullValue());
         assertThat(geoCentroid.getName(), equalTo(aggName));
         GeoPoint centroid = geoCentroid.centroid();
-        assertThat(centroid, equalTo(multiCentroid));
+        assertThat(centroid.lat(), closeTo(multiCentroid.lat(), GEOHASH_TOLERANCE));
+        assertThat(centroid.lon(), closeTo(multiCentroid.lon(), GEOHASH_TOLERANCE));
     }
 
     @Test
@@ -160,7 +165,10 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
             String geohash = cell.getKeyAsString();
             GeoPoint expectedCentroid = expectedCentroidsForGeoHash.get(geohash);
             GeoCentroid centroidAgg = cell.getAggregations().get(aggName);
-            assertEquals("Geohash " + geohash + " has wrong centroid ", expectedCentroid, centroidAgg.centroid());
+            assertThat("Geohash " + geohash + " has wrong centroid latitude ", expectedCentroid.lat(),
+                    closeTo(centroidAgg.centroid().lat(), GEOHASH_TOLERANCE));
+            assertThat("Geohash " + geohash + " has wrong centroid longitude", expectedCentroid.lon(),
+                    closeTo(centroidAgg.centroid().lon(), GEOHASH_TOLERANCE));
         }
     }
 }


### PR DESCRIPTION
`Geopoint.equals` was modified to consider two points equal if they are within a threshold. This change was done to accept round-off error introduced from GeoHash encoding methods. This PR removes this trappy leniency from `GeoPoint.equals` and instead forces round-off error to be handled at the encoding source. It also fixes the broken contract between the `GeoPoint.hashCode` and `.equals` methods raised in #14083 

closes #14083
