### PR TITLE
More BWC hardening

### DIFF
--- a/dev-tools/src/main/resources/shared-test-resources/log4j.properties
+++ b/dev-tools/src/main/resources/shared-test-resources/log4j.properties
@@ -4,6 +4,13 @@ log4j.rootLogger=${es.logger.level}, out
 log4j.logger.org.apache.http=INFO, out
 log4j.additivity.org.apache.http=false
 
+log4j.logger.test.external=${es.logger.level}, unformatted
+log4j.additivity.test.external=false
+
 log4j.appender.out=org.apache.log4j.ConsoleAppender
 log4j.appender.out.layout=org.apache.log4j.PatternLayout
 log4j.appender.out.layout.conversionPattern=[%d{ISO8601}][%-5p][%-25c] %m%n
+
+log4j.appender.unformatted=org.apache.log4j.ConsoleAppender
+log4j.appender.unformatted.layout=org.apache.log4j.PatternLayout
+log4j.appender.unformatted.layout.conversionPattern=%m%n

--- a/qa/backwards/shared/src/main/java/org/elasticsearch/test/ExternalNodeService.java
+++ b/qa/backwards/shared/src/main/java/org/elasticsearch/test/ExternalNodeService.java
@@ -384,15 +384,16 @@ public class ExternalNodeService {
             Future<Matcher> f = readLines.submit(new Callable<Matcher>() {
                 @Override
                 public Matcher call() throws IOException {
+                    ESLogger unformattedLogger = ESLoggerFactory.getLogger("test.external");
                     reader.mark(1024 * 1024);
                     String line;
                     while ((line = reader.readLine()) != null) {
                         Matcher m = compiled.matcher(line);
                         if (m.matches()) {
-                            logger.debug("Elasticsearch logged {}", line);
+                            unformattedLogger.debug(line);
                             return m;
                         } else {
-                            logger.trace("Elasticsearch logged {}", line);
+                            unformattedLogger.trace(line);
                         }
                     }
                     return null;

--- a/qa/backwards/shared/src/test/java/org/elasticsearch/test/ESBackcompatTestCase.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/test/ESBackcompatTestCase.java
@@ -84,9 +84,6 @@ import static org.hamcrest.Matchers.is;
  */
 // the transportClientRatio is tricky here since we don't fully control the cluster nodes
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 0, maxNumDataNodes = 2, scope = ESIntegTestCase.Scope.SUITE, numClientNodes = 0, transportClientRatio = 0.0)
-@ReproduceInfoPrinter.Properties({ ESBackcompatTestCase.TESTS_BACKWARDS_COMPATIBILITY,
-        ESBackcompatTestCase.TESTS_BACKWARDS_COMPATIBILITY_VERSION, ESBackcompatTestCase.TESTS_BACKWARDS_COMPATIBILITY_PATH,
-        ESBackcompatTestCase.TESTS_COMPATIBILITY })
 public abstract class ESBackcompatTestCase extends ESIntegTestCase {
     /**
      * Key used to set the path for the elasticsearch executable used to run backwards compatibility tests from


### PR DESCRIPTION
1. Nicer output format for when nodes fail to form a cluster or when TRACE
   logging its output.
2. Don't log reproduction options that are implied by the project.
3. ExternalNode should fail the test if it wasn't fed a port range. Because
   not having a port range is very likely to cause the tests to break each
   other.
