### PR TITLE
Enforce similar tasks run for dependencies first

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,15 +107,57 @@ subprojects {
     }
   }
 
-  configurations {
-    all {
-      resolutionStrategy {
-        dependencySubstitution {
-          substitute module("org.elasticsearch:rest-api-spec:${version}") with project("${projectsPrefix}:rest-api-spec")
-          substitute module("org.elasticsearch:elasticsearch:${version}") with project("${projectsPrefix}:core")
-          substitute module("org.elasticsearch:test-framework:${version}") with project("${projectsPrefix}:test-framework")
-          substitute module("org.elasticsearch.distribution.zip:elasticsearch:${version}") with project("${projectsPrefix}:distribution:zip")
-          substitute module("org.elasticsearch.distribution.tar:elasticsearch:${version}") with project("${projectsPrefix}:distribution:tar")
+  ext.projectSubstitutions = [
+    "org.elasticsearch:rest-api-spec:${version}": "${projectsPrefix}:rest-api-spec",
+    "org.elasticsearch:elasticsearch:${version}": "${projectsPrefix}:core",
+    "org.elasticsearch:test-framework:${version}": "${projectsPrefix}:test-framework",
+    "org.elasticsearch.distribution.zip:elasticsearch:${version}": "${projectsPrefix}:distribution:zip",
+    "org.elasticsearch.distribution.tar:elasticsearch:${version}": "${projectsPrefix}:distribution:tar"
+  ]
+  configurations.all {
+    resolutionStrategy.dependencySubstitution { DependencySubstitutions subs ->
+      projectSubstitutions.each { k,v ->
+        subs.substitute(subs.module(k)).with(subs.project(v))
+      }
+    }
+  }
+}
+
+// Ensure similar tasks in dependent projects run first. The projectsEvaluated here is
+// important because, while dependencies.all will pickup future dependencies,
+// it is not necessarily true that the task exists in both projects at the time
+// the dependency is added.
+gradle.projectsEvaluated {
+  allprojects {
+    if (project.path == ':test-framework') {
+      // :test-framework:test cannot run before and after :core:test
+      return
+    }
+    configurations.all {
+      dependencies.all { Dependency dep ->
+        Project upstreamProject = null
+        if (dep instanceof ProjectDependency) {
+          upstreamProject = dep.dependencyProject
+        } else {
+          // gradle doesn't apply substitutions until resolve time, so they won't
+          // show up as a ProjectDependency above
+          String substitution = projectSubstitutions.get("${dep.group}:${dep.name}:${dep.version}")
+          if (substitution != null) {
+            upstreamProject = findProject(substitution)
+          }
+        }
+        if (upstreamProject != null) {
+          if (project.path == upstreamProject.path) {
+            // TODO: distribution integ tests depend on themselves (!), fix that
+            return
+          }
+          for (String taskName : ['test', 'integTest']) {
+            Task task = project.tasks.findByName(taskName)
+            Task upstreamTask = upstreamProject.tasks.findByName(taskName)
+            if (task != null && upstreamTask != null) {
+              task.mustRunAfter(upstreamTask)
+            }
+          }
         }
       }
     }
@@ -130,7 +172,7 @@ allprojects {
 if (projectsPrefix.isEmpty()) {
   idea {
     project {
-      languageLevel = org.elasticsearch.gradle.BuildPlugin.minimumJava
+      languageLevel = org.elasticsearch.gradle.BuildPlugin.minimumJava.toString()
       vcs = 'Git'
     }
   }


### PR DESCRIPTION
Gradle ensures task dependencies are executed in the correct order.
However, project dependencies only build what is needed for the
dependency. This means the order of higher level tasks are not
guaranteed. This change adds task ordering between test and integTest
for a project and its dependencies.
