### PR TITLE
Forbid changing thread pool types

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -177,7 +177,7 @@ public class ClusterModule extends AbstractModule {
         registerClusterDynamicSetting(RecoverySettings.INDICES_RECOVERY_INTERNAL_ACTION_TIMEOUT, Validator.TIME_NON_NEGATIVE);
         registerClusterDynamicSetting(RecoverySettings.INDICES_RECOVERY_INTERNAL_LONG_ACTION_TIMEOUT, Validator.TIME_NON_NEGATIVE);
         registerClusterDynamicSetting(RecoverySettings.INDICES_RECOVERY_MAX_SIZE_PER_SEC, Validator.BYTES_SIZE);
-        registerClusterDynamicSetting(ThreadPool.THREADPOOL_GROUP + "*", Validator.EMPTY);
+        registerClusterDynamicSetting(ThreadPool.THREADPOOL_GROUP + "*", ThreadPool.THREAD_POOL_TYPE_SETTINGS_VALIDATOR);
         registerClusterDynamicSetting(ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES, Validator.INTEGER);
         registerClusterDynamicSetting(ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES, Validator.INTEGER);
         registerClusterDynamicSetting(DiskThresholdDecider.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK, Validator.EMPTY);

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -288,7 +288,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
                     }
                 }
 
-                table.addCell(poolInfo == null  ? null : poolInfo.getType());
+                table.addCell(poolInfo == null  ? null : poolInfo.getThreadPoolType());
                 table.addCell(poolStats == null ? null : poolStats.getActive());
                 table.addCell(poolStats == null ? null : poolStats.getThreads());
                 table.addCell(poolStats == null ? null : poolStats.getQueue());

