### PR TITLE
Deduplicate concrete indices after indices resolution

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -76,7 +76,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
     }
 
     /**
-     * Translates the provided index expression into actual concrete indices.
+     * Translates the provided index expression into actual concrete indices, properly deduplicated.
      *
      * @param state             the cluster state containing all the data to resolve to expressions to concrete indices
      * @param options           defines how the aliases or indices need to be resolved to concrete indices
@@ -94,7 +94,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
     }
 
     /**
-     * Translates the provided index expression into actual concrete indices.
+     * Translates the provided index expression into actual concrete indices, properly deduplicated.
      *
      * @param state             the cluster state containing all the data to resolve to expressions to concrete indices
      * @param options           defines how the aliases or indices need to be resolved to concrete indices
@@ -141,7 +141,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
             }
         }
 
-        List<String> concreteIndices = new ArrayList<>(expressions.size());
+        final Set<String> concreteIndices = new HashSet<>(expressions.size());
         for (String expression : expressions) {
             AliasOrIndex aliasOrIndex = metaData.getAliasAndIndexLookup().get(expression);
             if (aliasOrIndex == null) {

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -847,6 +847,19 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(results, arrayContainingInAnyOrder("foo1-closed", "foo2-closed", "foo3"));
     }
 
+    public void testDedupConcreteIndices() {
+        MetaData.Builder mdBuilder = MetaData.builder()
+                .put(indexBuilder("index1").putAlias(AliasMetaData.builder("alias1")));
+        ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
+        IndicesOptions[] indicesOptions = new IndicesOptions[]{ IndicesOptions.strictExpandOpen(), IndicesOptions.strictExpand(),
+                IndicesOptions.lenientExpandOpen(), IndicesOptions.strictExpandOpenAndForbidClosed()};
+        for (IndicesOptions options : indicesOptions) {
+            IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, options);
+            String[] results = indexNameExpressionResolver.concreteIndices(context, "index1", "index1", "alias1");
+            assertThat(results, equalTo(new String[]{"index1"}));
+        }
+    }
+
     private MetaData metaDataBuilder(String... indices) {
         MetaData.Builder mdBuilder = MetaData.builder();
         for (String concreteIndex : indices) {


### PR DESCRIPTION
This commit fixes a regression introduced with #12058 as we are not deduplicating concrete indices after indices resolution anymore. This causes failures with the delete index api when providing the same index name multiple times in the request, or aliases/wildcard expressions that end up pointing to the same concrete index. The bug was revealed after merging #11258 as we delete indices in batch rather than one by one. The master node will expect too many acknowledgements based on the number of indices that it's trying to delete, hence the request will never be acknowledged by all nodes.
