### PR TITLE
Give a better exception when running from freebsd jail without enforce_statfs=1

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/ESFileStore.java
+++ b/core/src/main/java/org/elasticsearch/env/ESFileStore.java
@@ -84,7 +84,18 @@ class ESFileStore extends FileStore {
             return getFileStoreWindows(path, fileStores);
         }
         
-        FileStore store = Files.getFileStore(path);
+        final FileStore store;
+        try {
+            store = Files.getFileStore(path);
+        } catch (IOException unexpected) {
+            // give a better error message if a filestore cannot be retrieved from inside a FreeBSD jail.
+            if (Constants.FREE_BSD) {
+                throw new IOException("Unable to retrieve mount point data for " + path +
+                                      ". If you are running within a jail, set enforce_statfs=1. See jail(8)", unexpected);
+            } else {
+                throw unexpected;
+            }
+        }
 
         try {
             String mount = getMountPointLinux(store);

--- a/core/src/main/java/org/elasticsearch/env/Environment.java
+++ b/core/src/main/java/org/elasticsearch/env/Environment.java
@@ -304,6 +304,7 @@ public class Environment {
      *       no permissions to the actual mount point are required.
      *   <li>Exception handling has the same semantics as {@link Files#getFileStore(Path)}.
      *   <li>Works around https://bugs.openjdk.java.net/browse/JDK-8034057.
+     *   <li>Gives a better exception when filestore cannot be retrieved from inside a FreeBSD jail.
      * </ul>
      */
     public static FileStore getFileStore(Path path) throws IOException {


### PR DESCRIPTION
We can't track disk usage in this situation, failing is the correct thing to do.
But we can give a FreeBSD-specific error message, so the user can set the
necessary jail parameters, versus a vague IOException.

Closes #12018
