### PR TITLE
Fix dangling comma in ClusterBlock#toString

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
+++ b/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
@@ -155,8 +155,10 @@ public class ClusterBlock implements Streamable, ToXContent {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append(id).append(",").append(description).append(", blocks ");
+        String delimiter = "";
         for (ClusterBlockLevel level : levels) {
-            sb.append(level.name()).append(",");
+            sb.append(delimiter).append(level.name());
+            delimiter = ",";
         }
         return sb.toString();
     }

--- a/core/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
@@ -28,7 +28,9 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.EnumSet;
 
 import static org.elasticsearch.test.VersionUtils.randomVersion;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 
 public class ClusterBlockTests extends ESTestCase {
     public void testSerialization() throws Exception {
@@ -62,5 +64,16 @@ public class ClusterBlockTests extends ESTestCase {
             assertThat(result.disableStatePersistence(), equalTo(clusterBlock.disableStatePersistence()));
             assertArrayEquals(result.levels().toArray(), clusterBlock.levels().toArray());
         }
+    }
+
+    public void testToStringDanglingComma() {
+        EnumSet<ClusterBlockLevel> levels = EnumSet.noneOf(ClusterBlockLevel.class);
+        int nbLevels = randomIntBetween(1, ClusterBlockLevel.values().length);
+        for (int j = 0; j < nbLevels; j++) {
+            levels.add(randomFrom(ClusterBlockLevel.values()));
+        }
+        ClusterBlock clusterBlock = new ClusterBlock(randomInt(), "cluster block #" + randomInt(), randomBoolean(),
+                randomBoolean(), randomFrom(RestStatus.values()), levels);
+        assertThat(clusterBlock.toString(), not(endsWith(",")));
     }
 }


### PR DESCRIPTION
This commit address some serious health issues that could arise from a
dangerous combination of OCD, string concatenation, and dangling
commas,
