### PR TITLE
Output more information when gradle can't start elasticsearch

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -278,6 +278,11 @@ class ClusterFormationTasks {
                 } else {
                     logger.error("Couldn't start elasticsearch and couldn't find ${logFile}")
                 }
+                logger.error("Command: ${executable} ${(esArgs + esProps).join(' ')}")
+                if (esEnv.isEmpty() == false) {
+                    logger.error('environment:')
+                    esEnv.each { k, v -> logger.error("  ${k}: ${v}")}
+                }
                 throw new GradleException('Failed to start elasticsearch')
             }
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -258,6 +258,15 @@ class ClusterFormationTasks {
 
         // this closure is the actual code to run elasticsearch
         Closure elasticsearchRunner = {
+            // Command as string for logging
+            String esCommandString = "Elasticsearch command: ${executable} "
+            esCommandString += (esArgs + esProps).join(' ')
+            if (esEnv.isEmpty() == false) {
+                esCommandString += '\nenvironment:'
+                esEnv.each { k, v -> esCommandString += "\n  ${k}: ${v}" }
+            }
+            logger.info(esCommandString)
+
             ByteArrayOutputStream buffer = new ByteArrayOutputStream()
             if (logger.isInfoEnabled() || config.daemonize == false) {
                 // run with piping streams directly out (even stderr to stdout since gradle would capture it)
@@ -278,10 +287,9 @@ class ClusterFormationTasks {
                 } else {
                     logger.error("Couldn't start elasticsearch and couldn't find ${logFile}")
                 }
-                logger.error("Command: ${executable} ${(esArgs + esProps).join(' ')}")
-                if (esEnv.isEmpty() == false) {
-                    logger.error('environment:')
-                    esEnv.each { k, v -> logger.error("  ${k}: ${v}")}
+                if (logger.isInfoEnabled() == false) {
+                    // We already log the command at info level. No need to do it twice.
+                    logger.error(esCommandString)
                 }
                 throw new GradleException('Failed to start elasticsearch')
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -275,11 +275,13 @@ class ClusterFormationTasks {
                 File logFile = new File(home, "logs/${clusterName}.log")
                 if (logFile.exists()) {
                     logFile.eachLine { line -> logger.error(line) }
+                } else {
+                    logger.error("Couldn't start elasticsearch and couldn't find ${logFile}")
                 }
                 throw new GradleException('Failed to start elasticsearch')
             }
         }
-        
+
         Task start = project.tasks.create(name: name, type: DefaultTask, dependsOn: setup)
         start.doLast(elasticsearchRunner)
         return start


### PR DESCRIPTION
When the build tries to start an elasticsearch instance but the start fails
if it fails to find the log file then we log a line about how we can't find
the file.

Also log the command that we attempted to use.
