### PR TITLE
Enforce Java 8 in Gradle builds

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -59,6 +59,11 @@ class BuildPlugin implements Plugin<Project> {
                 throw new GradleException('Gradle 2.6 or above is required to build elasticsearch')
             }
 
+            // enforce Java version
+            if (JavaVersion.current().compareTo(JavaVersion.VERSION_1_8) < 0) {
+                throw new GradleException('Java 8 or above is required to build Elasticsearch')
+            }
+
             // Build debugging info
             println '======================================='
             println 'Elasticsearch Build Hamster says Hello!'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -60,7 +60,7 @@ class BuildPlugin implements Plugin<Project> {
             }
 
             // enforce Java version
-            if (JavaVersion.current().compareTo(JavaVersion.VERSION_1_8) < 0) {
+            if (!JavaVersion.current().isJava8Compatible()) {
                 throw new GradleException('Java 8 or above is required to build Elasticsearch')
             }
 


### PR DESCRIPTION
This commit forces builds with Gradle to require at least Java 8.

Closes #14499
