### PR TITLE
restructure processors / addField for Data

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/Data.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/Data.java
@@ -47,7 +47,7 @@ public final class Data {
         return (T) XContentMapValues.extractValue(path, document);
     }
 
-    public void addField(String field, String value) {
+    public void addField(String field, Object value) {
         modified = true;
         document.put(field, value);
     }

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -20,6 +20,8 @@
 
 package org.elasticsearch.ingest;
 
+import org.elasticsearch.ingest.processor.Processor;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/Processor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/Processor.java
@@ -18,7 +18,9 @@
  */
 
 
-package org.elasticsearch.ingest;
+package org.elasticsearch.ingest.processor;
+
+import org.elasticsearch.ingest.Data;
 
 import java.util.Map;
 

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/simple/SimpleProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/simple/SimpleProcessor.java
@@ -17,7 +17,10 @@
  * under the License.
  */
 
-package org.elasticsearch.ingest;
+package org.elasticsearch.ingest.processor.simple;
+
+import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.processor.Processor;
 
 import java.util.Map;
 

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestModule.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestModule.java
@@ -21,8 +21,8 @@ package org.elasticsearch.plugin.ingest;
 
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
-import org.elasticsearch.ingest.Processor;
-import org.elasticsearch.ingest.SimpleProcessor;
+import org.elasticsearch.ingest.processor.Processor;
+import org.elasticsearch.ingest.processor.simple.SimpleProcessor;
 import org.elasticsearch.plugin.ingest.rest.IngestRestFilter;
 
 import java.util.HashMap;

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineStore.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineStore.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.ingest.Pipeline;
-import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.ingest.processor.Processor;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.threadpool.ThreadPool;
 

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.ingest;
 
 import org.elasticsearch.plugin.ingest.IngestPlugin;
-import org.elasticsearch.plugin.ingest.PipelineStore;
 import org.elasticsearch.plugin.ingest.transport.delete.DeletePipelineAction;
 import org.elasticsearch.plugin.ingest.transport.delete.DeletePipelineRequestBuilder;
 import org.elasticsearch.plugin.ingest.transport.delete.DeletePipelineResponse;
@@ -33,11 +32,9 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
 import static org.hamcrest.Matchers.*;
 
 public class IngestClientIT extends ESIntegTestCase {

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineExecutionServiceTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineExecutionServiceTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.plugin.ingest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.ingest.Data;
 import org.elasticsearch.ingest.Pipeline;
-import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.ingest.processor.Processor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.StringText;
-import org.elasticsearch.ingest.SimpleProcessor;
+import org.elasticsearch.ingest.processor.simple.SimpleProcessor;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.internal.InternalSearchHit;
 import org.elasticsearch.test.ESTestCase;

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilterTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilterTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.ingest.Data;
 import org.elasticsearch.ingest.Pipeline;
-import org.elasticsearch.ingest.SimpleProcessor;
+import org.elasticsearch.ingest.processor.simple.SimpleProcessor;
 import org.elasticsearch.plugin.ingest.IngestPlugin;
 import org.elasticsearch.plugin.ingest.PipelineExecutionService;
 import org.elasticsearch.plugin.ingest.PipelineStore;


### PR DESCRIPTION
This Commit does the following:
- moves processors into their own sub-packages
- adds ability to add any typed field value into Data

the idea is that each processor will have their own utility classes and keeping them 
contained within a single subpackage for that processor will make traversing the 
ingest directory nicer.
