### PR TITLE
Fix Java 9 type inference issue

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/collect/Iterators.java
+++ b/core/src/main/java/org/elasticsearch/common/collect/Iterators.java
@@ -28,7 +28,8 @@ public class Iterators {
             throw new NullPointerException("iterators");
         }
 
-        return new ConcatenatedIterator<>(iterators);
+        // explicit generic type argument needed for type inference
+        return new ConcatenatedIterator<T>(iterators);
     }
 
     static class ConcatenatedIterator<T> implements Iterator<T> {


### PR DESCRIPTION
This commit fixes a compilation issue due to modified type inference in
the latest JDK 9 early access builds. We just have to lend a helping
hand to type inference by being explicit about the type.

Closes #14496
