### PR TITLE
Enforce JAVA_HOME is set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,9 @@ if (projectsPrefix.isEmpty()) {
       vcs = 'Git'
     }
   }
+  tasks.cleanIdea {
+    delete '.idea'
+  }
 }
 
 // eclipse configuration
@@ -154,19 +157,17 @@ allprojects {
       }
     }
   }
-  task cleanEclipseSettings(type: Delete) {
-    delete '.settings'
-  }
   task copyEclipseSettings(type: Copy) {
     // TODO: "package this up" for external builds
     from new File(project.rootDir, 'buildSrc/src/main/resources/eclipse.settings')
     into '.settings'
   }
   // otherwise .settings is not nuked entirely
-  tasks.cleanEclipse.dependsOn(cleanEclipseSettings)
+  tasks.cleanEclipse {
+    delete '.settings'
+  }
   // otherwise the eclipse merging is *super confusing*
-  tasks.eclipse.dependsOn(cleanEclipse)
-  tasks.eclipse.dependsOn(copyEclipseSettings)
+  tasks.eclipse.dependsOn(cleanEclipse, copyEclipseSettings)
 }
 
 // add buildSrc itself as a groovy project

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -213,7 +213,7 @@ class ClusterFormationTasks {
     /** Adds a task to start an elasticsearch node with the given configuration */
     static Task configureStartTask(String name, Project project, Task setup, File cwd, ClusterConfiguration config, String clusterName, File pidFile, File home) {
         Map esEnv = [
-            'JAVA_HOME' : System.getProperty('java.home'),
+            'JAVA_HOME' : project.javaHome,
             'ES_GC_OPTS': config.jvmArgs
         ]
         List esProps = config.systemProperties.collect { key, value -> "-D${key}=${value}" }
@@ -288,9 +288,9 @@ class ClusterFormationTasks {
             ext.pid = "${ -> pidFile.getText('UTF-8').trim()}"
             File jps
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                jps = getJpsExecutableByName("jps.exe")
+                jps = getJpsExecutableByName(project, "jps.exe")
             } else {
-                jps = getJpsExecutableByName("jps")
+                jps = getJpsExecutableByName(project, "jps")
             }
             if (!jps.exists()) {
                 throw new GradleException("jps executable not found; ensure that you're running Gradle with the JDK rather than the JRE")
@@ -313,8 +313,8 @@ class ClusterFormationTasks {
         }
     }
 
-    private static File getJpsExecutableByName(String jpsExecutableName) {
-        return Paths.get(Jvm.current().javaHome.toString(), "bin/" + jpsExecutableName).toFile()
+    private static File getJpsExecutableByName(Project project, String jpsExecutableName) {
+        return Paths.get(project.javaHome.toString(), "bin/" + jpsExecutableName).toFile()
     }
 
     /** Adds a task to kill an elasticsearch node with the given pidfile */

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestBasePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestBasePlugin.groovy
@@ -32,10 +32,11 @@ class StandaloneTestBasePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        BuildPlugin.configureRepositories(project)
-
         project.pluginManager.apply(JavaBasePlugin)
         project.pluginManager.apply(RandomizedTestingPlugin)
+
+        BuildPlugin.globalBuildInfo(project)
+        BuildPlugin.configureRepositories(project)
 
         // remove some unnecessary tasks for a qa test
         project.tasks.removeAll { it.name in ['assemble', 'buildDependents'] }


### PR DESCRIPTION
If we use JAVA_HOME consistently for tests, we can run tests with a
different version of java than gradle runs with. For example, this
enables running tests with jigsaw, but building with java 8. The only
caveat is intellij does not set JAVA_HOME. This change enforces
JAVA_HOME is set, but ignores for intellij.
