### PR TITLE
The boost keyword changed to bool

### DIFF
--- a/docs/reference/query-dsl/geo-distance-range-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-range-query.asciidoc
@@ -6,7 +6,7 @@ Filters documents that exists within a range from a specific point:
 [source,js]
 --------------------------------------------------
 {
-    "boost" : {
+    "bool" : {
         "must" : {
             "match_all" : {}
         },


### PR DESCRIPTION
There is no query registered for boost, so changing it to bool query. Tested it and it works fine. For example
{
  "query": {
    "bool": {
      "must": {
        "match_all": {}
      },
      "filter": {
        "geo_distance_range": {
          "from": "100km",
          "to": "400km",
          "location": [77.42,28.67]
        }
      }
    }
  }
}

Please review and merge.
