### PR TITLE
add support for removeProperty

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/Data.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/Data.java
@@ -95,13 +95,16 @@ public final class Data {
         return innerMap.containsKey(leafKey);
     }
 
+    /**
+     * Removes the property identified by the provided path
+     * @param path the path of the property to be removed
+     */
     public void removeProperty(String path) {
         if (path == null || path.length() == 0) {
             return;
         }
         String[] pathElements = Strings.splitStringToArray(path, '.');
         assert pathElements.length > 0;
-
         Map<String, Object> parent = getParent(pathElements);
         if (parent != null) {
             String leafKey = pathElements[pathElements.length - 1];


### PR DESCRIPTION
Added the api to remove a property, so it can be used in the mutate processor (delete) to support inner fields specified using the dot notation.
