### PR TITLE
Explain api: move query parsing to the coordinating node

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -21,13 +21,11 @@ package org.elasticsearch.action.explain;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
-import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.single.shard.SingleShardRequest;
-import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 
 import java.io.IOException;
@@ -41,7 +39,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
     private String id;
     private String routing;
     private String preference;
-    private BytesReference source;
+    private QueryBuilder<?> query;
     private String[] fields;
     private FetchSourceContext fetchSourceContext;
 
@@ -102,17 +100,12 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         return this;
     }
 
-    public BytesReference source() {
-        return source;
+    public QueryBuilder<?> query() {
+        return query;
     }
 
-    public ExplainRequest source(QuerySourceBuilder sourceBuilder) {
-        this.source = sourceBuilder.buildAsBytes(Requests.CONTENT_TYPE);
-        return this;
-    }
-
-    public ExplainRequest source(BytesReference source) {
-        this.source = source;
+    public ExplainRequest query(QueryBuilder<?> query) {
+        this.query = query;
         return this;
     }
 
@@ -159,8 +152,8 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         if (id == null) {
             validationException = ValidateActions.addValidationError("id is missing", validationException);
         }
-        if (source == null) {
-            validationException = ValidateActions.addValidationError("source is missing", validationException);
+        if (query == null) {
+            validationException = ValidateActions.addValidationError("query is missing", validationException);
         }
         return validationException;
     }
@@ -172,7 +165,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         id = in.readString();
         routing = in.readOptionalString();
         preference = in.readOptionalString();
-        source = in.readBytesReference();
+        query = in.readQuery();
         filteringAlias = in.readStringArray();
         if (in.readBoolean()) {
             fields = in.readStringArray();
@@ -189,7 +182,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> {
         out.writeString(id);
         out.writeOptionalString(routing);
         out.writeOptionalString(preference);
-        out.writeBytesReference(source);
+        out.writeQuery(query);
         out.writeStringArray(filteringAlias);
         if (fields != null) {
             out.writeBoolean(true);

--- a/core/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
@@ -19,12 +19,10 @@
 
 package org.elasticsearch.action.explain;
 
-import org.elasticsearch.action.support.QuerySourceBuilder;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 
@@ -32,8 +30,6 @@ import org.elasticsearch.search.fetch.source.FetchSourceContext;
  * A builder for {@link ExplainRequest}.
  */
 public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<ExplainRequest, ExplainResponse, ExplainRequestBuilder> {
-
-    private QuerySourceBuilder sourceBuilder;
 
     ExplainRequestBuilder(ElasticsearchClient client, ExplainAction action) {
         super(client, action, new ExplainRequest());
@@ -87,15 +83,7 @@ public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<Ex
      * Sets the query to get a score explanation for.
      */
     public ExplainRequestBuilder setQuery(QueryBuilder query) {
-        sourceBuilder().setQuery(query);
-        return this;
-    }
-
-    /**
-     * Sets the query to get a score explanation for.
-     */
-    public ExplainRequestBuilder setQuery(BytesReference query) {
-        sourceBuilder().setQuery(query);
+        request.query(query);
         return this;
     }
 
@@ -151,28 +139,4 @@ public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<Ex
         }
         return this;
     }
-
-    /**
-     * Sets the full source of the explain request (for example, wrapping an actual query).
-     */
-    public ExplainRequestBuilder setSource(BytesReference source) {
-        request().source(source);
-        return this;
-    }
-
-    @Override
-    protected ExplainRequest beforeExecute(ExplainRequest request) {
-        if (sourceBuilder != null) {
-            request.source(sourceBuilder);
-        }
-        return request;
-    }
-
-    private QuerySourceBuilder sourceBuilder() {
-        if (sourceBuilder == null) {
-            sourceBuilder = new QuerySourceBuilder();
-        }
-        return sourceBuilder;
-    }
-
 }

--- a/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -121,7 +121,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
         SearchContext.setCurrent(context);
 
         try {
-            context.parsedQuery(indexService.queryParserService().parseTopLevelQuery(request.source()));
+            context.parsedQuery(indexService.queryParserService().toQuery(request.query()));
             context.preProcess();
             int topLevelDocId = result.docIdAndVersion().docId + result.docIdAndVersion().context.docBase;
             Explanation explanation = context.searcher().explain(context.query(), topLevelDocId);


### PR DESCRIPTION
Similarly to what we did with the search api, we can now also move query parsing on the coordinating node for the explain api. Given that the explain api is a single shard operation (compared to search which is instead a broadcast operation), this doesn't change a lot in how the api works internally. The main benefit is that we can simplify the java api by requiring a structured query object to be provided rather than a bytes array that will get parsed on the data node. Previously if you specified a QueryBuilder it would be serialized in json format and would get reparsed on the data node, while now it doesn't go through parsing anymore (as expected), given that after the query-refactoring we are able to properly stream queries natively.
