### PR TITLE
Simplify adding plugins that are another project in the build

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.gradle.test
 
+import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
 
@@ -64,7 +65,7 @@ class ClusterConfiguration {
 
     Map<String, String> settings = new HashMap<>()
 
-    LinkedHashMap<String, FileCollection> plugins = new LinkedHashMap<>()
+    LinkedHashMap<String, Object> plugins = new LinkedHashMap<>()
 
     LinkedHashMap<String, Object[]> setupCommands = new LinkedHashMap<>()
 
@@ -81,6 +82,11 @@ class ClusterConfiguration {
     @Input
     void plugin(String name, FileCollection file) {
         plugins.put(name, file)
+    }
+
+    @Input
+    void plugin(String name, Project pluginProject) {
+        plugins.put(name, pluginProject)
     }
 
     @Input

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -67,7 +67,9 @@ class RestIntegTestTask extends RandomizedTestingTask {
     }
 
     RestIntegTestTask() {
-        project.afterEvaluate {
+        // this must run after all projects have been configured, so we know any project
+        // references can be accessed as a fully configured
+        project.gradle.projectsEvaluated {
             Task test = project.tasks.findByName('test')
             if (test != null) {
                 mustRunAfter(test)

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -25,10 +25,9 @@ ext.pluginCount = 0
 for (Project subproj : project.rootProject.subprojects) {
   if (subproj.path.startsWith(':plugins:')) {
     integTest {
-      def bundlePlugin = subproj.tasks.findByName('bundlePlugin')
-      dependsOn bundlePlugin
       cluster {
-        plugin subproj.name, bundlePlugin.outputs.files
+        // need to get a non-decorated project object, so must re-lookup the project by path
+        plugin subproj.name, project(subproj.path)
       }
     }
     pluginCount += 1


### PR DESCRIPTION
The current mechanism for adding plugins to the integTest cluster is to
have a FileCollection. This works well for the integTests for a single
plugin, which automatically adds itself to be installed. However, for qa
tests where many plugins may be installed, and from other projects, it
is cumbersome to add configurations, dependencies and dependsOn
statements over and over. This simplifies installing a plugin from
another project by moving this common setup into the cluster
configuration code.
