### PR TITLE
Backport more ignores for gradle to simplify branch switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ work/
 logs/
 .DS_Store
 build/
+generated-resources/
 **/.local*
 docs/html/
 docs/build.log

--- a/pom.xml
+++ b/pom.xml
@@ -1162,6 +1162,7 @@ org.eclipse.jdt.ui.text.custom_code_templates=<?xml version\="1.0" encoding\="UT
                                             <include name="**/*.rb"/>
                                             <include name="**/*.pl"/>
                                             <exclude name="**/org/elasticsearch/cluster/routing/shard_routes.txt"/>
+                                            <exclude name="**/build/**/*"/>
                                             <exclude name="**/target/**/*"/>
                                             <exclude name="**/.metadata/**/*"/>
                                             <exclude name="**/.idea/**/*"/>


### PR DESCRIPTION
This adds generated-resources to gitignores, and the build/ dir to
excludes for pattern checks.

closes #14438
