### PR TITLE
Fix Build to correctly treat URLs and to not leak a file handle

### DIFF
--- a/core/src/main/java/org/elasticsearch/Build.java
+++ b/core/src/main/java/org/elasticsearch/Build.java
@@ -24,6 +24,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
@@ -38,14 +41,13 @@ public class Build {
         String shortHash = "Unknown";
         String date = "Unknown";
 
-        String path = Build.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-        try {
-            JarFile jar = new JarFile(path);
+        URL path = Build.class.getProtectionDomain().getCodeSource().getLocation();
+        try (JarFile jar = new JarFile(Paths.get(path.toURI()).toString())) {
             Manifest manifest = jar.getManifest();
             shortHash = manifest.getMainAttributes().getValue("Change");
             date = manifest.getMainAttributes().getValue("Build-Date");
-        } catch (IOException e) {
-            // just ignore...
+        } catch (IOException | URISyntaxException e) {
+            // just ignore... (in tests) we'll hit SecurityException if this logic is wrong (for real)
         }
 
         CURRENT = new Build(shortHash, date);

--- a/core/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
+++ b/core/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
@@ -390,7 +390,7 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
     /** ask this shard to check now whether it is inactive, and reduces its indexing and translog buffers if so.  returns Boolean.TRUE if
      *  it did deactive, Boolean.FALSE if it did not, and null if the shard is unknown */
     protected Boolean checkIdle(ShardId shardId) {
-        final String ignoreReason;
+        String ignoreReason; // eclipse compiler does not know it is really final
         final IndexShard shard = getShard(shardId);
         if (shard != null) {
             try {

--- a/core/src/test/java/org/elasticsearch/BuildTests.java
+++ b/core/src/test/java/org/elasticsearch/BuildTests.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.file.AccessMode;
+import java.nio.file.Path;
+
+public class BuildTests extends ESTestCase {
+
+    /** Asking for the jar metadata should not throw exception in tests, no matter how configured */
+    public void testJarMetadata() throws IOException {
+        Path path = Build.getElasticsearchCodebase();
+        // throws exception if does not exist, or we cannot access it
+        path.getFileSystem().provider().checkAccess(path, AccessMode.READ);
+        // these should never be null
+        assertNotNull(Build.CURRENT.date());
+        assertNotNull(Build.CURRENT.shortHash());
+    }
+}


### PR DESCRIPTION
The recent logic in Build leaks a file handle, and it incorrectly handles URLs. This means if the directory containing elasticsearch has a space, it won't work at all.

The only reasons test pass is because the gradle build is lenient about this at the moment.
