### PR TITLE
Stop Gradle from destroying IntelliJ project settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,9 +125,6 @@ if (projectsPrefix.isEmpty()) {
       vcs = 'Git'
     }
   }
-  tasks.cleanIdea {
-    delete '.idea'
-  }
 }
 
 // eclipse configuration


### PR DESCRIPTION
This commit stops Gradle from destroying the IntelliJ project settings
when a Gradle refresh is executed in IntelliJ.

Closes #14809
