### PR TITLE
Add CONTAINS relation to geo_shape query

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/ShapeRelation.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/ShapeRelation.java
@@ -34,7 +34,8 @@ public enum ShapeRelation implements Writeable<ShapeRelation>{
 
     INTERSECTS("intersects"),
     DISJOINT("disjoint"),
-    WITHIN("within");
+    WITHIN("within"),
+    CONTAINS("contains");
 
     private final String relationName;
 

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -361,6 +361,8 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
             return new SpatialArgs(SpatialOperation.Intersects, shape.build());
         case WITHIN:
             return new SpatialArgs(SpatialOperation.IsWithin, shape.build());
+        case CONTAINS:
+            return new SpatialArgs(SpatialOperation.Contains, shape.build());
         default:
             throw new IllegalArgumentException("invalid relation [" + relation + "]");
         }

--- a/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
+++ b/core/src/test/java/org/elasticsearch/test/geo/RandomShapeGenerator.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.geo.builders.PointCollection;
 import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.search.geo.GeoShapeQueryTests;
 import org.junit.Assert;
 
 import java.util.Random;
@@ -155,7 +156,7 @@ public class RandomShapeGenerator extends RandomGeoGenerator {
     /**
      * Creates a random shape useful for randomized testing, NOTE: exercise caution when using this to build random GeometryCollections
      * as creating a large random number of random shapes can result in massive resource consumption
-     * see: {@link org.elasticsearch.search.geo.GeoShapeIntegrationIT#testShapeFilterWithRandomGeoCollection}
+     * see: {@link GeoShapeQueryTests#testShapeFilterWithRandomGeoCollection}
      *
      * The following options are included
      * @param nearPoint Create a shape near a provided point

--- a/docs/reference/query-dsl/geo-shape-query.asciidoc
+++ b/docs/reference/query-dsl/geo-shape-query.asciidoc
@@ -50,7 +50,8 @@ The following query will find the point using the Elasticsearch's
                         "shape": {
                             "type": "envelope",
                             "coordinates" : [[13.0, 53.0], [14.0, 52.0]]
-                        }
+                        },
+                        "relation": "within"
                     }
                 }
             }
@@ -61,7 +62,7 @@ The following query will find the point using the Elasticsearch's
 
 ==== Pre-Indexed Shape
 
-The Filter also supports using a shape which has already been indexed in
+The Query also supports using a shape which has already been indexed in
 another index and/or index type. This is particularly useful for when
 you have a pre-defined list of shapes which are useful to your
 application and you want to reference this using a logical name (for
@@ -101,3 +102,15 @@ shape:
 }
 --------------------------------------------------
 
+==== Spatial Relations
+
+The Query supports the following spatial relations:
+
+* `INTERSECTS` - (default) Return all documents whose `geo_shape` field
+intersects the query geometry.
+* `DISJOINT` - Return all documents whose `geo_shape` field
+has nothing in common with the query geometry.
+* `WITHIN` - Return all documents whose `geo_shape` field
+is within the query geometry.
+* `CONTAINS` - Return all documents whose `geo_shape` field
+contains the query geometry.

--- a/plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/GeoShapeIntegrationTests.java
+++ b/plugins/lang-groovy/src/test/java/org/elasticsearch/messy/tests/GeoShapeIntegrationTests.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.messy.tests;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.script.groovy.GroovyPlugin;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ */
+public class GeoShapeIntegrationTests extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singleton(GroovyPlugin.class);
+    }
+
+    /**
+     * Test that orientation parameter correctly persists across cluster restart
+     */
+    public void testOrientationPersistence() throws Exception {
+        String idxName = "orientation";
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("shape")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("orientation", "left")
+                .endObject().endObject()
+                .endObject().endObject().string();
+
+        // create index
+        assertAcked(prepareCreate(idxName).addMapping("shape", mapping));
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("shape")
+                .startObject("properties").startObject("location")
+                .field("type", "geo_shape")
+                .field("orientation", "right")
+                .endObject().endObject()
+                .endObject().endObject().string();
+
+        assertAcked(prepareCreate(idxName+"2").addMapping("shape", mapping));
+        ensureGreen(idxName, idxName+"2");
+
+        internalCluster().fullRestart();
+        ensureGreen(idxName, idxName+"2");
+
+        // left orientation test
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, findNodeName(idxName));
+        IndexService indexService = indicesService.indexService(idxName);
+        MappedFieldType fieldType = indexService.mapperService().smartNameFieldType("location");
+        assertThat(fieldType, instanceOf(GeoShapeFieldMapper.GeoShapeFieldType.class));
+
+        GeoShapeFieldMapper.GeoShapeFieldType gsfm = (GeoShapeFieldMapper.GeoShapeFieldType)fieldType;
+        ShapeBuilder.Orientation orientation = gsfm.orientation();
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CLOCKWISE));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.LEFT));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CW));
+
+        // right orientation test
+        indicesService = internalCluster().getInstance(IndicesService.class, findNodeName(idxName+"2"));
+        indexService = indicesService.indexService(idxName+"2");
+        fieldType = indexService.mapperService().smartNameFieldType("location");
+        assertThat(fieldType, instanceOf(GeoShapeFieldMapper.GeoShapeFieldType.class));
+
+        gsfm = (GeoShapeFieldMapper.GeoShapeFieldType)fieldType;
+        orientation = gsfm.orientation();
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.COUNTER_CLOCKWISE));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.RIGHT));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CCW));
+    }
+
+    private String findNodeName(String index) {
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        IndexShardRoutingTable shard = state.getRoutingTable().index(index).shard(0);
+        String nodeId = shard.assignedShards().get(0).currentNodeId();
+        return state.getNodes().get(nodeId).name();
+    }
+}


### PR DESCRIPTION
At the time of `geo_shape` query conception, `CONTAINS` was not yet a supported spatial operation in Lucene. Since it is now available this PR adds `ShapeRelation.CONTAINS` to `GeoShapeQuery`. Randomized testing is included and documentation is updated.

closes #14713
Backport closes #17866
