### PR TITLE
Fork Lucene PatternTokenizer to apply LUCENE-6814

### DIFF
--- a/src/main/java/org/apache/lucene/analysis/pattern/XPatternTokenizer.java
+++ b/src/main/java/org/apache/lucene/analysis/pattern/XPatternTokenizer.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.analysis.pattern;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.Override;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.util.AttributeFactory;
+
+/**
+ * Note: This is forked from Lucene 4.10.4 org.apache.lucene.analysis.pattern.PatternTokenizer to
+ * apply LUCENE-6814.
+ *
+ * This tokenizer uses regex pattern matching to construct distinct tokens
+ * for the input stream.  It takes two arguments:  "pattern" and "group".
+ * <p/>
+ * <ul>
+ * <li>"pattern" is the regular expression.</li>
+ * <li>"group" says which group to extract into tokens.</li>
+ *  </ul>
+ * <p>
+ * group=-1 (the default) is equivalent to "split".  In this case, the tokens will
+ * be equivalent to the output from (without empty tokens):
+ * {@link String#split(java.lang.String)}
+ * </p>
+ * <p>
+ * Using group >= 0 selects the matching group as the token.  For example, if you have:<br/>
+ * <pre>
+ *  pattern = \'([^\']+)\'
+ *  group = 0
+ *  input = aaa 'bbb' 'ccc'
+ *</pre>
+ * the output will be two tokens: 'bbb' and 'ccc' (including the ' marks).  With the same input
+ * but using group=1, the output would be: bbb and ccc (no ' marks)
+ * </p>
+ * <p>NOTE: This Tokenizer does not output tokens that are of zero length.</p>
+ *
+ * @see Pattern
+ */
+public final class XPatternTokenizer extends Tokenizer {
+
+  private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+  private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+
+  private final StringBuilder str = new StringBuilder();
+  private int index;
+  
+  private final int group;
+  private final Matcher matcher;
+
+  /** creates a new PatternTokenizer returning tokens from group (-1 for split functionality) */
+  public XPatternTokenizer(Reader input, Pattern pattern, int group) {
+    this(DEFAULT_TOKEN_ATTRIBUTE_FACTORY, input, pattern, group);
+  }
+
+  /** creates a new PatternTokenizer returning tokens from group (-1 for split functionality) */
+  public XPatternTokenizer(AttributeFactory factory, Reader input, Pattern pattern, int group) {
+    super(factory, input);
+    this.group = group;
+
+    // Use "" instead of str so don't consume chars
+    // (fillBuffer) from the input on throwing IAE below:
+    matcher = pattern.matcher("");
+
+    // confusingly group count depends ENTIRELY on the pattern but is only accessible via matcher
+    if (group >= 0 && group > matcher.groupCount()) {
+      throw new IllegalArgumentException("invalid group specified: pattern only has: " + matcher.groupCount() + " capturing groups");
+    }
+  }
+
+  @Override
+  public boolean incrementToken() {
+    if (index >= str.length()) return false;
+    clearAttributes();
+    if (group >= 0) {
+    
+      // match a specific group
+      while (matcher.find()) {
+        index = matcher.start(group);
+        final int endIndex = matcher.end(group);
+        if (index == endIndex) continue;       
+        termAtt.setEmpty().append(str, index, endIndex);
+        offsetAtt.setOffset(correctOffset(index), correctOffset(endIndex));
+        return true;
+      }
+      
+      index = Integer.MAX_VALUE; // mark exhausted
+      return false;
+      
+    } else {
+    
+      // String.split() functionality
+      while (matcher.find()) {
+        if (matcher.start() - index > 0) {
+          // found a non-zero-length token
+          termAtt.setEmpty().append(str, index, matcher.start());
+          offsetAtt.setOffset(correctOffset(index), correctOffset(matcher.start()));
+          index = matcher.end();
+          return true;
+        }
+        
+        index = matcher.end();
+      }
+      
+      if (str.length() - index == 0) {
+        index = Integer.MAX_VALUE; // mark exhausted
+        return false;
+      }
+      
+      termAtt.setEmpty().append(str, index, str.length());
+      offsetAtt.setOffset(correctOffset(index), correctOffset(str.length()));
+      index = Integer.MAX_VALUE; // mark exhausted
+      return true;
+    }
+  }
+
+  @Override
+  public void end() throws IOException {
+    super.end();
+    final int ofs = correctOffset(str.length());
+    offsetAtt.setOffset(ofs, ofs);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    } finally {
+      str.setLength(0);
+      str.trimToSize();
+    }
+  }
+
+  @Override
+  public void reset() throws IOException {
+    super.reset();
+    fillBuffer(input);
+    matcher.reset(str);
+    index = 0;
+  }
+
+  // TODO: we should see if we can make this tokenizer work without reading
+  // the entire document into RAM, perhaps with Matcher.hitEnd/requireEnd ?
+  final char[] buffer = new char[8192];
+  private void fillBuffer(Reader input) throws IOException {
+    int len;
+    str.setLength(0);
+    while ((len = input.read(buffer)) > 0) {
+      str.append(buffer, 0, len);
+    }
+  }
+}

