### PR TITLE
Move logging for the amount of free disk to TRACE

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -466,8 +466,8 @@ public class DiskThresholdDecider extends AllocationDecider {
         // If this node is already above the high threshold, the shard cannot remain (get it off!)
         final double freeDiskPercentage = usage.getFreeDiskAsPercentage();
         final long freeBytes = usage.getFreeBytes();
-        if (logger.isDebugEnabled()) {
-            logger.debug("node [{}] has {}% free disk ({} bytes)", node.nodeId(), freeDiskPercentage, freeBytes);
+        if (logger.isTraceEnabled()) {
+            logger.trace("node [{}] has {}% free disk ({} bytes)", node.nodeId(), freeDiskPercentage, freeBytes);
         }
         if (dataPath == null || usage.getPath().equals(dataPath) == false) {
             return allocation.decision(Decision.YES, NAME, "shard is not allocated on the most utilized disk");


### PR DESCRIPTION
Since this can potentially be logged for every `canRemain`, it's nicer
to put it in TRACE rather than DEBUG.

Resolves #12843
