### PR TITLE
rpm uses non-portable `--system` flag to `useradd`

### DIFF
--- a/distribution/src/main/packaging/scripts/preinst
+++ b/distribution/src/main/packaging/scripts/preinst
@@ -64,7 +64,7 @@ case "$1" in
         # Create elasticsearch user if not existing
         if ! id $ES_USER > /dev/null 2>&1 ; then
             echo -n "Creating $ES_USER user..."
-            useradd --system \
+            useradd -r \
                     -M \
                     --gid "$ES_GROUP" \
                     --shell /sbin/nologin \


### PR DESCRIPTION
This PR provides a fix for https://github.com/elastic/elasticsearch/issues/14211
