### PR TITLE
Add stale shard issue to Resiliency page

### DIFF
--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -204,6 +204,13 @@ Commonly used filters are cached in Elasticsearch. That cache is limited in size
 
 While we are working on a longer term solution ({GIT}9176[#9176]), we introduced a minimum weight of 1k for each cache entry. This puts an effective limit on the number of entries in the cache. See {GIT}8304[#8304] (STATUS: DONE, fixed in v1.4.0)
 
+[float]
+=== Do not allow stale shards to automatically be promoted to primary (STATUS: ONGOING)
+
+In some scenarios, a succession of multiple isolated nodes can cause a stale replica shard to be promoted to primary
+leading to a loss of acknowledged indexing operations. Work is underway ({GIT}14671[#14671]) to prevent the automatic
+promotion of a stale primary and only allow such promotion to occur when a system operator manually intervenes.
+
 == Completed
 
 [float]


### PR DESCRIPTION
This commit adds a simple description of the stale shard issue to the
Resiliency page.

Relates #14671
