### PR TITLE
make gradle eclipse always run cleanEclipse

### DIFF
--- a/GRADLE.CHEATSHEET
+++ b/GRADLE.CHEATSHEET
@@ -1,0 +1,7 @@
+As a quick helper, below are the equivalent commands from maven to gradle (TESTING.md has also been updated). You can also run "gradle tasks" to see all tasks that are available to run.
+clean -> clean
+test -> test
+verify -> check
+verify -Dskip.unit.tests -> integTest
+package -DskipTests -> assemble
+install -DskipTests -> install

--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,8 @@ allprojects {
       defaultOutputDir = new File(project.buildDir, 'eclipse')
     }
   }
+  // otherwise the eclipse merging is *super confusing*
+  tasks.eclipse.dependsOn(cleanEclipse)
 }
 
 idea {


### PR DESCRIPTION
Otherwise the 'merging' gets really trappy. it basically never works without a clean.

See 38.4.1.1. Disabling merging with a complete rewrite:
https://docs.gradle.org/current/userguide/eclipse_plugin.html