--- a/core/src/test/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -37,7 +37,6 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
     @Override
     public Settings nodeSettings(int nodeOrdinal) {
         return settingsBuilder().put(super.nodeSettings(nodeOrdinal))
-                .put("threadpool.search.type", "fixed")
                 .put("threadpool.search.size", 1)
                 .put("threadpool.search.queue_size", 1)
                 .build();

--- a/core/src/test/java/org/elasticsearch/threadpool/ThreadPoolTypeSettingsValidatorTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/ThreadPoolTypeSettingsValidatorTests.java
@@ -1,0 +1,54 @@
+package org.elasticsearch.threadpool;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.settings.Validator;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class ThreadPoolTypeSettingsValidatorTests extends ESTestCase {
+    private Validator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        validator = ThreadPool.THREAD_POOL_TYPE_SETTINGS_VALIDATOR;
+    }
+
+    public void testValidThreadPoolTypeSettings() {
+        for (Map.Entry<String, ThreadPool.ThreadPoolType> entry : ThreadPool.THREAD_POOL_TYPES.entrySet()) {
+            assertNull(validateSetting(validator, entry.getKey(), entry.getValue().getType()));
+        }
+    }
+
+    public void testInvalidThreadPoolTypeSettings() {
+        for (Map.Entry<String, ThreadPool.ThreadPoolType> entry : ThreadPool.THREAD_POOL_TYPES.entrySet()) {
+            Set<ThreadPool.ThreadPoolType> set = new HashSet<>();
+            set.addAll(Arrays.asList(ThreadPool.ThreadPoolType.values()));
+            set.remove(entry.getValue());
+            ThreadPool.ThreadPoolType invalidThreadPoolType = randomFrom(set.toArray(new ThreadPool.ThreadPoolType[set.size()]));
+            String expectedMessage = String.format(
+                    Locale.ROOT,
+                    "thread pool type for [%s] can only be updated to [%s] but was [%s]",
+                    entry.getKey(),
+                    entry.getValue().getType(),
+                    invalidThreadPoolType.getType());
+            String message = validateSetting(validator, entry.getKey(), invalidThreadPoolType.getType());
+            assertNotNull(message);
+            assertEquals(expectedMessage, message);
+        }
+    }
+
+    public void testNonThreadPoolTypeSetting() {
+        String setting = ThreadPool.THREADPOOL_GROUP + randomAsciiOfLength(10) + "foo";
+        String value = randomAsciiOfLength(10);
+        assertNull(validator.validate(setting, value, ClusterState.PROTO));
+    }
+
+    private String validateSetting(Validator validator, String threadPoolName, String value) {
+        return validator.validate(ThreadPool.THREADPOOL_GROUP + threadPoolName + ".type", value, ClusterState.PROTO);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -25,22 +25,330 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.*;
 
 /**
  */
 public class UpdateThreadPoolSettingsTests extends ESTestCase {
+    public void testCorrectThreadPoolTypePermittedInSettings() throws InterruptedException {
+        String threadPoolName = randomThreadPoolName();
+        ThreadPool.ThreadPoolType correctThreadPoolType = ThreadPool.THREAD_POOL_TYPES.get(threadPoolName);
+        ThreadPool threadPool = null;
+        try {
+            threadPool = new ThreadPool(settingsBuilder()
+                    .put("name", "testCorrectThreadPoolTypePermittedInSettings")
+                    .put("threadpool." + threadPoolName + ".type", correctThreadPoolType.getType())
+                    .build());
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), correctThreadPoolType);
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    public void testThreadPoolCanNotOverrideThreadPoolType() throws InterruptedException {
+        String threadPoolName = randomThreadPoolName();
+        ThreadPool.ThreadPoolType incorrectThreadPoolType = randomIncorrectThreadPoolType(threadPoolName);
+        ThreadPool.ThreadPoolType correctThreadPoolType = ThreadPool.THREAD_POOL_TYPES.get(threadPoolName);
+        ThreadPool threadPool = null;
+        try {
+            threadPool = new ThreadPool(
+                    settingsBuilder()
+                            .put("name", "testThreadPoolCanNotOverrideThreadPoolType")
+                            .put("threadpool." + threadPoolName + ".type", incorrectThreadPoolType.getType())
+                            .build());
+            terminate(threadPool);
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(
+                    e.getMessage(),
+                    is("setting threadpool." + threadPoolName + ".type to " + incorrectThreadPoolType.getType() + " is not permitted; must be " + correctThreadPoolType.getType()));
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    public void testUpdateSettingsCanNotChangeThreadPoolType() throws InterruptedException {
+        String threadPoolName = randomThreadPoolName();
+        ThreadPool.ThreadPoolType invalidThreadPoolType = randomIncorrectThreadPoolType(threadPoolName);
+        ThreadPool.ThreadPoolType validThreadPoolType = ThreadPool.THREAD_POOL_TYPES.get(threadPoolName);
+        ThreadPool threadPool = null;
+        try {
+            threadPool = new ThreadPool(settingsBuilder().put("name", "testUpdateSettingsCanNotChangeThreadPoolType").build());
+
+
+            threadPool.updateSettings(
+                    settingsBuilder()
+                            .put("threadpool." + threadPoolName + ".type", invalidThreadPoolType.getType())
+                            .build()
+            );
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(
+                    e.getMessage(),
+                    is("setting threadpool." + threadPoolName + ".type to " + invalidThreadPoolType.getType() + " is not permitted; must be " + validThreadPoolType.getType()));
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    public void testCachedExecutorType() throws InterruptedException {
+        String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.CACHED);
+        ThreadPool threadPool = null;
+        try {
+            threadPool = new ThreadPool(
+                    Settings.settingsBuilder()
+                            .put("name", "testCachedExecutorType").build());
+
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.CACHED);
+            assertThat(threadPool.executor(threadPoolName), instanceOf(EsThreadPoolExecutor.class));
+
+            threadPool.updateSettings(settingsBuilder()
+                    .put("threadpool." + threadPoolName + ".keep_alive", "10m")
+                    .build());
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.CACHED);
+            assertThat(threadPool.executor(threadPoolName), instanceOf(EsThreadPoolExecutor.class));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getCorePoolSize(), equalTo(0));
+            // Make sure keep alive value changed
+            assertThat(info(threadPool, threadPoolName).getKeepAlive().minutes(), equalTo(10L));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(10L));
+
+            // Make sure keep alive value reused
+            assertThat(info(threadPool, threadPoolName).getKeepAlive().minutes(), equalTo(10L));
+            assertThat(threadPool.executor(threadPoolName), instanceOf(EsThreadPoolExecutor.class));
+
+            // Change keep alive
+            Executor oldExecutor = threadPool.executor(threadPoolName);
+            threadPool.updateSettings(settingsBuilder().put("threadpool." + threadPoolName + ".keep_alive", "1m").build());
+            // Make sure keep alive value changed
+            assertThat(info(threadPool, threadPoolName).getKeepAlive().minutes(), equalTo(1L));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(1L));
+            // Make sure executor didn't change
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.CACHED);
+            assertThat(threadPool.executor(threadPoolName), sameInstance(oldExecutor));
+
+            // Set the same keep alive
+            threadPool.updateSettings(settingsBuilder().put("threadpool." + threadPoolName + ".keep_alive", "1m").build());
+            // Make sure keep alive value didn't change
+            assertThat(info(threadPool, threadPoolName).getKeepAlive().minutes(), equalTo(1L));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(1L));
+            // Make sure executor didn't change
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.CACHED);
+            assertThat(threadPool.executor(threadPoolName), sameInstance(oldExecutor));
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    public void testFixedExecutorType() throws InterruptedException {
+        String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.FIXED);
+        ThreadPool threadPool = null;
+
+        try {
+            threadPool = new ThreadPool(settingsBuilder()
+                    .put("name", "testCachedExecutorType").build());
+            assertThat(threadPool.executor(threadPoolName), instanceOf(EsThreadPoolExecutor.class));
+
+            threadPool.updateSettings(settingsBuilder()
+                    .put("threadpool." + threadPoolName + ".size", "15")
+                    .build());
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.FIXED);
+            assertThat(threadPool.executor(threadPoolName), instanceOf(EsThreadPoolExecutor.class));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getCorePoolSize(), equalTo(15));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getMaximumPoolSize(), equalTo(15));
+            assertThat(info(threadPool, threadPoolName).getMin(), equalTo(15));
+            assertThat(info(threadPool, threadPoolName).getMax(), equalTo(15));
+            // keep alive does not apply to fixed thread pools
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(0L));
+
+            // Put old type back
+            threadPool.updateSettings(Settings.EMPTY);
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.FIXED);
+            // Make sure keep alive value is not used
+            assertThat(info(threadPool, threadPoolName).getKeepAlive(), nullValue());
+            // Make sure keep pool size value were reused
+            assertThat(info(threadPool, threadPoolName).getMin(), equalTo(15));
+            assertThat(info(threadPool, threadPoolName).getMax(), equalTo(15));
+            assertThat(threadPool.executor(threadPoolName), instanceOf(EsThreadPoolExecutor.class));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getCorePoolSize(), equalTo(15));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getMaximumPoolSize(), equalTo(15));
+
+            // Change size
+            Executor oldExecutor = threadPool.executor(threadPoolName);
+            threadPool.updateSettings(settingsBuilder().put("threadpool." + threadPoolName + ".size", "10").build());
+            // Make sure size values changed
+            assertThat(info(threadPool, threadPoolName).getMax(), equalTo(10));
+            assertThat(info(threadPool, threadPoolName).getMin(), equalTo(10));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getMaximumPoolSize(), equalTo(10));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getCorePoolSize(), equalTo(10));
+            // Make sure executor didn't change
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.FIXED);
+            assertThat(threadPool.executor(threadPoolName), sameInstance(oldExecutor));
+
+            // Change queue capacity
+            threadPool.updateSettings(settingsBuilder()
+                    .put("threadpool." + threadPoolName + ".queue", "500")
+                    .build());
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    public void testScalingExecutorType() throws InterruptedException {
+        String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.SCALING);
+        ThreadPool threadPool = null;
+        try {
+            threadPool = new ThreadPool(settingsBuilder()
+                    .put("threadpool." + threadPoolName + ".size", 10)
+                    .put("name", "testCachedExecutorType").build());
+            assertThat(info(threadPool, threadPoolName).getMin(), equalTo(1));
+            assertThat(info(threadPool, threadPoolName).getMax(), equalTo(10));
+            assertThat(info(threadPool, threadPoolName).getKeepAlive().minutes(), equalTo(5L));
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.SCALING);
+            assertThat(threadPool.executor(threadPoolName), instanceOf(EsThreadPoolExecutor.class));
+
+            // Change settings that doesn't require pool replacement
+            Executor oldExecutor = threadPool.executor(threadPoolName);
+            threadPool.updateSettings(settingsBuilder()
+                    .put("threadpool." + threadPoolName + ".keep_alive", "10m")
+                    .put("threadpool." + threadPoolName + ".min", "2")
+                    .put("threadpool." + threadPoolName + ".size", "15")
+                    .build());
+            assertEquals(info(threadPool, threadPoolName).getThreadPoolType(), ThreadPool.ThreadPoolType.SCALING);
+            assertThat(threadPool.executor(threadPoolName), instanceOf(EsThreadPoolExecutor.class));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getCorePoolSize(), equalTo(2));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getMaximumPoolSize(), equalTo(15));
+            assertThat(info(threadPool, threadPoolName).getMin(), equalTo(2));
+            assertThat(info(threadPool, threadPoolName).getMax(), equalTo(15));
+            // Make sure keep alive value changed
+            assertThat(info(threadPool, threadPoolName).getKeepAlive().minutes(), equalTo(10L));
+            assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(10L));
+            assertThat(threadPool.executor(threadPoolName), sameInstance(oldExecutor));
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    public void testShutdownNowInterrupts() throws Exception {
+        String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.FIXED);
+        ThreadPool threadPool = null;
+        try {
+            threadPool = new ThreadPool(Settings.settingsBuilder()
+                    .put("threadpool." + threadPoolName + ".queue_size", 1000)
+                    .put("name", "testCachedExecutorType").build());
+            assertEquals(info(threadPool, threadPoolName).getQueueSize().getSingles(), 1000L);
+
+            final CountDownLatch latch = new CountDownLatch(1);
+            ThreadPoolExecutor oldExecutor = (ThreadPoolExecutor) threadPool.executor(threadPoolName);
+            threadPool.executor(threadPoolName).execute(() -> {
+                        try {
+                            new CountDownLatch(1).await();
+                        } catch (InterruptedException ex) {
+                            latch.countDown();
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+            );
+            threadPool.updateSettings(settingsBuilder().put("threadpool." + threadPoolName + ".queue_size", 2000).build());
+            assertThat(threadPool.executor(threadPoolName), not(sameInstance(oldExecutor)));
+            assertThat(oldExecutor.isShutdown(), equalTo(true));
+            assertThat(oldExecutor.isTerminating(), equalTo(true));
+            assertThat(oldExecutor.isTerminated(), equalTo(false));
+            threadPool.shutdownNow(); // should interrupt the thread
+            latch.await(3, TimeUnit.SECONDS); // If this throws then ThreadPool#shutdownNow didn't interrupt
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    public void testCustomThreadPool() throws Exception {
+        ThreadPool threadPool = null;
+        try {
+            threadPool = new ThreadPool(Settings.settingsBuilder()
+                    .put("threadpool.my_pool1.type", "scaling")
+                    .put("threadpool.my_pool2.type", "fixed")
+                    .put("threadpool.my_pool2.size", "1")
+                    .put("threadpool.my_pool2.queue_size", "1")
+                    .put("name", "testCustomThreadPool").build());
+            ThreadPoolInfo groups = threadPool.info();
+            boolean foundPool1 = false;
+            boolean foundPool2 = false;
+            outer:
+            for (ThreadPool.Info info : groups) {
+                if ("my_pool1".equals(info.getName())) {
+                    foundPool1 = true;
+                    assertEquals(info.getThreadPoolType(), ThreadPool.ThreadPoolType.SCALING);
+                } else if ("my_pool2".equals(info.getName())) {
+                    foundPool2 = true;
+                    assertEquals(info.getThreadPoolType(), ThreadPool.ThreadPoolType.FIXED);
+                    assertThat(info.getMin(), equalTo(1));
+                    assertThat(info.getMax(), equalTo(1));
+                    assertThat(info.getQueueSize().singles(), equalTo(1l));
+                } else {
+                    for (Field field : Names.class.getFields()) {
+                        if (info.getName().equalsIgnoreCase(field.getName())) {
+                            // This is ok it is a default thread pool
+                            continue outer;
+                        }
+                    }
+                    fail("Unexpected pool name: " + info.getName());
+                }
+            }
+            assertThat(foundPool1, is(true));
+            assertThat(foundPool2, is(true));
+
+            // Updating my_pool2
+            Settings settings = Settings.builder()
+                    .put("threadpool.my_pool2.size", "10")
+                    .build();
+            threadPool.updateSettings(settings);
+
+            groups = threadPool.info();
+            foundPool1 = false;
+            foundPool2 = false;
+            outer:
+            for (ThreadPool.Info info : groups) {
+                if ("my_pool1".equals(info.getName())) {
+                    foundPool1 = true;
+                    assertEquals(info.getThreadPoolType(), ThreadPool.ThreadPoolType.SCALING);
+                } else if ("my_pool2".equals(info.getName())) {
+                    foundPool2 = true;
+                    assertThat(info.getMax(), equalTo(10));
+                    assertThat(info.getMin(), equalTo(10));
+                    assertThat(info.getQueueSize().singles(), equalTo(1l));
+                    assertEquals(info.getThreadPoolType(), ThreadPool.ThreadPoolType.FIXED);
+                } else {
+                    for (Field field : Names.class.getFields()) {
+                        if (info.getName().equalsIgnoreCase(field.getName())) {
+                            // This is ok it is a default thread pool
+                            continue outer;
+                        }
+                    }
+                    fail("Unexpected pool name: " + info.getName());
+                }
+            }
+            assertThat(foundPool1, is(true));
+            assertThat(foundPool2, is(true));
+        } finally {
+            terminateThreadPoolIfNeeded(threadPool);
+        }
+    }
+
+    private void terminateThreadPoolIfNeeded(ThreadPool threadPool) throws InterruptedException {
+        if (threadPool != null) {
+            terminate(threadPool);
+        }
+    }
+
     private ThreadPool.Info info(ThreadPool threadPool, String name) {
         for (ThreadPool.Info info : threadPool.info()) {
             if (info.getName().equals(name)) {
@@ -50,247 +358,20 @@ public class UpdateThreadPoolSettingsTests extends ESTestCase {
         return null;
     }
 
-    public void testCachedExecutorType() throws InterruptedException {
-        ThreadPool threadPool = new ThreadPool(
-                Settings.settingsBuilder()
-                        .put("threadpool.search.type", "cached")
-                        .put("name","testCachedExecutorType").build());
-
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("cached"));
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(5L));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
-
-        // Replace with different type
-        threadPool.updateSettings(settingsBuilder().put("threadpool.search.type", "same").build());
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("same"));
-        assertThat(threadPool.executor(Names.SEARCH), is(ThreadPool.DIRECT_EXECUTOR));
-
-        // Replace with different type again
-        threadPool.updateSettings(settingsBuilder()
-                .put("threadpool.search.type", "scaling")
-                .put("threadpool.search.keep_alive", "10m")
-                .build());
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("scaling"));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getCorePoolSize(), equalTo(1));
-        // Make sure keep alive value changed
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(10L));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(10L));
-
-        // Put old type back
-        threadPool.updateSettings(settingsBuilder().put("threadpool.search.type", "cached").build());
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("cached"));
-        // Make sure keep alive value reused
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(10L));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
-
-        // Change keep alive
-        Executor oldExecutor = threadPool.executor(Names.SEARCH);
-        threadPool.updateSettings(settingsBuilder().put("threadpool.search.keep_alive", "1m").build());
-        // Make sure keep alive value changed
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(1L));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(1L));
-        // Make sure executor didn't change
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("cached"));
-        assertThat(threadPool.executor(Names.SEARCH), sameInstance(oldExecutor));
-
-        // Set the same keep alive
-        threadPool.updateSettings(settingsBuilder().put("threadpool.search.keep_alive", "1m").build());
-        // Make sure keep alive value didn't change
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(1L));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(1L));
-        // Make sure executor didn't change
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("cached"));
-        assertThat(threadPool.executor(Names.SEARCH), sameInstance(oldExecutor));
-        terminate(threadPool);
+    private String randomThreadPoolName() {
+        Set<String> threadPoolNames = ThreadPool.THREAD_POOL_TYPES.keySet();
+        return randomFrom(threadPoolNames.toArray(new String[threadPoolNames.size()]));
     }
 
