### PR TITLE
Move RR gradle plugin files to match external repo paths

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/BalancersConfiguration.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/BalancersConfiguration.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 import com.carrotsearch.ant.tasks.junit4.SuiteBalancer
 import com.carrotsearch.ant.tasks.junit4.balancers.ExecutionTimeBalancer

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/ListenersConfiguration.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/ListenersConfiguration.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 import com.carrotsearch.ant.tasks.junit4.listeners.AggregatedEventListener
 import com.carrotsearch.ant.tasks.junit4.listeners.antxml.AntXmlReport

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/LoggingOutputStream.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/LoggingOutputStream.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingPlugin.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 import com.carrotsearch.ant.tasks.junit4.JUnit4
 import org.gradle.api.AntBuilder

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 import com.carrotsearch.ant.tasks.junit4.ListenersList
 import com.carrotsearch.ant.tasks.junit4.listeners.AggregatedEventListener

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/SlowTestsConfiguration.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/SlowTestsConfiguration.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 class SlowTestsConfiguration {
     int heartbeat = 0

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/StackTraceFiltersConfiguration.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/StackTraceFiltersConfiguration.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 class StackTraceFiltersConfiguration {
     List<String> patterns = new ArrayList<>()

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestLoggingConfiguration.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestLoggingConfiguration.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 import org.gradle.util.ConfigureUtil
 

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestProgressLogger.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestProgressLogger.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 import com.carrotsearch.ant.tasks.junit4.JUnit4
 import com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.eventbus.Subscribe

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestReportLogger.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestReportLogger.groovy
@@ -1,4 +1,4 @@
-package com.carrotsearch.gradle.randomizedtesting
+package com.carrotsearch.gradle.junit4
 
 import com.carrotsearch.ant.tasks.junit4.JUnit4
 import com.carrotsearch.ant.tasks.junit4.Pluralize
@@ -18,7 +18,7 @@ import org.junit.runner.Description
 import java.util.concurrent.atomic.AtomicInteger
 
 import static com.carrotsearch.ant.tasks.junit4.FormattingUtils.*
-import static com.carrotsearch.gradle.randomizedtesting.TestLoggingConfiguration.OutputMode
+import static com.carrotsearch.gradle.junit4.TestLoggingConfiguration.OutputMode
 
 class TestReportLogger extends TestsSummaryEventListener implements AggregatedEventListener {
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -37,7 +37,7 @@ class BuildPlugin implements Plugin<Project> {
     void apply(Project project) {
         globalBuildInfo(project)
         project.pluginManager.apply('java')
-        project.pluginManager.apply('carrotsearch.randomizedtesting')
+        project.pluginManager.apply('carrotsearch.randomized-testing')
         // these plugins add lots of info to our jars
         project.pluginManager.apply('nebula.info-broker')
         project.pluginManager.apply('nebula.info-basic')

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.gradle.test
 
-import com.carrotsearch.gradle.randomizedtesting.RandomizedTestingTask
+import com.carrotsearch.gradle.junit4.RandomizedTestingTask
 import org.elasticsearch.gradle.BuildPlugin
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.gradle.test
 
-import com.carrotsearch.gradle.randomizedtesting.RandomizedTestingTask
+import com.carrotsearch.gradle.junit4.RandomizedTestingTask
 import org.elasticsearch.gradle.ElasticsearchProperties
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -29,7 +29,7 @@ class RestTestPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.pluginManager.apply('java-base')
-        project.pluginManager.apply('carrotsearch.randomizedtesting')
+        project.pluginManager.apply('carrotsearch.randomized-testing')
         project.pluginManager.apply('idea')
 
         // remove some unnecessary tasks for a qa test

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/carrotsearch.randomized-testing.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/carrotsearch.randomized-testing.properties
@@ -1,0 +1,1 @@
+implementation-class=com.carrotsearch.gradle.junit4.RandomizedTestingPlugin

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/carrotsearch.randomizedtesting.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/carrotsearch.randomizedtesting.properties
@@ -1,1 +1,0 @@
-implementation-class=com.carrotsearch.gradle.randomizedtesting.RandomizedTestingPlugin

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import com.carrotsearch.gradle.randomizedtesting.RandomizedTestingTask
+import com.carrotsearch.gradle.junit4.RandomizedTestingTask
 import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.test.RestSpecHack
 


### PR DESCRIPTION
The RR gradle plugin is at
https://github.com/randomizedtesting/gradle-randomized-testing-plugin.
However, we currently have a copy of this, since the plugin is still in
heavy development. This change moves the files around so they can be
copied directly from the elasticsearch fork to that repo, for ease of
syncing.
