### PR TITLE
Field stats: Index constraints should remove indices in the response if the field to evaluate is empty

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/TransportFieldStatsTransportAction.java
@@ -119,18 +119,14 @@ public class TransportFieldStatsTransportAction extends TransportBroadcastAction
                 while (iterator.hasNext()) {
                     Map.Entry<String, Map<String, FieldStats>> entry = iterator.next();
                     FieldStats indexConstraintFieldStats = entry.getValue().get(indexConstraint.getField());
-                    if (indexConstraintFieldStats == null) {
-                        continue;
-                    }
-
-                    if (indexConstraintFieldStats.match(indexConstraint)) {
+                    if (indexConstraintFieldStats != null && indexConstraintFieldStats.match(indexConstraint)) {
                         // If the field stats didn't occur in the list of fields in the original request we need to remove the
                         // field stats, because it was never requested and was only needed to validate the index constraint
                         if (fieldStatFields.contains(indexConstraint.getField()) == false) {
                             entry.getValue().remove(indexConstraint.getField());
                         }
                     } else {
-                        // The index constraint didn't match, so we remove all the field stats of the index we're checking
+                        // The index constraint didn't match or was empty, so we remove all the field stats of the index we're checking
                         iterator.remove();
                     }
                 }

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -404,8 +404,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setIndexContraints(new IndexConstraint("value", MIN, GTE, "1998-01-01T00:00:00.000Z"))
                 .setLevel("indices")
                 .get();
-        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").size(), equalTo(0));
+        assertThat(response.getIndicesMergedFieldStats().size(), equalTo(0));
     }
 
 }


### PR DESCRIPTION
Index constraints should remove indices in the response if the field to evaluate if empty. Index constraints can't work with that and it is the same as if the field doesn't match.
