### PR TITLE
Build: Make run command work within plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,5 +171,9 @@ task clean(type: GradleBuild) {
   tasks = ['clean']
 }
 
-task run(dependsOn: ':distribution:run')
+task run() {
+  dependsOn ':distribution:run'
+  description = 'Runs elasticsearch in the foreground'
+  group = 'Verification'
+}
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -102,7 +102,7 @@ class ClusterFormationTasks {
             String camelName = plugin.getKey().replaceAll(/-(\w)/) { _, c -> c.toUpperCase(Locale.ROOT) }
             String taskName = "${task.name}#install${camelName[0].toUpperCase(Locale.ROOT) + camelName.substring(1)}Plugin"
             // delay reading the file location until execution time by wrapping in a closure within a GString
-            String file = "${ -> new File(pluginsTmpDir, plugin.getValue().singleFile.getName()).toURI().toURL().toString() }"
+            String file = "${-> new File(pluginsTmpDir, plugin.getValue().singleFile.getName()).toURI().toURL().toString()}"
             Object[] args = [new File(home, 'bin/plugin'), 'install', file]
             setup = configureExecTask(taskName, project, setup, cwd, args)
         }
@@ -115,8 +115,11 @@ class ClusterFormationTasks {
         Task start = configureStartTask("${task.name}#start", project, setup, cwd, config, clusterName, pidFile, home)
         task.dependsOn(start)
 
-        Task stop = configureStopTask("${task.name}#stop", project, [], pidFile)
-        task.finalizedBy(stop)
+        if (config.daemonize) {
+            // if we are running in the background, make sure to stop the server when the task completes
+            Task stop = configureStopTask("${task.name}#stop", project, [], pidFile)
+            task.finalizedBy(stop)
+        }
     }
 
     /** Adds a task to extract the elasticsearch distribution */

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
@@ -1,12 +1,23 @@
 package org.elasticsearch.gradle.test
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.Project
 
 class RunTask extends DefaultTask {
+
     ClusterConfiguration clusterConfig = new ClusterConfiguration(httpPort: 9200, transportPort: 9300, daemonize: false)
 
     RunTask() {
-        ClusterFormationTasks.setup(project, this, clusterConfig)
+        project.afterEvaluate {
+            ClusterFormationTasks.setup(project, this, clusterConfig)
+        }
+    }
+
+    static void configure(Project project) {
+        RunTask task = project.tasks.create(
+            name: 'run',
+            type: RunTask,
+            description: "Runs elasticsearch with '${project.path}'",
+            group: 'Verification')
     }
 }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -19,6 +19,7 @@
 
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.elasticsearch.gradle.precommit.DependencyLicensesTask
+import org.elasticsearch.gradle.test.RunTask
 import org.elasticsearch.gradle.MavenFilteringHack
 
 // for deb/rpm
@@ -196,4 +197,5 @@ DependencyLicensesTask.configure(project) {
   mapping from: /jackson-.*/, to: 'jackson'
 }
 
-task run(type:org.elasticsearch.gradle.test.RunTask){}
+RunTask.configure(project)
+


### PR DESCRIPTION
We recently got a run command with gradle, but it is sometimes useful to
run ES with a specific plugin. This is a start, by making each esplugin
have a run command which installs the plugin and runs elasticsearch in
the foreground.
