### PR TITLE
Add support for Lucene 5.4 GeoPoint queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.GeoPointInBBoxQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
@@ -194,19 +195,22 @@ public class GeoBoundingBoxQueryParser implements QueryParser {
         }
         GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
 
-        Query filter;
-        if ("indexed".equals(type)) {
-            filter = IndexedGeoBoundingBoxQuery.create(topLeft, bottomRight, geoFieldType);
+        Query query;
+        // todo move to .before(Version.V_2_2_0) once GeoPointField V2 is fully merged
+        if (parseContext.indexVersionCreated().after(Version.V_2_2_0)) {
+            query = new GeoPointInBBoxQuery(fieldType.names().fullName(), topLeft.lon(), bottomRight.lat(), bottomRight.lon(), topLeft.lat());
+        } else if ("indexed".equals(type)) {
+            query = IndexedGeoBoundingBoxQuery.create(topLeft, bottomRight, geoFieldType);
         } else if ("memory".equals(type)) {
             IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
-            filter = new InMemoryGeoBoundingBoxQuery(topLeft, bottomRight, indexFieldData);
+            query = new InMemoryGeoBoundingBoxQuery(topLeft, bottomRight, indexFieldData);
         } else {
             throw new QueryParsingException(parseContext, "failed to parse [{}] query. geo bounding box type [{}] is not supported. either [indexed] or [memory] are allowed", NAME, type);
         }
 
         if (queryName != null) {
-            parseContext.addNamedQuery(queryName, filter);
+            parseContext.addNamedQuery(queryName, query);
         }
-        return filter;
+        return query;
     }    
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryParser.java
@@ -196,7 +196,7 @@ public class GeoBoundingBoxQueryParser implements QueryParser {
         GeoPointFieldMapper.GeoPointFieldType geoFieldType = ((GeoPointFieldMapper.GeoPointFieldType) fieldType);
 
         Query query;
-        // todo move to .before(Version.V_2_2_0) once GeoPointField V2 is fully merged
+        // norelease move to .before(Version.V_2_2_0) once GeoPointField V2 is fully merged
         if (parseContext.indexVersionCreated().after(Version.V_2_2_0)) {
             query = new GeoPointInBBoxQuery(fieldType.names().fullName(), topLeft.lon(), bottomRight.lat(), bottomRight.lon(), topLeft.lat());
         } else if ("indexed".equals(type)) {

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -174,7 +174,7 @@ public class GeoDistanceQueryParser implements QueryParser {
 
         IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
         final Query query;
-        // todo move to .before(Version.V_2_2_0) once GeoPointField V2 is fully merged
+        // norelease move to .before(Version.V_2_2_0) once GeoPointField V2 is fully merged
         if (parseContext.indexVersionCreated().onOrBefore(Version.V_2_2_0)) {
             query = new GeoDistanceRangeQuery(point, null, distance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
         } else {

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryParser.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.search.GeoPointDistanceQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoDistance;
@@ -65,7 +66,7 @@ public class GeoDistanceQueryParser implements QueryParser {
         String currentFieldName = null;
         GeoPoint point = new GeoPoint();
         String fieldName = null;
-        double distance = 0;
+        double distance;
         Object vDistance = null;
         DistanceUnit unit = DistanceUnit.DEFAULT;
         GeoDistance geoDistance = GeoDistance.DEFAULT;
@@ -96,8 +97,7 @@ public class GeoDistanceQueryParser implements QueryParser {
                         } else if (currentName.equals(GeoPointFieldMapper.Names.GEOHASH)) {
                             point.resetFromGeoHash(parser.text());
                         } else {
-                            throw new QueryParsingException(parseContext, "[geo_distance] query does not support [" + currentFieldName
-                                    + "]");
+                            throw new QueryParsingException(parseContext, "[geo_distance] query does not support [" + currentFieldName + "]");
                         }
                     }
                 }
@@ -173,7 +173,14 @@ public class GeoDistanceQueryParser implements QueryParser {
 
 
         IndexGeoPointFieldData indexFieldData = parseContext.getForField(fieldType);
-        Query query = new GeoDistanceRangeQuery(point, null, distance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
+        final Query query;
+        // todo move to .before(Version.V_2_2_0) once GeoPointField V2 is fully merged
+        if (parseContext.indexVersionCreated().onOrBefore(Version.V_2_2_0)) {
+            query = new GeoDistanceRangeQuery(point, null, distance, true, false, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
+        } else {
+            query = new GeoPointDistanceQuery(indexFieldData.getFieldNames().indexName(), point.lon(), point.lat(), distance);
+        }
+
         if (queryName != null) {
             parseContext.addNamedQuery(queryName, query);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoDistanceRangeQueryParser.java
@@ -36,6 +36,8 @@ import org.elasticsearch.index.search.geo.GeoDistanceRangeQuery;
 
 import java.io.IOException;
 
+import static org.apache.lucene.util.GeoUtils.TOLERANCE;
+
 /**
  * <pre>
  * {
@@ -226,13 +228,13 @@ public class GeoDistanceRangeQueryParser implements QueryParser {
         }
 
         final Query query;
-        // todo move to .before(Version.V_2_2_0) once GeoPointField V2 is fully merged
+        // norelease move to .before(Version.V_2_2_0) once GeoPointField V2 is fully merged
         if (parseContext.indexVersionCreated().onOrBefore(Version.V_2_2_0)) {
             query = new GeoDistanceRangeQuery(point, from, to, includeLower, includeUpper, geoDistance, geoFieldType, indexFieldData, optimizeBbox);
         } else {
             query = new GeoPointDistanceRangeQuery(indexFieldData.getFieldNames().indexName(), point.lon(), point.lat(),
-                    (includeLower) ? from : from + org.apache.lucene.util.GeoUtils.TOLERANCE,
-                    (includeUpper) ? to : to - org.apache.lucene.util.GeoUtils.TOLERANCE);
+                    (includeLower) ? from : from + TOLERANCE,
+                    (includeUpper) ? to : to - TOLERANCE);
         }
 
         if (queryName != null) {


### PR DESCRIPTION
This is GeoPointV2 PR part 3. It adds query support for the new Lucene 5.4 GeoPointField type along with backward compatibility support for (soon to be) "legacy" geo_point indexes.
