### PR TITLE
fix gradle check under jigsaw

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -264,7 +264,6 @@ class ClusterFormationTasks {
                 args esExecutable
                 args esProps
                 environment esEnv
-                errorOutput = new ByteArrayOutputStream()
                 doLast {
                     esPostStartActions(ant, logger)
                 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -266,14 +266,6 @@ class ClusterFormationTasks {
                 environment esEnv
                 errorOutput = new ByteArrayOutputStream()
                 doLast {
-                    if (errorOutput.toString().isEmpty() == false) {
-                        logger.error(errorOutput.toString())
-                        File logFile = new File(home, "logs/${clusterName}.log")
-                        if (logFile.exists()) {
-                            logFile.eachLine { line -> logger.error(line) }
-                        }
-                        throw new GradleException('Failed to start elasticsearch')
-                    }
                     esPostStartActions(ant, logger)
                 }
             }

--- a/core/src/test/java/org/elasticsearch/ESExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ESExceptionTests.java
@@ -336,12 +336,7 @@ public class ESExceptionTests extends ESTestCase {
             } else {
                 assertEquals(e.getCause().getClass(), NotSerializableExceptionWrapper.class);
             }
-            // TODO: fix this test
-            // on java 9, expected:<sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)>
-            //            but was:<sun.reflect.NativeMethodAccessorImpl.invoke0(java.base@9.0/Native Method)>
-            if (!Constants.JRE_IS_MINIMUM_JAVA9) {
-                assertArrayEquals(e.getStackTrace(), ex.getStackTrace());
-            }
+            assertArrayEquals(e.getStackTrace(), ex.getStackTrace());
             assertTrue(e.getStackTrace().length > 1);
             ElasticsearchAssertions.assertVersionSerializable(VersionUtils.randomVersion(getRandom()), t);
             ElasticsearchAssertions.assertVersionSerializable(VersionUtils.randomVersion(getRandom()), ex);

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -561,15 +561,12 @@ public class ExceptionSerializationTests extends ESTestCase {
             }
             Throwable deserialized = serialize(t);
             assertTrue(deserialized instanceof NotSerializableExceptionWrapper);
-            // TODO: fix this test for more java 9 differences
-            if (!Constants.JRE_IS_MINIMUM_JAVA9) {
-                assertArrayEquals(t.getStackTrace(), deserialized.getStackTrace());
-                assertEquals(t.getSuppressed().length, deserialized.getSuppressed().length);
-                if (t.getSuppressed().length > 0) {
-                    assertTrue(deserialized.getSuppressed()[0] instanceof NotSerializableExceptionWrapper);
-                    assertArrayEquals(t.getSuppressed()[0].getStackTrace(), deserialized.getSuppressed()[0].getStackTrace());
-                    assertTrue(deserialized.getSuppressed()[1] instanceof NullPointerException);
-                }
+            assertArrayEquals(t.getStackTrace(), deserialized.getStackTrace());
+            assertEquals(t.getSuppressed().length, deserialized.getSuppressed().length);
+            if (t.getSuppressed().length > 0) {
+                assertTrue(deserialized.getSuppressed()[0] instanceof NotSerializableExceptionWrapper);
+                assertArrayEquals(t.getSuppressed()[0].getStackTrace(), deserialized.getSuppressed()[0].getStackTrace());
+                assertTrue(deserialized.getSuppressed()[1] instanceof NullPointerException);
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -1387,7 +1387,7 @@ public class StoreTests extends ESTestCase {
         } catch (CorruptIndexException e) {
             assertEquals(ex.getMessage(), e.getMessage());
             assertEquals(ex.toString(), e.toString());
-            assertEquals(ExceptionsHelper.stackTrace(ex), ExceptionsHelper.stackTrace(e));
+            assertArrayEquals(ex.getStackTrace(), e.getStackTrace());
         }
 
         store.removeCorruptionMarker();
@@ -1399,7 +1399,7 @@ public class StoreTests extends ESTestCase {
             fail("should be corrupted");
         } catch (CorruptIndexException e) {
             assertEquals("foobar (resource=preexisting_corruption)", e.getMessage());
-            assertEquals(ExceptionsHelper.stackTrace(ioe), ExceptionsHelper.stackTrace(e.getCause()));
+            assertArrayEquals(ioe.getStackTrace(), e.getCause().getStackTrace());
         }
         store.close();
     }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/PluginManagerTests.java
@@ -661,9 +661,14 @@ public class PluginManagerTests extends ESIntegTestCase {
 
         SSLSocketFactory defaultSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
         ServerBootstrap serverBootstrap = new ServerBootstrap(new NioServerSocketChannelFactory());
-        SelfSignedCertificate ssc = new SelfSignedCertificate("localhost");
+        SelfSignedCertificate ssc = null;
 
         try {
+            try {
+                ssc = new SelfSignedCertificate("localhost");
+            } catch (Exception e) {
+                assumeNoException("self signing shenanigans not supported by this JDK", e);
+            }
 
             //  Create a trust manager that does not validate certificate chains:
             SSLContext sc = SSLContext.getInstance("SSL");
@@ -700,7 +705,9 @@ public class PluginManagerTests extends ESIntegTestCase {
         } finally {
             HttpsURLConnection.setDefaultSSLSocketFactory(defaultSocketFactory);
             serverBootstrap.releaseExternalResources();
-            ssc.delete();
+            if (ssc != null) {
+                ssc.delete();
+            }
         }
     }
 

--- a/test-framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -36,6 +36,7 @@ import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.util.TestRuleMarkFailure;
 import org.apache.lucene.util.TestUtil;
 import org.apache.lucene.util.TimeUnits;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.BootstrapForTesting;
 import org.elasticsearch.cache.recycler.MockPageCacheRecycler;
@@ -615,5 +616,22 @@ public abstract class ESTestCase extends LuceneTestCase {
     /** Returns the suite failure marker: internal use only! */
     public static TestRuleMarkFailure getSuiteFailureMarker() {
         return suiteFailureMarker;
+    }
+
+    /** Compares two stack traces, ignoring module (which is not yet serialized) */
+    public static void assertArrayEquals(StackTraceElement expected[], StackTraceElement actual[]) {
+        assertEquals(expected.length, actual.length);
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], actual[i]);
+        }
+    }
+
+    /** Compares two stack trace elements, ignoring module (which is not yet serialized) */
+    public static void assertEquals(StackTraceElement expected, StackTraceElement actual) {
+        assertEquals(expected.getClassName(), actual.getClassName());
+        assertEquals(expected.getMethodName(), actual.getMethodName());
+        assertEquals(expected.getFileName(), actual.getFileName());
+        assertEquals(expected.getLineNumber(), actual.getLineNumber());
+        assertEquals(expected.isNativeMethod(), actual.isNativeMethod());
     }
 }


### PR DESCRIPTION
followup to #14723 

for integ tests the outputsniffing is bogus, we don't need this and its a false positive on java 9 (which warns about our garbage collection settings, and this is not the place to deal with any of that).

also includes tests fixes ported forward
