### PR TITLE
Add back integ tests to distributions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ subprojects {
             substitute module("org.elasticsearch:test-framework:${version}") with project("${projectsPrefix}:test-framework")
           }
           substitute module("org.elasticsearch.distribution.zip:elasticsearch:${version}") with project("${projectsPrefix}:distribution:zip")
+          substitute module("org.elasticsearch.distribution.tar:elasticsearch:${version}") with project("${projectsPrefix}:distribution:tar")
         }
       }
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -25,6 +25,9 @@ import org.gradle.api.tasks.Input
 class ClusterConfiguration {
 
     @Input
+    String distribution = 'zip'
+
+    @Input
     int numNodes = 1
 
     @Input

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -36,6 +36,9 @@ class ClusterConfiguration {
     @Input
     int transportPort = 9500
 
+    @Input
+    String jvmArgs = System.getProperty('tests.jvm.argline', '')
+
     Map<String, String> systemProperties = new HashMap<>()
 
     @Input

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -228,11 +228,12 @@ class ClusterFormationTasks {
 
     static void configureDistributionDependency(Project project, String distro) {
         String elasticsearchVersion = ElasticsearchProperties.version
+        String packaging = distro == 'tar' ? 'tgz' : distro
         project.configurations {
             elasticsearchDistro
         }
         project.dependencies {
-            elasticsearchDistro "org.elasticsearch.distribution.${distro}:elasticsearch:${elasticsearchVersion}@${distro}"
+            elasticsearchDistro "org.elasticsearch.distribution.${distro}:elasticsearch:${elasticsearchVersion}@${packaging}"
         }
     }
 }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -36,11 +36,17 @@ buildscript {
 allprojects {
   project.ext {
     // this is common configuration for distributions, but we also add it here for the license check to use
-    deps = project("${projectsPrefix}:core").configurations.runtime.copyRecursive().exclude(module: 'slf4j-api')
+    dependencyFiles = project("${projectsPrefix}:core").configurations.runtime.copyRecursive().exclude(module: 'slf4j-api')
   }
 }
 
 subprojects {
+  apply plugin: 'elasticsearch.rest-test'
+
+  integTest {
+    includePackaged true
+  }
+
   /*****************************************************************************
    *                              Maven config                                 *
    *****************************************************************************/
@@ -50,8 +56,8 @@ subprojects {
   // we must create our own install task, because it is only added when the java plugin is added
   task install(type: Upload, description: "Installs the 'archives' artifacts into the local Maven repository.", group: 'Upload') {
     configuration = configurations.archives
-    MavenRepositoryHandlerConvention repositoriesHandler = (MavenRepositoryHandlerConvention)getRepositories().getConvention().getPlugin(MavenRepositoryHandlerConvention);
-    repositoriesHandler.mavenInstaller();
+    MavenRepositoryHandlerConvention repositoriesHandler = (MavenRepositoryHandlerConvention)getRepositories().getConvention().getPlugin(MavenRepositoryHandlerConvention)
+    repositoriesHandler.mavenInstaller()
   }
 
   // TODO: the map needs to be an input of the tasks, so that when it changes, the task will re-run...
@@ -81,7 +87,7 @@ subprojects {
     libFiles = copySpec {
       into 'lib'
       from project("${projectsPrefix}:core").jar
-      from deps
+      from dependencyFiles
     }
 
     configFiles = copySpec {
@@ -151,7 +157,7 @@ buildDeb.dependsOn createEmptyDir
 /*****************************************************************************
  *                         Deb and rpm configuration                         *
  *****************************************************************************/
-configure(subprojects.findAll { it.name == 'zip' || it.name == 'tar' }) {
+configure(subprojects.findAll { it.name == 'deb' || it.name == 'rpm' }) {
   apply plugin: 'nebula.ospackage-base'
   ospackage {
     packageName = 'elasticsearch'
@@ -173,29 +179,17 @@ configure(subprojects.findAll { it.name == 'zip' || it.name == 'tar' }) {
     }
     directory('/etc/elasticsearch/scripts')
   }
-  if (project.name == 'deb') {
-    task buildDeb(type: Deb) {
-      dependsOn deps
-    }
-    artifacts {
-      archives buildDeb
-    }
-  } else if (project.name == 'rpm') {
-    task buildRpm(type: Rpm) {
-      dependsOn deps
-    }
-    artifacts {
-      archives buildRpm
-    }
-  }
+  
+  // TODO: re-enable tests when we have real rpm and deb distros!
+  integTest.enabled = false
 }
 
 // TODO: dependency checks should really be when building the jar itself, which would remove the need
 // for this hackery and instead we can do this inside the BuildPlugin
 task check(group: 'Verification', description: 'Runs all checks.') {} // dummy task!
 DependencyLicensesTask.configure(project) {
-  dependsOn = [deps]
-  dependencies = deps
+  dependsOn = [dependencyFiles]
+  dependencies = dependencyFiles
   mapping from: /lucene-.*/, to: 'lucene'
   mapping from: /jackson-.*/, to: 'jackson'
 }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -41,8 +41,10 @@ allprojects {
 }
 
 subprojects {
+  /*****************************************************************************
+   *                            Rest test config                               *
+   *****************************************************************************/
   apply plugin: 'elasticsearch.rest-test'
-
   integTest {
     includePackaged true
   }

--- a/distribution/deb/build.gradle
+++ b/distribution/deb/build.gradle
@@ -1,4 +1,25 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-/*task buildDeb(type: Deb) {
-  dependsOn deps
-}*/
+task buildDeb(type: Deb) {
+  dependsOn dependencyFiles
+}
+artifacts {
+  archives buildDeb
+}

--- a/distribution/deb/build.gradle
+++ b/distribution/deb/build.gradle
@@ -20,6 +20,9 @@
 task buildDeb(type: Deb) {
   dependsOn dependencyFiles
 }
+
 artifacts {
   archives buildDeb
 }
+
+integTest.dependsOn buildDeb

--- a/distribution/rpm/build.gradle
+++ b/distribution/rpm/build.gradle
@@ -1,4 +1,25 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-/*task buildRpm(type: Rpm) {
-  dependsOn deps
-}*/
+task buildRpm(type: Rpm) {
+  dependsOn dependencyFiles
+}
+artifacts {
+  archives buildRpm
+}

--- a/distribution/rpm/build.gradle
+++ b/distribution/rpm/build.gradle
@@ -20,6 +20,9 @@
 task buildRpm(type: Rpm) {
   dependsOn dependencyFiles
 }
+
 artifacts {
   archives buildRpm
 }
+
+integTest.dependsOn buildRpm

--- a/distribution/tar/build.gradle
+++ b/distribution/tar/build.gradle
@@ -24,5 +24,11 @@ task buildTar(type: Tar, dependsOn: dependencyFiles) {
 }
 
 artifacts {
+  'default' buildTar
   archives buildTar
+}
+
+integTest {
+  dependsOn buildTar
+  clusterConfig.distribution = 'tar'
 }

--- a/distribution/tar/build.gradle
+++ b/distribution/tar/build.gradle
@@ -1,5 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-task buildTar(type: Tar, dependsOn: deps) {
+task buildTar(type: Tar, dependsOn: dependencyFiles) {
   baseName = 'elasticsearch'
   with archivesFiles
   compression = Compression.GZIP

--- a/distribution/zip/build.gradle
+++ b/distribution/zip/build.gradle
@@ -1,5 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-task buildZip(type: Zip, dependsOn: deps) {
+task buildZip(type: Zip, dependsOn: dependencyFiles) {
   baseName = 'elasticsearch'
   with archivesFiles
 }

--- a/distribution/zip/build.gradle
+++ b/distribution/zip/build.gradle
@@ -27,3 +27,5 @@ artifacts {
   archives buildZip
 }
 
+integTest.dependsOn buildZip
+


### PR DESCRIPTION
rpm and deb are still skipped, but this configures rest tests to run for
zip and tgz distributions

closes #14361
