### PR TITLE
updated yum repo doku - load gpg via https

### DIFF
--- a/docs/reference/setup/repositories.asciidoc
+++ b/docs/reference/setup/repositories.asciidoc
@@ -97,7 +97,7 @@ in a file with a `.repo` suffix, for example `elasticsearch.repo`
 name=Elasticsearch repository for {major-version} packages
 baseurl=http://packages.elastic.co/elasticsearch/{major-version}/centos
 gpgcheck=1
-gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
 enabled=1
 --------------------------------------------------
 


### PR DESCRIPTION
Ensure the YUM GPG-Key is imported via **https** to preserve users having unprotected sex with the internet.
