### PR TITLE
only allow code to bind to the user's configured port numbers/ranges

### DIFF
--- a/core/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/NettyHttpServerTransport.java
@@ -81,6 +81,7 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
 
     public static final boolean DEFAULT_SETTING_PIPELINING = true;
     public static final int DEFAULT_SETTING_PIPELINING_MAX_EVENTS = 10000;
+    public static final String DEFAULT_PORT_RANGE = "9200-9300";
 
     protected final NetworkService networkService;
     protected final BigArrays bigArrays;
@@ -157,7 +158,7 @@ public class NettyHttpServerTransport extends AbstractLifecycleComponent<HttpSer
         this.maxCompositeBufferComponents = settings.getAsInt("http.netty.max_composite_buffer_components", -1);
         this.workerCount = settings.getAsInt("http.netty.worker_count", EsExecutors.boundedNumberOfProcessors(settings) * 2);
         this.blockingServer = settings.getAsBoolean("http.netty.http.blocking_server", settings.getAsBoolean(TCP_BLOCKING_SERVER, settings.getAsBoolean(TCP_BLOCKING, false)));
-        this.port = settings.get("http.netty.port", settings.get("http.port", "9200-9300"));
+        this.port = settings.get("http.netty.port", settings.get("http.port", DEFAULT_PORT_RANGE));
         this.bindHosts = settings.getAsArray("http.netty.bind_host", settings.getAsArray("http.bind_host", settings.getAsArray("http.host", null)));
         this.publishHosts = settings.getAsArray("http.netty.publish_host", settings.getAsArray("http.publish_host", settings.getAsArray("http.host", null)));
         this.publishPort = settings.getAsInt("http.netty.publish_port", settings.getAsInt("http.publish_port", 0));

--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -19,7 +19,7 @@
 
 // Default security policy file.
 // On startup, BootStrap reads environment and adds additional permissions
-// for configured paths to these.
+// for configured paths and network binding to these.
 
 //// System code permissions:
 //// These permissions apply to the JDK itself:
@@ -53,7 +53,7 @@ grant {
   permission org.elasticsearch.SpecialPermission;
 
   // Allow connecting to the internet anywhere
-  permission java.net.SocketPermission "*", "accept,listen,connect,resolve";
+  permission java.net.SocketPermission "*", "accept,connect,resolve";
 
   // Allow read/write to all system properties
   permission java.util.PropertyPermission "*", "read,write";

--- a/plugins/discovery-multicast/src/main/java/org/elasticsearch/plugin/discovery/multicast/MulticastChannel.java
+++ b/plugins/discovery-multicast/src/main/java/org/elasticsearch/plugin/discovery/multicast/MulticastChannel.java
@@ -45,7 +45,7 @@ import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadF
  * A multicast channel that supports registering for receive events, and sending datagram packets. Allows
  * to easily share the same multicast socket if it holds the same config.
  */
-public abstract class MulticastChannel implements Closeable {
+abstract class MulticastChannel implements Closeable {
 
     /**
      * Builds a channel based on the provided config, allowing to control if sharing a channel that uses

--- a/plugins/discovery-multicast/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/discovery-multicast/src/main/plugin-metadata/plugin-security.policy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+grant {
+  // needed to bind multicast to arbitrary port
+  permission java.net.SocketPermission "localhost:1024-", "listen,resolve";
+};

--- a/plugins/discovery-multicast/src/test/java/org/elasticsearch/plugin/discovery/multicast/MulticastZenPingTests.java
+++ b/plugins/discovery-multicast/src/test/java/org/elasticsearch/plugin/discovery/multicast/MulticastZenPingTests.java
@@ -161,7 +161,7 @@ public class MulticastZenPingTests extends ESTestCase {
         MulticastSocket multicastSocket = null;
         try {
             Loggers.getLogger(MulticastZenPing.class).setLevel("TRACE");
-            multicastSocket = new MulticastSocket(54328);
+            multicastSocket = new MulticastSocket();
             multicastSocket.setReceiveBufferSize(2048);
             multicastSocket.setSendBufferSize(2048);
             multicastSocket.setSoTimeout(60000);

--- a/test-framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test-framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -35,6 +35,7 @@ import org.junit.Assert;
 
 import java.io.FilePermission;
 import java.io.InputStream;
+import java.net.SocketPermission;
 import java.net.URL;
 import java.nio.file.Path;
 import java.security.Permission;
@@ -129,6 +130,14 @@ public class BootstrapForTesting {
                 if (System.getProperty("tests.maven") == null) {
                     perms.add(new RuntimePermission("setIO"));
                 }
+                
+                // add bind permissions for testing
+                // ephemeral ports (note, on java 7 before update 51, this is a different permission)
+                // this should really be the only one allowed for tests, otherwise they have race conditions
+                perms.add(new SocketPermission("localhost:0", "listen,resolve"));
+                // ... but tests are messy. like file permissions, just let them live in a fantasy for now.
+                // TODO: cut over all tests to bind to ephemeral ports
+                perms.add(new SocketPermission("localhost:1024-", "listen,resolve"));
                 
                 // read test-framework permissions
                 final Policy testFramework = Security.readPolicy(Bootstrap.class.getResource("test-framework.policy"), JarHell.parseClassPath());


### PR DESCRIPTION
Random code shouldn't be listening on sockets elsewhere.

Today its the wild west, but we only need to grant access to what the user configured.

This means e.g. multicast plugin has to declare its intentions in its security.policy
