### PR TITLE
Make PointBuilder, CircleBuilder & EnvelopeBuilder implement Writable 

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/builders/CircleBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/CircleBuilder.java
@@ -35,10 +35,10 @@ public class CircleBuilder extends ShapeBuilder {
     private DistanceUnit unit;
     private double radius;
     private Coordinate center;
-    
+
     /**
      * Set the center of the circle
-     * 
+     *
      * @param center coordinate of the circles center
      * @return this
      */
@@ -100,7 +100,7 @@ public class CircleBuilder extends ShapeBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_TYPE, TYPE.shapename);
+        builder.field(FIELD_TYPE, TYPE.shapeName());
         builder.field(FIELD_RADIUS, unit.toString(radius));
         builder.field(FIELD_COORDINATES);
         toXContent(builder, center);

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/CircleBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/CircleBuilder.java
@@ -171,7 +171,9 @@ public class CircleBuilder extends ShapeBuilder {
     }
 
     @Override
-    public ShapeBuilder readFrom(StreamInput in) throws IOException {
-        return new CircleBuilder().center(readCoordinateFrom(in)).radius(in.readDouble(), DistanceUnit.readDistanceUnit(in));
+    public CircleBuilder readFrom(StreamInput in) throws IOException {
+        return new CircleBuilder()
+                    .center(readCoordinateFrom(in))
+                    .radius(in.readDouble(), DistanceUnit.readDistanceUnit(in));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/EnvelopeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/EnvelopeBuilder.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 public class EnvelopeBuilder extends ShapeBuilder {
 
-    public static final GeoShapeType TYPE = GeoShapeType.ENVELOPE; 
+    public static final GeoShapeType TYPE = GeoShapeType.ENVELOPE;
 
     protected Coordinate topLeft;
     protected Coordinate bottomRight;
@@ -61,7 +61,7 @@ public class EnvelopeBuilder extends ShapeBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_TYPE, TYPE.shapename);
+        builder.field(FIELD_TYPE, TYPE.shapeName());
         builder.startArray(FIELD_COORDINATES);
         toXContent(builder, topLeft);
         toXContent(builder, bottomRight);

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/EnvelopeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/EnvelopeBuilder.java
@@ -21,13 +21,19 @@ package org.elasticsearch.common.geo.builders;
 
 import com.spatial4j.core.shape.Rectangle;
 import com.vividsolutions.jts.geom.Coordinate;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
 
 public class EnvelopeBuilder extends ShapeBuilder {
 
     public static final GeoShapeType TYPE = GeoShapeType.ENVELOPE;
+    public static final EnvelopeBuilder PROTOTYPE = new EnvelopeBuilder();
 
     protected Coordinate topLeft;
     protected Coordinate bottomRight;
@@ -62,6 +68,7 @@ public class EnvelopeBuilder extends ShapeBuilder {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(FIELD_TYPE, TYPE.shapeName());
+        builder.field(FIELD_ORIENTATION, orientation.name().toLowerCase(Locale.ROOT));
         builder.startArray(FIELD_COORDINATES);
         toXContent(builder, topLeft);
         toXContent(builder, bottomRight);
@@ -77,5 +84,39 @@ public class EnvelopeBuilder extends ShapeBuilder {
     @Override
     public GeoShapeType type() {
         return TYPE;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(orientation, topLeft, bottomRight);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        EnvelopeBuilder other = (EnvelopeBuilder) obj;
+        return Objects.equals(orientation, other.orientation) &&
+                Objects.equals(topLeft, other.topLeft) &&
+                Objects.equals(bottomRight, other.bottomRight);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(orientation == Orientation.RIGHT);
+        writeCoordinateTo(topLeft, out);
+        writeCoordinateTo(bottomRight, out);
+    }
+
+    @Override
+    public EnvelopeBuilder readFrom(StreamInput in) throws IOException {
+        Orientation orientation = in.readBoolean() ? Orientation.RIGHT : Orientation.LEFT;
+        return new EnvelopeBuilder(orientation)
+                .topLeft(readCoordinateFrom(in))
+                .bottomRight(readCoordinateFrom(in));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
@@ -102,7 +102,7 @@ public class GeometryCollectionBuilder extends ShapeBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_TYPE, TYPE.shapename);
+        builder.field(FIELD_TYPE, TYPE.shapeName());
         builder.startArray(FIELD_GEOMETRIES);
         for (ShapeBuilder shape : shapes) {
             shape.toXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/LineStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/LineStringBuilder.java
@@ -39,7 +39,7 @@ public class LineStringBuilder extends PointCollection<LineStringBuilder> {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_TYPE, TYPE.shapename);
+        builder.field(FIELD_TYPE, TYPE.shapeName());
         builder.field(FIELD_COORDINATES);
         coordinatesToXcontent(builder, false);
         builder.endObject();

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/MultiLineStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/MultiLineStringBuilder.java
@@ -57,7 +57,7 @@ public class MultiLineStringBuilder extends ShapeBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_TYPE, TYPE.shapename);
+        builder.field(FIELD_TYPE, TYPE.shapeName());
         builder.field(FIELD_COORDINATES);
         builder.startArray();
         for(LineStringBuilder line : lines) {

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/MultiPointBuilder.java
@@ -37,7 +37,7 @@ public class MultiPointBuilder extends PointCollection<MultiPointBuilder> {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_TYPE, TYPE.shapename);
+        builder.field(FIELD_TYPE, TYPE.shapeName());
         builder.field(FIELD_COORDINATES);
         super.coordinatesToXcontent(builder, false);
         builder.endObject();

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/MultiPolygonBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/MultiPolygonBuilder.java
@@ -51,7 +51,7 @@ public class MultiPolygonBuilder extends ShapeBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_TYPE, TYPE.shapename);
+        builder.field(FIELD_TYPE, TYPE.shapeName());
         builder.startArray(FIELD_COORDINATES);
         for(PolygonBuilder polygon : polygons) {
             builder.startArray();

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/PointBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/PointBuilder.java
@@ -20,7 +20,10 @@
 package org.elasticsearch.common.geo.builders;
 
 import java.io.IOException;
+import java.util.Objects;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import com.spatial4j.core.shape.Point;
@@ -29,6 +32,8 @@ import com.vividsolutions.jts.geom.Coordinate;
 public class PointBuilder extends ShapeBuilder {
 
     public static final GeoShapeType TYPE = GeoShapeType.POINT;
+
+    public static final PointBuilder PROTOTYPE = new PointBuilder();
 
     private Coordinate coordinate;
 
@@ -48,10 +53,10 @@ public class PointBuilder extends ShapeBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
        builder.startObject();
-       builder.field(FIELD_TYPE, TYPE.shapename);
+       builder.field(FIELD_TYPE, TYPE.shapeName());
        builder.field(FIELD_COORDINATES);
        toXContent(builder, coordinate);
-       return builder.endObject(); 
+       return builder.endObject();
     }
 
     @Override
@@ -62,5 +67,33 @@ public class PointBuilder extends ShapeBuilder {
     @Override
     public GeoShapeType type() {
         return TYPE;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(coordinate);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        PointBuilder other = (PointBuilder) obj;
+        return Objects.equals(coordinate, other.coordinate);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeDouble(coordinate.x);
+        out.writeDouble(coordinate.y);
+    }
+
+    @Override
+    public ShapeBuilder readFrom(StreamInput in) throws IOException {
+        return new PointBuilder().coordinate(new Coordinate(in.readDouble(), in.readDouble()));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/PointBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/PointBuilder.java
@@ -88,12 +88,11 @@ public class PointBuilder extends ShapeBuilder {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeDouble(coordinate.x);
-        out.writeDouble(coordinate.y);
+        writeCoordinateTo(coordinate, out);
     }
 
     @Override
     public ShapeBuilder readFrom(StreamInput in) throws IOException {
-        return new PointBuilder().coordinate(new Coordinate(in.readDouble(), in.readDouble()));
+        return new PointBuilder().coordinate(readCoordinateFrom(in));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/PointBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/PointBuilder.java
@@ -92,7 +92,7 @@ public class PointBuilder extends ShapeBuilder {
     }
 
     @Override
-    public ShapeBuilder readFrom(StreamInput in) throws IOException {
+    public PointBuilder readFrom(StreamInput in) throws IOException {
         return new PointBuilder().coordinate(readCoordinateFrom(in));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/PolygonBuilder.java
@@ -172,7 +172,7 @@ public class PolygonBuilder extends ShapeBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FIELD_TYPE, TYPE.shapename);
+        builder.field(FIELD_TYPE, TYPE.shapeName());
         builder.startArray(FIELD_COORDINATES);
         coordinatesArray(builder, params);
         builder.endArray();

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -843,13 +843,15 @@ public abstract class ShapeBuilder extends ToXContentToBytes implements NamedWri
 
     @Override
     public String getWriteableName() {
-        return type().shapename;
+        return type().shapeName();
     }
 
+    // NORELEASE this should be deleted as soon as all shape builders implement writable
     @Override
     public void writeTo(StreamOutput out) throws IOException {
     }
 
+    // NORELEASE this should be deleted as soon as all shape builders implement writable
     @Override
     public ShapeBuilder readFrom(StreamInput in) throws IOException {
         return null;

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -26,8 +26,12 @@ import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
+
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.ToXContentToBytes;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.unit.DistanceUnit.Distance;
@@ -43,7 +47,7 @@ import java.util.*;
 /**
  * Basic class for building GeoJSON shapes like Polygons, Linestrings, etc
  */
-public abstract class ShapeBuilder extends ToXContentToBytes {
+public abstract class ShapeBuilder extends ToXContentToBytes implements NamedWriteable<ShapeBuilder> {
 
     protected static final ESLogger LOGGER = ESLoggerFactory.getLogger(ShapeBuilder.class.getName());
 
@@ -565,10 +569,14 @@ public abstract class ShapeBuilder extends ToXContentToBytes {
         ENVELOPE("envelope"),
         CIRCLE("circle");
 
-        protected final String shapename;
+        private final String shapename;
 
         private GeoShapeType(String shapename) {
             this.shapename = shapename;
+        }
+
+        protected String shapeName() {
+            return shapename;
         }
 
         public static GeoShapeType forName(String geoshapename) {
@@ -822,5 +830,19 @@ public abstract class ShapeBuilder extends ToXContentToBytes {
 
             return geometryCollection;
         }
+    }
+
+    @Override
+    public String getWriteableName() {
+        return type().shapename;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+    }
+
+    @Override
+    public ShapeBuilder readFrom(StreamInput in) throws IOException {
+        return null;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -177,6 +177,15 @@ public abstract class ShapeBuilder extends ToXContentToBytes implements NamedWri
         return builder.startArray().value(coordinate.x).value(coordinate.y).endArray();
     }
 
+    protected static void writeCoordinateTo(Coordinate coordinate, StreamOutput out) throws IOException {
+        out.writeDouble(coordinate.x);
+        out.writeDouble(coordinate.y);
+    }
+
+    protected Coordinate readCoordinateFrom(StreamInput in) throws IOException {
+        return new Coordinate(in.readDouble(), in.readDouble());
+    }
+
     public static Orientation orientationFromString(String orientation) {
         orientation = orientation.toLowerCase(Locale.ROOT);
         switch (orientation) {

--- a/core/src/test/java/org/elasticsearch/common/geo/builders/AbstractShapeBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/builders/AbstractShapeBuilderTestCase.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.*;
 
 public abstract class AbstractShapeBuilderTestCase<SB extends ShapeBuilder> extends ESTestCase {
 
-    private static final int NUMBER_OF_TESTBUILDERS = 1;
+    private static final int NUMBER_OF_TESTBUILDERS = 20;
     private static final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
 
     /**
@@ -42,6 +42,7 @@ public abstract class AbstractShapeBuilderTestCase<SB extends ShapeBuilder> exte
     @BeforeClass
     public static void init() {
         namedWriteableRegistry.registerPrototype(ShapeBuilder.class, PointBuilder.PROTOTYPE);
+        namedWriteableRegistry.registerPrototype(ShapeBuilder.class, CircleBuilder.PROTOTYPE);
     }
 
     /**
@@ -52,7 +53,7 @@ public abstract class AbstractShapeBuilderTestCase<SB extends ShapeBuilder> exte
     /**
      * mutate the given query so the returned query is different
      */
-    protected abstract SB mutate(SB original);
+    protected abstract SB mutate(SB original) throws IOException;
 
     /**
      * Generic test that creates new shape from a random test shape and checks both for equality
@@ -61,8 +62,10 @@ public abstract class AbstractShapeBuilderTestCase<SB extends ShapeBuilder> exte
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
             SB testShape = createTestShapeBuilder();
             XContentBuilder builder = toXContent(testShape, randomFrom(XContentType.values()));
+            builder = toXContent(testShape, randomFrom(XContentType.values()));
 
             XContentParser shapeParser = XContentHelper.createParser(builder.bytes());
+            XContentHelper.createParser(builder.bytes());
             shapeParser.nextToken();
             ShapeBuilder parsedShape = ShapeBuilder.parse(shapeParser);
             assertNotSame(testShape, parsedShape);
@@ -120,7 +123,7 @@ public abstract class AbstractShapeBuilderTestCase<SB extends ShapeBuilder> exte
         }
     }
 
-    private SB copyShape(SB original) throws IOException {
+    protected SB copyShape(SB original) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             original.writeTo(output);
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {

--- a/core/src/test/java/org/elasticsearch/common/geo/builders/AbstractShapeBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/builders/AbstractShapeBuilderTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.geo.builders;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.*;
+
+public abstract class AbstractShapeBuilderTestCase<SB extends ShapeBuilder> extends ESTestCase {
+
+    private static final int NUMBER_OF_TESTBUILDERS = 1;
+    private static final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry();
+
+    /**
+     * Setup for the whole base test class.
+     */
+    @BeforeClass
+    public static void init() {
+        namedWriteableRegistry.registerPrototype(ShapeBuilder.class, PointBuilder.PROTOTYPE);
+    }
+
+    /**
+     * Create the shape that under test
+     */
+    protected abstract SB createTestShapeBuilder();
+
+    /**
+     * mutate the given query so the returned query is different
+     */
+    protected abstract SB mutate(SB original);
+
+    /**
+     * Generic test that creates new shape from a random test shape and checks both for equality
+     */
+    public void testFromXContent() throws IOException {
+        for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
+            SB testShape = createTestShapeBuilder();
+            XContentBuilder builder = toXContent(testShape, randomFrom(XContentType.values()));
+
+            XContentParser shapeParser = XContentHelper.createParser(builder.bytes());
+            shapeParser.nextToken();
+            ShapeBuilder parsedShape = ShapeBuilder.parse(shapeParser);
+            assertNotSame(testShape, parsedShape);
+            assertEquals(testShape, parsedShape);
+            assertEquals(testShape.hashCode(), parsedShape.hashCode());
+        }
+    }
+
+    protected static XContentBuilder toXContent(ShapeBuilder shape, XContentType contentType) throws IOException {
+        XContentBuilder builder = XContentFactory.contentBuilder(contentType);
+        if (randomBoolean()) {
+            builder.prettyPrint();
+        }
+        return shape.toXContent(builder, ToXContent.EMPTY_PARAMS);
+    }
+
+    /**
+     * Test serialization and deserialization of the test shape.
+     */
+    public void testSerialization() throws IOException {
+        for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
+            SB testShape = createTestShapeBuilder();
+            SB deserializedShape = copyShape(testShape);
+            assertEquals(deserializedShape, testShape);
+            assertEquals(deserializedShape.hashCode(), testShape.hashCode());
+            assertNotSame(deserializedShape, testShape);
+        }
+    }
+
+    public void testEqualsAndHashcode() throws IOException {
+        for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
+            SB firstShape = createTestShapeBuilder();
+            assertFalse("shape is equal to null", firstShape.equals(null));
+            assertFalse("shape is equal to incompatible type", firstShape.equals(""));
+            assertTrue("shape is not equal to self", firstShape.equals(firstShape));
+            assertThat("same shape's hashcode returns different values if called multiple times", firstShape.hashCode(),
+                    equalTo(firstShape.hashCode()));
+            assertThat("different shapes should not be equal", mutate(firstShape), not(equalTo(firstShape)));
+            assertThat("different shapes should have different hashcode", mutate(firstShape).hashCode(), not(equalTo(firstShape.hashCode())));
+
+            SB secondShape = copyShape(firstShape);
+            assertTrue("shape is not equal to self", secondShape.equals(secondShape));
+            assertTrue("shape is not equal to its copy", firstShape.equals(secondShape));
+            assertTrue("equals is not symmetric", secondShape.equals(firstShape));
+            assertThat("shape copy's hashcode is different from original hashcode", secondShape.hashCode(), equalTo(firstShape.hashCode()));
+
+            SB thirdShape = copyShape(secondShape);
+            assertTrue("shape is not equal to self", thirdShape.equals(thirdShape));
+            assertTrue("shape is not equal to its copy", secondShape.equals(thirdShape));
+            assertThat("shape copy's hashcode is different from original hashcode", secondShape.hashCode(), equalTo(thirdShape.hashCode()));
+            assertTrue("equals is not transitive", firstShape.equals(thirdShape));
+            assertThat("shape copy's hashcode is different from original hashcode", firstShape.hashCode(), equalTo(thirdShape.hashCode()));
+            assertTrue("equals is not symmetric", thirdShape.equals(secondShape));
+            assertTrue("equals is not symmetric", thirdShape.equals(firstShape));
+        }
+    }
+
+    private SB copyShape(SB original) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            original.writeTo(output);
+            try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
+                ShapeBuilder prototype = (ShapeBuilder) namedWriteableRegistry.getPrototype(ShapeBuilder.class, original.getWriteableName());
+                @SuppressWarnings("unchecked")
+                SB copy = (SB) prototype.readFrom(in);
+                return copy;
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/geo/builders/CirlceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/builders/CirlceBuilderTests.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.geo.builders;
+
+import com.vividsolutions.jts.geom.Coordinate;
+
+import org.elasticsearch.common.unit.DistanceUnit;
+
+import java.io.IOException;
+
+public class CirlceBuilderTests extends AbstractShapeBuilderTestCase<CircleBuilder> {
+
+    @Override
+    protected CircleBuilder createTestShapeBuilder() {
+        double centerX = randomDoubleBetween(-180, 180, false);
+        double centerY = randomDoubleBetween(-90, 90, false);
+        return new CircleBuilder()
+                .center(new Coordinate(centerX, centerY))
+                .radius(randomDoubleBetween(0.1, 10.0, false), randomFrom(DistanceUnit.values()));
+    }
+
+    @Override
+    protected CircleBuilder mutate(CircleBuilder original) throws IOException {
+        CircleBuilder mutation = copyShape(original);
+        double radius = original.radius();
+        DistanceUnit unit = original.unit();
+
+        if (randomBoolean()) {
+            mutation.center(new Coordinate(original.center().x/2, original.center().y/2));
+        } else if (randomBoolean()) {
+            radius = radius/2;
+        } else {
+            DistanceUnit newRandom = unit;
+            while (newRandom == unit) {
+                newRandom = randomFrom(DistanceUnit.values());
+            };
+            unit = newRandom;
+        }
+        return mutation.radius(radius, unit);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/geo/builders/EnvelopeBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/builders/EnvelopeBuilderTests.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.geo.builders;
+
+import com.spatial4j.core.shape.Rectangle;
+import com.vividsolutions.jts.geom.Coordinate;
+
+import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
+import org.elasticsearch.test.geo.RandomShapeGenerator;
+
+import java.io.IOException;
+
+public class EnvelopeBuilderTests extends AbstractShapeBuilderTestCase<EnvelopeBuilder> {
+
+    @Override
+    protected EnvelopeBuilder createTestShapeBuilder() {
+        EnvelopeBuilder envelope = new EnvelopeBuilder(randomFrom(Orientation.values()));
+        Rectangle box = RandomShapeGenerator.xRandomRectangle(getRandom(), RandomShapeGenerator.xRandomPoint(getRandom()));
+        envelope.topLeft(box.getMinX(), box.getMaxY())
+                .bottomRight(box.getMaxX(), box.getMinY());
+        return envelope;
+    }
+
+    @Override
+    protected EnvelopeBuilder mutate(EnvelopeBuilder original) throws IOException {
+        EnvelopeBuilder mutation = copyShape(original);
+        if (randomBoolean()) {
+            // toggle orientation
+            mutation.orientation = (original.orientation == Orientation.LEFT ? Orientation.RIGHT : Orientation.LEFT);
+        } else {
+            // move one corner to the middle of original
+            switch (randomIntBetween(0, 3)) {
+            case 0:
+                mutation.topLeft(new Coordinate(randomDoubleBetween(-180.0, original.bottomRight.x, true), original.topLeft.y));
+                break;
+            case 1:
+                mutation.topLeft(new Coordinate(original.topLeft.x, randomDoubleBetween(original.bottomRight.y, 90.0, true)));
+                break;
+            case 2:
+                mutation.bottomRight(new Coordinate(randomDoubleBetween(original.topLeft.x, 180.0, true), original.bottomRight.y));
+                break;
+            case 3:
+                mutation.bottomRight(new Coordinate(original.bottomRight.x, randomDoubleBetween(-90.0, original.topLeft.y, true)));
+                break;
+            }
+        }
+        return mutation;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/geo/builders/PointBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/builders/PointBuilderTests.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.geo.builders;
+
+import com.vividsolutions.jts.geom.Coordinate;
+
+import org.elasticsearch.test.geo.RandomShapeGenerator;
+import org.elasticsearch.test.geo.RandomShapeGenerator.ShapeType;
+
+public class PointBuilderTests extends AbstractShapeBuilderTestCase<PointBuilder> {
+
+    @Override
+    protected PointBuilder createTestShapeBuilder() {
+        return (PointBuilder) RandomShapeGenerator.createShape(getRandom(), ShapeType.POINT);
+    }
+
+    @Override
+    protected PointBuilder mutate(PointBuilder original) {
+        return new PointBuilder().coordinate(new Coordinate(original.longitude()/2, original.latitude()/2));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/unit/DistanceUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/DistanceUnitTests.java
@@ -57,4 +57,20 @@ public class DistanceUnitTests extends ESTestCase {
             assertThat("Value can be parsed from '" + testValue + unit.toString() + "'", DistanceUnit.Distance.parseDistance(unit.toString(testValue)).value, equalTo(testValue));
         }
     }
+
+    /**
+     * This test ensures that we are aware of accidental reordering in the distance unit ordinals,
+     * since equality in e.g. CircleShapeBuilder, hashCode and serialization rely on them
+     */
+    public void testDistanceUnitNames() {
+        assertEquals(0, DistanceUnit.INCH.ordinal());
+        assertEquals(1, DistanceUnit.YARD.ordinal());
+        assertEquals(2, DistanceUnit.FEET.ordinal());
+        assertEquals(3, DistanceUnit.KILOMETERS.ordinal());
+        assertEquals(4, DistanceUnit.NAUTICALMILES.ordinal());
+        assertEquals(5, DistanceUnit.MILLIMETERS.ordinal());
+        assertEquals(6, DistanceUnit.CENTIMETERS.ordinal());
+        assertEquals(7, DistanceUnit.MILES.ordinal());
+        assertEquals(8, DistanceUnit.METERS.ordinal());
+    }
 }


### PR DESCRIPTION
After refactoring the queries to make them parsable on the coordinating note and adding serialization and equals/hashCode capability to them. So far ShapeBuilders nested inside queries were still transported as a byte array that needs to be parsed later on the shard receiving the query. To be able to also serialize geo shapes this way, we also need to make all the implementations of ShapeBuilder implement Writable. This PR adds this to PointBuilder, CircleBuilder and EnvelopeBuilder and also adds tests for serialization, equality and hashCode.

Relates to #14416
