### PR TITLE
support symlinked .m2/repository in tests

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -133,10 +133,11 @@ final class Security {
                     Path policyFile = plugin.resolve(PluginInfo.ES_PLUGIN_POLICY);
                     if (Files.exists(policyFile)) {
                         // first get a list of URLs for the plugins' jars:
+                        // we resolve symlinks so map is keyed on the normalize codebase name
                         List<URL> codebases = new ArrayList<>();
                         try (DirectoryStream<Path> jarStream = Files.newDirectoryStream(plugin, "*.jar")) {
                             for (Path jar : jarStream) {
-                                codebases.add(jar.toUri().toURL());
+                                codebases.add(jar.toRealPath().toUri().toURL());
                             }
                         }
                         

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -174,7 +174,7 @@ public class BootstrapForTesting {
         }
         
         // compute classpath minus obvious places, all other jars will get the permission.
-        Set<URL> codebases = new HashSet<>(Arrays.asList(JarHell.parseClassPath()));
+        Set<URL> codebases = new HashSet<>(Arrays.asList(parseClassPathWithSymlinks()));
         Set<URL> excluded = new HashSet<>(Arrays.asList(
                 // es core
                 Bootstrap.class.getProtectionDomain().getCodeSource().getLocation(),
@@ -212,6 +212,19 @@ public class BootstrapForTesting {
             });
         }
         return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * return parsed classpath, but with symlinks resolved to destination files for matching
+     * this is for matching the toRealPath() in the code where we have a proper plugin structure
+     */
+    @SuppressForbidden(reason = "does evil stuff with paths and urls because devs and jenkins do evil stuff with paths and urls")
+    static URL[] parseClassPathWithSymlinks() throws Exception {
+        URL raw[] = JarHell.parseClassPath();
+        for (int i = 0; i < raw.length; i++) {
+            raw[i] = PathUtils.get(raw[i].toURI()).toRealPath().toUri().toURL();
+        }
+        return raw;
     }
 
     // does nothing, just easy way to make sure the class is loaded.


### PR DESCRIPTION
Some jenkins servers have this, but our codebase normalization doesn't
follow symlinks. Add this so that its correct.

Only really impacts tests, i suppose it helps if someone has a symlinked plugins/
but that is not recommended :)

Easy to see the current problems on e.g. jenkins servers configured this way:

```
mvn clean verify -Dmaven.repo.local=/some/symlink/to/the/real/m2/repository
```
