### PR TITLE
Add --debug-jvm option to run and integTest tasks

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -455,5 +455,9 @@ mvn -Dtests.coverage verify jacoco:report
 
 == Debugging from an IDE
 
-If you want to run elasticsearch from your IDE, you should execute gradle run
-It opens a remote debugging port that you can connect with your IDE.
+If you want to run elasticsearch from your IDE, the `gradle run` task
+supports a remote debugging option:
+
+---------------------------------------------------------------------------
+gradle run --debug-jvm
+---------------------------------------------------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,20 @@ task clean(type: GradleBuild) {
   tasks = ['clean']
 }
 
-task run() {
+// we need to add the same --debug-jvm option as
+// the real RunTask has, so we can pass it through
+class Run extends DefaultTask {
+  boolean debug = false
+
+  @org.gradle.api.internal.tasks.options.Option(
+        option = "debug-jvm",
+        description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch."
+  )
+  public void setDebug(boolean enabled) {
+    project.project(':distribution').run.clusterConfig.debug = enabled
+  } 
+}
+task run(type: Run) {
   dependsOn ':distribution:run'
   description = 'Runs elasticsearch in the foreground'
   group = 'Verification'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -40,6 +40,9 @@ class ClusterConfiguration {
     boolean daemonize = true
 
     @Input
+    boolean debug = false
+
+    @Input
     String jvmArgs = System.getProperty('tests.jvm.argline', '')
 
     Map<String, String> systemProperties = new HashMap<>()

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -212,7 +212,7 @@ class ClusterFormationTasks {
     static Task configureStartTask(String name, Project project, Task setup, File cwd, ClusterConfiguration config, String clusterName, File pidFile, File home) {
         Map esEnv = [
             'JAVA_HOME' : project.javaHome,
-            'ES_GC_OPTS': config.jvmArgs
+            'JAVA_OPTS': config.jvmArgs
         ]
         List<String> esProps = config.systemProperties.collect { key, value -> "-D${key}=${value}" }
         for (Map.Entry<String, String> property : System.properties.entrySet()) {
@@ -235,6 +235,13 @@ class ClusterFormationTasks {
 
         // this closure is converted into ant nodes by groovy's AntBuilder
         Closure antRunner = {
+            // we must add debug options inside the closure so the config is read at execution time, as
+            // gradle task options are not processed until the end of the configuration phase
+            if (config.debug) {
+                println 'Running elasticsearch in debug mode, connect on port 8000'
+                esEnv['JAVA_OPTS'] += ' -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000'
+            }
+
             exec(executable: executable, spawn: config.daemonize, dir: cwd, taskname: 'elasticsearch') {
                 esEnv.each { key, value -> env(key: key, value: value) }
                 (esArgs + esProps).each { arg(value: it) }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -238,7 +238,7 @@ class ClusterFormationTasks {
             // we must add debug options inside the closure so the config is read at execution time, as
             // gradle task options are not processed until the end of the configuration phase
             if (config.debug) {
-                println 'Running elasticsearch in debug mode, connect on port 8000'
+                println 'Running elasticsearch in debug mode, suspending until connected on port 8000'
                 esEnv['JAVA_OPTS'] += ' -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000'
             }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -22,6 +22,7 @@ import com.carrotsearch.gradle.junit4.RandomizedTestingTask
 import org.elasticsearch.gradle.BuildPlugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.internal.tasks.options.Option
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.tasks.Input
 import org.gradle.util.ConfigureUtil
@@ -77,6 +78,14 @@ class RestIntegTestTask extends RandomizedTestingTask {
                 systemProperty 'tests.cluster', "localhost:${clusterConfig.transportPort}"
             }
         }
+    }
+
+    @Option(
+        option = "debug-jvm",
+        description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch."
+    )
+    public void setDebug(boolean enabled) {
+        clusterConfig.debug = enabled;
     }
 
     @Input

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
@@ -2,6 +2,7 @@ package org.elasticsearch.gradle.test
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.internal.tasks.options.Option
 
 class RunTask extends DefaultTask {
 
@@ -11,6 +12,14 @@ class RunTask extends DefaultTask {
         project.afterEvaluate {
             ClusterFormationTasks.setup(project, this, clusterConfig)
         }
+    }
+
+    @Option(
+        option = "debug-jvm",
+        description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch."
+    )
+    public void setDebug(boolean enabled) {
+        clusterConfig.debug = enabled;
     }
 
     static void configure(Project project) {


### PR DESCRIPTION
Sometimes when running elasticsearch, it is useful to attach a remote
debugger. This change adds a --debug-jvm option (the same name gradle
uses for its tests debug option), which adds java agent config for a
remote debugger. The configuration is set to hava java suspend until the
remove debugger is attached.

closes #14772
