### PR TITLE
Enforce name is set for all plugins

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -42,29 +42,28 @@ class PluginPropertiesTask extends Copy {
         }
         dependsOn(copyPluginPropertiesTemplate)
         extension = project.extensions.create('esplugin', PluginPropertiesExtension, project)
-        project.clean {
-            delete generatedResourcesDir
-        }
+        project.clean.delete(generatedResourcesDir)
         project.afterEvaluate {
             // check require properties are set
+            if (extension.name == null) {
+                throw new InvalidUserDataException('name is a required setting for esplugin')
+            }
             if (extension.description == null) {
                 throw new InvalidUserDataException('description is a required setting for esplugin')
             }
             if (extension.jvm && extension.classname == null) {
                 throw new InvalidUserDataException('classname is a required setting for esplugin with jvm=true')
             }
-            configure {
-                doFirst {
-                    if (extension.jvm && extension.isolated == false) {
-                        String warning = "WARNING: Disabling plugin isolation in ${project.name} is deprecated and will be removed in the future"
-                        logger.warn("${'=' * warning.length()}\n${warning}\n${'=' * warning.length()}")
-                    }
+            doFirst {
+                if (extension.jvm && extension.isolated == false) {
+                    String warning = "WARNING: Disabling plugin isolation in ${project.path} is deprecated and will be removed in the future"
+                    logger.warn("${'=' * warning.length()}\n${warning}\n${'=' * warning.length()}")
                 }
-                // configure property substitution
-                from templateFile
-                into generatedResourcesDir
-                expand(generateSubstitutions())
             }
+            // configure property substitution
+            from(templateFile)
+            into(generatedResourcesDir)
+            expand(generateSubstitutions())
         }
     }
 

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -25,6 +25,11 @@ subprojects {
   apply plugin: 'elasticsearch.esplugin'
   apply plugin: 'com.bmuschko.nexus'
 
+  esplugin {
+    // for local ES plugins, the name of the plugin is the same as the directory
+    name project.name
+  }
+
   Task dependencyLicensesTask = DependencyLicensesTask.configure(project) {
     dependencies = project.configurations.runtime - project.configurations.provided
   }


### PR DESCRIPTION
The plugin name currently defaults to the gradle project name. But the
gradle project name for standalone repo (like an external plugin would
be) defaults to the directory name of the repo. This is trappy, since it
depends on how the repo was checked out.

This change enforces the plugin name is always set.

closes #14603