-    public void testFixedExecutorType() throws InterruptedException {
-        ThreadPool threadPool = new ThreadPool(settingsBuilder()
-                .put("threadpool.search.type", "fixed")
-                .put("name","testCachedExecutorType").build());
-
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
-
-        // Replace with different type
-        threadPool.updateSettings(settingsBuilder()
-                .put("threadpool.search.type", "scaling")
-                .put("threadpool.search.keep_alive", "10m")
-                .put("threadpool.search.min", "2")
-                .put("threadpool.search.size", "15")
-                .build());
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("scaling"));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getCorePoolSize(), equalTo(2));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getMaximumPoolSize(), equalTo(15));
-        assertThat(info(threadPool, Names.SEARCH).getMin(), equalTo(2));
-        assertThat(info(threadPool, Names.SEARCH).getMax(), equalTo(15));
-        // Make sure keep alive value changed
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(10L));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(10L));
-
-        // Put old type back
-        threadPool.updateSettings(settingsBuilder()
-                .put("threadpool.search.type", "fixed")
-                .build());
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("fixed"));
-        // Make sure keep alive value is not used
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive(), nullValue());
-        // Make sure keep pool size value were reused
-        assertThat(info(threadPool, Names.SEARCH).getMin(), equalTo(15));
-        assertThat(info(threadPool, Names.SEARCH).getMax(), equalTo(15));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getCorePoolSize(), equalTo(15));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getMaximumPoolSize(), equalTo(15));
-
-        // Change size
-        Executor oldExecutor = threadPool.executor(Names.SEARCH);
-        threadPool.updateSettings(settingsBuilder().put("threadpool.search.size", "10").build());
-        // Make sure size values changed
-        assertThat(info(threadPool, Names.SEARCH).getMax(), equalTo(10));
-        assertThat(info(threadPool, Names.SEARCH).getMin(), equalTo(10));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getMaximumPoolSize(), equalTo(10));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getCorePoolSize(), equalTo(10));
-        // Make sure executor didn't change
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("fixed"));
-        assertThat(threadPool.executor(Names.SEARCH), sameInstance(oldExecutor));
-
-        // Change queue capacity
-        threadPool.updateSettings(settingsBuilder()
-                .put("threadpool.search.queue", "500")
-                .build());
-
-        terminate(threadPool);
+    private ThreadPool.ThreadPoolType randomIncorrectThreadPoolType(String threadPoolName) {
+        Set<ThreadPool.ThreadPoolType> set = new HashSet<>();
+        set.addAll(Arrays.asList(ThreadPool.ThreadPoolType.values()));
+        set.remove(ThreadPool.THREAD_POOL_TYPES.get(threadPoolName));
+        ThreadPool.ThreadPoolType invalidThreadPoolType = randomFrom(set.toArray(new ThreadPool.ThreadPoolType[set.size()]));
+        return invalidThreadPoolType;
     }
 
