### PR TITLE
Build: Fix eclipse generation to add a core-tests projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,13 +97,14 @@ allprojects {
       randomizedrunner:   '2.2.0',
       httpclient:         '4.3.6'
     ]
+
+    // for eclipse hacks...
+    isEclipse = System.getProperty("eclipse.launcher") != null || gradle.startParameter.taskNames.contains('eclipse') || gradle.startParameter.taskNames.contains('cleanEclipse')
   }
 }
 
 subprojects {
   repositories {
-    // Uncomment the following line to first resolve against the maven local repo. This is useful for eclipse users who want to work on test-framework.
-    // mavenLocal()
     mavenCentral()
     maven {
       name 'sonatype-snapshots'
@@ -137,12 +138,7 @@ subprojects {
         dependencySubstitution {
           substitute module("org.elasticsearch:rest-api-spec:${version}") with project("${projectsPrefix}:rest-api-spec")
           substitute module("org.elasticsearch:elasticsearch:${version}") with project("${projectsPrefix}:core")
-          // so that eclipse doesn't have circular references
-          // the downside is, if you hack on test-framework, you have to gradle install
-          // the first prop detects eclipse itself, the second detects eclipse from commandline
-          if (System.getProperty("eclipse.launcher") == null && gradle.startParameter.taskNames.contains('eclipse') == false) {
-            substitute module("org.elasticsearch:test-framework:${version}") with project("${projectsPrefix}:test-framework")
-          }
+          substitute module("org.elasticsearch:test-framework:${version}") with project("${projectsPrefix}:test-framework")
           substitute module("org.elasticsearch.distribution.zip:elasticsearch:${version}") with project("${projectsPrefix}:distribution:zip")
           substitute module("org.elasticsearch.distribution.tar:elasticsearch:${version}") with project("${projectsPrefix}:distribution:tar")
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -89,9 +89,24 @@ dependencies {
 
   compile 'net.java.dev.jna:jna:4.1.0', optional
 
-  testCompile("org.elasticsearch:test-framework:${version}") {
-    // tests use the locally compiled version of core
-    exclude group: 'org.elasticsearch', module: 'elasticsearch'
+  if (isEclipse == false || project.path == "${projectsPrefix}:core-tests") {
+    testCompile("org.elasticsearch:test-framework:${version}") {
+      // tests use the locally compiled version of core
+      exclude group: 'org.elasticsearch', module: 'elasticsearch'
+    }
+  }
+}
+
+if (isEclipse) {
+  // in eclipse the project is under a fake root, we need to change around the source sets
+  sourceSets {
+    if (project.path == "${projectsPrefix}:core") {
+      main.java.srcDirs = ['java']
+      main.resources.srcDirs = ['resources']
+    } else {
+      test.java.srcDirs = ['java']
+      test.resources.srcDirs = ['resources']
+    }
   }
 }
 
@@ -104,19 +119,21 @@ forbiddenPatterns {
   exclude '**/org/elasticsearch/cluster/routing/shard_routes.txt'
 }
 
-task integTest(type: RandomizedTestingTask,
-               group: JavaBasePlugin.VERIFICATION_GROUP,
-               description: 'Multi-node tests',
-               dependsOn: test.dependsOn) {
-  configure(BuildPlugin.commonTestConfig(project))
-  classpath = project.test.classpath
-  testClassesDir = project.test.testClassesDir
-  include '**/*IT.class'
-}
-check.dependsOn integTest
-integTest.mustRunAfter test
+if (isEclipse == false || project.path == "${projectsPrefix}:core-tests") {
+  task integTest(type: RandomizedTestingTask,
+                 group: JavaBasePlugin.VERIFICATION_GROUP,
+                 description: 'Multi-node tests',
+                 dependsOn: test.dependsOn) {
+    configure(BuildPlugin.commonTestConfig(project))
+    classpath = project.test.classpath
+    testClassesDir = project.test.testClassesDir
+    include '**/*IT.class'
+  }
+  check.dependsOn integTest
+  integTest.mustRunAfter test
 
-RestSpecHack.configureDependencies(project)
-Task copyRestSpec = RestSpecHack.configureTask(project, true)
-integTest.dependsOn copyRestSpec
+  RestSpecHack.configureDependencies(project)
+  Task copyRestSpec = RestSpecHack.configureTask(project, true)
+  integTest.dependsOn copyRestSpec
+}
 

--- a/core/src/main/eclipse-build.gradle
+++ b/core/src/main/eclipse-build.gradle
@@ -1,0 +1,3 @@
+
+// this is just shell gradle file for eclipse to have separate projects for core src and tests
+apply from: '../../build.gradle'

--- a/core/src/test/eclipse-build.gradle
+++ b/core/src/test/eclipse-build.gradle
@@ -1,0 +1,7 @@
+
+// this is just shell gradle file for eclipse to have separate projects for core src and tests
+apply from: '../../build.gradle'
+
+dependencies {
+  testCompile project("${projectsPrefix}:core")
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name = 'elasticsearch'
 
-String[] projects = [
+List projects = [
   'rest-api-spec',
   'core',
   'distribution:zip',
@@ -35,9 +35,25 @@ String[] projects = [
   'qa:vagrant',
 ]
 
-if (hasProperty('elasticsearch.projectsPrefix')) {
-  String prefix = getProperty('elasticsearch.projectsPrefix')
-  projects = projects.collect { "${prefix}:${it}" }
+boolean isEclipse = System.getProperty("eclipse.launcher") != null || gradle.startParameter.taskNames.contains('eclipse') || gradle.startParameter.taskNames.contains('cleanEclipse')
+if (isEclipse) {
+  // eclipse cannot handle an intermediate dependency between main and test, so we must create separate projects
+  // for core-src and core-tests
+  projects << 'core-tests'
 }
 
-include projects
+String prefix = ''
+if (hasProperty('elasticsearch.projectsPrefix')) {
+  prefix = "${getProperty('elasticsearch.projectsPrefix')}:"
+  projects = projects.collect { "${prefix}${it}" }
+}
+
+include projects.toArray(new String[0])
+
+if (isEclipse) {
+  project(":${prefix}core").projectDir = new File(rootProject.projectDir, 'core/src/main')
+  project(":${prefix}core").buildFileName = 'eclipse-build.gradle'
+  project(":${prefix}core-tests").projectDir = new File(rootProject.projectDir, 'core/src/test')
+  project(":${prefix}core-tests").buildFileName = 'eclipse-build.gradle'
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,18 +42,12 @@ if (isEclipse) {
   projects << 'core-tests'
 }
 
-String prefix = ''
-if (hasProperty('elasticsearch.projectsPrefix')) {
-  prefix = "${getProperty('elasticsearch.projectsPrefix')}:"
-  projects = projects.collect { "${prefix}${it}" }
-}
-
 include projects.toArray(new String[0])
 
 if (isEclipse) {
-  project(":${prefix}core").projectDir = new File(rootProject.projectDir, 'core/src/main')
-  project(":${prefix}core").buildFileName = 'eclipse-build.gradle'
-  project(":${prefix}core-tests").projectDir = new File(rootProject.projectDir, 'core/src/test')
-  project(":${prefix}core-tests").buildFileName = 'eclipse-build.gradle'
+  project(":core").projectDir = new File(rootProject.projectDir, 'core/src/main')
+  project(":core").buildFileName = 'eclipse-build.gradle'
+  project(":core-tests").projectDir = new File(rootProject.projectDir, 'core/src/test')
+  project(":core-tests").buildFileName = 'eclipse-build.gradle'
 }
 


### PR DESCRIPTION
Eclipse does not have the ability to differentiate test dependencies
from main dependencies. This causes what looks like a circular
dependency through test-framework. This change sets up an additional
core-tests project for eclipse only, which removes this problem.
