### PR TITLE
Add duration field to /_cat/snapshots

### DIFF
--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -8,9 +8,9 @@ Querying the snapshots of a repository named `repo1` then looks as follows.
 [source,sh]
 --------------------------------------------------
 % curl 'localhost:9200/_cat/snapshots/repo1?v'
-id     status start_epoch start_time end_epoch  end_time indices successful_shards failed_shards total_shards
-snap1  FAILED 1445616705  18:11:45   1445616978 18:16:18       1                 4             1            5
-snap2 SUCCESS 1445634298  23:04:58   1445634672 23:11:12       2                10             0           10
+id     status start_epoch start_time end_epoch  end_time duration indices successful_shards failed_shards total_shards
+snap1  FAILED 1445616705  18:11:45   1445616978 18:16:18     4.6m       1                 4             1            5
+snap2 SUCCESS 1445634298  23:04:58   1445634672 23:11:12     6.2m       2                10             0           10
 --------------------------------------------------
 
 Each snapshot contains information about when it was started and stopped.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yaml
@@ -13,6 +13,7 @@
                     start_time        .+   \n
                     end_epoch         .+   \n
                     end_time          .+   \n
+                    duration          .+   \n
                     indices           .+   \n
                     successful_shards .+   \n
                     failed_shards     .+   \n
@@ -74,6 +75,6 @@
 
   - match:
       $body: |
-               /^   snap1\s+ SUCCESS\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ 2\s+ 2\s+ 0\s+ 2\s*\n
-                    snap2\s+ SUCCESS\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ 2\s+ 2\s+ 0\s+ 2\s*\n
+               /^   snap1\s+ SUCCESS\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \S+\s+ 2\s+ 2\s+ 0\s+ 2\s*\n
+                    snap2\s+ SUCCESS\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \S+\s+ 2\s+ 2\s+ 0\s+ 2\s*\n
                $/


### PR DESCRIPTION
Follows suggestion from https://github.com/elastic/elasticsearch/pull/14247/files#r43038922 to add duration field to `/_cat/snapshots` output.
