### PR TITLE
Fix NPE in Derivative Pipeline when current bucket value is null

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativePipelineAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/DerivativePipelineAggregator.java
@@ -92,7 +92,7 @@ public class DerivativePipelineAggregator extends PipelineAggregator {
         for (InternalHistogram.Bucket bucket : buckets) {
             Long thisBucketKey = resolveBucketKeyAsLong(bucket);
             Double thisBucketValue = resolveBucketValue(histo, bucket, bucketsPaths()[0], gapPolicy);
-            if (lastBucketValue != null) {
+            if (lastBucketValue != null && thisBucketValue != null) {
                 double gradient = thisBucketValue - lastBucketValue;
                 double xDiff = -1;
                 if (xAxisUnits != null) {


### PR DESCRIPTION
Sequence of events that lead to the NPE:
1. `avg` metric returns NaN for buckets
2. `movavg` skips null **or NaN** values, and simply re-uses the existing bucket (e.g. doesn't add
   a 'movavg' field to the bucket).  This would apply to any pipeline that opts to skip a bucket instead of returning NaN
3. Derivative references `movavg`, the bucket resolution returns null because movavg wasn't added
   to the bucket, NPE when trying to subtract null values

So the root problem is that `movavg` will skip NaN values in addition to null, which is why this particular NPE was only found when combining the deriv with a movavg.  I think we should add the validation check just to prevent potential NPEs, because `resolveBucketValue()` is allowed to return a null Double.

But I wonder if the movavg behavior is also broken though?  The problem is that a single NaN will "infect" the entire movavg from that point onwards, since values depend on the previous.  A single NaN will make all following calculations fail, so they are simply ignored right now.

But, technically, NaN is a value, so perhaps this is bad behavior?  In any case, that'd be a separate PR/issue.

 /cc @colings86 
