### PR TITLE
Adding US-Gov-West

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
@@ -134,6 +134,8 @@ public class AwsEc2ServiceImpl extends AbstractLifecycleComponent<AwsEc2Service>
                 endpoint = "ec2.us-west-2.amazonaws.com";
             } else if (region.equals("ap-southeast") || region.equals("ap-southeast-1")) {
                 endpoint = "ec2.ap-southeast-1.amazonaws.com";
+            } else if (region.equals("us-gov-west") || region.equals("us-gov-west-1")) {
+                endpoint = "ec2.us-gov-west-1.amazonaws.com";
             } else if (region.equals("ap-southeast-2")) {
                 endpoint = "ec2.ap-southeast-2.amazonaws.com";
             } else if (region.equals("ap-northeast") || region.equals("ap-northeast-1")) {


### PR DESCRIPTION
Adds support for EC2 and S3 gov end points: http://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html
- ec2.us-gov-west-1.amazonaws.com
- s3-us-gov-west-1.amazonaws.com
