### PR TITLE
Add System#exit(), Runtime#exit() and Runtime#halt() to forbidden APIs

### DIFF
--- a/buildSrc/src/main/resources/forbidden/all-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/all-signatures.txt
@@ -100,3 +100,8 @@ org.apache.lucene.index.IndexReader#getCombinedCoreAndDeletesKey()
 
 @defaultMessage this method needs special permission
 java.lang.Thread#getAllStackTraces()
+
+@defaultMessage Please do not terminate the application
+java.lang.System#exit(int)
+java.lang.Runtime#exit(int)
+java.lang.Runtime#halt(int)

--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -235,7 +235,7 @@ final class Bootstrap {
         CliTool.ExitStatus status = bootstrapCLIParser.execute(args);
 
         if (CliTool.ExitStatus.OK != status) {
-            System.exit(status.status());
+            exit(status.status());
         }
 
         INSTANCE = new Bootstrap();
@@ -343,7 +343,12 @@ final class Bootstrap {
         if (confFileSetting != null && confFileSetting.isEmpty() == false) {
             ESLogger logger = Loggers.getLogger(Bootstrap.class);
             logger.info("{} is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed.", settingName);
-            System.exit(1);
+            exit(1);
         }
+    }
+
+    @SuppressForbidden(reason = "Allowed to exit explicitly in bootstrap phase")
+    private static void exit(int status) {
+        System.exit(status);
     }
 }

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManagerCliParser.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManagerCliParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.plugins;
 
 import org.apache.commons.cli.CommandLine;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.cli.CliTool;
 import org.elasticsearch.common.cli.CliToolConfig;
 import org.elasticsearch.common.cli.Terminal;
@@ -65,6 +66,11 @@ public class PluginManagerCliParser extends CliTool {
         // configure but do not read the logging conf file
         LogConfigurator.configure(env.settings(), false);
         int status = new PluginManagerCliParser().execute(args).status();
+        exit(status);
+    }
+
+    @SuppressForbidden(reason = "Allowed to exit explicitly from #main()")
+    private static void exit(int status) {
         System.exit(status);
     }
 

--- a/core/src/test/java/org/elasticsearch/benchmark/search/geo/GeoDistanceSearchBenchmark.java
+++ b/core/src/test/java/org/elasticsearch/benchmark/search/geo/GeoDistanceSearchBenchmark.java
@@ -21,6 +21,7 @@ package org.elasticsearch.benchmark.search.geo;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.SizeValue;
@@ -46,7 +47,7 @@ public class GeoDistanceSearchBenchmark {
         ClusterHealthResponse clusterHealthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
         if (clusterHealthResponse.isTimedOut()) {
             System.err.println("Failed to wait for green status, bailing");
-            System.exit(1);
+            exit(1);
         }
 
         final long NUM_DOCS = SizeValue.parseSizeValue("1m").singles();
@@ -197,5 +198,10 @@ public class GeoDistanceSearchBenchmark {
                         .geoDistance(geoDistance)
                         .point(40.7143528, -74.0059731)))
                 .execute().actionGet();
+    }
+
+    @SuppressForbidden(reason = "Allowed to exit explicitly from #main()")
+    private static void exit(int status) {
+        System.exit(status);
     }
 }


### PR DESCRIPTION
I've added System#exit(), Runtime#exit() and Runtime#halt() to the forbidden APIs in all-signatures and added appropriate suppresses.

Can you please have a look @rmuir? Thanks a lot!

Closes #12596
