### PR TITLE
Drop ability to execute on Solaris

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
@@ -45,7 +45,7 @@ public final class BootstrapInfo {
     }
     
     /**
-     * Returns true if secure computing mode is enabled (linux/amd64, OS X only)
+     * Returns true if secure computing mode is enabled (supported systems only)
      */
     public static boolean isSeccompInstalled() {
         return Natives.isSeccompInstalled();


### PR DESCRIPTION
This is very simple to do and recommended by `privileges(5)` documentation:

```
Daemons that never need to exec subprocesses should remove the PRIV_PROC_EXEC privilege from their permitted and limit sets.
```
