### PR TITLE
Added new community R client, edited old entry

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -173,7 +173,10 @@ The following projects appear to be abandoned:
   R client for Elasticsearch
 
 * https://github.com/ropensci/elastic[elastic]:
-  A general purpose R client for Elasticsearch
+  A low-level R client for Elasticsearch.
+
+* https://github.com/ropensci/elasticdsl[elasticdsl]:
+  A high-level R DSL for Elasticsearch, wrapping the elastic R client.
 
 [[ruby]]
 == Ruby


### PR DESCRIPTION
I maintain two R clients, `elastic` and `elasticdsl`. This PR adds an entry for `elasticdsl` and edited `elastic` entry
