### PR TITLE
Also clean buildSrc when cleaning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,5 +166,10 @@ task buildSrcEclipse(type: GradleBuild) {
 }
 tasks.eclipse.dependsOn(buildSrcEclipse)
 
+task clean(type: GradleBuild) {
+  buildFile = 'buildSrc/build.gradle'
+  tasks = ['clean']
+}
+
 task run(dependsOn: ':distribution:run')
 


### PR DESCRIPTION
This forces buildSrc to be cleaned when running gradle clean. It's what
someone would expect, even though buildSrc is a pseudo-independent
project.
