### PR TITLE
Add javadocs to IndexingStats.Stats

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java
+++ b/core/src/main/java/org/elasticsearch/index/indexing/IndexingStats.java
@@ -43,19 +43,14 @@ public class IndexingStats implements Streamable, ToXContent {
         private long indexTimeInMillis;
         private long indexCurrent;
         private long indexFailedCount;
-
         private long deleteCount;
         private long deleteTimeInMillis;
         private long deleteCurrent;
-
         private long noopUpdateCount;
-
         private long throttleTimeInMillis;
         private boolean isThrottled;
 
-        Stats() {
-
-        }
+        Stats() {}
 
         public Stats(long indexCount, long indexTimeInMillis, long indexCurrent, long indexFailedCount, long deleteCount, long deleteTimeInMillis, long deleteCurrent, long noopUpdateCount, boolean isThrottled, long throttleTimeInMillis) {
             this.indexCount = indexCount;
@@ -87,26 +82,29 @@ public class IndexingStats implements Streamable, ToXContent {
             }
         }
 
-        public long getIndexCount() {
-            return indexCount;
-        }
+        /**
+         * The total number of indexing operations
+         */
+        public long getIndexCount() { return indexCount; }
 
-        public long getIndexFailedCount() {
-            return indexFailedCount;
-        }
+        /**
+         * The number of failed indexing operations
+         */
+        public long getIndexFailedCount() { return indexFailedCount; }
 
-        public TimeValue getIndexTime() {
-            return new TimeValue(indexTimeInMillis);
-        }
+        /**
+         * The total amount of time spend on executing index operations.
+         */
+        public TimeValue getIndexTime() { return new TimeValue(indexTimeInMillis); }
 
-        public long getIndexTimeInMillis() {
-            return indexTimeInMillis;
-        }
+        /**
+         * Returns the currently in-flight indexing operations.
+         */
+        public long getIndexCurrent() { return indexCurrent;}
 
-        public long getIndexCurrent() {
-            return indexCurrent;
-        }
-
+        /**
+         * Returns the number of delete operation executed
+         */
         public long getDeleteCount() {
             return deleteCount;
         }
@@ -114,32 +112,21 @@ public class IndexingStats implements Streamable, ToXContent {
         /**
          * Returns if the index is under merge throttling control
          */
-        public boolean isThrottled() {
-            return isThrottled;
-        }
-
-        /**
-         * Gets the amount of time in milliseconds that the index has been under merge throttling control
-         */
-        public long getThrottleTimeInMillis() {
-            return throttleTimeInMillis;
-        }
+        public boolean isThrottled() { return isThrottled; }
 
         /**
          * Gets the amount of time in a TimeValue that the index has been under merge throttling control
          */
-        public TimeValue getThrottleTime() {
-            return new TimeValue(throttleTimeInMillis);
-        }
+        public TimeValue getThrottleTime() { return new TimeValue(throttleTimeInMillis); }
 
-        public TimeValue getDeleteTime() {
-            return new TimeValue(deleteTimeInMillis);
-        }
+        /**
+         * The total amount of time spend on executing delete operations.
+         */
+        public TimeValue getDeleteTime() { return new TimeValue(deleteTimeInMillis); }
 
-        public long getDeleteTimeInMillis() {
-            return deleteTimeInMillis;
-        }
-
+        /**
+         * Returns the currently in-flight delete operations
+         */
         public long getDeleteCurrent() {
             return deleteCurrent;
         }

--- a/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -301,7 +301,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         //nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).get();
 
         stats = client().admin().indices().prepareStats().execute().actionGet();
-        assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTimeInMillis(), equalTo(0l));
+        assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis(), equalTo(0l));
     }
 
     public void testThrottleStats() throws Exception {
@@ -339,7 +339,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             refresh();
             stats = client().admin().indices().prepareStats().execute().actionGet();
             //nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).get();
-            done = stats.getPrimaries().getIndexing().getTotal().getThrottleTimeInMillis() > 0;
+            done = stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis() > 0;
             if (System.currentTimeMillis() - start > 300*1000) { //Wait 5 minutes for throttling to kick in
                 fail("index throttling didn't kick in after 5 minutes of intense merging");
             }
@@ -374,7 +374,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexCount(), equalTo(3l));
         assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexFailedCount(), equalTo(0l));
         assertThat(stats.getPrimaries().getIndexing().getTotal().isThrottled(), equalTo(false));
-        assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTimeInMillis(), equalTo(0l));
+        assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis(), equalTo(0l));
         assertThat(stats.getTotal().getIndexing().getTotal().getIndexCount(), equalTo(totalExpectedWrites));
         assertThat(stats.getTotal().getStore(), notNullValue());
         assertThat(stats.getTotal().getMerge(), notNullValue());


### PR DESCRIPTION
This commit adds some basic javadocs to IndexingStats.Stats.
A user on the forum asked for what getIndexingCurrent is so I figured
i can just fix it in the code.
