### PR TITLE
Fix minor typos in query dsl docs

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -51,7 +51,7 @@ final `_score` for each document.
         },
         "filter": {
             "term" : { "tag" : "tech" }
-        }
+        },
         "must_not" : {
             "range" : {
                 "age" : { "from" : 10, "to" : 20 }

--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -188,10 +188,10 @@ values separately.
         "filter" : {
             "geo_bounding_box" : {
                 "pin.location" : {
-                    "top" : -74.1,
-                    "left" : 40.73,
-                    "bottom" : -71.12,
-                    "right" : 40.01
+                    "top" : 40.73,
+                    "left" : -74.1,
+                    "bottom" : 40.01,
+                    "right" : -71.12
                 }
             }
         }

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -9,7 +9,7 @@ an example:
 --------------------------------------------------
 {
     "has_child" : {
-        "child_type" : "blog_tag",
+        "type" : "blog_tag",
         "query" : {
             "term" : {
                 "tag" : "something"
@@ -34,7 +34,7 @@ inside the `has_child` query:
 --------------------------------------------------
 {
     "has_child" : {
-        "child_type" : "blog_tag",
+        "type" : "blog_tag",
         "score_mode" : "min",
         "query" : {
             "term" : {
@@ -56,7 +56,7 @@ a match:
 --------------------------------------------------
 {
     "has_child" : {
-        "child_type" : "blog_tag",
+        "type" : "blog_tag",
         "score_mode" : "min",
         "min_children": 2, <1>
         "max_children": 10, <1>

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -9,7 +9,7 @@ an example:
 --------------------------------------------------
 {
     "has_child" : {
-        "type" : "blog_tag",
+        "child_type" : "blog_tag",
         "query" : {
             "term" : {
                 "tag" : "something"
@@ -34,8 +34,8 @@ inside the `has_child` query:
 --------------------------------------------------
 {
     "has_child" : {
-        "type" : "blog_tag",
-        "score_mode" : "sum",
+        "child_type" : "blog_tag",
+        "score_mode" : "min",
         "query" : {
             "term" : {
                 "tag" : "something"
@@ -56,8 +56,8 @@ a match:
 --------------------------------------------------
 {
     "has_child" : {
-        "type" : "blog_tag",
-        "score_mode" : "sum",
+        "child_type" : "blog_tag",
+        "score_mode" : "min",
         "min_children": 2, <1>
         "max_children": 10, <1>
         "query" : {

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -73,7 +73,6 @@ present in the index, the syntax is similar to <<docs-termvectors-artificial-doc
                 },
                 "tweet": "You got no idea what I'd... what I'd give to be invisible."
               }
-            }
         },
         {
             "_index" : "marvel",


### PR DESCRIPTION
When passing the example json snippets through the query parser while working
on #14249 some of the examples could not be parsed due to minor issues. This PR fixes those
examples.

Relates to #14249

@clintongormley would be good if you could have a look, the one interesting change is for the geo bounding box examples where on one occasion latitudes and longitudes had been switched I think.
