### PR TITLE
Make idea/eclipse project generation build generated resources for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ work/
 logs/
 .DS_Store
 build/
+generated-resources/
 **/.local*
 docs/html/
 docs/build.log

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ allprojects {
   apply plugin: 'idea'
 }
 
-if (hasProperty('projectsPrefix') == false) {
+if (projectsPrefix.isEmpty()) {
   idea {
     project {
       languageLevel = sourceCompatibility

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -84,9 +84,11 @@ class PluginBuildPlugin extends BuildPlugin {
     static Task configureBundleTask(Project project) {
         PluginPropertiesTask buildProperties = project.tasks.create(name: 'pluginProperties', type: PluginPropertiesTask)
         File pluginMetadata = project.file("src/main/plugin-metadata")
-        project.processTestResources {
-            from buildProperties
-            from pluginMetadata
+        project.sourceSets.test {
+            output.dir(buildProperties.propertiesFile.parentFile, builtBy: 'pluginProperties')
+            resources {
+                srcDir pluginMetadata
+            }
         }
         Task bundle = project.tasks.create(name: 'bundlePlugin', type: Zip, dependsOn: [project.jar, buildProperties])
         bundle.configure {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -33,9 +33,13 @@ class PluginPropertiesTask extends DefaultTask {
 
     PluginPropertiesExtension extension
     Map<String, String> properties = new HashMap<>()
+    File generatedResourcesDir = new File(project.projectDir, "generated-resources")
 
     PluginPropertiesTask() {
         extension = project.extensions.create('esplugin', PluginPropertiesExtension, project)
+        project.clean {
+            delete generatedResourcesDir
+        }
         project.afterEvaluate {
             if (extension.description == null) {
                 throw new InvalidUserDataException('description is a required setting for esplugin')
@@ -54,7 +58,7 @@ class PluginPropertiesTask extends DefaultTask {
     }
 
     @OutputFile
-    File propertiesFile = new File(project.buildDir, "plugin" + File.separator + "plugin-descriptor.properties")
+    File propertiesFile = new File(generatedResourcesDir, "plugin-descriptor.properties")
 
     void fillProperties() {
         // TODO: need to copy the templated plugin-descriptor with a dependent task, since copy requires a file (not uri)


### PR DESCRIPTION
This adds a generated-resources dir that the plugin properties are
generated into. This must be outside of the build dir, since intellij
has build as "excluded".