-    public void testScalingExecutorType() throws InterruptedException {
-        ThreadPool threadPool = new ThreadPool(settingsBuilder()
-                .put("threadpool.search.type", "scaling")
-                .put("threadpool.search.size", 10)
-                .put("name","testCachedExecutorType").build());
-
-        assertThat(info(threadPool, Names.SEARCH).getMin(), equalTo(1));
-        assertThat(info(threadPool, Names.SEARCH).getMax(), equalTo(10));
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(5L));
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("scaling"));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
-
-        // Change settings that doesn't require pool replacement
-        Executor oldExecutor = threadPool.executor(Names.SEARCH);
-        threadPool.updateSettings(settingsBuilder()
-                .put("threadpool.search.type", "scaling")
-                .put("threadpool.search.keep_alive", "10m")
-                .put("threadpool.search.min", "2")
-                .put("threadpool.search.size", "15")
-                .build());
-        assertThat(info(threadPool, Names.SEARCH).getType(), equalTo("scaling"));
-        assertThat(threadPool.executor(Names.SEARCH), instanceOf(EsThreadPoolExecutor.class));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getCorePoolSize(), equalTo(2));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getMaximumPoolSize(), equalTo(15));
-        assertThat(info(threadPool, Names.SEARCH).getMin(), equalTo(2));
-        assertThat(info(threadPool, Names.SEARCH).getMax(), equalTo(15));
-        // Make sure keep alive value changed
-        assertThat(info(threadPool, Names.SEARCH).getKeepAlive().minutes(), equalTo(10L));
-        assertThat(((EsThreadPoolExecutor) threadPool.executor(Names.SEARCH)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(10L));
-        assertThat(threadPool.executor(Names.SEARCH), sameInstance(oldExecutor));
-
-        terminate(threadPool);
+    private String randomThreadPool(ThreadPool.ThreadPoolType type) {
+        return randomFrom(ThreadPool.THREAD_POOL_TYPES.entrySet().stream().filter(t -> t.getValue().equals(type)).map(t -> t.getKey()).collect(Collectors.toList()));
     }
-
-    public void testShutdownNowInterrupts() throws Exception {
-        ThreadPool threadPool = new ThreadPool(Settings.settingsBuilder()
-                .put("threadpool.search.type", "cached")
-                .put("name","testCachedExecutorType").build());
-
-        final CountDownLatch latch = new CountDownLatch(1);
-        ThreadPoolExecutor oldExecutor = (ThreadPoolExecutor) threadPool.executor(Names.SEARCH);
-        threadPool.executor(Names.SEARCH).execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    new CountDownLatch(1).await();
-                } catch (InterruptedException ex) {
-                    latch.countDown();
-                    Thread.currentThread().interrupt();
-                }
-            }
-        });
-        threadPool.updateSettings(settingsBuilder().put("threadpool.search.type", "fixed").build());
-        assertThat(threadPool.executor(Names.SEARCH), not(sameInstance(oldExecutor)));
-        assertThat(oldExecutor.isShutdown(), equalTo(true));
-        assertThat(oldExecutor.isTerminating(), equalTo(true));
-        assertThat(oldExecutor.isTerminated(), equalTo(false));
-        threadPool.shutdownNow(); // should interrupt the thread
-        latch.await(3, TimeUnit.SECONDS); // If this throws then shotdownNow didn't interrupt
-        terminate(threadPool);
-    }
-
-    public void testCustomThreadPool() throws Exception {
-        ThreadPool threadPool = new ThreadPool(Settings.settingsBuilder()
-                .put("threadpool.my_pool1.type", "cached")
-                .put("threadpool.my_pool2.type", "fixed")
-                .put("threadpool.my_pool2.size", "1")
-                .put("threadpool.my_pool2.queue_size", "1")
-                .put("name", "testCustomThreadPool").build());
-
-        ThreadPoolInfo groups = threadPool.info();
-        boolean foundPool1 = false;
-        boolean foundPool2 = false;
-        outer: for (ThreadPool.Info info : groups) {
-            if ("my_pool1".equals(info.getName())) {
-                foundPool1 = true;
-                assertThat(info.getType(), equalTo("cached"));
-            } else if ("my_pool2".equals(info.getName())) {
-                foundPool2 = true;
-                assertThat(info.getType(), equalTo("fixed"));
-                assertThat(info.getMin(), equalTo(1));
-                assertThat(info.getMax(), equalTo(1));
-                assertThat(info.getQueueSize().singles(), equalTo(1l));
-            } else {
-                for (Field field : Names.class.getFields()) {
-                    if (info.getName().equalsIgnoreCase(field.getName())) {
-                        // This is ok it is a default thread pool
-                        continue outer;
-                    }
-                }
-                fail("Unexpected pool name: " + info.getName());
-            }
-        }
-        assertThat(foundPool1, is(true));
-        assertThat(foundPool2, is(true));
-
-        // Updating my_pool2
-        Settings settings = Settings.builder()
-                .put("threadpool.my_pool2.size", "10")
-                .build();
-        threadPool.updateSettings(settings);
-
-        groups = threadPool.info();
-        foundPool1 = false;
-        foundPool2 = false;
-        outer: for (ThreadPool.Info info : groups) {
-            if ("my_pool1".equals(info.getName())) {
-                foundPool1 = true;
-                assertThat(info.getType(), equalTo("cached"));
-            } else if ("my_pool2".equals(info.getName())) {
-                foundPool2 = true;
-                assertThat(info.getMax(), equalTo(10));
-                assertThat(info.getMin(), equalTo(10));
-                assertThat(info.getQueueSize().singles(), equalTo(1l));
-                assertThat(info.getType(), equalTo("fixed"));
-            } else {
-                for (Field field : Names.class.getFields()) {
-                    if (info.getName().equalsIgnoreCase(field.getName())) {
-                        // This is ok it is a default thread pool
-                        continue outer;
-                    }
-                }
-                fail("Unexpected pool name: " + info.getName());
-            }
-        }
-        assertThat(foundPool1, is(true));
-        assertThat(foundPool2, is(true));
-        terminate(threadPool);
-    }
-
 }

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -389,4 +389,12 @@ request cache and the field data cache.
 
 This setting would arbitrarily pick the first interface not marked as loopback. Instead, specify by address
 scope (e.g. `_local_,_site_` for all loopback and private network addresses) or by explicit interface names,
