### PR TITLE
add gradle build script to plugin

### DIFF
--- a/plugins/ingest/build.gradle
+++ b/plugins/ingest/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+esplugin {
+  description 'Plugin that allows to configure pipelines to preprocess documents before indexing'
+  classname 'org.elasticsearch.plugin.ingest.IngestPlugin'
+}
+
+dependencies {
+  testCompile 'org.elasticsearch:securemock:1.1'
+}
+
+compileJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
+compileTestJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ String[] projects = [
   'plugins:discovery-ec2',
   'plugins:discovery-gce',
   'plugins:discovery-multicast',
+  'plugins:ingest',
   'plugins:lang-expression',
   'plugins:lang-groovy',
   'plugins:lang-javascript',


### PR DESCRIPTION
Gradle build scripts were introduced into Elasticsearch!

This PR contains the necessary gradle build scripts to enable gradle building for IngestPlugin.
