### PR TITLE
Prevent writing to closed channel if translog is already closed

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/BufferingTranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/BufferingTranslogWriter.java
@@ -46,6 +46,7 @@ public final class BufferingTranslogWriter extends TranslogWriter {
 
     @Override
     public Translog.Location add(BytesReference data) throws IOException {
+        ensureOpen();
         try (ReleasableLock lock = writeLock.acquire()) {
             operationCounter++;
             final long offset = totalOffset;

--- a/core/src/main/java/org/elasticsearch/index/translog/BufferingTranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/BufferingTranslogWriter.java
@@ -46,8 +46,8 @@ public final class BufferingTranslogWriter extends TranslogWriter {
 
     @Override
     public Translog.Location add(BytesReference data) throws IOException {
-        ensureOpen();
         try (ReleasableLock lock = writeLock.acquire()) {
+            ensureOpen();
             operationCounter++;
             final long offset = totalOffset;
             if (data.length() >= buffer.length) {
@@ -107,19 +107,25 @@ public final class BufferingTranslogWriter extends TranslogWriter {
             return;
         }
         synchronized (this) {
-            try (ReleasableLock lock = writeLock.acquire()) {
-                flush();
-                lastSyncedOffset = totalOffset;
+            channelReference.incRef();
+            try {
+                try (ReleasableLock lock = writeLock.acquire()) {
+                    flush();
+                    lastSyncedOffset = totalOffset;
+                }
+                // we can do this outside of the write lock but we have to protect from
+                // concurrent syncs
+                checkpoint(lastSyncedOffset, operationCounter, channelReference);
+            } finally {
+                channelReference.decRef();
             }
-            // we can do this outside of the write lock but we have to protect from
-            // concurrent syncs
-            checkpoint(lastSyncedOffset, operationCounter, channelReference);
         }
     }
 
 
     public void updateBufferSize(int bufferSize) {
         try (ReleasableLock lock = writeLock.acquire()) {
+            ensureOpen();
             if (this.buffer.length != bufferSize) {
                 flush();
                 this.buffer = new byte[bufferSize];

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -407,6 +407,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             out.seek(end);
             final ReleasablePagedBytesReference bytes = out.bytes();
             try (ReleasableLock lock = readLock.acquire()) {
+                ensureOpen();
                 Location location = current.add(bytes);
                 if (config.isSyncOnEachOperation()) {
                     current.sync();
@@ -414,6 +415,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 assert current.assertBytesAtLocation(location, bytes);
                 return location;
             }
+        } catch (AlreadyClosedException ex) {
+            throw ex;
         } catch (Throwable e) {
             throw new TranslogException(shardId, "Failed to write operation [" + operation + "]", e);
         } finally {

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1288,8 +1288,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     @Override
     public void prepareCommit() throws IOException {
-        ensureOpen();
         try (ReleasableLock lock = writeLock.acquire()) {
+            ensureOpen();
             if (currentCommittingTranslog != null) {
                 throw new IllegalStateException("already committing a translog with generation: " + currentCommittingTranslog.getGeneration());
             }
@@ -1321,9 +1321,9 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     @Override
     public void commit() throws IOException {
-        ensureOpen();
         ImmutableTranslogReader toClose = null;
         try (ReleasableLock lock = writeLock.acquire()) {
+            ensureOpen();
             if (currentCommittingTranslog == null) {
                 prepareCommit();
             }

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -123,9 +123,9 @@ public class TranslogWriter extends TranslogReader {
      * add the given bytes to the translog and return the location they were written at
      */
     public Translog.Location add(BytesReference data) throws IOException {
-        ensureOpen();
         final long position;
         try (ReleasableLock lock = writeLock.acquire()) {
+            ensureOpen();
             position = writtenOffset;
             data.writeTo(channel);
             writtenOffset = writtenOffset + data.length();
@@ -200,9 +200,9 @@ public class TranslogWriter extends TranslogReader {
      * returns a new immutable reader which only exposes the current written operation *
      */
     public ImmutableTranslogReader immutableReader() throws TranslogException {
-        ensureOpen();
         if (channelReference.tryIncRef()) {
             try (ReleasableLock lock = writeLock.acquire()) {
+                ensureOpen();
                 flush();
                 ImmutableTranslogReader reader = new ImmutableTranslogReader(this.generation, channelReference, firstOperationOffset, writtenOffset, operationCounter);
                 channelReference.incRef(); // for new reader


### PR DESCRIPTION
We handle AlreadyClosedExceptions gracefully wherever IndexShard / Engine
is used. In some cases, instead of throwing the appropriate exception we
bubble up ChannelClosedException instead which causes shard failures etc.
Today, it seems like that this can only happen if the engine is closed without
acquireing the lock which means that the shard has failed already so the impact is really
just a confusing log message. Yet, this change enforces throwing the right exception
if the translog is already closed.

Closes #14866
