### PR TITLE
[Ingest] Geoip improvements

### DIFF
--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -309,18 +309,19 @@ is located at `$ES_HOME/config/ingest/geoip` and holds the shipped databases too
 .Geoip options
 [options="header"]
 |======
-| Name                   | Required  | Default             | Description
-| `ip_field`             | yes       | -                   | The field to get the ip address from for the geographical lookup.
-| `target_field`         | no        | geoip               | The field that will hold the geographical information looked up from the Maxmind database.
-| `database_file`        | no        | GeoLite2-City.mmdb  | The database filename in the geoip config directory. The ingest plugin ships with the GeoLite2-City.mmdb and GeoLite2-Country.mmdb files.
+| Name                   | Required  | Default                                                                            | Description
+| `source_field`         | yes       | -                                                                                  | The field to get the ip address or hostname from for the geographical lookup.
+| `target_field`         | no        | geoip                                                                              | The field that will hold the geographical information looked up from the Maxmind database.
+| `database_file`        | no        | GeoLite2-City.mmdb                                                                 | The database filename in the geoip config directory. The ingest plugin ships with the GeoLite2-City.mmdb and GeoLite2-Country.mmdb files.
+| `fields`               | no        | [`continent_name`, `country_iso_code`, `region_name`, `city_name`, `location`] <1> | Controls what properties are added to the `target_field` based on the geoip lookup.
 |======
 
-If the GeoLite2 City database is used then the following fields will be added under the `target_field`: `ip`,
+<1> Depends on what is available in `database_field`:
+* If the GeoLite2 City database is used then the following fields may be added under the `target_field`: `ip`,
 `country_iso_code`, `country_name`, `continent_name`, `region_name`, `city_name`, `timezone`, `latitude`, `longitude`
-and `location`.
-
-If the GeoLite2 Country database is used then the following fields will be added under the `target_field`: `ip`,
-`country_iso_code`, `country_name` and `continent_name`.
+and `location`. The fields actually added depend on what has been found and which fields were configured in `fields`.
+* If the GeoLite2 Country database is used then the following fields may be added under the `target_field`: `ip`,
+`country_iso_code`, `country_name` and `continent_name`.The fields actually added depend on what has been found and which fields were configured in `fields`.
 
 An example that uses the default city database and adds the geographical information to the `geoip` field based on the `ip` field:
 
@@ -331,7 +332,7 @@ An example that uses the default city database and adds the geographical informa
   "processors" : [
     {
       "geoip" : {
-        "ip_field" : "ip"
+        "source_field" : "ip"
       }
     }
   ]
@@ -347,7 +348,7 @@ An example that uses the default country database and add the geographical infor
   "processors" : [
     {
       "geoip" : {
-        "ip_field" : "ip",
+        "source_field" : "ip",
         "target_field" : "geo",
         "database_file" : "GeoLite2-Country.mmdb"
       }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/geoip/GeoIpProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/geoip/GeoIpProcessorTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ingest.Data;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.InputStream;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testCity() throws Exception {
         InputStream database = GeoIpProcessor.class.getResourceAsStream("/GeoLite2-City.mmdb");
-        GeoIpProcessor processor = new GeoIpProcessor("source_field", new DatabaseReader.Builder(database).build(), "target_field");
+        GeoIpProcessor processor = new GeoIpProcessor("source_field", new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Field.class));
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "82.170.213.79");
@@ -59,7 +60,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testCountry() throws Exception {
         InputStream database = GeoIpProcessor.class.getResourceAsStream("/GeoLite2-Country.mmdb");
-        GeoIpProcessor processor = new GeoIpProcessor("source_field", new DatabaseReader.Builder(database).build(), "target_field");
+        GeoIpProcessor processor = new GeoIpProcessor("source_field", new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Field.class));
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "82.170.213.79");
@@ -79,7 +80,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testAddressIsNotInTheDatabase() throws Exception {
         InputStream database = GeoIpProcessor.class.getResourceAsStream("/GeoLite2-City.mmdb");
-        GeoIpProcessor processor = new GeoIpProcessor("source_field", new DatabaseReader.Builder(database).build(), "target_field");
+        GeoIpProcessor processor = new GeoIpProcessor("source_field", new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Field.class));
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "202.45.11.11");

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/50_geoip_processor.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/50_geoip_processor.yaml
@@ -13,7 +13,59 @@
             "processors": [
               {
                 "geoip" : {
-                  "ip_field" : "field1"
+                  "source_field" : "field1"
+                }
+              }
+            ]
+          }
+  - match: { _id: "my_pipeline" }
+
+  # Simulate a Thread.sleep(), because pipeline are updated in the background
+  - do:
+      catch: request_timeout
+      cluster.health:
+        wait_for_nodes: 99
+        timeout: 2s
+  - match: { "timed_out": true }
+
+  - do:
+      ingest.index:
+        index: test
+        type: test
+        id: 1
+        pipeline_id: "my_pipeline"
+        body: {field1: "128.101.101.101"}
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.field1: "128.101.101.101" }
+  - length: { _source.geoip: 5 }
+  - match: { _source.geoip.city_name: "Minneapolis" }
+  - match: { _source.geoip.country_iso_code: "US" }
+  - match: { _source.geoip.location: [-93.2166, 44.9759] }
+  - match: { _source.geoip.region_name: "Minnesota" }
+  - match: { _source.geoip.continent_name: "North America" }
+
+---
+"Test geoip processor with fields":
+  - do:
+      cluster.health:
+          wait_for_status: green
+
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "geoip" : {
+                  "source_field" : "field1",
+                  "fields" : ["city_name", "country_iso_code", "ip", "latitude", "longitude", "location", "timezone", "country_name", "region_name", "continent_name"]
                 }
               }
             ]
@@ -69,7 +121,7 @@
             "processors": [
               {
                 "geoip" : {
-                  "ip_field" : "field1",
+                  "source_field" : "field1",
                   "database_file" : "GeoLite2-Country.mmdb"
                 }
               }
@@ -99,8 +151,6 @@
         type: test
         id: 1
   - match: { _source.field1: "128.101.101.101" }
-  - length: { _source.geoip: 4 }
+  - length: { _source.geoip: 2 }
   - match: { _source.geoip.country_iso_code: "US" }
-  - match: { _source.geoip.ip: "128.101.101.101" }
-  - match: { _source.geoip.country_name: "United States" }
   - match: { _source.geoip.continent_name: "North America" }


### PR DESCRIPTION
- renamed `ip_field` option to `source_field`, because it can contain a ip or hostname.
- added a new `fields` option to control what fields are added by geoip processor
- instead of by default adding all fields, only `country_code`, `city_name`, `location`, `continent_name` and `region_name` fields are added by default.
