### PR TITLE
Add back -Dtests.output support

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/randomizedtesting/RandomizedTestingTask.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/randomizedtesting/RandomizedTestingTask.groovy
@@ -20,8 +20,6 @@ import javax.inject.Inject
 
 class RandomizedTestingTask extends DefaultTask {
 
-    PatternFilterable patternSet = new PatternSet()
-
     // TODO: change to "executable" to match gradle test params?
     @Optional
     @Input
@@ -64,6 +62,7 @@ class RandomizedTestingTask extends DefaultTask {
 
     List<String> jvmArgs = new ArrayList<>()
     Map<String, String> systemProperties = new HashMap<>()
+    PatternFilterable patternSet = new PatternSet()
 
     RandomizedTestingTask() {
         outputs.upToDateWhen {false} // randomized tests are never up to date
@@ -166,7 +165,6 @@ class RandomizedTestingTask extends DefaultTask {
     }
 
     // TODO: add leaveTemporary
-    // TODO: add jvmOutputAction?
     // TODO: add ifNoTests!
 
     @TaskAction

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/randomizedtesting/TestLoggingConfiguration.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/randomizedtesting/TestLoggingConfiguration.groovy
@@ -3,6 +3,20 @@ package com.carrotsearch.gradle.randomizedtesting
 import org.gradle.util.ConfigureUtil
 
 class TestLoggingConfiguration {
+    /** Display mode for output streams. */
+    static enum OutputMode {
+        /** Always display the output emitted from tests. */
+        ALWAYS,
+        /**
+         * Display the output only if a test/ suite failed. This requires internal buffering
+         * so the output will be shown only after a test completes.
+         */
+        ONERROR,
+        /** Don't display the output, even on test failures. */
+        NEVER
+    }
+
+    OutputMode outputMode = OutputMode.ONERROR
     SlowTestsConfiguration slowTests = new SlowTestsConfiguration()
     StackTraceFiltersConfiguration stackTraceFilters = new StackTraceFiltersConfiguration()
 
@@ -12,5 +26,9 @@ class TestLoggingConfiguration {
 
     void stackTraceFilters(Closure closure) {
         ConfigureUtil.configure(closure, stackTraceFilters)
+    }
+
+    void outputMode(String mode) {
+        outputMode = mode.toUpperCase() as OutputMode
     }
 }

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/randomizedtesting/TestReportLogger.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/randomizedtesting/TestReportLogger.groovy
@@ -18,6 +18,7 @@ import org.junit.runner.Description
 import java.util.concurrent.atomic.AtomicInteger
 
 import static com.carrotsearch.ant.tasks.junit4.FormattingUtils.*
+import static com.carrotsearch.gradle.randomizedtesting.TestLoggingConfiguration.OutputMode
 
 class TestReportLogger extends TestsSummaryEventListener implements AggregatedEventListener {
 
@@ -53,20 +54,6 @@ class TestReportLogger extends TestsSummaryEventListener implements AggregatedEv
     /** Output stream that logs messages to the given logger */
     LoggingOutputStream outStream
     LoggingOutputStream errStream
-
-    /** Display mode for output streams. */
-    static enum OutputMode {
-        /** Always display the output emitted from tests. */
-        ALWAYS,
-        /**
-         * Display the output only if a test/ suite failed. This requires internal buffering
-         * so the output will be shown only after a test completes.
-         */
-        ONERROR,
-        /** Don't display the output, even on test failures. */
-        NEVER
-    }
-    OutputMode outputMode = OutputMode.ONERROR
 
     /** A list of failed tests, if to be displayed at the end. */
     List<Description> failedTests = new ArrayList<>()
@@ -238,7 +225,7 @@ class TestReportLogger extends TestsSummaryEventListener implements AggregatedEv
     }
 
     void emitBufferedEvents(LogLevel level, AggregatedSuiteResultEvent e) throws IOException {
-        if (outputMode == OutputMode.NEVER) {
+        if (config.outputMode == OutputMode.NEVER) {
             return
         }
 
@@ -247,8 +234,8 @@ class TestReportLogger extends TestsSummaryEventListener implements AggregatedEv
             eventMap.put(tre.getTestFinishedEvent(), tre)
         }
 
-        final boolean emitOutput = outputMode == OutputMode.ALWAYS && isPassthrough() == false ||
-                                   outputMode == OutputMode.ONERROR && e.isSuccessful() == false
+        final boolean emitOutput = config.outputMode == OutputMode.ALWAYS && isPassthrough() == false ||
+                                   config.outputMode == OutputMode.ONERROR && e.isSuccessful() == false
 
         for (IEvent event : e.getEventStream()) {
             switch (event.getType()) {
@@ -363,7 +350,7 @@ class TestReportLogger extends TestsSummaryEventListener implements AggregatedEv
 
     /** Returns true if output should be logged immediately. Only relevant when running with INFO log level. */
     boolean isPassthrough() {
-        return forkedJvmCount == 1 && outputMode == OutputMode.ALWAYS && logger.isInfoEnabled()
+        return forkedJvmCount == 1 && config.outputMode == OutputMode.ALWAYS && logger.isInfoEnabled()
     }
 
     @Override

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -151,6 +151,7 @@ class BuildPlugin implements Plugin<Project> {
                     regex(/^(\s+at )(org\.apache\.lucene\.util\.TestRule)/)
                     regex(/^(\s+at )(org\.apache\.lucene\.util\.AbstractBeforeAfterRule)/)
                 }
+                outputMode System.getProperty('tests.output', 'onerror')
             }
 
             balancers {


### PR DESCRIPTION
This change fixes the test logging for randomized testing to support
tests.output like maven/ant do.
