### PR TITLE
Restore previous optimize transport action name for bw comp

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.client.ElasticsearchClient;
 public class ForceMergeAction extends Action<ForceMergeRequest, ForceMergeResponse, ForceMergeRequestBuilder> {
 
     public static final ForceMergeAction INSTANCE = new ForceMergeAction();
-    public static final String NAME = "indices:admin/forcemerge";
+    public static final String NAME = "indices:admin/optimize";
 
     private ForceMergeAction() {
         super(NAME);


### PR DESCRIPTION
With #13778 we broke backwards compatibility on the transport layer in 2.x and 2.1 branches. We can potentially make breaking changes on the java api in 2.x when it comes to compile errors but we have to be careful with the transport layer. If we change a transport action name, it means that 2.0 won't be able to communicate with 2.1 for what concerns the optimize/forcemerge api.
