### PR TITLE
Tests: run base query tests for more than one random query

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -58,7 +58,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.EnvironmentModule;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisModule;
 import org.elasticsearch.index.cache.IndexCacheModule;
 import org.elasticsearch.index.mapper.MapperService;
@@ -123,6 +122,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             BOOLEAN_FIELD_NAME, DATE_FIELD_NAME, OBJECT_FIELD_NAME, GEO_POINT_FIELD_NAME, GEO_SHAPE_FIELD_NAME };
     protected static final String[] MAPPED_LEAF_FIELD_NAMES = new String[] { STRING_FIELD_NAME, INT_FIELD_NAME, DOUBLE_FIELD_NAME,
             BOOLEAN_FIELD_NAME, DATE_FIELD_NAME, GEO_POINT_FIELD_NAME };
+    private static final int NUMBER_OF_TESTQUERIES = 20;
 
     private static Injector injector;
     private static IndexQueryParserService queryParserService;
@@ -310,10 +310,12 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      * and asserts equality on the two queries.
      */
     public void testFromXContent() throws IOException {
-        QB testQuery = createTestQueryBuilder();
-        assertParsedQuery(testQuery.toString(), testQuery);
-        for (Map.Entry<String, QB> alternateVersion : getAlternateVersions().entrySet()) {
-            assertParsedQuery(alternateVersion.getKey(), alternateVersion.getValue());
+        for (int runs = 0; runs < NUMBER_OF_TESTQUERIES; runs++) {
+            QB testQuery = createTestQueryBuilder();
+            assertParsedQuery(testQuery.toString(), testQuery);
+            for (Map.Entry<String, QB> alternateVersion : getAlternateVersions().entrySet()) {
+                assertParsedQuery(alternateVersion.getKey(), alternateVersion.getValue());
+            }
         }
     }
 
@@ -365,42 +367,45 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      * assertions being made on the result to the implementing subclass.
      */
     public void testToQuery() throws IOException {
-        QueryShardContext context = createShardContext();
-        context.setAllowUnmappedFields(true);
-
-        QB firstQuery = createTestQueryBuilder();
-        QB controlQuery = copyQuery(firstQuery);
-        setSearchContext(randomTypes); // only set search context for toQuery to be more realistic
-        Query firstLuceneQuery = firstQuery.toQuery(context);
-        assertLuceneQuery(firstQuery, firstLuceneQuery, context);
-        SearchContext.removeCurrent(); // remove after assertLuceneQuery since the assertLuceneQuery impl might access the context as well
-        assertTrue("query is not equal to its copy after calling toQuery, firstQuery: " + firstQuery + ", secondQuery: " + controlQuery,
-                firstQuery.equals(controlQuery));
-        assertTrue("equals is not symmetric after calling toQuery, firstQuery: " + firstQuery + ", secondQuery: " + controlQuery,
-                controlQuery.equals(firstQuery));
-        assertThat("query copy's hashcode is different from original hashcode after calling toQuery, firstQuery: " + firstQuery
-                + ", secondQuery: " + controlQuery, controlQuery.hashCode(), equalTo(firstQuery.hashCode()));
-
-
-        QB secondQuery = copyQuery(firstQuery);
-        //query _name never should affect the result of toQuery, we randomly set it to make sure
-        if (randomBoolean()) {
-            secondQuery.queryName(secondQuery.queryName() == null ? randomAsciiOfLengthBetween(1, 30) : secondQuery.queryName() + randomAsciiOfLengthBetween(1, 10));
-        }
-        setSearchContext(randomTypes); // only set search context for toQuery to be more realistic
-        Query secondLuceneQuery = secondQuery.toQuery(context);
-        assertLuceneQuery(secondQuery, secondLuceneQuery, context);
-        SearchContext.removeCurrent(); // remove after assertLuceneQuery since the assertLuceneQuery impl might access the context as well
-
-        assertThat("two equivalent query builders lead to different lucene queries", secondLuceneQuery, equalTo(firstLuceneQuery));
-
-        //if the initial lucene query is null, changing its boost won't have any effect, we shouldn't test that
-        if (firstLuceneQuery != null && supportsBoostAndQueryName()) {
-            secondQuery.boost(firstQuery.boost() + 1f + randomFloat());
+        for (int runs = 0; runs < NUMBER_OF_TESTQUERIES; runs++) {
+            QueryShardContext context = createShardContext();
+            context.setAllowUnmappedFields(true);
+            QB firstQuery = createTestQueryBuilder();
+            QB controlQuery = copyQuery(firstQuery);
             setSearchContext(randomTypes); // only set search context for toQuery to be more realistic
-            Query thirdLuceneQuery = secondQuery.toQuery(context);
+            Query firstLuceneQuery = firstQuery.toQuery(context);
+            assertLuceneQuery(firstQuery, firstLuceneQuery, context);
+            SearchContext.removeCurrent(); // remove after assertLuceneQuery since the assertLuceneQuery impl might access the context as well
+            assertTrue(
+                    "query is not equal to its copy after calling toQuery, firstQuery: " + firstQuery + ", secondQuery: " + controlQuery,
+                    firstQuery.equals(controlQuery));
+            assertTrue("equals is not symmetric after calling toQuery, firstQuery: " + firstQuery + ", secondQuery: " + controlQuery,
+                    controlQuery.equals(firstQuery));
+            assertThat("query copy's hashcode is different from original hashcode after calling toQuery, firstQuery: " + firstQuery
+                    + ", secondQuery: " + controlQuery, controlQuery.hashCode(), equalTo(firstQuery.hashCode()));
+
+            QB secondQuery = copyQuery(firstQuery);
+            // query _name never should affect the result of toQuery, we randomly set it to make sure
+            if (randomBoolean()) {
+                secondQuery.queryName(secondQuery.queryName() == null ? randomAsciiOfLengthBetween(1, 30) : secondQuery.queryName()
+                        + randomAsciiOfLengthBetween(1, 10));
+            }
+            setSearchContext(randomTypes);
+            Query secondLuceneQuery = secondQuery.toQuery(context);
+            assertLuceneQuery(secondQuery, secondLuceneQuery, context);
             SearchContext.removeCurrent();
-            assertThat("modifying the boost doesn't affect the corresponding lucene query", firstLuceneQuery, not(equalTo(thirdLuceneQuery)));
+
+            assertThat("two equivalent query builders lead to different lucene queries", secondLuceneQuery, equalTo(firstLuceneQuery));
+
+            // if the initial lucene query is null, changing its boost won't have any effect, we shouldn't test that
+            if (firstLuceneQuery != null && supportsBoostAndQueryName()) {
+                secondQuery.boost(firstQuery.boost() + 1f + randomFloat());
+                setSearchContext(randomTypes);
+                Query thirdLuceneQuery = secondQuery.toQuery(context);
+                SearchContext.removeCurrent();
+                assertThat("modifying the boost doesn't affect the corresponding lucene query", firstLuceneQuery,
+                        not(equalTo(thirdLuceneQuery)));
+            }
         }
     }
 
@@ -448,8 +453,10 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      * Test serialization and deserialization of the test query.
      */
     public void testSerialization() throws IOException {
-        QB testQuery = createTestQueryBuilder();
-        assertSerialization(testQuery);
+        for (int runs = 0; runs < NUMBER_OF_TESTQUERIES; runs++) {
+            QB testQuery = createTestQueryBuilder();
+            assertSerialization(testQuery);
+        }
     }
 
     /**
@@ -471,35 +478,38 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
     }
 
     public void testEqualsAndHashcode() throws IOException {
-        QB firstQuery = createTestQueryBuilder();
-        assertFalse("query is equal to null", firstQuery.equals(null));
-        assertFalse("query is equal to incompatible type", firstQuery.equals(""));
-        assertTrue("query is not equal to self", firstQuery.equals(firstQuery));
-        assertThat("same query's hashcode returns different values if called multiple times", firstQuery.hashCode(), equalTo(firstQuery.hashCode()));
+        for (int runs = 0; runs < NUMBER_OF_TESTQUERIES; runs++) {
+            QB firstQuery = createTestQueryBuilder();
+            assertFalse("query is equal to null", firstQuery.equals(null));
+            assertFalse("query is equal to incompatible type", firstQuery.equals(""));
+            assertTrue("query is not equal to self", firstQuery.equals(firstQuery));
+            assertThat("same query's hashcode returns different values if called multiple times", firstQuery.hashCode(),
+                    equalTo(firstQuery.hashCode()));
 
-        QB secondQuery = copyQuery(firstQuery);
-        assertTrue("query is not equal to self", secondQuery.equals(secondQuery));
-        assertTrue("query is not equal to its copy", firstQuery.equals(secondQuery));
-        assertTrue("equals is not symmetric", secondQuery.equals(firstQuery));
-        assertThat("query copy's hashcode is different from original hashcode", secondQuery.hashCode(), equalTo(firstQuery.hashCode()));
+            QB secondQuery = copyQuery(firstQuery);
+            assertTrue("query is not equal to self", secondQuery.equals(secondQuery));
+            assertTrue("query is not equal to its copy", firstQuery.equals(secondQuery));
+            assertTrue("equals is not symmetric", secondQuery.equals(firstQuery));
+            assertThat("query copy's hashcode is different from original hashcode", secondQuery.hashCode(), equalTo(firstQuery.hashCode()));
 
-        QB thirdQuery = copyQuery(secondQuery);
-        assertTrue("query is not equal to self", thirdQuery.equals(thirdQuery));
-        assertTrue("query is not equal to its copy", secondQuery.equals(thirdQuery));
-        assertThat("query copy's hashcode is different from original hashcode", secondQuery.hashCode(), equalTo(thirdQuery.hashCode()));
-        assertTrue("equals is not transitive", firstQuery.equals(thirdQuery));
-        assertThat("query copy's hashcode is different from original hashcode", firstQuery.hashCode(), equalTo(thirdQuery.hashCode()));
-        assertTrue("equals is not symmetric", thirdQuery.equals(secondQuery));
-        assertTrue("equals is not symmetric", thirdQuery.equals(firstQuery));
+            QB thirdQuery = copyQuery(secondQuery);
+            assertTrue("query is not equal to self", thirdQuery.equals(thirdQuery));
+            assertTrue("query is not equal to its copy", secondQuery.equals(thirdQuery));
+            assertThat("query copy's hashcode is different from original hashcode", secondQuery.hashCode(), equalTo(thirdQuery.hashCode()));
+            assertTrue("equals is not transitive", firstQuery.equals(thirdQuery));
+            assertThat("query copy's hashcode is different from original hashcode", firstQuery.hashCode(), equalTo(thirdQuery.hashCode()));
+            assertTrue("equals is not symmetric", thirdQuery.equals(secondQuery));
+            assertTrue("equals is not symmetric", thirdQuery.equals(firstQuery));
 
-        if (randomBoolean()) {
-            secondQuery.queryName(secondQuery.queryName() == null ? randomAsciiOfLengthBetween(1, 30) : secondQuery.queryName()
-                    + randomAsciiOfLengthBetween(1, 10));
-        } else {
-            secondQuery.boost(firstQuery.boost() + 1f + randomFloat());
+            if (randomBoolean()) {
+                secondQuery.queryName(secondQuery.queryName() == null ? randomAsciiOfLengthBetween(1, 30) : secondQuery.queryName()
+                        + randomAsciiOfLengthBetween(1, 10));
+            } else {
+                secondQuery.boost(firstQuery.boost() + 1f + randomFloat());
+            }
+            assertThat("different queries should not be equal", secondQuery, not(equalTo(firstQuery)));
+            assertThat("different queries should have different hashcode", secondQuery.hashCode(), not(equalTo(firstQuery.hashCode())));
         }
-        assertThat("different queries should not be equal", secondQuery, not(equalTo(firstQuery)));
-        assertThat("different queries should have different hashcode", secondQuery.hashCode(), not(equalTo(firstQuery.hashCode())));
     }
 
     private QueryParser<?> queryParser(String queryId) {


### PR DESCRIPTION
Currently we only run the base tests in AbstractQueryTestCase for one randomly generated query. In order to extend coverage on the query builders and parsers we should run those test on more than one random query, especially since this comes at almost no cost and will increase the chance that when something breaks the query builders or parsers, this will more likely cause an immediate test failure when running `mvn test` locally instead of having to wait several CI cycles.

This PR also contains small change in GeoShapeQueryBuilderTest random query setup. The combination of having a `MULTILINESTRING` random shape together with `SpatialStrategy.TERM` causes very huge lucene queries (often > 8000 terms) and therefore slows down the test quiete significantly, so we try to avoid this combination.
