### PR TITLE
Open up QueryCache and SearcherWrapper extension points

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexServicesProvider.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexServicesProvider.java
@@ -56,12 +56,11 @@ public final class IndexServicesProvider {
     private final SimilarityService similarityService;
     private final EngineFactory factory;
     private final BigArrays bigArrays;
-    private final IndexSearcherWrapper indexSearcherWrapper;
     private final IndexingMemoryController indexingMemoryController;
     private final IndexEventListener listener;
 
     @Inject
-    public IndexServicesProvider(IndexEventListener listener, ThreadPool threadPool, MapperService mapperService, IndexQueryParserService queryParserService, IndexCache indexCache, IndicesQueryCache indicesQueryCache, CodecService codecService, TermVectorsService termVectorsService, IndexFieldDataService indexFieldDataService, @Nullable IndicesWarmer warmer, SimilarityService similarityService, EngineFactory factory, BigArrays bigArrays, @Nullable IndexSearcherWrapper indexSearcherWrapper, IndexingMemoryController indexingMemoryController) {
+    public IndexServicesProvider(IndexEventListener listener, ThreadPool threadPool, MapperService mapperService, IndexQueryParserService queryParserService, IndexCache indexCache, IndicesQueryCache indicesQueryCache, CodecService codecService, TermVectorsService termVectorsService, IndexFieldDataService indexFieldDataService, @Nullable IndicesWarmer warmer, SimilarityService similarityService, EngineFactory factory, BigArrays bigArrays, IndexingMemoryController indexingMemoryController) {
         this.listener = listener;
         this.threadPool = threadPool;
         this.mapperService = mapperService;
@@ -75,7 +74,6 @@ public final class IndexServicesProvider {
         this.similarityService = similarityService;
         this.factory = factory;
         this.bigArrays = bigArrays;
-        this.indexSearcherWrapper = indexSearcherWrapper;
         this.indexingMemoryController = indexingMemoryController;
     }
 
@@ -126,13 +124,7 @@ public final class IndexServicesProvider {
         return factory;
     }
 
-    public BigArrays getBigArrays() {
-        return bigArrays;
-    }
-
-    public IndexSearcherWrapper getIndexSearcherWrapper() {
-        return indexSearcherWrapper;
-    }
+    public BigArrays getBigArrays() { return bigArrays; }
 
     public IndexingMemoryController getIndexingMemoryController() {
         return indexingMemoryController;

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -196,7 +196,7 @@ public class IndexShard extends AbstractIndexShardComponent {
     private final IndexingMemoryController indexingMemoryController;
 
     @Inject
-    public IndexShard(ShardId shardId, IndexSettings indexSettings, ShardPath path, Store store, IndexServicesProvider provider) {
+    public IndexShard(ShardId shardId, IndexSettings indexSettings, ShardPath path, Store store, IndexSearcherWrapper indexSearcherWrapper, IndexServicesProvider provider) {
         super(shardId, indexSettings);
         this.idxSettings = indexSettings;
         this.codecService = provider.getCodecService();
@@ -249,7 +249,7 @@ public class IndexShard extends AbstractIndexShardComponent {
         this.disableFlush = this.indexSettings.getAsBoolean(INDEX_TRANSLOG_DISABLE_FLUSH, false);
         this.indexShardOperationCounter = new IndexShardOperationCounter(logger, shardId);
 
-        this.searcherWrapper = provider.getIndexSearcherWrapper();
+        this.searcherWrapper = indexSearcherWrapper;
         this.percolatorQueriesRegistry = new PercolatorQueriesRegistry(shardId, indexSettings, provider.getQueryParserService(), indexingService, mapperService, indexFieldDataService);
         if (mapperService.hasMapping(PercolatorService.TYPE_NAME)) {
             percolatorQueriesRegistry.enableRealTimePercolator();

--- a/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
@@ -37,8 +37,8 @@ import org.elasticsearch.index.translog.TranslogStats;
  */
 public final class ShadowIndexShard extends IndexShard {
 
-    public ShadowIndexShard(ShardId shardId, IndexSettings indexSettings, ShardPath path, Store store, IndexServicesProvider provider) throws IOException {
-        super(shardId, indexSettings, path, store, provider);
+    public ShadowIndexShard(ShardId shardId, IndexSettings indexSettings, ShardPath path, Store store, IndexSearcherWrapper wrapper, IndexServicesProvider provider) throws IOException {
+        super(shardId, indexSettings, path, store, wrapper, provider);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -57,7 +57,7 @@ public class IndexModuleTests extends ModuleTestCase {
         final Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(index, settings, Collections.EMPTY_LIST);
         IndexModule module = new IndexModule(indexSettings, null, null, warmer);
-        assertInstanceBinding(module, IndexSearcherWrapper.class, (x) -> x == null);
+        assertInstanceBinding(module, IndexModule.IndexSearcherWrapperFactory.class, (x) -> x.newWrapper(null) == null);
         module.setSearcherWrapper((s) ->  new Wrapper());
         assertInstanceBinding(module, IndexModule.IndexSearcherWrapperFactory.class, (x) -> x.newWrapper(null) instanceof Wrapper);
     }

--- a/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -58,8 +58,8 @@ public class IndexModuleTests extends ModuleTestCase {
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(index, settings, Collections.EMPTY_LIST);
         IndexModule module = new IndexModule(indexSettings, null, null, warmer);
         assertInstanceBinding(module, IndexSearcherWrapper.class, (x) -> x == null);
-        module.indexSearcherWrapper = Wrapper.class;
-        assertBinding(module, IndexSearcherWrapper.class, Wrapper.class);
+        module.setSearcherWrapper((s) ->  new Wrapper());
+        assertInstanceBinding(module, IndexModule.IndexSearcherWrapperFactory.class, (x) -> x.newWrapper(null) instanceof Wrapper);
     }
 
     public void testEngineFactoryBound() {

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1026,8 +1026,8 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         ShardRouting routing = new ShardRouting(shard.routingEntry());
         shard.close("simon says", true);
         IndexServicesProvider indexServices = indexService.getIndexServices();
-        IndexServicesProvider newProvider = new IndexServicesProvider(indexServices.getIndexEventListener(), indexServices.getThreadPool(), indexServices.getMapperService(), indexServices.getQueryParserService(), indexServices.getIndexCache(), indexServices.getIndicesQueryCache(), indexServices.getCodecService(), indexServices.getTermVectorsService(), indexServices.getIndexFieldDataService(), indexServices.getWarmer(), indexServices.getSimilarityService(), indexServices.getFactory(), indexServices.getBigArrays(), wrapper, indexServices.getIndexingMemoryController());
-        IndexShard newShard = new IndexShard(shard.shardId(), indexService.getIndexSettings(), shard.shardPath(), shard.store(), newProvider);
+        IndexServicesProvider newProvider = new IndexServicesProvider(indexServices.getIndexEventListener(), indexServices.getThreadPool(), indexServices.getMapperService(), indexServices.getQueryParserService(), indexServices.getIndexCache(), indexServices.getIndicesQueryCache(), indexServices.getCodecService(), indexServices.getTermVectorsService(), indexServices.getIndexFieldDataService(), indexServices.getWarmer(), indexServices.getSimilarityService(), indexServices.getFactory(), indexServices.getBigArrays(), indexServices.getIndexingMemoryController());
+        IndexShard newShard = new IndexShard(shard.shardId(), indexService.getIndexSettings(), shard.shardPath(), shard.store(), wrapper, newProvider);
         ShardRoutingHelper.reinit(routing);
         newShard.updateRoutingEntry(routing, false);
         DiscoveryNode localNode = new DiscoveryNode("foo", DummyTransportAddress.INSTANCE, Version.CURRENT);


### PR DESCRIPTION
This commit makes QueryCache and SearcherWrappoer registration public
otherwise plugins can't access those extension points due to security restrictions.
