### PR TITLE
Caching Weight wrappers should propagate the BulkScorer.

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/cache/query/IndicesQueryCache.java
@@ -21,6 +21,7 @@ package org.elasticsearch.indices.cache.query;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.LRUQueryCache;
 import org.apache.lucene.search.Query;
@@ -255,6 +256,12 @@ public class IndicesQueryCache extends AbstractComponent implements QueryCache, 
         public Scorer scorer(LeafReaderContext context) throws IOException {
             shardKeyMap.add(context.reader());
             return in.scorer(context);
+        }
+
+        @Override
+        public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
+            shardKeyMap.add(context.reader());
+            return in.bulkScorer(context);
         }
     }
 


### PR DESCRIPTION
If we don't, then we will use the default bulk scorer, which can be
significantly slower in some cases (eg. disjunctions).

Related to https://issues.apache.org/jira/browse/LUCENE-6856
