### PR TITLE
Update the disco node id seed on node restart in test cluster

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
@@ -39,6 +39,8 @@ import java.util.concurrent.TimeUnit;
 public class DiscoveryService extends AbstractLifecycleComponent<DiscoveryService> {
 
     public static final String SETTING_INITIAL_STATE_TIMEOUT = "discovery.initial_state_timeout";
+    public static final String SETTING_DISCOVERY_SEED = "discovery.id.seed";
+
 
     private static class InitialStateListener implements InitialStateDiscoveryListener {
 
@@ -130,7 +132,7 @@ public class DiscoveryService extends AbstractLifecycleComponent<DiscoveryServic
     }
 
     public static String generateNodeId(Settings settings) {
-        String seed = settings.get("discovery.id.seed");
+        String seed = settings.get(DiscoveryService.SETTING_DISCOVERY_SEED);
         if (seed != null) {
             return Strings.randomBase64UUID(new Random(Long.parseLong(seed)));
         }

--- a/test-framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -60,6 +60,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.discovery.DiscoveryService;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.IndexModule;
@@ -595,7 +596,7 @@ public final class InternalTestCluster extends TestCluster {
                 .put("path.home", baseDir) // allow overriding path.home
                 .put(settings)
                 .put("name", name)
-                .put("discovery.id.seed", seed)
+                .put(DiscoveryService.SETTING_DISCOVERY_SEED, seed)
                 .build();
         MockNode node = new MockNode(finalSettings, version, plugins);
         return new NodeAndClient(name, node);
@@ -842,7 +843,8 @@ public final class InternalTestCluster extends TestCluster {
                     IOUtils.rm(nodeEnv.nodeDataPaths());
                 }
             }
-            Settings finalSettings = Settings.builder().put(node.settings()).put(newSettings).build();
+            final long newIdSeed = node.settings().getAsLong(DiscoveryService.SETTING_DISCOVERY_SEED, 0l) + 1; // use a new seed to make sure we have new node id
+            Settings finalSettings = Settings.builder().put(node.settings()).put(newSettings).put(DiscoveryService.SETTING_DISCOVERY_SEED, newIdSeed).build();
             Collection<Class<? extends Plugin>> plugins = node.getPlugins();
             Version version = node.getVersion();
             node = new MockNode(finalSettings, version, plugins);


### PR DESCRIPTION
To make sure the new node's id is changed.