-hostnames, or addresses. 
+hostnames, or addresses.
+
+=== Forbid changing of thread pool types
+
+Previously, <<modules-threadpool,thread pool types>> could be dynamically adjusted. The thread pool type effectively
+controls the backing queue for the thread pool and modifying this is an expert setting with minimal practical benefits
+and high risk of being misused. The ability to change the thread pool type for any thread pool has been removed; do note
+that it is still possible to adjust relevant thread pool parameters for each of the thread pools (e.g., depending on
+the thread pool type, `keep_alive`, `queue_size`, etc.).

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -9,87 +9,92 @@ of discarded.
 
 There are several thread pools, but the important ones include:
 
+`generic`::
+    For generic operations (e.g., background node discovery).
+    Thread pool type is `cached`.
+
 `index`::
-    For index/delete operations. Defaults to `fixed`
+    For index/delete operations. Thread pool type is `fixed`
     with a size of `# of available processors`,
     queue_size of `200`.
 
 `search`::
-    For count/search operations. Defaults to `fixed`
+    For count/search operations. Thread pool type is `fixed`
     with a size of `int((# of available_processors * 3) / 2) + 1`,
     queue_size of `1000`.
 
 `suggest`::
-    For suggest operations. Defaults to `fixed`
+    For suggest operations. Thread pool type is `fixed`
     with a size of `# of available processors`,
     queue_size of `1000`.
 
 `get`::
