### PR TITLE
Uniform exceptions for TransportMasterNodeAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -164,7 +164,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
             } else {
                 if (nodes.masterNode() == null) {
                     logger.debug("no known master node, scheduling a retry");
-                    retry(new MasterNotDiscoveredException(), masterNodeChangedPredicate);
+                    retry(null, masterNodeChangedPredicate);
                 } else {
                     transportService.sendRequest(nodes.masterNode(), actionName, request, new ActionListenerResponseHandler<Response>(listener) {
                         @Override
@@ -205,7 +205,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                     @Override
                     public void onTimeout(TimeValue timeout) {
                         logger.debug("timed out while retrying [{}] after failure (timeout [{}])", failure, actionName, timeout);
-                        listener.onFailure(failure);
+                        listener.onFailure(new MasterNotDiscoveredException(failure));
                     }
                 }, changePredicate
             );

--- a/core/src/main/java/org/elasticsearch/discovery/MasterNotDiscoveredException.java
+++ b/core/src/main/java/org/elasticsearch/discovery/MasterNotDiscoveredException.java
@@ -34,6 +34,10 @@ public class MasterNotDiscoveredException extends ElasticsearchException {
         super("");
     }
 
+    public MasterNotDiscoveredException(Throwable cause) {
+        super(cause);
+    }
+
     public MasterNotDiscoveredException(String message) {
         super(message);
     }

--- a/core/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -214,7 +214,17 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         }
 
         assertTrue(listener.isDone());
-        assertListenerThrows("ClusterBlockException should be thrown", listener, ClusterBlockException.class);
+        if (retryableBlock) {
+            try {
+                listener.get();
+                fail("Expected exception but returned proper result");
+            } catch (ExecutionException ex) {
+                assertThat(ex.getCause(), instanceOf(MasterNotDiscoveredException.class));
+                assertThat(ex.getCause().getCause(), instanceOf(ClusterBlockException.class));
+            }
+        } else {
+            assertListenerThrows("ClusterBlockException should be thrown", listener, ClusterBlockException.class);
+        }
     }
 
     public void testForceLocalOperation() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
Throw MasterNotDiscoveredException whenever retry logic of TransportMasterNodeAction times out. This makes it easier to classify failures on client side.
