### PR TITLE
IT for plugins should use plugin name and not artifactId

### DIFF
--- a/dev-tools/src/main/resources/ant/integration-tests.xml
+++ b/dev-tools/src/main/resources/ant/integration-tests.xml
@@ -293,7 +293,7 @@
 
   <!-- unzip core release artifact, install plugin, then start ES -->
   <target name="start-external-cluster-with-plugin" depends="setup-workspace">
-    <install-plugin name="${project.artifactId}" file="${project.build.directory}/releases/${project.artifactId}-${project.version}.zip"/>
+    <install-plugin name="${elasticsearch.plugin.name}" file="${project.build.directory}/releases/${project.artifactId}-${project.version}.zip"/>
     <startup-elasticsearch/>
   </target>
 


### PR DESCRIPTION
In mapper attachments plugin, we needed to change the default value for `elasticsearch.plugin.name`. It was by default `artifactId` (elasticsearch-mapper-attachments) but it should have been `mapper-attachments`.

So we changed in `pom.xml`

```
<elasticsearch.plugin.name>mapper-attachments</elasticsearch.plugin.name>
```

The problem is that integration tests expect to install a plugin which name is the `project.artifactId` and not the `elasticsearch.plugin.name`.

This commit fixes that.

Note that I have no idea on how to fix that in master branch. So I propose for now to push this in 2.x, 2.1 and 2.0 branches.
