### PR TITLE
Fix missed comma in bool query

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -51,7 +51,7 @@ final `_score` for each document.
         },
         "filter": {
             "term" : { "tag" : "tech" }
-        }
+        },
         "must_not" : {
             "range" : {
                 "age" : { "from" : 10, "to" : 20 }


### PR DESCRIPTION
Seems that this mistake appear in 2.0 reference and higher. https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-bool-query.html 
