### PR TITLE
Make Build work without git

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -240,6 +240,10 @@ class BuildPlugin implements Plugin<Project> {
                         'X-Compile-Elasticsearch-Version': VersionProperties.elasticsearch,
                         'X-Compile-Lucene-Version': VersionProperties.lucene,
                         'Build-Date': ZonedDateTime.now(ZoneOffset.UTC))
+                if (jarTask.manifest.attributes.containsKey('Change') == false) {
+                    logger.warn('Building without git revision id.')
+                    jarTask.manifest.attributes('Change': 'N/A')
+                }
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/Build.java
+++ b/core/src/main/java/org/elasticsearch/Build.java
@@ -33,9 +33,13 @@ import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
 /**
+ * Information about a build of Elasticsearch.
  */
 public class Build {
-
+    /**
+     * The current build of Elasticsearch. Filled with information scanned at
+     * startup from the jar.
+     */
     public static final Build CURRENT;
 
     static {
@@ -55,6 +59,14 @@ public class Build {
             // not running from a jar (unit tests, IDE)
             shortHash = "Unknown";
             date = "Unknown";
+        }
+        if (shortHash == null) {
+            throw new IllegalStateException("Error finding the build shortHash. " +
+                "Stopping Elasticsearch now so it doesn't run in subtly broken ways. This is likely a build bug.");
+        }
+        if (date == null) {
+            throw new IllegalStateException("Error finding the build date. " +
+                "Stopping Elasticsearch now so it doesn't run in subtly broken ways. This is likely a build bug.");
         }
 
         CURRENT = new Build(shortHash, date);


### PR DESCRIPTION
If you build elasticsearch without a git repository it was creating a null
shortHash which was causing Elasticsearch not to be able to form transport
connections.

Closes #14748
