### PR TITLE
Failure to update the cluster state with the recovered state should make sure it will be recovered later

### DIFF
--- a/core/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -20,12 +20,7 @@
 package org.elasticsearch.gateway;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.*;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -264,6 +259,7 @@ public class GatewayService extends AbstractLifecycleComponent<GatewayService> i
                 @Override
                 public void onFailure(String source, Throwable t) {
                     logger.error("unexpected failure during [{}]", t, source);
+                    GatewayRecoveryListener.this.onFailure("failed to updated cluster state");
                 }
 
                 @Override


### PR DESCRIPTION
We currently fail to follow the right failure paths.

See http://build-us-00.elastic.co/job/es_core_master_window-2008/2477/
