### PR TITLE
Use always set java.home

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -279,7 +279,7 @@ class ClusterFormationTasks {
             onlyIf { pidFile.exists() }
             // the pid file won't actually be read until execution time, since the read is wrapped within an inner closure of the GString
             ext.pid = "${ -> pidFile.getText('UTF-8').trim()}"
-            commandLine new File(System.getenv('JAVA_HOME'), 'bin/jps'), '-l'
+            commandLine new File(System.getProperty('java.home'), 'bin/jps'), '-l'
             standardOutput = new ByteArrayOutputStream()
             doLast {
                 String out = standardOutput.toString()


### PR DESCRIPTION
`System.getenv('JAVA_HOME')` relies on JAVA_HOME being setup by the user.
`System.getProperty('java.home')` is set by Java all the time.

Closes #14614
