### PR TITLE
Docs: `exists` query does not need to be wrapped inside `constant_score`

### DIFF
--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -6,7 +6,7 @@ Returns documents that have at least one non-`null` value in the original field:
 [source,js]
 --------------------------------------------------
 {
-        "exists" : { "field" : "user" }
+    "exists" : { "field" : "user" }
 }
 --------------------------------------------------
 

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -6,11 +6,7 @@ Returns documents that have at least one non-`null` value in the original field:
 [source,js]
 --------------------------------------------------
 {
-    "constant_score" : {
-        "filter" : {
-            "exists" : { "field" : "user" }
-        }
-    }
+        "exists" : { "field" : "user" }
 }
 --------------------------------------------------
 


### PR DESCRIPTION
In the example we show an `exists` query inside a constant score query. While this is possible, it can mislead users to think it is necessary so we should remove it.
