### PR TITLE
Field stats: Fix NPE for index constraint on empty index

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
@@ -119,6 +119,10 @@ public class TransportFieldStatsTransportAction extends TransportBroadcastAction
                 while (iterator.hasNext()) {
                     Map.Entry<String, Map<String, FieldStats>> entry = iterator.next();
                     FieldStats indexConstraintFieldStats = entry.getValue().get(indexConstraint.getField());
+                    if (indexConstraintFieldStats == null) {
+                        continue;
+                    }
+
                     if (indexConstraintFieldStats.match(indexConstraint)) {
                         // If the field stats didn't occur in the list of fields in the original request we need to remove the
                         // field stats, because it was never requested and was only needed to validate the index constraint

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -390,4 +390,22 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         }
     }
 
+    public void testEmptyIndex() {
+        createIndex("test1", Settings.EMPTY, "type", "value", "type=date");
+        FieldStatsResponse response = client().prepareFieldStats()
+                .setFields("value")
+                .setLevel("indices")
+                .get();
+        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").size(), equalTo(0));
+
+        response = client().prepareFieldStats()
+                .setFields("value")
+                .setIndexContraints(new IndexConstraint("value", MIN, GTE, "1998-01-01T00:00:00.000Z"))
+                .setLevel("indices")
+                .get();
+        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").size(), equalTo(0));
+    }
+
 }


### PR DESCRIPTION
The field does exist used in the index constraint does exist in the mapping, but no document uses it or the index is empty and this causes an NPE:

```
java.lang.NullPointerException
    at org.elasticsearch.action.fieldstats.TransportFieldStatsTransportAction.newResponse(TransportFieldStatsTransportAction.java:122)
    at org.elasticsearch.action.fieldstats.TransportFieldStatsTransportAction.newResponse(TransportFieldStatsTransportAction.java:54)
    at org.elasticsearch.action.support.broadcast.TransportBroadcastAction$AsyncBroadcastAction.finishHim(TransportBroadcastAction.java:229)
    at org.elasticsearch.action.support.broadcast.TransportBroadcastAction$AsyncBroadcastAction.onOperation(TransportBroadcastAction.java:194)
    at org.elasticsearch.action.support.broadcast.TransportBroadcastAction$AsyncBroadcastAction$1.handleResponse(TransportBroadcastAction.java:174)
    at org.elasticsearch.action.support.broadcast.TransportBroadcastAction$AsyncBroadcastAction$1.handleResponse(TransportBroadcastAction.java:161)
    at org.elasticsearch.transport.TransportService$DirectResponseChannel.processResponse(TransportService.java:785)
    at org.elasticsearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:769)
    at org.elasticsearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:759)
    at org.elasticsearch.action.support.broadcast.TransportBroadcastAction$ShardTransportHandler.messageReceived(TransportBroadcastAction.java:268)
    at org.elasticsearch.action.support.broadcast.TransportBroadcastAction$ShardTransportHandler.messageReceived(TransportBroadcastAction.java:264)
    at org.elasticsearch.transport.TransportService$4.doRun(TransportService.java:350)
    at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```
