### PR TITLE
Decouple routing and primary operation logic in TransportReplicationAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/ShardFlushRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.flush;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -29,8 +30,8 @@ public class ShardFlushRequest extends ReplicationRequest<ShardFlushRequest> {
 
     private FlushRequest request = new FlushRequest();
 
-    public ShardFlushRequest(FlushRequest request) {
-        super(request);
+    public ShardFlushRequest(FlushRequest request, ShardId shardId) {
+        super(request, shardId);
         this.request = request;
     }
 
@@ -53,5 +54,8 @@ public class ShardFlushRequest extends ReplicationRequest<ShardFlushRequest> {
         request.writeTo(out);
     }
 
-
+    @Override
+    public String toString() {
+        return "flush {" + super.toString() + "}";
+    }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -53,7 +53,7 @@ public class TransportFlushAction extends TransportBroadcastReplicationAction<Fl
 
     @Override
     protected ShardFlushRequest newShardRequest(FlushRequest request, ShardId shardId) {
-        return new ShardFlushRequest(request).setShardId(shardId);
+        return new ShardFlushRequest(request, shardId);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -54,7 +54,7 @@ public class TransportRefreshAction extends TransportBroadcastReplicationAction<
 
     @Override
     protected ReplicationRequest newShardRequest(RefreshRequest request, ShardId shardId) {
-        return new ReplicationRequest(request).setShardId(shardId);
+        return new ReplicationRequest(request, shardId);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -24,13 +24,11 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.routing.ShardIterator;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -62,15 +60,16 @@ public class TransportShardRefreshAction extends TransportReplicationAction<Repl
     }
 
     @Override
-    protected Tuple<ActionWriteResponse, ReplicationRequest> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) throws Throwable {
-        IndexShard indexShard = indicesService.indexServiceSafe(shardRequest.shardId.getIndex()).getShard(shardRequest.shardId.id());
+    protected Tuple<ActionWriteResponse, ReplicationRequest> shardOperationOnPrimary(MetaData metaData, ReplicationRequest shardRequest) throws Throwable {
+        IndexShard indexShard = indicesService.indexServiceSafe(shardRequest.shardId().getIndex()).getShard(shardRequest.shardId().id());
         indexShard.refresh("api");
         logger.trace("{} refresh request executed on primary", indexShard.shardId());
-        return new Tuple<>(new ActionWriteResponse(), shardRequest.request);
+        return new Tuple<>(new ActionWriteResponse(), shardRequest);
     }
 
     @Override
-    protected void shardOperationOnReplica(ShardId shardId, ReplicationRequest request) {
+    protected void shardOperationOnReplica(ReplicationRequest request) {
+        final ShardId shardId = request.shardId();
         IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShard(shardId.id());
         indexShard.refresh("api");
         logger.trace("{} refresh request executed on replica", indexShard.shardId());
@@ -82,18 +81,13 @@ public class TransportShardRefreshAction extends TransportReplicationAction<Repl
     }
 
     @Override
-    protected ShardIterator shards(ClusterState clusterState, InternalRequest request) {
-        return clusterState.getRoutingTable().indicesRouting().get(request.concreteIndex()).getShards().get(request.request().shardId().getId()).shardsIt();
+    protected ClusterBlockLevel globalBlockLevel() {
+        return ClusterBlockLevel.METADATA_WRITE;
     }
 
     @Override
-    protected ClusterBlockException checkGlobalBlock(ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
-    }
-
-    @Override
-    protected ClusterBlockException checkRequestBlock(ClusterState state, InternalRequest request) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, new String[]{request.concreteIndex()});
+    protected ClusterBlockLevel indexBlockLevel() {
+        return ClusterBlockLevel.METADATA_WRITE;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -40,10 +40,8 @@ public class BulkShardRequest extends ReplicationRequest<BulkShardRequest> {
     public BulkShardRequest() {
     }
 
-    BulkShardRequest(BulkRequest bulkRequest, String index, int shardId, boolean refresh, BulkItemRequest[] items) {
-        super(bulkRequest);
-        this.index = index;
-        this.setShardId(new ShardId(index, shardId));
+    BulkShardRequest(BulkRequest bulkRequest, ShardId shardId, boolean refresh, BulkItemRequest[] items) {
+        super(bulkRequest, shardId);
         this.items = items;
         this.refresh = refresh;
     }
@@ -92,5 +90,10 @@ public class BulkShardRequest extends ReplicationRequest<BulkShardRequest> {
             }
         }
         refresh = in.readBoolean();
+    }
+
+    @Override
+    public String toString() {
+        return "shard bulk {" + super.toString() + "}";
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -275,7 +275,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                         list.add(new BulkItemRequest(i, new DeleteRequest(deleteRequest)));
                     }
                 } else {
-                    ShardId shardId = clusterService.operationRouting().deleteShards(clusterState, concreteIndex, deleteRequest.type(), deleteRequest.id(), deleteRequest.routing()).shardId();
+                    ShardId shardId = clusterService.operationRouting().indexShards(clusterState, concreteIndex, deleteRequest.type(), deleteRequest.id(), deleteRequest.routing()).shardId();
                     List<BulkItemRequest> list = requestsByShard.get(shardId);
                     if (list == null) {
                         list = new ArrayList<>();
@@ -312,7 +312,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         for (Map.Entry<ShardId, List<BulkItemRequest>> entry : requestsByShard.entrySet()) {
             final ShardId shardId = entry.getKey();
             final List<BulkItemRequest> requests = entry.getValue();
-            BulkShardRequest bulkShardRequest = new BulkShardRequest(bulkRequest, shardId.index().name(), shardId.id(), bulkRequest.refresh(), requests.toArray(new BulkItemRequest[requests.size()]));
+            BulkShardRequest bulkShardRequest = new BulkShardRequest(bulkRequest, shardId, bulkRequest.refresh(), requests.toArray(new BulkItemRequest[requests.size()]));
             bulkShardRequest.consistencyLevel(bulkRequest.consistencyLevel());
             bulkShardRequest.timeout(bulkRequest.timeout());
             shardBulkAction.execute(bulkShardRequest, new ActionListener<BulkShardResponse>() {

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -35,12 +35,11 @@ import org.elasticsearch.action.update.UpdateHelper;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
-import org.elasticsearch.cluster.routing.ShardIterator;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
@@ -88,11 +87,6 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
     }
 
     @Override
-    protected boolean checkWriteConsistency() {
-        return true;
-    }
-
-    @Override
     protected TransportRequestOptions transportOptions() {
         return BulkAction.INSTANCE.transportOptions(settings);
     }
@@ -108,15 +102,9 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
     }
 
     @Override
-    protected ShardIterator shards(ClusterState clusterState, InternalRequest request) {
-        return clusterState.routingTable().index(request.concreteIndex()).shard(request.request().shardId().id()).shardsIt();
-    }
-
-    @Override
-    protected Tuple<BulkShardResponse, BulkShardRequest> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) {
-        final BulkShardRequest request = shardRequest.request;
+    protected Tuple<BulkShardResponse, BulkShardRequest> shardOperationOnPrimary(MetaData metaData, BulkShardRequest request) {
         final IndexService indexService = indicesService.indexServiceSafe(request.index());
-        final IndexShard indexShard = indexService.getShard(shardRequest.shardId.id());
+        final IndexShard indexShard = indexService.getShard(request.shardId().id());
 
         long[] preVersions = new long[request.items().length];
         VersionType[] preVersionTypes = new VersionType[request.items().length];
@@ -128,7 +116,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                 preVersions[requestIndex] = indexRequest.version();
                 preVersionTypes[requestIndex] = indexRequest.versionType();
                 try {
-                    WriteResult<IndexResponse> result = shardIndexOperation(request, indexRequest, clusterState, indexShard, true);
+                    WriteResult<IndexResponse> result = shardIndexOperation(request, indexRequest, metaData, indexShard, true);
                     location = locationToSync(location, result.location);
                     // add the response
                     IndexResponse indexResponse = result.response();
@@ -143,9 +131,9 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                         throw (ElasticsearchException) e;
                     }
                     if (ExceptionsHelper.status(e) == RestStatus.CONFLICT) {
-                        logger.trace("{} failed to execute bulk item (index) {}", e, shardRequest.shardId, indexRequest);
+                        logger.trace("{} failed to execute bulk item (index) {}", e, request.shardId(), indexRequest);
                     } else {
-                        logger.debug("{} failed to execute bulk item (index) {}", e, shardRequest.shardId, indexRequest);
+                        logger.debug("{} failed to execute bulk item (index) {}", e, request.shardId(), indexRequest);
                     }
                     // if its a conflict failure, and we already executed the request on a primary (and we execute it
                     // again, due to primary relocation and only processing up to N bulk items when the shard gets closed)
@@ -178,9 +166,9 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                         throw (ElasticsearchException) e;
                     }
                     if (ExceptionsHelper.status(e) == RestStatus.CONFLICT) {
-                        logger.trace("{} failed to execute bulk item (delete) {}", e, shardRequest.shardId, deleteRequest);
+                        logger.trace("{} failed to execute bulk item (delete) {}", e, request.shardId(), deleteRequest);
                     } else {
-                        logger.debug("{} failed to execute bulk item (delete) {}", e, shardRequest.shardId, deleteRequest);
+                        logger.debug("{} failed to execute bulk item (delete) {}", e, request.shardId(), deleteRequest);
                     }
                     // if its a conflict failure, and we already executed the request on a primary (and we execute it
                     // again, due to primary relocation and only processing up to N bulk items when the shard gets closed)
@@ -200,7 +188,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                 for (int updateAttemptsCount = 0; updateAttemptsCount <= updateRequest.retryOnConflict(); updateAttemptsCount++) {
                     UpdateResult updateResult;
                     try {
-                        updateResult = shardUpdateOperation(clusterState, request, updateRequest, indexShard);
+                        updateResult = shardUpdateOperation(metaData, request, updateRequest, indexShard);
                     } catch (Throwable t) {
                         updateResult = new UpdateResult(null, null, false, t, null);
                     }
@@ -219,7 +207,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                                 UpdateResponse updateResponse = new UpdateResponse(indexResponse.getShardInfo(), indexResponse.getIndex(), indexResponse.getType(), indexResponse.getId(), indexResponse.getVersion(), indexResponse.isCreated());
                                 if (updateRequest.fields() != null && updateRequest.fields().length > 0) {
                                     Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(indexSourceAsBytes, true);
-                                    updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, shardRequest.request.index(), indexResponse.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), indexSourceAsBytes));
+                                    updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), indexResponse.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), indexSourceAsBytes));
                                 }
                                 item = request.items()[requestIndex] = new BulkItemRequest(request.items()[requestIndex].id(), indexRequest);
                                 setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, updateResponse));
@@ -229,7 +217,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                                 DeleteResponse response = writeResult.response();
                                 DeleteRequest deleteRequest = updateResult.request();
                                 updateResponse = new UpdateResponse(response.getShardInfo(), response.getIndex(), response.getType(), response.getId(), response.getVersion(), false);
-                                updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, shardRequest.request.index(), response.getVersion(), updateResult.result.updatedSourceAsMap(), updateResult.result.updateSourceContentType(), null));
+                                updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), response.getVersion(), updateResult.result.updatedSourceAsMap(), updateResult.result.updateSourceContentType(), null));
                                 // Replace the update request to the translated delete request to execute on the replica.
                                 item = request.items()[requestIndex] = new BulkItemRequest(request.items()[requestIndex].id(), deleteRequest);
                                 setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, updateResponse));
