### PR TITLE
Fix doc of nested_path sort option

### DIFF
--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -84,13 +84,12 @@ field support has the following parameters on top of the already
 existing sort options:
 
 `nested_path`::
-    Defines the on what nested object to sort. The actual
-    sort field must be a direct field inside this nested object. The default
-    is to use the most immediate inherited nested object from the sort
-    field.
+    Defines on which nested object to sort. The actual
+    sort field must be a direct field inside this nested object.
+    When sorting by nested field, this field is mandatory.
 
 `nested_filter`::
-    A filter the inner objects inside the nested path
+    A filter that the inner objects inside the nested path
     should match with in order for its field values to be taken into account
     by sorting. Common case is to repeat the query / filter inside the
     nested filter or query. By default no `nested_filter` is active.
@@ -98,7 +97,7 @@ existing sort options:
 ===== Nested sorting example
 
 In the below example `offer` is a field of type `nested`.
-The `nested_path` needs to be specified other elasticsearch doesn't on what nested level sort values need to be captured.
+The `nested_path` needs to be specified; otherwise, elasticsearch doesn't know on what nested level sort values need to be captured.
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
In 2eadc6d5958a88187692e3514428413d9ffef508 the option of using a default path when sorting by nested field was [removed](https://github.com/elastic/elasticsearch/commit/2eadc6d5958a88187692e3514428413d9ffef508#diff-514b67619414b8fc77f08ddcc27f5680L240). The documentation was partially updated to reflect this, but the paragraph on `nested_path` itself was skipped and still referenced the possibility of using a default. I updated it to reflect that change.

I also made some of the surrounding language a little clearer.
