### PR TITLE
[Ingest] Ingest better bulk failure handling

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineExecutionService.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineExecutionService.java
@@ -43,7 +43,7 @@ public class PipelineExecutionService {
     public void execute(IngestDocument ingestDocument, String pipelineId, Listener listener) {
         Pipeline pipeline = store.get(pipelineId);
         if (pipeline == null) {
-            listener.failed(new IllegalArgumentException(LoggerMessageFormat.format("pipeline with id [{}] does not exist", pipelineId)));
+            listener.failed(new IllegalArgumentException("pipeline with id [" + pipelineId + "] does not exist"));
             return;
         }
 
@@ -53,7 +53,7 @@ public class PipelineExecutionService {
                 try {
                     pipeline.execute(ingestDocument);
                     listener.executed(ingestDocument);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     listener.failed(e);
                 }
             }
@@ -64,7 +64,7 @@ public class PipelineExecutionService {
 
         void executed(IngestDocument ingestDocument);
 
-        void failed(Exception e);
+        void failed(Throwable e);
 
     }
 

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilter.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilter.java
@@ -22,7 +22,9 @@ package org.elasticsearch.plugin.ingest.transport;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilterChain;
@@ -33,10 +35,9 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.plugin.ingest.IngestPlugin;
 import org.elasticsearch.plugin.ingest.PipelineExecutionService;
 
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
-public class IngestActionFilter extends AbstractComponent implements ActionFilter {
+public final class IngestActionFilter extends AbstractComponent implements ActionFilter {
 
     private final PipelineExecutionService executionService;
 
@@ -61,7 +62,10 @@ public class IngestActionFilter extends AbstractComponent implements ActionFilte
             processIndexRequest(action, listener, chain, (IndexRequest) request, pipelineId);
         } else if (request instanceof BulkRequest) {
             BulkRequest bulkRequest = (BulkRequest) request;
-            processBulkIndexRequest(action, listener, chain, bulkRequest, pipelineId, bulkRequest.requests().iterator());
+            @SuppressWarnings("unchecked")
+            ActionListener<BulkResponse> actionListener = (ActionListener<BulkResponse>) listener;
+            BulkRequestModifier bulkRequestModifier = new BulkRequestModifier(bulkRequest);
+            processBulkIndexRequest(bulkRequestModifier, pipelineId, action, chain, actionListener);
         } else {
             chain.proceed(action, request, listener);
         }
@@ -94,22 +98,31 @@ public class IngestActionFilter extends AbstractComponent implements ActionFilte
             }
 
             @Override
-            public void failed(Exception e) {
+            public void failed(Throwable e) {
                 logger.error("failed to execute pipeline [{}]", e, pipelineId);
                 listener.onFailure(e);
             }
         });
     }
 
-    void processBulkIndexRequest(String action, ActionListener listener, ActionFilterChain chain, BulkRequest bulkRequest, String pipelineId, Iterator<ActionRequest> requests) {
-        if (!requests.hasNext()) {
-            chain.proceed(action, bulkRequest, listener);
+    void processBulkIndexRequest(BulkRequestModifier bulkRequestModifier, String pipelineId, String action, ActionFilterChain chain, ActionListener<BulkResponse> listener) {
+        if (!bulkRequestModifier.hasNext()) {
+            BulkRequest bulkRequest = bulkRequestModifier.getBulkRequest();
+            ActionListener<BulkResponse> actionListener = bulkRequestModifier.wrapActionListenerIfNeeded(listener);
+            if (bulkRequest.requests().isEmpty()) {
+                // in this stage, the transport bulk action can't deal with a bulk request with no requests,
+                // so we stop and send a empty response back to the client.
+                // (this will happen if all preprocessing all items in the bulk failed)
+                actionListener.onResponse(new BulkResponse(new BulkItemResponse[0], 0));
+            } else {
+                chain.proceed(action, bulkRequest, actionListener);
+            }
             return;
         }
 
-        ActionRequest actionRequest = requests.next();
+        ActionRequest actionRequest = bulkRequestModifier.next();
         if (!(actionRequest instanceof IndexRequest)) {
-            processBulkIndexRequest(action, listener, chain, bulkRequest, pipelineId, requests);
+            processBulkIndexRequest(bulkRequestModifier, pipelineId, action, chain, listener);
             return;
         }
 
@@ -122,13 +135,14 @@ public class IngestActionFilter extends AbstractComponent implements ActionFilte
                 if (ingestDocument.isModified()) {
                     indexRequest.source(ingestDocument.getSource());
                 }
-                processBulkIndexRequest(action, listener, chain, bulkRequest, pipelineId, requests);
+                processBulkIndexRequest(bulkRequestModifier, pipelineId, action, chain, listener);
             }
 
             @Override
-            public void failed(Exception e) {
-                logger.error("failed to execute pipeline [{}]", e, pipelineId);
-                listener.onFailure(e);
+            public void failed(Throwable e) {
+                logger.debug("failed to execute pipeline [{}]", e, pipelineId);
+                bulkRequestModifier.markCurrentItemAsFailed(e);
+                processBulkIndexRequest(bulkRequestModifier, pipelineId, action, chain, listener);
             }
         });
     }
