### PR TITLE
Get eclipse working easier with gradle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Contributing to the Elasticsearch codebase
 
 **Repository:** [https://github.com/elastic/elasticsearch](https://github.com/elastic/elasticsearch)
 
-Make sure you have [Gradle](http://gradle.org) installed, as Elasticsearch uses it as its build system. Integration with IntelliJ and Eclipse should work out of the box. Eclipse users can automatically configure their IDE: `File > Import -> Gradle -> Gradle project`. When the `Import Options` dialog is presented, add `-Declipse` to the JVM Options box. Additionally you will want to ensure that Eclipse is using 2048m of heap by modifying `eclipse.ini` accordingly to avoid GC overhead errors.
+Make sure you have [Gradle](http://gradle.org) installed, as Elasticsearch uses it as its build system. Integration with IntelliJ and Eclipse should work out of the box. Eclipse users can automatically configure their IDE: `File > Import -> Gradle -> Gradle project`. Additionally you will want to ensure that Eclipse is using 2048m of heap by modifying `eclipse.ini` accordingly to avoid GC overhead errors.
 
 Please follow these formatting guidelines:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Contributing to the Elasticsearch codebase
 
 **Repository:** [https://github.com/elastic/elasticsearch](https://github.com/elastic/elasticsearch)
 
-Make sure you have [Gradle](http://gradle.org) installed, as Elasticsearch uses it as its build system. Integration with IntelliJ and Eclipse should work out of the box. Eclipse users can automatically configure their IDE by running `gradle eclipse` and then importing the project into their workspace: `File > Import > Existing project into workspace` and make sure to select `Search for nested projects...` option as Elasticsearch is a multi-module maven project. Additionally you will want to ensure that Eclipse is using 2048m of heap by modifying `eclipse.ini` accordingly to avoid GC overhead errors.
+Make sure you have [Gradle](http://gradle.org) installed, as Elasticsearch uses it as its build system. Integration with IntelliJ and Eclipse should work out of the box. Eclipse users can automatically configure their IDE: `File > Import -> Gradle -> Gradle project`. When the `Import Options` dialog is presented, add `-Declipse` to the JVM Options box. Additionally you will want to ensure that Eclipse is using 2048m of heap by modifying `eclipse.ini` accordingly to avoid GC overhead errors.
 
 Please follow these formatting guidelines:
 

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,11 @@ subprojects {
         dependencySubstitution {
           substitute module("org.elasticsearch:rest-api-spec:${version}") with project("${projectsPrefix}:rest-api-spec")
           substitute module("org.elasticsearch:elasticsearch:${version}") with project("${projectsPrefix}:core")
-          substitute module("org.elasticsearch:test-framework:${version}") with project("${projectsPrefix}:test-framework")
+          // easy to type bypass so that eclipse doesn't have circular references
+          // the downside is, if you hack on test-framework, you have to gradle install
+          if (System.getProperty("eclipse") == null) {
+            substitute module("org.elasticsearch:test-framework:${version}") with project("${projectsPrefix}:test-framework")
+          }
           substitute module("org.elasticsearch.distribution.zip:elasticsearch:${version}") with project("${projectsPrefix}:distribution:zip")
         }
       }

--- a/build.gradle
+++ b/build.gradle
@@ -134,9 +134,10 @@ subprojects {
         dependencySubstitution {
           substitute module("org.elasticsearch:rest-api-spec:${version}") with project("${projectsPrefix}:rest-api-spec")
           substitute module("org.elasticsearch:elasticsearch:${version}") with project("${projectsPrefix}:core")
-          // easy to type bypass so that eclipse doesn't have circular references
+          // so that eclipse doesn't have circular references
           // the downside is, if you hack on test-framework, you have to gradle install
-          if (System.getProperty("eclipse") == null) {
+          // the first prop detects eclipse itself, the second detects eclipse from commandline
+          if (System.getProperty("eclipse.launcher") == null && gradle.startParameter.taskNames.contains('eclipse') == false) {
             substitute module("org.elasticsearch:test-framework:${version}") with project("${projectsPrefix}:test-framework")
           }
           substitute module("org.elasticsearch.distribution.zip:elasticsearch:${version}") with project("${projectsPrefix}:distribution:zip")


### PR DESCRIPTION
This prevents recursive dependencies between 'core' and 'test-framework' and updates the docs.