@@ -264,16 +252,16 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                             if (item.getPrimaryResponse() != null && isConflictException(t)) {
                                 setResponse(item, item.getPrimaryResponse());
                             } else if (updateResult.result == null) {
-                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, new BulkItemResponse.Failure(shardRequest.request.index(), updateRequest.type(), updateRequest.id(), t)));
+                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, new BulkItemResponse.Failure(request.index(), updateRequest.type(), updateRequest.id(), t)));
                             } else {
                                 switch (updateResult.result.operation()) {
                                     case UPSERT:
                                     case INDEX:
                                         IndexRequest indexRequest = updateResult.request();
                                         if (ExceptionsHelper.status(t) == RestStatus.CONFLICT) {
-                                            logger.trace("{} failed to execute bulk item (index) {}", t, shardRequest.shardId, indexRequest);
+                                            logger.trace("{} failed to execute bulk item (index) {}", t, request.shardId(), indexRequest);
                                         } else {
-                                            logger.debug("{} failed to execute bulk item (index) {}", t, shardRequest.shardId, indexRequest);
+                                            logger.debug("{} failed to execute bulk item (index) {}", t, request.shardId(), indexRequest);
                                         }
                                         setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE,
                                                 new BulkItemResponse.Failure(request.index(), indexRequest.type(), indexRequest.id(), t)));
@@ -281,9 +269,9 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                                     case DELETE:
                                         DeleteRequest deleteRequest = updateResult.request();
                                         if (ExceptionsHelper.status(t) == RestStatus.CONFLICT) {
-                                            logger.trace("{} failed to execute bulk item (delete) {}", t, shardRequest.shardId, deleteRequest);
+                                            logger.trace("{} failed to execute bulk item (delete) {}", t, request.shardId(), deleteRequest);
                                         } else {
-                                            logger.debug("{} failed to execute bulk item (delete) {}", t, shardRequest.shardId, deleteRequest);
+                                            logger.debug("{} failed to execute bulk item (delete) {}", t, request.shardId(), deleteRequest);
                                         }
                                         setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_DELETE,
                                                 new BulkItemResponse.Failure(request.index(), deleteRequest.type(), deleteRequest.id(), t)));
@@ -310,7 +298,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
         for (int i = 0; i < items.length; i++) {
             responses[i] = items[i].getPrimaryResponse();
         }
-        return new Tuple<>(new BulkShardResponse(shardRequest.shardId, responses), shardRequest.request);
+        return new Tuple<>(new BulkShardResponse(request.shardId(), responses), request);
     }
 
     private void setResponse(BulkItemRequest request, BulkItemResponse response) {
@@ -320,11 +308,11 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
         }
     }
 
