### PR TITLE
Allow CIDR notation in query string query

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/core/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -16,6 +16,8 @@
 
 package org.elasticsearch.common.network;
 
+import org.elasticsearch.search.aggregations.bucket.range.ipv4.InternalIPv4Range;
+
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -23,10 +25,12 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class InetAddresses {
     private static int IPV4_PART_COUNT = 4;
     private static int IPV6_PART_COUNT = 8;
+    private static final Pattern MASK_PATTERN = Pattern.compile("[\\.|/]");
 
     public static boolean isInetAddress(String ipString) {
         return ipStringToBytes(ipString) != null;
@@ -353,5 +357,60 @@ public class InetAddresses {
         } catch (UnknownHostException e) {
             throw new AssertionError(e);
         }
+    }
+
+    /**
+     * Computes the min &amp; max ip addresses (represented as long values - same way as stored in index) represented by the given CIDR mask
+     * expression. The returned array has the length of 2, where the first entry represents the {@code min} address and the second the {@code max}.
+     * A {@code -1} value for either the {@code min} or the {@code max}, represents an unbounded end. In other words:
+     *
+     * <p>
+     * {@code min == -1 == "0.0.0.0" }
+     * </p>
+     *
+     * and
+     *
+     * <p>
+     * {@code max == -1 == "255.255.255.255" }
+     * </p>
+     */
+    public static long[] cidrMaskToMinMax(String cidr) {
+        String[] parts = MASK_PATTERN.split(cidr);
+        if (parts.length != 5) {
+            return null;
+        }
+        int addr = (( Integer.parseInt(parts[0]) << 24 ) & 0xFF000000)
+                | (( Integer.parseInt(parts[1]) << 16 ) & 0xFF0000)
+                | (( Integer.parseInt(parts[2]) << 8 ) & 0xFF00)
+                |  ( Integer.parseInt(parts[3]) & 0xFF);
+
+        int mask = (-1) << (32 - Integer.parseInt(parts[4]));
+
+        if (Integer.parseInt(parts[4]) == 0) {
+            mask = 0 << 32;
+        }
+
+        int from = addr & mask;
+        long longFrom = intIpToLongIp(from);
+        if (longFrom == 0) {
+            longFrom = -1;
+        }
+
+        int to = from + (~mask);
+        long longTo = intIpToLongIp(to) + 1; // we have to +1 here as the range is non-inclusive on the "to" side
+
+        if (longTo == InternalIPv4Range.MAX_IP) {
+            longTo = -1;
+        }
+
+        return new long[] { longFrom, longTo };
+    }
+
+    private static long intIpToLongIp(int i) {
+        long p1 = ((long) ((i >> 24 ) & 0xFF)) << 24;
+        int p2 = ((i >> 16 ) & 0xFF) << 16;
+        int p3 = ((i >>  8 ) & 0xFF) << 8;
+        int p4 = i & 0xFF;
+        return p1 + p2 + p3 + p4;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/core/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -25,12 +25,13 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class InetAddresses {
     private static int IPV4_PART_COUNT = 4;
     private static int IPV6_PART_COUNT = 8;
-    private static final Pattern MASK_PATTERN = Pattern.compile("[\\.|/]");
+    private static final Pattern MASK_PATTERN = Pattern.compile("(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,3})");
 
     public static boolean isInetAddress(String ipString) {
         return ipStringToBytes(ipString) != null;
@@ -375,18 +376,18 @@ public class InetAddresses {
      * </p>
      */
     public static long[] cidrMaskToMinMax(String cidr) {
-        String[] parts = MASK_PATTERN.split(cidr);
-        if (parts.length != 5) {
+        Matcher matcher = MASK_PATTERN.matcher(cidr);
+        if (!matcher.matches()) {
             return null;
         }
-        int addr = (( Integer.parseInt(parts[0]) << 24 ) & 0xFF000000)
-                | (( Integer.parseInt(parts[1]) << 16 ) & 0xFF0000)
-                | (( Integer.parseInt(parts[2]) << 8 ) & 0xFF00)
-                |  ( Integer.parseInt(parts[3]) & 0xFF);
+        int addr = (( Integer.parseInt(matcher.group(1)) << 24 ) & 0xFF000000)
+                | (( Integer.parseInt(matcher.group(2)) << 16 ) & 0xFF0000)
+                | (( Integer.parseInt(matcher.group(3)) << 8 ) & 0xFF00)
+                |  ( Integer.parseInt(matcher.group(4)) & 0xFF);
 
-        int mask = (-1) << (32 - Integer.parseInt(parts[4]));
+        int mask = (-1) << (32 - Integer.parseInt(matcher.group(5)));
 
-        if (Integer.parseInt(parts[4]) == 0) {
+        if (Integer.parseInt(matcher.group(5)) == 0) {
             mask = 0 << 32;
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4RangeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4RangeBuilder.java
@@ -19,11 +19,10 @@
 
 package org.elasticsearch.search.aggregations.bucket.range.ipv4;
 
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.search.aggregations.bucket.range.AbstractRangeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilderException;
 
-import java.util.regex.Pattern;
+import static org.elasticsearch.index.mapper.ip.IpFieldMapper.cidrMaskToMinMax;
 
 /**
  * Builder for the {@code IPv4Range} aggregation.
@@ -60,7 +59,7 @@ public class IPv4RangeBuilder extends AbstractRangeBuilder<IPv4RangeBuilder> {
      * Add a range based on a CIDR mask.
      */
     public IPv4RangeBuilder addMaskRange(String key, String mask) {
-        long[] fromTo = InetAddresses.cidrMaskToMinMax(mask);
+        long[] fromTo = cidrMaskToMinMax(mask);
         if (fromTo == null) {
             throw new SearchSourceBuilderException("invalid CIDR mask [" + mask + "] in ip_range aggregation [" + getName() + "]");
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4RangeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IPv4RangeBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.range.ipv4;
 
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.search.aggregations.bucket.range.AbstractRangeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilderException;
 
@@ -28,8 +29,6 @@ import java.util.regex.Pattern;
  * Builder for the {@code IPv4Range} aggregation.
  */
 public class IPv4RangeBuilder extends AbstractRangeBuilder<IPv4RangeBuilder> {
-
-    private static final Pattern MASK_PATTERN = Pattern.compile("[\\.|/]");
 
     /**
      * Sole constructor.
@@ -61,7 +60,7 @@ public class IPv4RangeBuilder extends AbstractRangeBuilder<IPv4RangeBuilder> {
      * Add a range based on a CIDR mask.
      */
     public IPv4RangeBuilder addMaskRange(String key, String mask) {
-        long[] fromTo = cidrMaskToMinMax(mask);
+        long[] fromTo = InetAddresses.cidrMaskToMinMax(mask);
         if (fromTo == null) {
             throw new SearchSourceBuilderException("invalid CIDR mask [" + mask + "] in ip_range aggregation [" + getName() + "]");
         }
@@ -109,58 +108,4 @@ public class IPv4RangeBuilder extends AbstractRangeBuilder<IPv4RangeBuilder> {
         return addUnboundedFrom(null, from);
     }
 
-    /**
-     * Computes the min &amp; max ip addresses (represented as long values - same way as stored in index) represented by the given CIDR mask
-     * expression. The returned array has the length of 2, where the first entry represents the {@code min} address and the second the {@code max}.
-     * A {@code -1} value for either the {@code min} or the {@code max}, represents an unbounded end. In other words:
-     *
-     * <p>
-     * {@code min == -1 == "0.0.0.0" }
-     * </p>
-     *
-     * and
-     *
-     * <p>
-     * {@code max == -1 == "255.255.255.255" }
-     * </p>
-     */
-    static long[] cidrMaskToMinMax(String cidr) {
-        String[] parts = MASK_PATTERN.split(cidr);
-        if (parts.length != 5) {
-            return null;
-        }
-        int addr = (( Integer.parseInt(parts[0]) << 24 ) & 0xFF000000)
-                | (( Integer.parseInt(parts[1]) << 16 ) & 0xFF0000)
-                | (( Integer.parseInt(parts[2]) << 8 ) & 0xFF00)
-                |  ( Integer.parseInt(parts[3]) & 0xFF);
-
-        int mask = (-1) << (32 - Integer.parseInt(parts[4]));
-
-        if (Integer.parseInt(parts[4]) == 0) {
-            mask = 0 << 32;
-        }
-
-        int from = addr & mask;
-        long longFrom = intIpToLongIp(from);
-        if (longFrom == 0) {
-            longFrom = -1;
-        }
-
-        int to = from + (~mask);
-        long longTo = intIpToLongIp(to) + 1; // we have to +1 here as the range is non-inclusive on the "to" side
-
-        if (longTo == InternalIPv4Range.MAX_IP) {
-            longTo = -1;
-        }
-
-        return new long[] { longFrom, longTo };
-    }
-
-    private static long intIpToLongIp(int i) {
-        long p1 = ((long) ((i >> 24 ) & 0xFF)) << 24;
-        int p2 = ((i >> 16 ) & 0xFF) << 16;
-        int p3 = ((i >>  8 ) & 0xFF) << 8;
-        int p4 = i & 0xFF;
-        return p1 + p2 + p3 + p4;
-    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/InternalIPv4Range.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/InternalIPv4Range.java
@@ -32,12 +32,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.index.mapper.ip.IpFieldMapper.MAX_IP;
+
 /**
  *
  */
 public class InternalIPv4Range extends InternalRange<InternalIPv4Range.Bucket, InternalIPv4Range> {
-
-    public static final long MAX_IP = 4294967296l;
 
     public final static Type TYPE = new Type("ip_range", "iprange");
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range.ipv4;
 
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -124,7 +125,7 @@ public class IpRangeParser implements Aggregator.Parser {
     }
 
     private static void parseMaskRange(String cidr, RangeAggregator.Range range, String aggregationName, SearchContext ctx) {
-        long[] fromTo = IPv4RangeBuilder.cidrMaskToMinMax(cidr);
+        long[] fromTo = InetAddresses.cidrMaskToMinMax(cidr);
         if (fromTo == null) {
             throw new SearchParseException(ctx, "invalid CIDR mask [" + cidr + "] in aggregation [" + aggregationName + "]",
                     null);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ipv4/IpRangeParser.java
@@ -18,8 +18,8 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range.ipv4;
 
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.ip.IpFieldMapper;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -125,7 +125,7 @@ public class IpRangeParser implements Aggregator.Parser {
     }
 
     private static void parseMaskRange(String cidr, RangeAggregator.Range range, String aggregationName, SearchContext ctx) {
-        long[] fromTo = InetAddresses.cidrMaskToMinMax(cidr);
+        long[] fromTo = IpFieldMapper.cidrMaskToMinMax(cidr);
         if (fromTo == null) {
             throw new SearchParseException(ctx, "invalid CIDR mask [" + cidr + "] in aggregation [" + aggregationName + "]",
                     null);

--- a/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.internal.DefaultSearchContext;
 import org.elasticsearch.test.ESIntegTestCase;
 
@@ -41,6 +42,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.containsString;
@@ -149,6 +151,10 @@ public class SimpleSearchIT extends ESIntegTestCase {
                 .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.168.1.5/32")))
                 .execute().actionGet();
         assertHitCount(search, 0l);
+
+        assertFailures(client().prepareSearch().setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "0/0/0/0/0"))),
+                RestStatus.BAD_REQUEST,
+                containsString("not a valid ip address"));
     }
 
     public void testSimpleId() {


### PR DESCRIPTION
Allow IP ranges to be specified with CIDR notation in a query string query.

I refactored the cidrMaskToMinMax method from IPv4RangeBuilder so it could be used for the IpFieldMapper as well.

Closes #7464
