### PR TITLE
Names of indexRouting and searchRouting infos are out of date.

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -7,7 +7,7 @@ including filter and routing infos.
 [source,sh]
 --------------------------------------------------
 % curl '192.168.56.10:9200/_cat/aliases?v'
-alias  index filter indexRouting searchRouting
+alias  index filter routing.index routing.search
 alias2 test1 *      -            -
 alias4 test1 -      2            1,2
 alias1 test1 -      -            -


### PR DESCRIPTION
Hi,

I belive indexRouting should be changed to routing.index and searchRouting to routing.search.
This is what my ES 2.0.0-rc1 instance returns when I hit cat alias api:

![image](https://cloud.githubusercontent.com/assets/2392583/10525856/6b27b198-7387-11e5-81f2-3f4df799fbca.png)

Let me know if I should change other versions of documentation for this issue as well(Looks to me like it always was incorrect in docs).

PS: @clintongormley thanks for pointing right repo :+1: 
