### PR TITLE
fix mvn verify under jigsaw

### DIFF
--- a/core/src/test/java/org/elasticsearch/ESExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ESExceptionTests.java
@@ -325,12 +325,7 @@ public class ESExceptionTests extends ESTestCase {
             } else {
                 assertEquals(e.getCause().getClass(), NotSerializableExceptionWrapper.class);
             }
-            // TODO: fix this test
-            // on java 9, expected:<sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)> 
-            //            but was:<sun.reflect.NativeMethodAccessorImpl.invoke0(java.base@9.0/Native Method)>
-            if (!Constants.JRE_IS_MINIMUM_JAVA9) {
-                assertArrayEquals(e.getStackTrace(), ex.getStackTrace());
-            }
+            assertArrayEquals(e.getStackTrace(), ex.getStackTrace());
             assertTrue(e.getStackTrace().length > 1);
             ElasticsearchAssertions.assertVersionSerializable(VersionUtils.randomVersion(getRandom()), t);
             ElasticsearchAssertions.assertVersionSerializable(VersionUtils.randomVersion(getRandom()), ex);

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -566,15 +566,12 @@ public class ExceptionSerializationTests extends ESTestCase {
             }
             Throwable deserialized = serialize(t);
             assertTrue(deserialized instanceof NotSerializableExceptionWrapper);
-            // TODO: fix this test for more java 9 differences
-            if (!Constants.JRE_IS_MINIMUM_JAVA9) {
-                assertArrayEquals(t.getStackTrace(), deserialized.getStackTrace());
-                assertEquals(t.getSuppressed().length, deserialized.getSuppressed().length);
-                if (t.getSuppressed().length > 0) {
-                    assertTrue(deserialized.getSuppressed()[0] instanceof NotSerializableExceptionWrapper);
-                    assertArrayEquals(t.getSuppressed()[0].getStackTrace(), deserialized.getSuppressed()[0].getStackTrace());
-                    assertTrue(deserialized.getSuppressed()[1] instanceof NullPointerException);
-                }
+            assertArrayEquals(t.getStackTrace(), deserialized.getStackTrace());
+            assertEquals(t.getSuppressed().length, deserialized.getSuppressed().length);
+            if (t.getSuppressed().length > 0) {
+                assertTrue(deserialized.getSuppressed()[0] instanceof NotSerializableExceptionWrapper);
+                assertArrayEquals(t.getSuppressed()[0].getStackTrace(), deserialized.getSuppressed()[0].getStackTrace());
+                assertTrue(deserialized.getSuppressed()[1] instanceof NullPointerException);
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -1367,7 +1367,7 @@ public class StoreTests extends ESTestCase {
         } catch (CorruptIndexException e) {
             assertEquals(ex.getMessage(), e.getMessage());
             assertEquals(ex.toString(), e.toString());
-            assertEquals(ExceptionsHelper.stackTrace(ex), ExceptionsHelper.stackTrace(e));
+            assertArrayEquals(ex.getStackTrace(), e.getStackTrace());
         }
 
         store.removeCorruptionMarker();
@@ -1379,7 +1379,7 @@ public class StoreTests extends ESTestCase {
             fail("should be corrupted");
         } catch (CorruptIndexException e) {
             assertEquals("foobar (resource=preexisting_corruption)", e.getMessage());
-            assertEquals(ExceptionsHelper.stackTrace(ioe), ExceptionsHelper.stackTrace(e.getCause()));
+            assertArrayEquals(ioe.getStackTrace(), e.getCause().getStackTrace());
         }
         store.close();
     }

--- a/core/src/test/java/org/elasticsearch/test/ESTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESTestCase.java
@@ -37,6 +37,7 @@ import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.util.TestRuleMarkFailure;
 import org.apache.lucene.util.TestUtil;
 import org.apache.lucene.util.TimeUnits;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.BootstrapForTesting;
 import org.elasticsearch.cache.recycler.MockPageCacheRecycler;
@@ -589,5 +590,22 @@ public abstract class ESTestCase extends LuceneTestCase {
     /** Returns the suite failure marker: internal use only! */
     public static TestRuleMarkFailure getSuiteFailureMarker() {
         return suiteFailureMarker;
+    }
+
+    /** Compares two stack traces, ignoring module (which is not yet serialized) */
+    public static void assertArrayEquals(StackTraceElement expected[], StackTraceElement actual[]) {
+        assertEquals(expected.length, actual.length);
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], actual[i]);
+        }
+    }
+
+    /** Compares two stack trace elements, ignoring module (which is not yet serialized) */
+    public static void assertEquals(StackTraceElement expected, StackTraceElement actual) {
+        assertEquals(expected.getClassName(), actual.getClassName());
+        assertEquals(expected.getMethodName(), actual.getMethodName());
+        assertEquals(expected.getFileName(), actual.getFileName());
+        assertEquals(expected.getLineNumber(), actual.getLineNumber());
+        assertEquals(expected.isNativeMethod(), actual.isNativeMethod());
     }
 }

--- a/qa/backwards/2.0.0/pom.xml
+++ b/qa/backwards/2.0.0/pom.xml
@@ -18,4 +18,17 @@
         <tests.bwc.version>2.0.0</tests.bwc.version>
         <skip.integ.tests>${skipTests}</skip.integ.tests>
     </properties>
+
+    <!-- disable backwards tests with 2.0.0 on java 9, because that
+         version will die instantly under jigsaw -->
+    <profiles>
+        <profile>
+            <activation>
+                <jdk>1.9</jdk>
+            </activation>
+            <properties>
+                <skip.integ.tests>true</skip.integ.tests>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This is against 2.x branch since builds are working there currently. I will forward port test fixes to master.

This deals with two things:
1. Exception serialization tests: our exception will drop the new `module` information in java 9 `StackTraceElement` so the tests based on strings, etc will compare. Preserving this when both ends are java 9 might be complex, but I fixed the asserts so at least serialization tests are tested correctly.
2. 2.0 backwards tests are skipped for java 9, as 2.0 will die an instant death under jigsaw:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
Likely root cause: java.lang.UnsupportedOperationException: Boot class path mechanism is not supported
at sun.management.RuntimeImpl.getBootClassPath(java.management@9.0/RuntimeImpl.java:99)
at org.elasticsearch.monitor.jvm.JvmInfo.<clinit>(JvmInfo.java:76)
at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:256)
at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:35)
```

Closes #13774
