### PR TITLE
Kill backwards nodes

### DIFF
--- a/qa/backwards/shared/pom.xml
+++ b/qa/backwards/shared/pom.xml
@@ -55,4 +55,36 @@
             </testResource>
         </testResources>
     </build>
+
+    <profiles>
+        <profile>
+            <id>kill</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.4.0</version>
+                        <executions>
+                            <execution>
+                                <id>kill-all-backwards-nodes</id>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <mainClass>org.elasticsearch.test.ExternalNodeService</mainClass>
+                                    <arguments>
+                                        <argument>kill</argument>
+                                    </arguments>
+                                    <!-- Use the test scop to pick up log4j configuration -->
+                                    <classpathScope>test</classpathScope>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/qa/backwards/two-versions-parent/pom.xml
+++ b/qa/backwards/two-versions-parent/pom.xml
@@ -135,7 +135,7 @@
                         <id>integ-tests</id>
                         <configuration>
                             <!-- Paranoia around external clusters interfering with eachother -->
-                            <parallelism>1</parallelism>
+                            <!-- <parallelism>1</parallelism> -->
                             <testClassesDirectory>../shared/target/test-classes</testClassesDirectory>
                         </configuration>
                     </execution>


### PR DESCRIPTION
[test] Lots of work around leaking backwards nodes

We have a problem where we can leak backwards nodes. Several problems, really.
This commit addresses most of them:
1. Windows will always leak backwards nodes. We address this by killing the
   node directly rather than killing the bat process that runs it.
2. If we leak any zombie backwards nodes we never kill them. We address this
   by attempting to any straggler backwards compatibility nodes before running
   any backwards compatibility tests. It can also be used to kill any straggler
   nodes with this rather obtuse maven invocation:

mvn -pl qa/backwards/shared/ -Pkill test

That'll just kill the nodes without doing anything else and should be useful
for continuous integration.
1. Backwards nodes can steal ports that regular test nodes want to use. This
   is especially nasty if they leak and poison subsequent test runs. We address
   this by moving their transport ports to 29200+.

We also refuse to start the backwards node if it doesn't have a port range
configured. This prevents accidentally running the external nodes in the
standard port range and _forces_ you to put them in 29200+.

Along for the ride is a cleanup to track the running backwards nodes by
transport address rather than http address. Both are useful but only transport
is useful in the context of the tests in which we run them.

Finally this removes the restriction that backwards compatibility tests run
in a single JVM. I added this restriction early on in the process of reviving
the backwards compatibility tests because I was worried about port conflicts.
Now that we're very very careful with ports this isn't require. Running on
multiple JVMs speeds up the process 70% for me. It might not do it for
everyone but 70% is still awesome.

Note: This has been edited to include the entire commit message.
