### PR TITLE
Fix automatic installation of plugin for integ tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -49,7 +49,7 @@ class PluginBuildPlugin extends BuildPlugin {
             project.integTest.configure {
                 dependsOn project.bundlePlugin
                 cluster {
-                    plugin project.name, project.bundlePlugin.outputs.files
+                    plugin project.pluginProperties.extension.name, project.bundlePlugin.outputs.files
                 }
             }
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -105,7 +105,7 @@ class ClusterFormationTasks {
         for (Map.Entry<String, FileCollection> plugin : config.plugins.entrySet()) {
             // replace every dash followed by a character with just the uppercase character
             String camelName = plugin.getKey().replaceAll(/-(\w)/) { _, c -> c.toUpperCase(Locale.ROOT) }
-            String taskName = "${task.name}#install${camelName[0].toUpperCase(Locale.ROOT) + camelName.substring(1)}"
+            String taskName = "${task.name}#install${camelName[0].toUpperCase(Locale.ROOT) + camelName.substring(1)}Plugin"
             // delay reading the file location until execution time by wrapping in a closure within a GString
             String file = "${ -> new File(pluginsTmpDir, plugin.getValue().singleFile.getName()).toURI().toURL().toString() }"
             Object[] args = [new File(home, 'bin/plugin'), 'install', file]
@@ -177,12 +177,10 @@ class ClusterFormationTasks {
         if (config.plugins.isEmpty()) {
             return setup
         }
-        // collect the files for plugins into a list, but wrap each in a closure to delay
-        // looking for the filename until execution time
-        List files = config.plugins.values().collect { plugin -> return { plugin.singleFile } }
+
         return project.tasks.create(name: name, type: Copy, dependsOn: setup) {
             into pluginsTmpDir
-            from(*files) // spread the list into varargs
+            from(config.plugins.values())
         }
     }
 


### PR DESCRIPTION
The esplugin gradle plugin automatically adds the pluging being built to the integTest cluster. However, there were two issues with this. First was a bug in the name, which should have been the configured
esplugin.name instead of the project name. Second, the files configuration was overcomplicated (trying to use the groovy spreader operator after delaying calls to singleFile). Instead, we can just pass the file collections (which will just be a single file at execution time).
