### PR TITLE
Startup script exit status should catch daemonized startup failures

### DIFF
--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -64,6 +64,7 @@ export ES_HEAP_NEWSIZE
 export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
 export ES_GC_LOG_FILE
+export ES_STARTUP_SLEEP_TIME
 export JAVA_HOME
 
 lockfile=/var/lock/subsys/$prog

--- a/distribution/src/main/packaging/env/elasticsearch
+++ b/distribution/src/main/packaging/env/elasticsearch
@@ -50,6 +50,9 @@
 #ES_USER=${packaging.elasticsearch.user}
 #ES_GROUP=${packaging.elasticsearch.group}
 
+# The number of seconds to wait before checking if Elasticsearch started successfully as a daemon process
+ES_STARTUP_SLEEP_TIME=${packaging.elasticsearch.startup.sleep.time}
+
 ################################
 # System properties
 ################################

--- a/distribution/src/main/packaging/packaging.properties
+++ b/distribution/src/main/packaging/packaging.properties
@@ -19,6 +19,9 @@ packaging.os.max.open.files=65535
 # Maximum number of VMA (Virtual Memory Areas) a process can own
 packaging.os.max.map.count=262144
 
+# Default number of seconds to wait before checking if Elasticsearch started successfully as a daemon process
+packaging.elasticsearch.startup.sleep.time=5
+
 # Simple marker to check that properties are correctly overridden
 packaging.type=tar.gz
 

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -142,6 +142,16 @@ if [ -z "$daemonized" ] ; then
 else
     exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" \
           org.elasticsearch.bootstrap.Elasticsearch start "$@" <&- &
+    retval=$?
+    pid=$!
+    [ $retval -eq 0 ] || exit $retval
+    if [ ! -z "$ES_STARTUP_SLEEP_TIME" ]; then
+      sleep $ES_STARTUP_SLEEP_TIME
+    fi
+    if ! ps -p $pid > /dev/null ; then
+      exit 1
+    fi
+    exit 0
 fi
 
 exit $?


### PR DESCRIPTION
This commit fixes an issue where when starting Elasticsearch in
daemonized mode, a failed startup would not cause a non-zero exit code
to be returned. This can prevent the SysV init system from detecting
startup failures.

Closes #14163