--- a/src/main/java/org/apache/lucene/analysis/pattern/XPatternTokenizer.java
+++ b/src/main/java/org/apache/lucene/analysis/pattern/XPatternTokenizer.java
@@ -1,20 +1,18 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.lucene.analysis.pattern;

--- a/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzerProvider.java
@@ -24,7 +24,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.core.StopFilter;
-import org.apache.lucene.analysis.pattern.PatternTokenizer;
+import org.apache.lucene.analysis.pattern.XPatternTokenizer;
 import org.apache.lucene.analysis.util.CharArraySet;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.Version;
@@ -62,7 +62,7 @@ public class PatternAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analy
 
         @Override
         protected TokenStreamComponents createComponents(String s, Reader reader) {
-            final TokenStreamComponents source = new TokenStreamComponents(new PatternTokenizer(reader, pattern, -1));
+            final TokenStreamComponents source = new TokenStreamComponents(new XPatternTokenizer(reader, pattern, -1));
             TokenStream result = null;
             if (lowercase) {
                  result = new LowerCaseFilter(version, source.getTokenStream());

--- a/src/main/java/org/elasticsearch/index/analysis/PatternTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/PatternTokenizerFactory.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.pattern.PatternTokenizer;
+import org.apache.lucene.analysis.pattern.XPatternTokenizer;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
@@ -52,6 +52,6 @@ public class PatternTokenizerFactory extends AbstractTokenizerFactory {
 
     @Override
     public Tokenizer create(Reader reader) {
-        return new PatternTokenizer(reader, pattern, group);
+        return new XPatternTokenizer(reader, pattern, group);
     }
 }

--- a/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenizers.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenizers.java
@@ -26,7 +26,7 @@ import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.analysis.ngram.EdgeNGramTokenizer;
 import org.apache.lucene.analysis.ngram.NGramTokenizer;
 import org.apache.lucene.analysis.path.PathHierarchyTokenizer;
-import org.apache.lucene.analysis.pattern.PatternTokenizer;
+import org.apache.lucene.analysis.pattern.XPatternTokenizer;
 import org.apache.lucene.analysis.standard.ClassicTokenizer;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizer;
@@ -117,7 +117,7 @@ public enum PreBuiltTokenizers {
     PATTERN(CachingStrategy.ONE) {
         @Override
         protected Tokenizer create(Reader reader, Version version) {
-            return new PatternTokenizer(reader, Regex.compile("\\W+", null), -1);
+            return new XPatternTokenizer(reader, Regex.compile("\\W+", null), -1);
         }
     },
 

--- a/src/test/java/org/apache/lucene/analysis/pattern/XPatternTokenizerTests.java
+++ b/src/test/java/org/apache/lucene/analysis/pattern/XPatternTokenizerTests.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.analysis.pattern;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.BaseTokenStreamTestCase;
+import org.apache.lucene.analysis.CharFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.Analyzer.TokenStreamComponents;
+import org.apache.lucene.analysis.charfilter.MappingCharFilter;
+import org.apache.lucene.analysis.charfilter.NormalizeCharMap;
+import org.apache.lucene.analysis.path.PathHierarchyTokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+public class XPatternTokenizerTests extends BaseTokenStreamTestCase
+{
+  @Test
+  public void testSplitting() throws Exception 
+  {
+    String qpattern = "\\'([^\\']+)\\'"; // get stuff between "'"
+    String[][] tests = {
+      // group  pattern        input                    output
+      { "-1",   "--",          "aaa--bbb--ccc",         "aaa bbb ccc" },
+      { "-1",   ":",           "aaa:bbb:ccc",           "aaa bbb ccc" },
+      { "-1",   "\\p{Space}",  "aaa   bbb \t\tccc  ",   "aaa bbb ccc" },
+      { "-1",   ":",           "boo:and:foo",           "boo and foo" },
+      { "-1",   "o",           "boo:and:foo",           "b :and:f" },
+      { "0",    ":",           "boo:and:foo",           ": :" },
+      { "0",    qpattern,      "aaa 'bbb' 'ccc'",       "'bbb' 'ccc'" },
+      { "1",    qpattern,      "aaa 'bbb' 'ccc'",       "bbb ccc" }
+    };
+    
+    for( String[] test : tests ) {     
+      TokenStream stream = new PatternTokenizer(newAttributeFactory(), new StringReader(test[2]), Pattern.compile(test[1]), Integer.parseInt(test[0]));
+      String out = tsToString( stream );
+      // System.out.println( test[2] + " ==> " + out );
+
+      assertEquals("pattern: "+test[1]+" with input: "+test[2], test[3], out );
+      
+      // Make sure it is the same as if we called 'split'
+      // test disabled, as we remove empty tokens
+      /*if( "-1".equals( test[0] ) ) {
+        String[] split = test[2].split( test[1] );
+        stream = tokenizer.create( new StringReader( test[2] ) );
+        int i=0;
+        for( Token t = stream.next(); null != t; t = stream.next() ) 
+        {
+          assertEquals( "split: "+test[1] + " "+i, split[i++], new String(t.termBuffer(), 0, t.termLength()) );
+        }
+      }*/
+    } 
+  }
+
+  @Test
+  public void testOffsetCorrection() throws Exception {
+    final String INPUT = "G&uuml;nther G&uuml;nther is here";
+
+    // create MappingCharFilter
+    List<String> mappingRules = new ArrayList<>();
+    mappingRules.add( "\"&uuml;\" => \"ü\"" );
+    NormalizeCharMap.Builder builder = new NormalizeCharMap.Builder();
+    builder.add("&uuml;", "ü");
+    NormalizeCharMap normMap = builder.build();
+    CharFilter charStream = new MappingCharFilter( normMap, new StringReader( INPUT ) );
+
+    // create PatternTokenizer
+    Tokenizer stream = new PatternTokenizer(newAttributeFactory(), charStream, Pattern.compile("[,;/\\s]+"), -1);
+    assertTokenStreamContents(stream,
+        new String[] { "Günther", "Günther", "is", "here" },
+        new int[] { 0, 13, 26, 29 },
+        new int[] { 12, 25, 28, 33 },
+        INPUT.length());
+    
+    charStream = new MappingCharFilter( normMap, new StringReader( INPUT ) );
+    stream = new PatternTokenizer(newAttributeFactory(), charStream, Pattern.compile("Günther"), 0);
+    assertTokenStreamContents(stream,
+        new String[] { "Günther", "Günther" },
+        new int[] { 0, 13 },
+        new int[] { 12, 25 },
+        INPUT.length());
+  }
+  
+  /** 
+   * TODO: rewrite tests not to use string comparison.
+   */
+  private static String tsToString(TokenStream in) throws IOException {
+    StringBuilder out = new StringBuilder();
+    CharTermAttribute termAtt = in.addAttribute(CharTermAttribute.class);
+    // extra safety to enforce, that the state is not preserved and also
+    // assign bogus values
+    in.clearAttributes();
+    termAtt.setEmpty().append("bogusTerm");
+    in.reset();
+    while (in.incrementToken()) {
+      if (out.length() > 0)
+        out.append(' ');
+      out.append(termAtt.toString());
+      in.clearAttributes();
+      termAtt.setEmpty().append("bogusTerm");
+    }
+
+    in.close();
+    return out.toString();
+  }
+  
+  /** blast some random strings through the analyzer */
+  @Test
+  public void testRandomStrings() throws Exception {
+    Analyzer a = new Analyzer() {
+      @Override
+      protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
+        Tokenizer tokenizer = new PatternTokenizer(newAttributeFactory(), reader, Pattern.compile("a"), -1);
+        return new TokenStreamComponents(tokenizer);
+      }    
+    };
+    checkRandomData(random(), a, 1000*RANDOM_MULTIPLIER);
+    
+    Analyzer b = new Analyzer() {
+      @Override
+      protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
+        Tokenizer tokenizer = new PatternTokenizer(newAttributeFactory(), reader, Pattern.compile("a"), 0);
+        return new TokenStreamComponents(tokenizer);
+      }    
+    };
+    checkRandomData(random(), b, 1000*RANDOM_MULTIPLIER);
+  }
+}

--- a/src/test/java/org/apache/lucene/analysis/pattern/XPatternTokenizerTests.java
+++ b/src/test/java/org/apache/lucene/analysis/pattern/XPatternTokenizerTests.java
@@ -57,7 +57,7 @@ public class XPatternTokenizerTests extends BaseTokenStreamTestCase
     };
     
     for( String[] test : tests ) {     
-      TokenStream stream = new PatternTokenizer(newAttributeFactory(), new StringReader(test[2]), Pattern.compile(test[1]), Integer.parseInt(test[0]));
+      TokenStream stream = new XPatternTokenizer(newAttributeFactory(), new StringReader(test[2]), Pattern.compile(test[1]), Integer.parseInt(test[0]));
       String out = tsToString( stream );
       // System.out.println( test[2] + " ==> " + out );
 
@@ -90,7 +90,7 @@ public class XPatternTokenizerTests extends BaseTokenStreamTestCase
     CharFilter charStream = new MappingCharFilter( normMap, new StringReader( INPUT ) );
 
     // create PatternTokenizer
-    Tokenizer stream = new PatternTokenizer(newAttributeFactory(), charStream, Pattern.compile("[,;/\\s]+"), -1);
+    Tokenizer stream = new XPatternTokenizer(newAttributeFactory(), charStream, Pattern.compile("[,;/\\s]+"), -1);
     assertTokenStreamContents(stream,
         new String[] { "Günther", "Günther", "is", "here" },
         new int[] { 0, 13, 26, 29 },
@@ -98,7 +98,7 @@ public class XPatternTokenizerTests extends BaseTokenStreamTestCase
         INPUT.length());
     
     charStream = new MappingCharFilter( normMap, new StringReader( INPUT ) );
-    stream = new PatternTokenizer(newAttributeFactory(), charStream, Pattern.compile("Günther"), 0);
+    stream = new XPatternTokenizer(newAttributeFactory(), charStream, Pattern.compile("Günther"), 0);
     assertTokenStreamContents(stream,
         new String[] { "Günther", "Günther" },
         new int[] { 0, 13 },
@@ -135,7 +135,7 @@ public class XPatternTokenizerTests extends BaseTokenStreamTestCase
     Analyzer a = new Analyzer() {
       @Override
       protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
-        Tokenizer tokenizer = new PatternTokenizer(newAttributeFactory(), reader, Pattern.compile("a"), -1);
+        Tokenizer tokenizer = new XPatternTokenizer(newAttributeFactory(), reader, Pattern.compile("a"), -1);
         return new TokenStreamComponents(tokenizer);
       }    
     };
@@ -144,7 +144,7 @@ public class XPatternTokenizerTests extends BaseTokenStreamTestCase
     Analyzer b = new Analyzer() {
       @Override
       protected TokenStreamComponents createComponents(String fieldName, Reader reader) {
-        Tokenizer tokenizer = new PatternTokenizer(newAttributeFactory(), reader, Pattern.compile("a"), 0);
+        Tokenizer tokenizer = new XPatternTokenizer(newAttributeFactory(), reader, Pattern.compile("a"), 0);
         return new TokenStreamComponents(tokenizer);
       }    
     };

--- a/src/test/java/org/apache/lucene/analysis/pattern/XPatternTokenizerTests.java
+++ b/src/test/java/org/apache/lucene/analysis/pattern/XPatternTokenizerTests.java
@@ -1,20 +1,18 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.lucene.analysis.pattern;


### PR DESCRIPTION
While LUCENE-6814 fixes #13721, it will only make it into Lucene 5.4. This will make it only available to elasticsearch 2.0.

There appears to be a very low chance of LUCENE-6814 getting fixed in 4.10, which elasticsearch 1.x uses. I've made a copy of Lucene 4.10.4 PatternTokenizer with the fix so that 1.x versions will also be able to benefit.
