### PR TITLE
Restore build properties

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -661,7 +661,7 @@ public class Version {
 
     @SuppressForbidden(reason = "System.out.*")
     public static void main(String[] args) {
-        System.out.println("Version: " + Version.CURRENT + ", Build: " + Build.CURRENT.hashShort() + "/" + Build.CURRENT.timestamp() + ", JVM: " + JvmInfo.jvmInfo().version());
+        System.out.println("Version: " + Version.CURRENT + ", Build: " + Build.CURRENT.shortHash() + "/" + Build.CURRENT.date() + ", JVM: " + JvmInfo.jvmInfo().version());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -77,7 +77,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
             builder.field("ip", nodeInfo.getNode().getHostAddress(), XContentBuilder.FieldCaseConversion.NONE);
 
             builder.field("version", nodeInfo.getVersion());
-            builder.field("build", nodeInfo.getBuild().hashShort());
+            builder.field("build_hash", nodeInfo.getBuild().shortHash());
 
             if (nodeInfo.getServiceAttributes() != null) {
                 for (Map.Entry<String, String> nodeAttribute : nodeInfo.getServiceAttributes().entrySet()) {

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCLIParser.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapCLIParser.java
@@ -81,7 +81,7 @@ final class BootstrapCLIParser extends CliTool {
 
         @Override
         public ExitStatus execute(Settings settings, Environment env) throws Exception {
-            terminal.println("Version: %s, Build: %s/%s, JVM: %s", org.elasticsearch.Version.CURRENT, Build.CURRENT.hashShort(), Build.CURRENT.timestamp(), JvmInfo.jvmInfo().version());
+            terminal.println("Version: %s, Build: %s/%s, JVM: %s", org.elasticsearch.Version.CURRENT, Build.CURRENT.shortHash(), Build.CURRENT.date(), JvmInfo.jvmInfo().version());
             return ExitStatus.OK_AND_EXIT;
         }
     }

--- a/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
+++ b/core/src/main/java/org/elasticsearch/common/http/client/HttpDownloadHelper.java
@@ -358,7 +358,7 @@ public class HttpDownloadHelper {
                 connection.setConnectTimeout(5000);
             }
             connection.setRequestProperty("ES-Version", Version.CURRENT.toString());
-            connection.setRequestProperty("ES-Build-Hash", Build.CURRENT.hashShort());
+            connection.setRequestProperty("ES-Build-Hash", Build.CURRENT.shortHash());
             connection.setRequestProperty("User-Agent", "elasticsearch-plugin-manager");
 
             // connect to the remote site (may take some time)

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -135,7 +135,7 @@ public class Node implements Releasable {
         Settings tmpSettings = TribeService.processSettings(tmpEnv.settings());
 
         ESLogger logger = Loggers.getLogger(Node.class, tmpSettings.get("name"));
-        logger.info("version[{}], pid[{}], build[{}/{}]", version, JvmInfo.jvmInfo().pid(), Build.CURRENT.hashShort(), Build.CURRENT.timestamp());
+        logger.info("version[{}], pid[{}], build[{}/{}]", version, JvmInfo.jvmInfo().pid(), Build.CURRENT.shortHash(), Build.CURRENT.date());
 
         logger.info("initializing ...");
 

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -574,7 +574,7 @@ public class PluginManager {
                 // Elasticsearch new download service uses groupId org.elasticsearch.plugin from 2.0.0
                 if (user == null) {
                     if (!Strings.isNullOrEmpty(System.getProperty(PROPERTY_SUPPORT_STAGING_URLS))) {
-                        addUrl(urls, String.format(Locale.ROOT, "https://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip", version, Build.CURRENT.hashShort(), name, version, name, version));
+                        addUrl(urls, String.format(Locale.ROOT, "https://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip", version, Build.CURRENT.shortHash(), name, version, name, version));
                     }
                     addUrl(urls, String.format(Locale.ROOT, "https://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/%s/%s/%s-%s.zip", name, version, name, version));
                 } else {

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -245,7 +245,7 @@ public class RestNodesAction extends AbstractCatAction {
             }
 
             table.addCell(node.getVersion().number());
-            table.addCell(info == null ? null : info.getBuild().hashShort());
+            table.addCell(info == null ? null : info.getBuild().shortHash());
             table.addCell(jvmInfo == null ? null : jvmInfo.version());
             table.addCell(fsInfo == null ? null : fsInfo.getTotal().getAvailable());
             table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsed());

--- a/core/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/main/RestMainAction.java
@@ -77,8 +77,8 @@ public class RestMainAction extends BaseRestHandler {
         builder.field("cluster_name", clusterName.value());
         builder.startObject("version")
                 .field("number", version.number())
-                .field("build_hash", Build.CURRENT.hash())
-                .field("build_timestamp", Build.CURRENT.timestamp())
+                .field("build_hash", Build.CURRENT.shortHash())
+                .field("build_date", Build.CURRENT.date())
                 .field("build_snapshot", version.snapshot)
                 .field("lucene_version", version.luceneVersion.toString())
                 .endObject();

--- a/core/src/main/resources/es-build.properties
+++ b/core/src/main/resources/es-build.properties
@@ -1,3 +1,0 @@
-version=${project.version}
-hash=${buildNumber}
-timestamp=${timestamp}

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCliParserTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapCliParserTests.java
@@ -54,8 +54,8 @@ public class BootstrapCliParserTests extends CliToolTestCase {
         assertStatus(status, OK_AND_EXIT);
 
         assertThatTerminalOutput(containsString(Version.CURRENT.toString()));
-        assertThatTerminalOutput(containsString(Build.CURRENT.hashShort()));
-        assertThatTerminalOutput(containsString(Build.CURRENT.timestamp()));
+        assertThatTerminalOutput(containsString(Build.CURRENT.shortHash()));
+        assertThatTerminalOutput(containsString(Build.CURRENT.date()));
         assertThatTerminalOutput(containsString(JvmInfo.jvmInfo().version()));
     }
 
@@ -65,8 +65,8 @@ public class BootstrapCliParserTests extends CliToolTestCase {
         assertStatus(status, OK_AND_EXIT);
 
         assertThatTerminalOutput(containsString(Version.CURRENT.toString()));
-        assertThatTerminalOutput(containsString(Build.CURRENT.hashShort()));
-        assertThatTerminalOutput(containsString(Build.CURRENT.timestamp()));
+        assertThatTerminalOutput(containsString(Build.CURRENT.shortHash()));
+        assertThatTerminalOutput(containsString(Build.CURRENT.date()));
         assertThatTerminalOutput(containsString(JvmInfo.jvmInfo().version()));
 
         CaptureOutputTerminal terminal = new CaptureOutputTerminal();
@@ -75,8 +75,8 @@ public class BootstrapCliParserTests extends CliToolTestCase {
         assertStatus(status, OK_AND_EXIT);
 
         assertThatTerminalOutput(containsString(Version.CURRENT.toString()));
-        assertThatTerminalOutput(containsString(Build.CURRENT.hashShort()));
-        assertThatTerminalOutput(containsString(Build.CURRENT.timestamp()));
+        assertThatTerminalOutput(containsString(Build.CURRENT.shortHash()));
+        assertThatTerminalOutput(containsString(Build.CURRENT.date()));
         assertThatTerminalOutput(containsString(JvmInfo.jvmInfo().version()));
     }
 

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerUnitTests.java
@@ -78,7 +78,7 @@ public class PluginManagerUnitTests extends ESTestCase {
 
         if (supportStagingUrls) {
             String expectedStagingURL = String.format(Locale.ROOT, "https://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip",
-                    Version.CURRENT.number(), Build.CURRENT.hashShort(), pluginName, Version.CURRENT.number(), pluginName, Version.CURRENT.number());
+                    Version.CURRENT.number(), Build.CURRENT.shortHash(), pluginName, Version.CURRENT.number(), pluginName, Version.CURRENT.number());
             assertThat(iterator.next().toExternalForm(), is(expectedStagingURL));
         }
 
@@ -103,7 +103,7 @@ public class PluginManagerUnitTests extends ESTestCase {
 
         if (supportStagingUrls) {
             String expectedStagingUrl = String.format(Locale.ROOT, "https://download.elastic.co/elasticsearch/staging/%s-%s/org/elasticsearch/plugin/%s/%s/%s-%s.zip",
-                    Version.CURRENT.number(), Build.CURRENT.hashShort(), randomPluginName, Version.CURRENT.number(), randomPluginName, Version.CURRENT.number());
+                    Version.CURRENT.number(), Build.CURRENT.shortHash(), randomPluginName, Version.CURRENT.number(), randomPluginName, Version.CURRENT.number());
             assertThat(iterator.next().toExternalForm(), is(expectedStagingUrl));
         }
 


### PR DESCRIPTION
This commit restores the build properties provided in
org.elasticsearch.Build. This class previously obtained the build hash
and timestamp from a resource es-build.properties that was included in
the jar and produced by the Maven resources plugin. After the switch to
Gradle, the production of this file was lost and these build properties
defaulted to “NA” in all instances.

The most important place that the build hash is used is in the plugin
manager to determine the URL of staging artifacts for plugins.

The build hash is also used in several responses including the /_nodes
response and the response to HTTP GET requests on the root path.

These properties can now be obtained from the jar manifest as they are
currently placed there by the gradle-info plugin. However, only the
short hash is provided. We now read the manifest for these properties
and no longer provide the full hash in responses to HTTP GET requests
on the root path.
