### PR TITLE
Add community plugin

### DIFF
--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -338,4 +338,5 @@ deprecated[1.5.0,Rivers have been deprecated.  See https://www.elastic.co/blog/d
 * https://github.com/codelibs/elasticsearch-taste[Elasticsearch Taste Plugin] (by CodeLibs Project)
 * http://siren.solutions/siren/downloads/[Elasticsearch SIREn Plugin]: Nested data search (by SIREn Solutions)
 * https://github.com/hadashiA/elasticsearch-flavor[Elasticsearch Flavor Plugin] using http://mahout.apache.org/[Mahout] Collaboration filtering (by hadashiA)
+* https://github.com/jurgc11/es-change-feed-plugin[WebSocket Change Feed Plugin] (by ForgeRock/Chris Clifton)
 


### PR DESCRIPTION
Add a link to a community plugin which allows a WebSocket client to connect to Elasticsearch and receive a feed of changes being made in the database
