### PR TITLE
Restore support for escaped '/' as part of document id

### DIFF
--- a/core/src/test/java/org/elasticsearch/plugins/SitePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/plugins/SitePluginIT.java
@@ -98,7 +98,7 @@ public class SitePluginIT extends ESIntegTestCase {
         notFoundUris.add("/_plugin/dummy/%2e%2e/%2e%2e/%2e%2e/%2e%2e/index.html");
         notFoundUris.add("/_plugin/dummy/%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2findex.html");
         notFoundUris.add("/_plugin/dummy/%2E%2E/%2E%2E/%2E%2E/%2E%2E/index.html");
-        notFoundUris.add("/_plugin/dummy/..\\..\\..\\..\\..\\log4j.properties");
+        notFoundUris.add("/_plugin/dummy/..%5C..%5C..%5C..%5C..%5Clog4j.properties");
 
         for (String uri : notFoundUris) {
             HttpResponse response = httpClient().path(uri).execute();

--- a/core/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/client/RestClient.java
@@ -230,8 +230,9 @@ public class RestClient implements Closeable {
             httpRequestBuilder.method(RandomizedTest.randomFrom(supportedMethods));
         }
 
-        //the http method is randomized (out of the available ones with the chosen api)
-        return httpRequestBuilder.path(RandomizedTest.randomFrom(restApi.getFinalPaths(pathParts)));
+        //the rest path to use is randomized out of the matching ones (if more than one)
+        RestPath restPath = RandomizedTest.randomFrom(restApi.getFinalPaths(pathParts));
+        return httpRequestBuilder.pathParts(restPath.getPathParts());
     }
 
     private RestApi restApi(String apiName) {

--- a/core/src/test/java/org/elasticsearch/test/rest/client/RestPath.java
+++ b/core/src/test/java/org/elasticsearch/test/rest/client/RestPath.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.client;
+
+import java.util.*;
+
+public class RestPath {
+    private final List<PathPart> parts;
+    private final List<String> placeholders;
+
+    public RestPath(List<String> parts) {
+        List<PathPart> pathParts = new ArrayList<>(parts.size());
+        for (String part : parts) {
+            pathParts.add(new PathPart(part, false));
+        }
+        this.parts = pathParts;
+        this.placeholders = Collections.emptyList();
+    }
+
+    public RestPath(String path) {
+        String[] pathParts = path.split("/");
+        List<String> placeholders = new ArrayList<>();
+        List<PathPart> parts = new ArrayList<>();
+        for (String pathPart : pathParts) {
+            if (pathPart.length() > 0) {
+                if (pathPart.startsWith("{")) {
+                    if (pathPart.indexOf('}') != pathPart.length() - 1) {
+                        throw new IllegalArgumentException("more than one parameter found in the same path part: [" + pathPart + "]");
+                    }
+                    String placeholder = pathPart.substring(1, pathPart.length() - 1);
+                    parts.add(new PathPart(placeholder, true));
+                    placeholders.add(placeholder);
+                } else {
+                    parts.add(new PathPart(pathPart, false));
+                }
+            }
+        }
+        this.placeholders = placeholders;
+        this.parts = parts;
+    }
+
+    public String[] getPathParts() {
+        String[] parts = new String[this.parts.size()];
+        int i = 0;
+        for (PathPart part : this.parts) {
+            parts[i++] = part.pathPart;
+        }
+        return parts;
+    }
+
+    public boolean matches(Set<String> params) {
+        return placeholders.size() == params.size() && placeholders.containsAll(params);
+    }
+
+    public RestPath replacePlaceholders(Map<String,String> params) {
+        List<String> finalPathParts = new ArrayList<>(parts.size());
+        for (PathPart pathPart : parts) {
+            if (pathPart.isPlaceholder) {
+                String value = params.get(pathPart.pathPart);
+                if (value == null) {
+                    throw new IllegalArgumentException("parameter [" + pathPart.pathPart + "] missing");
+                }
+                finalPathParts.add(value);
+            } else {
+                finalPathParts.add(pathPart.pathPart);
+            }
+        }
+        return new RestPath(finalPathParts);
+    }
+
+    private static class PathPart {
+        private final boolean isPlaceholder;
+        private final String pathPart;
+
+        private PathPart(String pathPart, boolean isPlaceholder) {
+            this.isPlaceholder = isPlaceholder;
+            this.pathPart = pathPart;
+        }
+    }
+}


### PR DESCRIPTION
With #13691 we introduced some custom logic to make sure that date math expressions like `<logstash-{now/D}>` don't get broken up into two where the slash appears in the expression. That said the only correct way to provide such a date math expression as part of the uri would be to properly escape the '/' instead. This fix also introduced a regression, as it would make sure that unescaped '/' are handled only in the case of date math expressions, but it removed support for properly escaped slashes anywhere else. The solution is to keep supporting escaped slashes only and require client libraries to properly escape them.

This commit reverts 93ad6969669e65db6ba7f35c375109e3f186675b and makes sure that our REST tests runner supports escaping of path parts, which was more involving than expected as each single part of the path needs to be properly escaped. I am not too happy with the current solution but it's the best I could do for now, maybe not that concerning anyway given that it's just test code. I do find uri encoding quite frustrating in java.

Relates to #13691
Relates to #13665

Closes #14177
