### PR TITLE
Use general cluster state batching mechanism for shard started

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -151,7 +151,6 @@ public class ShardStateAction extends AbstractComponent {
             BatchResult.Builder<ShardRoutingEntry> batchResultBuilder = BatchResult.builder();
             List<FailedRerouteAllocation.FailedShard> shardRoutingsToBeApplied = new ArrayList<>(tasks.size());
             for (ShardRoutingEntry task : tasks) {
-                task.processed = true;
                 shardRoutingsToBeApplied.add(new FailedRerouteAllocation.FailedShard(task.shardRouting, task.message, task.failure));
             }
             ClusterState maybeUpdatedState = currentState;
@@ -201,7 +200,6 @@ public class ShardStateAction extends AbstractComponent {
             BatchResult.Builder<ShardRoutingEntry> builder = BatchResult.builder();
             List<ShardRouting> shardRoutingsToBeApplied = new ArrayList<>(tasks.size());
             for (ShardRoutingEntry task : tasks) {
-                task.processed = true;
                 shardRoutingsToBeApplied.add(task.shardRouting);
             }
             ClusterState maybeUpdatedState = currentState;
@@ -249,8 +247,6 @@ public class ShardStateAction extends AbstractComponent {
         String indexUUID = IndexMetaData.INDEX_UUID_NA_VALUE;
         String message;
         Throwable failure;
-
-        volatile boolean processed; // state field, no need to serialize
 
         public ShardRoutingEntry() {
         }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -64,6 +64,22 @@ public class AllocationService extends AbstractComponent {
     }
 
     /**
+     * Applies the started shard. Note, shards can be called several
+     * times within this method. If the same instance of the routing
+     * table is returned, then no change has been made.
+     * @param clusterState the cluster state
+     * @param startedShard the shard to start
+     * @param withReroute whether or not to reroute the resulting allocation
+     * @return the resulting routing table
+     */
+    public RoutingAllocation.Result applyStartedShard(
+            ClusterState clusterState,
+            ShardRouting startedShard,
+            boolean withReroute) {
+        return applyStartedShards(clusterState, Collections.singletonList(startedShard), withReroute);
+    }
+
+    /**
      * Applies the started shards. Note, shards can be called several times within this method.
      * <p>
      * If the same instance of the routing table is returned, then no change has been made.</p>

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -64,22 +64,6 @@ public class AllocationService extends AbstractComponent {
     }
 
     /**
-     * Applies the started shard. Note, shards can be called several
-     * times within this method. If the same instance of the routing
-     * table is returned, then no change has been made.
-     * @param clusterState the cluster state
-     * @param startedShard the shard to start
-     * @param withReroute whether or not to reroute the resulting allocation
-     * @return the resulting routing table
-     */
-    public RoutingAllocation.Result applyStartedShard(
-            ClusterState clusterState,
-            ShardRouting startedShard,
-            boolean withReroute) {
-        return applyStartedShards(clusterState, Collections.singletonList(startedShard), withReroute);
-    }
-
-    /**
      * Applies the started shards. Note, shards can be called several times within this method.
      * <p>
      * If the same instance of the routing table is returned, then no change has been made.</p>


### PR DESCRIPTION
This commit modifies the handling of shard started cluster state updates
to use the general cluster state batching mechanism. An advantage of
this approach is we now get correct per-listener notification on
failures.

Relates #14899, relates #14725
