### PR TITLE
Add property permissions so groovy scripts can serialize json

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/untrusted.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/untrusted.policy
@@ -26,6 +26,10 @@ grant {
   // groovy IndyInterface bootstrap requires this property for indy logging
   permission java.util.PropertyPermission "groovy.indy.logging", "read";
   
+  // groovy JsonOutput, just allow it to read these props so it works (unsafe is not allowed)
+  permission java.util.PropertyPermission "groovy.json.faststringutils.disable", "read";
+  permission java.util.PropertyPermission "groovy.json.faststringutils.write.to.final.fields", "read";
+
   // needed by Rhino engine exception handling
   permission java.util.PropertyPermission "rhino.stack.style", "read";
 

--- a/plugins/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
+++ b/plugins/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
@@ -64,6 +64,8 @@ public class GroovySecurityTests extends ESTestCase {
         assertSuccess("def range = 1..doc['foo'].value; def v = range.get(0)");
         // Maps
         assertSuccess("def v = doc['foo'].value; def m = [:]; m.put(\"value\", v)");
+        // serialization to json (this is best effort considering the unsafe etc at play)
+        assertSuccess("def x = 5; groovy.json.JsonOutput.toJson(x)");
         // Times
         assertSuccess("def t = Instant.now().getMillis()");
         // GroovyCollections


### PR DESCRIPTION
Allowing read to these properties is not really dangerous, even if
the code surrounding them is.

Closes #14488
