### PR TITLE
Add cat API for repositories and snapshots

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/RestActionModule.java
@@ -92,8 +92,10 @@ import org.elasticsearch.rest.action.cat.RestMasterAction;
 import org.elasticsearch.rest.action.cat.RestNodeAttrsAction;
 import org.elasticsearch.rest.action.cat.RestNodesAction;
 import org.elasticsearch.rest.action.cat.RestPluginsAction;
+import org.elasticsearch.rest.action.cat.RestRepositoriesAction;
 import org.elasticsearch.rest.action.cat.RestSegmentsAction;
 import org.elasticsearch.rest.action.cat.RestShardsAction;
+import org.elasticsearch.rest.action.cat.RestSnapshotAction;
 import org.elasticsearch.rest.action.cat.RestThreadPoolAction;
 import org.elasticsearch.rest.action.delete.RestDeleteAction;
 import org.elasticsearch.rest.action.explain.RestExplainAction;
@@ -263,6 +265,8 @@ public class RestActionModule extends AbstractModule {
         catActionMultibinder.addBinding().to(RestPluginsAction.class).asEagerSingleton();
         catActionMultibinder.addBinding().to(RestFielddataAction.class).asEagerSingleton();
         catActionMultibinder.addBinding().to(RestNodeAttrsAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(RestRepositoriesAction.class).asEagerSingleton();
+        catActionMultibinder.addBinding().to(RestSnapshotAction.class).asEagerSingleton();
         // no abstract cat action
         bind(RestCatAction.class).asEagerSingleton();
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestRepositoriesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestRepositoriesAction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.cat;
+
+import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
+import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.RepositoryMetaData;
+import org.elasticsearch.common.Table;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.action.support.RestResponseListener;
+import org.elasticsearch.rest.action.support.RestTable;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+/**
+ * Cat API class to display information about snapshot repositories
+ */
+public class RestRepositoriesAction extends AbstractCatAction {
+    @Inject
+    public RestRepositoriesAction(Settings settings, RestController controller, Client client) {
+        super(settings, controller, client);
+        controller.registerHandler(GET, "/_cat/repositories", this);
+    }
+
+    @Override
+    protected void doRequest(RestRequest request, RestChannel channel, Client client) {
+        GetRepositoriesRequest getRepositoriesRequest = new GetRepositoriesRequest();
+        getRepositoriesRequest.local(request.paramAsBoolean("local", getRepositoriesRequest.local()));
+        getRepositoriesRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getRepositoriesRequest.masterNodeTimeout()));
+
+        client.admin().cluster().getRepositories(getRepositoriesRequest, new RestResponseListener<GetRepositoriesResponse>(channel) {
+            @Override
+            public RestResponse buildResponse(GetRepositoriesResponse getRepositoriesResponse) throws Exception {
+                return RestTable.buildResponse(buildTable(request, getRepositoriesResponse), channel);
+            }
+        });
+    }
+
+    @Override
+    protected void documentation(StringBuilder sb) {
+        sb.append("/_cat/repositories\n");
+    }
+
+    @Override
+    protected Table getTableWithHeader(RestRequest request) {
+        return new Table()
+                .startHeaders()
+                .addCell("id", "alias:id,repoId;desc:unique repository id")
+                .addCell("type", "alias:t,type;text-align:right;desc:repository type")
+                .endHeaders();
+    }
+
+    private Table buildTable(RestRequest req, GetRepositoriesResponse getRepositoriesResponse) {
+        Table table = getTableWithHeader(req);
+        for (RepositoryMetaData repositoryMetaData : getRepositoriesResponse.repositories()) {
+            table.startRow();
+
+            table.addCell(repositoryMetaData.name());
+            table.addCell(repositoryMetaData.type());
+
+            table.endRow();
+        }
+
+        return table;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestSnapshotAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestSnapshotAction.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.cat;
+
+
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Table;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.action.support.RestResponseListener;
+import org.elasticsearch.rest.action.support.RestTable;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+/**
+ * Cat API class to display information about snapshots
+ */
+public class RestSnapshotAction extends AbstractCatAction {
+    @Inject
+    public RestSnapshotAction(Settings settings, RestController controller, Client client) {
+        super(settings, controller, client);
+        controller.registerHandler(GET, "/_cat/snapshots/{repository}", this);
+    }
+
+    @Override
+    protected void doRequest(final RestRequest request, RestChannel channel, Client client) {
+        GetSnapshotsRequest getSnapshotsRequest = new GetSnapshotsRequest();
+        getSnapshotsRequest.repository(request.param("repository"));
+        getSnapshotsRequest.snapshots(new String[] { GetSnapshotsRequest.ALL_SNAPSHOTS });
+        getSnapshotsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getSnapshotsRequest.masterNodeTimeout()));
+
+        client.admin().cluster().getSnapshots(getSnapshotsRequest, new RestResponseListener<GetSnapshotsResponse>(channel) {
+            @Override
+            public RestResponse buildResponse(GetSnapshotsResponse getSnapshotsResponse) throws Exception {
+                return RestTable.buildResponse(buildTable(request, getSnapshotsResponse), channel);
+            }
+        });
+    }
+
+    @Override
+    protected void documentation(StringBuilder sb) {
+        sb.append("/_cat/snapshots/{repository}\n");
+    }
+
+    @Override
+    protected Table getTableWithHeader(RestRequest request) {
+        return new Table()
+                .startHeaders()
+                .addCell("id", "alias:id,snapshotId;desc:unique snapshot id")
+                .addCell("status", "alias:s,status;text-align:right;desc:snapshot name")
+                .addCell("start_epoch", "alias:ste,startEpoch;desc:start time in seconds since 1970-01-01 00:00:00")
+                .addCell("start_time", "alias:sti,startTime;desc:start time in HH:MM:SS")
+                .addCell("end_epoch", "alias:ete,endEpoch;desc:end time in seconds since 1970-01-01 00:00:00")
+                .addCell("end_time", "alias:eti,endTime;desc:end time in HH:MM:SS")
+                .addCell("indices", "alias:i,indices;text-align:right;desc:number of indices")
+                .addCell("successful_shards", "alias:ss,successful_shards;text-align:right;desc:number of successful shards")
+                .addCell("failed_shards", "alias:fs,failed_shards;text-align:right;desc:number of failed shards")
+                .addCell("total_shards", "alias:ts,total_shards;text-align:right;desc:number of total shards")
+                .addCell("reason", "default:false;alias:r,reason;desc:reason for failures")
+                .endHeaders();
+    }
+
+    private DateTimeFormatter dateFormat = DateTimeFormat.forPattern("HH:mm:ss");
+
+    private Table buildTable(RestRequest req, GetSnapshotsResponse getSnapshotsResponse) {
+        Table table = getTableWithHeader(req);
+        for (SnapshotInfo snapshotStatus : getSnapshotsResponse.getSnapshots()) {
+            table.startRow();
+
+            table.addCell(snapshotStatus.name());
+            table.addCell(snapshotStatus.state());
+            table.addCell(TimeUnit.SECONDS.convert(snapshotStatus.startTime(), TimeUnit.MILLISECONDS));
+            table.addCell(dateFormat.print(snapshotStatus.startTime()));
+            table.addCell(TimeUnit.SECONDS.convert(snapshotStatus.endTime(), TimeUnit.MILLISECONDS));
+            table.addCell(dateFormat.print(snapshotStatus.endTime()));
+            table.addCell(snapshotStatus.indices().size());
+            table.addCell(snapshotStatus.successfulShards());
+            table.addCell(snapshotStatus.failedShards());
+            table.addCell(snapshotStatus.totalShards());
+            table.addCell(snapshotStatus.reason());
+
+            table.endRow();
+        }
+
+        return table;
+    }
+}

