### PR TITLE
Fixed minor typo in documentation

### DIFF
--- a/test-framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1035,7 +1035,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
     /**
      * Sets the cluster's minimum master node and make sure the response is acknowledge.
-     * Note: this doesn't guaranty the new settings is in effect, just that it has been received bu all nodes.
+     * Note: this doesn't guarantee the new settings are in effect, just that it has been received by all nodes.
      */
     public void setMinimumMasterNodes(int n) {
         assertTrue(client().admin().cluster().prepareUpdateSettings().setTransientSettings(


### PR DESCRIPTION
Just a minor documentation issue I found while reading through the code. Not major.