-    For get operations. Defaults to `fixed`
+    For get operations. Thread pool type is `fixed`
     with a size of `# of available processors`,
     queue_size of `1000`.
 
 `bulk`::
-    For bulk operations. Defaults to `fixed`
+    For bulk operations. Thread pool type is `fixed`
     with a size of `# of available processors`,
     queue_size of `50`.
 
 `percolate`::
-    For percolate operations. Defaults to `fixed`
+    For percolate operations. Thread pool type is `fixed`
     with a size of `# of available processors`,
     queue_size of `1000`.
 
 `snapshot`::
-    For snapshot/restore operations. Defaults to `scaling` with a
-    keep-alive of `5m` and a size of `min(5, (# of available processors)/2)`, max at 5.
+    For snapshot/restore operations. Thread pool type is `scaling` with a
+    keep-alive of `5m` and a size of `min(5, (# of available processors)/2)`.
 
 `warmer`::
-    For segment warm-up operations. Defaults to `scaling` with a
-    keep-alive of `5m` and a size of `min(5, (# of available processors)/2)`, max at 5.
+    For segment warm-up operations. Thread pool type is `scaling` with a
+    keep-alive of `5m` and a size of `min(5, (# of available processors)/2)`.
 
 `refresh`::
-    For refresh operations. Defaults to `scaling` with a
-    keep-alive of `5m` and a size of `min(10, (# of available processors)/2)`, max at 10.
+    For refresh operations. Thread pool type is `scaling` with a
+    keep-alive of `5m` and a size of `min(10, (# of available processors)/2)`.
 
 `listener`::
     Mainly for java client executing of action when listener threaded is set to true.
