### PR TITLE
add ability to add nested field values to Data document

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/Data.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/Data.java
@@ -22,8 +22,10 @@ package org.elasticsearch.ingest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -45,7 +47,6 @@ public final class Data {
         this.document = document;
     }
 
-    // TODO(talevy): support elements of lists
     @SuppressWarnings("unchecked")
     public <T> T getProperty(String path) {
         return (T) XContentMapValues.extractValue(path, document);
@@ -68,7 +69,9 @@ public final class Data {
         Map<String, Object> inner = document;
 
         for (int i = 0; i < pathElements.length - 1; i++) {
-            inner.putIfAbsent(pathElements[i], new HashMap<String, Object>());
+            if (!inner.containsKey(pathElements[i])) {
+                inner.put(pathElements[i], new HashMap<String, Object>());
+            }
             inner = (HashMap<String, Object>) inner.get(pathElements[i]);
         }
 

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/DataTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/DataTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.*;
+
+public class DataTests extends ESTestCase {
+
+    private Data data;
+
+    @Before
+    public void setData() {
+        data = new Data("index", "type", "id",
+                new HashMap<String, Object>() {{
+                    put("foo", "bar");
+                    put("fizz", new HashMap<String, Object>() {{
+                        put("buzz", "hello world");
+                    }});
+                }});
+    }
+
+    public void testSimpleGetProperty() {
+        assertThat(data.getProperty("foo"), equalTo("bar"));
+    }
+
+    public void testNestedGetProperty() {
+        assertThat(data.getProperty("fizz.buzz"), equalTo("hello world"));
+    }
+
+    public void testSimpleAddField() {
+        data.addField("new_field", "foo");
+        assertThat(data.getDocument().get("new_field"), equalTo("foo"));
+    }
+
+    public void testNestedAddField() {
+        data.addField("a.b.c.d", "foo");
+        assertThat(data.getProperty("a.b.c.d"), equalTo("foo"));
+    }
+}

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/DataTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/DataTests.java
@@ -58,4 +58,14 @@ public class DataTests extends ESTestCase {
         data.addField("a.b.c.d", "foo");
         assertThat(data.getProperty("a.b.c.d"), equalTo("foo"));
     }
+
+    public void testAddFieldOnExistingField() {
+        data.addField("foo", "newbar");
+        assertThat(data.getProperty("foo"), equalTo("newbar"));
+    }
+
+    public void testAddFieldOnExistingParent() {
+        data.addField("fizz.new", "bar");
+        assertThat(data.getProperty("fizz.new"), equalTo("bar"));
+    }
 }


### PR DESCRIPTION
Small commit to add ability to add nested paths.

This will be used by processors such as `mutate` for building custom document structure.
