### PR TITLE
Upgrade to randomizedtesting 2.2.0

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -214,7 +214,12 @@ mvn test -Dtests.heap.size=512m
 Pass arbitrary jvm arguments.
 
 ------------------------------
+# specify heap dump path
 mvn test -Dtests.jvm.argline="-XX:HeapDumpPath=/path/to/heapdumps"
+# enable gc logging
+mvn test -Dtests.jvm.argline="-verbose:gc"
+# enable security debugging
+mvn test -Dtests.jvm.argline="-Djava.security.debug=access,failure"
 ------------------------------
 
 == Backwards Compatibility Tests

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -88,6 +88,11 @@ import java.util.Map;
  * <pre>
  * JAVA_OPTS="-Djava.security.debug=access,failure" bin/elasticsearch
  * </pre>
+ * <p>
+ * When running tests you have to pass it to the test runner like this:
+ * <pre>
+ * mvn test -Dtests.jvm.argline="-Djava.security.debug=access,failure" ...
+ * </pre>
  * See <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/troubleshooting-security.html">
  * Troubleshooting Security</a> for information.
  */

--- a/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -35,7 +35,7 @@ grant codeBase "${codebase.lucene-test-framework-5.4.0-snapshot-1710880.jar}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-grant codeBase "${codebase.randomizedtesting-runner-2.1.17.jar}" {
+grant codeBase "${codebase.randomizedtesting-runner-2.2.0.jar}" {
   // optionally needed for access to private test methods (e.g. beforeClass)
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed to fail tests on uncaught exceptions from other threads
@@ -44,10 +44,7 @@ grant codeBase "${codebase.randomizedtesting-runner-2.1.17.jar}" {
   permission java.lang.RuntimePermission "modifyThreadGroup";
 };
 
-grant codeBase "${codebase.junit4-ant-2.1.17.jar}" {
-  // needed for gson serialization
-  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
-
+grant codeBase "${codebase.junit4-ant-2.2.0.jar}" {
   // needed for stream redirection
   permission java.lang.RuntimePermission "setIO";
 };

--- a/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
+++ b/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.test.geo;
 
-import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.generators.RandomInts;
 import com.spatial4j.core.context.jts.JtsSpatialContext;
 import com.spatial4j.core.distance.DistanceUtils;
@@ -30,6 +29,7 @@ import com.spatial4j.core.shape.impl.Range;
 import com.vividsolutions.jts.algorithm.ConvexHull;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.geo.builders.BaseLineStringBuilder;
 import org.elasticsearch.common.geo.builders.GeometryCollectionBuilder;
@@ -40,6 +40,7 @@ import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.geo.builders.PointCollection;
 import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.junit.Assert;
 
 import java.util.Random;
 
@@ -251,7 +252,7 @@ public class RandomShapeGenerator extends RandomGeoGenerator {
         double[] pt = new double[2];
         randomPointIn(rand, r.getMinX(), r.getMinY(), r.getMaxX(), r.getMaxY(), pt);
         Point p = ctx.makePoint(pt[0], pt[1]);
-        RandomizedTest.assertEquals(CONTAINS, r.relate(p));
+        Assert.assertEquals(CONTAINS, r.relate(p));
         return p;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <lucene.version>5.4.0</lucene.version>
         <lucene.snapshot.revision>1710880</lucene.snapshot.revision>
         <lucene.maven.version>5.4.0-snapshot-${lucene.snapshot.revision}</lucene.maven.version>
-        <testframework.version>2.1.17</testframework.version>
+        <testframework.version>2.2.0</testframework.version>
         <securemock.version>1.1</securemock.version>
 
         <jackson.version>2.6.2</jackson.version>


### PR DESCRIPTION
This is just released (https://github.com/randomizedtesting/randomizedtesting/blob/master/CHANGES.txt)

Most important is it solves a long running issue (https://issues.apache.org/jira/browse/LUCENE-6478) which prevented us from being able to use `java.security.debug` in tests... this is really important to be able to do!
