### PR TITLE
Restore thread interrupt flag after an InterruptedException

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
@@ -103,6 +103,8 @@ public class NodeIndexDeletedAction extends AbstractComponent {
                     INDEX_STORE_DELETED_ACTION_NAME, new NodeIndexStoreDeletedMessage(index, nodeId), EmptyTransportResponseHandler.INSTANCE_SAME);
         } catch (LockObtainFailedException exc) {
             logger.warn("[{}] failed to lock all shards for index - timed out after 30 seconds", index);
+        } catch (InterruptedException e) {
+            logger.warn("[{}] failed to lock all shards for index - interrupted", index);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/AbstractRunnable.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/AbstractRunnable.java
@@ -35,9 +35,6 @@ public abstract class AbstractRunnable implements Runnable {
     public final void run() {
         try {
             doRun();
-        } catch (InterruptedException ex) {
-            Thread.interrupted();
-            onFailure(ex);
         } catch (Throwable t) {
             onFailure(t);
         } finally {

--- a/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -99,7 +99,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
         try {
             this.purgerThread.shutdown();
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            // we intentionally do not want to restore the interruption flag, we're about to shutdown anyway
         }
     }
 
@@ -340,7 +340,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
             try {
                 condition.await(timeout.millis(), TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
-                Thread.interrupted();
+                // we intentionally do not want to restore the interruption flag, we're about to shutdown anyway
             } finally {
                 lock.unlock();
             }

--- a/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -135,7 +134,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         ensureGreen("test");
     }
 
-    public void testPendingTasks() throws IOException {
+    public void testPendingTasks() throws Exception {
         IndicesService indicesService = getIndicesService();
         IndexService test = createIndex("test");
 

--- a/test-framework/src/main/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -63,19 +63,14 @@ public class CompositeTestCluster extends TestCluster {
     }
 
     @Override
-    public synchronized void beforeTest(Random random, double transportClientRatio) throws IOException {
+    public synchronized void beforeTest(Random random, double transportClientRatio) throws IOException, InterruptedException {
         super.beforeTest(random, transportClientRatio);
         cluster.beforeTest(random, transportClientRatio);
         Settings defaultSettings = cluster.getDefaultSettings();
         final Client client = cluster.size() > 0 ? cluster.client() : cluster.clientNodeClient();
         for (int i = 0; i < externalNodes.length; i++) {
             if (!externalNodes[i].running()) {
-                try {
-                    externalNodes[i] = externalNodes[i].start(client, defaultSettings, NODE_PREFIX + i, cluster.getClusterName(), i);
-                } catch (InterruptedException e) {
-                    Thread.interrupted();
-                    return;
-                }
+                externalNodes[i] = externalNodes[i].start(client, defaultSettings, NODE_PREFIX + i, cluster.getClusterName(), i);
             }
             externalNodes[i].reset(random.nextLong());
         }

--- a/test-framework/src/main/java/org/elasticsearch/test/ExternalNode.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/ExternalNode.java
@@ -206,7 +206,7 @@ final class ExternalNode implements Closeable {
         this.random.setSeed(seed);
     }
 
-    synchronized void stop() {
+    synchronized void stop() throws InterruptedException {
         if (running()) {
             try {
                 if (this.client != null) {
@@ -214,11 +214,7 @@ final class ExternalNode implements Closeable {
                 }
             } finally {
                 process.destroy();
-                try {
-                    process.waitFor();
-                } catch (InterruptedException e) {
-                    Thread.interrupted();
-                }
+                process.waitFor();
                 process = null;
                 nodeInfo = null;
 
@@ -233,7 +229,11 @@ final class ExternalNode implements Closeable {
 
     @Override
     public void close() {
-        stop();
+        try {
+            stop();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     synchronized String getName() {

--- a/test-framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -910,7 +910,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     @Override
-    public synchronized void beforeTest(Random random, double transportClientRatio) throws IOException {
+    public synchronized void beforeTest(Random random, double transportClientRatio) throws IOException, InterruptedException {
         super.beforeTest(random, transportClientRatio);
         reset(true);
     }

--- a/test-framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -63,7 +63,7 @@ public abstract class TestCluster implements Iterable<Client>, Closeable {
     /**
      * This method should be executed before each test to reset the cluster to its initial state.
      */
-    public void beforeTest(Random random, double transportClientRatio) throws IOException {
+    public void beforeTest(Random random, double transportClientRatio) throws IOException, InterruptedException {
         assert transportClientRatio >= 0.0 && transportClientRatio <= 1.0;
         logger.debug("Reset test cluster with transport client ratio: [{}]", transportClientRatio);
         this.transportClientRatio = transportClientRatio;

--- a/test-framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test-framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -94,7 +94,7 @@ public class InternalTestClusterTests extends ESTestCase {
         }
     }
 
-    public void testBeforeTest() throws IOException {
+    public void testBeforeTest() throws Exception {
         long clusterSeed = randomLong();
         int minNumDataNodes = randomIntBetween(0, 3);
         int maxNumDataNodes = randomIntBetween(minNumDataNodes, 4);


### PR DESCRIPTION
This commit replaces all occurrences of Thread.interrupted() with
Thread.currentThread().interrupt(). While the former checks and clears the current
thread's interrupt flag the latter sets it, which is actually intended.

Closes #14798
