### PR TITLE
Simplify plugin properties generation

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -85,7 +85,7 @@ class PluginBuildPlugin extends BuildPlugin {
         PluginPropertiesTask buildProperties = project.tasks.create(name: 'pluginProperties', type: PluginPropertiesTask)
         File pluginMetadata = project.file("src/main/plugin-metadata")
         project.sourceSets.test {
-            output.dir(buildProperties.propertiesFile.parentFile, builtBy: 'pluginProperties')
+            output.dir(buildProperties.generatedResourcesDir, builtBy: 'pluginProperties')
             resources {
                 srcDir pluginMetadata
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -19,81 +19,66 @@
 package org.elasticsearch.gradle.plugin
 
 import org.elasticsearch.gradle.ElasticsearchProperties
-import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.Task
+import org.gradle.api.tasks.Copy
 
 /**
  * Creates a plugin descriptor.
- *
- * TODO: copy the example properties file to plugin documentation
  */
-class PluginPropertiesTask extends DefaultTask {
+class PluginPropertiesTask extends Copy {
 
     PluginPropertiesExtension extension
-    Map<String, String> properties = new HashMap<>()
-    File generatedResourcesDir = new File(project.projectDir, "generated-resources")
+    File generatedResourcesDir = new File(project.projectDir, 'generated-resources')
 
     PluginPropertiesTask() {
+        File templateFile = new File(project.buildDir, 'templates/plugin-descriptor.properties')
+        Task copyPluginPropertiesTemplate = project.tasks.create('copyPluginPropertiesTemplate') {
+            doLast {
+                InputStream resourceTemplate = PluginPropertiesTask.getResourceAsStream('/plugin-descriptor.properties')
+                templateFile.parentFile.mkdirs()
+                templateFile.setText(resourceTemplate.getText('UTF-8'), 'UTF-8')
+            }
+        }
+        dependsOn(copyPluginPropertiesTemplate)
         extension = project.extensions.create('esplugin', PluginPropertiesExtension, project)
         project.clean {
             delete generatedResourcesDir
         }
         project.afterEvaluate {
+            // check require properties are set
             if (extension.description == null) {
                 throw new InvalidUserDataException('description is a required setting for esplugin')
             }
             if (extension.jvm && extension.classname == null) {
                 throw new InvalidUserDataException('classname is a required setting for esplugin with jvm=true')
             }
-            if (extension.jvm) {
-                dependsOn(project.classes) // so we can check for the classname
-            }
-            fillProperties()
             configure {
-                inputs.properties(properties)
+                doFirst {
+                    if (extension.jvm && extension.isolated == false) {
+                        String warning = "WARNING: Disabling plugin isolation in ${project.name} is deprecated and will be removed in the future"
+                        logger.warn("${'=' * warning.length()}\n${warning}\n${'=' * warning.length()}")
+                    }
+                }
+                // configure property substitution
+                from templateFile
+                into generatedResourcesDir
+                expand(generateSubstitutions())
             }
         }
     }
 
-    @OutputFile
-    File propertiesFile = new File(generatedResourcesDir, "plugin-descriptor.properties")
-
-    void fillProperties() {
-        // TODO: need to copy the templated plugin-descriptor with a dependent task, since copy requires a file (not uri)
-        properties = [
+    Map generateSubstitutions() {
+        return [
             'name': extension.name,
             'description': extension.description,
             'version': extension.version,
-            'elasticsearch.version': ElasticsearchProperties.version,
+            'elasticsearchVersion': ElasticsearchProperties.version,
+            'javaVersion': project.targetCompatibility as String,
             'jvm': extension.jvm as String,
-            'site': extension.site as String
+            'site': extension.site as String,
+            'isolated': extension.isolated as String,
+            'classname': extension.jvm ? extension.classname : 'NA'
         ]
-        if (extension.jvm) {
-            properties['classname'] = extension.classname
-            properties['isolated'] = extension.isolated as String
-            properties['java.version'] = project.targetCompatibility as String
-        }
-    }
-
-    @TaskAction
-    void buildProperties() {
-        if (extension.jvm) {
-            File classesDir = project.sourceSets.main.output.classesDir
-            File classFile = new File(classesDir, extension.classname.replace('.', File.separator) + '.class')
-            if (classFile.exists() == false) {
-                throw new InvalidUserDataException('classname ' + extension.classname + ' does not exist')
-            }
-            if (extension.isolated == false) {
-                logger.warn('Disabling isolation is deprecated and will be removed in the future')
-            }
-        }
-
-        Properties props = new Properties()
-        for (Map.Entry<String, String> prop : properties) {
-            props.put(prop.getKey(), prop.getValue())
-        }
-        props.store(propertiesFile.newWriter(), null)
     }
 }

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -31,19 +31,19 @@
 ### mandatory elements for all plugins:
 #
 # 'description': simple summary of the plugin
-description=${project.description}
+description=${description}
 #
 # 'version': plugin's version
-version=${project.version}
+version=${version}
 #
 # 'name': the plugin name
-name=${elasticsearch.plugin.name}
+name=${name}
 
 ### mandatory elements for site plugins:
 #
 # 'site': set to true to indicate contents of the _site/
 #  directory in the root of the plugin should be served.
-site=${elasticsearch.plugin.site}
+site=${site}
 #
 ### mandatory elements for jvm plugins :
 #
@@ -52,19 +52,19 @@ site=${elasticsearch.plugin.site}
 #  Note that only jar files in the root directory are
 #  added to the classpath for the plugin! If you need
 #  other resources, package them into a resources jar.
-jvm=${elasticsearch.plugin.jvm}
+jvm=${jvm}
 #
 # 'classname': the name of the class to load, fully-qualified.
-classname=${elasticsearch.plugin.classname}
+classname=${classname}
 #
 # 'java.version' version of java the code is built against
 # use the system property java.specification.version
 # version string must be a sequence of nonnegative decimal integers
 # separated by "."'s and may have leading zeros
-java.version=${java.target.version}
+java.version=${javaVersion}
 #
 # 'elasticsearch.version' version of elasticsearch compiled against
-elasticsearch.version=${elasticsearch.version}
+elasticsearch.version=${elasticsearchVersion}
 #
 ### deprecated elements for jvm plugins :
 #
@@ -72,5 +72,5 @@ elasticsearch.version=${elasticsearch.version}
 # passing false is deprecated, and only intended to support plugins
 # that have hard dependencies against each other. If this is
 # not specified, then the plugin is isolated by default.
-isolated=${elasticsearch.plugin.isolated}
+isolated=${isolated}
 #


### PR DESCRIPTION
The gradle task to generate plugin properties files now is a simple copy
with expansion (ie maven filtering). It also no longer depends on
compiling.

closes #14450
