### PR TITLE
Log failures immediately

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestReportLogger.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestReportLogger.groovy
@@ -175,13 +175,10 @@ class TestReportLogger extends TestsSummaryEventListener implements AggregatedEv
 
     @Subscribe
     void onTestResult(AggregatedTestResultEvent e) throws IOException {
-        if (isPassthrough() && e.getStatus() != TestStatus.OK) {
-            flushOutput();
-            emitStatusLine(LogLevel.ERROR, e, e.getStatus(), e.getExecutionTime());
-        }
-
         if (!e.isSuccessful()) {
             failedTests.add(e.getDescription());
+            flushOutput();
+            emitStatusLine(LogLevel.ERROR, e, e.getStatus(), e.getExecutionTime());
         }
     }
 


### PR DESCRIPTION
With this change all failures are immediately logged in gory detail.
