### PR TITLE
Change tar extension back to tar.gz instead of tgz

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -235,7 +235,7 @@ class ClusterFormationTasks {
 
     static void configureDistributionDependency(Project project, String distro) {
         String elasticsearchVersion = ElasticsearchProperties.version
-        String packaging = distro == 'tar' ? 'tgz' : distro
+        String packaging = distro == 'tar' ? 'tar.gz' : distro
         project.configurations {
             elasticsearchDistro
         }

--- a/distribution/tar/build.gradle
+++ b/distribution/tar/build.gradle
@@ -19,6 +19,7 @@
 
 task buildTar(type: Tar, dependsOn: dependencyFiles) {
   baseName = 'elasticsearch'
+  extension = 'tar.gz'
   with archivesFiles
   compression = Compression.GZIP
 }


### PR DESCRIPTION
Gradle defaults to tgz extension when tar is compressed. This changes
the tar distribution back to tar.gz. Note that this also means the maven
packaging type is now tar.gz.
