### PR TITLE
Use built-in method for computing hash code of longs

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -234,7 +234,7 @@ public class MultiGetRequest extends ActionRequest<MultiGetRequest> implements I
             result = 31 * result + id.hashCode();
             result = 31 * result + (routing != null ? routing.hashCode() : 0);
             result = 31 * result + (fields != null ? Arrays.hashCode(fields) : 0);
-            result = 31 * result + (int) (version ^ (version >>> 32));
+            result = 31 * result + Long.hashCode(version);
             result = 31 * result + versionType.hashCode();
             result = 31 * result + (fetchSourceContext != null ? fetchSourceContext.hashCode() : 0);
             return result;

--- a/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -152,7 +152,7 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
             result = 31 * result + shards.hashCode();
             result = 31 * result + indices.hashCode();
             result = 31 * result + waitingIndices.hashCode();
-            result = 31 * result + (int) (startTime ^ (startTime >>> 32));
+            result = 31 * result + Long.hashCode(startTime);
             return result;
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -654,7 +654,7 @@ public final class ShardRouting implements Streamable, ToXContent {
         result = 31 * result + (relocatingNodeId != null ? relocatingNodeId.hashCode() : 0);
         result = 31 * result + (primary ? 1 : 0);
         result = 31 * result + (state != null ? state.hashCode() : 0);
-        result = 31 * result + (int) (version ^ (version >>> 32));
+        result = 31 * result + Long.hashCode(version);
         result = 31 * result + (restoreSource != null ? restoreSource.hashCode() : 0);
         result = 31 * result + (allocationId != null ? allocationId.hashCode() : 0);
         result = 31 * result + (unassignedInfo != null ? unassignedInfo.hashCode() : 0);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -311,7 +311,7 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
     @Override
     public int hashCode() {
         int result = reason != null ? reason.hashCode() : 0;
-        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = 31 * result + Long.hashCode(timestamp);
         result = 31 * result + (message != null ? message.hashCode() : 0);
         result = 31 * result + (failure != null ? failure.hashCode() : 0);
         return result;

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -138,9 +138,9 @@ public final class GeoPoint {
         int result;
         long temp;
         temp = lat != +0.0d ? Double.doubleToLongBits(lat) : 0L;
-        result = (int) (temp ^ (temp >>> 32));
+        result = Long.hashCode(temp);
         temp = lon != +0.0d ? Double.doubleToLongBits(lon) : 0L;
-        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + Long.hashCode(temp);
         return result;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -259,7 +259,7 @@ public class ByteSizeValue implements Streamable {
 
     @Override
     public int hashCode() {
-        int result = (int) (size ^ (size >>> 32));
+        int result = Long.hashCode(size);
         result = 31 * result + (sizeUnit != null ? sizeUnit.hashCode() : 0);
         return result;
     }

--- a/core/src/main/java/org/elasticsearch/common/unit/SizeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/SizeValue.java
@@ -228,7 +228,7 @@ public class SizeValue implements Streamable {
 
     @Override
     public int hashCode() {
-        int result = (int) (size ^ (size >>> 32));
+        int result = Long.hashCode(size);
         result = 31 * result + (sizeUnit != null ? sizeUnit.hashCode() : 0);
         return result;
     }

--- a/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -311,7 +311,7 @@ public class TimeValue implements Streamable {
     @Override
     public int hashCode() {
         long normalized = timeUnit.toNanos(duration);
-        return (int) (normalized ^ (normalized >>> 32));
+        return Long.hashCode(normalized);
     }
 
     public static long nsecToMSec(long ns) {

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionBuilder.java
@@ -131,6 +131,6 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
     }
 
     private static int hash(long value) {
-        return (int) (value ^ (value >>> 32));
+        return Long.hashCode(value);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeQuery.java
@@ -204,13 +204,13 @@ public class GeoDistanceRangeQuery extends Query {
         int result = super.hashCode();
         long temp;
         temp = lat != +0.0d ? Double.doubleToLongBits(lat) : 0L;
-        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + Long.hashCode(temp);
         temp = lon != +0.0d ? Double.doubleToLongBits(lon) : 0L;
-        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + Long.hashCode(temp);
         temp = inclusiveLowerPoint != +0.0d ? Double.doubleToLongBits(inclusiveLowerPoint) : 0L;
-        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + Long.hashCode(temp);
         temp = inclusiveUpperPoint != +0.0d ? Double.doubleToLongBits(inclusiveUpperPoint) : 0L;
-        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + Long.hashCode(temp);
         result = 31 * result + (geoDistance != null ? geoDistance.hashCode() : 0);
         result = 31 * result + indexFieldData.getFieldNames().indexName().hashCode();
         return result;

--- a/core/src/main/java/org/elasticsearch/index/shard/ShardStateMetaData.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardStateMetaData.java
@@ -75,7 +75,7 @@ public final class ShardStateMetaData {
 
     @Override
     public int hashCode() {
-        int result = (int) (version ^ (version >>> 32));
+        int result = Long.hashCode(version);
         result = 31 * result + (indexUUID != null ? indexUUID.hashCode() : 0);
         result = 31 * result + (primary ? 1 : 0);
         return result;

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -746,8 +746,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         @Override
         public int hashCode() {
-            int result = (int) (generation ^ (generation >>> 32));
-            result = 31 * result + (int) (translogLocation ^ (translogLocation >>> 32));
+            int result = Long.hashCode(generation);
+            result = 31 * result + Long.hashCode(translogLocation);
             result = 31 * result + size;
             return result;
         }
@@ -1005,13 +1005,13 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         public int hashCode() {
             int result = id.hashCode();
             result = 31 * result + type.hashCode();
-            result = 31 * result + (int) (version ^ (version >>> 32));
+            result = 31 * result + Long.hashCode(version);
             result = 31 * result + versionType.hashCode();
             result = 31 * result + source.hashCode();
             result = 31 * result + (routing != null ? routing.hashCode() : 0);
             result = 31 * result + (parent != null ? parent.hashCode() : 0);
-            result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
-            result = 31 * result + (int) (ttl ^ (ttl >>> 32));
+            result = 31 * result + Long.hashCode(timestamp);
+            result = 31 * result + Long.hashCode(ttl);
             return result;
         }
 
@@ -1119,7 +1119,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         @Override
         public int hashCode() {
             int result = uid.hashCode();
-            result = 31 * result + (int) (version ^ (version >>> 32));
+            result = 31 * result + Long.hashCode(version);
             result = 31 * result + versionType.hashCode();
             return result;
         }

--- a/core/src/main/java/org/elasticsearch/indices/cache/request/IndicesRequestCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/cache/request/IndicesRequestCache.java
@@ -344,7 +344,7 @@ public class IndicesRequestCache extends AbstractComponent implements RemovalLis
         @Override
         public int hashCode() {
             int result = shard.hashCode();
-            result = 31 * result + (int) (readerVersion ^ (readerVersion >>> 32));
+            result = 31 * result + Long.hashCode(readerVersion);
             result = 31 * result + value.hashCode();
             return result;
         }
@@ -379,7 +379,7 @@ public class IndicesRequestCache extends AbstractComponent implements RemovalLis
         @Override
         public int hashCode() {
             int result = indexShard.hashCode();
-            result = 31 * result + (int) (readerVersion ^ (readerVersion >>> 32));
+            result = 31 * result + Long.hashCode(readerVersion);
             return result;
         }
     }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -690,8 +690,8 @@ public class RecoveryState implements ToXContent, Streamable {
         @Override
         public int hashCode() {
             int result = name.hashCode();
-            result = 31 * result + (int) (length ^ (length >>> 32));
-            result = 31 * result + (int) (recovered ^ (recovered >>> 32));
+            result = 31 * result + Long.hashCode(length);
+            result = 31 * result + Long.hashCode(recovered);
             result = 31 * result + (reused ? 1 : 0);
             return result;
         }

--- a/core/src/main/java/org/elasticsearch/snapshots/Snapshot.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/Snapshot.java
@@ -227,7 +227,7 @@ public class Snapshot implements Comparable<Snapshot>, ToXContent, FromXContentB
     @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + (int) (startTime ^ (startTime >>> 32));
+        result = 31 * result + Long.hashCode(startTime);
         return result;
     }
 

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -489,9 +489,9 @@ public class MetaDataStateFormatTests extends ESTestCase {
             long temp;
             result = string.hashCode();
             result = 31 * result + aInt;
-            result = 31 * result + (int) (aLong ^ (aLong >>> 32));
+            result = 31 * result + Long.hashCode(aLong);
             temp = Double.doubleToLongBits(aDouble);
-            result = 31 * result + (int) (temp ^ (temp >>> 32));
+            result = 31 * result + Long.hashCode(temp);
             result = 31 * result + (aBoolean ? 1 : 0);
             return result;
         }


### PR DESCRIPTION
This commit replaces instances of manually computing a hash code for
primitive longs by XORing the upper bits with the lower bits with a
built-in method for doing the same.