--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -122,8 +122,12 @@ include::cat/plugins.asciidoc[]
 
 include::cat/recovery.asciidoc[]
 
+include::cat/repositories.asciidoc[]
+
 include::cat/thread_pool.asciidoc[]
 
 include::cat/shards.asciidoc[]
 
 include::cat/segments.asciidoc[]
+
+include::cat/snapshots.asciidoc[]

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -1,0 +1,14 @@
+[[cat-repositories]]
+== cat repositories
+
+The `repositories` command shows the snapshot repositories registered in the cluster.
+
+[source,sh]
+--------------------------------------------------
+% curl 'localhost:9200/_cat/repositories?v'
+id    type
+repo1   fs
+repo2   s3
+--------------------------------------------------
+
+We can quickly see which repositories are registered and their type.

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -1,0 +1,19 @@
+[[cat-snapshots]]
+== cat snapshots
+
+The `snapshots` command shows all snapshots that belong to a specific repository.
+To find a list of available repositories to query, the command `/_cat/repositories` can be used.
+Querying the snapshots of a repository named `repo1` then looks as follows.
+
+[source,sh]
+--------------------------------------------------
+% curl 'localhost:9200/_cat/snapshots/repo1?v'
+id     status start_epoch start_time end_epoch  end_time indices successful_shards failed_shards total_shards
+snap1  FAILED 1445616705  18:11:45   1445616978 18:16:18       1                 4             1            5
+snap2 SUCCESS 1445634298  23:04:58   1445634672 23:11:12       2                10             0           10
+--------------------------------------------------
+
+Each snapshot contains information about when it was started and stopped.
+Start and stop timestamps are available in two formats.
+The `HH:MM:SS` output is simply for quick human consumption.
+The epoch time retains more information, including date, and is machine sortable if the snapshot process spans days.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -1,0 +1,38 @@
+{
+  "cat.repositories": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html",
+    "methods": ["GET"],
+    "url": {
+      "path": "/_cat/repositories",
+      "paths": ["/_cat/repositories"],
+      "parts": {
+      },
+      "params": {
+        "local": {
+          "type" : "boolean",
+          "description" : "Return local information, do not retrieve the state from master node",
+          "default": false
+        },
+        "master_timeout": {
+          "type" : "time",
+          "description" : "Explicit operation timeout for connection to master node"
+        },
+        "h": {
+          "type": "list",
+          "description" : "Comma-separated list of column names to display"
+        },
+        "help": {
+          "type": "boolean",
+          "description": "Return help information",
+          "default": false
+        },
+        "v": {
+          "type": "boolean",
+          "description": "Verbose mode. Display column headers",
+          "default": false
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -1,0 +1,37 @@
+{
+  "cat.snapshots": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html",
+    "methods": ["GET"],
+    "url": {
+      "path": "/_cat/snapshots/{repository}",
+      "paths": ["/_cat/snapshots/{repository}"],
+      "parts": {
+        "repository": {
+          "type" : "list",
+          "description": "Name of repository from which to fetch the snapshot information"
+        }
+      },
+      "params": {
+        "master_timeout": {
+          "type" : "time",
+          "description" : "Explicit operation timeout for connection to master node"
+        },
+        "h": {
+          "type": "list",
+          "description" : "Comma-separated list of column names to display"
+        },
+        "help": {
+          "type": "boolean",
+          "description": "Return help information",
+          "default": false
+        },
+        "v": {
+          "type": "boolean",
+          "description": "Verbose mode. Display column headers",
+          "default": false
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.repositories/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.repositories/10_basic.yaml
@@ -1,0 +1,45 @@
+---
+"Help":
+  - do:
+      cat.repositories:
+        help: true
+
+  - match:
+      $body: |
+               /^  id   .+ \n
+                   type .+ \n
+               $/
+---
+"Test cat repositories output":
+
+  - do:
+      cat.repositories: {}
+
+  - match:
+      $body: |
+               /^$/
+
+  - do:
+      snapshot.create_repository:
+        repository: repo1
+        body:
+          type: fs
+          settings:
+            location: "repo1_loc"
+
+  - do:
+      snapshot.create_repository:
+        repository: repo2
+        body:
+          type: fs
+          settings:
+            location: "repo2_loc"
+
+  - do:
+      cat.repositories: {}
+
+  - match:
+      $body: |
+               /^   repo1\s+ fs\s*\n
+                    repo2\s+ fs\s*\n
+               $/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yaml
@@ -1,0 +1,79 @@
+---
+"Help":
+  - do:
+      cat.snapshots:
+        repository: repo1
+        help: true
+
+  - match:
+      $body: |
+               /^   id                .+   \n
+                    status            .+   \n
+                    start_epoch       .+   \n
+                    start_time        .+   \n
+                    end_epoch         .+   \n
+                    end_time          .+   \n
+                    indices           .+   \n
+                    successful_shards .+   \n
+                    failed_shards     .+   \n
+                    total_shards      .+   \n
+                    reason            .+   \n
+               $/
+---
+"Test cat snapshots output":
+
+  - do:
+      snapshot.create_repository:
+        repository: repo1
+        body:
+          type: fs
+          settings:
+            location: "repo1_loc"
+
+  - do:
+      cat.snapshots:
+        repository: repo1
+
+  - match:
+      $body: |
+               /^$/
+
+  - do:
+      indices.create:
+        index: index1
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+  - do:
+      indices.create:
+        index: index2
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+  - do:
+       cluster.health:
+         wait_for_status: green
+
+  - do:
+        snapshot.create:
+          repository: repo1
+          snapshot: snap1
+          wait_for_completion: true
+
+  - do:
+        snapshot.create:
+          repository: repo1
+          snapshot: snap2
+          wait_for_completion: true
+
+  - do:
+      cat.snapshots:
+        repository: repo1
+
+  - match:
+      $body: |
+               /^   snap1\s+ SUCCESS\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ 2\s+ 2\s+ 0\s+ 2\s*\n
+                    snap2\s+ SUCCESS\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ 2\s+ 2\s+ 0\s+ 2\s*\n
+               $/


### PR DESCRIPTION
Adds the following two endpoints:
- /_cat/repositories
- /_cat/snapshots/{repository}

Relates to #13919
