### PR TITLE
Add support for Lucene 5.4 GeoPoint queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -66,6 +66,19 @@ public class GeoUtils {
     /** Earth ellipsoid polar distance in meters */
     public static final double EARTH_POLAR_DISTANCE = Math.PI * EARTH_SEMI_MINOR_AXIS;
 
+    /** Returns the maximum distance/radius from the point 'center' before overlapping */
+    public static double maxRadialDistance(GeoPoint center) {
+        return SloppyMath.haversin(center.lat(), center.lon(), center.lat(), (180.0 + center.lon()) % 360)*1000.0;
+    }
+
+    /** Returns the minimum between the provided distance 'initialRadius' and the
+     * maximum distance/radius from the point 'center' before overlapping
+     **/
+    public static double maxRadialDistance(GeoPoint center, double initialRadius) {
+        final double maxRadius = maxRadialDistance(center);
+        return Math.min(initialRadius, maxRadius);
+    }
+
     /** Returns true if latitude is actually a valid latitude value.*/
     public static boolean isValidLatitude(double latitude) {
         if (Double.isNaN(latitude) || Double.isInfinite(latitude) || latitude < GeoUtils.MIN_LAT || latitude > GeoUtils.MAX_LAT) {

--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -21,7 +21,10 @@ package org.elasticsearch.index.query;
 
 import com.spatial4j.core.shape.Point;
 
+import org.apache.lucene.search.GeoPointDistanceQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.GeoUtils;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
@@ -158,6 +161,16 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
 
     @Override
     protected void doAssertLuceneQuery(GeoDistanceQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        Version version = context.indexVersionCreated();
+        // norelease update to .before(Version.V_2_2_0 once GeoPointFieldV2 is fully merged
+        if (version.onOrBefore(Version.CURRENT)) {
+            assertLegacyQuery(queryBuilder, query);
+        } else {
+            assertGeoPointQuery(queryBuilder, query);
+        }
+    }
+
+    private void assertLegacyQuery(GeoDistanceQueryBuilder queryBuilder, Query query) throws IOException {
         assertThat(query, instanceOf(GeoDistanceRangeQuery.class));
         GeoDistanceRangeQuery geoQuery = (GeoDistanceRangeQuery) query;
         assertThat(geoQuery.fieldName(), equalTo(queryBuilder.fieldName()));
@@ -169,9 +182,24 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         assertThat(geoQuery.minInclusiveDistance(), equalTo(Double.NEGATIVE_INFINITY));
         double distance = queryBuilder.distance();
         if (queryBuilder.geoDistance() != null) {
-                distance = queryBuilder.geoDistance().normalize(distance, DistanceUnit.DEFAULT);
+            distance = queryBuilder.geoDistance().normalize(distance, DistanceUnit.DEFAULT);
         }
         assertThat(geoQuery.maxInclusiveDistance(), closeTo(distance, Math.abs(distance) / 1000));
+    }
+
+    private void assertGeoPointQuery(GeoDistanceQueryBuilder queryBuilder, Query query) throws IOException {
+        assertThat(query, instanceOf(GeoPointDistanceQuery.class));
+        GeoPointDistanceQuery geoQuery = (GeoPointDistanceQuery) query;
+        assertThat(geoQuery.getField(), equalTo(queryBuilder.fieldName()));
+        if (queryBuilder.point() != null) {
+            assertThat(geoQuery.getCenterLat(), equalTo(queryBuilder.point().lat()));
+            assertThat(geoQuery.getCenterLon(), equalTo(queryBuilder.point().lon()));
+        }
+        double distance = queryBuilder.distance();
+        if (queryBuilder.geoDistance() != null) {
+            distance = queryBuilder.geoDistance().normalize(distance, DistanceUnit.DEFAULT);
+            assertThat(geoQuery.getRadiusMeters(), closeTo(distance, GeoUtils.TOLERANCE));
+        }
     }
 
     public void testParsingAndToQuery1() throws IOException {
@@ -185,7 +213,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery2() throws IOException {
@@ -196,7 +224,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        \"" + GEO_POINT_FIELD_NAME + "\":[-70, 40]\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery3() throws IOException {
@@ -207,7 +235,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        \"" + GEO_POINT_FIELD_NAME + "\":\"40, -70\"\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery4() throws IOException {
@@ -218,7 +246,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        \"" + GEO_POINT_FIELD_NAME + "\":\"drn5x1g8cu2y\"\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery5() throws IOException {
@@ -233,7 +261,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery6() throws IOException {
@@ -248,7 +276,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery7() throws IOException {
@@ -262,13 +290,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "      }\n" +
                 "  }\n" +
                 "}\n";
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
-        GeoDistanceRangeQuery filter = (GeoDistanceRangeQuery) parsedQuery;
-        assertThat(filter.fieldName(), equalTo(GEO_POINT_FIELD_NAME));
-        assertThat(filter.lat(), closeTo(40, 0.00001));
-        assertThat(filter.lon(), closeTo(-70, 0.00001));
-        assertThat(filter.minInclusiveDistance(), equalTo(Double.NEGATIVE_INFINITY));
-        assertThat(filter.maxInclusiveDistance(), closeTo(DistanceUnit.DEFAULT.convert(0.012, DistanceUnit.MILES), 0.00001));
+        assertGeoDistanceRangeQuery(query, 40, -70, 0.012, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery8() throws IOException {
@@ -282,13 +304,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
-        GeoDistanceRangeQuery filter = (GeoDistanceRangeQuery) parsedQuery;
-        assertThat(filter.fieldName(), equalTo(GEO_POINT_FIELD_NAME));
-        assertThat(filter.lat(), closeTo(40, 0.00001));
-        assertThat(filter.lon(), closeTo(-70, 0.00001));
-        assertThat(filter.minInclusiveDistance(), equalTo(Double.NEGATIVE_INFINITY));
-        assertThat(filter.maxInclusiveDistance(), closeTo(DistanceUnit.KILOMETERS.convert(12, DistanceUnit.MILES), 0.00001));
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.KILOMETERS);
     }
 
     public void testParsingAndToQuery9() throws IOException {
@@ -303,7 +319,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery10() throws IOException {
@@ -318,7 +334,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery11() throws IOException {
@@ -332,7 +348,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
     public void testParsingAndToQuery12() throws IOException {
@@ -347,17 +363,27 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
                 "        }\n" +
                 "    }\n" +
                 "}\n";
-        assertGeoDistanceRangeQuery(query);
+        assertGeoDistanceRangeQuery(query, 40, -70, 12, DistanceUnit.DEFAULT);
     }
 
-    private void assertGeoDistanceRangeQuery(String query) throws IOException {
+    private void assertGeoDistanceRangeQuery(String query, double lat, double lon, double distance, DistanceUnit distanceUnit) throws IOException {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query parsedQuery = parseQuery(query).toQuery(createShardContext());
-        GeoDistanceRangeQuery filter = (GeoDistanceRangeQuery) parsedQuery;
-        assertThat(filter.fieldName(), equalTo(GEO_POINT_FIELD_NAME));
-        assertThat(filter.lat(), closeTo(40, 0.00001));
-        assertThat(filter.lon(), closeTo(-70, 0.00001));
-        assertThat(filter.minInclusiveDistance(), equalTo(Double.NEGATIVE_INFINITY));
-        assertThat(filter.maxInclusiveDistance(), closeTo(DistanceUnit.DEFAULT.convert(12, DistanceUnit.MILES), 0.00001));
+        Version version = queryShardContext().indexVersionCreated();
+        // norelease update to .before(Version.V_2_2_0 once GeoPointFieldV2 is fully merged
+        if (version.onOrBefore(Version.CURRENT)) {
+            GeoDistanceRangeQuery q = (GeoDistanceRangeQuery) parsedQuery;
+            assertThat(q.fieldName(), equalTo(GEO_POINT_FIELD_NAME));
+            assertThat(q.lat(), closeTo(lat, 1E-5D));
+            assertThat(q.lon(), closeTo(lon, 1E-5D));
+            assertThat(q.minInclusiveDistance(), equalTo(Double.NEGATIVE_INFINITY));
+            assertThat(q.maxInclusiveDistance(), closeTo(distanceUnit.convert(distance, DistanceUnit.MILES), 1E-5D));
+        } else {
+            GeoPointDistanceQuery q = (GeoPointDistanceQuery) parsedQuery;
+            assertThat(q.getField(), equalTo(GEO_POINT_FIELD_NAME));
+            assertThat(q.getCenterLat(), closeTo(lat, 1E-5D));
+            assertThat(q.getCenterLon(), closeTo(lon, 1E-5D));
+            assertThat(q.getRadiusMeters(), closeTo(distanceUnit.convert(distance, DistanceUnit.MILES), 1E-5D));
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -22,7 +22,9 @@ package org.elasticsearch.index.query;
 import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.vividsolutions.jts.geom.Coordinate;
 
+import org.apache.lucene.search.GeoPointInPolygonQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
@@ -56,6 +58,16 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
 
     @Override
     protected void doAssertLuceneQuery(GeoPolygonQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        Version version = context.indexVersionCreated();
+        // norelease update to .before(Version.V_2_2_0 once GeoPointFieldV2 is fully merged
+        if (version.onOrBefore(Version.CURRENT)) {
+            assertLegacyQuery(queryBuilder, query);
+        } else {
+            assertGeoPointQuery(queryBuilder, query);
+        }
+    }
+
+    private void assertLegacyQuery(GeoPolygonQueryBuilder queryBuilder, Query query) {
         assertThat(query, instanceOf(GeoPolygonQuery.class));
         GeoPolygonQuery geoQuery = (GeoPolygonQuery) query;
         assertThat(geoQuery.fieldName(), equalTo(queryBuilder.fieldName()));
@@ -73,6 +85,24 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
             for (int i = 0; i < queryBuilderPoints.size(); i++) {
                 assertThat(queryPoints[i], equalTo(queryBuilderPoints.get(i)));
             }
+        }
+    }
+
+    private void assertGeoPointQuery(GeoPolygonQueryBuilder queryBuilder, Query query) {
+        assertThat(query, instanceOf(GeoPointInPolygonQuery.class));
+        GeoPointInPolygonQuery geoQuery = (GeoPointInPolygonQuery) query;
+        assertThat(geoQuery.getField(), equalTo(queryBuilder.fieldName()));
+        List<GeoPoint> queryBuilderPoints = queryBuilder.points();
+        double[] lats = geoQuery.getLats();
+        double[] lons = geoQuery.getLons();
+        assertThat(lats.length, equalTo(queryBuilderPoints.size()));
+        assertThat(lons.length, equalTo(queryBuilderPoints.size()));
+        for (int i=0; i < queryBuilderPoints.size(); ++i) {
+            final GeoPoint queryBuilderPoint = queryBuilderPoints.get(i);
+            final GeoPoint pointCopy = new GeoPoint(queryBuilderPoint);
+            GeoUtils.normalizePoint(pointCopy);
+            assertThat(lats[i], closeTo(pointCopy.getLat(), 1E-5D));
+            assertThat(lons[i], closeTo(pointCopy.getLon(), 1E-5D));
         }
     }
 
@@ -267,15 +297,35 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
     }
 
     private void assertGeoPolygonQuery(String query) throws IOException {
-        Query parsedQuery = parseQuery(query).toQuery(createShardContext());
-        GeoPolygonQuery filter = (GeoPolygonQuery) parsedQuery;
-        assertThat(filter.fieldName(), equalTo(GEO_POINT_FIELD_NAME));
-        assertThat(filter.points().length, equalTo(4));
-        assertThat(filter.points()[0].lat(), closeTo(40, 0.00001));
-        assertThat(filter.points()[0].lon(), closeTo(-70, 0.00001));
-        assertThat(filter.points()[1].lat(), closeTo(30, 0.00001));
-        assertThat(filter.points()[1].lon(), closeTo(-80, 0.00001));
-        assertThat(filter.points()[2].lat(), closeTo(20, 0.00001));
-        assertThat(filter.points()[2].lon(), closeTo(-90, 0.00001));
+        QueryShardContext context = createShardContext();
+        Version version = context.indexVersionCreated();
+        Query parsedQuery = parseQuery(query).toQuery(context);
+        // norelease update to .before(Version.V_2_2_0 once GeoPointFieldV2 is fully merged
+        if (version.onOrBefore(Version.CURRENT)) {
+            GeoPolygonQuery filter = (GeoPolygonQuery) parsedQuery;
+            assertThat(filter.fieldName(), equalTo(GEO_POINT_FIELD_NAME));
+            assertThat(filter.points().length, equalTo(4));
+            assertThat(filter.points()[0].lat(), closeTo(40, 0.00001));
+            assertThat(filter.points()[0].lon(), closeTo(-70, 0.00001));
+            assertThat(filter.points()[1].lat(), closeTo(30, 0.00001));
+            assertThat(filter.points()[1].lon(), closeTo(-80, 0.00001));
+            assertThat(filter.points()[2].lat(), closeTo(20, 0.00001));
+            assertThat(filter.points()[2].lon(), closeTo(-90, 0.00001));
+        } else {
+            GeoPointInPolygonQuery q = (GeoPointInPolygonQuery) parsedQuery;
+            assertThat(q.getField(), equalTo(GEO_POINT_FIELD_NAME));
+            final double[] lats = q.getLats();
+            final double[] lons = q.getLons();
+            assertThat(lats.length, equalTo(4));
+            assertThat(lons.length, equalTo(4));
+            assertThat(lats[0], closeTo(40, 1E-5));
+            assertThat(lons[0], closeTo(-70, 1E-5));
+            assertThat(lats[1], closeTo(30, 1E-5));
+            assertThat(lons[1], closeTo(-80, 1E-5));
+            assertThat(lats[2], closeTo(20, 1E-5));
+            assertThat(lons[2], closeTo(-90, 1E-5));
+            assertThat(lats[3], equalTo(lats[0]));
+            assertThat(lons[3], equalTo(lons[0]));
+        }
     }
 }


### PR DESCRIPTION
This PR adds query support for Lucene 5.4 GeoPointField type along with backward compatibility for "legacy" geo_point indexes.