-    Default size of `(# of available processors)/2`, max at 10.
+    Thread pool type is `scaling` with a default size of `min(10, (# of available processors)/2)`.
 
-Changing a specific thread pool can be done by setting its type and
-specific type parameters, for example, changing the `index` thread pool
-to have more threads:
+Changing a specific thread pool can be done by setting its type-specific parameters; for example, changing the `index`
+thread pool to have more threads:
 
 [source,js]
 --------------------------------------------------
 threadpool:
     index:
-        type: fixed
         size: 30
 --------------------------------------------------
 
-NOTE: you can update threadpool settings live using
-      <<cluster-update-settings>>.
-
+NOTE: you can update thread pool settings dynamically using <<cluster-update-settings>>.
 
 [float]
 [[types]]
 === Thread pool types
 
-The following are the types of thread pools that can be used and their
-respective parameters:
+The following are the types of thread pools and their respective parameters:
 
 [float]
-==== `cache`
+==== `cached`
 
-The `cache` thread pool is an unbounded thread pool that will spawn a
-thread if there are pending requests. Here is an example of how to set
-it:
+The `cached` thread pool is an unbounded thread pool that will spawn a
+thread if there are pending requests. This thread pool is used to
+prevent requests submitted to this pool from blocking or being
+rejected. Unused threads in this thread pool will be terminated after
+a keep alive expires (defaults to five minutes). The `cached` thread
+pool is reserved for the <<modules-threadpool,`generic`>> thread pool.
+
+The `keep_alive` parameter determines how long a thread should be kept
+around in the thread pool without doing any work.
 
 [source,js]
 --------------------------------------------------
 threadpool:
