### PR TITLE
Docs: Add match_none query to Query DSL documentation

### DIFF
--- a/docs/reference/query-dsl/match-all-query.asciidoc
+++ b/docs/reference/query-dsl/match-all-query.asciidoc
@@ -15,3 +15,14 @@ The `_score` can be changed with the `boost` parameter:
 --------------------------------------------------
 { "match_all": { "boost" : 1.2 }}
 --------------------------------------------------
+
+[[query-dsl-match-none-query]]
+[float]
+== Match None Query
+
+This is the inverse of the `match_all` query, which matches no documents.
+
+[source,js]
+--------------------------------------------------
+{ "match_none": {} }
+--------------------------------------------------


### PR DESCRIPTION
We introduced the MatchNoneQueryBuilder query that does not
return any documents during the query refactoring, mainly as
an internal representation for the NONE option in the IndicesQueryBuilder. 
However, such a query has also been requested for the query dsl, 
and since we already have a parser for it we should document it as 
`match_none` query in the relevant reference docs as well.
