### PR TITLE
Fixed typo in range filter documentation

### DIFF
--- a/docs/reference/query-dsl/filters/range-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/range-filter.asciidoc
@@ -45,7 +45,7 @@ The `execution` option controls how the range filter internally executes. The `e
 
 In general for small ranges the `index` execution is faster and for longer ranges the `fielddata` execution is faster.
 
-The `fielddata` execution as the same suggests uses field data and therefore requires more memory, so make sure you have
+The `fielddata` execution as the name suggests uses field data and therefore requires more memory, so make sure you have
 sufficient memory on your nodes in order to use this execution mode. It usually makes sense to use it on fields  you're
 already faceting or sorting by.
 


### PR DESCRIPTION
The sentence:

"The `fielddata` execution as the same suggests uses field data and therefore requires more memory, so make sure you have sufficient memory on your nodes in order to use this execution mode." 

has a typo in it. The word "same" I believe should read "name".
