### PR TITLE
Update surefire to 2.19, checkstyle to 2.17, clean to 3.0.0, shade to 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,7 +767,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
+                    <version>2.19</version>
                     <configuration>
                         <skip>true</skip>
                     </configuration>
@@ -1264,7 +1264,7 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.15</version>
+                    <version>2.17</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -888,7 +888,7 @@
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.4.1</version>
+                    <version>2.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# Release notes for maven-surefire-plugin 2.19:
- new parser of test patterns, let's call it Test Filter API, related to
  parameters: test, ex/includes, ex/includesFile;
- a feature to interrupting the test-set after exceedded certain number of
  errors/failures
- new Doxia Version
- anchoring test class names
- shutdown operations
- command based communication between in-plugin and forked process
- improvements in JUnit and TestNG runners
- etc.

See http://www.mail-archive.com/announce@maven.apache.org/msg00710.html for details.
# Release notes for maven-checkstyle-plugin 2.17:
## Bug
- [MCHECKSTYLE-302] - Using inline configuration does not work with Maven 2.2.1
- [MCHECKSTYLE-304] - Using inline configuration, checkstyle-checker.xml is generated using DTD v1.2
- [MCHECKSTYLE-310] - Parrallel build failing with various errors
- [MCHECKSTYLE-311] - "mvn clean site -Preporting" fails with Could not find resource 'config/maven_checks.xml'
## Improvement
- [MCHECKSTYLE-291] - Change format of violation message
- [MCHECKSTYLE-293] - Update to use non deprecated method Checker.setClassLoader()
## Task
- [MCHECKSTYLE-307] - Upgrade to Checkstyle 6.11
- [MCHECKSTYLE-313] - Upgrade to Checkstyle 6.11.2
# Release Notes - Apache Maven Clean Plugin  Version 3.0.0

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317224&version=12330417
## Improvements:
- [MCLEAN-56] - Make Plugin only 3.X compatible - get rid of Maven 2.
- [MCLEAN-62] - Upgrade to maven-plugins parent version 27
- [MCLEAN-63] - Make naming of properties consistent
- [MCLEAN-65] - Bump version to 3.0.0
- [MCLEAN-66] - Upgrade maven-shared-utils to 0.9
- [MCLEAN-67] - Change package name to org.apache.maven.plugins
- [MCLEAN-69] - Upgrade maven-shared-utils to 3.0.0
# Release Notes - Apache Maven Shade Plugin  Version 2.4.2

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317921&version=12333008
## Bugs:
- [MSHADE-172] - "java.lang.ArithmeticException: / by zero" in MinijarFilter
- [MSHADE-190] - Shade does not relocate the contents of META-INF/services files
- [MSHADE-209] - [REGRESSION] "java.lang.ArithmeticException: / by zero" in MinijarFilter (reporter Jon McLean).
## Improvements:
- [MSHADE-205] - Better use of ClazzpathUnit for improved jar minimization (contribution of Benoit Perrot).
- [MSHADE-207] - Replace wrong link to codehaus with correct location
- [MSHADE-210] - Upgrade maven-plugins parent to version 28.
- [MSHADE-211] - Keep Java 1.5
