### PR TITLE
Shift significant terms score test back into core without Groovy dependency

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreTests.java
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-package org.elasticsearch.messy.tests;
+package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -33,9 +32,7 @@ import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptModule;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptService.ScriptType;
-import org.elasticsearch.script.groovy.GroovyPlugin;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
@@ -89,17 +86,10 @@ public class SignificantTermsSignificanceScoreTests extends ESIntegTestCase {
     static final String TEXT_FIELD = "text";
     static final String CLASS_FIELD = "class";
 
-    @Override
-    public Settings nodeSettings(int nodeOrdinal) {
-        return settingsBuilder()
-                .put(super.nodeSettings(nodeOrdinal))
-                .put("path.conf", this.getDataPath("conf"))
-                .build();
-    }
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(CustomSignificanceHeuristicPlugin.class, GroovyPlugin.class);
+        return pluginList(CustomSignificanceHeuristicPlugin.class);
     }
 
     public String randomExecutionHint() {
@@ -505,91 +495,15 @@ public class SignificantTermsSignificanceScoreTests extends ESIntegTestCase {
         }
     }
 
-    public void testNoNumberFormatExceptionWithDefaultScriptingEngine() throws ExecutionException, InterruptedException, IOException {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 1)));
-        index("test", "doc", "1", "{\"field\":\"a\"}");
-        index("test", "doc", "11", "{\"field\":\"a\"}");
-        index("test", "doc", "2", "{\"field\":\"b\"}");
-        index("test", "doc", "22", "{\"field\":\"b\"}");
-        index("test", "doc", "3", "{\"field\":\"a b\"}");
-        index("test", "doc", "33", "{\"field\":\"a b\"}");
-        ScriptHeuristic.ScriptHeuristicBuilder scriptHeuristicBuilder = new ScriptHeuristic.ScriptHeuristicBuilder();
-        scriptHeuristicBuilder.setScript(new Script("_subset_freq/(_superset_freq - _subset_freq + 1)"));
-        ensureYellow();
-        refresh();
-        SearchResponse response = client()
-                .prepareSearch("test")
-                .addAggregation(
-                        new TermsBuilder("letters").field("field").subAggregation(
-                                new SignificantTermsBuilder("mySignificantTerms").field("field").executionHint(randomExecutionHint())
-                                        .significanceHeuristic(scriptHeuristicBuilder).minDocCount(1).shardSize(2).size(2))).execute()
-                .actionGet();
-        assertSearchResponse(response);
-        assertThat(((Terms) response.getAggregations().get("letters")).getBuckets().size(), equalTo(2));
-        for (Terms.Bucket classBucket : ((Terms) response.getAggregations().get("letters")).getBuckets()) {
-            assertThat(((SignificantStringTerms) classBucket.getAggregations().get("mySignificantTerms")).getBuckets().size(), equalTo(2));
-            for (SignificantTerms.Bucket bucket : ((SignificantTerms) classBucket.getAggregations().get("mySignificantTerms")).getBuckets()) {
-                assertThat(bucket.getSignificanceScore(),
-                        closeTo((double) bucket.getSubsetDf() / (bucket.getSupersetDf() - bucket.getSubsetDf() + 1), 1.e-6));
-            }
-        }
-    }
-
     private ScriptHeuristic.ScriptHeuristicBuilder getScriptSignificanceHeuristicBuilder() throws IOException {
-        Map<String, Object> params = null;
         Script script = null;
-        String lang = null;
         if (randomBoolean()) {
+            Map<String, Object> params = null;
             params = new HashMap<>();
             params.put("param", randomIntBetween(1, 100));
-        }
-        int randomScriptKind = randomIntBetween(0, 3);
-        if (randomBoolean()) {
-            lang = "groovy";
-        }
-        switch (randomScriptKind) {
-        case 0: {
-            if (params == null) {
-                script = new Script("return _subset_freq + _subset_size + _superset_freq + _superset_size");
-            } else {
-                script = new Script("return param*(_subset_freq + _subset_size + _superset_freq + _superset_size)/param",
-                        ScriptType.INLINE, lang, params);
-            }
-            break;
-        }
-        case 1: {
-            String scriptString;
-            if (params == null) {
-                scriptString = "return _subset_freq + _subset_size + _superset_freq + _superset_size";
-            } else {
-                scriptString = "return param*(_subset_freq + _subset_size + _superset_freq + _superset_size)/param";
-            }
-            client().prepareIndex().setIndex(ScriptService.SCRIPT_INDEX).setType(ScriptService.DEFAULT_LANG).setId("my_script")
-                    .setSource(XContentFactory.jsonBuilder().startObject().field("script", scriptString).endObject()).get();
-            refresh();
-            script = new Script("my_script", ScriptType.INDEXED, lang, params);
-            break;
-        }
-        case 2: {
-            if (params == null) {
-                script = new Script("significance_script_no_params", ScriptType.FILE, lang, null);
-            } else {
-                script = new Script("significance_script_with_params", ScriptType.FILE, lang, params);
-            }
-            break;
-        }
-        case 3: {
-            logger.info("NATIVE SCRIPT");
-            if (params == null) {
-                script = new Script("native_significance_score_script_no_params", ScriptType.INLINE, "native", null);
-            } else {
-                script = new Script("native_significance_score_script_with_params", ScriptType.INLINE, "native", params);
-            }
-            lang = "native";
-            if (randomBoolean()) {
-            }
-            break;
-        }
+            script = new Script("native_significance_score_script_with_params", ScriptType.INLINE, "native", params);
+        } else {
+            script = new Script("native_significance_score_script_no_params", ScriptType.INLINE, "native", null);
         }
         ScriptHeuristic.ScriptHeuristicBuilder builder = new ScriptHeuristic.ScriptHeuristicBuilder().setScript(script);
 


### PR DESCRIPTION
This completely removes any testing of Groovy-scripted significance scoring so is a cleaner PR to review than https://github.com/elastic/elasticsearch/pull/14886 which kept some significance test code in lang-groovy. So this is "option 1" from [the comment here](https://github.com/elastic/elasticsearch/pull/14886#issuecomment-158424384) and would replace that PR