-    private WriteResult<IndexResponse> shardIndexOperation(BulkShardRequest request, IndexRequest indexRequest, ClusterState clusterState,
+    private WriteResult shardIndexOperation(BulkShardRequest request, IndexRequest indexRequest, MetaData metaData,
                                             IndexShard indexShard, boolean processed) throws Throwable {
 
         // validate, if routing is required, that we got routing
-        MappingMetaData mappingMd = clusterState.metaData().index(request.index()).mappingOrDefault(indexRequest.type());
+        MappingMetaData mappingMd = metaData.index(request.index()).mappingOrDefault(indexRequest.type());
         if (mappingMd != null && mappingMd.routing().required()) {
             if (indexRequest.routing() == null) {
                 throw new RoutingMissingException(request.index(), indexRequest.type(), indexRequest.id());
@@ -332,7 +320,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
         }
 
         if (!processed) {
-            indexRequest.process(clusterState.metaData(), mappingMd, allowIdGeneration, request.index());
+            indexRequest.process(metaData, mappingMd, allowIdGeneration, request.index());
         }
         return TransportIndexAction.executeIndexRequestOnPrimary(indexRequest, indexShard, mappingUpdatedAction);
     }
@@ -390,14 +378,14 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
 
     }
 
-    private UpdateResult shardUpdateOperation(ClusterState clusterState, BulkShardRequest bulkShardRequest, UpdateRequest updateRequest, IndexShard indexShard) {
+    private UpdateResult shardUpdateOperation(MetaData metaData, BulkShardRequest bulkShardRequest, UpdateRequest updateRequest, IndexShard indexShard) {
         UpdateHelper.Result translate = updateHelper.prepare(updateRequest, indexShard);
         switch (translate.operation()) {
             case UPSERT:
             case INDEX:
                 IndexRequest indexRequest = translate.action();
                 try {
-                    WriteResult result = shardIndexOperation(bulkShardRequest, indexRequest, clusterState, indexShard, false);
+                    WriteResult result = shardIndexOperation(bulkShardRequest, indexRequest, metaData, indexShard, false);
                     return new UpdateResult(translate, indexRequest, result);
                 } catch (Throwable t) {
                     t = ExceptionsHelper.unwrapCause(t);
@@ -431,7 +419,8 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
 
 
     @Override
-    protected void shardOperationOnReplica(ShardId shardId, BulkShardRequest request) {
+    protected void shardOperationOnReplica(BulkShardRequest request) {
+        final ShardId shardId = request.shardId();
         IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         IndexShard indexShard = indexService.getShard(shardId.id());
         Translog.Location location = null;

--- a/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -36,7 +36,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -120,23 +119,18 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
     }
 
     @Override
-    protected void resolveRequest(ClusterState state, InternalRequest request, ActionListener<IndexResponse> indexResponseActionListener) {
-        MetaData metaData = clusterService.state().metaData();
-
+    protected void resolveRequest(MetaData metaData, String concreteIndex, IndexRequest request) {
         MappingMetaData mappingMd = null;
-        if (metaData.hasIndex(request.concreteIndex())) {
-            mappingMd = metaData.index(request.concreteIndex()).mappingOrDefault(request.request().type());
+        if (metaData.hasIndex(concreteIndex)) {
+            mappingMd = metaData.index(concreteIndex).mappingOrDefault(request.type());
         }
-        request.request().process(metaData, mappingMd, allowIdGeneration, request.concreteIndex());
+        request.process(metaData, mappingMd, allowIdGeneration, concreteIndex);
+        ShardId shardId = clusterService.operationRouting().shardId(clusterService.state(), concreteIndex, request.id(), request.routing());
+        request.setShardId(shardId);
     }
 
     private void innerExecute(final IndexRequest request, final ActionListener<IndexResponse> listener) {
         super.doExecute(request, listener);
-    }
-
-    @Override
-    protected boolean checkWriteConsistency() {
-        return true;
     }
 
     @Override
@@ -145,37 +139,31 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
     }
 
     @Override
-    protected ShardIterator shards(ClusterState clusterState, InternalRequest request) {
-        return clusterService.operationRouting()
-                .indexShards(clusterService.state(), request.concreteIndex(), request.request().type(), request.request().id(), request.request().routing());
-    }
-
-    @Override
-    protected Tuple<IndexResponse, IndexRequest> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) throws Throwable {
-        final IndexRequest request = shardRequest.request;
+    protected Tuple<IndexResponse, IndexRequest> shardOperationOnPrimary(MetaData metaData, IndexRequest request) throws Throwable {
 
         // validate, if routing is required, that we got routing
-        IndexMetaData indexMetaData = clusterState.metaData().index(shardRequest.shardId.getIndex());
+        IndexMetaData indexMetaData = metaData.index(request.shardId().getIndex());
         MappingMetaData mappingMd = indexMetaData.mappingOrDefault(request.type());
         if (mappingMd != null && mappingMd.routing().required()) {
             if (request.routing() == null) {
-                throw new RoutingMissingException(shardRequest.shardId.getIndex(), request.type(), request.id());
+                throw new RoutingMissingException(request.shardId().getIndex(), request.type(), request.id());
             }
         }
 
-        IndexService indexService = indicesService.indexServiceSafe(shardRequest.shardId.getIndex());
-        IndexShard indexShard = indexService.getShard(shardRequest.shardId.id());
+        IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
+        IndexShard indexShard = indexService.getShard(request.shardId().id());
 
         final WriteResult<IndexResponse> result = executeIndexRequestOnPrimary(request, indexShard, mappingUpdatedAction);
 
         final IndexResponse response = result.response;
         final Translog.Location location = result.location;
         processAfterWrite(request.refresh(), indexShard, location);
-        return new Tuple<>(response, shardRequest.request);
+        return new Tuple<>(response, request);
     }
 
     @Override
-    protected void shardOperationOnReplica(ShardId shardId, IndexRequest request) {
+    protected void shardOperationOnReplica(IndexRequest request) {
+        final ShardId shardId = request.shardId();
         IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         IndexShard indexShard = indexService.getShard(shardId.id());
         final Engine.Index operation = executeIndexRequestOnReplica(request, indexShard);

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -37,11 +37,10 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.IndexRoutingTable;
-import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
-import org.elasticsearch.cluster.routing.ShardIterator;
-import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.*;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -63,6 +62,8 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,6 +71,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 /**
+ * Base class for requests that should be executed on a primary copy followed by replica copies.
+ * Subclasses can resolve the target shard and provide implementation for primary and replica operations.
+ *
+ * The action samples cluster state on the receiving node to reroute to node with primary copy and on the
+ * primary node to validate request before primary operation followed by sampling state again for resolving
+ * nodes with replica copies to perform replication.
  */
 public abstract class TransportReplicationAction<Request extends ReplicationRequest, ReplicaRequest extends ReplicationRequest, Response extends ActionWriteResponse> extends TransportAction<Request, Response> {
 
@@ -85,6 +92,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
     private final TimeValue shardFailedTimeout;
 
     final String transportReplicaAction;
+    final String transportPrimaryAction;
     final String executor;
     final boolean checkWriteConsistency;
 
@@ -101,11 +109,12 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         this.shardStateAction = shardStateAction;
         this.mappingUpdatedAction = mappingUpdatedAction;
 
+        this.transportPrimaryAction = actionName + "[p]";
         this.transportReplicaAction = actionName + "[r]";
         this.executor = executor;
         this.checkWriteConsistency = checkWriteConsistency();
-
         transportService.registerRequestHandler(actionName, request, ThreadPool.Names.SAME, new OperationTransportHandler());
+        transportService.registerRequestHandler(transportPrimaryAction, request, executor, new PrimaryOperationTransportHandler());
         // we must never reject on because of thread pool capacity on replicas
         transportService.registerRequestHandler(transportReplicaAction, replicaRequest, executor, true, new ReplicaOperationTransportHandler());
 
@@ -118,40 +127,57 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
 
     @Override
     protected void doExecute(Request request, ActionListener<Response> listener) {
-        new PrimaryPhase(request, listener).run();
+        new ReroutePhase(request, listener).run();
     }
 
     protected abstract Response newResponseInstance();
 
     /**
+     * Resolves the target shard id of the incoming request.
+     * Additional processing or validation of the request should be done here.
+     */
+    protected void resolveRequest(MetaData metaData, String concreteIndex, Request request) {
+        // implementation should be provided if request shardID is not already resolved at request construction
+    }
+
+    /**
+     * Primary operation on node with primary copy, the provided metadata should be used for request validation if needed
      * @return A tuple containing not null values, as first value the result of the primary operation and as second value
      * the request to be executed on the replica shards.
      */
-    protected abstract Tuple<Response, ReplicaRequest> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) throws Throwable;
+    protected abstract Tuple<Response, ReplicaRequest> shardOperationOnPrimary(MetaData metaData, Request shardRequest) throws Throwable;
 
-    protected abstract void shardOperationOnReplica(ShardId shardId, ReplicaRequest shardRequest);
+    /**
+     * Replica operation on nodes with replica copies
+     */
+    protected abstract void shardOperationOnReplica(ReplicaRequest shardRequest);
 
-    protected abstract ShardIterator shards(ClusterState clusterState, InternalRequest request);
-
-    protected abstract boolean checkWriteConsistency();
-
-    protected ClusterBlockException checkGlobalBlock(ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.WRITE);
-    }
-
-    protected ClusterBlockException checkRequestBlock(ClusterState state, InternalRequest request) {
-        return state.blocks().indexBlockedException(ClusterBlockLevel.WRITE, request.concreteIndex());
-    }
-
-    protected boolean resolveIndex() {
+    /**
+     * True if write consistency should be checked for an implementation
+     */
+    protected boolean checkWriteConsistency() {
         return true;
     }
 
     /**
-     * Resolves the request, by default doing nothing. Can be subclassed to do
-     * additional processing or validation depending on the incoming request
+     * Cluster level block to check before request execution
      */
-    protected void resolveRequest(ClusterState state, InternalRequest request, ActionListener<Response> listener) {
+    protected ClusterBlockLevel globalBlockLevel() {
+        return ClusterBlockLevel.WRITE;
+    }
+
+    /**
+     * Index level block to check before request execution
+     */
+    protected ClusterBlockLevel indexBlockLevel() {
+        return ClusterBlockLevel.WRITE;
+    }
+
+    /**
+     * True if provided index should be resolved when resolving request
+     */
+    protected boolean resolveIndex() {
+        return true;
     }
 
     protected TransportRequestOptions transportOptions() {
@@ -233,6 +259,13 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         }
     }
 
+    class PrimaryOperationTransportHandler implements TransportRequestHandler<Request> {
+        @Override
+        public void messageReceived(final Request request, final TransportChannel channel) throws Exception {
+            new PrimaryPhase(request, channel).run();
+        }
+    }
+
     class ReplicaOperationTransportHandler implements TransportRequestHandler<ReplicaRequest> {
         @Override
         public void messageReceived(final ReplicaRequest request, final TransportChannel channel) throws Exception {
@@ -258,7 +291,6 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         // important: we pass null as a timeout as failing a replica is
         // something we want to avoid at all costs
         private final ClusterStateObserver observer = new ClusterStateObserver(clusterService, null, logger);
-
 
         AsyncReplicaAction(ReplicaRequest request, TransportChannel channel) {
             this.request = request;
@@ -287,12 +319,30 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
                 });
             } else {
                 try {
-                    failReplicaIfNeeded(request.internalShardId.getIndex(), request.internalShardId.id(), t, request);
+                    failReplicaIfNeeded(t);
                 } catch (Throwable unexpected) {
-                    logger.error("{} unexpected error while failing replica", request.internalShardId.id(), unexpected);
+                    logger.error("{} unexpected error while failing replica", unexpected, request.shardId().id());
                 } finally {
                     responseWithFailure(t);
                 }
+            }
+        }
+        private void failReplicaIfNeeded(Throwable t) {
+            String index = request.shardId().getIndex();
+            int shardId = request.shardId().id();
+            logger.trace("failure on replica [{}][{}], action [{}], request [{}]", t, index, shardId, actionName, request);
+            if (ignoreReplicaException(t) == false) {
+                IndexService indexService = indicesService.indexService(index);
+                if (indexService == null) {
+                    logger.debug("ignoring failed replica [{}][{}] because index was already removed.", index, shardId);
+                    return;
+                }
+                IndexShard indexShard = indexService.getShardOrNull(shardId);
+                if (indexShard == null) {
+                    logger.debug("ignoring failed replica [{}][{}] because index was already removed.", index, shardId);
+                    return;
+                }
+                indexShard.failShard(actionName + " failed on replica", t);
             }
         }
 
@@ -307,20 +357,14 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
 
         @Override
         protected void doRun() throws Exception {
-            try (Releasable shardReference = getIndexShardOperationsCounter(request.internalShardId)) {
-                shardOperationOnReplica(request.internalShardId, request);
+            assert request.shardId() != null : "request shardId must be set";
+            try (Releasable ignored = getIndexShardOperationsCounter(request.shardId())) {
+                shardOperationOnReplica(request);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("action [{}] completed on shard [{}] for request [{}]", transportReplicaAction, request.shardId(), request);
+                }
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
-        }
-    }
-
-    protected class PrimaryOperationRequest {
-        public final ShardId shardId;
-        public final Request request;
-
-        public PrimaryOperationRequest(int shardId, String index, Request request) {
-            this.shardId = new ShardId(index, shardId);
-            this.request = request;
         }
     }
 
@@ -336,22 +380,22 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
     }
 
     /**
-     * Responsible for performing all operations up to the point we start starting sending requests to replica shards.
-     * Including forwarding the request to another node if the primary is not assigned locally.
-     * <p>
-     * Note that as soon as we start sending request to replicas, state responsibility is transferred to {@link ReplicationPhase}
+     * Responsible for routing and retrying failed operations on the primary.
+     * The actual primary operation is done in {@link PrimaryPhase} on the
+     * node with primary copy.
+     *
+     * Resolves index and shard id for the request before routing it to target node
      */
-    final class PrimaryPhase extends AbstractRunnable {
+    final class ReroutePhase extends AbstractRunnable {
         private final ActionListener<Response> listener;
-        private final InternalRequest internalRequest;
+        private final Request request;
         private final ClusterStateObserver observer;
-        private final AtomicBoolean finished = new AtomicBoolean(false);
-        private volatile Releasable indexShardReference;
+        private final AtomicBoolean finished = new AtomicBoolean();
 
-        PrimaryPhase(Request request, ActionListener<Response> listener) {
-            this.internalRequest = new InternalRequest(request);
+        ReroutePhase(Request request, ActionListener<Response> listener) {
+            this.request = request;
             this.listener = listener;
-            this.observer = new ClusterStateObserver(clusterService, internalRequest.request().timeout(), logger);
+            this.observer = new ClusterStateObserver(clusterService, request.timeout(), logger);
         }
 
         @Override
@@ -361,135 +405,91 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
 
         @Override
         protected void doRun() {
-            if (checkBlocks() == false) {
-                return;
-            }
-            final ShardIterator shardIt = shards(observer.observedState(), internalRequest);
-            final ShardRouting primary = resolvePrimary(shardIt);
-            if (primary == null) {
-                retryBecauseUnavailable(shardIt.shardId(), "No active shards.");
-                return;
-            }
-            if (primary.active() == false) {
-                logger.trace("primary shard [{}] is not yet active, scheduling a retry. action [{}], request [{}]", primary.shardId(), actionName, internalRequest.request);
-                retryBecauseUnavailable(shardIt.shardId(), "Primary shard is not active or isn't assigned to a known node.");
-                return;
-            }
-            if (observer.observedState().nodes().nodeExists(primary.currentNodeId()) == false) {
-                logger.trace("primary shard [{}] is assigned to anode we do not know the node, scheduling a retry.", primary.shardId(), primary.currentNodeId());
-                retryBecauseUnavailable(shardIt.shardId(), "Primary shard is not active or isn't assigned to a known node.");
-                return;
-            }
-            routeRequestOrPerformLocally(primary, shardIt);
-        }
-
-        /**
-         * checks for any cluster state blocks. Returns true if operation is OK to proceeded.
-         * if false is return, no further action is needed. The method takes care of any continuation, by either
-         * responding to the listener or scheduling a retry
-         */
-        protected boolean checkBlocks() {
-            ClusterBlockException blockException = checkGlobalBlock(observer.observedState());
+            final ClusterState state = observer.observedState();
+            ClusterBlockException blockException = state.blocks().globalBlockedException(globalBlockLevel());
             if (blockException != null) {
-                if (blockException.retryable()) {
-                    logger.trace("cluster is blocked ({}), scheduling a retry", blockException.getMessage());
-                    retry(blockException);
-                } else {
-                    finishAsFailed(blockException);
-                }
-                return false;
+                handleBlockException(blockException);
+                return;
             }
-            if (resolveIndex()) {
-                internalRequest.concreteIndex(indexNameExpressionResolver.concreteSingleIndex(observer.observedState(), internalRequest.request()));
-            } else {
-                internalRequest.concreteIndex(internalRequest.request().index());
-            }
-
-            resolveRequest(observer.observedState(), internalRequest, listener);
-
-            blockException = checkRequestBlock(observer.observedState(), internalRequest);
+            final String concreteIndex = resolveIndex() ? indexNameExpressionResolver.concreteSingleIndex(state, request) : request.index();
+            blockException = state.blocks().indexBlockedException(indexBlockLevel(), concreteIndex);
             if (blockException != null) {
-                if (blockException.retryable()) {
-                    logger.trace("cluster is blocked ({}), scheduling a retry", blockException.getMessage());
-                    retry(blockException);
-                } else {
-                    finishAsFailed(blockException);
-                }
-                return false;
+                handleBlockException(blockException);
+                return;
             }
-            return true;
-        }
+            // request does not have a shardId yet, we need to pass the concrete index to resolve shardId
+            resolveRequest(state.metaData(), concreteIndex, request);
+            assert request.shardId() != null : "request shardId must be set in resolveRequest";
 
-        protected ShardRouting resolvePrimary(ShardIterator shardIt) {
-            // no shardIt, might be in the case between index gateway recovery and shardIt initialization
-            ShardRouting shard;
-            while ((shard = shardIt.nextOrNull()) != null) {
-                // we only deal with primary shardIt here...
-                if (shard.primary()) {
-                    return shard;
-                }
+            IndexShardRoutingTable indexShard = state.getRoutingTable().shardRoutingTable(request.shardId().getIndex(), request.shardId().id());
+            final ShardRouting primary = indexShard.primaryShard();
+            if (primary == null || primary.active() == false) {
+                logger.trace("primary shard [{}] is not yet active, scheduling a retry: action [{}], request [{}], cluster state version [{}]", request.shardId(), actionName, request, state.version());
+                retryBecauseUnavailable(request.shardId(), "primary shard is not active");
+                return;
             }
-            return null;
-        }
-
-        /**
-         * send the request to the node holding the primary or execute if local
-         */
-        protected void routeRequestOrPerformLocally(final ShardRouting primary, final ShardIterator shardsIt) {
-            if (primary.currentNodeId().equals(observer.observedState().nodes().localNodeId())) {
-                try {
-                    threadPool.executor(executor).execute(new AbstractRunnable() {
-                        @Override
-                        public void onFailure(Throwable t) {
-                            finishAsFailed(t);
-                        }
-
-                        @Override
-                        protected void doRun() throws Exception {
-                            performOnPrimary(primary, shardsIt);
-                        }
-                    });
-                } catch (Throwable t) {
-                    finishAsFailed(t);
+            if (state.nodes().nodeExists(primary.currentNodeId()) == false) {
+                logger.trace("primary shard [{}] is assigned to an unknown node [{}], scheduling a retry: action [{}], request [{}], cluster state version [{}]", request.shardId(), primary.currentNodeId(), actionName, request, state.version());
+                retryBecauseUnavailable(request.shardId(), "primary shard isn't assigned to a known node.");
+                return;
+            }
+            final DiscoveryNode node = state.nodes().get(primary.currentNodeId());
+            if (primary.currentNodeId().equals(state.nodes().localNodeId())) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("send action [{}] on primary [{}] for request [{}] with cluster state version [{}] to [{}] ", transportPrimaryAction, request.shardId(), request, state.version(), primary.currentNodeId());
                 }
+                performAction(node, transportPrimaryAction, true);
             } else {
-                DiscoveryNode node = observer.observedState().nodes().get(primary.currentNodeId());
-                transportService.sendRequest(node, actionName, internalRequest.request(), transportOptions, new BaseTransportResponseHandler<Response>() {
-
-                    @Override
-                    public Response newInstance() {
-                        return newResponseInstance();
-                    }
-
-                    @Override
-                    public String executor() {
-                        return ThreadPool.Names.SAME;
-                    }
-
-                    @Override
-                    public void handleResponse(Response response) {
-                        finishOnRemoteSuccess(response);
-                    }
-
-                    @Override
-                    public void handleException(TransportException exp) {
-                        try {
-                            // if we got disconnected from the node, or the node / shard is not in the right state (being closed)
-                            if (exp.unwrapCause() instanceof ConnectTransportException || exp.unwrapCause() instanceof NodeClosedException ||
-                                    retryPrimaryException(exp)) {
-                                // we already marked it as started when we executed it (removed the listener) so pass false
-                                // to re-add to the cluster listener
-                                logger.trace("received an error from node the primary was assigned to ({}), scheduling a retry", exp.getMessage());
-                                retry(exp);
-                            } else {
-                                finishAsFailed(exp);
-                            }
-                        } catch (Throwable t) {
-                            finishWithUnexpectedFailure(t);
-                        }
-                    }
-                });
+                if (logger.isTraceEnabled()) {
+                    logger.trace("send action [{}] on primary [{}] for request [{}] with cluster state version [{}] to [{}]", actionName, request.shardId(), request, state.version(), primary.currentNodeId());
+                }
+                performAction(node, actionName, false);
             }
+        }
+
+        private void handleBlockException(ClusterBlockException blockException) {
+            if (blockException.retryable()) {
+                logger.trace("cluster is blocked ({}), scheduling a retry", blockException.getMessage());
+                retry(blockException);
+            } else {
+                finishAsFailed(blockException);
+            }
+        }
+
+        private void performAction(final DiscoveryNode node, final String action, final boolean isPrimaryAction) {
+            transportService.sendRequest(node, action, request, transportOptions, new BaseTransportResponseHandler<Response>() {
+
+                @Override
+                public Response newInstance() {
+                    return newResponseInstance();
+                }
+
+                @Override
+                public String executor() {
+                    return ThreadPool.Names.SAME;
+                }
+
+                @Override
+                public void handleResponse(Response response) {
+                    finishOnSuccess(response);
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    try {
+                        // if we got disconnected from the node, or the node / shard is not in the right state (being closed)
+                        if (exp.unwrapCause() instanceof ConnectTransportException || exp.unwrapCause() instanceof NodeClosedException ||
+                                (isPrimaryAction && retryPrimaryException(exp.unwrapCause()))) {
+                            logger.trace("received an error from node [{}] for request [{}], scheduling a retry", exp, node.id(), request);
+                            retry(exp);
+                        } else {
+                            finishAsFailed(exp);
+                        }
+                    } catch (Throwable t) {
+                        finishWithUnexpectedFailure(t);
+                    }
+                }
+            });
         }
 
         void retry(Throwable failure) {
@@ -518,22 +518,9 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
             });
         }
 
-        /**
-         * upon success, finish the first phase and transfer responsibility to the {@link ReplicationPhase}
-         */
-        void finishAndMoveToReplication(ReplicationPhase replicationPhase) {
-            if (finished.compareAndSet(false, true)) {
-                replicationPhase.run();
-            } else {
-                assert false : "finishAndMoveToReplication called but operation is already finished";
-            }
-        }
-
-
         void finishAsFailed(Throwable failure) {
             if (finished.compareAndSet(false, true)) {
-                Releasables.close(indexShardReference);
-                logger.trace("operation failed. action [{}], request [{}]", failure, actionName, internalRequest.request);
+                logger.trace("operation failed. action [{}], request [{}]", failure, actionName, request);
                 listener.onFailure(failure);
             } else {
                 assert false : "finishAsFailed called but operation is already finished";
@@ -541,64 +528,79 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         }
 
         void finishWithUnexpectedFailure(Throwable failure) {
-            logger.warn("unexpected error during the primary phase for action [{}], request [{}]", failure, actionName, internalRequest.request);
+            logger.warn("unexpected error during the primary phase for action [{}], request [{}]", failure, actionName, request);
             if (finished.compareAndSet(false, true)) {
-                Releasables.close(indexShardReference);
                 listener.onFailure(failure);
             } else {
                 assert false : "finishWithUnexpectedFailure called but operation is already finished";
             }
         }
 
-        void finishOnRemoteSuccess(Response response) {
+        void finishOnSuccess(Response response) {
             if (finished.compareAndSet(false, true)) {
                 if (logger.isTraceEnabled()) {
-                    logger.trace("operation succeeded. action [{}],request [{}]", actionName, internalRequest.request);
+                    logger.trace("operation succeeded. action [{}],request [{}]", actionName, request);
                 }
                 listener.onResponse(response);
             } else {
-                assert false : "finishOnRemoteSuccess called but operation is already finished";
+                assert false : "finishOnSuccess called but operation is already finished";
             }
         }
 
-        /**
-         * perform the operation on the node holding the primary
-         */
-        void performOnPrimary(final ShardRouting primary, final ShardIterator shardsIt) {
-            final String writeConsistencyFailure = checkWriteConsistency(primary);
+        void retryBecauseUnavailable(ShardId shardId, String message) {
+            retry(new UnavailableShardsException(shardId, "{} Timeout: [{}], request: [{}]", message, request.timeout(), request));
+        }
+    }
+
+    /**
+     * Responsible for performing primary operation locally and delegating to replication action once successful
+     * <p>
+     * Note that as soon as we move to replication action, state responsibility is transferred to {@link ReplicationPhase}.
+     */
+    final class PrimaryPhase extends AbstractRunnable {
+        private final Request request;
+        private final TransportChannel channel;
+        private final ClusterState state;
+        private final AtomicBoolean finished = new AtomicBoolean();
+        private Releasable indexShardReference;
+
+        PrimaryPhase(Request request, TransportChannel channel) {
+            this.state = clusterService.state();
+            this.request = request;
+            this.channel = channel;
+        }
+
+        @Override
+        public void onFailure(Throwable e) {
+            finishAsFailed(e);
+        }
+
+        @Override
+        protected void doRun() throws Exception {
+            // request shardID was set in ReroutePhase
+            assert request.shardId() != null : "request shardID must be set prior to primary phase";
+            final ShardId shardId = request.shardId();
+            final String writeConsistencyFailure = checkWriteConsistency(shardId);
             if (writeConsistencyFailure != null) {
-                retryBecauseUnavailable(primary.shardId(), writeConsistencyFailure);
+                finishBecauseUnavailable(shardId, writeConsistencyFailure);
                 return;
             }
             final ReplicationPhase replicationPhase;
             try {
-                indexShardReference = getIndexShardOperationsCounter(primary.shardId());
-                PrimaryOperationRequest por = new PrimaryOperationRequest(primary.id(), internalRequest.concreteIndex(), internalRequest.request());
-                Tuple<Response, ReplicaRequest> primaryResponse = shardOperationOnPrimary(observer.observedState(), por);
+                indexShardReference = getIndexShardOperationsCounter(shardId);
+                Tuple<Response, ReplicaRequest> primaryResponse = shardOperationOnPrimary(state.metaData(), request);
                 if (logger.isTraceEnabled()) {
-                    logger.trace("operation completed on primary [{}], action [{}], request [{}], cluster state version [{}]", primary, actionName, por.request, observer.observedState().version());
+                    logger.trace("action [{}] completed on shard [{}] for request [{}] with cluster state version [{}]", transportPrimaryAction, shardId, request, state.version());
                 }
-                replicationPhase = new ReplicationPhase(shardsIt, primaryResponse.v2(), primaryResponse.v1(), observer, primary, internalRequest, listener, indexShardReference, shardFailedTimeout);
+                replicationPhase = new ReplicationPhase(primaryResponse.v2(), primaryResponse.v1(), shardId, channel, indexShardReference, shardFailedTimeout);
             } catch (Throwable e) {
-                // shard has not been allocated yet, retry it here
-                if (retryPrimaryException(e)) {
-                    logger.trace("had an error while performing operation on primary ({}, action [{}], request [{}]), scheduling a retry.", e, primary, actionName, internalRequest.request);
-                    // We have to close here because when we retry we will increment get a new reference on index shard again and we do not want to
-                    // increment twice.
-                    Releasables.close(indexShardReference);
-                    // We have to reset to null here because whe we retry it might be that we never get to the point where we assign a new reference
-                    // (for example, in case the operation was rejected because queue is full). In this case we would release again once one of the finish methods is called.
-                    indexShardReference = null;
-                    retry(e);
-                    return;
-                }
                 if (ExceptionsHelper.status(e) == RestStatus.CONFLICT) {
                     if (logger.isTraceEnabled()) {
-                        logger.trace(primary.shortSummary() + ": Failed to execute [" + internalRequest.request() + "]", e);
+                        logger.trace("failed to execute [{}] on [{}]", e, request, shardId);
                     }
                 } else {
                     if (logger.isDebugEnabled()) {
-                        logger.debug(primary.shortSummary() + ": Failed to execute [" + internalRequest.request() + "]", e);
+                        logger.debug("failed to execute [{}] on [{}]", e, request, shardId);
                     }
                 }
                 finishAsFailed(e);
@@ -611,22 +613,22 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
          * checks whether we can perform a write based on the write consistency setting
          * returns **null* if OK to proceed, or a string describing the reason to stop
          */
-        String checkWriteConsistency(ShardRouting shard) {
+        String checkWriteConsistency(ShardId shardId) {
             if (checkWriteConsistency == false) {
                 return null;
             }
 
             final WriteConsistencyLevel consistencyLevel;
-            if (internalRequest.request().consistencyLevel() != WriteConsistencyLevel.DEFAULT) {
-                consistencyLevel = internalRequest.request().consistencyLevel();
+            if (request.consistencyLevel() != WriteConsistencyLevel.DEFAULT) {
+                consistencyLevel = request.consistencyLevel();
             } else {
                 consistencyLevel = defaultWriteConsistencyLevel;
             }
             final int sizeActive;
             final int requiredNumber;
-            IndexRoutingTable indexRoutingTable = observer.observedState().getRoutingTable().index(shard.index());
+            IndexRoutingTable indexRoutingTable = state.getRoutingTable().index(shardId.getIndex());
             if (indexRoutingTable != null) {
-                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shard.getId());
+                IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId.getId());
                 if (shardRoutingTable != null) {
                     sizeActive = shardRoutingTable.activeShards().size();
                     if (consistencyLevel == WriteConsistencyLevel.QUORUM && shardRoutingTable.getSize() > 2) {
@@ -648,17 +650,44 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
 
             if (sizeActive < requiredNumber) {
                 logger.trace("not enough active copies of shard [{}] to meet write consistency of [{}] (have {}, needed {}), scheduling a retry. action [{}], request [{}]",
-                        shard.shardId(), consistencyLevel, sizeActive, requiredNumber, actionName, internalRequest.request);
+                        shardId, consistencyLevel, sizeActive, requiredNumber, transportPrimaryAction, request);
                 return "Not enough active copies to meet write consistency of [" + consistencyLevel + "] (have " + sizeActive + ", needed " + requiredNumber + ").";
             } else {
                 return null;
             }
         }
 
-        void retryBecauseUnavailable(ShardId shardId, String message) {
-            retry(new UnavailableShardsException(shardId, message + " Timeout: [" + internalRequest.request().timeout() + "], request: " + internalRequest.request().toString()));
+        /**
+         * upon success, finish the first phase and transfer responsibility to the {@link ReplicationPhase}
+         */
+        void finishAndMoveToReplication(ReplicationPhase replicationPhase) {
+            if (finished.compareAndSet(false, true)) {
+                replicationPhase.run();
+            } else {
+                assert false : "finishAndMoveToReplication called but operation is already finished";
+            }
         }
 
+        /**
+         * upon failure, send failure back to the {@link ReroutePhase} for retrying if appropriate
+         */
+        void finishAsFailed(Throwable failure) {
+            if (finished.compareAndSet(false, true)) {
+                Releasables.close(indexShardReference);
+                logger.trace("operation failed", failure);
+                try {
+                    channel.sendResponse(failure);
+                } catch (IOException responseException) {
+                    logger.warn("failed to send error message back to client for action [{}]", responseException, transportPrimaryAction);
+                }
+            } else {
+                assert false : "finishAsFailed called but operation is already finished";
+            }
+        }
+
+        void finishBecauseUnavailable(ShardId shardId, String message) {
+            finishAsFailed(new UnavailableShardsException(shardId, "{} Timeout: [{}], request: [{}]", message, request.timeout(), request));
+        }
     }
 
     protected Releasable getIndexShardOperationsCounter(ShardId shardId) {
@@ -667,135 +696,78 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         return new IndexShardReference(indexShard);
     }
 
-    private void failReplicaIfNeeded(String index, int shardId, Throwable t, ReplicaRequest request) {
-        logger.trace("failure on replica [{}][{}], action [{}], request [{}]", t, index, shardId, actionName, request);
-        if (ignoreReplicaException(t) == false) {
-            IndexService indexService = indicesService.indexService(index);
-            if (indexService == null) {
-                logger.debug("ignoring failed replica [{}][{}] because index was already removed.", index, shardId);
-                return;
-            }
-            IndexShard indexShard = indexService.getShardOrNull(shardId);
-            if (indexShard == null) {
-                logger.debug("ignoring failed replica [{}][{}] because index was already removed.", index, shardId);
-                return;
-            }
-            indexShard.failShard(actionName + " failed on replica", t);
-        }
-    }
-
     /**
-     * inner class is responsible for send the requests to all replica shards and manage the responses
+     * Responsible for sending replica requests (see {@link AsyncReplicaAction}) to nodes with replica copy, including
+     * relocating copies
      */
     final class ReplicationPhase extends AbstractRunnable {
 
         private final ReplicaRequest replicaRequest;
         private final Response finalResponse;
-        private final ShardIterator shardIt;
-        private final ActionListener<Response> listener;
-        private final AtomicBoolean finished = new AtomicBoolean(false);
+        private final TransportChannel channel;
+        private final ShardId shardId;
+        private final List<ShardRouting> shards;
+        private final DiscoveryNodes nodes;
+        private final boolean executeOnReplica;
+        private final String indexUUID;
+        private final AtomicBoolean finished = new AtomicBoolean();
         private final AtomicInteger success = new AtomicInteger(1); // We already wrote into the primary shard
         private final ConcurrentMap<String, Throwable> shardReplicaFailures = ConcurrentCollections.newConcurrentMap();
-        private final IndexMetaData indexMetaData;
-        private final ShardRouting originalPrimaryShard;
         private final AtomicInteger pending;
         private final int totalShards;
-        private final ClusterStateObserver observer;
         private final Releasable indexShardReference;
         private final TimeValue shardFailedTimeout;
 
-        /**
-         * the constructor doesn't take any action, just calculates state. Call {@link #run()} to start
-         * replicating.
-         */
-        public ReplicationPhase(ShardIterator originalShardIt, ReplicaRequest replicaRequest, Response finalResponse,
-                                ClusterStateObserver observer, ShardRouting originalPrimaryShard,
-                                InternalRequest internalRequest, ActionListener<Response> listener, Releasable indexShardReference,
-                                TimeValue shardFailedTimeout) {
+        public ReplicationPhase(ReplicaRequest replicaRequest, Response finalResponse, ShardId shardId,
+                                TransportChannel channel, Releasable indexShardReference, TimeValue shardFailedTimeout) {
             this.replicaRequest = replicaRequest;
-            this.listener = listener;
+            this.channel = channel;
             this.finalResponse = finalResponse;
-            this.originalPrimaryShard = originalPrimaryShard;
-            this.observer = observer;
-            indexMetaData = observer.observedState().metaData().index(internalRequest.concreteIndex());
             this.indexShardReference = indexShardReference;
             this.shardFailedTimeout = shardFailedTimeout;
+            this.shardId = shardId;
 
-            ShardRouting shard;
-            // we double check on the state, if it got changed we need to make sure we take the latest one cause
-            // maybe a replica shard started its recovery process and we need to apply it there...
+            // we have to get a new state after successfully indexing into the primary in order to honour recovery semantics.
+            // we have to make sure that every operation indexed into the primary after recovery start will also be replicated
+            // to the recovery target. If we use an old cluster state, we may miss a relocation that has started since then.
+            // If the index gets deleted after primary operation, we skip replication
+            final ClusterState state = clusterService.state();
+            final IndexRoutingTable index = state.getRoutingTable().index(shardId.getIndex());
+            final IndexShardRoutingTable shardRoutingTable = (index != null) ? index.shard(shardId.id()) : null;
+            final IndexMetaData indexMetaData = state.getMetaData().index(shardId.getIndex());
+            this.shards = (shardRoutingTable != null) ? shardRoutingTable.shards() : Collections.emptyList();
+            this.executeOnReplica = (indexMetaData == null) || shouldExecuteReplication(indexMetaData.getSettings());
+            this.indexUUID = (indexMetaData != null) ? indexMetaData.getIndexUUID() : null;
+            this.nodes = state.getNodes();
 
-            // we also need to make sure if the new state has a new primary shard (that we indexed to before) started
-            // and assigned to another node (while the indexing happened). In that case, we want to apply it on the
-            // new primary shard as well...
-            ClusterState newState = clusterService.state();
+            if (shards.isEmpty()) {
+                logger.debug("replication phase for request [{}] on [{}] is skipped due to index deletion after primary operation", replicaRequest, shardId);
+            }
 
-            int numberOfUnassignedOrIgnoredReplicas = 0;
+            // we calculate number of target nodes to send replication operations, including nodes with relocating shards
+            int numberOfIgnoredShardInstances = 0;
             int numberOfPendingShardInstances = 0;
-            if (observer.observedState() != newState) {
-                observer.reset(newState);
-                shardIt = shards(newState, internalRequest);
-                while ((shard = shardIt.nextOrNull()) != null) {
-                    if (shard.primary()) {
-                        if (originalPrimaryShard.currentNodeId().equals(shard.currentNodeId()) == false) {
-                            // there is a new primary, we'll have to replicate to it.
-                            numberOfPendingShardInstances++;
-                        }
-                        if (shard.relocating()) {
-                            numberOfPendingShardInstances++;
-                        }
-                    } else if (shouldExecuteReplication(indexMetaData.getSettings()) == false) {
-                        // If the replicas use shadow replicas, there is no reason to
-                        // perform the action on the replica, so skip it and
-                        // immediately return
-
-                        // this delays mapping updates on replicas because they have
-                        // to wait until they get the new mapping through the cluster
-                        // state, which is why we recommend pre-defined mappings for
-                        // indices using shadow replicas
-                        numberOfUnassignedOrIgnoredReplicas++;
-                    } else if (shard.unassigned()) {
-                        numberOfUnassignedOrIgnoredReplicas++;
-                    } else if (shard.relocating()) {
-                        // we need to send to two copies
-                        numberOfPendingShardInstances += 2;
-                    } else {
+            for (ShardRouting shard : shards) {
+                if (shard.primary() == false && executeOnReplica == false) {
+                    numberOfIgnoredShardInstances++;
+                } else if (shard.unassigned()) {
+                    numberOfIgnoredShardInstances++;
+                } else {
+                    if (shard.currentNodeId().equals(nodes.localNodeId()) == false) {
                         numberOfPendingShardInstances++;
                     }
-                }
-            } else {
-                shardIt = originalShardIt;
-                shardIt.reset();
-                while ((shard = shardIt.nextOrNull()) != null) {
-                    if (shard.unassigned()) {
-                        numberOfUnassignedOrIgnoredReplicas++;
-                    } else if (shard.primary()) {
-                        if (shard.relocating()) {
-                            // we have to replicate to the other copy
-                            numberOfPendingShardInstances += 1;
-                        }
-                    } else if (shouldExecuteReplication(indexMetaData.getSettings()) == false) {
-                        // If the replicas use shadow replicas, there is no reason to
-                        // perform the action on the replica, so skip it and
-                        // immediately return
-
-                        // this delays mapping updates on replicas because they have
-                        // to wait until they get the new mapping through the cluster
-                        // state, which is why we recommend pre-defined mappings for
-                        // indices using shadow replicas
-                        numberOfUnassignedOrIgnoredReplicas++;
-                    } else if (shard.relocating()) {
-                        // we need to send to two copies
-                        numberOfPendingShardInstances += 2;
-                    } else {
+                    if (shard.relocating()) {
                         numberOfPendingShardInstances++;
                     }
                 }
             }
-
-            // one for the primary already done
-            this.totalShards = 1 + numberOfPendingShardInstances + numberOfUnassignedOrIgnoredReplicas;
+            // one for the local primary copy
+            this.totalShards = 1 + numberOfPendingShardInstances + numberOfIgnoredShardInstances;
             this.pending = new AtomicInteger(numberOfPendingShardInstances);
+            if (logger.isTraceEnabled()) {
+                logger.trace("replication phase started. pending [{}], action [{}], request [{}], cluster state version used [{}]", pending.get(),
+                    transportReplicaAction, replicaRequest, state.version());
+            }
         }
 
         /**
@@ -821,114 +793,84 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
 
         @Override
         public void onFailure(Throwable t) {
-            logger.error("unexpected error while replicating for action [{}]. shard [{}]. ", t, actionName, shardIt.shardId());
+            logger.error("unexpected error while replicating for action [{}]. shard [{}]. ", t, actionName, shardId);
             forceFinishAsFailed(t);
         }
 
         /**
-         * start sending current requests to replicas
+         * start sending replica requests to target nodes
          */
         @Override
         protected void doRun() {
-            if (logger.isTraceEnabled()) {
-                logger.trace("replication phase started. pending [{}], action [{}], request [{}], cluster state version used [{}]", pending.get(),
-                        actionName, replicaRequest, observer.observedState().version());
-            }
             if (pending.get() == 0) {
                 doFinish();
                 return;
             }
-            ShardRouting shard;
-            shardIt.reset(); // reset the iterator
-            while ((shard = shardIt.nextOrNull()) != null) {
-                // if its unassigned, nothing to do here...
+            for (ShardRouting shard : shards) {
+                if (shard.primary() == false && executeOnReplica == false) {
+                    // If the replicas use shadow replicas, there is no reason to
+                    // perform the action on the replica, so skip it and
+                    // immediately return
+
+                    // this delays mapping updates on replicas because they have
+                    // to wait until they get the new mapping through the cluster
+                    // state, which is why we recommend pre-defined mappings for
+                    // indices using shadow replicas
+                    continue;
+                }
                 if (shard.unassigned()) {
                     continue;
                 }
-
                 // we index on a replica that is initializing as well since we might not have got the event
                 // yet that it was started. We will get an exception IllegalShardState exception if its not started
                 // and that's fine, we will ignore it
-                if (shard.primary()) {
-                    if (originalPrimaryShard.currentNodeId().equals(shard.currentNodeId()) == false) {
-                        // there is a new primary, we'll have to replicate to it.
-                        performOnReplica(shard, shard.currentNodeId());
-                    }
-                    if (shard.relocating()) {
-                        performOnReplica(shard, shard.relocatingNodeId());
-                    }
-                } else if (shouldExecuteReplication(indexMetaData.getSettings())) {
+
+                // we never execute replication operation locally as primary operation has already completed locally
+                // hence, we ignore any local shard for replication
+                if (nodes.localNodeId().equals(shard.currentNodeId()) == false) {
                     performOnReplica(shard, shard.currentNodeId());
-                    if (shard.relocating()) {
-                        performOnReplica(shard, shard.relocatingNodeId());
-                    }
+                }
+                // send operation to relocating shard
+                if (shard.relocating()) {
+                    performOnReplica(shard, shard.relocatingNodeId());
                 }
             }
         }
 
         /**
-         * send operation to the given node or perform it if local
+         * send replica operation to target node
          */
         void performOnReplica(final ShardRouting shard, final String nodeId) {
             // if we don't have that node, it means that it might have failed and will be created again, in
             // this case, we don't have to do the operation, and just let it failover
-            if (!observer.observedState().nodes().nodeExists(nodeId)) {
+            if (!nodes.nodeExists(nodeId)) {
+                logger.trace("failed to send action [{}] on replica [{}] for request [{}] due to unknown node [{}]", transportReplicaAction, shard.shardId(), replicaRequest, nodeId);
                 onReplicaFailure(nodeId, null);
                 return;
             }
-
-            replicaRequest.internalShardId = shardIt.shardId();
-
-            if (!nodeId.equals(observer.observedState().nodes().localNodeId())) {
-                final DiscoveryNode node = observer.observedState().nodes().get(nodeId);
-                transportService.sendRequest(node, transportReplicaAction, replicaRequest,
-                        transportOptions, new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
-                            @Override
-                            public void handleResponse(TransportResponse.Empty vResponse) {
-                                onReplicaSuccess();
-                            }
-
-                            @Override
-                            public void handleException(TransportException exp) {
-                                logger.trace("[{}] transport failure during replica request [{}], action [{}]", exp, node, replicaRequest, actionName);
-                                if (ignoreReplicaException(exp)) {
-                                    onReplicaFailure(nodeId, exp);
-                                } else {
-                                    logger.warn("{} failed to perform {} on node {}", exp, shardIt.shardId(), actionName, node);
-                                    shardStateAction.shardFailed(shard, indexMetaData.getIndexUUID(), "failed to perform " + actionName + " on replica on node " + node, exp, shardFailedTimeout, new ReplicationFailedShardStateListener(nodeId, exp));
-                                }
-                            }
-                        });
-            } else {
-                try {
-                    threadPool.executor(executor).execute(new AbstractRunnable() {
-                        @Override
-                        protected void doRun() {
-                            try {
-                                shardOperationOnReplica(shard.shardId(), replicaRequest);
-                                onReplicaSuccess();
-                            } catch (Throwable e) {
-                                onReplicaFailure(nodeId, e);
-                                failReplicaIfNeeded(shard.index(), shard.id(), e, replicaRequest);
-                            }
-                        }
-
-                        // we must never reject on because of thread pool capacity on replicas
-                        @Override
-                        public boolean isForceExecution() {
-                            return true;
-                        }
-
-                        @Override
-                        public void onFailure(Throwable t) {
-                            onReplicaFailure(nodeId, t);
-                        }
-                    });
-                } catch (Throwable e) {
-                    failReplicaIfNeeded(shard.index(), shard.id(), e, replicaRequest);
-                    onReplicaFailure(nodeId, e);
-                }
+            if (logger.isTraceEnabled()) {
+                logger.trace("send action [{}] on replica [{}] for request [{}] to [{}]", transportReplicaAction, shard.shardId(), replicaRequest, nodeId);
             }
+
+            final DiscoveryNode node = nodes.get(nodeId);
+            transportService.sendRequest(node, transportReplicaAction, replicaRequest, transportOptions, new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
+                        @Override
+                        public void handleResponse(TransportResponse.Empty vResponse) {
+                            onReplicaSuccess();
+                        }
+
+                        @Override
+                        public void handleException(TransportException exp) {
+                            logger.trace("[{}] transport failure during replica request [{}], action [{}]", exp, node, replicaRequest, transportReplicaAction);
+                            if (ignoreReplicaException(exp)) {
+                                onReplicaFailure(nodeId, exp);
+                            } else {
+                                logger.warn("{} failed to perform {} on node {}", exp, shardId, transportReplicaAction, node);
+                                shardStateAction.shardFailed(shard, indexUUID, "failed to perform " + transportReplicaAction + " on replica on node " + node, exp, shardFailedTimeout, new ReplicationFailedShardStateListener(nodeId, exp));
+                            }
+                        }
+                    }
+            );
         }
 
 
@@ -954,14 +896,18 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         private void forceFinishAsFailed(Throwable t) {
             if (finished.compareAndSet(false, true)) {
                 Releasables.close(indexShardReference);
-                listener.onFailure(t);
+                try {
+                    channel.sendResponse(t);
+                } catch (IOException responseException) {
+                    logger.warn("failed to send error message back to client for action [{}]", responseException, transportReplicaAction);
+                    logger.warn("actual Exception", t);
+                }
             }
         }
 
         private void doFinish() {
             if (finished.compareAndSet(false, true)) {
                 Releasables.close(indexShardReference);
-                final ShardId shardId = shardIt.shardId();
                 final ActionWriteResponse.ShardInfo.Failure[] failuresArray;
                 if (!shardReplicaFailures.isEmpty()) {
                     int slot = 0;
@@ -982,7 +928,14 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
 
                         )
                 );
-                listener.onResponse(finalResponse);
+                try {
+                    channel.sendResponse(finalResponse);
+                } catch (IOException responseException) {
+                    logger.warn("failed to send error message back to client for action [" + transportReplicaAction + "]", responseException);
+                }
+                if (logger.isTraceEnabled()) {
+                    logger.trace("action [{}] completed on all replicas [{}] for request [{}]", transportReplicaAction, shardId, replicaRequest);
+                }
             }
         }
 
@@ -1023,34 +976,10 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         return IndexMetaData.isIndexUsingShadowReplicas(settings) == false;
     }
 
-    /**
-     * Internal request class that gets built on each node. Holds the original request plus additional info.
-     */
-    protected class InternalRequest {
-        final Request request;
-        String concreteIndex;
-
-        InternalRequest(Request request) {
-            this.request = request;
-        }
-
-        public Request request() {
-            return request;
-        }
-
-        void concreteIndex(String concreteIndex) {
-            this.concreteIndex = concreteIndex;
-        }
-
-        public String concreteIndex() {
-            return concreteIndex;
-        }
-    }
-
     static class IndexShardReference implements Releasable {
 
         final private IndexShard counter;
-        private final AtomicBoolean closed = new AtomicBoolean(false);
+        private final AtomicBoolean closed = new AtomicBoolean();
 
         IndexShardReference(IndexShard counter) {
             counter.incrementOperationCounter();

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.termvectors;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocumentRequest;
 import org.elasticsearch.action.support.ActionFilters;
@@ -79,8 +78,8 @@ public class TransportMultiTermVectorsAction extends HandledTransportAction<Mult
                         new IllegalArgumentException("routing is required for [" + concreteSingleIndex + "]/[" + termVectorsRequest.type() + "]/[" + termVectorsRequest.id() + "]"))));
                 continue;
             }
-            ShardId shardId = clusterService.operationRouting().getShards(clusterState, concreteSingleIndex,
-                    termVectorsRequest.type(), termVectorsRequest.id(), termVectorsRequest.routing(), null).shardId();
+            ShardId shardId = clusterService.operationRouting().shardId(clusterState, concreteSingleIndex,
+                    termVectorsRequest.id(), termVectorsRequest.routing());
             MultiTermVectorsShardRequest shardRequest = shardRequests.get(shardId);
             if (shardRequest == null) {
                 shardRequest = new MultiTermVectorsShardRequest(request, shardId.index().name(), shardId.id());

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -33,6 +33,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -93,6 +95,24 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
 
     public ImmutableOpenMap<String, IndexRoutingTable> getIndicesRouting() {
         return indicesRouting();
+    }
+
+    /**
+     * All shards for the provided index and shard id
+     * @return All the shard routing entries for the given index and shard id
+     * @throws IndexNotFoundException if provided index does not exist
+     * @throws ShardNotFoundException if provided shard id is unknown
+     */
+    public IndexShardRoutingTable shardRoutingTable(String index, int shardId) {
+        IndexRoutingTable indexRouting = index(index);
+        if (indexRouting == null) {
+            throw new IndexNotFoundException(index);
+        }
+        IndexShardRoutingTable shard = indexRouting.shard(shardId);
+        if (shard == null) {
+            throw new ShardNotFoundException(new ShardId(index, shardId));
+        }
+        return shard;
     }
 
     public RoutingTable validateRaiseException(MetaData metaData) throws RoutingValidationException {

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -46,18 +45,17 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.IndexShardNotStartedException;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.cluster.TestClusterService;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportChannel;
-import org.elasticsearch.transport.TransportResponse;
-import org.elasticsearch.transport.TransportResponseOptions;
-import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.*;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -132,22 +130,22 @@ public class TransportReplicationActionTests extends ESTestCase {
         ClusterBlocks.Builder block = ClusterBlocks.builder()
                 .addGlobalBlock(new ClusterBlock(1, "non retryable", false, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL));
         clusterService.setState(ClusterState.builder(clusterService.state()).blocks(block));
-        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, listener);
-        assertFalse("primary phase should stop execution", primaryPhase.checkBlocks());
+        TransportReplicationAction.ReroutePhase reroutePhase = action.new ReroutePhase(request, listener);
+        reroutePhase.run();
         assertListenerThrows("primary phase should fail operation", listener, ClusterBlockException.class);
 
         block = ClusterBlocks.builder()
                 .addGlobalBlock(new ClusterBlock(1, "retryable", true, true, RestStatus.SERVICE_UNAVAILABLE, ClusterBlockLevel.ALL));
         clusterService.setState(ClusterState.builder(clusterService.state()).blocks(block));
         listener = new PlainActionFuture<>();
-        primaryPhase = action.new PrimaryPhase(new Request().timeout("5ms"), listener);
-        assertFalse("primary phase should stop execution on retryable block", primaryPhase.checkBlocks());
+        reroutePhase = action.new ReroutePhase(new Request().timeout("5ms"), listener);
+        reroutePhase.run();
         assertListenerThrows("failed to timeout on retryable block", listener, ClusterBlockException.class);
 
 
         listener = new PlainActionFuture<>();
-        primaryPhase = action.new PrimaryPhase(new Request(), listener);
-        assertFalse("primary phase should stop execution on retryable block", primaryPhase.checkBlocks());
+        reroutePhase = action.new ReroutePhase(new Request(), listener);
+        reroutePhase.run();
         assertFalse("primary phase should wait on retryable block", listener.isDone());
 
         block = ClusterBlocks.builder()
@@ -172,25 +170,47 @@ public class TransportReplicationActionTests extends ESTestCase {
 
         Request request = new Request(shardId).timeout("1ms");
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
-        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, listener);
-        primaryPhase.run();
+        TransportReplicationAction.ReroutePhase reroutePhase = action.new ReroutePhase(request, listener);
+        reroutePhase.run();
         assertListenerThrows("unassigned primary didn't cause a timeout", listener, UnavailableShardsException.class);
 
         request = new Request(shardId);
         listener = new PlainActionFuture<>();
-        primaryPhase = action.new PrimaryPhase(request, listener);
-        primaryPhase.run();
+        reroutePhase = action.new ReroutePhase(request, listener);
+        reroutePhase.run();
         assertFalse("unassigned primary didn't cause a retry", listener.isDone());
 
         clusterService.setState(state(index, true, ShardRoutingState.STARTED));
         logger.debug("--> primary assigned state:\n{}", clusterService.state().prettyPrint());
 
-        listener.get();
-        assertTrue("request wasn't processed on primary, despite of it being assigned", request.processedOnPrimary.get());
+        final IndexShardRoutingTable shardRoutingTable = clusterService.state().routingTable().index(index).shard(shardId.id());
+        final String primaryNodeId = shardRoutingTable.primaryShard().currentNodeId();
+        final List<CapturingTransport.CapturedRequest> capturedRequests = transport.capturedRequestsByTargetNode().get(primaryNodeId);
+        assertThat(capturedRequests, notNullValue());
+        assertThat(capturedRequests.size(), equalTo(1));
+        assertThat(capturedRequests.get(0).action, equalTo("testAction[p]"));
         assertIndexShardCounter(1);
     }
 
-    public void testRoutingToPrimary() {
+    public void testUnknownIndexOrShardOnReroute() throws InterruptedException {
+        final String index = "test";
+        // no replicas in oder to skip the replication part
+        clusterService.setState(state(index, true,
+                randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.UNASSIGNED));
+        logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
+        Request request = new Request(new ShardId("unknown_index", 0)).timeout("1ms");
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+        TransportReplicationAction.ReroutePhase reroutePhase = action.new ReroutePhase(request, listener);
+        reroutePhase.run();
+        assertListenerThrows("must throw index not found exception", listener, IndexNotFoundException.class);
+        request = new Request(new ShardId(index, 10)).timeout("1ms");
+        listener = new PlainActionFuture<>();
+        reroutePhase = action.new ReroutePhase(request, listener);
+        reroutePhase.run();
+        assertListenerThrows("must throw shard not found exception", listener, ShardNotFoundException.class);
+    }
+
+    public void testRoutePhaseExecutesRequest() {
         final String index = "test";
         final ShardId shardId = new ShardId(index, 0);
 
@@ -203,25 +223,126 @@ public class TransportReplicationActionTests extends ESTestCase {
         Request request = new Request(shardId);
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
 
-        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, listener);
-        assertTrue(primaryPhase.checkBlocks());
-        primaryPhase.routeRequestOrPerformLocally(shardRoutingTable.primaryShard(), shardRoutingTable.shardsIt());
-        if (primaryNodeId.equals(clusterService.localNode().id())) {
-            logger.info("--> primary is assigned locally, testing for execution");
-            assertTrue("request failed to be processed on a local primary", request.processedOnPrimary.get());
-            if (transport.capturedRequests().length > 0) {
-                assertIndexShardCounter(2);
-            } else {
-                assertIndexShardCounter(1);
-            }
+        TransportReplicationAction.ReroutePhase reroutePhase = action.new ReroutePhase(request, listener);
+        reroutePhase.run();
+        assertThat(request.shardId(), equalTo(shardId));
+        logger.info("--> primary is assigned to [{}], checking request forwarded", primaryNodeId);
+        final List<CapturingTransport.CapturedRequest> capturedRequests = transport.capturedRequestsByTargetNode().get(primaryNodeId);
+        assertThat(capturedRequests, notNullValue());
+        assertThat(capturedRequests.size(), equalTo(1));
+        if (clusterService.state().nodes().localNodeId().equals(primaryNodeId)) {
+            assertThat(capturedRequests.get(0).action, equalTo("testAction[p]"));
         } else {
-            logger.info("--> primary is assigned to [{}], checking request forwarded", primaryNodeId);
-            final List<CapturingTransport.CapturedRequest> capturedRequests = transport.capturedRequestsByTargetNode().get(primaryNodeId);
-            assertThat(capturedRequests, notNullValue());
-            assertThat(capturedRequests.size(), equalTo(1));
             assertThat(capturedRequests.get(0).action, equalTo("testAction"));
-            assertIndexShardUninitialized();
         }
+        assertIndexShardUninitialized();
+    }
+
+    public void testPrimaryPhaseExecutesRequest() throws InterruptedException, ExecutionException {
+        final String index = "test";
+        final ShardId shardId = new ShardId(index, 0);
+        clusterService.setState(state(index, true, ShardRoutingState.STARTED, ShardRoutingState.STARTED));
+        Request request = new Request(shardId).timeout("1ms");
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+        TransportReplicationAction.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, createTransportChannel(listener));
+        primaryPhase.run();
+        assertThat("request was not processed on primary", request.processedOnPrimary.get(), equalTo(true));
+        final String replicaNodeId = clusterService.state().getRoutingTable().shardRoutingTable(index, shardId.id()).replicaShards().get(0).currentNodeId();
+        final List<CapturingTransport.CapturedRequest> requests = transport.capturedRequestsByTargetNode().get(replicaNodeId);
+        assertThat(requests, notNullValue());
+        assertThat(requests.size(), equalTo(1));
+        assertThat("replica request was not sent", requests.get(0).action, equalTo("testAction[r]"));
+    }
+
+    public void testAddedReplicaAfterPrimaryOperation() {
+        final String index = "test";
+        final ShardId shardId = new ShardId(index, 0);
+        // start with no replicas
+        clusterService.setState(stateWithStartedPrimary(index, true, 0));
+        logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
+        final ClusterState stateWithAddedReplicas = state(index, true, ShardRoutingState.STARTED, randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.STARTED);
+
+        final Action actionWithAddedReplicaAfterPrimaryOp = new Action(Settings.EMPTY, "testAction", transportService, clusterService, threadPool) {
+            @Override
+            protected Tuple<Response, Request> shardOperationOnPrimary(MetaData metaData, Request shardRequest) throws Throwable {
+                final Tuple<Response, Request> operationOnPrimary = super.shardOperationOnPrimary(metaData, shardRequest);
+                // add replicas after primary operation
+                ((TestClusterService) clusterService).setState(stateWithAddedReplicas);
+                logger.debug("--> state after primary operation:\n{}", clusterService.state().prettyPrint());
+                return operationOnPrimary;
+            }
+        };
+
+        Request request = new Request(shardId);
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = actionWithAddedReplicaAfterPrimaryOp.new PrimaryPhase(request, createTransportChannel(listener));
+        primaryPhase.run();
+        assertThat("request was not processed on primary", request.processedOnPrimary.get(), equalTo(true));
+        for (ShardRouting replica : stateWithAddedReplicas.getRoutingTable().shardRoutingTable(index, shardId.id()).replicaShards()) {
+            List<CapturingTransport.CapturedRequest> requests = transport.capturedRequestsByTargetNode().get(replica.currentNodeId());
+            assertThat(requests, notNullValue());
+            assertThat(requests.size(), equalTo(1));
+            assertThat("replica request was not sent", requests.get(0).action, equalTo("testAction[r]"));
+        }
+    }
+
+    public void testRelocatingReplicaAfterPrimaryOperation() {
+        final String index = "test";
+        final ShardId shardId = new ShardId(index, 0);
+        // start with a replica
+        clusterService.setState(state(index, true, ShardRoutingState.STARTED,  randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.STARTED));
+        logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
+        final ClusterState stateWithRelocatingReplica = state(index, true, ShardRoutingState.STARTED, ShardRoutingState.RELOCATING);
+
+        final Action actionWithRelocatingReplicasAfterPrimaryOp = new Action(Settings.EMPTY, "testAction", transportService, clusterService, threadPool) {
+            @Override
+            protected Tuple<Response, Request> shardOperationOnPrimary(MetaData metaData, Request shardRequest) throws Throwable {
+                final Tuple<Response, Request> operationOnPrimary = super.shardOperationOnPrimary(metaData, shardRequest);
+                // set replica to relocating
+                ((TestClusterService) clusterService).setState(stateWithRelocatingReplica);
+                logger.debug("--> state after primary operation:\n{}", clusterService.state().prettyPrint());
+                return operationOnPrimary;
+            }
+        };
+
+        Request request = new Request(shardId);
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = actionWithRelocatingReplicasAfterPrimaryOp.new PrimaryPhase(request, createTransportChannel(listener));
+        primaryPhase.run();
+        assertThat("request was not processed on primary", request.processedOnPrimary.get(), equalTo(true));
+        ShardRouting relocatingReplicaShard = stateWithRelocatingReplica.getRoutingTable().shardRoutingTable(index, shardId.id()).replicaShards().get(0);
+        for (String node : new String[] {relocatingReplicaShard.currentNodeId(), relocatingReplicaShard.relocatingNodeId()}) {
+            List<CapturingTransport.CapturedRequest> requests = transport.capturedRequestsByTargetNode().get(node);
+            assertThat(requests, notNullValue());
+            assertThat(requests.size(), equalTo(1));
+            assertThat("replica request was not sent to replica", requests.get(0).action, equalTo("testAction[r]"));
+        }
+    }
+
+    public void testIndexDeletedAfterPrimaryOperation() {
+        final String index = "test";
+        final ShardId shardId = new ShardId(index, 0);
+        clusterService.setState(state(index, true, ShardRoutingState.STARTED, ShardRoutingState.STARTED));
+        logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
+        final ClusterState stateWithDeletedIndex = state(index + "_new", true, ShardRoutingState.STARTED, ShardRoutingState.RELOCATING);
+
+        final Action actionWithDeletedIndexAfterPrimaryOp = new Action(Settings.EMPTY, "testAction", transportService, clusterService, threadPool) {
+            @Override
+            protected Tuple<Response, Request> shardOperationOnPrimary(MetaData metaData, Request shardRequest) throws Throwable {
+                final Tuple<Response, Request> operationOnPrimary = super.shardOperationOnPrimary(metaData, shardRequest);
+                // delete index after primary op
+                ((TestClusterService) clusterService).setState(stateWithDeletedIndex);
+                logger.debug("--> state after primary operation:\n{}", clusterService.state().prettyPrint());
+                return operationOnPrimary;
+            }
+        };
+
+        Request request = new Request(shardId);
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = actionWithDeletedIndexAfterPrimaryOp.new PrimaryPhase(request, createTransportChannel(listener));
+        primaryPhase.run();
+        assertThat("request was not processed on primary", request.processedOnPrimary.get(), equalTo(true));
+        assertThat("replication phase should be skipped if index gets deleted after primary operation", transport.capturedRequestsByTargetNode().size(), equalTo(0));
     }
 
     public void testWriteConsistency() throws ExecutionException, InterruptedException {
@@ -266,10 +387,9 @@ public class TransportReplicationActionTests extends ESTestCase {
 
         final IndexShardRoutingTable shardRoutingTable = clusterService.state().routingTable().index(index).shard(shardId.id());
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
-
-        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, listener);
+        TransportReplicationAction.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, createTransportChannel(listener));
         if (passesWriteConsistency) {
-            assertThat(primaryPhase.checkWriteConsistency(shardRoutingTable.primaryShard()), nullValue());
+            assertThat(primaryPhase.checkWriteConsistency(shardRoutingTable.primaryShard().shardId()), nullValue());
             primaryPhase.run();
             assertTrue("operations should have been perform, consistency level is met", request.processedOnPrimary.get());
             if (assignedReplicas > 0) {
@@ -278,14 +398,18 @@ public class TransportReplicationActionTests extends ESTestCase {
                 assertIndexShardCounter(1);
             }
         } else {
-            assertThat(primaryPhase.checkWriteConsistency(shardRoutingTable.primaryShard()), notNullValue());
+            assertThat(primaryPhase.checkWriteConsistency(shardRoutingTable.primaryShard().shardId()), notNullValue());
             primaryPhase.run();
             assertFalse("operations should not have been perform, consistency level is *NOT* met", request.processedOnPrimary.get());
+            assertListenerThrows("should throw exception to trigger retry", listener, UnavailableShardsException.class);
             assertIndexShardUninitialized();
             for (int i = 0; i < replicaStates.length; i++) {
                 replicaStates[i] = ShardRoutingState.STARTED;
             }
             clusterService.setState(state(index, true, ShardRoutingState.STARTED, replicaStates));
+            listener = new PlainActionFuture<>();
+            primaryPhase = action.new PrimaryPhase(request, createTransportChannel(listener));
+            primaryPhase.run();
             assertTrue("once the consistency level met, operation should continue", request.processedOnPrimary.get());
             assertIndexShardCounter(2);
         }
@@ -340,23 +464,19 @@ public class TransportReplicationActionTests extends ESTestCase {
 
 
     protected void runReplicateTest(IndexShardRoutingTable shardRoutingTable, int assignedReplicas, int totalShards) throws InterruptedException, ExecutionException {
-        final ShardRouting primaryShard = shardRoutingTable.primaryShard();
         final ShardIterator shardIt = shardRoutingTable.shardsIt();
         final ShardId shardId = shardIt.shardId();
-        final Request request = new Request();
-        PlainActionFuture<Response> listener = new PlainActionFuture<>();
-
+        final Request request = new Request(shardId);
+        final PlainActionFuture<Response> listener = new PlainActionFuture<>();
         logger.debug("expecting [{}] assigned replicas, [{}] total shards. using state: \n{}", assignedReplicas, totalShards, clusterService.state().prettyPrint());
 
-        final TransportReplicationAction<Request, Request, Response>.InternalRequest internalRequest = action.new InternalRequest(request);
-        internalRequest.concreteIndex(shardId.index().name());
         Releasable reference = getOrCreateIndexShardOperationsCounter();
         assertIndexShardCounter(2);
         // TODO: set a default timeout
         TransportReplicationAction<Request, Request, Response>.ReplicationPhase replicationPhase =
-                action.new ReplicationPhase(shardIt, request,
-                        new Response(), new ClusterStateObserver(clusterService, logger),
-                        primaryShard, internalRequest, listener, reference, null);
+                action.new ReplicationPhase(request,
+                        new Response(),
+                        request.shardId(), createTransportChannel(listener), reference, null);
 
         assertThat(replicationPhase.totalShards(), equalTo(totalShards));
         assertThat(replicationPhase.pending(), equalTo(assignedReplicas));
@@ -433,7 +553,7 @@ public class TransportReplicationActionTests extends ESTestCase {
          * However, this failure would only become apparent once listener.get is called. Seems a little implicit.
          * */
         action = new ActionWithDelay(Settings.EMPTY, "testActionWithExceptions", transportService, clusterService, threadPool);
-        final TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, listener);
+        final TransportReplicationAction.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, createTransportChannel(listener));
         Thread t = new Thread() {
             @Override
             public void run() {
@@ -464,7 +584,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
         Request request = new Request(shardId).timeout("100ms");
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
-        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, listener);
+        TransportReplicationAction.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, createTransportChannel(listener));
         primaryPhase.run();
         assertIndexShardCounter(2);
         assertThat(transport.capturedRequests().length, equalTo(1));
@@ -473,7 +593,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         assertIndexShardCounter(1);
         transport.clear();
         request = new Request(shardId).timeout("100ms");
-        primaryPhase = action.new PrimaryPhase(request, listener);
+        primaryPhase = action.new PrimaryPhase(request, createTransportChannel(listener));
         primaryPhase.run();
         assertIndexShardCounter(2);
         CapturingTransport.CapturedRequest[] replicationRequests = transport.capturedRequests();
@@ -498,7 +618,7 @@ public class TransportReplicationActionTests extends ESTestCase {
             @Override
             public void run() {
                 try {
-                    replicaOperationTransportHandler.messageReceived(new Request(), createTransportChannel());
+                    replicaOperationTransportHandler.messageReceived(new Request(), createTransportChannel(new PlainActionFuture<>()));
                 } catch (Exception e) {
                 }
             }
@@ -515,7 +635,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         action = new ActionWithExceptions(Settings.EMPTY, "testActionWithExceptions", transportService, clusterService, threadPool);
         final Action.ReplicaOperationTransportHandler replicaOperationTransportHandlerForException = action.new ReplicaOperationTransportHandler();
         try {
-            replicaOperationTransportHandlerForException.messageReceived(new Request(shardId), createTransportChannel());
+            replicaOperationTransportHandlerForException.messageReceived(new Request(shardId), createTransportChannel(new PlainActionFuture<>()));
             fail();
         } catch (Throwable t2) {
         }
@@ -531,7 +651,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
         Request request = new Request(shardId).timeout("100ms");
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
-        TransportReplicationAction<Request, Request, Response>.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, listener);
+        TransportReplicationAction.PrimaryPhase primaryPhase = action.new PrimaryPhase(request, createTransportChannel(listener));
         primaryPhase.run();
         // no replica request should have been sent yet
         assertThat(transport.capturedRequests().length, equalTo(0));
@@ -559,7 +679,6 @@ public class TransportReplicationActionTests extends ESTestCase {
     }
 
     public static class Request extends ReplicationRequest<Request> {
-        int shardId;
         public AtomicBoolean processedOnPrimary = new AtomicBoolean();
         public AtomicInteger processedOnReplicas = new AtomicInteger();
 
@@ -568,21 +687,19 @@ public class TransportReplicationActionTests extends ESTestCase {
 
         Request(ShardId shardId) {
             this();
-            this.shardId = shardId.id();
-            this.index(shardId.index().name());
+            this.shardId = shardId;
+            this.index = shardId.getIndex();
             // keep things simple
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeVInt(shardId);
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            shardId = in.readVInt();
         }
     }
 
@@ -605,20 +722,15 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
 
         @Override
-        protected Tuple<Response, Request> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) throws Throwable {
-            boolean executedBefore = shardRequest.request.processedOnPrimary.getAndSet(true);
+        protected Tuple<Response, Request> shardOperationOnPrimary(MetaData metaData, Request shardRequest) throws Throwable {
+            boolean executedBefore = shardRequest.processedOnPrimary.getAndSet(true);
             assert executedBefore == false : "request has already been executed on the primary";
-            return new Tuple<>(new Response(), shardRequest.request);
+            return new Tuple<>(new Response(), shardRequest);
         }
 
         @Override
-        protected void shardOperationOnReplica(ShardId shardId, Request request) {
+        protected void shardOperationOnReplica(Request request) {
             request.processedOnReplicas.incrementAndGet();
-        }
-
-        @Override
-        protected ShardIterator shards(ClusterState clusterState, InternalRequest request) {
-            return clusterState.getRoutingTable().index(request.concreteIndex()).shard(request.request().shardId).shardsIt();
         }
 
         @Override
@@ -659,8 +771,8 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
 
         @Override
-        protected Tuple<Response, Request> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) throws Throwable {
-            return throwException(shardRequest.shardId);
+        protected Tuple<Response, Request> shardOperationOnPrimary(MetaData metaData, Request shardRequest) throws Throwable {
+            return throwException(shardRequest.shardId());
         }
 
         private Tuple<Response, Request> throwException(ShardId shardId) {
@@ -681,8 +793,8 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
 
         @Override
-        protected void shardOperationOnReplica(ShardId shardId, Request shardRequest) {
-            throwException(shardRequest.internalShardId);
+        protected void shardOperationOnReplica(Request shardRequest) {
+            throwException(shardRequest.shardId());
         }
     }
 
@@ -697,9 +809,9 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
 
         @Override
-        protected Tuple<Response, Request> shardOperationOnPrimary(ClusterState clusterState, PrimaryOperationRequest shardRequest) throws Throwable {
+        protected Tuple<Response, Request> shardOperationOnPrimary(MetaData metaData, Request shardRequest) throws Throwable {
             awaitLatch();
-            return new Tuple<>(new Response(), shardRequest.request);
+            return new Tuple<>(new Response(), shardRequest);
         }
 
         private void awaitLatch() throws InterruptedException {
@@ -708,7 +820,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
 
         @Override
-        protected void shardOperationOnReplica(ShardId shardId, Request shardRequest) {
+        protected void shardOperationOnReplica(Request shardRequest) {
             try {
                 awaitLatch();
             } catch (InterruptedException e) {
@@ -720,7 +832,7 @@ public class TransportReplicationActionTests extends ESTestCase {
     /*
     * Transport channel that is needed for replica operation testing.
     * */
-    public TransportChannel createTransportChannel() {
+    public TransportChannel createTransportChannel(final PlainActionFuture<Response> listener) {
         return new TransportChannel() {
 
             @Override
@@ -735,14 +847,17 @@ public class TransportReplicationActionTests extends ESTestCase {
 
             @Override
             public void sendResponse(TransportResponse response) throws IOException {
+                listener.onResponse(((Response) response));
             }
 
             @Override
             public void sendResponse(TransportResponse response, TransportResponseOptions options) throws IOException {
+                listener.onResponse(((Response) response));
             }
 
             @Override
             public void sendResponse(Throwable error) throws IOException {
+                listener.onFailure(error);
             }
         };
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityTests.java
@@ -26,13 +26,11 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.nio.file.Path;
 import java.util.Arrays;
 
 public class RoutingBackwardCompatibilityTests extends ESTestCase {

--- a/core/src/test/java/org/elasticsearch/consistencylevel/WriteConsistencyLevelIT.java
+++ b/core/src/test/java/org/elasticsearch/consistencylevel/WriteConsistencyLevelIT.java
@@ -53,7 +53,7 @@ public class WriteConsistencyLevelIT extends ESIntegTestCase {
             fail("can't index, does not match consistency");
         } catch (UnavailableShardsException e) {
             assertThat(e.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
-            assertThat(e.getMessage(), equalTo("[test][0] Not enough active copies to meet write consistency of [QUORUM] (have 1, needed 2). Timeout: [100ms], request: index {[test][type1][1], source[{ type1 : { \"id\" : \"1\", \"name\" : \"test\" } }]}"));
+            assertThat(e.getMessage(), equalTo("[test][0] Not enough active copies to meet write consistency of [QUORUM] (have 1, needed 2). Timeout: [100ms], request: [index {[test][type1][1], source[{ type1 : { \"id\" : \"1\", \"name\" : \"test\" } }]}]"));
             // but really, all is well
         }
 
@@ -76,7 +76,7 @@ public class WriteConsistencyLevelIT extends ESIntegTestCase {
             fail("can't index, does not match consistency");
         } catch (UnavailableShardsException e) {
             assertThat(e.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
-            assertThat(e.getMessage(), equalTo("[test][0] Not enough active copies to meet write consistency of [ALL] (have 2, needed 3). Timeout: [100ms], request: index {[test][type1][1], source[{ type1 : { \"id\" : \"1\", \"name\" : \"test\" } }]}"));
+            assertThat(e.getMessage(), equalTo("[test][0] Not enough active copies to meet write consistency of [ALL] (have 2, needed 3). Timeout: [100ms], request: [index {[test][type1][1], source[{ type1 : { \"id\" : \"1\", \"name\" : \"test\" } }]}]"));
             // but really, all is well
         }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -117,8 +118,9 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
             if (t instanceof ExecutionException) {
                 t = ((ExecutionException) t).getCause();
             }
-            if (t instanceof IllegalArgumentException) {
-                assertEquals("It is forbidden to index into the default mapping [_default_]", t.getMessage());
+            final Throwable throwable = ExceptionsHelper.unwrapCause(t);
+            if (throwable instanceof IllegalArgumentException) {
+                assertEquals("It is forbidden to index into the default mapping [_default_]", throwable.getMessage());
             } else {
                 throw t;
             }
@@ -133,8 +135,9 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
             if (t instanceof ExecutionException) {
                 t = ((ExecutionException) t).getCause();
             }
-            if (t instanceof IllegalArgumentException) {
-                assertEquals("It is forbidden to index into the default mapping [_default_]", t.getMessage());
+            final Throwable throwable = ExceptionsHelper.unwrapCause(t);
+            if (throwable instanceof IllegalArgumentException) {
+                assertEquals("It is forbidden to index into the default mapping [_default_]", throwable.getMessage());
             } else {
                 throw t;
             }

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndicesRequestTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndicesRequestTests.java
@@ -178,7 +178,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
     }
 
     public void testIndex() {
-        String[] indexShardActions = new String[]{IndexAction.NAME, IndexAction.NAME + "[r]"};
+        String[] indexShardActions = new String[]{IndexAction.NAME, IndexAction.NAME + "[p]", IndexAction.NAME + "[r]"};
         interceptTransportActions(indexShardActions);
 
         IndexRequest indexRequest = new IndexRequest(randomIndexOrAlias(), "type", "id").source("field", "value");
@@ -189,7 +189,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
     }
 
     public void testDelete() {
-        String[] deleteShardActions = new String[]{DeleteAction.NAME, DeleteAction.NAME + "[r]"};
+        String[] deleteShardActions = new String[]{DeleteAction.NAME, DeleteAction.NAME + "[p]", DeleteAction.NAME + "[r]"};
         interceptTransportActions(deleteShardActions);
 
         DeleteRequest deleteRequest = new DeleteRequest(randomIndexOrAlias(), "type", "id");
@@ -244,7 +244,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
     }
 
     public void testBulk() {
-        String[] bulkShardActions = new String[]{BulkAction.NAME + "[s]", BulkAction.NAME + "[s][r]"};
+        String[] bulkShardActions = new String[]{BulkAction.NAME + "[s][p]", BulkAction.NAME + "[s][r]"};
         interceptTransportActions(bulkShardActions);
 
         List<String> indices = new ArrayList<>();
@@ -344,7 +344,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
     }
 
     public void testFlush() {
-        String[] indexShardActions = new String[]{TransportShardFlushAction.NAME + "[r]", TransportShardFlushAction.NAME};
+        String[] indexShardActions = new String[]{TransportShardFlushAction.NAME, TransportShardFlushAction.NAME + "[r]", TransportShardFlushAction.NAME + "[p]"};
         interceptTransportActions(indexShardActions);
 
         FlushRequest flushRequest = new FlushRequest(randomIndicesOrAliases());
@@ -367,7 +367,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
     }
 
     public void testRefresh() {
-        String[] indexShardActions = new String[]{TransportShardRefreshAction.NAME + "[r]", TransportShardRefreshAction.NAME};
+        String[] indexShardActions = new String[]{TransportShardRefreshAction.NAME, TransportShardRefreshAction.NAME + "[r]", TransportShardRefreshAction.NAME + "[p]"};
         interceptTransportActions(indexShardActions);
 
         RefreshRequest refreshRequest = new RefreshRequest(randomIndicesOrAliases());


### PR DESCRIPTION
Currently the logic to route an operation to the primary and the local primary operation is tightly coupled in `TransportReplicationAction#PrimaryPhase`. This change decouples the routing and retrying logic to `ReroutePhase` and the primary operation to `PrimaryPhase`, allowing to perform more informed shard level operations in the future.
