### PR TITLE
Allow parser to move on the START_OBJECT token when parsing search source

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -697,9 +697,9 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
 
     public SearchSourceBuilder fromXContent(XContentParser parser, QueryParseContext context) throws IOException {
         SearchSourceBuilder builder = new SearchSourceBuilder();
-        XContentParser.Token token;
+        XContentParser.Token token = parser.currentToken();
         String currentFieldName = null;
-        if ((token = parser.nextToken()) != XContentParser.Token.START_OBJECT) {
+        if (token != XContentParser.Token.START_OBJECT && (token = parser.nextToken()) != XContentParser.Token.START_OBJECT) {
             throw new ParsingException(parser.getTokenLocation(), "Expected [" + XContentParser.Token.START_OBJECT + "] but found [" + token + "]",
                     parser.getTokenLocation());
         }

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -302,7 +302,12 @@ public class SearchSourceBuilderTests extends ESTestCase {
 
     private void assertParseSearchSource(SearchSourceBuilder testBuilder, String builderAsString) throws IOException {
         XContentParser parser = XContentFactory.xContent(builderAsString).createParser(builderAsString);
-        SearchSourceBuilder newBuilder = SearchSourceBuilder.parseSearchSource(parser, createParseContext(parser));
+        QueryParseContext parseContext = createParseContext(parser);
+        parseContext.reset(parser);
+        if (randomBoolean()) {
+            parser.nextToken(); // sometimes we move it on the START_OBJECT to test the embedded case
+        }
+        SearchSourceBuilder newBuilder = SearchSourceBuilder.parseSearchSource(parser, parseContext);
         assertNotSame(testBuilder, newBuilder);
         assertEquals(testBuilder, newBuilder);
         assertEquals(testBuilder.hashCode(), newBuilder.hashCode());


### PR DESCRIPTION
Currently we require parser to be right before the sources START_OBJECT
but if we are parsing embedded search sources this won't work since we potentially
moved already on to the START_OBJECT. This commit make this optional such that
both ways work.
