### PR TITLE
Correct README.textile

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -209,7 +209,7 @@ The distribution for each project will be created under the @target/releases@ di
 See the "TESTING":TESTING.asciidoc file for more information about
 running the Elasticsearch test suite.
 
-h3. Upgrading to Elasticsearch 1.x?
+h3. Upgrading from Elasticsearch 1.x?
 
 In order to ensure a smooth upgrade process from earlier versions of Elasticsearch (< 1.0.0), it is recommended to perform a full cluster restart. Please see the "setup reference":https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html for more details on the upgrade process.
 


### PR DESCRIPTION
It should be "h3. Upgrading from Elasticsearch 1.x?" in README.textile.
