### PR TITLE
Clarify where index.similarity.default.type is set

### DIFF
--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -157,7 +157,7 @@ implementation used for these two methods, while not changing the
 `default`, it is possible to configure a similarity with the name
 `base`. This similarity will then be used for the two methods.
 
-You can change the default similarity for all fields like this:
+You can change the default similarity for all fields by putting the following setting into `elasticsearch.yml`:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Updating documentation to include adding the setting to `elasticsearch.yml`

Fixes: #14849 
