### PR TITLE
Update plugin-script.asciidoc

### DIFF
--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -229,7 +229,7 @@ example:
 
 [source,yaml]
 --------------------------------------------------
-plugin.mandatory: mapper-attachments,lang-groovy
+plugin.mandatory: mapper-attachments,lang-python
 --------------------------------------------------
 
 For safety reasons, a node will not start if it is missing a mandatory plugin.


### PR DESCRIPTION
It is better not to show lang-groovy plugin in the example, as it is not used since elasticsearch 1.4.0
