### PR TITLE
Make _type use doc values

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/TypeFieldMapper.java
@@ -30,6 +30,8 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
@@ -86,7 +88,7 @@ public class TypeFieldMapper extends MetadataFieldMapper {
 
         @Override
         public TypeFieldMapper build(BuilderContext context) {
-            fieldType.setNames(new MappedFieldType.Names(indexName, indexName, name));
+            fieldType.setNames(buildNames(context));
             return new TypeFieldMapper(fieldType, context.indexSettings());
         }
     }
@@ -146,12 +148,21 @@ public class TypeFieldMapper extends MetadataFieldMapper {
     }
 
     public TypeFieldMapper(Settings indexSettings, MappedFieldType existing) {
-        this(existing == null ? Defaults.FIELD_TYPE.clone() : existing.clone(),
+        this(existing == null ? defaultFieldType(indexSettings) : existing.clone(),
              indexSettings);
     }
 
     public TypeFieldMapper(MappedFieldType fieldType, Settings indexSettings) {
-        super(NAME, fieldType, Defaults.FIELD_TYPE, indexSettings);
+        super(NAME, fieldType, defaultFieldType(indexSettings), indexSettings);
+    }
+
+    private static MappedFieldType defaultFieldType(Settings indexSettings) {
+        MappedFieldType defaultFieldType = Defaults.FIELD_TYPE.clone();
+        Version indexCreated = Version.indexCreated(indexSettings);
+        if (indexCreated.onOrAfter(Version.V_2_1_0)) {
+            defaultFieldType.setHasDocValues(true);
+        }
+        return defaultFieldType;
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/mapper/internal/TypeFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/internal/TypeFieldMapperTests.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper.internal;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+public class TypeFieldMapperTests extends ESSingleNodeTestCase {
+
+    public void testDocValues() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().endObject().string();
+
+        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        TypeFieldMapper typeMapper = docMapper.rootMapper(TypeFieldMapper.class);
+        assertTrue(typeMapper.fieldType().hasDocValues());
+    }
+
+    public void testDocValuesPre21() throws Exception {
+        // between 2.0 and 2.1, doc values was disabled for _type
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().endObject().string();
+        Settings bwcSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_0_0_beta1.id).build();
+
+        DocumentMapper docMapper = createIndex("test", bwcSettings).mapperService().documentMapperParser().parse(mapping);
+        TypeFieldMapper typeMapper = docMapper.rootMapper(TypeFieldMapper.class);
+        assertFalse(typeMapper.fieldType().hasDocValues());
+    }
+}


### PR DESCRIPTION
_type should have got doc values with the change to default doc values.
However, due to how metadata fields have separate builders and special
constructors, it was not picking it up. This change updates the field
type for _type to have doc values.

closes #14781
