### PR TITLE
Adding a link to the guide from the docs.

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -95,6 +95,8 @@ The response to a bulk action is a large JSON structure with the
 individual results of each action that was performed. The failure of a
 single action does not affect the remaining actions.
 
+For more details see our link:../../guide/current/bulk.html[bulk api guide].
+
 There is no "correct" number of actions to perform in a single bulk
 call. You should experiment with different settings to find the optimum
 size for your particular workload.


### PR DESCRIPTION
fixed #14257

The guide has nice examples of the json responses to the bulk api.
