### PR TITLE
Build: Add gradle version check and some build info that is always output

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -46,11 +46,11 @@ props.load(project.file('../gradle.properties').newDataInputStream())
 version = props.getProperty('version')
 
 processResources {
-    inputs.file('../gradle.properties')
-    filter ReplaceTokens, tokens: [
-        'version': props.getProperty('version'),
-        'luceneVersion': props.getProperty('luceneVersion')
-    ]
+  inputs.file('../gradle.properties')
+  filter ReplaceTokens, tokens: [
+    'version': props.getProperty('version'),
+    'luceneVersion': props.getProperty('luceneVersion')
+  ]
 }
 
 extraArchive {


### PR DESCRIPTION
The build info looks like the following:

```
=======================================
Elasticsearch Build Hamster says Hello!
=======================================
  Gradle Version : 2.7
  JDK Version    : 1.8.0_60-b27 (Oracle Corporation)
  OS Info        : Mac OS X 10.10.5 (x86_64)
```
