### PR TITLE
Fix a quick documentation typo.

### DIFF
--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -194,7 +194,7 @@ It returns a list of nodes where repository was successfully verified or an erro
 [float]
 === Snapshot
 
-A repository can contain multiple snapshots of the same cluster. Snapshot are identified by unique names within the
+A repository can contain multiple snapshots of the same cluster. Snapshots are identified by unique names within the
 cluster. A snapshot with the name `snapshot_1` in the repository `my_backup` can be created by executing the following
 command:
 


### PR DESCRIPTION
Fix the object of the sentence to agree with the plural verb.
