### PR TITLE
Fix calculation of next delay for delayed shard allocation

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingService.java
@@ -118,11 +118,17 @@ public class RoutingService extends AbstractLifecycleComponent<RoutingService> i
             if (nextDelaySetting > 0 && nextDelaySetting < registeredNextDelaySetting) {
                 FutureUtils.cancel(registeredNextDelayFuture);
                 registeredNextDelaySetting = nextDelaySetting;
-                // We use System.currentTimeMillis here because we want the
-                // next delay from the "now" perspective, rather than the
-                // delay from the last time the GatewayAllocator tried to
-                // assign/delay the shard
-                TimeValue nextDelay = TimeValue.timeValueMillis(UnassignedInfo.findNextDelayedAllocationIn(System.currentTimeMillis(), settings, event.state()));
+                // We calculate nextDelay based on System.currentTimeMillis() here because we want the next delay from the "now" perspective
+                // rather than the delay from the last time the GatewayAllocator tried to assign/delay the shard.
+                // The actual calculation is based on the latter though, to account for shards that should have been allocated
+                // between unassignedShardsAllocatedTimestamp and System.currentTimeMillis()
+                long nextDelayBasedOnUnassignedShardsAllocatedTimestamp = UnassignedInfo.findNextDelayedAllocationIn(unassignedShardsAllocatedTimestamp, settings, event.state());
+                // adjust from unassignedShardsAllocatedTimestamp to now
+                long nextDelayMillis = nextDelayBasedOnUnassignedShardsAllocatedTimestamp - (System.currentTimeMillis() - unassignedShardsAllocatedTimestamp);
+                if (nextDelayMillis < 0) {
+                    nextDelayMillis = 0;
+                }
+                TimeValue nextDelay = TimeValue.timeValueMillis(nextDelayMillis);
                 int unassignedDelayedShards = UnassignedInfo.getNumberOfDelayedUnassigned(unassignedShardsAllocatedTimestamp, settings, event.state());
                 if (unassignedDelayedShards > 0) {
                     logger.info("delaying allocation for [{}] unassigned shards, next check in [{}]",


### PR DESCRIPTION
Currently the next delay is calculated based on System.currentTimeMillis() but the actual shards to delay based on the last time the GatewayAllocator tried to assign/delay the shard.

This introduces an inconsistency for the case where shards should have been delay-allocated between the GatewayAllocator-based timestamp and System.currentTimeMillis().

Failing test highlighting the issue:

http://build-us-00.elastic.co/job/es_core_master_centos/8512/testReport/junit/org.elasticsearch.cluster.routing/RoutingServiceTests/testDelayedUnassignedScheduleRerouteAfterDelayedReroute/

Relevant lines of log output:

```
[2015-11-13 19:25:05,559][DEBUG][org.elasticsearch.cluster.routing.allocation] [short_delay][0] failed shard [short_delay][0], node[node3], [R], v[3], s[STARTED], a[id=FBy1b6neT6yNj4McTu6jlg] found in routingNodes, failing it ([reason=NODE_LEFT], at[2015-11-13T18:25:05.559Z], details[node_left[node3]])
[2015-11-13 19:25:05,559][DEBUG][org.elasticsearch.cluster.routing.allocation] [long_delay][0] failed shard [long_delay][0], node[node1], [R], v[3], s[STARTED], a[id=owLPLgX8RB-ssPs-xvQyQg] found in routingNodes, failing it ([reason=NODE_LEFT], at[2015-11-13T18:25:05.559Z], details[node_left[node1]])
[2015-11-13 19:25:05,877][INFO ][org.elasticsearch.cluster.routing] delaying allocation for [2] unassigned shards, next check in [9.6s]
```

Analysis:
Two shards fail, one with a delay configured to 100ms ([short_delay][0]), the other configured to 10s ([long_delay][0]). 
The last line of log shows that 2 shards have been correctly recognised as being delay-unassigned. But, as the last log line has been executed more than 100ms after the node failure, only long_delay is taken into account for calculating the next check. 
