### PR TITLE
Add Field Mapping Support for GeoPointV2

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperBuilders.java
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.core.*;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapperLegacy;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
-import org.elasticsearch.index.mapper.internal.*;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.mapper.object.RootObjectMapper;
@@ -92,8 +94,11 @@ public final class MapperBuilders {
         return new DoubleFieldMapper.Builder(name);
     }
 
-    public static GeoPointFieldMapper.Builder geoPointField(String name) {
-        return new GeoPointFieldMapper.Builder(name);
+    public static BaseGeoPointFieldMapper.Builder geoPointField(String name, Version version) {
+        // TODO switch to version.onOrBefore(Version.V_2_1_0) once GeoPointField V2 is fully merged
+        return (version.onOrBefore(Version.V_2_2_0) ?
+                new GeoPointFieldMapperLegacy.Builder(name) :
+                new GeoPointFieldMapper.Builder(name));
     }
 
     public static GeoShapeFieldMapper.Builder geoShapeField(String name) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/BaseGeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/BaseGeoPointFieldMapper.java
@@ -1,0 +1,510 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.geo;
+
+import com.google.common.collect.Iterators;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.util.GeoHashUtils;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MergeMappingException;
+import org.elasticsearch.index.mapper.MergeResult;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper;
+import org.elasticsearch.index.mapper.core.StringFieldMapper;
+import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.elasticsearch.index.mapper.MapperBuilders.doubleField;
+import static org.elasticsearch.index.mapper.MapperBuilders.geoPointField;
+import static org.elasticsearch.index.mapper.MapperBuilders.stringField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
+
+/**
+ *
+ */
+public abstract class BaseGeoPointFieldMapper extends FieldMapper implements ArrayValueMapperParser {
+    public static final String CONTENT_TYPE = "geo_point";
+
+    public static class Names {
+        public static final String LAT = "lat";
+        public static final String LAT_SUFFIX = "." + LAT;
+        public static final String LON = "lon";
+        public static final String LON_SUFFIX = "." + LON;
+        public static final String GEOHASH = "geohash";
+        public static final String GEOHASH_SUFFIX = "." + GEOHASH;
+        public static final String IGNORE_MALFORMED = "ignore_malformed";
+    }
+
+    public static class Defaults {
+        public static final ContentPath.Type PATH_TYPE = ContentPath.Type.FULL;
+        public static final boolean ENABLE_LATLON = false;
+        public static final boolean ENABLE_GEOHASH = false;
+        public static final boolean ENABLE_GEOHASH_PREFIX = false;
+        public static final int GEO_HASH_PRECISION = GeoHashUtils.PRECISION;
+        public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit(false, false);
+    }
+
+    public abstract static class Builder<T extends Builder, Y extends BaseGeoPointFieldMapper> extends FieldMapper.Builder<T, Y> {
+        protected ContentPath.Type pathType = Defaults.PATH_TYPE;
+
+        protected boolean enableLatLon = Defaults.ENABLE_LATLON;
+
+        protected Integer precisionStep;
+
+        protected boolean enableGeoHash = Defaults.ENABLE_GEOHASH;
+
+        protected boolean enableGeohashPrefix = Defaults.ENABLE_GEOHASH_PREFIX;
+
+        protected int geoHashPrecision = Defaults.GEO_HASH_PRECISION;
+
+        protected Boolean ignoreMalformed;
+
+        public Builder(String name, BaseGeoPointFieldType fieldType) {
+            super(name, fieldType);
+        }
+
+        public T enableLatLon(boolean enableLatLon) {
+            this.enableLatLon = enableLatLon;
+            return builder;
+        }
+
+        public T precisionStep(int precisionStep) {
+            this.precisionStep = precisionStep;
+            return builder;
+        }
+
+        public T enableGeoHash(boolean enableGeoHash) {
+            this.enableGeoHash = enableGeoHash;
+            return builder;
+        }
+
+        public T geohashPrefix(boolean enableGeohashPrefix) {
+            this.enableGeohashPrefix = enableGeohashPrefix;
+            return builder;
+        }
+
+        public T geoHashPrecision(int precision) {
+            this.geoHashPrecision = precision;
+            return builder;
+        }
+
+        public Builder ignoreMalformed(boolean ignoreMalformed) {
+            this.ignoreMalformed = ignoreMalformed;
+            return builder;
+        }
+
+        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
+            if (ignoreMalformed != null) {
+                return new Explicit<>(ignoreMalformed, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(context.indexSettings().getAsBoolean("index.mapping.ignore_malformed", Defaults.IGNORE_MALFORMED.value()), false);
+            }
+            return Defaults.IGNORE_MALFORMED;
+        }
+
+        public abstract Y build(BuilderContext context, String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                                Settings indexSettings, ContentPath.Type pathType, DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper,
+                                StringFieldMapper geohashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed, CopyTo copyTo);
+
+        public Y build(Mapper.BuilderContext context) {
+            ContentPath.Type origPathType = context.path().pathType();
+            context.path().pathType(pathType);
+
+            BaseGeoPointFieldType geoPointFieldType = (BaseGeoPointFieldType)fieldType;
+
+            DoubleFieldMapper latMapper = null;
+            DoubleFieldMapper lonMapper = null;
+
+            context.path().add(name);
+            if (enableLatLon) {
+                NumberFieldMapper.Builder<?, ?> latMapperBuilder = doubleField(Names.LAT).includeInAll(false);
+                NumberFieldMapper.Builder<?, ?> lonMapperBuilder = doubleField(Names.LON).includeInAll(false);
+                if (precisionStep != null) {
+                    latMapperBuilder.precisionStep(precisionStep);
+                    lonMapperBuilder.precisionStep(precisionStep);
+                }
+                latMapper = (DoubleFieldMapper) latMapperBuilder.includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
+                lonMapper = (DoubleFieldMapper) lonMapperBuilder.includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
+                geoPointFieldType.setLatLonEnabled(latMapper.fieldType(), lonMapper.fieldType());
+            }
+            StringFieldMapper geohashMapper = null;
+            if (enableGeoHash || enableGeohashPrefix) {
+                // TODO: possible also implicitly enable geohash if geohash precision is set
+                geohashMapper = stringField(Names.GEOHASH).index(true).tokenized(false).includeInAll(false).store(fieldType.stored())
+                        .omitNorms(true).indexOptions(IndexOptions.DOCS).build(context);
+                geoPointFieldType.setGeohashEnabled(geohashMapper.fieldType(), geoHashPrecision, enableGeohashPrefix);
+            }
+            context.path().remove();
+            context.path().pathType(origPathType);
+
+            return build(context, name, fieldType, defaultFieldType, context.indexSettings(), origPathType,
+                    latMapper, lonMapper, geohashMapper, multiFieldsBuilder.build(this, context), ignoreMalformed(context), copyTo);
+        }
+    }
+
+    public abstract static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            Builder builder = geoPointField(name, parserContext.indexVersionCreated());
+            parseField(builder, name, node, parserContext);
+
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = Strings.toUnderscoreCase(entry.getKey());
+                Object propNode = entry.getValue();
+                if (propName.equals("lat_lon")) {
+                    builder.enableLatLon(XContentMapValues.nodeBooleanValue(propNode));
+                    iterator.remove();
+                } else if (propName.equals("precision_step")) {
+                    builder.precisionStep(XContentMapValues.nodeIntegerValue(propNode));
+                    iterator.remove();
+                } else if (propName.equals("path") && parserContext.indexVersionCreated().before(Version.V_2_0_0_beta1)) {
+                    builder.multiFieldPathType(parsePathType(name, propNode.toString()));
+                    iterator.remove();
+                } else if (propName.equals("geohash")) {
+                    builder.enableGeoHash(XContentMapValues.nodeBooleanValue(propNode));
+                    iterator.remove();
+                } else if (propName.equals("geohash_prefix")) {
+                    builder.geohashPrefix(XContentMapValues.nodeBooleanValue(propNode));
+                    if (XContentMapValues.nodeBooleanValue(propNode)) {
+                        builder.enableGeoHash(true);
+                    }
+                    iterator.remove();
+                } else if (propName.equals("geohash_precision")) {
+                    if (propNode instanceof Integer) {
+                        builder.geoHashPrecision(XContentMapValues.nodeIntegerValue(propNode));
+                    } else {
+                        builder.geoHashPrecision(GeoUtils.geoHashLevelsForPrecision(propNode.toString()));
+                    }
+                    iterator.remove();
+                } else if (propName.equals(Names.IGNORE_MALFORMED)) {
+                    builder.ignoreMalformed(XContentMapValues.nodeBooleanValue(propNode));
+                    iterator.remove();
+                } else if (parseMultiField(builder, name, parserContext, propName, propNode)) {
+                    iterator.remove();
+                }
+            }
+
+            if (builder instanceof GeoPointFieldMapperLegacy.Builder) {
+                return GeoPointFieldMapperLegacy.parse((GeoPointFieldMapperLegacy.Builder) builder, node, parserContext);
+            }
+
+            return (GeoPointFieldMapper.Builder) builder;
+        }
+    }
+
+    public abstract static class BaseGeoPointFieldType extends MappedFieldType {
+        protected MappedFieldType geohashFieldType;
+        protected int geohashPrecision;
+        protected boolean geohashPrefixEnabled;
+
+        protected MappedFieldType latFieldType;
+        protected MappedFieldType lonFieldType;
+
+        BaseGeoPointFieldType() {}
+
+        BaseGeoPointFieldType(BaseGeoPointFieldType ref) {
+            super(ref);
+            this.geohashFieldType = ref.geohashFieldType; // copying ref is ok, this can never be modified
+            this.geohashPrecision = ref.geohashPrecision;
+            this.geohashPrefixEnabled = ref.geohashPrefixEnabled;
+            this.latFieldType = ref.latFieldType; // copying ref is ok, this can never be modified
+            this.lonFieldType = ref.lonFieldType; // copying ref is ok, this can never be modified
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!super.equals(o)) return false;
+            BaseGeoPointFieldType that = (BaseGeoPointFieldType) o;
+            return  geohashPrecision == that.geohashPrecision &&
+                    geohashPrefixEnabled == that.geohashPrefixEnabled &&
+                    java.util.Objects.equals(geohashFieldType, that.geohashFieldType) &&
+                    java.util.Objects.equals(latFieldType, that.latFieldType) &&
+                    java.util.Objects.equals(lonFieldType, that.lonFieldType);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(super.hashCode(), geohashFieldType, geohashPrecision, geohashPrefixEnabled, latFieldType,
+                    lonFieldType);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
+            super.checkCompatibility(fieldType, conflicts, strict);
+            BaseGeoPointFieldType other = (BaseGeoPointFieldType)fieldType;
+            if (isLatLonEnabled() != other.isLatLonEnabled()) {
+                conflicts.add("mapper [" + names().fullName() + "] has different [lat_lon]");
+            }
+            if (isLatLonEnabled() && other.isLatLonEnabled() &&
+                    latFieldType().numericPrecisionStep() != other.latFieldType().numericPrecisionStep()) {
+                conflicts.add("mapper [" + names().fullName() + "] has different [precision_step]");
+            }
+            if (isGeohashEnabled() != other.isGeohashEnabled()) {
+                conflicts.add("mapper [" + names().fullName() + "] has different [geohash]");
+            }
+            if (geohashPrecision() != other.geohashPrecision()) {
+                conflicts.add("mapper [" + names().fullName() + "] has different [geohash_precision]");
+            }
+            if (isGeohashPrefixEnabled() != other.isGeohashPrefixEnabled()) {
+                conflicts.add("mapper [" + names().fullName() + "] has different [geohash_prefix]");
+            }
+        }
+
+        public boolean isGeohashEnabled() {
+            return geohashFieldType != null;
+        }
+
+        public MappedFieldType geohashFieldType() {
+            return geohashFieldType;
+        }
+
+        public int geohashPrecision() {
+            return geohashPrecision;
+        }
+
+        public boolean isGeohashPrefixEnabled() {
+            return geohashPrefixEnabled;
+        }
+
+        public void setGeohashEnabled(MappedFieldType geohashFieldType, int geohashPrecision, boolean geohashPrefixEnabled) {
+            checkIfFrozen();
+            this.geohashFieldType = geohashFieldType;
+            this.geohashPrecision = geohashPrecision;
+            this.geohashPrefixEnabled = geohashPrefixEnabled;
+        }
+
+        public boolean isLatLonEnabled() {
+            return latFieldType != null;
+        }
+
+        public MappedFieldType latFieldType() {
+            return latFieldType;
+        }
+
+        public MappedFieldType lonFieldType() {
+            return lonFieldType;
+        }
+
+        public void setLatLonEnabled(MappedFieldType latFieldType, MappedFieldType lonFieldType) {
+            checkIfFrozen();
+            this.latFieldType = latFieldType;
+            this.lonFieldType = lonFieldType;
+        }
+    }
+
+    protected final DoubleFieldMapper latMapper;
+
+    protected final DoubleFieldMapper lonMapper;
+
+    protected final ContentPath.Type pathType;
+
+    protected final StringFieldMapper geohashMapper;
+
+    protected Explicit<Boolean> ignoreMalformed;
+
+    protected BaseGeoPointFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Settings indexSettings,
+                                      ContentPath.Type pathType, DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper, StringFieldMapper geohashMapper,
+                                      MultiFields multiFields, Explicit<Boolean> ignoreMalformed, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        this.pathType = pathType;
+        this.latMapper = latMapper;
+        this.lonMapper = lonMapper;
+        this.geohashMapper = geohashMapper;
+        this.ignoreMalformed = ignoreMalformed;
+    }
+
+    @Override
+    public BaseGeoPointFieldType fieldType() {
+        return (BaseGeoPointFieldType) super.fieldType();
+    }
+
+    @Override
+    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
+        super.merge(mergeWith, mergeResult);
+        if (!this.getClass().equals(mergeWith.getClass())) {
+            return;
+        }
+
+        BaseGeoPointFieldMapper gpfmMergeWith = (BaseGeoPointFieldMapper) mergeWith;
+        if (mergeResult.simulate() == false && mergeResult.hasConflicts() == false) {
+            if (gpfmMergeWith.ignoreMalformed.explicit()) {
+                this.ignoreMalformed = gpfmMergeWith.ignoreMalformed;
+            }
+        }
+    }
+
+    @Override
+    public Iterator<Mapper> iterator() {
+        List<Mapper> extras = new ArrayList<>();
+        if (fieldType().isGeohashEnabled()) {
+            extras.add(geohashMapper);
+        }
+        if (fieldType().isLatLonEnabled()) {
+            extras.add(latMapper);
+            extras.add(lonMapper);
+        }
+        return Iterators.concat(super.iterator(), extras.iterator());
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    protected void parse(ParseContext context, GeoPoint point, String geohash) throws IOException {
+        if (fieldType().isGeohashEnabled()) {
+            if (geohash == null) {
+                geohash = GeoHashUtils.stringEncode(point.lon(), point.lat());
+            }
+            addGeohashField(context, geohash);
+        }
+        if (fieldType().isLatLonEnabled()) {
+            latMapper.parse(context.createExternalValueContext(point.lat()));
+            lonMapper.parse(context.createExternalValueContext(point.lon()));
+        }
+        multiFields.parse(this, context);
+    }
+
+    @Override
+    public Mapper parse(ParseContext context) throws IOException {
+        ContentPath.Type origPathType = context.path().pathType();
+        context.path().pathType(pathType);
+        context.path().add(simpleName());
+
+        GeoPoint sparse = context.parseExternalValue(GeoPoint.class);
+
+        if (sparse != null) {
+            parse(context, sparse, null);
+        } else {
+            sparse = new GeoPoint();
+            XContentParser.Token token = context.parser().currentToken();
+            if (token == XContentParser.Token.START_ARRAY) {
+                token = context.parser().nextToken();
+                if (token == XContentParser.Token.START_ARRAY) {
+                    // its an array of array of lon/lat [ [1.2, 1.3], [1.4, 1.5] ]
+                    while (token != XContentParser.Token.END_ARRAY) {
+                        parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
+                        token = context.parser().nextToken();
+                    }
+                } else {
+                    // its an array of other possible values
+                    if (token == XContentParser.Token.VALUE_NUMBER) {
+                        double lon = context.parser().doubleValue();
+                        token = context.parser().nextToken();
+                        double lat = context.parser().doubleValue();
+                        while ((token = context.parser().nextToken()) != XContentParser.Token.END_ARRAY);
+                        parse(context, sparse.reset(lat, lon), null);
+                    } else {
+                        while (token != XContentParser.Token.END_ARRAY) {
+                            if (token == XContentParser.Token.VALUE_STRING) {
+                                parsePointFromString(context, sparse, context.parser().text());
+                            } else {
+                                parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
+                            }
+                            token = context.parser().nextToken();
+                        }
+                    }
+                }
+            } else if (token == XContentParser.Token.VALUE_STRING) {
+                parsePointFromString(context, sparse, context.parser().text());
+            } else if (token != XContentParser.Token.VALUE_NULL) {
+                parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
+            }
+        }
+
+        context.path().remove();
+        context.path().pathType(origPathType);
+        return null;
+    }
+
+    private void addGeohashField(ParseContext context, String geohash) throws IOException {
+        int len = Math.min(fieldType().geohashPrecision(), geohash.length());
+        int min = fieldType().isGeohashPrefixEnabled() ? 1 : len;
+
+        for (int i = len; i >= min; i--) {
+            // side effect of this call is adding the field
+            geohashMapper.parse(context.createExternalValueContext(geohash.substring(0, i)));
+        }
+    }
+
+    private void parsePointFromString(ParseContext context, GeoPoint sparse, String point) throws IOException {
+        if (point.indexOf(',') < 0) {
+            parse(context, sparse.resetFromGeoHash(point), point);
+        } else {
+            parse(context, sparse.resetFromString(point), null);
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+        if (includeDefaults || pathType != Defaults.PATH_TYPE) {
+            builder.field("path", pathType.name().toLowerCase(Locale.ROOT));
+        }
+        if (includeDefaults || fieldType().isLatLonEnabled() != GeoPointFieldMapper.Defaults.ENABLE_LATLON) {
+            builder.field("lat_lon", fieldType().isLatLonEnabled());
+        }
+        if (fieldType().isLatLonEnabled() && (includeDefaults || fieldType().latFieldType().numericPrecisionStep() != NumericUtils.PRECISION_STEP_DEFAULT)) {
+            builder.field("precision_step", fieldType().latFieldType().numericPrecisionStep());
+        }
+        if (includeDefaults || fieldType().isGeohashEnabled() != Defaults.ENABLE_GEOHASH) {
+            builder.field("geohash", fieldType().isGeohashEnabled());
+        }
+        if (includeDefaults || fieldType().isGeohashPrefixEnabled() != Defaults.ENABLE_GEOHASH_PREFIX) {
+            builder.field("geohash_prefix", fieldType().isGeohashPrefixEnabled());
+        }
+        if (fieldType().isGeohashEnabled() && (includeDefaults || fieldType().geohashPrecision() != Defaults.GEO_HASH_PRECISION)) {
+            builder.field("geohash_precision", fieldType().geohashPrecision());
+        }
+        if (includeDefaults || ignoreMalformed.explicit()) {
+            builder.field(Names.IGNORE_MALFORMED, ignoreMalformed.value());
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapper.java
@@ -19,53 +19,26 @@
 
 package org.elasticsearch.index.mapper.geo;
 
-import com.carrotsearch.hppc.ObjectHashSet;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import com.google.common.collect.Iterators;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.GeoPointField;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.NumericUtils;
-import org.apache.lucene.util.GeoHashUtils;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.DistanceUnit;
-import org.elasticsearch.common.util.ByteUtils;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.mapper.ContentPath;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MergeMappingException;
-import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper;
-import org.elasticsearch.index.mapper.core.NumberFieldMapper.CustomNumericDocValuesField;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
-import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-
-import static org.elasticsearch.index.mapper.MapperBuilders.doubleField;
-import static org.elasticsearch.index.mapper.MapperBuilders.geoPointField;
-import static org.elasticsearch.index.mapper.MapperBuilders.stringField;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
-import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
 
 /**
  * Parsing: We handle:
@@ -77,92 +50,35 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parsePathType;
  * "lon" : 2.1
  * }
  */
-public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapperParser {
+public class GeoPointFieldMapper extends BaseGeoPointFieldMapper  {
 
     public static final String CONTENT_TYPE = "geo_point";
 
-    public static class Names {
-        public static final String LAT = "lat";
-        public static final String LAT_SUFFIX = "." + LAT;
-        public static final String LON = "lon";
-        public static final String LON_SUFFIX = "." + LON;
-        public static final String GEOHASH = "geohash";
-        public static final String GEOHASH_SUFFIX = "." + GEOHASH;
-        public static final String IGNORE_MALFORMED = "ignore_malformed";
-        public static final String COERCE = "coerce";
-    }
+    public static class Defaults extends BaseGeoPointFieldMapper.Defaults {
 
-    public static class Defaults {
-        public static final ContentPath.Type PATH_TYPE = ContentPath.Type.FULL;
-        public static final boolean ENABLE_LATLON = false;
-        public static final boolean ENABLE_GEOHASH = false;
-        public static final boolean ENABLE_GEOHASH_PREFIX = false;
-        public static final int GEO_HASH_PRECISION = GeoHashUtils.PRECISION;
-
-        public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit(false, false);
-        public static final Explicit<Boolean> COERCE = new Explicit(false, false);
-
-        public static final MappedFieldType FIELD_TYPE = new GeoPointFieldType();
+        public static final BaseGeoPointFieldType FIELD_TYPE = new GeoPointFieldType();
 
         static {
             FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
             FIELD_TYPE.setTokenized(false);
             FIELD_TYPE.setOmitNorms(true);
+            FIELD_TYPE.setNumericType(FieldType.NumericType.LONG);
+            FIELD_TYPE.setNumericPrecisionStep(GeoPointField.PRECISION_STEP);
+            FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_NUMERIC);
+            FIELD_TYPE.setHasDocValues(true);
+            FIELD_TYPE.setStored(true);
             FIELD_TYPE.freeze();
         }
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder, GeoPointFieldMapper> {
-
-        private ContentPath.Type pathType = Defaults.PATH_TYPE;
-
-        private boolean enableGeoHash = Defaults.ENABLE_GEOHASH;
-
-        private boolean enableGeohashPrefix = Defaults.ENABLE_GEOHASH_PREFIX;
-
-        private boolean enableLatLon = Defaults.ENABLE_LATLON;
-
-        private Integer precisionStep;
-
-        private int geoHashPrecision = Defaults.GEO_HASH_PRECISION;
-
-        private Boolean ignoreMalformed;
-
-        private Boolean coerce;
+    /**
+     * Concrete builder for indexed GeoPointField type
+     */
+    public static class Builder extends BaseGeoPointFieldMapper.Builder<Builder, GeoPointFieldMapper> {
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
             this.builder = this;
-        }
-
-        public Builder ignoreMalformed(boolean ignoreMalformed) {
-            this.ignoreMalformed = ignoreMalformed;
-            return builder;
-        }
-
-        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
-            if (ignoreMalformed != null) {
-                return new Explicit<>(ignoreMalformed, true);
-            }
-            if (context.indexSettings() != null) {
-                return new Explicit<>(context.indexSettings().getAsBoolean("index.mapping.ignore_malformed", Defaults.IGNORE_MALFORMED.value()), false);
-            }
-            return Defaults.IGNORE_MALFORMED;
-        }
-
-        public Builder coerce(boolean coerce) {
-            this.coerce = coerce;
-            return builder;
-        }
-
-        protected Explicit<Boolean> coerce(BuilderContext context) {
-            if (coerce != null) {
-                return new Explicit<>(coerce, true);
-            }
-            if (context.indexSettings() != null) {
-                return new Explicit<>(context.indexSettings().getAsBoolean("index.mapping.coerce", Defaults.COERCE.value()), false);
-            }
-            return Defaults.COERCE;
         }
 
         @Override
@@ -176,31 +92,6 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
             return this;
         }
 
-        public Builder enableGeoHash(boolean enableGeoHash) {
-            this.enableGeoHash = enableGeoHash;
-            return this;
-        }
-
-        public Builder geohashPrefix(boolean enableGeohashPrefix) {
-            this.enableGeohashPrefix = enableGeohashPrefix;
-            return this;
-        }
-
-        public Builder enableLatLon(boolean enableLatLon) {
-            this.enableLatLon = enableLatLon;
-            return this;
-        }
-
-        public Builder precisionStep(int precisionStep) {
-            this.precisionStep = precisionStep;
-            return this;
-        }
-
-        public Builder geoHashPrecision(int precision) {
-            this.geoHashPrecision = precision;
-            return this;
-        }
-
         @Override
         public Builder fieldDataSettings(Settings settings) {
             this.fieldDataSettings = settings;
@@ -208,223 +99,41 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
         }
 
         @Override
-        public GeoPointFieldMapper build(BuilderContext context) {
-            ContentPath.Type origPathType = context.path().pathType();
-            context.path().pathType(pathType);
-
-            DoubleFieldMapper latMapper = null;
-            DoubleFieldMapper lonMapper = null;
-            GeoPointFieldType geoPointFieldType = (GeoPointFieldType)fieldType;
-
-            context.path().add(name);
-            if (enableLatLon) {
-                NumberFieldMapper.Builder<?, ?> latMapperBuilder = doubleField(Names.LAT).includeInAll(false);
-                NumberFieldMapper.Builder<?, ?> lonMapperBuilder = doubleField(Names.LON).includeInAll(false);
-                if (precisionStep != null) {
-                    latMapperBuilder.precisionStep(precisionStep);
-                    lonMapperBuilder.precisionStep(precisionStep);
-                }
-                latMapper = (DoubleFieldMapper) latMapperBuilder.includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
-                lonMapper = (DoubleFieldMapper) lonMapperBuilder.includeInAll(false).store(fieldType.stored()).docValues(false).build(context);
-                geoPointFieldType.setLatLonEnabled(latMapper.fieldType(), lonMapper.fieldType());
-            }
-            StringFieldMapper geohashMapper = null;
-            if (enableGeoHash || enableGeohashPrefix) {
-                // TODO: possible also implicitly enable geohash if geohash precision is set
-                geohashMapper = stringField(Names.GEOHASH).index(true).tokenized(false).includeInAll(false).store(fieldType.stored())
-                        .omitNorms(true).indexOptions(IndexOptions.DOCS).build(context);
-                geoPointFieldType.setGeohashEnabled(geohashMapper.fieldType(), geoHashPrecision, enableGeohashPrefix);
-            }
-            context.path().remove();
-
-            context.path().pathType(origPathType);
-
-            // this is important: even if geo points feel like they need to be tokenized to distinguish lat from lon, we actually want to
-            // store them as a single token.
+        public GeoPointFieldMapper build(BuilderContext context, String simpleName, MappedFieldType fieldType,
+                                         MappedFieldType defaultFieldType, Settings indexSettings, ContentPath.Type pathType, DoubleFieldMapper latMapper,
+                                         DoubleFieldMapper lonMapper, StringFieldMapper geohashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed,
+                                         CopyTo copyTo) {
             fieldType.setTokenized(false);
             setupFieldType(context);
-            fieldType.setHasDocValues(false);
-            defaultFieldType.setHasDocValues(false);
-            return new GeoPointFieldMapper(name, fieldType, defaultFieldType, context.indexSettings(), origPathType,
-                     latMapper, lonMapper, geohashMapper, multiFieldsBuilder.build(this, context), ignoreMalformed(context), coerce(context));
+            return new GeoPointFieldMapper(simpleName, fieldType, defaultFieldType, indexSettings, pathType, latMapper, lonMapper,
+                    geohashMapper, multiFields, ignoreMalformed, copyTo);
+        }
+
+        @Override
+        public GeoPointFieldMapper build(BuilderContext context) {
+            return super.build(context);
         }
     }
 
-    public static class TypeParser implements Mapper.TypeParser {
+    public static class TypeParser extends BaseGeoPointFieldMapper.TypeParser {
         @Override
         public Mapper.Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            Builder builder = geoPointField(name);
-            final boolean indexCreatedBeforeV2_0 = parserContext.indexVersionCreated().before(Version.V_2_0_0);
-            parseField(builder, name, node, parserContext);
-            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
-                Map.Entry<String, Object> entry = iterator.next();
-                String propName = Strings.toUnderscoreCase(entry.getKey());
-                Object propNode = entry.getValue();
-                if (propName.equals("path") && parserContext.indexVersionCreated().before(Version.V_2_0_0_beta1)) {
-                    builder.multiFieldPathType(parsePathType(name, propNode.toString()));
-                    iterator.remove();
-                } else if (propName.equals("lat_lon")) {
-                    builder.enableLatLon(XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (propName.equals("geohash")) {
-                    builder.enableGeoHash(XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (propName.equals("geohash_prefix")) {
-                    builder.geohashPrefix(XContentMapValues.nodeBooleanValue(propNode));
-                    if (XContentMapValues.nodeBooleanValue(propNode)) {
-                        builder.enableGeoHash(true);
-                    }
-                    iterator.remove();
-                } else if (propName.equals("precision_step")) {
-                    builder.precisionStep(XContentMapValues.nodeIntegerValue(propNode));
-                    iterator.remove();
-                } else if (propName.equals("geohash_precision")) {
-                    if (propNode instanceof Integer) {
-                        builder.geoHashPrecision(XContentMapValues.nodeIntegerValue(propNode));
-                    } else {
-                        builder.geoHashPrecision(GeoUtils.geoHashLevelsForPrecision(propNode.toString()));
-                    }
-                    iterator.remove();
-                } else if (propName.equals(Names.IGNORE_MALFORMED)) {
-                    builder.ignoreMalformed(XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (indexCreatedBeforeV2_0 && propName.equals("validate")) {
-                    builder.ignoreMalformed(!XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (indexCreatedBeforeV2_0 && propName.equals("validate_lon")) {
-                    builder.ignoreMalformed(!XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (indexCreatedBeforeV2_0 && propName.equals("validate_lat")) {
-                    builder.ignoreMalformed(!XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (propName.equals(Names.COERCE)) {
-                    builder.coerce(XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (indexCreatedBeforeV2_0 && propName.equals("normalize")) {
-                    builder.coerce(XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (indexCreatedBeforeV2_0 && propName.equals("normalize_lat")) {
-                    builder.coerce(XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (indexCreatedBeforeV2_0 && propName.equals("normalize_lon")) {
-                    builder.coerce(XContentMapValues.nodeBooleanValue(propNode));
-                    iterator.remove();
-                } else if (parseMultiField(builder, name, parserContext, propName, propNode)) {
-                    iterator.remove();
-                }
-            }
-            return builder;
+            return super.parse(name, node, parserContext);
         }
     }
 
-    public static final class GeoPointFieldType extends MappedFieldType {
+    public static final class GeoPointFieldType extends BaseGeoPointFieldType {
 
-        private MappedFieldType geohashFieldType;
-        private int geohashPrecision;
-        private boolean geohashPrefixEnabled;
-
-        private MappedFieldType latFieldType;
-        private MappedFieldType lonFieldType;
-
-        public GeoPointFieldType() {}
+        public GeoPointFieldType() {
+        }
 
         protected GeoPointFieldType(GeoPointFieldType ref) {
             super(ref);
-            this.geohashFieldType = ref.geohashFieldType; // copying ref is ok, this can never be modified
-            this.geohashPrecision = ref.geohashPrecision;
-            this.geohashPrefixEnabled = ref.geohashPrefixEnabled;
-            this.latFieldType = ref.latFieldType; // copying ref is ok, this can never be modified
-            this.lonFieldType = ref.lonFieldType; // copying ref is ok, this can never be modified
         }
 
         @Override
         public MappedFieldType clone() {
             return new GeoPointFieldType(this);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!super.equals(o)) return false;
-            GeoPointFieldType that = (GeoPointFieldType) o;
-            return geohashPrecision == that.geohashPrecision &&
-                geohashPrefixEnabled == that.geohashPrefixEnabled &&
-                java.util.Objects.equals(geohashFieldType, that.geohashFieldType) &&
-                java.util.Objects.equals(latFieldType, that.latFieldType) &&
-                java.util.Objects.equals(lonFieldType, that.lonFieldType);
-        }
-
-        @Override
-        public int hashCode() {
-            return java.util.Objects.hash(super.hashCode(), geohashFieldType, geohashPrecision, geohashPrefixEnabled, latFieldType,
-                    lonFieldType);
-        }
-
-        @Override
-        public String typeName() {
-            return CONTENT_TYPE;
-        }
-        
-        @Override
-        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(fieldType, conflicts, strict);
-            GeoPointFieldType other = (GeoPointFieldType)fieldType;
-            if (isLatLonEnabled() != other.isLatLonEnabled()) {
-                conflicts.add("mapper [" + names().fullName() + "] has different [lat_lon]");
-            }
-            if (isGeohashEnabled() != other.isGeohashEnabled()) {
-                conflicts.add("mapper [" + names().fullName() + "] has different [geohash]");
-            }
-            if (geohashPrecision() != other.geohashPrecision()) {
-                conflicts.add("mapper [" + names().fullName() + "] has different [geohash_precision]");
-            }
-            if (isGeohashPrefixEnabled() != other.isGeohashPrefixEnabled()) {
-                conflicts.add("mapper [" + names().fullName() + "] has different [geohash_prefix]");
-            }
-            if (isLatLonEnabled() && other.isLatLonEnabled() &&
-                latFieldType().numericPrecisionStep() != other.latFieldType().numericPrecisionStep()) {
-                conflicts.add("mapper [" + names().fullName() + "] has different [precision_step]");
-            }
-        }
-
-        public boolean isGeohashEnabled() {
-            return geohashFieldType != null;
-        }
-
-        public MappedFieldType geohashFieldType() {
-            return geohashFieldType;
-        }
-
-        public int geohashPrecision() {
-            return geohashPrecision;
-        }
-
-        public boolean isGeohashPrefixEnabled() {
-            return geohashPrefixEnabled;
-        }
-
-        public void setGeohashEnabled(MappedFieldType geohashFieldType, int geohashPrecision, boolean geohashPrefixEnabled) {
-            checkIfFrozen();
-            this.geohashFieldType = geohashFieldType;
-            this.geohashPrecision = geohashPrecision;
-            this.geohashPrefixEnabled = geohashPrefixEnabled;
-        }
-
-        public boolean isLatLonEnabled() {
-            return latFieldType != null;
-        }
-
-        public MappedFieldType latFieldType() {
-            return latFieldType;
-        }
-
-        public MappedFieldType lonFieldType() {
-            return lonFieldType;
-        }
-
-        public void setLatLonEnabled(MappedFieldType latFieldType, MappedFieldType lonFieldType) {
-            checkIfFrozen();
-            this.latFieldType = latFieldType;
-            this.lonFieldType = lonFieldType;
         }
 
         @Override
@@ -437,158 +146,11 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
         }
     }
 
-    /**
-     * A byte-aligned fixed-length encoding for latitudes and longitudes.
-     */
-    public static final class Encoding {
-
-        // With 14 bytes we already have better precision than a double since a double has 11 bits of exponent
-        private static final int MAX_NUM_BYTES = 14;
-
-        private static final Encoding[] INSTANCES;
-        static {
-            INSTANCES = new Encoding[MAX_NUM_BYTES + 1];
-            for (int numBytes = 2; numBytes <= MAX_NUM_BYTES; numBytes += 2) {
-                INSTANCES[numBytes] = new Encoding(numBytes);
-            }
-        }
-
-        /** Get an instance based on the number of bytes that has been used to encode values. */
-        public static final Encoding of(int numBytesPerValue) {
-            final Encoding instance = INSTANCES[numBytesPerValue];
-            if (instance == null) {
-                throw new IllegalStateException("No encoding for " + numBytesPerValue + " bytes per value");
-            }
-            return instance;
-        }
-
-        /** Get an instance based on the expected precision. Here are examples of the number of required bytes per value depending on the
-         *  expected precision:<ul>
-         *  <li>1km: 4 bytes</li>
-         *  <li>3m: 6 bytes</li>
-         *  <li>1m: 8 bytes</li>
-         *  <li>1cm: 8 bytes</li>
-         *  <li>1mm: 10 bytes</li></ul> */
-        public static final Encoding of(DistanceUnit.Distance precision) {
-            for (Encoding encoding : INSTANCES) {
-                if (encoding != null && encoding.precision().compareTo(precision) <= 0) {
-                    return encoding;
-                }
-            }
-            return INSTANCES[MAX_NUM_BYTES];
-        }
-
-        private final DistanceUnit.Distance precision;
-        private final int numBytes;
-        private final int numBytesPerCoordinate;
-        private final double factor;
-
-        private Encoding(int numBytes) {
-            assert numBytes >= 1 && numBytes <= MAX_NUM_BYTES;
-            assert (numBytes & 1) == 0; // we don't support odd numBytes for the moment
-            this.numBytes = numBytes;
-            this.numBytesPerCoordinate = numBytes / 2;
-            this.factor = Math.pow(2, - numBytesPerCoordinate * 8 + 9);
-            assert (1L << (numBytesPerCoordinate * 8 - 1)) * factor > 180 && (1L << (numBytesPerCoordinate * 8 - 2)) * factor < 180 : numBytesPerCoordinate + " " + factor;
-            if (numBytes == MAX_NUM_BYTES) {
-                // no precision loss compared to a double
-                precision = new DistanceUnit.Distance(0, DistanceUnit.DEFAULT);
-            } else {
-                precision = new DistanceUnit.Distance(
-                        GeoDistance.PLANE.calculate(0, 0, factor / 2, factor / 2, DistanceUnit.DEFAULT), // factor/2 because we use Math.round instead of a cast to convert the double to a long
-                        DistanceUnit.DEFAULT);
-            }
-        }
-
-        public DistanceUnit.Distance precision() {
-            return precision;
-        }
-
-        /** The number of bytes required to encode a single geo point. */
-        public final int numBytes() {
-            return numBytes;
-        }
-
-        /** The number of bits required to encode a single coordinate of a geo point. */
-        public int numBitsPerCoordinate() {
-            return numBytesPerCoordinate << 3;
-        }
-
-        /** Return the bits that encode a latitude/longitude. */
-        public long encodeCoordinate(double lat) {
-            return Math.round((lat + 180) / factor);
-        }
-
-        /** Decode a sequence of bits into the original coordinate. */
-        public double decodeCoordinate(long bits) {
-            return bits * factor - 180;
-        }
-
-        private void encodeBits(long bits, byte[] out, int offset) {
-            for (int i = 0; i < numBytesPerCoordinate; ++i) {
-                out[offset++] = (byte) bits;
-                bits >>>= 8;
-            }
-            assert bits == 0;
-        }
-
-        private long decodeBits(byte [] in, int offset) {
-            long r = in[offset++] & 0xFFL;
-            for (int i = 1; i < numBytesPerCoordinate; ++i) {
-                r = (in[offset++] & 0xFFL) << (i * 8);
-            }
-            return r;
-        }
-
-        /** Encode a geo point into a byte-array, over {@link #numBytes()} bytes. */
-        public void encode(double lat, double lon, byte[] out, int offset) {
-            encodeBits(encodeCoordinate(lat), out, offset);
-            encodeBits(encodeCoordinate(lon), out, offset + numBytesPerCoordinate);
-        }
-
-        /** Decode a geo point from a byte-array, reading {@link #numBytes()} bytes. */
-        public GeoPoint decode(byte[] in, int offset, GeoPoint out) {
-            final long latBits = decodeBits(in, offset);
-            final long lonBits = decodeBits(in, offset + numBytesPerCoordinate);
-            return decode(latBits, lonBits, out);
-        }
-
-        /** Decode a geo point from the bits of the encoded latitude and longitudes. */
-        public GeoPoint decode(long latBits, long lonBits, GeoPoint out) {
-            final double lat = decodeCoordinate(latBits);
-            final double lon = decodeCoordinate(lonBits);
-            return out.reset(lat, lon);
-        }
-
-    }
-
-    private final ContentPath.Type pathType;
-
-    private final DoubleFieldMapper latMapper;
-
-    private final DoubleFieldMapper lonMapper;
-
-    private final StringFieldMapper geohashMapper;
-
-    protected Explicit<Boolean> ignoreMalformed;
-
-    protected Explicit<Boolean> coerce;
-
     public GeoPointFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Settings indexSettings,
-            ContentPath.Type pathType, DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper, StringFieldMapper geohashMapper,
-            MultiFields multiFields, Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce) {
-        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, null);
-        this.pathType = pathType;
-        this.latMapper = latMapper;
-        this.lonMapper = lonMapper;
-        this.geohashMapper = geohashMapper;
-        this.ignoreMalformed = ignoreMalformed;
-        this.coerce = coerce;
-    }
-
-    @Override
-    protected String contentType() {
-        return CONTENT_TYPE;
+                               ContentPath.Type pathType, DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper,
+                               StringFieldMapper geohashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, pathType, latMapper, lonMapper, geohashMapper, multiFields,
+                ignoreMalformed, copyTo);
     }
 
     @Override
@@ -597,216 +159,26 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
     }
 
     @Override
-    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
-        super.merge(mergeWith, mergeResult);
-        if (!this.getClass().equals(mergeWith.getClass())) {
-            return;
-        }
-
-        GeoPointFieldMapper gpfmMergeWith = (GeoPointFieldMapper) mergeWith;
-        if (gpfmMergeWith.coerce.explicit()) {
-            if (coerce.explicit() && coerce.value() != gpfmMergeWith.coerce.value()) {
-                mergeResult.addConflict("mapper [" + fieldType().names().fullName() + "] has different [coerce]");
-            }
-        }
-
-        if (mergeResult.simulate() == false && mergeResult.hasConflicts() == false) {
-            if (gpfmMergeWith.ignoreMalformed.explicit()) {
-                this.ignoreMalformed = gpfmMergeWith.ignoreMalformed;
-            }
-            if (gpfmMergeWith.coerce.explicit()) {
-                this.coerce = gpfmMergeWith.coerce;
-            }
-        }
-    }
-
-    @Override
     protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
         throw new UnsupportedOperationException("Parsing is implemented in parse(), this method should NEVER be called");
     }
 
     @Override
-    public Mapper parse(ParseContext context) throws IOException {
-        ContentPath.Type origPathType = context.path().pathType();
-        context.path().pathType(pathType);
-        context.path().add(simpleName());
-
-        GeoPoint sparse = context.parseExternalValue(GeoPoint.class);
-        
-        if (sparse != null) {
-            parse(context, sparse, null);
-        } else {
-            sparse = new GeoPoint();
-            XContentParser.Token token = context.parser().currentToken();
-            if (token == XContentParser.Token.START_ARRAY) {
-                token = context.parser().nextToken();
-                if (token == XContentParser.Token.START_ARRAY) {
-                    // its an array of array of lon/lat [ [1.2, 1.3], [1.4, 1.5] ]
-                    while (token != XContentParser.Token.END_ARRAY) {
-                        parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
-                        token = context.parser().nextToken();
-                    }
-                } else {
-                    // its an array of other possible values
-                    if (token == XContentParser.Token.VALUE_NUMBER) {
-                        double lon = context.parser().doubleValue();
-                        token = context.parser().nextToken();
-                        double lat = context.parser().doubleValue();
-                        while ((token = context.parser().nextToken()) != XContentParser.Token.END_ARRAY);
-                        parse(context, sparse.reset(lat, lon), null);
-                    } else {
-                        while (token != XContentParser.Token.END_ARRAY) {
-                            if (token == XContentParser.Token.VALUE_STRING) {
-                                parsePointFromString(context, sparse, context.parser().text());
-                            } else {
-                                parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
-                            }
-                            token = context.parser().nextToken();
-                        }
-                    }
-                }
-            } else if (token == XContentParser.Token.VALUE_STRING) {
-                parsePointFromString(context, sparse, context.parser().text());
-            } else if (token != XContentParser.Token.VALUE_NULL) {
-                parse(context, GeoUtils.parseGeoPoint(context.parser(), sparse), null);
-            }
-        }
-
-        context.path().remove();
-        context.path().pathType(origPathType);
-        return null;
-    }
-
-    private void addGeohashField(ParseContext context, String geohash) throws IOException {
-        int len = Math.min(fieldType().geohashPrecision(), geohash.length());
-        int min = fieldType().isGeohashPrefixEnabled() ? 1 : len;
-
-        for (int i = len; i >= min; i--) {
-            // side effect of this call is adding the field
-            geohashMapper.parse(context.createExternalValueContext(geohash.substring(0, i)));
-        }
-    }
-
-    private void parsePointFromString(ParseContext context, GeoPoint sparse, String point) throws IOException {
-        if (point.indexOf(',') < 0) {
-            parse(context, sparse.resetFromGeoHash(point), point);
-        } else {
-            parse(context, sparse.resetFromString(point), null);
-        }
-    }
-
-    private void parse(ParseContext context, GeoPoint point, String geohash) throws IOException {
-        boolean validPoint = false;
-        if (coerce.value() == false && ignoreMalformed.value() == false) {
+    protected void parse(ParseContext context, GeoPoint point, String geohash) throws IOException {
+        if (ignoreMalformed.value() == false) {
             if (point.lat() > 90.0 || point.lat() < -90.0) {
                 throw new IllegalArgumentException("illegal latitude value [" + point.lat() + "] for " + name());
             }
             if (point.lon() > 180.0 || point.lon() < -180) {
                 throw new IllegalArgumentException("illegal longitude value [" + point.lon() + "] for " + name());
             }
-            validPoint = true;
-        }
-
-        if (coerce.value() == true && validPoint == false) {
-            // by setting coerce to false we are assuming all geopoints are already in a valid coordinate system
-            // thus this extra step can be skipped
+        } else {
             // LUCENE WATCH: This will be folded back into Lucene's GeoPointField
-            GeoUtils.normalizePoint(point, true, true);
+            GeoUtils.normalizePoint(point);
         }
-
         if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
-            Field field = new Field(fieldType().names().indexName(), Double.toString(point.lat()) + ',' + Double.toString(point.lon()), fieldType());
-            context.doc().add(field);
+            context.doc().add(new GeoPointField(fieldType().names().indexName(), point.lon(), point.lat(), fieldType() ));
         }
-        if (fieldType().isGeohashEnabled()) {
-            if (geohash == null) {
-                geohash = GeoHashUtils.stringEncode(point.lon(), point.lat());
-            }
-            addGeohashField(context, geohash);
-        }
-        if (fieldType().isLatLonEnabled()) {
-            latMapper.parse(context.createExternalValueContext(point.lat()));
-            lonMapper.parse(context.createExternalValueContext(point.lon()));
-        }
-        if (fieldType().hasDocValues()) {
-            CustomGeoPointDocValuesField field = (CustomGeoPointDocValuesField) context.doc().getByKey(fieldType().names().indexName());
-            if (field == null) {
-                field = new CustomGeoPointDocValuesField(fieldType().names().indexName(), point.lat(), point.lon());
-                context.doc().addWithKey(fieldType().names().indexName(), field);
-            } else {
-                field.add(point.lat(), point.lon());
-            }
-        }
-        multiFields.parse(this, context);
-    }
-
-    @Override
-    public Iterator<Mapper> iterator() {
-        List<Mapper> extras = new ArrayList<>();
-        if (fieldType().isGeohashEnabled()) {
-            extras.add(geohashMapper);
-        }
-        if (fieldType().isLatLonEnabled()) {
-            extras.add(latMapper);
-            extras.add(lonMapper);
-        }
-        return Iterators.concat(super.iterator(), extras.iterator());
-    }
-
-    @Override
-    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
-        super.doXContentBody(builder, includeDefaults, params);
-        if (includeDefaults || pathType != Defaults.PATH_TYPE) {
-            builder.field("path", pathType.name().toLowerCase(Locale.ROOT));
-        }
-        if (includeDefaults || fieldType().isLatLonEnabled() != Defaults.ENABLE_LATLON) {
-            builder.field("lat_lon", fieldType().isLatLonEnabled());
-        }
-        if (includeDefaults || fieldType().isGeohashEnabled() != Defaults.ENABLE_GEOHASH) {
-            builder.field("geohash", fieldType().isGeohashEnabled());
-        }
-        if (includeDefaults || fieldType().isGeohashPrefixEnabled() != Defaults.ENABLE_GEOHASH_PREFIX) {
-            builder.field("geohash_prefix", fieldType().isGeohashPrefixEnabled());
-        }
-        if (fieldType().isGeohashEnabled() && (includeDefaults || fieldType().geohashPrecision() != Defaults.GEO_HASH_PRECISION)) {
-            builder.field("geohash_precision", fieldType().geohashPrecision());
-        }
-        if (fieldType().isLatLonEnabled() && (includeDefaults || fieldType().latFieldType().numericPrecisionStep() != NumericUtils.PRECISION_STEP_DEFAULT)) {
-            builder.field("precision_step", fieldType().latFieldType().numericPrecisionStep());
-        }
-        if (includeDefaults || coerce.explicit()) {
-            builder.field(Names.COERCE, coerce.value());
-        }
-        if (includeDefaults || ignoreMalformed.explicit()) {
-            builder.field(Names.IGNORE_MALFORMED, ignoreMalformed.value());
-        }
-    }
-
-    public static class CustomGeoPointDocValuesField extends CustomNumericDocValuesField {
-
-        private final ObjectHashSet<GeoPoint> points;
-
-        public CustomGeoPointDocValuesField(String name, double lat, double lon) {
-            super(name);
-            points = new ObjectHashSet<>(2);
-            points.add(new GeoPoint(lat, lon));
-        }
-
-        public void add(double lat, double lon) {
-            points.add(new GeoPoint(lat, lon));
-        }
-
-        @Override
-        public BytesRef binaryValue() {
-            final byte[] bytes = new byte[points.size() * 16];
-            int off = 0;
-            for (Iterator<ObjectCursor<GeoPoint>> it = points.iterator(); it.hasNext(); ) {
-                final GeoPoint point = it.next().value;
-                ByteUtils.writeDoubleLE(point.getLat(), bytes, off);
-                ByteUtils.writeDoubleLE(point.getLon(), bytes, off + 8);
-                off += 16;
-            }
-            return new BytesRef(bytes);
-        }
+        super.parse(context, point, geohash);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperLegacy.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/geo/GeoPointFieldMapperLegacy.java
@@ -1,0 +1,447 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.geo;
+
+import com.carrotsearch.hppc.ObjectHashSet;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.common.util.ByteUtils;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.mapper.ContentPath;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MergeMappingException;
+import org.elasticsearch.index.mapper.MergeResult;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
+import org.elasticsearch.index.mapper.core.NumberFieldMapper.CustomNumericDocValuesField;
+import org.elasticsearch.index.mapper.core.StringFieldMapper;
+import org.elasticsearch.index.mapper.object.ArrayValueMapperParser;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Parsing: We handle:
+ * <p/>
+ * - "field" : "geo_hash"
+ * - "field" : "lat,lon"
+ * - "field" : {
+ * "lat" : 1.1,
+ * "lon" : 2.1
+ * }
+ */
+public class GeoPointFieldMapperLegacy extends BaseGeoPointFieldMapper implements ArrayValueMapperParser {
+
+    public static final String CONTENT_TYPE = "geo_point";
+
+    public static class Names extends BaseGeoPointFieldMapper.Names {
+        public static final String COERCE = "coerce";
+    }
+
+    public static class Defaults extends BaseGeoPointFieldMapper.Defaults{
+        public static final Explicit<Boolean> COERCE = new Explicit(false, false);
+
+        public static final BaseGeoPointFieldType FIELD_TYPE = new GeoPointFieldType();
+
+        static {
+            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
+            FIELD_TYPE.setTokenized(false);
+            FIELD_TYPE.setOmitNorms(true);
+            FIELD_TYPE.freeze();
+        }
+    }
+
+    /**
+     * Concrete builder for legacy GeoPointField
+     */
+    public static class Builder extends BaseGeoPointFieldMapper.Builder<Builder, GeoPointFieldMapperLegacy> {
+
+        private Boolean coerce;
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE);
+            this.builder = this;
+        }
+
+        public Builder coerce(boolean coerce) {
+            this.coerce = coerce;
+            return builder;
+        }
+
+        protected Explicit<Boolean> coerce(BuilderContext context) {
+            if (coerce != null) {
+                return new Explicit<>(coerce, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(context.indexSettings().getAsBoolean("index.mapping.coerce", Defaults.COERCE.value()), false);
+            }
+            return Defaults.COERCE;
+        }
+
+        @Override
+        public GeoPointFieldType fieldType() {
+            return (GeoPointFieldType)fieldType;
+        }
+
+        @Override
+        public Builder multiFieldPathType(ContentPath.Type pathType) {
+            this.pathType = pathType;
+            return this;
+        }
+
+        @Override
+        public Builder fieldDataSettings(Settings settings) {
+            this.fieldDataSettings = settings;
+            return builder;
+        }
+
+        @Override
+        public GeoPointFieldMapperLegacy build(BuilderContext context, String simpleName, MappedFieldType fieldType,
+                                               MappedFieldType defaultFieldType, Settings indexSettings, ContentPath.Type pathType, DoubleFieldMapper latMapper,
+                                               DoubleFieldMapper lonMapper, StringFieldMapper geohashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed,
+                                               CopyTo copyTo) {
+            fieldType.setTokenized(false);
+            setupFieldType(context);
+            fieldType.setHasDocValues(false);
+            defaultFieldType.setHasDocValues(false);
+            return new GeoPointFieldMapperLegacy(simpleName, fieldType, defaultFieldType, indexSettings, pathType, latMapper, lonMapper,
+                    geohashMapper, multiFields, ignoreMalformed, coerce(context), copyTo);
+        }
+
+        @Override
+        public GeoPointFieldMapperLegacy build(BuilderContext context) {
+            return super.build(context);
+        }
+    }
+
+    public static Builder parse(Builder builder, Map<String, Object> node, Mapper.TypeParser.ParserContext parserContext) throws MapperParsingException {
+        final boolean indexCreatedBeforeV2_0 = parserContext.indexVersionCreated().before(Version.V_2_0_0);
+        for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+            Map.Entry<String, Object> entry = iterator.next();
+            String propName = Strings.toUnderscoreCase(entry.getKey());
+            Object propNode = entry.getValue();
+            if (indexCreatedBeforeV2_0 && propName.equals("validate")) {
+                builder.ignoreMalformed = !XContentMapValues.nodeBooleanValue(propNode);
+                iterator.remove();
+            } else if (indexCreatedBeforeV2_0 && propName.equals("validate_lon")) {
+                builder.ignoreMalformed = !XContentMapValues.nodeBooleanValue(propNode);
+                iterator.remove();
+            } else if (indexCreatedBeforeV2_0 && propName.equals("validate_lat")) {
+                builder.ignoreMalformed = !XContentMapValues.nodeBooleanValue(propNode);
+                iterator.remove();
+            } else if (propName.equals(Names.COERCE)) {
+                builder.coerce = XContentMapValues.nodeBooleanValue(propNode);
+                iterator.remove();
+            } else if (indexCreatedBeforeV2_0 && propName.equals("normalize")) {
+                builder.coerce = XContentMapValues.nodeBooleanValue(propNode);
+                iterator.remove();
+            } else if (indexCreatedBeforeV2_0 && propName.equals("normalize_lat")) {
+                builder.coerce = XContentMapValues.nodeBooleanValue(propNode);
+                iterator.remove();
+            } else if (indexCreatedBeforeV2_0 && propName.equals("normalize_lon")) {
+                builder.coerce = XContentMapValues.nodeBooleanValue(propNode);
+                iterator.remove();
+            }
+        }
+        return builder;
+    }
+
+    public static final class GeoPointFieldType extends BaseGeoPointFieldType {
+
+        public GeoPointFieldType() {
+            super();
+        }
+
+        protected GeoPointFieldType(GeoPointFieldType ref) {
+            super(ref);
+        }
+
+        @Override
+        public MappedFieldType clone() {
+            return new GeoPointFieldType(this);
+        }
+
+        @Override
+        public GeoPoint value(Object value) {
+            if (value instanceof GeoPoint) {
+                return (GeoPoint) value;
+            } else {
+                return GeoPoint.parseFromLatLon(value.toString());
+            }
+        }
+    }
+
+    /**
+     * A byte-aligned fixed-length encoding for latitudes and longitudes.
+     */
+    public static final class Encoding {
+
+        // With 14 bytes we already have better precision than a double since a double has 11 bits of exponent
+        private static final int MAX_NUM_BYTES = 14;
+
+        private static final Encoding[] INSTANCES;
+        static {
+            INSTANCES = new Encoding[MAX_NUM_BYTES + 1];
+            for (int numBytes = 2; numBytes <= MAX_NUM_BYTES; numBytes += 2) {
+                INSTANCES[numBytes] = new Encoding(numBytes);
+            }
+        }
+
+        /** Get an instance based on the number of bytes that has been used to encode values. */
+        public static final Encoding of(int numBytesPerValue) {
+            final Encoding instance = INSTANCES[numBytesPerValue];
+            if (instance == null) {
+                throw new IllegalStateException("No encoding for " + numBytesPerValue + " bytes per value");
+            }
+            return instance;
+        }
+
+        /** Get an instance based on the expected precision. Here are examples of the number of required bytes per value depending on the
+         *  expected precision:<ul>
+         *  <li>1km: 4 bytes</li>
+         *  <li>3m: 6 bytes</li>
+         *  <li>1m: 8 bytes</li>
+         *  <li>1cm: 8 bytes</li>
+         *  <li>1mm: 10 bytes</li></ul> */
+        public static final Encoding of(DistanceUnit.Distance precision) {
+            for (Encoding encoding : INSTANCES) {
+                if (encoding != null && encoding.precision().compareTo(precision) <= 0) {
+                    return encoding;
+                }
+            }
+            return INSTANCES[MAX_NUM_BYTES];
+        }
+
+        private final DistanceUnit.Distance precision;
+        private final int numBytes;
+        private final int numBytesPerCoordinate;
+        private final double factor;
+
+        private Encoding(int numBytes) {
+            assert numBytes >= 1 && numBytes <= MAX_NUM_BYTES;
+            assert (numBytes & 1) == 0; // we don't support odd numBytes for the moment
+            this.numBytes = numBytes;
+            this.numBytesPerCoordinate = numBytes / 2;
+            this.factor = Math.pow(2, - numBytesPerCoordinate * 8 + 9);
+            assert (1L << (numBytesPerCoordinate * 8 - 1)) * factor > 180 && (1L << (numBytesPerCoordinate * 8 - 2)) * factor < 180 : numBytesPerCoordinate + " " + factor;
+            if (numBytes == MAX_NUM_BYTES) {
+                // no precision loss compared to a double
+                precision = new DistanceUnit.Distance(0, DistanceUnit.DEFAULT);
+            } else {
+                precision = new DistanceUnit.Distance(
+                        GeoDistance.PLANE.calculate(0, 0, factor / 2, factor / 2, DistanceUnit.DEFAULT), // factor/2 because we use Math.round instead of a cast to convert the double to a long
+                        DistanceUnit.DEFAULT);
+            }
+        }
+
+        public DistanceUnit.Distance precision() {
+            return precision;
+        }
+
+        /** The number of bytes required to encode a single geo point. */
+        public final int numBytes() {
+            return numBytes;
+        }
+
+        /** The number of bits required to encode a single coordinate of a geo point. */
+        public int numBitsPerCoordinate() {
+            return numBytesPerCoordinate << 3;
+        }
+
+        /** Return the bits that encode a latitude/longitude. */
+        public long encodeCoordinate(double lat) {
+            return Math.round((lat + 180) / factor);
+        }
+
+        /** Decode a sequence of bits into the original coordinate. */
+        public double decodeCoordinate(long bits) {
+            return bits * factor - 180;
+        }
+
+        private void encodeBits(long bits, byte[] out, int offset) {
+            for (int i = 0; i < numBytesPerCoordinate; ++i) {
+                out[offset++] = (byte) bits;
+                bits >>>= 8;
+            }
+            assert bits == 0;
+        }
+
+        private long decodeBits(byte [] in, int offset) {
+            long r = in[offset++] & 0xFFL;
+            for (int i = 1; i < numBytesPerCoordinate; ++i) {
+                r = (in[offset++] & 0xFFL) << (i * 8);
+            }
+            return r;
+        }
+
+        /** Encode a geo point into a byte-array, over {@link #numBytes()} bytes. */
+        public void encode(double lat, double lon, byte[] out, int offset) {
+            encodeBits(encodeCoordinate(lat), out, offset);
+            encodeBits(encodeCoordinate(lon), out, offset + numBytesPerCoordinate);
+        }
+
+        /** Decode a geo point from a byte-array, reading {@link #numBytes()} bytes. */
+        public GeoPoint decode(byte[] in, int offset, GeoPoint out) {
+            final long latBits = decodeBits(in, offset);
+            final long lonBits = decodeBits(in, offset + numBytesPerCoordinate);
+            return decode(latBits, lonBits, out);
+        }
+
+        /** Decode a geo point from the bits of the encoded latitude and longitudes. */
+        public GeoPoint decode(long latBits, long lonBits, GeoPoint out) {
+            final double lat = decodeCoordinate(latBits);
+            final double lon = decodeCoordinate(lonBits);
+            return out.reset(lat, lon);
+        }
+
+    }
+
+    protected Explicit<Boolean> coerce;
+
+    public GeoPointFieldMapperLegacy(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType, Settings indexSettings,
+                                     ContentPath.Type pathType, DoubleFieldMapper latMapper, DoubleFieldMapper lonMapper,
+                                     StringFieldMapper geohashMapper, MultiFields multiFields, Explicit<Boolean> ignoreMalformed,
+                                     Explicit<Boolean> coerce, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, pathType, latMapper, lonMapper, geohashMapper, multiFields,
+                ignoreMalformed, copyTo);
+        this.coerce = coerce;
+    }
+
+    @Override
+    public GeoPointFieldType fieldType() {
+        return (GeoPointFieldType) super.fieldType();
+    }
+
+    @Override
+    public void merge(Mapper mergeWith, MergeResult mergeResult) throws MergeMappingException {
+        super.merge(mergeWith, mergeResult);
+        if (!this.getClass().equals(mergeWith.getClass())) {
+            return;
+        }
+
+        GeoPointFieldMapperLegacy gpfmMergeWith = (GeoPointFieldMapperLegacy) mergeWith;
+        if (gpfmMergeWith.coerce.explicit()) {
+            if (coerce.explicit() && coerce.value() != gpfmMergeWith.coerce.value()) {
+                mergeResult.addConflict("mapper [" + fieldType().names().fullName() + "] has different [coerce]");
+            }
+        }
+
+        if (mergeResult.simulate() == false && mergeResult.hasConflicts() == false) {
+            if (gpfmMergeWith.coerce.explicit()) {
+                this.coerce = gpfmMergeWith.coerce;
+            }
+        }
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<Field> fields) throws IOException {
+        throw new UnsupportedOperationException("Parsing is implemented in parse(), this method should NEVER be called");
+    }
+
+    @Override
+    protected void parse(ParseContext context, GeoPoint point, String geohash) throws IOException {
+        boolean validPoint = false;
+        if (coerce.value() == false && ignoreMalformed.value() == false) {
+            if (point.lat() > 90.0 || point.lat() < -90.0) {
+                throw new IllegalArgumentException("illegal latitude value [" + point.lat() + "] for " + name());
+            }
+            if (point.lon() > 180.0 || point.lon() < -180) {
+                throw new IllegalArgumentException("illegal longitude value [" + point.lon() + "] for " + name());
+            }
+            validPoint = true;
+        }
+
+        if (coerce.value() == true && validPoint == false) {
+            // by setting coerce to false we are assuming all geopoints are already in a valid coordinate system
+            // thus this extra step can be skipped
+            GeoUtils.normalizePoint(point, true, true);
+        }
+
+        if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+            Field field = new Field(fieldType().names().indexName(), Double.toString(point.lat()) + ',' + Double.toString(point.lon()), fieldType());
+            context.doc().add(field);
+        }
+
+        super.parse(context, point, geohash);
+
+        if (fieldType().hasDocValues()) {
+            CustomGeoPointDocValuesField field = (CustomGeoPointDocValuesField) context.doc().getByKey(fieldType().names().indexName());
+            if (field == null) {
+                field = new CustomGeoPointDocValuesField(fieldType().names().indexName(), point.lat(), point.lon());
+                context.doc().addWithKey(fieldType().names().indexName(), field);
+            } else {
+                field.add(point.lat(), point.lon());
+            }
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+        if (includeDefaults || coerce.explicit()) {
+            builder.field(Names.COERCE, coerce.value());
+        }
+    }
+
+    public static class CustomGeoPointDocValuesField extends CustomNumericDocValuesField {
+
+        private final ObjectHashSet<GeoPoint> points;
+
+        public CustomGeoPointDocValuesField(String name, double lat, double lon) {
+            super(name);
+            points = new ObjectHashSet<>(2);
+            points.add(new GeoPoint(lat, lon));
+        }
+
+        public void add(double lat, double lon) {
+            points.add(new GeoPoint(lat, lon));
+        }
+
+        @Override
+        public BytesRef binaryValue() {
+            final byte[] bytes = new byte[points.size() * 16];
+            int off = 0;
+            for (Iterator<ObjectCursor<GeoPoint>> it = points.iterator(); it.hasNext(); ) {
+                final GeoPoint point = it.next().value;
+                ByteUtils.writeDoubleLE(point.getLat(), bytes, off);
+                ByteUtils.writeDoubleLE(point.getLon(), bytes, off + 8);
+                off += 16;
+            }
+            return new BytesRef(bytes);
+        }
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -28,7 +28,9 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapperLegacy;
 import org.elasticsearch.index.search.geo.InMemoryGeoBoundingBoxQuery;
 import org.elasticsearch.index.search.geo.IndexedGeoBoundingBoxQuery;
 
@@ -189,10 +191,10 @@ public class GeoBoundingBoxQueryParser implements QueryParser {
         if (fieldType == null) {
             throw new QueryParsingException(parseContext, "failed to parse [{}] query. could not find [{}] field [{}]", NAME, GeoPointFieldMapper.CONTENT_TYPE, fieldName);
         }
-        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+        if (!(fieldType instanceof BaseGeoPointFieldMapper.BaseGeoPointFieldType)) {
             throw new QueryParsingException(parseContext, "failed to parse [{}] query. field [{}] is expected to be of type [{}], but is of [{}] type instead", NAME, fieldName, GeoPointFieldMapper.CONTENT_TYPE, fieldType.typeName());
         }
-        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+        GeoPointFieldMapperLegacy.GeoPointFieldType geoFieldType = ((GeoPointFieldMapperLegacy.GeoPointFieldType) fieldType);
 
         Query filter;
         if ("indexed".equals(type)) {

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -29,7 +29,9 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapperLegacy;
 import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
 import java.io.IOException;
@@ -166,11 +168,10 @@ public class GeoDistanceQueryParser implements QueryParser {
         if (fieldType == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+        if (!(fieldType instanceof BaseGeoPointFieldMapper.BaseGeoPointFieldType)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
-        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
-
+        GeoPointFieldMapperLegacy.GeoPointFieldType geoFieldType = ((GeoPointFieldMapperLegacy.GeoPointFieldType) fieldType);
 
         IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
         Query query = new GeoDistanceRangeQuery(point, null, distance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
@@ -29,7 +29,9 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapperLegacy;
 import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
 import java.io.IOException;
@@ -206,10 +208,10 @@ public class GeoDistanceRangeQueryParser implements QueryParser {
         if (fieldType == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+        if (!(fieldType instanceof BaseGeoPointFieldMapper.BaseGeoPointFieldType)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
-        GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+        GeoPointFieldMapperLegacy.GeoPointFieldType geoFieldType = ((GeoPointFieldMapperLegacy.GeoPointFieldType) fieldType);
 
         IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
         Query query = new GeoDistanceRangeQuery(point, from, to, includeLower, includeUpper, geoDistance, geoFieldType, indexFieldData, optimizeBbox);

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.index.search.geo.GeoPolygonQuery;
 
@@ -159,7 +160,7 @@ public class GeoPolygonQueryParser implements QueryParser {
         if (fieldType == null) {
             throw new QueryParsingException(parseContext, "failed to find geo_point field [" + fieldName + "]");
         }
-        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+        if (!(fieldType instanceof BaseGeoPointFieldMapper.BaseGeoPointFieldType)) {
             throw new QueryParsingException(parseContext, "field [" + fieldName + "] is not a geo_point field");
         }
 

--- a/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeohashCellQuery.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 
 import java.io.IOException;
@@ -69,7 +70,8 @@ public class GeohashCellQuery {
      * @param geohashes   optional array of additional geohashes
      * @return a new GeoBoundinboxfilter
      */
-    public static Query create(QueryParseContext context, GeoPointFieldMapper.GeoPointFieldType fieldType, String geohash, @Nullable List<CharSequence> geohashes) {
+    public static Query create(QueryParseContext context, BaseGeoPointFieldMapper.BaseGeoPointFieldType fieldType, String geohash,
+                               @Nullable List<CharSequence> geohashes) {
         MappedFieldType geoHashMapper = fieldType.geohashFieldType();
         if (geoHashMapper == null) {
             throw new IllegalArgumentException("geohash filter needs geohash_prefix to be enabled");
@@ -240,11 +242,11 @@ public class GeohashCellQuery {
                 throw new QueryParsingException(parseContext, "failed to parse [{}] query. missing [{}] field [{}]", NAME, GeoPointFieldMapper.CONTENT_TYPE, fieldName);
             }
 
-            if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+            if (!(fieldType instanceof BaseGeoPointFieldMapper.BaseGeoPointFieldType)) {
                 throw new QueryParsingException(parseContext, "failed to parse [{}] query. field [{}] is not a geo_point field", NAME, fieldName);
             }
 
-            GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
+            BaseGeoPointFieldMapper.BaseGeoPointFieldType geoFieldType = ((BaseGeoPointFieldMapper.BaseGeoPointFieldType) fieldType);
             if (!geoFieldType.isGeohashPrefixEnabled()) {
                 throw new QueryParsingException(parseContext, "failed to parse [{}] query. [geohash_prefix] is not enabled for field [{}]", NAME, fieldName);
             }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionParser.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query.functionscore;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -42,7 +43,7 @@ import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.index.mapper.core.NumberFieldMapper;
-import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryParsingException;
 import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionBuilder;
@@ -160,8 +161,8 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
         parser.nextToken();
         if (fieldType instanceof DateFieldMapper.DateFieldType) {
             return parseDateVariable(fieldName, parser, parseContext, (DateFieldMapper.DateFieldType) fieldType, mode);
-        } else if (fieldType instanceof GeoPointFieldMapper.GeoPointFieldType) {
-            return parseGeoVariable(fieldName, parser, parseContext, (GeoPointFieldMapper.GeoPointFieldType) fieldType, mode);
+        } else if (fieldType instanceof BaseGeoPointFieldMapper.BaseGeoPointFieldType) {
+            return parseGeoVariable(fieldName, parser, parseContext, (BaseGeoPointFieldMapper.BaseGeoPointFieldType) fieldType, mode);
         } else if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
             return parseNumberVariable(fieldName, parser, parseContext, (NumberFieldMapper.NumberFieldType) fieldType, mode);
         } else {
@@ -204,7 +205,7 @@ public abstract class DecayFunctionParser implements ScoreFunctionParser {
     }
 
     private AbstractDistanceScoreFunction parseGeoVariable(String fieldName, XContentParser parser, QueryParseContext parseContext,
-            GeoPointFieldMapper.GeoPointFieldType fieldType, MultiValueMode mode) throws IOException {
+            BaseGeoPointFieldMapper.BaseGeoPointFieldType fieldType, MultiValueMode mode) throws IOException {
         XContentParser.Token token;
         String parameterName = null;
         GeoPoint origin = new GeoPoint();

--- a/core/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeQuery.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapperLegacy;
 
 import java.io.IOException;
 
@@ -58,8 +59,9 @@ public class GeoDistanceRangeQuery extends Query {
 
     private final IndexGeoPointFieldData indexFieldData;
 
-    public GeoDistanceRangeQuery(GeoPoint point, Double lowerVal, Double upperVal, boolean includeLower, boolean includeUpper, GeoDistance geoDistance, GeoPointFieldMapper.GeoPointFieldType fieldType, IndexGeoPointFieldData indexFieldData,
-                                  String optimizeBbox) {
+    public GeoDistanceRangeQuery(GeoPoint point, Double lowerVal, Double upperVal, boolean includeLower, boolean includeUpper,
+                                 GeoDistance geoDistance, GeoPointFieldMapperLegacy.GeoPointFieldType fieldType,
+                                 IndexGeoPointFieldData indexFieldData, String optimizeBbox) {
         this.lat = point.lat();
         this.lon = point.lon();
         this.geoDistance = geoDistance;

--- a/core/src/main/java/org/elasticsearch/index/search/geo/IndexedGeoBoundingBoxQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/geo/IndexedGeoBoundingBoxQuery.java
@@ -25,12 +25,13 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapperLegacy;
 
 /**
  */
 public class IndexedGeoBoundingBoxQuery {
 
-    public static Query create(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper.GeoPointFieldType fieldType) {
+    public static Query create(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapperLegacy.GeoPointFieldType fieldType) {
         if (!fieldType.isLatLonEnabled()) {
             throw new IllegalArgumentException("lat/lon is not enabled (indexed) for field [" + fieldType.names().fullName() + "], can't use indexed filter on it");
         }
@@ -42,7 +43,7 @@ public class IndexedGeoBoundingBoxQuery {
         }
     }
 
-    private static Query westGeoBoundingBoxFilter(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper.GeoPointFieldType fieldType) {
+    private static Query westGeoBoundingBoxFilter(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapperLegacy.GeoPointFieldType fieldType) {
         BooleanQuery.Builder filter = new BooleanQuery.Builder();
         filter.setMinimumNumberShouldMatch(1);
         filter.add(fieldType.lonFieldType().rangeQuery(null, bottomRight.lon(), true, true), Occur.SHOULD);
@@ -51,7 +52,7 @@ public class IndexedGeoBoundingBoxQuery {
         return new ConstantScoreQuery(filter.build());
     }
 
-    private static Query eastGeoBoundingBoxFilter(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapper.GeoPointFieldType fieldType) {
+    private static Query eastGeoBoundingBoxFilter(GeoPoint topLeft, GeoPoint bottomRight, GeoPointFieldMapperLegacy.GeoPointFieldType fieldType) {
         BooleanQuery.Builder filter = new BooleanQuery.Builder();
         filter.add(fieldType.lonFieldType().rangeQuery(topLeft.lon(), bottomRight.lon(), true, true), Occur.MUST);
         filter.add(fieldType.latFieldType().rangeQuery(bottomRight.lat(), topLeft.lat(), true, true), Occur.MUST);

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -28,15 +28,19 @@ import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.RAMDirectory;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
 import org.elasticsearch.index.mapper.MapperBuilders;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapperLegacy;
 import org.elasticsearch.index.mapper.internal.ParentFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
@@ -92,7 +96,9 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
         } else if (type.getType().equals("byte")) {
             fieldType = MapperBuilders.byteField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
         } else if (type.getType().equals("geo_point")) {
-            fieldType = MapperBuilders.geoPointField(fieldName).docValues(docValues).fieldDataSettings(type.getSettings()).build(context).fieldType();
+            final Mapper mapper = MapperBuilders.geoPointField(fieldName, Version.indexCreated(indexService.settingsService().indexSettings()))
+                    .docValues(docValues).fieldDataSettings(type.getSettings()).build(context);
+            fieldType = (mapper instanceof GeoPointFieldMapper) ? ((GeoPointFieldMapper)mapper).fieldType() : ((GeoPointFieldMapperLegacy)mapper).fieldType();
         } else if (type.getType().equals("_parent")) {
             fieldType = new ParentFieldMapper.Builder("_type").type(fieldName).build(context).fieldType();
         } else if (type.getType().equals("binary")) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/ExternalMapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper.externalvalues;
 import com.google.common.collect.Iterators;
 import com.spatial4j.core.shape.Point;
 import org.apache.lucene.document.Field;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
@@ -37,7 +38,9 @@ import org.elasticsearch.index.mapper.MergeResult;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.core.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.core.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.geo.GeoPointFieldMapperLegacy;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
 
 import java.io.IOException;
@@ -72,6 +75,7 @@ public class ExternalMapper extends FieldMapper {
         private BinaryFieldMapper.Builder binBuilder = new BinaryFieldMapper.Builder(Names.FIELD_BIN);
         private BooleanFieldMapper.Builder boolBuilder = new BooleanFieldMapper.Builder(Names.FIELD_BOOL);
         private GeoPointFieldMapper.Builder pointBuilder = new GeoPointFieldMapper.Builder(Names.FIELD_POINT);
+        private GeoPointFieldMapperLegacy.Builder legacyPointBuilder = new GeoPointFieldMapperLegacy.Builder(Names.FIELD_POINT);
         private GeoShapeFieldMapper.Builder shapeBuilder = new GeoShapeFieldMapper.Builder(Names.FIELD_SHAPE);
         private Mapper.Builder stringBuilder;
         private String generatedValue;
@@ -98,7 +102,9 @@ public class ExternalMapper extends FieldMapper {
             context.path().add(name);
             BinaryFieldMapper binMapper = binBuilder.build(context);
             BooleanFieldMapper boolMapper = boolBuilder.build(context);
-            GeoPointFieldMapper pointMapper = pointBuilder.build(context);
+            // todo: switch to .onOrAfter(Version.V_2_2_0) once GeoPointField V2 is fully merged
+            BaseGeoPointFieldMapper pointMapper = (context.indexCreatedVersion().onOrBefore(Version.V_2_2_0)) ?
+                    legacyPointBuilder.build(context) : pointBuilder.build(context);
             GeoShapeFieldMapper shapeMapper = shapeBuilder.build(context);
             FieldMapper stringMapper = (FieldMapper)stringBuilder.build(context);
             context.path().remove();
@@ -164,13 +170,13 @@ public class ExternalMapper extends FieldMapper {
 
     private final BinaryFieldMapper binMapper;
     private final BooleanFieldMapper boolMapper;
-    private final GeoPointFieldMapper pointMapper;
+    private final BaseGeoPointFieldMapper pointMapper;
     private final GeoShapeFieldMapper shapeMapper;
     private final FieldMapper stringMapper;
 
     public ExternalMapper(String simpleName, MappedFieldType fieldType,
                           String generatedValue, String mapperName,
-                          BinaryFieldMapper binMapper, BooleanFieldMapper boolMapper, GeoPointFieldMapper pointMapper,
+                          BinaryFieldMapper binMapper, BooleanFieldMapper boolMapper, BaseGeoPointFieldMapper pointMapper,
                           GeoShapeFieldMapper shapeMapper, FieldMapper stringMapper, Settings indexSettings, MultiFields multiFields, CopyTo copyTo) {
         super(simpleName, fieldType, new ExternalFieldType(), indexSettings, multiFields, copyTo);
         this.generatedValue = generatedValue;

--- a/core/src/test/java/org/elasticsearch/index/mapper/geo/GeoEncodingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/geo/GeoEncodingTests.java
@@ -37,7 +37,7 @@ public class GeoEncodingTests extends ESTestCase {
             final double lat = randomDouble() * 180 - 90;
             final double lon = randomDouble() * 360 - 180;
             final Distance precision = new Distance(1+(randomDouble() * 9), randomFrom(Arrays.asList(DistanceUnit.MILLIMETERS, DistanceUnit.METERS, DistanceUnit.KILOMETERS)));
-            final GeoPointFieldMapper.Encoding encoding = GeoPointFieldMapper.Encoding.of(precision);
+            final GeoPointFieldMapperLegacy.Encoding encoding = GeoPointFieldMapperLegacy.Encoding.of(precision);
             assertThat(encoding.precision().convert(DistanceUnit.METERS).value, lessThanOrEqualTo(precision.convert(DistanceUnit.METERS).value));
             final GeoPoint geoPoint = encoding.decode(encoding.encodeCoordinate(lat), encoding.encodeCoordinate(lon), new GeoPoint());
             final double error = GeoDistance.PLANE.calculate(lat, lon, geoPoint.lat(), geoPoint.lon(), DistanceUnit.METERS);

--- a/core/src/test/java/org/elasticsearch/index/mapper/geo/GeohashMappingGeoPointTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/geo/GeohashMappingGeoPointTests.java
@@ -100,8 +100,8 @@ public class GeohashMappingGeoPointTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         FieldMapper mapper = defaultMapper.mappers().smartNameFieldMapper("point");
-        assertThat(mapper, instanceOf(GeoPointFieldMapper.class));
-        GeoPointFieldMapper geoPointFieldMapper = (GeoPointFieldMapper) mapper;
+        assertThat(mapper, instanceOf(BaseGeoPointFieldMapper.class));
+        BaseGeoPointFieldMapper geoPointFieldMapper = (BaseGeoPointFieldMapper) mapper;
         assertThat(geoPointFieldMapper.fieldType().geohashPrecision(), is(10));
     }
 
@@ -112,8 +112,8 @@ public class GeohashMappingGeoPointTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
         FieldMapper mapper = defaultMapper.mappers().smartNameFieldMapper("point");
-        assertThat(mapper, instanceOf(GeoPointFieldMapper.class));
-        GeoPointFieldMapper geoPointFieldMapper = (GeoPointFieldMapper) mapper;
+        assertThat(mapper, instanceOf(BaseGeoPointFieldMapper.class));
+        BaseGeoPointFieldMapper geoPointFieldMapper = (BaseGeoPointFieldMapper) mapper;
         assertThat(geoPointFieldMapper.fieldType().geohashPrecision(), is(10));
     }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.mapper.core.DateFieldMapper;
 import org.elasticsearch.index.mapper.core.LongFieldMapper;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.index.mapper.core.TokenCountFieldMapper;
+import org.elasticsearch.index.mapper.geo.BaseGeoPointFieldMapper;
 import org.elasticsearch.index.mapper.geo.GeoPointFieldMapper;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.junit.Test;
@@ -268,7 +269,7 @@ public class MultiFieldTests extends ESSingleNodeTestCase {
         assertThat(docMapper.mappers().getMapper("a").fieldType().tokenized(), equalTo(false));
 
         assertThat(docMapper.mappers().getMapper("a.b"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("a.b"), instanceOf(GeoPointFieldMapper.class));
+        assertThat(docMapper.mappers().getMapper("a.b"), instanceOf(BaseGeoPointFieldMapper.class));
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("a.b").fieldType().indexOptions());
         assertThat(docMapper.mappers().getMapper("a.b").fieldType().stored(), equalTo(false));
         assertThat(docMapper.mappers().getMapper("a.b").fieldType().tokenized(), equalTo(false));
@@ -293,7 +294,7 @@ public class MultiFieldTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
 
         assertThat(docMapper.mappers().getMapper("b"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("b"), instanceOf(GeoPointFieldMapper.class));
+        assertThat(docMapper.mappers().getMapper("b"), instanceOf(BaseGeoPointFieldMapper.class));
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("b").fieldType().indexOptions());
         assertThat(docMapper.mappers().getMapper("b").fieldType().stored(), equalTo(false));
         assertThat(docMapper.mappers().getMapper("b").fieldType().tokenized(), equalTo(false));


### PR DESCRIPTION
This is GeoPointV2 PR part 2. It adds the abstraction layer to GeoPointFieldMapper needed to cut over to Lucene 5.4's new GeoPointField type while maintaining backward compatibility with existing `geo_point` indexes.
