### PR TITLE
Remove cache concurrency level settings that no longer apply

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/cache/request/IndicesRequestCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/cache/request/IndicesRequestCache.java
@@ -79,7 +79,6 @@ public class IndicesRequestCache extends AbstractComponent implements RemovalLis
     @Deprecated
     public static final String DEPRECATED_INDICES_CACHE_QUERY_SIZE = "indices.cache.query.size";
     public static final String INDICES_CACHE_QUERY_EXPIRE = "indices.requests.cache.expire";
-    public static final String INDICES_CACHE_QUERY_CONCURRENCY_LEVEL = "indices.requests.cache.concurrency_level";
 
     private static final Set<SearchType> CACHEABLE_SEARCH_TYPES = EnumSet.of(SearchType.QUERY_THEN_FETCH, SearchType.QUERY_AND_FETCH);
 
@@ -96,7 +95,6 @@ public class IndicesRequestCache extends AbstractComponent implements RemovalLis
     //TODO make these changes configurable on the cluster level
     private final String size;
     private final TimeValue expire;
-    private final int concurrencyLevel;
 
     private volatile Cache<Key, Value> cache;
 
@@ -122,11 +120,6 @@ public class IndicesRequestCache extends AbstractComponent implements RemovalLis
         this.size = size;
 
         this.expire = settings.getAsTime(INDICES_CACHE_QUERY_EXPIRE, null);
-        // defaults to 4, but this is a busy map for all indices, increase it a bit by default
-        this.concurrencyLevel =  settings.getAsInt(INDICES_CACHE_QUERY_CONCURRENCY_LEVEL, 16);
-        if (concurrencyLevel <= 0) {
-            throw new IllegalArgumentException("concurrency_level must be > 0 but was: " + concurrencyLevel);
-        }
         buildCache();
 
         this.reaper = new Reaper();

--- a/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -55,7 +55,6 @@ import java.util.function.ToLongBiFunction;
 public class IndicesFieldDataCache extends AbstractComponent implements RemovalListener<IndicesFieldDataCache.Key, Accountable> {
 
     public static final String FIELDDATA_CLEAN_INTERVAL_SETTING = "indices.fielddata.cache.cleanup_interval";
-    public static final String FIELDDATA_CACHE_CONCURRENCY_LEVEL = "indices.fielddata.cache.concurrency_level";
     public static final String INDICES_FIELDDATA_CACHE_SIZE_KEY = "indices.fielddata.cache.size";
 
 

--- a/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -479,10 +479,6 @@ public final class InternalTestCluster extends TestCluster {
         }
 
         if (random.nextBoolean()) {
-            builder.put(IndicesRequestCache.INDICES_CACHE_QUERY_CONCURRENCY_LEVEL, RandomInts.randomIntBetween(random, 1, 32));
-            builder.put(IndicesFieldDataCache.FIELDDATA_CACHE_CONCURRENCY_LEVEL, RandomInts.randomIntBetween(random, 1, 32));
-        }
-        if (random.nextBoolean()) {
             builder.put(NettyTransport.PING_SCHEDULE, RandomInts.randomIntBetween(random, 100, 2000) + "ms");
         }
 

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -312,3 +312,9 @@ For simplicity, only one way of adding the ids to the existing list (empty by de
 `DocumentAlreadyExistsException` is removed and a `VersionConflictException` is thrown instead (with a better
 error description). This will influence code that use the `IndexRequest.opType()` or `IndexRequest.create()`
 to index a document only if it doesn't already exist.
+
+=== Cache concurrency level settings removed
+
+Two cache concurrency level settings `indices.requests.cache.concurrency_level` and
+`indices.fielddata.cache.concurrency_level` because they no longer apply to the cache implementation used for the
+request cache and the field data cache.


### PR DESCRIPTION
This commit removes some cache concurrency level settings that were
applicable when the cache was backed by the Guava cache implementation,
but no longer apply with the cache implementation completed in #13717.

Relates #7836, relates #13224, relates #13717
