### PR TITLE
Effectively remove transitive deps from generated maven poms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,6 @@
 import com.bmuschko.gradle.nexus.NexusPlugin
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-  }
-}
-
 // common maven publishing configuration
 subprojects {
   group = 'org.elasticsearch'
@@ -110,8 +101,6 @@ subprojects {
   configurations {
     all {
       resolutionStrategy {
-        failOnVersionConflict()
-
         dependencySubstitution {
           substitute module("org.elasticsearch:rest-api-spec:${version}") with project("${projectsPrefix}:rest-api-spec")
           substitute module("org.elasticsearch:elasticsearch:${version}") with project("${projectsPrefix}:core")

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -53,6 +53,7 @@ dependencies {
   compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
   compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
   compile 'de.thetaphi:forbiddenapis:2.0'
+  compile 'com.bmuschko:gradle-nexus-plugin:2.3.1'
 }
 
 processResources {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -18,23 +18,10 @@
  */
 package org.elasticsearch.gradle
 
-import groovy.xml.Namespace
-import groovy.xml.QName
 import nebula.plugin.extraconfigurations.ProvidedBasePlugin
-import org.apache.maven.model.Exclusion
 import org.elasticsearch.gradle.precommit.PrecommitTasks
-import org.gradle.api.XmlProvider
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.ModuleDependency
-import org.gradle.api.artifacts.ModuleVersionIdentifier
-import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.GradleException
-import org.gradle.api.JavaVersion
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.*
+import org.gradle.api.artifacts.*
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.maven.MavenPom
 import org.gradle.api.tasks.bundling.Jar
@@ -165,7 +152,6 @@ class BuildPlugin implements Plugin<Project> {
                     String depId = "${groupId}:${artifactId}:${version}"
                     String depConfig = "_transitive_${depId}"
                     Configuration configuration = project.configurations.findByName(depConfig)
-                    println ("Inspecting dep: ${depId}")
                     if (configuration == null) {
                         continue // we did not make this dep non-transitive
                     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -180,7 +180,6 @@ class BuildPlugin implements Plugin<Project> {
     /** Adds repositores used by ES dependencies */
     static void configureRepositories(Project project) {
         RepositoryHandler repos = project.repositories
-        repos.mavenLocal() // nocommit: remove
         repos.mavenCentral()
         repos.maven {
             name 'sonatype-snapshots'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -111,7 +111,7 @@ class BuildPlugin implements Plugin<Project> {
      * Makes dependencies non-transitive.
      *
      * Gradle allows setting all dependencies as non-transitive very easily.
-     * But this mechanism does not translate into maven pom generation. In order
+     * Sadly this mechanism does not translate into maven pom generation. In order
      * to effectively make the pom act as if it has no transitive dependencies,
      * we must exclude each transitive dependency of each direct dependency.
      *

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -33,7 +33,6 @@ class PluginBuildPlugin extends BuildPlugin {
     @Override
     void apply(Project project) {
         super.apply(project)
-        project.pluginManager.apply(ProvidedBasePlugin)
         // TODO: add target compatibility (java version) to elasticsearch properties and set for the project
         configureDependencies(project)
         // this afterEvaluate must happen before the afterEvaluate added by integTest configure,

--- a/test-framework/build.gradle
+++ b/test-framework/build.gradle
@@ -23,15 +23,15 @@ apply plugin: 'com.bmuschko.nexus'
 
 dependencies {
   compile "org.elasticsearch:elasticsearch:${version}"
-  compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}@jar"
-  compile "junit:junit:${versions.junit}@jar"
-  compile 'org.hamcrest:hamcrest-all:1.3@jar'
-  compile "org.apache.lucene:lucene-test-framework:${versions.lucene}@jar"
-  compile "org.apache.lucene:lucene-codecs:${versions.lucene}@jar"
-  compile "org.apache.httpcomponents:httpclient:${versions.httpclient}@jar"
-  compile "org.apache.httpcomponents:httpcore:${versions.httpcore}@jar"
-  compile "commons-logging:commons-logging:${versions.commonslogging}@jar"
-  compile "commons-codec:commons-codec:${versions.commonscodec}@jar"
+  compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  compile "junit:junit:${versions.junit}"
+  compile 'org.hamcrest:hamcrest-all:1.3'
+  compile "org.apache.lucene:lucene-test-framework:${versions.lucene}"
+  compile "org.apache.lucene:lucene-codecs:${versions.lucene}"
+  compile "org.apache.httpcomponents:httpclient:${versions.httpclient}"
+  compile "org.apache.httpcomponents:httpcore:${versions.httpcore}"
+  compile "commons-logging:commons-logging:${versions.commonslogging}"
+  compile "commons-codec:commons-codec:${versions.commonscodec}"
 }
 
 compileJava.options.compilerArgs << '-Xlint:-cast,-deprecation,-fallthrough,-overrides,-rawtypes,-serial,-try,-unchecked'

--- a/test-framework/build.gradle
+++ b/test-framework/build.gradle
@@ -23,15 +23,15 @@ apply plugin: 'com.bmuschko.nexus'
 
 dependencies {
   compile "org.elasticsearch:elasticsearch:${version}"
-  compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  compile "junit:junit:${versions.junit}"
-  compile 'org.hamcrest:hamcrest-all:1.3'
-  compile "org.apache.lucene:lucene-test-framework:${versions.lucene}"
-  compile "org.apache.lucene:lucene-codecs:${versions.lucene}"
-  compile "org.apache.httpcomponents:httpclient:${versions.httpclient}"
-  compile "org.apache.httpcomponents:httpcore:${versions.httpcore}"
-  compile "commons-logging:commons-logging:${versions.commonslogging}"
-  compile "commons-codec:commons-codec:${versions.commonscodec}"
+  compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}@jar"
+  compile "junit:junit:${versions.junit}@jar"
+  compile 'org.hamcrest:hamcrest-all:1.3@jar'
+  compile "org.apache.lucene:lucene-test-framework:${versions.lucene}@jar"
+  compile "org.apache.lucene:lucene-codecs:${versions.lucene}@jar"
+  compile "org.apache.httpcomponents:httpclient:${versions.httpclient}@jar"
+  compile "org.apache.httpcomponents:httpcore:${versions.httpcore}@jar"
+  compile "commons-logging:commons-logging:${versions.commonslogging}@jar"
+  compile "commons-codec:commons-codec:${versions.commonscodec}@jar"
 }
 
 compileJava.options.compilerArgs << '-Xlint:-cast,-deprecation,-fallthrough,-overrides,-rawtypes,-serial,-try,-unchecked'


### PR DESCRIPTION
With gradle, deploying to maven means first generating poms. These are
filled in based on dependencies of the project. Recently, we started
disallowing transitive dependencies. However, this configuration does
not translate to maven poms because maven has no concept of excluding
all transitive dependencies.

This change adds exclusions for each of the transitive deps of each
dependency being added to the maven pom. It does so by creating dummy
configurations for each direct dependency (which does not have
transitive deps excluded), so that we can iterate the transitive deps
when building the pom.

Note, this should be simpler (just modifying maven's pom model), but
gradle tries to hide that from their api, causing us to need to
manipulate the xml directly.
https://discuss.gradle.org/t/modifying-maven-pom-generation-to-add-excludes/12744
