### PR TITLE
Consolidate dependencies specified in multiple places

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ buildscript {
 
 // common maven publishing configuration
 subprojects {
+  group = 'org.elasticsearch'
+  version = org.elasticsearch.gradle.VersionProperties.elasticsearch
+
   plugins.withType(NexusPlugin).whenPluginAdded {
     modifyPom {
       project {
@@ -91,34 +94,12 @@ allprojects {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = sourceCompatibility
 
-    // dependency versions that are used in more than one place
-    versions = [
-      lucene:             "${luceneVersion}",
-      randomizedrunner:   '2.2.0',
-      httpclient:         '4.3.6'
-    ]
-
     // for eclipse hacks...
     isEclipse = System.getProperty("eclipse.launcher") != null || gradle.startParameter.taskNames.contains('eclipse') || gradle.startParameter.taskNames.contains('cleanEclipse')
   }
 }
 
 subprojects {
-  repositories {
-    mavenCentral()
-    maven {
-      name 'sonatype-snapshots'
-      url 'http://oss.sonatype.org/content/repositories/snapshots/'
-    }
-    if (versions.lucene.contains('-snapshot')) {
-      String revision = (luceneVersion =~ /\d\.\d\.\d-snapshot-(\d+)/)[0][1]
-      maven {
-        name 'lucene-snapshots'
-        url "http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/${revision}"
-      }
-    }
-  }
-
   // include license and notice in jars
   gradle.projectsEvaluated {
     tasks.withType(Jar) {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,4 +1,21 @@
-import org.apache.tools.ant.filters.ReplaceTokens
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 plugins {
   id 'groovy'
@@ -8,15 +25,12 @@ plugins {
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 
-/*idea {
-  project {
-    languageLevel = '1.8'
-    vcs = 'Git'
-  }
-}*/
-
 group = 'org.elasticsearch.gradle'
 archivesBaseName = 'build-tools'
+
+Properties props = new Properties()
+props.load(project.file('version.properties').newDataInputStream())
+version = props.getProperty('elasticsearch')
 
 repositories {
   mavenCentral()
@@ -30,8 +44,8 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'com.carrotsearch.randomizedtesting:junit4-ant:2.2.0'
-  compile('junit:junit:4.11') {
+  compile "com.carrotsearch.randomizedtesting:junit4-ant:${props.getProperty('randomizedrunner')}"
+  compile("junit:junit:${props.getProperty('junit')}") {
     transitive = false
   }
   compile 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3'
@@ -41,25 +55,12 @@ dependencies {
   compile 'de.thetaphi:forbiddenapis:2.0'
 }
 
-Properties props = new Properties()
-props.load(project.file('../gradle.properties').newDataInputStream())
-version = props.getProperty('version')
-
 processResources {
-  inputs.file('../gradle.properties')
-  filter ReplaceTokens, tokens: [
-    'version': props.getProperty('version'),
-    'luceneVersion': props.getProperty('luceneVersion')
-  ]
+  inputs.file('version.properties')
+  from 'version.properties'
 }
 
 extraArchive {
   javadoc = false
   tests = false
-}
-
-eclipse {
-  classpath {
-    defaultOutputDir = new File(file('build'), 'eclipse')
-  }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -64,3 +64,9 @@ extraArchive {
   javadoc = false
   tests = false
 }
+
+eclipse {
+  classpath {
+    defaultOutputDir = new File(file('build'), 'eclipse')
+  }
+}

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/VersionProperties.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/VersionProperties.groovy
@@ -19,19 +19,23 @@
 package org.elasticsearch.gradle
 
 /**
- * Accessor for properties about the version of elasticsearch this was built with.
+ * Accessor for shared dependency versions used by elasticsearch, namely the elasticsearch and lucene versions.
  */
-class ElasticsearchProperties {
-    static final String version
-    static final String luceneVersion
+class VersionProperties {
+    static final String elasticsearch
+    static final String lucene
+    static final Map<String, String> versions = new HashMap<>()
     static {
         Properties props = new Properties()
-        InputStream propsStream = ElasticsearchProperties.class.getResourceAsStream('/elasticsearch.properties')
+        InputStream propsStream = VersionProperties.class.getResourceAsStream('/version.properties')
         if (propsStream == null) {
-            throw new RuntimeException('/elasticsearch.properties resource missing')
+            throw new RuntimeException('/version.properties resource missing')
         }
         props.load(propsStream)
-        version = props.getProperty('version')
-        luceneVersion = props.getProperty('luceneVersion')
+        elasticsearch = props.getProperty('elasticsearch')
+        lucene = props.getProperty('lucene')
+        for (String property : props.stringPropertyNames()) {
+            versions.put(property, props.getProperty(property))
+        }
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -20,7 +20,6 @@ package org.elasticsearch.gradle.plugin
 
 import nebula.plugin.extraconfigurations.ProvidedBasePlugin
 import org.elasticsearch.gradle.BuildPlugin
-import org.elasticsearch.gradle.ElasticsearchProperties
 import org.elasticsearch.gradle.test.RestIntegTestTask
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -64,20 +63,18 @@ class PluginBuildPlugin extends BuildPlugin {
     }
 
     static void configureDependencies(Project project) {
-        String elasticsearchVersion = ElasticsearchProperties.version
         project.dependencies {
-            provided "org.elasticsearch:elasticsearch:${elasticsearchVersion}"
-            testCompile "org.elasticsearch:test-framework:${elasticsearchVersion}"
+            provided "org.elasticsearch:elasticsearch:${project.versions.elasticsearch}"
+            testCompile "org.elasticsearch:test-framework:${project.versions.elasticsearch}"
             // we "upgrade" these optional deps to provided for plugins, since they will run
             // with a full elasticsearch server that includes optional deps
-            // TODO: remove duplication of version here with core...
-            provided 'com.spatial4j:spatial4j:0.4.1'
-            provided 'com.vividsolutions:jts:1.13'
-            provided 'com.github.spullara.mustache.java:compiler:0.9.1'
-            provided "log4j:log4j:1.2.17"
-            provided "log4j:apache-log4j-extras:1.2.17"
-            provided "org.slf4j:slf4j-api:1.6.2"
-            provided 'net.java.dev.jna:jna:4.1.0'
+            provided "com.spatial4j:spatial4j:${project.versions.spatial4j}"
+            provided "com.vividsolutions:jts:${project.versions.jts}"
+            provided "com.github.spullara.mustache.java:compiler:${project.versions.mustache}"
+            provided "log4j:log4j:${project.versions.log4j}"
+            provided "log4j:apache-log4j-extras:${project.versions.log4j}"
+            provided "org.slf4j:slf4j-api:${project.versions.slf4j}"
+            provided "net.java.dev.jna:jna:${project.versions.jna}"
         }
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.gradle.plugin
 
-import org.elasticsearch.gradle.ElasticsearchProperties
+import org.elasticsearch.gradle.VersionProperties
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Task
 import org.gradle.api.tasks.Copy
@@ -72,7 +72,7 @@ class PluginPropertiesTask extends Copy {
             'name': extension.name,
             'description': extension.description,
             'version': extension.version,
-            'elasticsearchVersion': ElasticsearchProperties.version,
+            'elasticsearchVersion': VersionProperties.elasticsearch,
             'javaVersion': project.targetCompatibility as String,
             'jvm': extension.jvm as String,
             'site': extension.site as String,

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -23,7 +23,7 @@ import org.gradle.internal.jvm.Jvm
 import java.nio.file.Paths
 
 import org.apache.tools.ant.taskdefs.condition.Os
-import org.elasticsearch.gradle.ElasticsearchProperties
+import org.elasticsearch.gradle.VersionProperties
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
@@ -56,7 +56,7 @@ class ClusterFormationTasks {
 
     /** Adds a dependency on the given distribution */
     static void configureDistributionDependency(Project project, String distro) {
-        String elasticsearchVersion = ElasticsearchProperties.version
+        String elasticsearchVersion = VersionProperties.elasticsearch
         String packaging = distro == 'tar' ? 'tar.gz' : distro
         project.configurations {
             elasticsearchDistro
@@ -336,7 +336,7 @@ class ClusterFormationTasks {
         switch (distro) {
             case 'zip':
             case 'tar':
-                path = "elasticsearch-${ElasticsearchProperties.version}"
+                path = "elasticsearch-${VersionProperties.elasticsearch}"
                 break;
             default:
                 throw new InvalidUserDataException("Unknown distribution: ${distro}")

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestSpecHack.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestSpecHack.groovy
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.gradle.test
 
-import org.elasticsearch.gradle.ElasticsearchProperties
+import org.elasticsearch.gradle.VersionProperties
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.Copy
@@ -38,7 +38,7 @@ class RestSpecHack {
             restSpec
         }
         project.dependencies {
-            restSpec "org.elasticsearch:rest-api-spec:${ElasticsearchProperties.version}"
+            restSpec "org.elasticsearch:rest-api-spec:${VersionProperties.elasticsearch}"
         }
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestBasePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestBasePlugin.groovy
@@ -21,7 +21,8 @@
 package org.elasticsearch.gradle.test
 
 import com.carrotsearch.gradle.junit4.RandomizedTestingPlugin
-import org.elasticsearch.gradle.ElasticsearchProperties
+import org.elasticsearch.gradle.BuildPlugin
+import org.elasticsearch.gradle.VersionProperties
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
@@ -31,6 +32,8 @@ class StandaloneTestBasePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        BuildPlugin.configureRepositories(project)
+
         project.pluginManager.apply(JavaBasePlugin)
         project.pluginManager.apply(RandomizedTestingPlugin)
 
@@ -42,7 +45,7 @@ class StandaloneTestBasePlugin implements Plugin<Project> {
             test
         }
         project.dependencies {
-            testCompile "org.elasticsearch:test-framework:${ElasticsearchProperties.version}"
+            testCompile "org.elasticsearch:test-framework:${VersionProperties.elasticsearch}"
         }
 
         project.eclipse {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestPlugin.groovy
@@ -21,7 +21,6 @@ package org.elasticsearch.gradle.test
 
 import com.carrotsearch.gradle.junit4.RandomizedTestingTask
 import org.elasticsearch.gradle.BuildPlugin
-import org.elasticsearch.gradle.ElasticsearchProperties
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,0 +1,17 @@
+elasticsearch     = 3.0.0-SNAPSHOT
+lucene            = 5.4.0-snapshot-1712973
+
+# optional dependencies
+spatial4j         = 0.5
+jts               = 1.13
+mustache          = 0.9.1
+jackson           = 2.6.2
+log4j             = 1.2.17
+slf4j             = 1.6.2
+jna               = 4.1.0
+
+
+# test dependencies
+randomizedrunner  = 2.2.0
+junit             = 4.11
+httpclient        = 4.3.6

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,12 +27,6 @@ apply plugin: 'nebula.optional-base'
 
 archivesBaseName = 'elasticsearch'
 
-versions << [
-  jackson:  '2.6.2',
-  log4j:    '1.2.17',
-  slf4j:    '1.6.2'
-]
-
 dependencies {
 
   // lucene
@@ -76,18 +70,18 @@ dependencies {
   compile 'org.hdrhistogram:HdrHistogram:2.1.6'
 
   // lucene spatial
-  compile 'com.spatial4j:spatial4j:0.5', optional
-  compile 'com.vividsolutions:jts:1.13', optional
+  compile "com.spatial4j:spatial4j:${versions.spatial4j}", optional
+  compile "com.vividsolutions:jts:${versions.jts}", optional
 
   // templating
-  compile 'com.github.spullara.mustache.java:compiler:0.9.1', optional
+  compile "com.github.spullara.mustache.java:compiler:${versions.mustache}", optional
 
   // logging
   compile "log4j:log4j:${versions.log4j}", optional
   compile "log4j:apache-log4j-extras:${versions.log4j}", optional
   compile "org.slf4j:slf4j-api:${versions.slf4j}", optional
 
-  compile 'net.java.dev.jna:jna:4.1.0', optional
+  compile "net.java.dev.jna:jna:${versions.jna}", optional
 
   if (isEclipse == false || project.path == "${projectsPrefix}:core-tests") {
     testCompile("org.elasticsearch:test-framework:${version}") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,0 @@
-group=org.elasticsearch
-version=3.0.0-SNAPSHOT
-luceneVersion=5.4.0-snapshot-1712973

--- a/plugins/mapper-attachments/build.gradle
+++ b/plugins/mapper-attachments/build.gradle
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import org.elasticsearch.gradle.ElasticsearchProperties
-
 esplugin {
   name 'mapper-attachments'
   description 'The mapper attachments plugin adds the attachment type to Elasticsearch using Apache Tika.'

--- a/test-framework/build.gradle
+++ b/test-framework/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.bmuschko.nexus'
 dependencies {
   compile "org.elasticsearch:elasticsearch:${version}"
   compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  compile(group: 'junit', name: 'junit', version: '4.11') {
+  compile("junit:junit:${versions.junit}") {
     exclude group: 'org.hamcrest', module: 'hamcrest-core'
   }
   compile("org.apache.lucene:lucene-test-framework:${versions.lucene}") {


### PR DESCRIPTION
Some dependencies must be specified in a couple places in the build.
e.g. randomized runner is specified both in buildSrc (for the gradle
wrapper plugin), as well as in the test-framework.

This change creates buildSrc/version.properties which acts similar to
the set of shared version properties we used to have in the maven parent
pom.
