### PR TITLE
Remove and forbid usage of Thread#getAllThreadGroups()

### DIFF
--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -326,28 +326,21 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
     protected final void beforeInternal() throws Exception {
         assert Thread.getDefaultUncaughtExceptionHandler() instanceof ElasticsearchUncaughtExceptionHandler;
-        try {
-            final Scope currentClusterScope = getCurrentClusterScope();
-            switch (currentClusterScope) {
-                case SUITE:
-                    assert SUITE_SEED != null : "Suite seed was not initialized";
-                    currentCluster = buildAndPutCluster(currentClusterScope, SUITE_SEED);
-                    break;
-                case TEST:
-                    currentCluster = buildAndPutCluster(currentClusterScope, randomLong());
-                    break;
-                default:
-                    fail("Unknown Scope: [" + currentClusterScope + "]");
-            }
-            cluster().beforeTest(getRandom(), getPerTestTransportClientRatio());
-            cluster().wipe(excludeTemplates());
-            randomIndexTemplate();
-        } catch (OutOfMemoryError e) {
-            if (e.getMessage().contains("unable to create new native thread")) {
-                ESTestCase.printStackDump(logger);
-            }
-            throw e;
+        final Scope currentClusterScope = getCurrentClusterScope();
+        switch (currentClusterScope) {
+            case SUITE:
+                assert SUITE_SEED != null : "Suite seed was not initialized";
+                currentCluster = buildAndPutCluster(currentClusterScope, SUITE_SEED);
+                break;
+            case TEST:
+                currentCluster = buildAndPutCluster(currentClusterScope, randomLong());
+                break;
+            default:
+                fail("Unknown Scope: [" + currentClusterScope + "]");
         }
+        cluster().beforeTest(getRandom(), getPerTestTransportClientRatio());
+        cluster().wipe(excludeTemplates());
+        randomIndexTemplate();
     }
 
     private void printTestMessage(String message) {

--- a/core/src/test/java/org/elasticsearch/test/ESTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESTestCase.java
@@ -570,39 +570,9 @@ public abstract class ESTestCase extends LuceneTestCase {
                 if (e.getMessage() != null && ((EsRejectedExecutionException) e).isExecutorShutdown()) {
                     return; // ignore the EsRejectedExecutionException when a node shuts down
                 }
-            } else if (e instanceof OutOfMemoryError) {
-                if (e.getMessage() != null && e.getMessage().contains("unable to create new native thread")) {
-                    printStackDump(logger);
-                }
             }
             parent.uncaughtException(t, e);
         }
-    }
-
-    protected static final void printStackDump(ESLogger logger) {
-        // print stack traces if we can't create any native thread anymore
-        Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
-        logger.error(formatThreadStacks(allStackTraces));
-    }
-
-    /** Dump threads and their current stack trace. */
-    public static String formatThreadStacks(Map<Thread, StackTraceElement[]> threads) {
-        StringBuilder message = new StringBuilder();
-        int cnt = 1;
-        final Formatter f = new Formatter(message, Locale.ENGLISH);
-        for (Map.Entry<Thread, StackTraceElement[]> e : threads.entrySet()) {
-            if (e.getKey().isAlive()) {
-                f.format(Locale.ENGLISH, "\n  %2d) %s", cnt++, threadName(e.getKey())).flush();
-            }
-            if (e.getValue().length == 0) {
-                message.append("\n        at (empty stack)");
-            } else {
-                for (StackTraceElement ste : e.getValue()) {
-                    message.append("\n        at ").append(ste);
-                }
-            }
-        }
-        return message.toString();
     }
 
     private static String threadName(Thread t) {

--- a/core/src/test/java/org/elasticsearch/test/TestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/TestCluster.java
@@ -153,12 +153,6 @@ public abstract class TestCluster implements Iterable<Client>, Closeable {
                         assertAcked(client().admin().indices().prepareDelete(concreteIndices.toArray(String.class)));
                     }
                 }
-            } catch (AssertionError ae) {
-                // Try to see what threads are doing when we hit the "Delete index failed - not acked":
-                logger.info("dump all threads on AssertionError");
-                ESTestCase.printStackDump(logger);
-                logger.info("done dump all threads on AssertionError");
-                throw ae;
             }
         }
     }

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -97,3 +97,6 @@ java.lang.reflect.AccessibleObject#setAccessible(java.lang.reflect.AccessibleObj
 
 @defaultMessage this should not have been added to lucene in the first place
 org.apache.lucene.index.IndexReader#getCombinedCoreAndDeletesKey()
+
+@defaultMessage this method needs special permission
+java.lang.Thread#getAllStackTraces()


### PR DESCRIPTION
This method needs special permission and can cause all kinds of other problems
if we are creating lots of theads. Also the reason why we added this are fixed
long ago, no need to maintain this code.
