### PR TITLE
Running tests with Gradle fails when path to project contains spaces

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/randomizedtesting/RandomizedTestingTask.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/randomizedtesting/RandomizedTestingTask.groovy
@@ -187,13 +187,13 @@ class RandomizedTestingTask extends DefaultTask {
                 pathElement(path: classpath.asPath)
             }
             if (enableAssertions) {
-                jvmarg(line: '-ea')
+                jvmarg(value: '-ea')
             }
             if (enableSystemAssertions) {
-                jvmarg(line: '-esa')
+                jvmarg(value: '-esa')
             }
             for (String arg : jvmArgs) {
-                jvmarg(line: arg)
+                jvmarg(value: arg)
             }
             fileset(dir: testClassesDir) {
                 for (String includePattern : patternSet.getIncludes()) {


### PR DESCRIPTION
To reproduce error, clone `elasticsearch` repo into folder with spaces and run `gradle test`.
