### PR TITLE
Deprecate NotQueryBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/NotQueryBuilder.java
@@ -26,7 +26,9 @@ import java.util.Objects;
 
 /**
  * A filter that matches documents matching boolean combinations of other filters.
+ * @deprecated Use {@link BoolQueryBuilder#mustNot(QueryBuilder)} instead
  */
+@Deprecated
 public class NotQueryBuilder extends QueryBuilder {
 
     private final QueryBuilder filter;

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -684,7 +684,7 @@ public abstract class QueryBuilders {
     public static GeohashCellQuery.Builder geoHashCellQuery(String name, String geohash, boolean neighbors) {
         return new GeohashCellQuery.Builder(name, geohash, neighbors);
     }
-    
+
     /**
      * A filter to filter based on a polygon defined by a set of locations  / points.
      *
@@ -773,6 +773,10 @@ public abstract class QueryBuilders {
         return new MissingQueryBuilder(name);
     }
 
+    /**
+     * @deprecated use {@link #boolQuery()} and add a mustNot clause instead
+     */
+    @Deprecated
     public static NotQueryBuilder notQuery(QueryBuilder filter) {
         return new NotQueryBuilder(filter);
     }

--- a/docs/java-api/query-dsl/not-query.asciidoc
+++ b/docs/java-api/query-dsl/not-query.asciidoc
@@ -1,6 +1,8 @@
 [[java-query-dsl-not-query]]
 ==== Not Query
 
+deprecated[2.1.0, Use `boolQuery()` with added `mustNot()` clause instead]
+
 See {ref}/query-dsl-not-query.html[Not Query]
 
 

--- a/docs/reference/query-dsl/not-query.asciidoc
+++ b/docs/reference/query-dsl/not-query.asciidoc
@@ -1,6 +1,8 @@
 [[query-dsl-not-query]]
 === Not Query
 
+deprecated[2.1.0, Use the `bool` query with `must_not` clause instead]
+
 A query that filters out matched documents using a query. For example:
 
 [source,js]


### PR DESCRIPTION
This PR deprecates the use of NotQueryBuilder like we
did with And- and OrQueryBuilder before. BooleanQueryBuilder 
is now the only way to combine several filters together, so all 
uses of the not filter can be replaced
with a must_not clause.

Relates to #13761 
