### PR TITLE
Mutate processor improvements

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/ConfigurationUtils.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/ConfigurationUtils.java
@@ -84,13 +84,7 @@ public final class ConfigurationUtils {
         if (value == null) {
             throw new IllegalArgumentException("required property [" + propertyName + "] is missing");
         }
-        if (value instanceof List) {
-            @SuppressWarnings("unchecked")
-            List<String> stringList = (List<String>) value;
-            return stringList;
-        } else {
-            throw new IllegalArgumentException("property [" + propertyName + "] isn't a list, but of type [" + value.getClass().getName() + "]");
-        }
+        return readStringList(propertyName, value);
     }
 
     /**
@@ -103,6 +97,10 @@ public final class ConfigurationUtils {
         if (value == null) {
             return null;
         }
+        return readStringList(propertyName, value);
+    }
+
+    private static List<String> readStringList(String propertyName, Object value) {
         if (value instanceof List) {
             @SuppressWarnings("unchecked")
             List<String> stringList = (List<String>) value;
@@ -117,54 +115,14 @@ public final class ConfigurationUtils {
      *
      * If the property value isn't of type map an {@link IllegalArgumentException} is thrown.
      */
-    public static Map<String, List<String>> readOptionalStringListMap(Map<String, Object> configuration, String propertyName) {
+    public static <T> Map<String, T> readOptionalMap(Map<String, Object> configuration, String propertyName) {
         Object value = configuration.remove(propertyName);
         if (value == null) {
             return null;
         }
         if (value instanceof Map) {
             @SuppressWarnings("unchecked")
-            Map<String, List<String>> stringList = (Map<String, List<String>>) value;
-            return stringList;
-        } else {
-            throw new IllegalArgumentException("property [" + propertyName + "] isn't a map, but of type [" + value.getClass().getName() + "]");
-        }
-    }
-
-    /**
-     * Returns and removes the specified property of type map from the specified configuration map.
-     *
-     * If the property value isn't of type map an {@link IllegalArgumentException} is thrown.
-     */
-    public static Map<String, String> readOptionalStringMap(Map<String, Object> configuration, String propertyName) {
-        Object value = configuration.remove(propertyName);
-
-        if (value == null) {
-            return null;
-        }
-
-        if (value instanceof Map) {
-            Map<String, String> map = (Map<String, String>) value;
-            return map;
-        } else {
-            throw new IllegalArgumentException("property [" + propertyName + "] isn't a map, but of type [" + value.getClass().getName() + "]");
-        }
-    }
-
-    /**
-     * Returns and removes the specified property of type map from the specified configuration map.
-     *
-     * If the property value isn't of type map an {@link IllegalArgumentException} is thrown.
-     */
-    public static Map<String, Object> readOptionalObjectMap(Map<String, Object> configuration, String propertyName) {
-        Object value = configuration.remove(propertyName);
-
-        if (value == null) {
-            return null;
-        }
-
-        if (value instanceof Map) {
-            Map<String, Object> map = (Map<String, Object>) value;
+            Map<String, T> map = (Map<String, T>) value;
             return map;
         } else {
             throw new IllegalArgumentException("property [" + propertyName + "] isn't a map, but of type [" + value.getClass().getName() + "]");

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/mutate/GsubExpression.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/mutate/GsubExpression.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor.mutate;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -31,9 +32,9 @@ public class GsubExpression {
     private final String replacement;
 
     public GsubExpression(String fieldName, Pattern pattern, String replacement) {
-        this.fieldName = fieldName;
-        this.pattern = pattern;
-        this.replacement = replacement;
+        this.fieldName = Objects.requireNonNull(fieldName);
+        this.pattern = Objects.requireNonNull(pattern);
+        this.replacement = Objects.requireNonNull(replacement);
     }
 
     public String getFieldName() {
@@ -46,5 +47,24 @@ public class GsubExpression {
 
     public String getReplacement() {
         return replacement;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GsubExpression that = (GsubExpression) o;
+        return Objects.equals(fieldName, that.fieldName) &&
+                Objects.equals(pattern.pattern(), that.pattern.pattern()) &&
+                Objects.equals(replacement, that.replacement);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, pattern, replacement);
     }
 }

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/mutate/GsubExpression.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/mutate/GsubExpression.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.processor.mutate;
+
+import java.util.regex.Pattern;
+
+/**
+ * Represents a gsub expression containing the field name, the pattern to look for and its string replacement.
+ */
+public class GsubExpression {
+
+    private final String fieldName;
+    private final Pattern pattern;
+    private final String replacement;
+
+    public GsubExpression(String fieldName, Pattern pattern, String replacement) {
+        this.fieldName = fieldName;
+        this.pattern = pattern;
+        this.replacement = replacement;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public Pattern getPattern() {
+        return pattern;
+    }
+
+    public String getReplacement() {
+        return replacement;
+    }
+}

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/mutate/MutateProcessorFactoryTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/mutate/MutateProcessorFactoryTests.java
@@ -19,28 +19,181 @@
 
 package org.elasticsearch.ingest.processor.mutate;
 
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class MutateProcessorFactoryTests extends ESTestCase {
 
-    public void testCreate() throws Exception {
+    public void testCreateUpdate() throws Exception {
         MutateProcessor.Factory factory = new MutateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
         Map<String, Object> update = new HashMap<>();
         update.put("foo", 123);
         config.put("update", update);
         MutateProcessor processor = factory.create(config);
+        assertThat(processor.getRename(), nullValue());
+        assertThat(processor.getRemove(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getConvert(), nullValue());
+        assertThat(processor.getJoin(), nullValue());
+        assertThat(processor.getLowercase(), nullValue());
+        assertThat(processor.getUppercase(), nullValue());
+        assertThat(processor.getSplit(), nullValue());
+        assertThat(processor.getTrim(), nullValue());
         assertThat(processor.getUpdate(), equalTo(update));
+    }
+
+    public void testCreateRename() throws Exception {
+        MutateProcessor.Factory factory = new MutateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        Map<String, Object> rename = new HashMap<>();
+        rename.put("foo", "bar");
+        config.put("rename", rename);
+        MutateProcessor processor = factory.create(config);
+        assertThat(processor.getUpdate(), nullValue());
+        assertThat(processor.getRemove(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getConvert(), nullValue());
+        assertThat(processor.getJoin(), nullValue());
+        assertThat(processor.getLowercase(), nullValue());
+        assertThat(processor.getUppercase(), nullValue());
+        assertThat(processor.getSplit(), nullValue());
+        assertThat(processor.getTrim(), nullValue());
+        assertThat(processor.getRename(), equalTo(rename));
+    }
+
+    public void testCreateRemove() throws Exception {
+        MutateProcessor.Factory factory = new MutateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        List<String> remove = Collections.singletonList("foo");
+        config.put("remove", remove);
+        MutateProcessor processor = factory.create(config);
+        assertThat(processor.getUpdate(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getConvert(), nullValue());
+        assertThat(processor.getJoin(), nullValue());
+        assertThat(processor.getLowercase(), nullValue());
+        assertThat(processor.getUppercase(), nullValue());
+        assertThat(processor.getSplit(), nullValue());
+        assertThat(processor.getTrim(), nullValue());
+        assertThat(processor.getRename(), nullValue());
+        assertThat(processor.getRemove(), equalTo(remove));
+    }
+
+    public void testCreateConvert() throws Exception {
+        MutateProcessor.Factory factory = new MutateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        Map<String, Object> convert = new HashMap<>();
+        convert.put("foo", "integer");
+        config.put("convert", convert);
+        MutateProcessor processor = factory.create(config);
+        assertThat(processor.getUpdate(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getJoin(), nullValue());
+        assertThat(processor.getLowercase(), nullValue());
+        assertThat(processor.getUppercase(), nullValue());
+        assertThat(processor.getSplit(), nullValue());
+        assertThat(processor.getTrim(), nullValue());
+        assertThat(processor.getRename(), nullValue());
+        assertThat(processor.getRemove(), nullValue());
+        assertThat(processor.getConvert(), equalTo(convert));
+    }
+
+    public void testCreateJoin() throws Exception {
+        MutateProcessor.Factory factory = new MutateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        Map<String, Object> join = new HashMap<>();
+        join.put("foo", "bar");
+        config.put("join", join);
+        MutateProcessor processor = factory.create(config);
+        assertThat(processor.getUpdate(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getConvert(), nullValue());
+        assertThat(processor.getLowercase(), nullValue());
+        assertThat(processor.getUppercase(), nullValue());
+        assertThat(processor.getSplit(), nullValue());
+        assertThat(processor.getTrim(), nullValue());
+        assertThat(processor.getRename(), nullValue());
+        assertThat(processor.getRemove(), nullValue());
+        assertThat(processor.getJoin(), equalTo(join));
+    }
+
+    public void testCreateSplit() throws Exception {
+        MutateProcessor.Factory factory = new MutateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        Map<String, Object> split = new HashMap<>();
+        split.put("foo", "bar");
+        config.put("split", split);
+        MutateProcessor processor = factory.create(config);
+        assertThat(processor.getUpdate(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getConvert(), nullValue());
+        assertThat(processor.getLowercase(), nullValue());
+        assertThat(processor.getUppercase(), nullValue());
+        assertThat(processor.getJoin(), nullValue());
+        assertThat(processor.getTrim(), nullValue());
+        assertThat(processor.getRename(), nullValue());
+        assertThat(processor.getRemove(), nullValue());
+        assertThat(processor.getSplit(), equalTo(split));
+    }
+
+    public void testCreateLowercase() throws Exception {
+        MutateProcessor.Factory factory = new MutateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        List<String> lowercase = Collections.singletonList("foo");
+        config.put("lowercase", lowercase);
+        MutateProcessor processor = factory.create(config);
+        assertThat(processor.getUpdate(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getConvert(), nullValue());
+        assertThat(processor.getJoin(), nullValue());
+        assertThat(processor.getRemove(), nullValue());
+        assertThat(processor.getUppercase(), nullValue());
+        assertThat(processor.getSplit(), nullValue());
+        assertThat(processor.getTrim(), nullValue());
+        assertThat(processor.getRename(), nullValue());
+        assertThat(processor.getLowercase(), equalTo(lowercase));
+    }
+
+    public void testCreateUppercase() throws Exception {
+        MutateProcessor.Factory factory = new MutateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        List<String> uppercase = Collections.singletonList("foo");
+        config.put("uppercase", uppercase);
+        MutateProcessor processor = factory.create(config);
+        assertThat(processor.getUpdate(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getConvert(), nullValue());
+        assertThat(processor.getJoin(), nullValue());
+        assertThat(processor.getRemove(), nullValue());
+        assertThat(processor.getLowercase(), nullValue());
+        assertThat(processor.getSplit(), nullValue());
+        assertThat(processor.getTrim(), nullValue());
+        assertThat(processor.getRename(), nullValue());
+        assertThat(processor.getUppercase(), equalTo(uppercase));
+    }
+
+    public void testCreateTrim() throws Exception {
+        MutateProcessor.Factory factory = new MutateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        List<String> trim = Collections.singletonList("foo");
+        config.put("trim", trim);
+        MutateProcessor processor = factory.create(config);
+        assertThat(processor.getUpdate(), nullValue());
+        assertThat(processor.getGsub(), nullValue());
+        assertThat(processor.getConvert(), nullValue());
+        assertThat(processor.getJoin(), nullValue());
+        assertThat(processor.getRemove(), nullValue());
+        assertThat(processor.getUppercase(), nullValue());
+        assertThat(processor.getSplit(), nullValue());
+        assertThat(processor.getLowercase(), nullValue());
+        assertThat(processor.getRename(), nullValue());
+        assertThat(processor.getTrim(), equalTo(trim));
     }
 
     public void testCreateGsubPattern() throws Exception {
@@ -50,32 +203,26 @@ public class MutateProcessorFactoryTests extends ESTestCase {
         gsub.put("foo", Arrays.asList("\\s.*e\\s", "<word_ending_with_e>"));
         config.put("gsub", gsub);
 
-        Map<String, Tuple<Pattern, String>> compiledGsub = new HashMap<>();
-        Pattern searchPattern = Pattern.compile("\\s.*e\\s");
-        compiledGsub.put("foo", new Tuple<>(searchPattern, "<word_ending_with_e>"));
-
         MutateProcessor processor = factory.create(config);
-        for (Map.Entry<String, Tuple<Pattern, String>> entry : compiledGsub.entrySet()) {
-            Tuple<Pattern, String> actualSearchAndReplace = processor.getGsub().get(entry.getKey());
-            assertThat(actualSearchAndReplace, notNullValue());
-            assertThat(actualSearchAndReplace.v1().pattern(), equalTo(entry.getValue().v1().pattern()));
-            assertThat(actualSearchAndReplace.v2(), equalTo(entry.getValue().v2()));
-        }
+        assertThat(processor.getGsub().size(), equalTo(1));
+        GsubExpression gsubExpression = processor.getGsub().get(0);
+        assertThat(gsubExpression.getFieldName(), equalTo("foo"));
+        assertThat(gsubExpression.getPattern().pattern(), equalTo(Pattern.compile("\\s.*e\\s").pattern()));
+        assertThat(gsubExpression.getReplacement(), equalTo("<word_ending_with_e>"));
     }
 
-    public void testCreateGsubPattern_InvalidFormat() throws Exception {
+    public void testCreateGsubPatternInvalidFormat() throws Exception {
         MutateProcessor.Factory factory = new MutateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
         Map<String, List<String>> gsub = new HashMap<>();
-        gsub.put("foo", Arrays.asList("only_one"));
+        gsub.put("foo", Collections.singletonList("only_one"));
         config.put("gsub", gsub);
 
         try {
             factory.create(config);
-            fail();
+            fail("processor creation should have failed");
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("Invalid search and replace values ([only_one]) for field: foo"));
+            assertThat(e.getMessage(), equalTo("Invalid search and replace values [only_one] for field: foo"));
         }
     }
-
 }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/mutate/MutateProcessorFactoryTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/mutate/MutateProcessorFactoryTests.java
@@ -205,10 +205,7 @@ public class MutateProcessorFactoryTests extends ESTestCase {
 
         MutateProcessor processor = factory.create(config);
         assertThat(processor.getGsub().size(), equalTo(1));
-        GsubExpression gsubExpression = processor.getGsub().get(0);
-        assertThat(gsubExpression.getFieldName(), equalTo("foo"));
-        assertThat(gsubExpression.getPattern().pattern(), equalTo(Pattern.compile("\\s.*e\\s").pattern()));
-        assertThat(gsubExpression.getReplacement(), equalTo("<word_ending_with_e>"));
+        assertThat(processor.getGsub().get(0), equalTo(new GsubExpression("foo", Pattern.compile("\\s.*e\\s"), "<word_ending_with_e>")));
     }
 
     public void testCreateGsubPatternInvalidFormat() throws Exception {

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/mutate/MutateProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/mutate/MutateProcessorTests.java
@@ -25,10 +25,8 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -36,9 +34,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 
 public class MutateProcessorTests extends ESTestCase {
-    private static final MutateProcessor.Factory FACTORY = new MutateProcessor.Factory();
     private Data data;
-    private Map<String, Object> config;
 
     @Before
     public void setData() {
@@ -54,25 +50,23 @@ public class MutateProcessorTests extends ESTestCase {
         document.put("fizz", fizz);
 
         data = new Data("index", "type", "id", document);
-        config = new HashMap<>();
     }
 
     public void testUpdate() throws IOException {
         Map<String, Object> update = new HashMap<>();
         update.put("foo", 123);
-        config.put("update", update);
-
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(update, null, null, null, null, null, null, null, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("foo"), equalTo(123));
     }
 
     public void testRename() throws IOException {
         Map<String, String> rename = new HashMap<>();
         rename.put("foo", "bar");
-        config.put("rename", rename);
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(null, rename, null, null, null, null, null, null, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("bar"), equalTo("bar"));
         assertThat(data.containsProperty("foo"), is(false));
     }
@@ -80,66 +74,56 @@ public class MutateProcessorTests extends ESTestCase {
     public void testConvert() throws IOException {
         Map<String, String> convert = new HashMap<>();
         convert.put("num", "integer");
-        config.put("convert", convert);
-
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(null, null, convert, null, null, null, null, null, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("num"), equalTo(64));
     }
 
-    public void testConvert_NullField() throws IOException {
+    public void testConvertNullField() throws IOException {
         Map<String, String> convert = new HashMap<>();
         convert.put("null", "integer");
-        config.put("convert", convert);
-
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(null, null, convert, null, null, null, null, null, null, null);
         try {
             processor.execute(data);
-            fail();
+            fail("processor execute should have failed");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), equalTo("Field \"null\" is null, cannot be converted to a/an integer"));
         }
     }
 
-    public void testConvert_List() throws IOException {
+    public void testConvertList() throws IOException {
         Map<String, String> convert = new HashMap<>();
         convert.put("arr", "integer");
-        config.put("convert", convert);
-
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(null, null, convert, null, null, null, null, null, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("arr"), equalTo(Arrays.asList(1, 2, 3)));
     }
 
     public void testSplit() throws IOException {
-        HashMap<String, String> split = new HashMap<>();
+        Map<String, String> split = new HashMap<>();
         split.put("ip", "\\.");
-        config.put("split", split);
-
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(null, null, null, split, null, null, null, null, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("ip"), equalTo(Arrays.asList("127", "0", "0", "1")));
     }
 
     public void testGsub() throws IOException {
-        HashMap<String, List<String>> gsub = new HashMap<>();
-        gsub.put("ip", Arrays.asList("\\.", "-"));
-        config.put("gsub", gsub);
-
-        Processor processor = FACTORY.create(config);
+        List<GsubExpression> gsubExpressions = Collections.singletonList(new GsubExpression("ip", Pattern.compile("\\."), "-"));
+        Processor processor = new MutateProcessor(null, null, null, null, gsubExpressions, null, null, null, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("ip"), equalTo("127-0-0-1"));
     }
 
     public void testGsub_NullValue() throws IOException {
-        HashMap<String, List<String>> gsub = new HashMap<>();
-        gsub.put("null_field", Arrays.asList("\\.", "-"));
-        config.put("gsub", gsub);
-
-        Processor processor = FACTORY.create(config);
+        List<GsubExpression> gsubExpressions = Collections.singletonList(new GsubExpression("null_field", Pattern.compile("\\."), "-"));
+        Processor processor = new MutateProcessor(null, null, null, null, gsubExpressions, null, null, null, null, null);
         try {
             processor.execute(data);
-            fail();
+            fail("processor execution should have failed");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), equalTo("Field \"null_field\" is null, cannot match pattern."));
         }
@@ -148,46 +132,43 @@ public class MutateProcessorTests extends ESTestCase {
     public void testJoin() throws IOException {
         HashMap<String, String> join = new HashMap<>();
         join.put("arr", "-");
-        config.put("join", join);
-
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(null, null, null, null, null, join, null, null, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("arr"), equalTo("1-2-3"));
     }
 
     public void testRemove() throws IOException {
         List<String> remove = Arrays.asList("foo", "ip");
-        config.put("remove", remove);
-
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(null, null, null, null, null, null, remove, null, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(5));
         assertThat(data.getProperty("foo"), nullValue());
         assertThat(data.getProperty("ip"), nullValue());
     }
 
     public void testTrim() throws IOException {
         List<String> trim = Arrays.asList("to_strip", "foo");
-        config.put("trim", trim);
-
-        Processor processor = FACTORY.create(config);
+        Processor processor = new MutateProcessor(null, null, null, null, null, null, null, trim, null, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("foo"), equalTo("bar"));
         assertThat(data.getProperty("to_strip"), equalTo("clean"));
     }
 
     public void testUppercase() throws IOException {
-        List<String> uppercase = Arrays.asList("foo");
-        config.put("uppercase", uppercase);
-        Processor processor = FACTORY.create(config);
+        List<String> uppercase = Collections.singletonList("foo");
+        Processor processor = new MutateProcessor(null, null, null, null, null, null, null, null, uppercase, null);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("foo"), equalTo("BAR"));
     }
 
     public void testLowercase() throws IOException {
-        List<String> lowercase = Arrays.asList("alpha");
-        config.put("lowercase", lowercase);
-        Processor processor = FACTORY.create(config);
+        List<String> lowercase = Collections.singletonList("alpha");
+        Processor processor = new MutateProcessor(null, null, null, null, null, null, null, null, null, lowercase);
         processor.execute(data);
+        assertThat(data.getDocument().size(), equalTo(7));
         assertThat(data.getProperty("alpha"), equalTo("abcd"));
     }
 }


### PR DESCRIPTION
Remove code duplications from ConfigurationUtils
Make sure that the mutate processor doesn't use Tuple as that would require to depend on core.
Also make sure that the MutateProcessor tests don't end up testing the factory as well.
Make processor getters package private as they are only needed in tests.
Add new tests to MutateProcessorFactoryTests
