### PR TITLE
Map log-level 'trace' to JDK-Level 'FINEST'

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/logging/jdk/JdkESLogger.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/jdk/JdkESLogger.java
@@ -50,7 +50,7 @@ public class JdkESLogger extends AbstractESLogger {
         } else if ("debug".equalsIgnoreCase(level)) {
             logger.setLevel(Level.FINE);
         } else if ("trace".equalsIgnoreCase(level)) {
-            logger.setLevel(Level.FINE);
+            logger.setLevel(Level.FINEST);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/common/logging/jdk/JDKESLoggerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/logging/jdk/JDKESLoggerTests.java
@@ -91,6 +91,20 @@ public class JDKESLoggerTests extends ESTestCase {
         assertThat(record.getSourceMethodName(), equalTo("testLocationInfoTest"));
     }
 
+    public void testSetLogLevelString() {
+        // verify the string based level-setters
+        esTestLogger.setLevel("error");
+        assertThat(esTestLogger.getLevel(), equalTo("SEVERE"));
+        esTestLogger.setLevel("warn");
+        assertThat(esTestLogger.getLevel(), equalTo("WARNING"));
+        esTestLogger.setLevel("info");
+        assertThat(esTestLogger.getLevel(), equalTo("INFO"));
+        esTestLogger.setLevel("debug");
+        assertThat(esTestLogger.getLevel(), equalTo("FINE"));
+        esTestLogger.setLevel("trace");
+        assertThat(esTestLogger.getLevel(), equalTo("FINEST"));
+    }
+
     private static class TestHandler extends Handler {
 
         private List<LogRecord> records = new ArrayList<>();


### PR DESCRIPTION
This allows to enable the trace-log via JdkESLogger.setLevel(), otherwise both 'debug' and 'trace' are mapped to 'FINE' and there is no way to enable 'FINER'.

Without this, it is not possible to adjust the trace logs when using JDK Logging and trying to adjust the loglevel during runtime, e.g. in Java Clients in order to enable debug-log dynamically.
