### PR TITLE
Use projectsPrefix in project references for vagrant tests

### DIFF
--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -33,14 +33,14 @@ configurations {
 }
 
 dependencies {
-  test project(path: ':distribution:tar', configuration: 'archives')
+  test project("${projectsPrefix}:distribution:tar")
   // NOCOMMMIT: we need the rpm and deb!
   // test project(path: ':distribution:rpm', configuration: 'archives')
   // test project(path: ':distribution:deb', configuration: 'archives')
   // Collect all the plugins
   for (Project subproj : project.rootProject.subprojects) {
     if (subproj.path.startsWith(':plugins:')) {
-      test project(subproj.path)
+      test project("${projectsPrefix}${subproj.path}")
     }
   }
 }


### PR DESCRIPTION
It is important we use projectsPrefix whenever addinga direct project
dependency, so that attachment still works.
