### PR TITLE
Only allow rebalance operations to run if all shard store data is available

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -77,7 +77,7 @@ public class TransportRecoveryAction extends TransportBroadcastByNodeAction<Reco
             }
             String indexName = recoveryState.getShardId().getIndex();
             if (!shardResponses.containsKey(indexName)) {
-                shardResponses.put(indexName, new ArrayList<RecoveryState>());
+                shardResponses.put(indexName, new ArrayList<>());
             }
             if (request.activeOnly()) {
                 if (recoveryState.getStage() != RecoveryState.Stage.DONE) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -118,6 +118,9 @@ public class RoutingAllocation {
 
     private boolean debugDecision = false;
 
+    private boolean hasPendingAsyncFetch = false;
+
+
     /**
      * Creates a new {@link RoutingAllocation}
      * 
@@ -245,5 +248,21 @@ public class RoutingAllocation {
         } else {
             return decision;
         }
+    }
+
+    /**
+     * Returns <code>true</code> iff the current allocation run has not processed all of the in-flight or available
+     * shard or store fetches. Otherwise <code>true</code>
+     */
+    public boolean hasPendingAsyncFetch() {
+        return hasPendingAsyncFetch;
+    }
+
+    /**
+     * Sets a flag that signals that current allocation run has not processed all of the in-flight or available shard or store fetches.
+     * This state is anti-viral and can be reset in on allocation run.
+     */
+    public void setHasPendingAsyncFetch() {
+        this.hasPendingAsyncFetch = true;
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardsAllocators.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardsAllocators.java
@@ -86,9 +86,9 @@ public class ShardsAllocators extends AbstractComponent implements ShardsAllocat
              */
             return allocator.rebalance(allocation);
         } else {
-            logger.debug("skip rebalance more that on shard/store fetch operations is still in-flight");
+            logger.debug("skipping rebalance due to in-flight shard/store fetches");
+            return false;
         }
-        return false;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardsAllocators.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardsAllocators.java
@@ -76,8 +76,7 @@ public class ShardsAllocators extends AbstractComponent implements ShardsAllocat
 
     @Override
     public boolean rebalance(RoutingAllocation allocation) {
-        final int numberOfInFlightFetch = gatewayAllocator.getNumberOfInFlightFetch();
-        if (numberOfInFlightFetch == 0) {
+        if (allocation.hasPendingAsyncFetch() == false) {
             /*
              * see https://github.com/elastic/elasticsearch/issues/14387
              * if we allow rebalance operations while we are still fetching shard store data
@@ -87,7 +86,7 @@ public class ShardsAllocators extends AbstractComponent implements ShardsAllocat
              */
             return allocator.rebalance(allocation);
         } else {
-            logger.debug("skip rebalance [{}] shard store fetch operations are still in-flight", numberOfInFlightFetch);
+            logger.debug("skip rebalance more that on shard/store fetch operations is still in-flight");
         }
         return false;
     }

--- a/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -65,6 +65,7 @@ public abstract class PrimaryShardAllocator extends AbstractComponent {
             AsyncShardFetch.FetchResult<TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> shardState = fetchData(shard, allocation);
             if (shardState.hasData() == false) {
                 logger.trace("{}: ignoring allocation, still fetching shard started state", shard);
+                allocation.setHasPendingAsyncFetch();
                 unassignedIterator.removeAndIgnore();
                 continue;
             }

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -139,6 +139,7 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
             AsyncShardFetch.FetchResult<TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> shardStores = fetchData(shard, allocation);
             if (shardStores.hasData() == false) {
                 logger.trace("{}: ignoring allocation, still fetching shard stores", shard);
+                allocation.setHasPendingAsyncFetch();
                 unassignedIterator.removeAndIgnore();
                 continue; // still fetching
             }
@@ -186,6 +187,7 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
                      * see {@link org.elasticsearch.cluster.routing.RoutingService#clusterChanged(ClusterChangedEvent)}).
                      */
                     changed = true;
+                    allocation.setHasPendingAsyncFetch();
                     unassignedIterator.removeAndIgnore();
                 }
             }

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -187,7 +187,6 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
                      * see {@link org.elasticsearch.cluster.routing.RoutingService#clusterChanged(ClusterChangedEvent)}).
                      */
                     changed = true;
-                    allocation.setHasPendingAsyncFetch();
                     unassignedIterator.removeAndIgnore();
                 }
             }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -646,6 +646,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
                 .put(IndexMetaData.builder("test1").settings(settings(Version.CURRENT).put(FilterAllocationDecider.INDEX_ROUTING_EXCLUDE_GROUP + "_id", "node1,node2")).numberOfShards(2).numberOfReplicas(0))
                 .build();
 
+        // we use a second index here (test1) that never gets assigned otherwise allocateUnassinged is never called if we don't have unassigned shards.
         RoutingTable routingTable = RoutingTable.builder()
                 .addAsNew(metaData.index("test"))
                 .addAsNew(metaData.index("test1"))

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -677,6 +677,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes())
                 .put(newNode("node2")))
                 .build();
