### PR TITLE
Use plugin name from plugin's properties file rather than plugin's class

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -129,7 +129,7 @@ public class PluginsService extends AbstractComponent {
         for (Tuple<PluginInfo, Plugin> tuple : plugins) {
             PluginInfo info = tuple.v1();
             if (info.isJvm()) {
-                jvmPlugins.put(tuple.v2().name(), tuple.v2());
+                jvmPlugins.put(info.getName(), tuple.v2());
             }
             if (info.isSite()) {
                 sitePlugins.add(info.getName());


### PR DESCRIPTION
Simple backport for 2.0 branch (already fixed in 2.1, 2.x and master)

closes #14357 
