### PR TITLE
Fix SnapshotBackwardsCompatibilityIT

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -296,6 +296,8 @@
                                 <include>org/elasticsearch/search/aggregations/bucket/script/NativeSignificanceScoreScriptWithParams$*.class</include>
                                 <include>org/elasticsearch/search/aggregations/bucket/script/TestScript.class</include>
                                 <include>org/elasticsearch/search/aggregations/metrics/AbstractNumericTestCase.class</include>
+                                <include>org/elasticsearch/snapshots/SnapshotSharedTest.class</include>
+                                <include>org/elasticsearch/snapshots/SnapshotSharedTest$*.class</include>
                                 <include>org/elasticsearch/percolator/PercolatorTestUtil.class</include>
                                 <include>org/elasticsearch/cache/recycler/MockPageCacheRecycler.class</include>
                                 <include>org/elasticsearch/cache/recycler/MockPageCacheRecycler$*.class</include>

--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotSharedTest.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotSharedTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ListenableActionFuture;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotIndexShardStatus;
+import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotStatus;
+import org.elasticsearch.action.admin.indices.flush.FlushResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.hamcrest.Matcher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.elasticsearch.test.ESIntegTestCase.client;
+import static org.elasticsearch.test.ESIntegTestCase.cluster;
+import static org.elasticsearch.test.ESTestCase.randomBoolean;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test cases shared between SharedClusterSnapshotRestoreIT and SnapshotBackwardsCompatibilityIT.
+ */
+public class SnapshotSharedTest {
+    /**
+     * Callback used after snapshots have been created.
+     */
+    public static interface AfterSnapshotAction {
+        public static AfterSnapshotAction NOOP = new AfterSnapshotAction() {
+            @Override
+            public void run(String[] indices, int numDocs) {
+            }
+        };
+        /**
+         * Called after the snapshots have been created.
+         * @param indices the indices that the test is using
+         * @param numDocs the number of docs in open indices on the cluster
+         */
+        public void run(String[] indices, int numDocs);
+    }
+
+    public static void testBasicWorkflow(ESLogger logger, ESIntegTestCase testCase, AfterSnapshotAction afterSnapshotAction, Matcher<Version> snapshotVersion) {
+        logger.info("-->  creating repository");
+        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
+                .setType("fs").setSettings(Settings.settingsBuilder()
+                        .put("location", testCase.randomRepoPath())
+                        .put("compress", randomBoolean())
+                        .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
+
+        testCase.createIndex("test-idx-1", "test-idx-2", "test-idx-3");
+        testCase.ensureGreen();
+
+        logger.info("--> indexing some data");
+        for (int i = 0; i < 100; i++) {
+            testCase.index("test-idx-1", "doc", Integer.toString(i), "foo", "bar" + i);
+            testCase.index("test-idx-2", "doc", Integer.toString(i), "foo", "baz" + i);
+            testCase.index("test-idx-3", "doc", Integer.toString(i), "foo", "baz" + i);
+        }
+        testCase.refresh();
+        assertHitCount(client().prepareSearch("test-idx-1").get(), 100L);
+        assertHitCount(client().prepareSearch("test-idx-2").get(), 100L);
+        assertHitCount(client().prepareSearch("test-idx-3").get(), 100L);
+
+        ListenableActionFuture<FlushResponse> flushResponseFuture = null;
+        if (randomBoolean()) {
+            ArrayList<String> indicesToFlush = new ArrayList<>();
+            for (int i = 1; i < 4; i++) {
+                if (randomBoolean()) {
+                    indicesToFlush.add("test-idx-" + i);
+                }
+            }
+            if (!indicesToFlush.isEmpty()) {
+                String[] indices = indicesToFlush.toArray(new String[indicesToFlush.size()]);
+                logger.info("--> starting asynchronous flush for indices {}", Arrays.toString(indices));
+                flushResponseFuture = client().admin().indices().prepareFlush(indices).execute();
+            }
+        }
+        logger.info("--> snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap").setWaitForCompletion(true).setIndices("test-idx-*", "-test-idx-3").get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+
+        SnapshotInfo snapshotInfo = client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-snap").get().getSnapshots().get(0);
+        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo.version(), snapshotVersion);
+
+        logger.info("--> delete some data");
+        for (int i = 0; i < 50; i++) {
+            client().prepareDelete("test-idx-1", "doc", Integer.toString(i)).get();
+        }
+        for (int i = 50; i < 100; i++) {
+            client().prepareDelete("test-idx-2", "doc", Integer.toString(i)).get();
+        }
+        for (int i = 0; i < 100; i += 2) {
+            client().prepareDelete("test-idx-3", "doc", Integer.toString(i)).get();
+        }
+        assertAllSuccessful(testCase.refresh());
+        assertHitCount(client().prepareSearch("test-idx-1").get(), 50L);
+        assertHitCount(client().prepareSearch("test-idx-2").get(), 50L);
+        assertHitCount(client().prepareSearch("test-idx-3").get(), 50L);
+
+        logger.info("--> close indices");
+        client().admin().indices().prepareClose("test-idx-1", "test-idx-2").get();
+
+        afterSnapshotAction.run(new String[] {"test-idx-1", "test-idx-2", "test-idx-3"}, 50);
+
+        logger.info("--> restore all indices from the snapshot");
+        RestoreSnapshotResponse restoreSnapshotResponse = client().admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setWaitForCompletion(true).execute().actionGet();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
+
+        testCase.ensureGreen();
+        for (int i=0; i<5; i++) {
+            assertHitCount(client().prepareSearch("test-idx-1").get(), 100L);
+            assertHitCount(client().prepareSearch("test-idx-2").get(), 100L);
+            assertHitCount(client().prepareSearch("test-idx-3").get(), 50L);
+        }
+
+        // Test restore after index deletion
+        logger.info("--> delete indices");
+        cluster().wipeIndices("test-idx-1", "test-idx-2");
+        logger.info("--> restore one index after deletion");
+        restoreSnapshotResponse = client().admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap").setWaitForCompletion(true).setIndices("test-idx-*", "-test-idx-2").execute().actionGet();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
+
+        testCase.ensureGreen();
+        for (int i=0; i<5; i++) {
+            assertHitCount(client().prepareSearch("test-idx-1").get(), 100L);
+        }
+        ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        assertThat(clusterState.getMetaData().hasIndex("test-idx-1"), equalTo(true));
+        assertThat(clusterState.getMetaData().hasIndex("test-idx-2"), equalTo(false));
+
+        if (flushResponseFuture != null) {
+            // Finish flush
+            flushResponseFuture.actionGet();
+        }
+    }
+
+    /**
+     * Take multiple snapshots of the same index and assert things along the
+     * way.
+     *
+     * @param actionBetweenSnapshots action run after the first snapshot is created
+     */
+    public static void testSnapshotMoreThanOnce(ESLogger logger, ESIntegTestCase testCase, AfterSnapshotAction actionBetweenSnapshots) throws Exception {
+        logger.info("-->  creating repository");
+        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
+                .setType("fs").setSettings(Settings.settingsBuilder()
+                        .put("location", testCase.randomRepoPath())
+                        .put("compress", randomBoolean())
+                        .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
+
+        // only one shard
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(testCase.indexSettings()).setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)));
+        testCase.ensureGreen();
+        logger.info("-->  indexing");
+
+        final int numdocs = randomIntBetween(10, 100);
+        IndexRequestBuilder[] builders = new IndexRequestBuilder[numdocs];
+        for (int i = 0; i < builders.length; i++) {
+            builders[i] = client().prepareIndex("test", "doc", Integer.toString(i)).setSource("foo", "bar" + i);
+        }
+        testCase.indexRandom(true, builders);
+        testCase.flushAndRefresh();
+        assertNoFailures(client().admin().indices().prepareForceMerge("test").setFlush(true).setMaxNumSegments(1).get());
+
+        CreateSnapshotResponse createSnapshotResponseFirst = client().admin().cluster().prepareCreateSnapshot("test-repo", "test").setWaitForCompletion(true).setIndices("test").get();
+        assertThat(createSnapshotResponseFirst.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponseFirst.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponseFirst.getSnapshotInfo().totalShards()));
+        assertThat(client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
+        {
+            SnapshotStatus snapshotStatus = client().admin().cluster().prepareSnapshotStatus("test-repo").setSnapshots("test").get().getSnapshots().get(0);
+            List<SnapshotIndexShardStatus> shards = snapshotStatus.getShards();
+            for (SnapshotIndexShardStatus status : shards) {
+                assertThat(status.getStats().getProcessedFiles(), greaterThan(1));
+            }
+        }
+
+        actionBetweenSnapshots.run(new String[] {"test"}, numdocs);
+
+        CreateSnapshotResponse createSnapshotResponseSecond = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-1").setWaitForCompletion(true).setIndices("test").get();
+        assertThat(createSnapshotResponseSecond.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponseSecond.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponseSecond.getSnapshotInfo().totalShards()));
+        assertThat(client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-1").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
+        {
+            SnapshotStatus snapshotStatus = client().admin().cluster().prepareSnapshotStatus("test-repo").setSnapshots("test-1").get().getSnapshots().get(0);
+            List<SnapshotIndexShardStatus> shards = snapshotStatus.getShards();
+            for (SnapshotIndexShardStatus status : shards) {
+                assertThat(status.getStats().getProcessedFiles(), equalTo(0));
+            }
+        }
+
+        client().prepareDelete("test", "doc", "1").get();
+        CreateSnapshotResponse createSnapshotResponseThird = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-2").setWaitForCompletion(true).setIndices("test").get();
+        assertThat(createSnapshotResponseThird.getSnapshotInfo().successfulShards(), greaterThan(0));
+        assertThat(createSnapshotResponseThird.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponseThird.getSnapshotInfo().totalShards()));
+        assertThat(client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-2").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
+        {
+            SnapshotStatus snapshotStatus = client().admin().cluster().prepareSnapshotStatus("test-repo").setSnapshots("test-2").get().getSnapshots().get(0);
+            List<SnapshotIndexShardStatus> shards = snapshotStatus.getShards();
+            for (SnapshotIndexShardStatus status : shards) {
+                assertThat(status.getStats().getProcessedFiles(), equalTo(2)); // we flush before the snapshot such that we have to process the segments_N files plus the .del file
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -37,7 +37,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -64,6 +63,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -1219,7 +1219,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
      *   return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
      * </pre>
      */
-    protected final IndexResponse index(String index, String type, String id, Object... source) {
+    public final IndexResponse index(String index, String type, String id, Object... source) {
         return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
     }
 
@@ -1241,7 +1241,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
      *
      * @see #waitForRelocation()
      */
-    protected final RefreshResponse refresh() {
+    public final RefreshResponse refresh() {
         waitForRelocation();
         // TODO RANDOMIZE with flush?
         RefreshResponse actionGet = client().admin().indices().prepareRefresh().execute().actionGet();
@@ -1252,7 +1252,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     /**
      * Flushes and refreshes all indices in the cluster
      */
-    protected final void flushAndRefresh(String... indices) {
+    public final void flushAndRefresh(String... indices) {
         flush(indices);
         refresh();
     }

--- a/qa/backwards/shared/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
@@ -24,7 +24,6 @@ import org.apache.lucene.index.Fields;
 import org.apache.lucene.util.English;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
@@ -47,6 +46,7 @@ import org.elasticsearch.action.termvectors.TermVectorsResponse;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -217,7 +217,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
      */
     public void testNoRecoveryFromNewNodes() throws ExecutionException, InterruptedException {
         assumeFalse("Only makes sense if backwards version isn't the current version",
-                Version.fromString(backwardsCompatibilityVersion()).equals(Version.CURRENT));
+                backwardsCompatibilityVersion().equals(Version.CURRENT));
         assertAcked(prepareCreate("test").setSettings(Settings.builder().put("index.routing.allocation.exclude._name", backwardsCluster().backwardsNodePattern()).put(indexSettings())));
         if (backwardsCluster().numNewDataNodes() == 0) {
             backwardsCluster().startNewNode();

--- a/qa/backwards/shared/src/test/java/org/elasticsearch/bwcompat/SnapshotBackwardsCompatibilityIT.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/bwcompat/SnapshotBackwardsCompatibilityIT.java
@@ -18,229 +18,60 @@
  */
 package org.elasticsearch.bwcompat;
 
-import com.carrotsearch.randomizedtesting.generators.RandomPicks;
-
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
-import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
-import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
-import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotIndexShardStatus;
-import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotStatus;
-import org.elasticsearch.action.count.CountResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.io.FileSystemUtils;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.snapshots.SnapshotSharedTest;
+import org.elasticsearch.snapshots.SnapshotSharedTest.AfterSnapshotAction;
 import org.elasticsearch.test.ESBackcompatTestCase;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
 
-@AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/13522")
 public class SnapshotBackwardsCompatibilityIT extends ESBackcompatTestCase {
-    public void testSnapshotAndRestore() throws ExecutionException, InterruptedException, IOException {
-        logger.info("-->  creating repository");
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.settingsBuilder()
-                        .put("location", randomRepoPath().toAbsolutePath())
-                        .put("compress", randomBoolean())
-                        .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
-        String[] indicesBefore = new String[randomIntBetween(2,5)];
-        String[] indicesAfter = new String[randomIntBetween(2,5)];
-        for (int i = 0; i < indicesBefore.length; i++) {
-            indicesBefore[i] = "index_before_" + i;
-            createIndex(indicesBefore[i]);
-        }
-        for (int i = 0; i < indicesAfter.length; i++) {
-            indicesAfter[i] = "index_after_" + i;
-            createIndex(indicesAfter[i]);
-        }
-        String[] indices = new String[indicesBefore.length + indicesAfter.length];
-        System.arraycopy(indicesBefore, 0, indices, 0, indicesBefore.length);
-        System.arraycopy(indicesAfter, 0, indices, indicesBefore.length, indicesAfter.length);
-        ensureYellow();
-        logger.info("--> indexing some data");
-        IndexRequestBuilder[] buildersBefore = new IndexRequestBuilder[randomIntBetween(10, 200)];
-        for (int i = 0; i < buildersBefore.length; i++) {
-            buildersBefore[i] = client().prepareIndex(RandomPicks.randomFrom(getRandom(), indicesBefore), "foo", Integer.toString(i)).setSource("{ \"foo\" : \"bar\" } ");
-        }
-        IndexRequestBuilder[] buildersAfter = new IndexRequestBuilder[randomIntBetween(10, 200)];
-        for (int i = 0; i < buildersAfter.length; i++) {
-            buildersAfter[i] = client().prepareIndex(RandomPicks.randomFrom(getRandom(), indicesBefore), "bar", Integer.toString(i)).setSource("{ \"foo\" : \"bar\" } ");
-        }
-        indexRandom(true, buildersBefore);
-        indexRandom(true, buildersAfter);
-        assertThat(client().prepareCount(indices).get().getCount(), equalTo((long) (buildersBefore.length + buildersAfter.length)));
-        long[] counts = new long[indices.length];
-        for (int i = 0; i < indices.length; i++) {
-            counts[i] = client().prepareCount(indices[i]).get().getCount();
-        }
+    /**
+     * Tests that we can restore a snapshot made by a mixed version cluster when
+     * we're on a modern version cluster.
+     */
+    public void testBasicWorkflow() {
+        SnapshotSharedTest.testBasicWorkflow(logger, this, frequentlyUpgradeCluster,
+                either(equalTo(backwardsCompatibilityVersion())).or(equalTo(Version.CURRENT)));
+    }
 
-        logger.info("--> snapshot subset of indices before upgrage");
-        CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap-1").setWaitForCompletion(true).setIndices("index_before_*").get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
+    public void testSnapshotMoreThanOnce() throws Exception {
+        SnapshotSharedTest.testSnapshotMoreThanOnce(logger, this, frequentlyUpgradeCluster);
+    }
 
-        assertThat(client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-snap-1").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
-
-        logger.info("--> delete some data from indices that were already snapshotted");
-        int howMany = randomIntBetween(1, buildersBefore.length);
-
-        for (int i = 0; i < howMany; i++) {
-            IndexRequestBuilder indexRequestBuilder = RandomPicks.randomFrom(getRandom(), buildersBefore);
-            IndexRequest request = indexRequestBuilder.request();
-            client().prepareDelete(request.index(), request.type(), request.id()).get();
+    AfterSnapshotAction frequentlyUpgradeCluster = new AfterSnapshotAction() {
+        @Override
+        public void run(String[] indices, int numDocs) {
+            if (frequently()) {
+                upgradeCluster(indices, numDocs);
+            }
         }
-        refresh();
-        final long numDocs = client().prepareCount(indices).get().getCount();
-        assertThat(client().prepareCount(indices).get().getCount(), lessThan((long) (buildersBefore.length + buildersAfter.length)));
+    };
 
-
+    private void upgradeCluster(String[] indices, int numDocs) {
+        logger.info("-->  upgrade");
         disableAllocation(indices);
         backwardsCluster().allowOnAllNodes(indices);
         logClusterState();
         boolean upgraded;
         do {
             logClusterState();
-            CountResponse countResponse = client().prepareCount().get();
+            SearchResponse countResponse = client().prepareSearch().setSize(0).get();
             assertHitCount(countResponse, numDocs);
-            upgraded = backwardsCluster().upgradeOneNode();
+            try {
+                upgraded = backwardsCluster().upgradeOneNode();
+            } catch (InterruptedException | IOException e) {
+                throw new RuntimeException(e);
+            }
             ensureYellow();
-            countResponse = client().prepareCount().get();
+            countResponse = client().prepareSearch().setSize(0).get();
             assertHitCount(countResponse, numDocs);
         } while (upgraded);
         enableAllocation(indices);
-
-        logger.info("--> close indices");
-        client().admin().indices().prepareClose("index_before_*").get();
-
-        logger.info("--> verify repository");
-        client().admin().cluster().prepareVerifyRepository("test-repo").get();
-
-        logger.info("--> restore all indices from the snapshot");
-        RestoreSnapshotResponse restoreSnapshotResponse = client().admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap-1").setWaitForCompletion(true).execute().actionGet();
-        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
-
-        ensureYellow();
-        assertThat(client().prepareCount(indices).get().getCount(), equalTo((long) (buildersBefore.length + buildersAfter.length)));
-        for (int i = 0; i < indices.length; i++) {
-            assertThat(counts[i], equalTo(client().prepareCount(indices[i]).get().getCount()));
-        }
-
-        logger.info("--> snapshot subset of indices after upgrade");
-        createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap-2").setWaitForCompletion(true).setIndices("index_*").get();
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
-
-        // Test restore after index deletion
-        logger.info("--> delete indices");
-        String index = RandomPicks.randomFrom(getRandom(), indices);
-        cluster().wipeIndices(index);
-        logger.info("--> restore one index after deletion");
-        restoreSnapshotResponse = client().admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap-2").setWaitForCompletion(true).setIndices(index).execute().actionGet();
-        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
-        ensureYellow();
-        assertThat(client().prepareCount(indices).get().getCount(), equalTo((long) (buildersBefore.length + buildersAfter.length)));
-        for (int i = 0; i < indices.length; i++) {
-            assertThat(counts[i], equalTo(client().prepareCount(indices[i]).get().getCount()));
-        }
-    }
-
-    public void testSnapshotMoreThanOnce() throws ExecutionException, InterruptedException, IOException {
-        final Path tempDir = randomRepoPath().toAbsolutePath();
-        logger.info("-->  creating repository");
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.settingsBuilder()
-                        .put("location", tempDir)
-                        .put("compress", randomBoolean())
-                        .put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES)));
-
-        // only one shard
-        assertAcked(prepareCreate("test").setSettings(Settings.builder()
-                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-        ));
-        ensureYellow();
-        logger.info("-->  indexing");
-
-        final int numDocs = randomIntBetween(10, 100);
-        IndexRequestBuilder[] builders = new IndexRequestBuilder[numDocs];
-        for (int i = 0; i < builders.length; i++) {
-            builders[i] = client().prepareIndex("test", "doc", Integer.toString(i)).setSource("foo", "bar" + i);
-        }
-        indexRandom(true, builders);
-        flushAndRefresh();
-        assertNoFailures(client().admin().indices().prepareForceMerge("test").setFlush(true).setMaxNumSegments(1).get());
-
-        CreateSnapshotResponse createSnapshotResponseFirst = client().admin().cluster().prepareCreateSnapshot("test-repo", "test").setWaitForCompletion(true).setIndices("test").get();
-        assertThat(createSnapshotResponseFirst.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponseFirst.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponseFirst.getSnapshotInfo().totalShards()));
-        assertThat(client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
-        {
-            SnapshotStatus snapshotStatus = client().admin().cluster().prepareSnapshotStatus("test-repo").setSnapshots("test").get().getSnapshots().get(0);
-            List<SnapshotIndexShardStatus> shards = snapshotStatus.getShards();
-            for (SnapshotIndexShardStatus status : shards) {
-                assertThat(status.getStats().getProcessedFiles(), greaterThan(1));
-            }
-        }
-        if (frequently()) {
-            logger.info("-->  upgrade");
-            disableAllocation("test");
-            backwardsCluster().allowOnAllNodes("test");
-            logClusterState();
-            boolean upgraded;
-            do {
-                logClusterState();
-                CountResponse countResponse = client().prepareCount().get();
-                assertHitCount(countResponse, numDocs);
-                upgraded = backwardsCluster().upgradeOneNode();
-                ensureYellow();
-                countResponse = client().prepareCount().get();
-                assertHitCount(countResponse, numDocs);
-            } while (upgraded);
-            enableAllocation("test");
-        }
-        if (cluster().numDataNodes() > 1 && randomBoolean()) { // only bump the replicas if we have enough nodes
-            logger.info("--> move from 0 to 1 replica");
-            client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)).get();
-        }
-        logger.debug("---> repo exists: " + Files.exists(tempDir.resolve("indices/test/0")) + " files: " + Arrays.toString(FileSystemUtils.files(tempDir.resolve("indices/test/0")))); // it's only one shard!
-        CreateSnapshotResponse createSnapshotResponseSecond = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-1").setWaitForCompletion(true).setIndices("test").get();
-        assertThat(createSnapshotResponseSecond.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponseSecond.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponseSecond.getSnapshotInfo().totalShards()));
-        assertThat(client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-1").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
-        {
-            SnapshotStatus snapshotStatus = client().admin().cluster().prepareSnapshotStatus("test-repo").setSnapshots("test-1").get().getSnapshots().get(0);
-            List<SnapshotIndexShardStatus> shards = snapshotStatus.getShards();
-            for (SnapshotIndexShardStatus status : shards) {
-                assertThat(status.getStats().getProcessedFiles(), equalTo(1)); // we flush before the snapshot such that we have to process the segments_N files
-            }
-        }
-
-        client().prepareDelete("test", "doc", "1").get();
-        CreateSnapshotResponse createSnapshotResponseThird = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-2").setWaitForCompletion(true).setIndices("test").get();
-        assertThat(createSnapshotResponseThird.getSnapshotInfo().successfulShards(), greaterThan(0));
-        assertThat(createSnapshotResponseThird.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponseThird.getSnapshotInfo().totalShards()));
-        assertThat(client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-2").get().getSnapshots().get(0).state(), equalTo(SnapshotState.SUCCESS));
-        {
-            SnapshotStatus snapshotStatus = client().admin().cluster().prepareSnapshotStatus("test-repo").setSnapshots("test-2").get().getSnapshots().get(0);
-            List<SnapshotIndexShardStatus> shards = snapshotStatus.getShards();
-            for (SnapshotIndexShardStatus status : shards) {
-                assertThat(status.getStats().getProcessedFiles(), equalTo(2)); // we flush before the snapshot such that we have to process the segments_N files plus the .del file
-            }
-        }
     }
 }

--- a/qa/backwards/shared/src/test/java/org/elasticsearch/test/ESBackcompatTestCase.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/test/ESBackcompatTestCase.java
@@ -106,7 +106,7 @@ public abstract class ESBackcompatTestCase extends ESIntegTestCase {
     private static final Version GLOABL_COMPATIBILITY_VERSION = Version.fromString(compatibilityVersionProperty());
     private static final int EXTERNAL_NODE_BASE_PORT = 29200;
 
-    public static String backwardsCompatibilityVersion() {
+    public static Version backwardsCompatibilityVersion() {
         String version = System.getProperty(TESTS_BACKWARDS_COMPATIBILITY_VERSION);
         if (version == null || version.isEmpty()) {
             throw new IllegalArgumentException("Must specify backwards test version with property " + TESTS_BACKWARDS_COMPATIBILITY_VERSION);
@@ -116,7 +116,7 @@ public abstract class ESBackcompatTestCase extends ESIntegTestCase {
             throw new IllegalArgumentException("Backcompat elasticsearch version must be same major version as current. " +
                 "backcompat: " + version + ", current: " + Version.CURRENT.toString());
         }
-        return version;
+        return v;
     }
 
     @Override
@@ -189,7 +189,7 @@ public abstract class ESBackcompatTestCase extends ESIntegTestCase {
         TestCluster cluster = super.buildTestCluster(scope, seed);
         logger.info("Build internal cluster at {}", new Object[] {cluster.httpAddresses()});
         ExternalNodeServiceClient nodeServiceClient = new ExternalNodeServiceClient();
-        ExternalNode externalNode = new ExternalNode(backwardsCompatibilityVersion(), randomLong(), nodeServiceClient, new NodeConfigurationSource() {
+        ExternalNode externalNode = new ExternalNode(backwardsCompatibilityVersion().toString(), randomLong(), nodeServiceClient, new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
                 return externalNodeSettings(nodeOrdinal);

--- a/qa/backwards/shared/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -116,7 +116,6 @@ final class ExternalNode implements Closeable {
             switch (entry.getKey()) {
             case "path.home":
             case "node.local":
-            case "path.repo":
             case "path.shared_data":
             case TransportModule.TRANSPORT_TYPE_KEY:
             case DiscoveryModule.DISCOVERY_TYPE_KEY:


### PR DESCRIPTION
SnapshotBackwardsCompatibilityIT had drifted from its twin methods in
SharedClusterSnapshotRestoreIT. This creates SnapshotSharedTestCases which
makes the similar methods in both test cases use the same code, modulo the
cluster upgrade.

Related to #13522
