### PR TITLE
Using the accept header in the request instead of content-type in _cat API.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentType.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentType.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.smile.SmileXContent;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 
 import java.io.IOException;
+import java.util.Locale;
 
 /**
  * The content type of {@link org.elasticsearch.common.xcontent.XContent}.
@@ -38,7 +39,12 @@ public enum XContentType {
      */
     JSON(0) {
         @Override
-        public String restContentType() {
+        protected String mediaTypeWithoutParameters() {
+            return "application/json";
+        }
+
+        @Override
+        public String mediaType() {
             return "application/json; charset=UTF-8";
         }
 
@@ -57,7 +63,7 @@ public enum XContentType {
      */
     SMILE(1) {
         @Override
-        public String restContentType() {
+        protected String mediaTypeWithoutParameters() {
             return "application/smile";
         }
 
@@ -76,7 +82,7 @@ public enum XContentType {
      */
     YAML(2) {
         @Override
-        public String restContentType() {
+        protected String mediaTypeWithoutParameters() {
             return "application/yaml";
         }
 
@@ -95,7 +101,7 @@ public enum XContentType {
      */
     CBOR(3) {
         @Override
-        public String restContentType() {
+        protected String mediaTypeWithoutParameters() {
             return "application/cbor";
         }
 
@@ -108,29 +114,28 @@ public enum XContentType {
         public XContent xContent() {
             return CborXContent.cborXContent;
         }
-    },;
+    };
 
-    public static XContentType fromRestContentType(String contentType) {
-        if (contentType == null) {
+    public static XContentType fromMediaTypeOrFormat(String mediaType) {
+        if (mediaType == null) {
             return null;
         }
-        if ("application/json".equals(contentType) || "json".equalsIgnoreCase(contentType)) {
+        for (XContentType type : values()) {
+            if (isSameMediaTypeAs(mediaType, type)) {
+                return type;
+            }
+        }
+        if(mediaType.toLowerCase(Locale.ROOT).startsWith("application/*")) {
             return JSON;
         }
 
-        if ("application/smile".equals(contentType) || "smile".equalsIgnoreCase(contentType)) {
-            return SMILE;
-        }
-
-        if ("application/yaml".equals(contentType) || "yaml".equalsIgnoreCase(contentType)) {
-            return YAML;
-        }
-
-        if ("application/cbor".equals(contentType) || "cbor".equalsIgnoreCase(contentType)) {
-            return CBOR;
-        }
-
         return null;
+    }
+
+    private static boolean isSameMediaTypeAs(String stringType, XContentType type) {
+        return type.mediaTypeWithoutParameters().equalsIgnoreCase(stringType) ||
+                stringType.toLowerCase(Locale.ROOT).startsWith(type.mediaTypeWithoutParameters().toLowerCase(Locale.ROOT) + ";") ||
+                type.shortName().equalsIgnoreCase(stringType);
     }
 
     private int index;
@@ -143,11 +148,15 @@ public enum XContentType {
         return index;
     }
 
-    public abstract String restContentType();
+    public String mediaType() {
+        return mediaTypeWithoutParameters();
+    }
 
     public abstract String shortName();
 
     public abstract XContent xContent();
+
+    protected abstract String mediaTypeWithoutParameters();
 
     public static XContentType readFrom(StreamInput in) throws IOException {
         int index = in.readVInt();

--- a/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -59,7 +59,7 @@ public class MetaStateService extends AbstractComponent {
     public MetaStateService(Settings settings, NodeEnvironment nodeEnv) {
         super(settings);
         this.nodeEnv = nodeEnv;
-        this.format = XContentType.fromRestContentType(settings.get(FORMAT_SETTING, "smile"));
+        this.format = XContentType.fromMediaTypeOrFormat(settings.get(FORMAT_SETTING, "smile"));
         if (this.format == XContentType.SMILE) {
             Map<String, String> params = new HashMap<>();
             params.put("binary", "true");

--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -48,7 +48,7 @@ public class BytesRestResponse extends RestResponse {
      * Creates a new response based on {@link XContentBuilder}.
      */
     public BytesRestResponse(RestStatus status, XContentBuilder builder) {
-        this(status, builder.contentType().restContentType(), builder.bytes());
+        this(status, builder.contentType().mediaType(), builder.bytes());
     }
 
     /**
@@ -93,7 +93,7 @@ public class BytesRestResponse extends RestResponse {
         } else {
             XContentBuilder builder = convert(channel, status, t);
             this.content = builder.bytes();
-            this.contentType = builder.contentType().restContentType();
+            this.contentType = builder.contentType().mediaType();
         }
         if (t instanceof ElasticsearchException) {
             copyHeaders(((ElasticsearchException) t));

--- a/core/src/main/java/org/elasticsearch/rest/RestChannel.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestChannel.java
@@ -53,7 +53,7 @@ public abstract class RestChannel {
     }
 
     public XContentBuilder newBuilder(@Nullable BytesReference autoDetectSource, boolean useFiltering) throws IOException {
-        XContentType contentType = XContentType.fromRestContentType(request.param("format", request.header("Content-Type")));
+        XContentType contentType = XContentType.fromMediaTypeOrFormat(request.param("format", request.header("Accept")));
         if (contentType == null) {
             // try and guess it from the auto detect source
             if (autoDetectSource != null) {

--- a/core/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/support/RestTable.java
@@ -48,7 +48,7 @@ public class RestTable {
 
     public static RestResponse buildResponse(Table table, RestChannel channel) throws Exception {
         RestRequest request = channel.request();
-        XContentType xContentType = XContentType.fromRestContentType(request.param("format", request.header("Content-Type")));
+        XContentType xContentType = XContentType.fromMediaTypeOrFormat(request.param("format", request.header("Accept")));
         if (xContentType != null) {
             return buildXContentBuilder(table, channel);
         }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
@@ -1,0 +1,69 @@
+package org.elasticsearch.common.xcontent;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class XContentTypeTests extends ESTestCase {
+    public void testFromJson() throws Exception {
+        String mediaType = "application/json";
+        XContentType expectedXContentType = XContentType.JSON;
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + ";"), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + "; charset=UTF-8"), equalTo(expectedXContentType));
+    }
+
+    public void testFromJsonUppercase() throws Exception {
+        String mediaType = "application/json".toUpperCase(Locale.ROOT);
+        XContentType expectedXContentType = XContentType.JSON;
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + ";"), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + "; charset=UTF-8"), equalTo(expectedXContentType));
+    }
+
+    public void testFromYaml() throws Exception {
+        String mediaType = "application/yaml";
+        XContentType expectedXContentType = XContentType.YAML;
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + ";"), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + "; charset=UTF-8"), equalTo(expectedXContentType));
+    }
+
+    public void testFromSmile() throws Exception {
+        String mediaType = "application/smile";
+        XContentType expectedXContentType = XContentType.SMILE;
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + ";"), equalTo(expectedXContentType));
+    }
+
+    public void testFromCbor() throws Exception {
+        String mediaType = "application/cbor";
+        XContentType expectedXContentType = XContentType.CBOR;
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + ";"), equalTo(expectedXContentType));
+    }
+
+    public void testFromWildcard() throws Exception {
+        String mediaType = "application/*";
+        XContentType expectedXContentType = XContentType.JSON;
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + ";"), equalTo(expectedXContentType));
+    }
+
+    public void testFromWildcardUppercase() throws Exception {
+        String mediaType = "APPLICATION/*";
+        XContentType expectedXContentType = XContentType.JSON;
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType), equalTo(expectedXContentType));
+        assertThat(XContentType.fromMediaTypeOrFormat(mediaType + ";"), equalTo(expectedXContentType));
+    }
+
+    public void testFromRubbish() throws Exception {
+        assertThat(XContentType.fromMediaTypeOrFormat(null), nullValue());
+        assertThat(XContentType.fromMediaTypeOrFormat(""), nullValue());
+        assertThat(XContentType.fromMediaTypeOrFormat("text/plain"), nullValue());
+        assertThat(XContentType.fromMediaTypeOrFormat("gobbly;goop"), nullValue());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.elasticsearch.common.xcontent;
 
 import org.elasticsearch.test.ESTestCase;

--- a/core/src/test/java/org/elasticsearch/rest/action/support/RestTableTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/support/RestTableTests.java
@@ -130,7 +130,7 @@ public class RestTableTests extends ESTestCase {
     }
 
     private RestResponse assertResponseContentType(Map<String, String> headers, String mediaType) throws Exception {
-        FakeRestRequest requestWithAcceptHeader = new FakeRestRequest(headers, Collections.emptyMap());
+        FakeRestRequest requestWithAcceptHeader = new FakeRestRequest(headers);
         table.startRow();
         table.addCell("foo");
         table.addCell("foo");

--- a/core/src/test/java/org/elasticsearch/rest/action/support/RestTableTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/support/RestTableTests.java
@@ -20,20 +20,45 @@
 package org.elasticsearch.rest.action.support;
 
 import org.elasticsearch.common.Table;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.junit.Before;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.rest.action.support.RestTable.buildDisplayHeaders;
+import static org.elasticsearch.rest.action.support.RestTable.buildResponse;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
 public class RestTableTests extends ESTestCase {
 
+    private static final String APPLICATION_JSON = XContentType.JSON.mediaType();
+    private static final String APPLICATION_YAML = XContentType.YAML.mediaType();
+    private static final String APPLICATION_SMILE = XContentType.SMILE.mediaType();
+    private static final String APPLICATION_CBOR = XContentType.CBOR.mediaType();
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String ACCEPT = "Accept";
+    private static final String TEXT_PLAIN = "text/plain; charset=UTF-8";
+    private static final String TEXT_TABLE_BODY = "foo foo foo foo foo foo\n";
+    private static final String JSON_TABLE_BODY = "[{\"bulk.foo\":\"foo\",\"bulk.bar\":\"foo\",\"aliasedBulk\":\"foo\"," +
+            "\"aliasedSecondBulk\":\"foo\",\"unmatched\":\"foo\"," +
+            "\"invalidAliasesBulk\":\"foo\"}]";
+    private static final String YAML_TABLE_BODY = "---\n" +
+            "- bulk.foo: \"foo\"\n" +
+            "  bulk.bar: \"foo\"\n" +
+            "  aliasedBulk: \"foo\"\n" +
+            "  aliasedSecondBulk: \"foo\"\n" +
+            "  unmatched: \"foo\"\n" +
+            "  invalidAliasesBulk: \"foo\"\n";
     private Table table = new Table();
     private FakeRestRequest restRequest = new FakeRestRequest();
 
@@ -68,6 +93,65 @@ public class RestTableTests extends ESTestCase {
         List<String> headerNames = getHeaderNames(headers);
         assertThat(headerNames, contains("bulk.foo", "bulk.bar", "aliasedBulk", "aliasedSecondBulk"));
         assertThat(headerNames, not(hasItem("unmatched")));
+    }
+
+    public void testThatWeUseTheAcceptHeaderJson() throws Exception {
+        assertResponse(Collections.singletonMap(ACCEPT, APPLICATION_JSON),
+                APPLICATION_JSON,
+                JSON_TABLE_BODY);
+    }
+
+    public void testThatWeUseTheAcceptHeaderYaml() throws Exception {
+        assertResponse(Collections.singletonMap(ACCEPT, APPLICATION_YAML),
+                APPLICATION_YAML,
+                YAML_TABLE_BODY);
+    }
+
+    public void testThatWeUseTheAcceptHeaderSmile() throws Exception {
+        assertResponseContentType(Collections.singletonMap(ACCEPT, APPLICATION_SMILE),
+                APPLICATION_SMILE);
+    }
+
+    public void testThatWeUseTheAcceptHeaderCbor() throws Exception {
+        assertResponseContentType(Collections.singletonMap(ACCEPT, APPLICATION_CBOR),
+                APPLICATION_CBOR);
+    }
+
+    public void testThatWeUseTheAcceptHeaderText() throws Exception {
+        assertResponse(Collections.singletonMap(ACCEPT, TEXT_PLAIN),
+                TEXT_PLAIN,
+                TEXT_TABLE_BODY);
+    }
+
+    public void testIgnoreContentType() throws Exception {
+        assertResponse(Collections.singletonMap(CONTENT_TYPE, APPLICATION_JSON),
+                TEXT_PLAIN,
+                TEXT_TABLE_BODY);
+    }
+
+    private RestResponse assertResponseContentType(Map<String, String> headers, String mediaType) throws Exception {
+        FakeRestRequest requestWithAcceptHeader = new FakeRestRequest(headers, Collections.emptyMap());
+        table.startRow();
+        table.addCell("foo");
+        table.addCell("foo");
+        table.addCell("foo");
+        table.addCell("foo");
+        table.addCell("foo");
+        table.addCell("foo");
+        table.endRow();
+        RestResponse response = buildResponse(table, new RestChannel(requestWithAcceptHeader, true) {
+            @Override
+            public void sendResponse(RestResponse response) {
+            }
+        });
+
+        assertThat(response.contentType(), equalTo(mediaType));
+        return response;
+    }
+
+    private void assertResponse(Map<String, String> headers, String mediaType, String body) throws Exception {
+        RestResponse response = assertResponseContentType(headers, mediaType);
+        assertThat(response.content().toUtf8(), equalTo(body));
     }
 
     private List<String> getHeaderNames(List<RestTable.DisplayHeader> headers) {

--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -96,6 +96,55 @@ green foo   1 0   227   0   2065131   2065131
 --------------------------------------------------
 
 
+=== Response as text, json, smile, yaml or cbor
+
+[source,sh]
+--------------------------------------------------
+% curl '192.168.56.10:9200/_cat/indices?format=json' | jq .
+[
+  {
+    "pri.store.size": "650b",
+    "health": "yellow",
+    "status": "open",
+    "index": "twitter",
+    "pri": "5",
+    "rep": "1",
+    "docs.count": "0",
+    "docs.deleted": "0",
+    "store.size": "650b"
+  }
+]
+--------------------------------------------------
+
+Currently supported formats (for the ?format parameter):
+- text (default)
+- json
+- smile
+- yaml
+- cbor
+
+alternatively you can set the "Accept" HTTP header to the appropriate media format.
+All formats above are supported, the GET parameter takes precedence over the header.
+
+For example
+[source,sh]
+--------------------------------------------------
+% curl '192.168.56.10:9200/_cat/indices' -H "Accept: application/json" | jq .
+[
+  {
+    "pri.store.size": "650b",
+    "health": "yellow",
+    "status": "open",
+    "index": "twitter",
+    "pri": "5",
+    "rep": "1",
+    "docs.count": "0",
+    "docs.deleted": "0",
+    "store.size": "650b"
+  }
+]
+--------------------------------------------------
+
 --
 
 include::cat/alias.asciidoc[]

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -6,6 +6,7 @@ your application to Elasticsearch 3.0.
 
 * <<breaking_30_search_changes>>
 * <<breaking_30_rest_api_changes>>
+* <<breaking_30_cat_api>>
 * <<breaking_30_parent_child_changes>>
 * <<breaking_30_settings_changes>>
 * <<breaking_30_mapping_changes>>
@@ -157,6 +158,14 @@ Removed support for the undocumented `query_binary` and `filter_binary` sections
 ==== `span_near`'s' `collect_payloads` deprecated
 
 Payloads are now loaded when needed.
+
+[[breaking_30_cat_api]]
+=== REST API changes
+
+==== Replace use of Content-Type header in _cat API in favour of the Accept header
+
+Before we would mistakenly use the Content-Type of the request to establish the response media type, that's the
+role of the Accept header as per HTTP spec.
 
 [[breaking_30_parent_child_changes]]
 === Parent/Child changes

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "bytes": {
           "type": "enum",
           "description" : "The unit in which to display byte values",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "bytes": {
           "type": "enum",
           "description" : "The unit in which to display byte values",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
@@ -8,6 +8,10 @@
       "parts": {
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "bytes": {
           "type": "enum",
           "description" : "The unit in which to display byte values",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -8,6 +8,10 @@
       "parts": {
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -8,6 +8,10 @@
       "parts": {
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -8,6 +8,10 @@
       "parts": {
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -8,6 +8,10 @@
       "parts": {
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -6,6 +6,10 @@
       "path": "/_cat/plugins",
       "paths": ["/_cat/plugins"],
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "bytes": {
           "type": "enum",
           "description" : "The unit in which to display byte values",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -8,6 +8,10 @@
       "parts": {
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "h": {
             "type": "list",
             "description" : "Comma-separated list of column names to display"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -12,6 +12,10 @@
         }
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "ignore_unavailable": {
           "type": "boolean",
           "description": "Set to true to ignore unavailable snapshots",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -8,6 +8,10 @@
       "parts": {
       },
       "params": {
+        "format": {
+          "type" : "string",
+          "description" : "a short version of the Accept header, e.g. json, yaml"
+        },
         "local": {
           "type" : "boolean",
           "description" : "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
@@ -50,6 +50,56 @@
                 $/
 
 ---
+"Simple alias with yaml body through Accept header":
+
+  - do:
+        indices.create:
+            index: test
+
+  - do:
+        indices.put_alias:
+            index: test
+            name:  test_alias
+
+  - do:
+      cat.aliases: {}
+      headers:
+        Accept: application/yaml
+
+  - match:
+      $body: |
+        /^---\n
+          -\s+alias:\s+"test_alias"\s+
+              index:\s+"test"\s+
+              filter:\s+"-"\s+
+              routing.index:\s+"-"\s+
+              routing.search:\s+"-"\s+$/
+---
+"Simple alias with yaml body through format argument":
+
+  - do:
+        indices.create:
+            index: test
+
+  - do:
+        indices.put_alias:
+            index: test
+            name:  test_alias
+
+  - do:
+      cat.aliases:
+        format: yaml
+
+  - match:
+      $body: |
+        /^---\n
+          -\s+alias:\s+"test_alias"\s+
+              index:\s+"test"\s+
+              filter:\s+"-"\s+
+              routing.index:\s+"-"\s+
+              routing.search:\s+"-"\s+$/
+
+---
 "Complex alias":
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/50_with_headers.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/50_with_headers.yaml
@@ -12,7 +12,7 @@
 
   - do:
       headers:
-        Content-Type: application/yaml
+        Accept: application/yaml
       get:
         index: test_1
         type: _all


### PR DESCRIPTION
Using the accept header in the request instead of content-type.

fixes #14195.
