### PR TITLE
Remove ActionFuture.getRootFailure()

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionFuture.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionFuture.java
@@ -37,10 +37,6 @@ public interface ActionFuture<T> extends Future<T> {
      * Similar to {@link #get()}, just catching the {@link InterruptedException} and throwing
      * an {@link IllegalStateException} instead. Also catches
      * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
-     * <p>
-     * Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
-     * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
-     * still accessible using {@link #getRootFailure()}.
      */
     T actionGet();
 
@@ -48,10 +44,6 @@ public interface ActionFuture<T> extends Future<T> {
      * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
      * an {@link IllegalStateException} instead. Also catches
      * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
-     * <p>
-     * Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
-     * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
-     * still accessible using {@link #getRootFailure()}.
      */
     T actionGet(String timeout);
 
@@ -59,10 +51,6 @@ public interface ActionFuture<T> extends Future<T> {
      * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
      * an {@link IllegalStateException} instead. Also catches
      * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
-     * <p>
-     * Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
-     * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
-     * still accessible using {@link #getRootFailure()}.
      *
      * @param timeoutMillis Timeout in millis
      */
@@ -72,10 +60,6 @@ public interface ActionFuture<T> extends Future<T> {
      * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
      * an {@link IllegalStateException} instead. Also catches
      * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
-     * <p>
-     * Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
-     * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
-     * still accessible using {@link #getRootFailure()}.
      */
     T actionGet(long timeout, TimeUnit unit);
 
@@ -83,16 +67,6 @@ public interface ActionFuture<T> extends Future<T> {
      * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
      * an {@link IllegalStateException} instead. Also catches
      * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
-     * <p>
-     * Note, the actual cause is unwrapped to the actual failure (for example, unwrapped
-     * from {@link org.elasticsearch.transport.RemoteTransportException}. The root failure is
-     * still accessible using {@link #getRootFailure()}.
      */
     T actionGet(TimeValue timeout);
-
-    /**
-     * The root (possibly) wrapped failure.
-     */
-    @Nullable
-    Throwable getRootFailure();
 }

--- a/core/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
+++ b/core/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
@@ -36,8 +36,6 @@ import java.util.concurrent.TimeoutException;
  */
 public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements ActionFuture<T>, ActionListener<L> {
 
-    private Throwable rootFailure;
-
     @Override
     public T actionGet() {
         try {
@@ -105,9 +103,4 @@ public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements
     }
 
     protected abstract T convert(L listenerResponse);
-
-    @Override
-    public Throwable getRootFailure() {
-        return rootFailure;
-    }
 }


### PR DESCRIPTION
`ActionFuture.getRootFailure()` is not used anywhere.
It has only a single (completely useless) implementation in `AdapterActionFuture`, returning a private field that is never assigned.
