### PR TITLE
Replace processor builder and builder factory for a simple processor factory

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/Processor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/Processor.java
@@ -39,40 +39,24 @@ public interface Processor {
     void execute(Data data);
 
     /**
-     * A builder to construct a processor to be used in a pipeline.
+     * A factory that knows how to construct a processor based on a map of maps.
      */
-    interface Builder {
+    interface Factory extends Closeable {
 
         /**
-         * A general way to set processor related settings based on the config map.
+         * Creates a processor based on the specified map of maps config
          */
-        void fromMap(Map<String, Object> config);
+        Processor create(Map<String, Object> config) throws IOException;
 
         /**
-         * Builds the processor based on previous set settings.
          */
-        Processor build() throws IOException;
-
-        /**
-         * A factory that creates a processor builder when processor instances for pipelines are being created.
-         */
-        interface Factory extends Closeable {
-
-            /**
-             * Creates the builder.
-             */
-            Builder create();
-
-            /**
-             */
-            default void setConfigDirectory(Path configDirectory) {
-            }
-
-            @Override
-            default void close() throws IOException {
-            }
+        default void setConfigDirectory(Path configDirectory) {
         }
 
+        @Override
+        default void close() throws IOException {
+        }
+        
     }
 
 }

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/simple/SimpleProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/simple/SimpleProcessor.java
@@ -52,48 +52,14 @@ public final class SimpleProcessor implements Processor {
         }
     }
 
-    public static class Builder implements Processor.Builder {
+    public static class Factory implements Processor.Factory {
 
-        private String path;
-        private String expectedValue;
-        private String addField;
-        private String addFieldValue;
-
-        public void setPath(String path) {
-            this.path = path;
-        }
-
-        public void setExpectedValue(String value) {
-            this.expectedValue = value;
-        }
-
-        public void setAddField(String addField) {
-            this.addField = addField;
-        }
-
-        public void setAddFieldValue(String addFieldValue) {
-            this.addFieldValue = addFieldValue;
-        }
-
-        public void fromMap(Map<String, Object> config) {
-            this.path = (String) config.get("path");
-            this.expectedValue = (String) config.get("expected_value");
-            this.addField = (String) config.get("add_field");
-            this.addFieldValue = (String) config.get("add_field_value");
-        }
-
-        @Override
-        public Processor build() {
+        public Processor create(Map<String, Object> config) {
+            String path = (String) config.get("path");
+            String expectedValue = (String) config.get("expected_value");
+            String addField = (String) config.get("add_field");
+            String addFieldValue = (String) config.get("add_field_value");
             return new SimpleProcessor(path, expectedValue, addField, addFieldValue);
-        }
-
-        public static class Factory implements Processor.Builder.Factory {
-
-            @Override
-            public Processor.Builder create() {
-                return new Builder();
-            }
-
         }
 
     }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestModule.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestModule.java
@@ -32,7 +32,7 @@ import java.util.Map;
 
 public class IngestModule extends AbstractModule {
 
-    private final Map<String, Class<? extends Processor.Builder.Factory>> processors = new HashMap<>();
+    private final Map<String, Processor.Factory> processors = new HashMap<>();
 
     @Override
     protected void configure() {
@@ -41,18 +41,21 @@ public class IngestModule extends AbstractModule {
         binder().bind(PipelineStore.class).asEagerSingleton();
         binder().bind(PipelineStoreClient.class).asEagerSingleton();
 
-        registerProcessor(SimpleProcessor.TYPE, SimpleProcessor.Builder.Factory.class);
-        registerProcessor(GeoIpProcessor.TYPE, GeoIpProcessor.Builder.Factory.class);
-        registerProcessor(GrokProcessor.TYPE, GrokProcessor.Builder.Factory.class);
+        addProcessor(SimpleProcessor.TYPE, new SimpleProcessor.Factory());
+        addProcessor(GeoIpProcessor.TYPE, new GeoIpProcessor.Factory());
+        addProcessor(GrokProcessor.TYPE, new GrokProcessor.Factory());
 
-        MapBinder<String, Processor.Builder.Factory> mapBinder = MapBinder.newMapBinder(binder(), String.class, Processor.Builder.Factory.class);
-        for (Map.Entry<String, Class<? extends Processor.Builder.Factory>> entry : processors.entrySet()) {
-            mapBinder.addBinding(entry.getKey()).to(entry.getValue());
+        MapBinder<String, Processor.Factory> mapBinder = MapBinder.newMapBinder(binder(), String.class, Processor.Factory.class);
+        for (Map.Entry<String, Processor.Factory> entry : processors.entrySet()) {
+            mapBinder.addBinding(entry.getKey()).toInstance(entry.getValue());
         }
     }
 
-    public void registerProcessor(String processorType, Class<? extends Processor.Builder.Factory> processorFactory) {
-        processors.put(processorType, processorFactory);
+    /**
+     * Adds a processor factory under a specific type name.
+     */
+    public void addProcessor(String type, Processor.Factory factory) {
+        processors.put(type, factory);
     }
 
 }

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineExecutionServiceTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineExecutionServiceTests.java
@@ -28,8 +28,8 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -67,20 +67,8 @@ public class PipelineExecutionServiceTests extends ESTestCase {
     }
 
     public void testExecute_success() throws Exception {
-        Pipeline.Builder builder = new Pipeline.Builder("_id");
         Processor processor = mock(Processor.class);
-        builder.addProcessors(new Processor.Builder() {
-            @Override
-            public void fromMap(Map<String, Object> config) {
-            }
-
-            @Override
-            public Processor build() {
-                return processor;
-            }
-        });
-
-        when(store.get("_id")).thenReturn(builder.build());
+        when(store.get("_id")).thenReturn(new Pipeline("_id", "_description", Arrays.asList(processor)));
 
         Data data = new Data("_index", "_type", "_id", Collections.emptyMap());
         PipelineExecutionService.Listener listener = mock(PipelineExecutionService.Listener.class);
@@ -96,20 +84,8 @@ public class PipelineExecutionServiceTests extends ESTestCase {
     }
 
     public void testExecute_failure() throws Exception {
-        Pipeline.Builder builder = new Pipeline.Builder("_id");
         Processor processor = mock(Processor.class);
-        builder.addProcessors(new Processor.Builder() {
-            @Override
-            public void fromMap(Map<String, Object> config) {
-            }
-
-            @Override
-            public Processor build() {
-                return processor;
-            }
-        });
-
-        when(store.get("_id")).thenReturn(builder.build());
+        when(store.get("_id")).thenReturn(new Pipeline("_id", "_description", Arrays.asList(processor)));
         Data data = new Data("_index", "_type", "_id", Collections.emptyMap());
         doThrow(new RuntimeException()).when(processor).execute(data);
         PipelineExecutionService.Listener listener = mock(PipelineExecutionService.Listener.class);

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineStoreTests.java
@@ -57,7 +57,7 @@ public class PipelineStoreTests extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         client = mock(PipelineStoreClient.class);
         Environment environment = mock(Environment.class);
-        store = new PipelineStore(Settings.EMPTY, threadPool, environment, clusterService, client, Collections.singletonMap(SimpleProcessor.TYPE, new SimpleProcessor.Builder.Factory()));
+        store = new PipelineStore(Settings.EMPTY, threadPool, environment, clusterService, client, Collections.singletonMap(SimpleProcessor.TYPE, new SimpleProcessor.Factory()));
         store.start();
     }
 

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilterTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilterTests.java
@@ -39,6 +39,8 @@ import org.junit.Before;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.Arrays;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -162,14 +164,7 @@ public class IngestActionFilterTests extends ESTestCase {
                         .build()
         );
         PipelineStore store = mock(PipelineStore.class);
-        Pipeline.Builder pipelineBuilder = new Pipeline.Builder("_id");
-        SimpleProcessor.Builder processorBuilder = new SimpleProcessor.Builder();
-        processorBuilder.setPath("field1");
-        processorBuilder.setExpectedValue("value1");
-        processorBuilder.setAddField("field2");
-        processorBuilder.setAddFieldValue("value2");
-        pipelineBuilder.addProcessors(processorBuilder);
-        when(store.get("_id")).thenReturn(pipelineBuilder.build());
+        when(store.get("_id")).thenReturn(new Pipeline("_id", "_description", Arrays.asList(new SimpleProcessor("field1", "value1", "field2", "value2"))));
         executionService = new PipelineExecutionService(store, threadPool);
         filter = new IngestActionFilter(Settings.EMPTY, executionService);
 


### PR DESCRIPTION
Instead of having a factory builder that created a builder and a builder that creates the actual processor, have just a factory that known how to build a processor from a map of maps. If processor need to be created programatically then the constructor of a processor should just be directly used.

Based on comments from:
- https://github.com/elastic/elasticsearch/pull/14132#discussion_r43151138
- https://github.com/elastic/elasticsearch/pull/14132#discussion_r43151271