@@ -136,5 +150,99 @@ public class IngestActionFilter extends AbstractComponent implements ActionFilte
     @Override
     public int order() {
         return Integer.MAX_VALUE;
+    }
+
+    final static class BulkRequestModifier implements Iterator<ActionRequest> {
+
+        final BulkRequest bulkRequest;
+        final Set<Integer> failedSlots;
+        final List<BulkItemResponse> itemResponses;
+
+        int currentSlot = -1;
+        int[] originalSlots;
+
+        BulkRequestModifier(BulkRequest bulkRequest) {
+            this.bulkRequest = bulkRequest;
+            this.failedSlots = new HashSet<>();
+            this.itemResponses = new ArrayList<>(bulkRequest.requests().size());
+        }
+
+        @Override
+        public ActionRequest next() {
+            return bulkRequest.requests().get(++currentSlot);
+        }
+
+        @Override
+        public boolean hasNext() {
+            return (currentSlot + 1) < bulkRequest.requests().size();
+        }
+
+        BulkRequest getBulkRequest() {
+            if (itemResponses.isEmpty()) {
+                return bulkRequest;
+            } else {
+                BulkRequest modifiedBulkRequest = new BulkRequest(bulkRequest);
+                modifiedBulkRequest.refresh(bulkRequest.refresh());
+                modifiedBulkRequest.consistencyLevel(bulkRequest.consistencyLevel());
+                modifiedBulkRequest.timeout(bulkRequest.timeout());
+
+                int slot = 0;
+                originalSlots = new int[bulkRequest.requests().size() - failedSlots.size()];
+                for (int i = 0; i < bulkRequest.requests().size(); i++) {
+                    ActionRequest request = bulkRequest.requests().get(i);
+                    if (failedSlots.contains(i) == false) {
+                        modifiedBulkRequest.add(request);
+                        originalSlots[slot++] = i;
+                    }
+                }
+                return modifiedBulkRequest;
+            }
+        }
+
+        ActionListener<BulkResponse> wrapActionListenerIfNeeded(ActionListener<BulkResponse> actionListener) {
+            if (itemResponses.isEmpty()) {
+                return actionListener;
+            } else {
+                return new IngestBulkResponseListener(originalSlots, itemResponses, actionListener);
+            }
+        }
+
+        void markCurrentItemAsFailed(Throwable e) {
+            IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(currentSlot);
+            // We hit a error during preprocessing a request, so we:
+            // 1) Remember the request item slot from the bulk, so that we're done processing all requests we know what failed
+            // 2) Add a bulk item failure for this request
+            // 3) Continue with the next request in the bulk.
+            failedSlots.add(currentSlot);
+            BulkItemResponse.Failure failure = new BulkItemResponse.Failure(indexRequest.index(), indexRequest.type(), indexRequest.id(), e);
+            itemResponses.add(new BulkItemResponse(currentSlot, indexRequest.opType().lowercase(), failure));
+        }
+
+    }
+
+    private final static class IngestBulkResponseListener implements ActionListener<BulkResponse> {
+
+        private final int[] originalSlots;
+        private final List<BulkItemResponse> itemResponses;
+        private final ActionListener<BulkResponse> actionListener;
+
+        IngestBulkResponseListener(int[] originalSlots, List<BulkItemResponse> itemResponses, ActionListener<BulkResponse> actionListener) {
+            this.itemResponses = itemResponses;
+            this.actionListener = actionListener;
+            this.originalSlots = originalSlots;
+        }
+
+        @Override
+        public void onResponse(BulkResponse bulkItemResponses) {
+            for (int i = 0; i < bulkItemResponses.getItems().length; i++) {
+                itemResponses.add(originalSlots[i], bulkItemResponses.getItems()[i]);
+            }
+            actionListener.onResponse(new BulkResponse(itemResponses.toArray(new BulkItemResponse[itemResponses.size()]), bulkItemResponses.getTookInMillis()));
+        }
+
+        @Override
+        public void onFailure(Throwable e) {
+            actionListener.onFailure(e);
+        }
     }
 }


### PR DESCRIPTION
With this change if ingest pipeline fails only the index request in the bulk fails whereas right now the entire bulk request is failed.

If pipeline processing fails then the index request gets reported as a failure in the bulk response in its respective place. The index request will not be executed after pipeline processing has been completed.

If pipeline failures occur a new bulk request will be created based on the current bulk request. Only index requests that have successfully been processed by the pipeline will be included in this new bulk request. Then when sending back the bulk response the new bulk request will map its response items in such a way that the order of all items and errors is the same and matches with the original bulk request that was sent.