+        logger.debug("reroute and check that nothing has changed");
         RoutingAllocation.Result reroute = strategy.reroute(clusterState);
         assertFalse(reroute.changed());
         routingTable = reroute.routingTable();
@@ -690,7 +691,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
             assertThat(routingTable.index("test1").shard(i).shards().size(), equalTo(1));
             assertThat(routingTable.index("test1").shard(i).primaryShard().state(), equalTo(UNASSIGNED));
         }
-
+        logger.debug("now set hasFetches to true and reroute we should now see exactly one relocating shard");
         hasFetches.set(false);
         reroute = strategy.reroute(clusterState);
         assertTrue(reroute.changed());

--- a/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -21,10 +21,16 @@ package org.elasticsearch.recovery;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.zen.ZenDiscovery;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
@@ -122,6 +128,38 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         refresh();
         for (int i = 0; i < 10; i++) {
             assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000l);
+        }
+    }
+
+    public void testNoRebalanceOnRollingRestart() throws Exception {
+        // see https://github.com/elastic/elasticsearch/issues/14387
+        internalCluster().startMasterOnlyNode(Settings.EMPTY);
+        internalCluster().startNodesAsync(3, Settings.builder().put("node.master", false).build()).get();
+        /**
+         * We start 3 nodes and a dedicated master. Restart on of the data-nodes and ensure that we got no relocations.
+         * Yet we have 6 shards 0 replica so that means if the restarting node comes back both other nodes are subject
+         * to relocating to the restarting node since all had 2 shards and now one node has nothing allocated.
+         * We have a fix for this to wait until we have allocated unallocated shards now so this shouldn't happen.
+         */
+        prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "6").put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "0").put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING, TimeValue.timeValueMinutes(1))).get();
+
+        for (int i = 0; i < 100; i++) {
+            client().prepareIndex("test", "type1", Long.toString(i))
+                    .setSource(MapBuilder.<String, Object>newMapBuilder().put("test", "value" + i).map()).execute().actionGet();
+        }
+        ensureGreen();
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
+        for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
+            assertTrue("relocated from: " + recoveryState.getSourceNode() + " to: " + recoveryState.getTargetNode() + "\n" + state.prettyPrint(), recoveryState.getType() != RecoveryState.Type.RELOCATION);
+        }
+        internalCluster().restartRandomDataNode();
+        ensureGreen();
+        ClusterState afterState = client().admin().cluster().prepareState().get().getState();
+
+        recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
+        for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
+           assertTrue("relocated from: " + recoveryState.getSourceNode() + " to: " + recoveryState.getTargetNode()+ "-- \nbefore: \n" + state.prettyPrint() + "\nafter: \n" + afterState.prettyPrint(), recoveryState.getType() != RecoveryState.Type.RELOCATION);
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -134,7 +134,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
     public void testNoRebalanceOnRollingRestart() throws Exception {
         // see https://github.com/elastic/elasticsearch/issues/14387
         internalCluster().startMasterOnlyNode(Settings.EMPTY);
-        internalCluster().startNodesAsync(3, Settings.builder().put("node.master", false).build()).get();
+        internalCluster().startDataOnlyNodesAsync(3).get();
         /**
          * We start 3 nodes and a dedicated master. Restart on of the data-nodes and ensure that we got no relocations.
          * Yet we have 6 shards 0 replica so that means if the restarting node comes back both other nodes are subject

--- a/test-framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.gateway.GatewayAllocator;
 import org.elasticsearch.node.settings.NodeSettingsService;
 import org.elasticsearch.test.gateway.NoopGatewayAllocator;
 
@@ -77,6 +78,12 @@ public abstract class ESAllocationTestCase extends ESTestCase {
         return new AllocationService(settings,
                 randomAllocationDeciders(settings, new NodeSettingsService(Settings.Builder.EMPTY_SETTINGS), getRandom()),
                 new ShardsAllocators(settings, NoopGatewayAllocator.INSTANCE), clusterInfoService);
+    }
+
+    public static AllocationService createAllocationService(Settings settings, GatewayAllocator allocator) {
+        return new AllocationService(settings,
+                randomAllocationDeciders(settings, new NodeSettingsService(Settings.Builder.EMPTY_SETTINGS), getRandom()),
+                new ShardsAllocators(settings, allocator), EmptyClusterInfoService.INSTANCE);
     }
 
 

--- a/test-framework/src/main/java/org/elasticsearch/test/gateway/NoopGatewayAllocator.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/gateway/NoopGatewayAllocator.java
@@ -32,7 +32,7 @@ public class NoopGatewayAllocator extends GatewayAllocator {
 
     public static final NoopGatewayAllocator INSTANCE = new NoopGatewayAllocator();
 
-    private NoopGatewayAllocator() {
+    protected NoopGatewayAllocator() {
         super(Settings.EMPTY, null, null);
     }
 


### PR DESCRIPTION
This commit prevents running rebalance operations if the store allocator is
still fetching async shard / store data to prevent pre-mature rebalance decisions
which need to be reverted once shard store data is available. This is typically happening
on rolling restarts which can make those restarts extremely painful.

Closes #14387
