### PR TITLE
Check exception from query parsers for unknown field

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -130,8 +130,13 @@ public class GeoDistanceQueryParser implements QueryParser<GeoDistanceQueryBuild
                 } else if ("validation_method".equals(currentFieldName)) {
                     validationMethod = GeoValidationMethod.fromString(parser.text());
                 } else {
-                    point.resetFromString(parser.text());
-                    fieldName = currentFieldName;
+                    if (fieldName == null) {
+                        point.resetFromString(parser.text());
+                        fieldName = currentFieldName;
+                    } else {
+                        throw new ParsingException(parser.getTokenLocation(), "[" + GeoDistanceQueryBuilder.NAME +
+                                "] field name already set to [" + fieldName + "] but found [" + currentFieldName + "]");
+                    }
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/query/MatchNoneQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchNoneQueryBuilder.java
@@ -39,17 +39,13 @@ public class MatchNoneQueryBuilder extends AbstractQueryBuilder<MatchNoneQueryBu
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME);
+        printBoostAndQueryName(builder);
         builder.endObject();
     }
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         return Queries.newMatchNoDocsQuery();
-    }
-
-    @Override
-    protected void setFinalBoost(Query query) {
-        //no-op this query doesn't support boost
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/MatchNoneQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchNoneQueryParser.java
@@ -36,12 +36,28 @@ public class MatchNoneQueryParser implements QueryParser<MatchNoneQueryBuilder> 
     public MatchNoneQueryBuilder fromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
 
-        XContentParser.Token token = parser.nextToken();
-        if (token != XContentParser.Token.END_OBJECT) {
-            throw new ParsingException(parser.getTokenLocation(), "[match_none] query malformed");
+        String currentFieldName = null;
+        XContentParser.Token token;
+        String queryName = null;
+        float boost = AbstractQueryBuilder.DEFAULT_BOOST;
+        while (((token = parser.nextToken()) != XContentParser.Token.END_OBJECT && token != XContentParser.Token.END_ARRAY)) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if ("_name".equals(currentFieldName)) {
+                    queryName = parser.text();
+                } else if ("boost".equals(currentFieldName)) {
+                    boost = parser.floatValue();
+                } else {
+                    throw new ParsingException(parser.getTokenLocation(), "["+MatchNoneQueryBuilder.NAME+"] query does not support [" + currentFieldName + "]");
+                }
+            }
         }
 
-        return new MatchNoneQueryBuilder();
+        MatchNoneQueryBuilder matchNoneQueryBuilder = new MatchNoneQueryBuilder();
+        matchNoneQueryBuilder.boost(boost);
+        matchNoneQueryBuilder.queryName(queryName);
+        return matchNoneQueryBuilder;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TypeQueryParser.java
@@ -55,14 +55,16 @@ public class TypeQueryParser implements QueryParser<TypeQueryBuilder> {
                     boost = parser.floatValue();
                 } else if ("value".equals(currentFieldName)) {
                     type = parser.utf8Bytes();
+                } else {
+                    throw new ParsingException(parser.getTokenLocation(), "[" + TypeQueryBuilder.NAME + "] filter doesn't support [" + currentFieldName + "]");
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(), "[type] filter doesn't support [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "[" + TypeQueryBuilder.NAME + "] filter doesn't support [" + currentFieldName + "]");
             }
         }
 
         if (type == null) {
-            throw new ParsingException(parser.getTokenLocation(), "[type] filter needs to be provided with a value for the type");
+            throw new ParsingException(parser.getTokenLocation(), "[" + TypeQueryBuilder.NAME + "] filter needs to be provided with a value for the type");
         }
         return new TypeQueryBuilder(type)
                 .boost(boost)

--- a/core/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WrapperQueryParser.java
@@ -44,7 +44,7 @@ public class WrapperQueryParser implements QueryParser {
         }
         String fieldName = parser.currentName();
         if (!fieldName.equals("query")) {
-            throw new ParsingException(parser.getTokenLocation(), "[wrapper] query malformed");
+            throw new ParsingException(parser.getTokenLocation(), "[wrapper] query malformed, expected `query` but was" + fieldName);
         }
         parser.nextToken();
 

--- a/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ConstantScoreQueryBuilderTests.java
@@ -71,4 +71,9 @@ public class ConstantScoreQueryBuilderTests extends AbstractQueryTestCase<Consta
             // expected
         }
     }
+
+    @Override
+    public void testUnknownField() throws IOException {
+        assumeTrue("test doesn't apply for query filter queries", false);
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/MatchNoneQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchNoneQueryBuilderTests.java
@@ -27,20 +27,15 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class MatchNoneQueryBuilderTests extends AbstractQueryTestCase {
+public class MatchNoneQueryBuilderTests extends AbstractQueryTestCase<MatchNoneQueryBuilder> {
 
     @Override
-    protected boolean supportsBoostAndQueryName() {
-        return false;
-    }
-
-    @Override
-    protected AbstractQueryBuilder doCreateTestQueryBuilder() {
+    protected MatchNoneQueryBuilder doCreateTestQueryBuilder() {
         return new MatchNoneQueryBuilder();
     }
 
     @Override
-    protected void doAssertLuceneQuery(AbstractQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+    protected void doAssertLuceneQuery(MatchNoneQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses().size(), equalTo(0));

--- a/core/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.support.ToXContentToBytes;
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -100,6 +101,21 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
             fail("cannot be null or empty");
         } catch (IllegalArgumentException e) {
             // expected
+        }
+    }
+
+    /**
+     * Replace the generic test from superclass, wrapper query only expects
+     * to find `query` field with nested query and should throw exception for
+     * anything else.
+     */
+    @Override
+    public void testUnknownField() throws IOException {
+        try {
+            parseQuery("{ \"" + WrapperQueryBuilder.NAME + "\" : {\"bogusField\" : \"someValue\"} }");
+            fail("ParsingException expected.");
+        } catch (ParsingException e) {
+            assertTrue(e.getMessage().contains("bogusField"));
         }
     }
 }


### PR DESCRIPTION
Most query parsers throw a ParsingException when they trying to parse a field with an unknown name. This adds a generic check for this to the AbstractQueryTestCase so the behaviour
gets tested for all query parsers. The test works by first making sure the test query has a `boost` field and then changing this to an unknown field name and checking for an error.

There are exceptions to this for WrapperQueryBuilder and QueryFilterBuilder, because here the parser only expects the wrapped `query` element. MatchNoneQueryBuilder and MatchAllQueryBuilder so far had setters for boost() and queryName() but didn't render them, which is added here for
consistency.

GeoDistanceQuery, GeoDistanceRangeQuery and GeoHashCellQuery so far treat unknown field names in the json as the target field name of the center point of the query, which so far was handled by
overwriting points previously specified in the query. This is changed here so that an attempt to use two different field names to specify the central point of the query throws a ParsingException

Relates to #10974