-    index:
-        type: cached
+    generic:
+        keep_alive: 2m
 --------------------------------------------------
 
 [float]
@@ -111,7 +116,6 @@ full, it will abort the request.
 --------------------------------------------------
 threadpool:
     index:
-        type: fixed
         size: 30
         queue_size: 1000
 --------------------------------------------------
@@ -130,7 +134,6 @@ around in the thread pool without it doing any work.
 --------------------------------------------------
 threadpool:
     warmer:
-        type: scaling
         size: 8
         keep_alive: 2m
 --------------------------------------------------

--- a/test-framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -64,10 +64,10 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.MockEngineFactoryPlugin;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.index.MockEngineFactoryPlugin;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.IndexStoreConfig;
 import org.elasticsearch.indices.IndicesService;
@@ -88,7 +88,6 @@ import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.store.MockFSIndexStore;
 import org.elasticsearch.test.transport.AssertingLocalTransport;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.netty.NettyTransport;
@@ -98,20 +97,11 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Random;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.*;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
@@ -119,15 +109,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static junit.framework.Assert.fail;
-import static org.apache.lucene.util.LuceneTestCase.TEST_NIGHTLY;
-import static org.apache.lucene.util.LuceneTestCase.rarely;
-import static org.apache.lucene.util.LuceneTestCase.usually;
+import static org.apache.lucene.util.LuceneTestCase.*;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -403,18 +389,6 @@ public final class InternalTestCluster extends TestCluster {
         }
         if (random.nextBoolean()) { // sometimes set a
             builder.put(SearchService.DEFAULT_KEEPALIVE_KEY, TimeValue.timeValueSeconds(100 + random.nextInt(5 * 60)));
-        }
-        if (random.nextBoolean()) {
-            // change threadpool types to make sure we don't have components that rely on the type of thread pools
-            for (String name : Arrays.asList(ThreadPool.Names.BULK, ThreadPool.Names.FLUSH, ThreadPool.Names.GET,
-                    ThreadPool.Names.INDEX, ThreadPool.Names.MANAGEMENT, ThreadPool.Names.FORCE_MERGE,
-                    ThreadPool.Names.PERCOLATE, ThreadPool.Names.REFRESH, ThreadPool.Names.SEARCH, ThreadPool.Names.SNAPSHOT,
-                    ThreadPool.Names.SUGGEST, ThreadPool.Names.WARMER)) {
-                if (random.nextBoolean()) {
-                    final String type = RandomPicks.randomFrom(random, Arrays.asList("fixed", "cached", "scaling"));
-                    builder.put(ThreadPool.THREADPOOL_GROUP + name + ".type", type);
-                }
-            }
         }
 
         if (random.nextInt(10) == 0) {


### PR DESCRIPTION
This commit forbids the changing of thread pool types for any thread
pool. The motivation here is that these are expert settings with
little practical advantage.

Closes #14294, relates #2509, relates #2858, relates #5152
