### PR TITLE
Add workaround for JDK-8014008

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.security.Permission;
 import java.security.PermissionCollection;
+import java.security.Permissions;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.security.URIParameter;
@@ -90,6 +91,21 @@ final class ESPolicy extends Policy {
         }
         // otherwise defer to template + dynamic file permissions
         return template.implies(domain, permission) || dynamic.implies(permission);
+    }
+
+    @Override
+    public PermissionCollection getPermissions(CodeSource codesource) {
+        // code should not rely on this method, or at least use it correctly:
+        // https://bugs.openjdk.java.net/browse/JDK-8014008
+        // return them a new empty permissions object so jvisualvm etc work
+        for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+            if ("sun.rmi.server.LoaderHandler".equals(element.getClassName()) &&
+                    "loadClass".equals(element.getMethodName())) {
+                return new Permissions();
+            }
+        }
+        // return UNSUPPORTED_EMPTY_COLLECTION since it is safe.
+        return super.getPermissions(codesource);
     }
 
     /**


### PR DESCRIPTION
We should not implement this method, it is a real problem to do that. 

But I think it is ok to workaround the JDK bug (https://bugs.openjdk.java.net/browse/JDK-8014008). We can just give it new empty mutable permissions (no permissions at all) and otherwise return UNSUPPORTED which is the right thing to do. Under normal operation of ES this method never even gets called, so its not a performance issue.

This allows jconsole/visualvm to work in the meantime.

I would like to see progress on the jdk bug before pushing though, it should not have to come from me. The track record/attitude around RMI on security is not good (e.g.: https://bugs.openjdk.java.net/browse/JDK-8035404) and this is their bug to fix, we can't maintain these workarounds forever.
