### PR TITLE
Add sync_id to cat shards API

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.engine.CommitStats;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,7 +46,7 @@ public class IndicesStatsResponse extends BroadcastResponse implements ToXConten
 
     private ShardStats[] shards;
 
-    private Map<ShardRouting, CommonStats> shardStatsMap;
+    private Map<ShardRouting, ShardStats> shardStatsMap;
 
     IndicesStatsResponse() {
 
@@ -56,11 +57,11 @@ public class IndicesStatsResponse extends BroadcastResponse implements ToXConten
         this.shards = shards;
     }
 
-    public Map<ShardRouting, CommonStats> asMap() {
+    public Map<ShardRouting, ShardStats> asMap() {
         if (this.shardStatsMap == null) {
-            Map<ShardRouting, CommonStats> shardStatsMap = new HashMap<>();
+            Map<ShardRouting, ShardStats> shardStatsMap = new HashMap<>();
             for (ShardStats ss : shards) {
-                shardStatsMap.put(ss.getShardRouting(), ss.getStats());
+                shardStatsMap.put(ss.getShardRouting(), ss);
             }
             this.shardStatsMap = unmodifiableMap(shardStatsMap);
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
@@ -15,6 +15,7 @@
                     ip                               .+   \n
                     id                               .+   \n
                     node                             .+   \n
+                    sync_id                          .+   \n
                     unassigned.reason                .+   \n
                     unassigned.at                    .+   \n
                     unassigned.for                   .+   \n
@@ -83,6 +84,60 @@
   - match:
       $body: |
                /^$/
+
+  - do:
+      indices.create:
+        index: sync_id_test
+        body:
+          settings:
+            number_of_shards: 5
+            number_of_replicas: 1
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+        wait_for_relocating_shards: 0
+  - do:
+      indices.flush_synced:
+        index: sync_id_test
+
+  - is_false: _shards.failed
+
+  - do:
+      cat.shards:
+        index: sync_id_test
+        h: index,state,sync_id
+  - match:
+      $body: |
+               /^(sync_id_test\s+(STARTED\s+[A-Za-z0-9_\-]{20}|UNASSIGNED\s+)\s+\n){10}$/
+
+  - do:
+      indices.delete:
+        index: sync_id_test
+
+  - do:
+      indices.create:
+        index: sync_id_no_flush_test
+        body:
+          settings:
+            number_of_shards: 5
+            number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      cat.shards:
+        index: sync_id_no_flush_test
+        h: index,state,sync_id
+  - match:
+      $body: |
+               /^(sync_id_no_flush_test\s+STARTED\s+\n){5}$/
+
+  - do:
+      indices.delete:
+        index: sync_id_no_flush_test
 
   - do:
       indices.create:


### PR DESCRIPTION
This commit adds the ability to get the sync_id from the cat shards API.

Closes #14705
