### PR TITLE
Fix IndexSearcherWrapper interface to not depend on the EngineConfig

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -727,7 +727,7 @@ public class IndexShard extends AbstractIndexShardComponent {
         final Engine.Searcher searcher = engine.acquireSearcher(source);
         boolean success = false;
         try {
-            final Engine.Searcher wrappedSearcher = searcherWrapper == null ? searcher : searcherWrapper.wrap(engineConfig, searcher);
+            final Engine.Searcher wrappedSearcher = searcherWrapper == null ? searcher : searcherWrapper.wrap(searcher);
             assert wrappedSearcher != null;
             success = true;
             return wrappedSearcher;

--- a/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -385,7 +385,7 @@ public class IndexModuleTests extends ESTestCase {
         }
 
         @Override
-        public IndexSearcher wrap(EngineConfig engineConfig, IndexSearcher searcher) throws EngineException {
+        public IndexSearcher wrap(IndexSearcher searcher) throws EngineException {
             return null;
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -519,7 +519,7 @@ public class InternalEngineTests extends ESTestCase {
             }
 
             @Override
-            public IndexSearcher wrap(EngineConfig engineConfig, IndexSearcher searcher) throws EngineException {
+            public IndexSearcher wrap(IndexSearcher searcher) throws EngineException {
                 counter.incrementAndGet();
                 return searcher;
             }
@@ -530,7 +530,7 @@ public class InternalEngineTests extends ESTestCase {
         engine.close();
 
         engine = new InternalEngine(engine.config(), false);
-        Engine.Searcher searcher = wrapper.wrap(engine.config(), engine.acquireSearcher("test"));
+        Engine.Searcher searcher = wrapper.wrap(engine.acquireSearcher("test"));
         assertThat(counter.get(), equalTo(2));
         searcher.close();
         IOUtils.close(store, engine);

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexSearcherWrapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexSearcherWrapperTests.java
@@ -67,7 +67,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
             }
 
             @Override
-            public IndexSearcher wrap(EngineConfig engineConfig, IndexSearcher searcher) throws EngineException {
+            public IndexSearcher wrap(IndexSearcher searcher) throws EngineException {
                 return searcher;
             }
 
@@ -76,7 +76,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         final AtomicInteger count = new AtomicInteger();
         final AtomicInteger outerCount = new AtomicInteger();
         try (Engine.Searcher engineSearcher = new Engine.Searcher("foo", searcher)) {
-            final Engine.Searcher wrap =  wrapper.wrap(ENGINE_CONFIG, engineSearcher);
+            final Engine.Searcher wrap =  wrapper.wrap(engineSearcher);
             assertEquals(1, wrap.reader().getRefCount());
             ElasticsearchDirectoryReader.addReaderCloseListener(wrap.getDirectoryReader(), reader -> {
                 if (reader == open) {
@@ -118,13 +118,13 @@ public class IndexSearcherWrapperTests extends ESTestCase {
             }
 
             @Override
-            public IndexSearcher wrap(EngineConfig engineConfig, IndexSearcher searcher) throws EngineException {
+            public IndexSearcher wrap(IndexSearcher searcher) throws EngineException {
                 return searcher;
             }
         };
         final ConcurrentHashMap<Object, TopDocs> cache = new ConcurrentHashMap<>();
         try (Engine.Searcher engineSearcher = new Engine.Searcher("foo", searcher)) {
-            try (final Engine.Searcher wrap = wrapper.wrap(ENGINE_CONFIG, engineSearcher)) {
+            try (final Engine.Searcher wrap = wrapper.wrap(engineSearcher)) {
                 ElasticsearchDirectoryReader.addReaderCloseListener(wrap.getDirectoryReader(), reader -> {
                     cache.remove(reader.getCoreCacheKey());
                 });
@@ -154,7 +154,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         searcher.setSimilarity(iwc.getSimilarity());
         IndexSearcherWrapper wrapper = new IndexSearcherWrapper();
         try (Engine.Searcher engineSearcher = new Engine.Searcher("foo", searcher)) {
-            final Engine.Searcher wrap = wrapper.wrap(ENGINE_CONFIG, engineSearcher);
+            final Engine.Searcher wrap = wrapper.wrap(engineSearcher);
             assertSame(wrap, engineSearcher);
         }
         IOUtils.close(open, writer, dir);
@@ -180,7 +180,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         };
         try (Engine.Searcher engineSearcher = new Engine.Searcher("foo", searcher)) {
             try {
-                wrapper.wrap(ENGINE_CONFIG, engineSearcher);
+                wrapper.wrap(engineSearcher);
                 fail("reader must delegate cache key");
             } catch (IllegalStateException ex) {
                 // all is well
@@ -194,7 +194,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         };
         try (Engine.Searcher engineSearcher = new Engine.Searcher("foo", searcher)) {
             try {
-                wrapper.wrap(ENGINE_CONFIG, engineSearcher);
+                wrapper.wrap(engineSearcher);
                 fail("reader must delegate cache key");
             } catch (IllegalStateException ex) {
                 // all is well

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -908,7 +908,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
             }
 
             @Override
-            public IndexSearcher wrap(EngineConfig engineConfig, IndexSearcher searcher) throws EngineException {
+            public IndexSearcher wrap(IndexSearcher searcher) throws EngineException {
                 return searcher;
             }
         };
@@ -947,7 +947,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
             }
 
             @Override
-            public IndexSearcher wrap(EngineConfig engineConfig, IndexSearcher searcher) throws EngineException {
+            public IndexSearcher wrap(IndexSearcher searcher) throws EngineException {
                 return searcher;
             }
         };
@@ -990,8 +990,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
                 throw new RuntimeException("boom");
             }
 
-            @Override
-            public IndexSearcher wrap(EngineConfig engineConfig, IndexSearcher searcher) throws EngineException {
+            public IndexSearcher wrap(IndexSearcher searcher) throws EngineException {
                 return searcher;
             }
         };


### PR DESCRIPTION
We only passed the engine config since we had no chance to get the cache
etc. from the IndexSearcher. Now that we have these getters we can just pass the
searcher instead.
