### PR TITLE
rename Data to IngestDocument

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -44,9 +44,9 @@ public final class Pipeline {
     /**
      * Modifies the data of a document to be indexed based on the processor this pipeline holds
      */
-    public void execute(Data data) {
+    public void execute(IngestDocument ingestDocument) {
         for (Processor processor : processors) {
-            processor.execute(data);
+            processor.execute(ingestDocument);
         }
     }
 

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/Processor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/Processor.java
@@ -20,7 +20,7 @@
 
 package org.elasticsearch.ingest.processor;
 
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -36,7 +36,7 @@ public interface Processor {
     /**
      * Introspect and potentially modify the incoming data.
      */
-    void execute(Data data);
+    void execute(IngestDocument ingestDocument);
 
     /**
      * Gets the type of a processor

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/date/DateProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/date/DateProcessor.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.ingest.processor.date;
 
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.processor.ConfigurationUtils;
 import org.elasticsearch.ingest.processor.Processor;
 import org.joda.time.DateTime;
@@ -56,8 +56,8 @@ public final class DateProcessor implements Processor {
     }
 
     @Override
-    public void execute(Data data) {
-        String value = data.getPropertyValue(matchField, String.class);
+    public void execute(IngestDocument ingestDocument) {
+        String value = ingestDocument.getPropertyValue(matchField, String.class);
         // TODO(talevy): handle custom timestamp fields
 
         DateTime dateTime = null;
@@ -75,7 +75,7 @@ public final class DateProcessor implements Processor {
             throw new IllegalArgumentException("unable to parse date [" + value + "]", lastException);
         }
 
-        data.setPropertyValue(targetField, ISODateTimeFormat.dateTime().print(dateTime));
+        ingestDocument.setPropertyValue(targetField, ISODateTimeFormat.dateTime().print(dateTime));
     }
 
     @Override

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/geoip/GeoIpProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/geoip/GeoIpProcessor.java
@@ -26,7 +26,7 @@ import com.maxmind.geoip2.model.CountryResponse;
 import com.maxmind.geoip2.record.*;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.network.NetworkAddress;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.processor.Processor;
 
 import java.io.IOException;
@@ -60,8 +60,8 @@ public final class GeoIpProcessor implements Processor {
     }
 
     @Override
-    public void execute(Data data) {
-        String ip = data.getPropertyValue(sourceField, String.class);
+    public void execute(IngestDocument ingestDocument) {
+        String ip = ingestDocument.getPropertyValue(sourceField, String.class);
         final InetAddress ipAddress;
         try {
             ipAddress = InetAddress.getByName(ip);
@@ -88,7 +88,7 @@ public final class GeoIpProcessor implements Processor {
             default:
                 throw new IllegalStateException("Unsupported database type [" + dbReader.getMetadata().getDatabaseType() + "]");
         }
-        data.setPropertyValue(targetField, geoData);
+        ingestDocument.setPropertyValue(targetField, geoData);
     }
 
     @Override

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/grok/GrokProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/grok/GrokProcessor.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.ingest.processor.grok;
 
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.processor.ConfigurationUtils;
 import org.elasticsearch.ingest.processor.Processor;
 
@@ -45,13 +45,13 @@ public final class GrokProcessor implements Processor {
     }
 
     @Override
-    public void execute(Data data) {
-        Object field = data.getPropertyValue(matchField, Object.class);
+    public void execute(IngestDocument ingestDocument) {
+        Object field = ingestDocument.getPropertyValue(matchField, Object.class);
         // TODO(talevy): handle invalid field types
         if (field instanceof String) {
             Map<String, Object> matches = grok.captures((String) field);
             if (matches != null) {
-                matches.forEach((k, v) -> data.setPropertyValue(k, v));
+                matches.forEach((k, v) -> ingestDocument.setPropertyValue(k, v));
             }
         }
     }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineExecutionService.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineExecutionService.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.support.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -40,7 +40,7 @@ public class PipelineExecutionService {
         this.threadPool = threadPool;
     }
 
-    public void execute(Data data, String pipelineId, Listener listener) {
+    public void execute(IngestDocument ingestDocument, String pipelineId, Listener listener) {
         Pipeline pipeline = store.get(pipelineId);
         if (pipeline == null) {
             listener.failed(new IllegalArgumentException(LoggerMessageFormat.format("pipeline with id [{}] does not exist", pipelineId)));
@@ -51,8 +51,8 @@ public class PipelineExecutionService {
             @Override
             public void run() {
                 try {
-                    pipeline.execute(data);
-                    listener.executed(data);
+                    pipeline.execute(ingestDocument);
+                    listener.executed(ingestDocument);
                 } catch (Exception e) {
                     listener.failed(e);
                 }
@@ -62,7 +62,7 @@ public class PipelineExecutionService {
 
     public interface Listener {
 
-        void executed(Data data);
+        void executed(IngestDocument ingestDocument);
 
         void failed(Exception e);
 

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilter.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilter.java
@@ -29,7 +29,7 @@ import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.plugin.ingest.IngestPlugin;
 import org.elasticsearch.plugin.ingest.PipelineExecutionService;
 
@@ -82,12 +82,12 @@ public class IngestActionFilter extends AbstractComponent implements ActionFilte
         }
 
         Map<String, Object> sourceAsMap = indexRequest.sourceAsMap();
-        Data data = new Data(indexRequest.index(), indexRequest.type(), indexRequest.id(), sourceAsMap);
-        executionService.execute(data, pipelineId, new PipelineExecutionService.Listener() {
+        IngestDocument ingestDocument = new IngestDocument(indexRequest.index(), indexRequest.type(), indexRequest.id(), sourceAsMap);
+        executionService.execute(ingestDocument, pipelineId, new PipelineExecutionService.Listener() {
             @Override
-            public void executed(Data data) {
-                if (data.isModified()) {
-                    indexRequest.source(data.getDocument());
+            public void executed(IngestDocument ingestDocument) {
+                if (ingestDocument.isModified()) {
+                    indexRequest.source(ingestDocument.getSource());
                 }
                 indexRequest.putHeader(IngestPlugin.PIPELINE_ALREADY_PROCESSED, true);
                 chain.proceed(action, indexRequest, listener);
@@ -115,12 +115,12 @@ public class IngestActionFilter extends AbstractComponent implements ActionFilte
 
         IndexRequest indexRequest = (IndexRequest) actionRequest;
         Map<String, Object> sourceAsMap = indexRequest.sourceAsMap();
-        Data data = new Data(indexRequest.index(), indexRequest.type(), indexRequest.id(), sourceAsMap);
-        executionService.execute(data, pipelineId, new PipelineExecutionService.Listener() {
+        IngestDocument ingestDocument = new IngestDocument(indexRequest.index(), indexRequest.type(), indexRequest.id(), sourceAsMap);
+        executionService.execute(ingestDocument, pipelineId, new PipelineExecutionService.Listener() {
             @Override
-            public void executed(Data data) {
-                if (data.isModified()) {
-                    indexRequest.source(data.getDocument());
+            public void executed(IngestDocument ingestDocument) {
+                if (ingestDocument.isModified()) {
+                    indexRequest.source(ingestDocument.getSource());
                 }
                 processBulkIndexRequest(action, listener, chain, bulkRequest, pipelineId, requests);
             }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/simulate/ParsedSimulateRequest.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/simulate/ParsedSimulateRequest.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.plugin.ingest.transport.simulate;
 
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.ingest.processor.ConfigurationUtils;
 import org.elasticsearch.plugin.ingest.PipelineStore;
@@ -29,11 +29,11 @@ import java.util.*;
 import static org.elasticsearch.plugin.ingest.transport.simulate.SimulatePipelineRequest.Fields;
 
 public class ParsedSimulateRequest {
-    private final List<Data> documents;
+    private final List<IngestDocument> documents;
     private final Pipeline pipeline;
     private final boolean verbose;
 
-    ParsedSimulateRequest(Pipeline pipeline, List<Data> documents, boolean verbose) {
+    ParsedSimulateRequest(Pipeline pipeline, List<IngestDocument> documents, boolean verbose) {
         this.pipeline = pipeline;
         this.documents = Collections.unmodifiableList(documents);
         this.verbose = verbose;
@@ -43,7 +43,7 @@ public class ParsedSimulateRequest {
         return pipeline;
     }
 
-    public List<Data> getDocuments() {
+    public List<IngestDocument> getDocuments() {
         return documents;
     }
 
@@ -55,18 +55,18 @@ public class ParsedSimulateRequest {
         private static final Pipeline.Factory PIPELINE_FACTORY = new Pipeline.Factory();
         public static final String SIMULATED_PIPELINE_ID = "_simulate_pipeline";
 
-        private List<Data> parseDocs(Map<String, Object> config) {
+        private List<IngestDocument> parseDocs(Map<String, Object> config) {
             List<Map<String, Object>> docs = ConfigurationUtils.readList(config, Fields.DOCS);
-            List<Data> dataList = new ArrayList<>();
+            List<IngestDocument> ingestDocumentList = new ArrayList<>();
             for (Map<String, Object> dataMap : docs) {
                 Map<String, Object> document = ConfigurationUtils.readMap(dataMap, Fields.SOURCE);
-                Data data = new Data(ConfigurationUtils.readStringProperty(dataMap, Fields.INDEX),
+                IngestDocument ingestDocument = new IngestDocument(ConfigurationUtils.readStringProperty(dataMap, Fields.INDEX),
                         ConfigurationUtils.readStringProperty(dataMap, Fields.TYPE),
                         ConfigurationUtils.readStringProperty(dataMap, Fields.ID),
                         document);
-                dataList.add(data);
+                ingestDocumentList.add(ingestDocument);
             }
-            return dataList;
+            return ingestDocumentList;
         }
 
         public ParsedSimulateRequest parseWithPipelineId(String pipelineId, Map<String, Object> config, boolean verbose, PipelineStore pipelineStore) {
@@ -74,16 +74,16 @@ public class ParsedSimulateRequest {
                 throw new IllegalArgumentException("param [pipeline] is null");
             }
             Pipeline pipeline = pipelineStore.get(pipelineId);
-            List<Data> dataList = parseDocs(config);
-            return new ParsedSimulateRequest(pipeline, dataList, verbose);
+            List<IngestDocument> ingestDocumentList = parseDocs(config);
+            return new ParsedSimulateRequest(pipeline, ingestDocumentList, verbose);
 
         }
 
         public ParsedSimulateRequest parse(Map<String, Object> config, boolean verbose, PipelineStore pipelineStore) throws IOException {
             Map<String, Object> pipelineConfig = ConfigurationUtils.readMap(config, Fields.PIPELINE);
             Pipeline pipeline = PIPELINE_FACTORY.create(SIMULATED_PIPELINE_ID, pipelineConfig, pipelineStore.getProcessorFactoryRegistry());
-            List<Data> dataList = parseDocs(config);
-            return new ParsedSimulateRequest(pipeline, dataList, verbose);
+            List<IngestDocument> ingestDocumentList = parseDocs(config);
+            return new ParsedSimulateRequest(pipeline, ingestDocumentList, verbose);
         }
     }
 }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateDocumentSimpleResult.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateDocumentSimpleResult.java
@@ -22,20 +22,20 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.plugin.ingest.transport.TransportData;
 
 import java.io.IOException;
 
 public class SimulateDocumentSimpleResult implements SimulateDocumentResult<SimulateDocumentSimpleResult> {
 
-    private static final SimulateDocumentSimpleResult PROTOTYPE = new SimulateDocumentSimpleResult((Data)null);
+    private static final SimulateDocumentSimpleResult PROTOTYPE = new SimulateDocumentSimpleResult((IngestDocument)null);
 
     private TransportData data;
     private Exception failure;
 
-    public SimulateDocumentSimpleResult(Data data) {
-        this.data = new TransportData(data);
+    public SimulateDocumentSimpleResult(IngestDocument ingestDocument) {
+        this.data = new TransportData(ingestDocument);
     }
 
     private SimulateDocumentSimpleResult(TransportData data) {
@@ -46,7 +46,7 @@ public class SimulateDocumentSimpleResult implements SimulateDocumentResult<Simu
         this.failure = failure;
     }
 
-    public Data getData() {
+    public IngestDocument getData() {
         if (data == null) {
             return null;
         }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateProcessorResult.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateProcessorResult.java
@@ -25,22 +25,22 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.plugin.ingest.transport.TransportData;
 
 import java.io.IOException;
 
 public class SimulateProcessorResult implements Writeable<SimulateProcessorResult>, ToXContent {
 
-    private static final SimulateProcessorResult PROTOTYPE = new SimulateProcessorResult(null, (Data)null);
+    private static final SimulateProcessorResult PROTOTYPE = new SimulateProcessorResult(null, (IngestDocument)null);
 
     private String processorId;
     private TransportData data;
     private Exception failure;
 
-    public SimulateProcessorResult(String processorId, Data data) {
+    public SimulateProcessorResult(String processorId, IngestDocument ingestDocument) {
         this.processorId = processorId;
-        this.data = new TransportData(data);
+        this.data = new TransportData(ingestDocument);
     }
 
     private SimulateProcessorResult(String processorId, TransportData data) {
@@ -53,7 +53,7 @@ public class SimulateProcessorResult implements Writeable<SimulateProcessorResul
         this.failure = failure;
     }
 
-    public Data getData() {
+    public IngestDocument getData() {
         if (data == null) {
             return null;
         }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -106,8 +106,8 @@ public class IngestClientIT extends ESIntegTestCase {
         assertThat(response.getResults().size(), equalTo(1));
         assertThat(response.getResults().get(0), instanceOf(SimulateDocumentSimpleResult.class));
         SimulateDocumentSimpleResult simulateDocumentSimpleResult = (SimulateDocumentSimpleResult) response.getResults().get(0);
-        Data expectedData = new Data("index", "type", "id", Collections.singletonMap("foo", "bar"));
-        assertThat(simulateDocumentSimpleResult.getData(), equalTo(expectedData));
+        IngestDocument expectedIngestDocument = new IngestDocument("index", "type", "id", Collections.singletonMap("foo", "bar"));
+        assertThat(simulateDocumentSimpleResult.getData(), equalTo(expectedIngestDocument));
         assertThat(simulateDocumentSimpleResult.getFailure(), nullValue());
     }
 

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/date/DateProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/date/DateProcessorTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.ingest.processor.date;
 
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -36,9 +36,9 @@ public class DateProcessorTests extends ESTestCase {
                 "date_as_string", Collections.singletonList("yyyy dd MM hh:mm:ss"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "2010 12 06 11:05:15");
-        Data data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T11:05:15.000+02:00"));
+        IngestDocument ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T11:05:15.000+02:00"));
     }
 
     public void testJodaPatternMultipleFormats() {
@@ -51,27 +51,27 @@ public class DateProcessorTests extends ESTestCase {
 
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "2010 12 06");
-        Data data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T00:00:00.000+02:00"));
+        IngestDocument ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T00:00:00.000+02:00"));
 
         document = new HashMap<>();
         document.put("date_as_string", "12/06/2010");
-        data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T00:00:00.000+02:00"));
+        ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T00:00:00.000+02:00"));
 
         document = new HashMap<>();
         document.put("date_as_string", "12-06-2010");
-        data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T00:00:00.000+02:00"));
+        ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T00:00:00.000+02:00"));
 
         document = new HashMap<>();
         document.put("date_as_string", "2010");
-        data = new Data("index", "type", "id", document);
+        ingestDocument = new IngestDocument("index", "type", "id", document);
         try {
-            dateProcessor.execute(data);
+            dateProcessor.execute(ingestDocument);
             fail("processor should have failed due to not supported date format");
         } catch(IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("unable to parse date [2010]"));
@@ -83,9 +83,9 @@ public class DateProcessorTests extends ESTestCase {
                 "date_as_string", Collections.singletonList("yyyy dd MMM"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "2010 12 giugno");
-        Data data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T00:00:00.000+02:00"));
+        IngestDocument ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo("2010-06-12T00:00:00.000+02:00"));
     }
 
     public void testJodaPatternDefaultYear() {
@@ -93,9 +93,9 @@ public class DateProcessorTests extends ESTestCase {
                 "date_as_string", Collections.singletonList("dd/MM"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "12/06");
-        Data data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo(DateTime.now().getYear() + "-06-12T00:00:00.000+02:00"));
+        IngestDocument ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo(DateTime.now().getYear() + "-06-12T00:00:00.000+02:00"));
     }
 
     public void testTAI64N() {
@@ -104,9 +104,9 @@ public class DateProcessorTests extends ESTestCase {
         Map<String, Object> document = new HashMap<>();
         String dateAsString = (randomBoolean() ? "@" : "") + "4000000050d506482dbdf024";
         document.put("date_as_string", dateAsString);
-        Data data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo("2012-12-22T03:00:46.767+02:00"));
+        IngestDocument ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo("2012-12-22T03:00:46.767+02:00"));
     }
 
     public void testUnixMs() {
@@ -114,9 +114,9 @@ public class DateProcessorTests extends ESTestCase {
                 "date_as_string", Collections.singletonList(DateParserFactory.UNIX_MS), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "1000500");
-        Data data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo("1970-01-01T00:16:40.500Z"));
+        IngestDocument ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo("1970-01-01T00:16:40.500Z"));
     }
 
     public void testUnix() {
@@ -124,8 +124,8 @@ public class DateProcessorTests extends ESTestCase {
                 "date_as_string", Collections.singletonList(DateParserFactory.UNIX), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "1000.5");
-        Data data = new Data("index", "type", "id", document);
-        dateProcessor.execute(data);
-        assertThat(data.getPropertyValue("date_as_date", String.class), equalTo("1970-01-01T00:16:40.500Z"));
+        IngestDocument ingestDocument = new IngestDocument("index", "type", "id", document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getPropertyValue("date_as_date", String.class), equalTo("1970-01-01T00:16:40.500Z"));
     }
 }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/geoip/GeoIpProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/geoip/GeoIpProcessorTests.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.ingest.processor.geoip;
 
 import com.maxmind.geoip2.DatabaseReader;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.InputStream;
@@ -38,13 +38,13 @@ public class GeoIpProcessorTests extends ESTestCase {
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "82.170.213.79");
-        Data data = new Data("_index", "_type", "_id", document);
-        processor.execute(data);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", document);
+        processor.execute(ingestDocument);
 
-        assertThat(data.getDocument().size(), equalTo(2));
-        assertThat(data.getDocument().get("source_field"), equalTo("82.170.213.79"));
+        assertThat(ingestDocument.getSource().size(), equalTo(2));
+        assertThat(ingestDocument.getSource().get("source_field"), equalTo("82.170.213.79"));
         @SuppressWarnings("unchecked")
-        Map<String, Object> geoData = (Map<String, Object>) data.getDocument().get("target_field");
+        Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSource().get("target_field");
         assertThat(geoData.size(), equalTo(10));
         assertThat(geoData.get("ip"), equalTo("82.170.213.79"));
         assertThat(geoData.get("country_iso_code"), equalTo("NL"));
@@ -64,13 +64,13 @@ public class GeoIpProcessorTests extends ESTestCase {
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "82.170.213.79");
-        Data data = new Data("_index", "_type", "_id", document);
-        processor.execute(data);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", document);
+        processor.execute(ingestDocument);
 
-        assertThat(data.getDocument().size(), equalTo(2));
-        assertThat(data.getDocument().get("source_field"), equalTo("82.170.213.79"));
+        assertThat(ingestDocument.getSource().size(), equalTo(2));
+        assertThat(ingestDocument.getSource().get("source_field"), equalTo("82.170.213.79"));
         @SuppressWarnings("unchecked")
-        Map<String, Object> geoData = (Map<String, Object>) data.getDocument().get("target_field");
+        Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSource().get("target_field");
         assertThat(geoData.size(), equalTo(4));
         assertThat(geoData.get("ip"), equalTo("82.170.213.79"));
         assertThat(geoData.get("country_iso_code"), equalTo("NL"));
@@ -84,10 +84,10 @@ public class GeoIpProcessorTests extends ESTestCase {
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", "202.45.11.11");
-        Data data = new Data("_index", "_type", "_id", document);
-        processor.execute(data);
+        IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", document);
+        processor.execute(ingestDocument);
         @SuppressWarnings("unchecked")
-        Map<String, Object> geoData = (Map<String, Object>) data.getDocument().get("target_field");
+        Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSource().get("target_field");
         assertThat(geoData.size(), equalTo(0));
     }
 

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilterTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilterTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.ingest.processor.Processor;
 import org.elasticsearch.ingest.processor.mutate.MutateProcessor;
@@ -80,7 +80,7 @@ public class IngestActionFilterTests extends ESTestCase {
 
         filter.apply("_action", indexRequest, actionListener, actionFilterChain);
 
-        verify(executionService).execute(any(Data.class), eq("_id"), any(PipelineExecutionService.Listener.class));
+        verify(executionService).execute(any(IngestDocument.class), eq("_id"), any(PipelineExecutionService.Listener.class));
         verifyZeroInteractions(actionFilterChain);
     }
 
@@ -93,7 +93,7 @@ public class IngestActionFilterTests extends ESTestCase {
 
         filter.apply("_action", indexRequest, actionListener, actionFilterChain);
 
-        verify(executionService).execute(any(Data.class), eq("_id"), any(PipelineExecutionService.Listener.class));
+        verify(executionService).execute(any(IngestDocument.class), eq("_id"), any(PipelineExecutionService.Listener.class));
         verifyZeroInteractions(actionFilterChain);
     }
 
@@ -121,16 +121,16 @@ public class IngestActionFilterTests extends ESTestCase {
         Answer answer = new Answer() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                Data data = (Data) invocationOnMock.getArguments()[0];
+                IngestDocument ingestDocument = (IngestDocument) invocationOnMock.getArguments()[0];
                 PipelineExecutionService.Listener listener = (PipelineExecutionService.Listener) invocationOnMock.getArguments()[2];
-                listener.executed(data);
+                listener.executed(ingestDocument);
                 return null;
             }
         };
-        doAnswer(answer).when(executionService).execute(any(Data.class), eq("_id"), any(PipelineExecutionService.Listener.class));
+        doAnswer(answer).when(executionService).execute(any(IngestDocument.class), eq("_id"), any(PipelineExecutionService.Listener.class));
         filter.apply("_action", indexRequest, actionListener, actionFilterChain);
 
-        verify(executionService).execute(any(Data.class), eq("_id"), any(PipelineExecutionService.Listener.class));
+        verify(executionService).execute(any(IngestDocument.class), eq("_id"), any(PipelineExecutionService.Listener.class));
         verify(actionFilterChain).proceed("_action", indexRequest, actionListener);
         verifyZeroInteractions(actionListener);
     }
@@ -151,10 +151,10 @@ public class IngestActionFilterTests extends ESTestCase {
                 return null;
             }
         };
-        doAnswer(answer).when(executionService).execute(any(Data.class), eq("_id"), any(PipelineExecutionService.Listener.class));
+        doAnswer(answer).when(executionService).execute(any(IngestDocument.class), eq("_id"), any(PipelineExecutionService.Listener.class));
         filter.apply("_action", indexRequest, actionListener, actionFilterChain);
 
-        verify(executionService).execute(any(Data.class), eq("_id"), any(PipelineExecutionService.Listener.class));
+        verify(executionService).execute(any(IngestDocument.class), eq("_id"), any(PipelineExecutionService.Listener.class));
         verify(actionListener).onFailure(exception);
         verifyZeroInteractions(actionFilterChain);
     }

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/TransportDataTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/TransportDataTests.java
@@ -21,7 +21,7 @@ package org.elasticsearch.plugin.ingest.transport;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ public class TransportDataTests extends ESTestCase {
         String id = randomAsciiOfLengthBetween(1, 10);
         String fieldName = randomAsciiOfLengthBetween(1, 10);
         String fieldValue = randomAsciiOfLengthBetween(1, 10);
-        TransportData transportData = new TransportData(new Data(index, type, id, Collections.singletonMap(fieldName, fieldValue)));
+        TransportData transportData = new TransportData(new IngestDocument(index, type, id, Collections.singletonMap(fieldName, fieldValue)));
 
         boolean changed = false;
         String otherIndex;
@@ -71,23 +71,23 @@ public class TransportDataTests extends ESTestCase {
             document = Collections.singletonMap(fieldName, fieldValue);
         }
 
-        TransportData otherTransportData = new TransportData(new Data(otherIndex, otherType, otherId, document));
+        TransportData otherTransportData = new TransportData(new IngestDocument(otherIndex, otherType, otherId, document));
         if (changed) {
             assertThat(transportData, not(equalTo(otherTransportData)));
             assertThat(otherTransportData, not(equalTo(transportData)));
         } else {
             assertThat(transportData, equalTo(otherTransportData));
             assertThat(otherTransportData, equalTo(transportData));
-            TransportData thirdTransportData = new TransportData(new Data(index, type, id, Collections.singletonMap(fieldName, fieldValue)));
+            TransportData thirdTransportData = new TransportData(new IngestDocument(index, type, id, Collections.singletonMap(fieldName, fieldValue)));
             assertThat(thirdTransportData, equalTo(transportData));
             assertThat(transportData, equalTo(thirdTransportData));
         }
     }
 
     public void testSerialization() throws IOException {
-        Data data = new Data(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10),
+        IngestDocument ingestDocument = new IngestDocument(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10),
                 Collections.singletonMap(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10)));
-        TransportData transportData = new TransportData(data);
+        TransportData transportData = new TransportData(ingestDocument);
 
         BytesStreamOutput out = new BytesStreamOutput();
         transportData.writeTo(out);

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/ParsedSimulateRequestParserTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/ParsedSimulateRequestParserTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.plugin.ingest.transport.simulate;
 
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.ingest.processor.Processor;
 import org.elasticsearch.plugin.ingest.PipelineStore;
@@ -29,6 +29,9 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.*;
 
+import static org.elasticsearch.ingest.IngestDocument.MetaData.ID;
+import static org.elasticsearch.ingest.IngestDocument.MetaData.INDEX;
+import static org.elasticsearch.ingest.IngestDocument.MetaData.TYPE;
 import static org.elasticsearch.plugin.ingest.transport.simulate.SimulatePipelineRequest.Fields;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -80,12 +83,12 @@ public class ParsedSimulateRequestParserTests extends ESTestCase {
         assertThat(actualRequest.isVerbose(), equalTo(false));
         assertThat(actualRequest.getDocuments().size(), equalTo(numDocs));
         Iterator<Map<String, Object>> expectedDocsIterator = expectedDocs.iterator();
-        for (Data data : actualRequest.getDocuments()) {
+        for (IngestDocument ingestDocument : actualRequest.getDocuments()) {
             Map<String, Object> expectedDocument = expectedDocsIterator.next();
-            assertThat(data.getDocument(), equalTo(expectedDocument.get(Fields.SOURCE)));
-            assertThat(data.getIndex(), equalTo(expectedDocument.get(Fields.INDEX)));
-            assertThat(data.getType(), equalTo(expectedDocument.get(Fields.TYPE)));
-            assertThat(data.getId(), equalTo(expectedDocument.get(Fields.ID)));
+            assertThat(ingestDocument.getSource(), equalTo(expectedDocument.get(Fields.SOURCE)));
+            assertThat(ingestDocument.getMetadata(INDEX), equalTo(expectedDocument.get(Fields.INDEX)));
+            assertThat(ingestDocument.getMetadata(TYPE), equalTo(expectedDocument.get(Fields.TYPE)));
+            assertThat(ingestDocument.getMetadata(ID), equalTo(expectedDocument.get(Fields.ID)));
         }
 
         assertThat(actualRequest.getPipeline().getId(), equalTo(ParsedSimulateRequest.Parser.SIMULATED_PIPELINE_ID));
@@ -133,12 +136,12 @@ public class ParsedSimulateRequestParserTests extends ESTestCase {
         assertThat(actualRequest.isVerbose(), equalTo(false));
         assertThat(actualRequest.getDocuments().size(), equalTo(numDocs));
         Iterator<Map<String, Object>> expectedDocsIterator = expectedDocs.iterator();
-        for (Data data : actualRequest.getDocuments()) {
+        for (IngestDocument ingestDocument : actualRequest.getDocuments()) {
             Map<String, Object> expectedDocument = expectedDocsIterator.next();
-            assertThat(data.getDocument(), equalTo(expectedDocument.get(Fields.SOURCE)));
-            assertThat(data.getIndex(), equalTo(expectedDocument.get(Fields.INDEX)));
-            assertThat(data.getType(), equalTo(expectedDocument.get(Fields.TYPE)));
-            assertThat(data.getId(), equalTo(expectedDocument.get(Fields.ID)));
+            assertThat(ingestDocument.getSource(), equalTo(expectedDocument.get(Fields.SOURCE)));
+            assertThat(ingestDocument.getMetadata(INDEX), equalTo(expectedDocument.get(Fields.INDEX)));
+            assertThat(ingestDocument.getMetadata(TYPE), equalTo(expectedDocument.get(Fields.TYPE)));
+            assertThat(ingestDocument.getMetadata(ID), equalTo(expectedDocument.get(Fields.ID)));
         }
 
         assertThat(actualRequest.getPipeline().getId(), equalTo(ParsedSimulateRequest.Parser.SIMULATED_PIPELINE_ID));

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateDocumentSimpleResultTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateDocumentSimpleResultTests.java
@@ -21,7 +21,7 @@ package org.elasticsearch.plugin.ingest.transport.simulate;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -38,9 +38,9 @@ public class SimulateDocumentSimpleResultTests extends ESTestCase {
         if (isFailure) {
             simulateDocumentSimpleResult = new SimulateDocumentSimpleResult(new IllegalArgumentException("test"));
         } else {
-            Data data = new Data(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10),
+            IngestDocument ingestDocument = new IngestDocument(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10),
                     Collections.singletonMap(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10)));
-            simulateDocumentSimpleResult = new SimulateDocumentSimpleResult(data);
+            simulateDocumentSimpleResult = new SimulateDocumentSimpleResult(ingestDocument);
         }
 
         BytesStreamOutput out = new BytesStreamOutput();

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulatePipelineResponseTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulatePipelineResponseTests.java
@@ -21,7 +21,7 @@ package org.elasticsearch.plugin.ingest.transport.simulate;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -42,7 +42,7 @@ public class SimulatePipelineResponseTests extends ESTestCase {
         List<SimulateDocumentResult> results = new ArrayList<>(numResults);
         for (int i = 0; i < numResults; i++) {
             boolean isFailure = randomBoolean();
-            Data data = new Data(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10),
+            IngestDocument ingestDocument = new IngestDocument(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10),
                     Collections.singletonMap(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10)));
             if (isVerbose) {
                 int numProcessors = randomIntBetween(1, 10);
@@ -53,18 +53,18 @@ public class SimulatePipelineResponseTests extends ESTestCase {
                     if (isFailure) {
                         processorResult = new SimulateProcessorResult(processorId, new IllegalArgumentException("test"));
                     } else {
-                        processorResult = new SimulateProcessorResult(processorId, data);
+                        processorResult = new SimulateProcessorResult(processorId, ingestDocument);
                     }
                     processorResults.add(processorResult);
                 }
                 results.add(new SimulateDocumentVerboseResult(processorResults));
             } else {
-                results.add(new SimulateDocumentSimpleResult(data));
+                results.add(new SimulateDocumentSimpleResult(ingestDocument));
                 SimulateDocumentSimpleResult simulateDocumentSimpleResult;
                 if (isFailure) {
                     simulateDocumentSimpleResult = new SimulateDocumentSimpleResult(new IllegalArgumentException("test"));
                 } else {
-                    simulateDocumentSimpleResult = new SimulateDocumentSimpleResult(data);
+                    simulateDocumentSimpleResult = new SimulateDocumentSimpleResult(ingestDocument);
                 }
                 results.add(simulateDocumentSimpleResult);
             }

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateProcessorResultTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateProcessorResultTests.java
@@ -21,7 +21,7 @@ package org.elasticsearch.plugin.ingest.transport.simulate;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.ingest.Data;
+import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -39,9 +39,9 @@ public class SimulateProcessorResultTests extends ESTestCase {
         if (isFailure) {
             simulateProcessorResult = new SimulateProcessorResult(processorId, new IllegalArgumentException("test"));
         } else {
-            Data data = new Data(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10),
+            IngestDocument ingestDocument = new IngestDocument(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10),
                     Collections.singletonMap(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10)));
-            simulateProcessorResult = new SimulateProcessorResult(processorId, data);
+            simulateProcessorResult = new SimulateProcessorResult(processorId, ingestDocument);
         }
 
         BytesStreamOutput out = new BytesStreamOutput();


### PR DESCRIPTION
Also move metadata to a map instead of separate fields. This would make it easier to operate on metadata in general from processors.
