### PR TITLE
Gradle daemon is a demon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false


### PR DESCRIPTION
This commit adds a property that will prevent the Gradle daemon from
being used for builds (even if one is running). This is to avoid some
nasty issues (e.g., SIGBUS faults and other mmap disasters) that result
from class loaders not being closed properly.
