### PR TITLE
Update error in documentation for multi-fields

### DIFF
--- a/docs/reference/mapping/params/multi-fields.asciidoc
+++ b/docs/reference/mapping/params/multi-fields.asciidoc
@@ -83,12 +83,12 @@ PUT my_index
     "my_type": {
       "properties": {
         "text": { <1>
-          "type": "string"
-        },
-        "fields": {
-          "english": { <2>
-            "type":     "string",
-            "analyzer": "english"
+          "type": "string",
+          "fields": {
+            "english": { <2>
+              "type":     "string",
+              "analyzer": "english"
+            }
           }
         }
       }


### PR DESCRIPTION
The mapping example for defining multi-fields with multiple analyzers had an error which would prevent the mapping from being applied.
