### PR TITLE
Forbid cached thread pools

### DIFF
--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -39,12 +39,7 @@ import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.node.settings.NodeSettingsService;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -336,6 +331,9 @@ public class ThreadPool extends AbstractComponent {
             }
             return new ExecutorHolder(DIRECT_EXECUTOR, new Info(name, type));
         } else if ("cached".equals(type)) {
+            if (!Names.GENERIC.equals(name)) {
+                throw new IllegalArgumentException("thread pool type cached is reserved only for the generic thread pool and can not be applied to [" + name + "]");
+            }
             TimeValue defaultKeepAlive = defaultSettings.getAsTime("keep_alive", timeValueMinutes(5));
             if (previousExecutorHolder != null) {
                 if ("cached".equals(previousInfo.getType())) {

--- a/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/core/src/test/java/org/elasticsearch/test/InternalTestCluster.java
@@ -411,7 +411,7 @@ public final class InternalTestCluster extends TestCluster {
                     ThreadPool.Names.PERCOLATE, ThreadPool.Names.REFRESH, ThreadPool.Names.SEARCH, ThreadPool.Names.SNAPSHOT,
                     ThreadPool.Names.SUGGEST, ThreadPool.Names.WARMER)) {
                 if (random.nextBoolean()) {
-                    final String type = RandomPicks.randomFrom(random, Arrays.asList("fixed", "cached", "scaling"));
+                    final String type = RandomPicks.randomFrom(random, Arrays.asList("fixed", "scaling"));
                     builder.put(ThreadPool.THREADPOOL_GROUP + name + ".type", type);
                 }
             }

--- a/core/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
@@ -67,7 +67,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class SimpleThreadPoolIT extends ESIntegTestCase {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.settingsBuilder().put(super.nodeSettings(nodeOrdinal)).put("threadpool.search.type", "cached").build();
+        return Settings.settingsBuilder().put(super.nodeSettings(nodeOrdinal)).put("threadpool.search.type", "scaling").build();
     }
 
     public void testThreadNames() throws Exception {

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -376,4 +376,13 @@ request cache and the field data cache.
 
 This setting would arbitrarily pick the first interface not marked as loopback. Instead, specify by address
 scope (e.g. `_local_,_site_` for all loopback and private network addresses) or by explicit interface names,
-hostnames, or addresses. 
+hostnames, or addresses.
+
+=== Forbid thread pool from being of type `cached`
+
+Previously, <<modules-threadpool,thread pools>> could be of type `cached`, `fixed`, or `scaling`. The `cached` type is
+generally dangerous because it is an unbounded thread pool. The ability to set a thread pool to be of type `cached` has
+been removed; the `cached` thread pool remains and is reserved only for the <<modules-threadpool,`generic`>> thread pool
+because operations submitted to this thread pool must not block and can not be rejected. Elasticsearch will throw an
+`IllegalArgumentException` if the `cached` thread pool type is applied to any thread pool other than the `generic`
+thread pool.

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -9,6 +9,9 @@ of discarded.
 
 There are several thread pools, but the important ones include:
 
+`generic`::
+    For generic operations (e.g., background node discovery).
+
 `index`::
     For index/delete operations. Defaults to `fixed`
     with a size of `# of available processors`,
@@ -67,7 +70,7 @@ threadpool:
         size: 30
 --------------------------------------------------
 
-NOTE: you can update threadpool settings live using
+NOTE: you can update thread pool settings live using
       <<cluster-update-settings>>.
 
 
@@ -79,18 +82,16 @@ The following are the types of thread pools that can be used and their
 respective parameters:
 
 [float]
-==== `cache`
+==== `cached`
 
-The `cache` thread pool is an unbounded thread pool that will spawn a
-thread if there are pending requests. Here is an example of how to set
-it:
-
-[source,js]
---------------------------------------------------
-threadpool:
-    index:
-        type: cached
---------------------------------------------------
+The `cached` thread pool is an unbounded thread pool that will spawn a
+thread if there are pending requests. This thread pool is used to
+prevent requests submitted to this pool from blocking or being
+rejected. Unused threads in this thread pool will be terminated after
+a keep alive expires (defaults to thirty seconds). The `cached` thread
+pool is reserved for the <<modules-threadpool,`generic`>> thread pool
+(which must be of type `cached`) and can not be applied to any other
+thread pool.
 
 [float]
 ==== `fixed`


### PR DESCRIPTION
This commit forbids the “cached” thread pool setting for any thread
pool other than the generic thread pool (which we continue to require
to be of type “cached”).

Closes #14294, relates #2858, relates #5152
