### PR TITLE
Geo: Fix toString() in GeoDistanceRangeQuery and GeoPolygonQuery

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/geo/GeoDistanceRangeQuery.java
@@ -206,7 +206,7 @@ public class GeoDistanceRangeQuery extends Query {
 
     @Override
     public String toString(String field) {
-        return "GeoDistanceRangeFilter(" + indexFieldData.getFieldNames().indexName() + ", " + geoDistance + ", [" + inclusiveLowerPoint + " - " + inclusiveUpperPoint + "], " + lat + ", " + lon + ")";
+        return "GeoDistanceRangeQuery(" + indexFieldData.getFieldNames().indexName() + ", " + geoDistance + ", [" + inclusiveLowerPoint + " - " + inclusiveUpperPoint + "], " + lat + ", " + lon + ")";
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/geo/GeoPolygonQuery.java
@@ -103,7 +103,7 @@ public class GeoPolygonQuery extends Query {
 
     @Override
     public String toString(String field) {
-        StringBuilder sb = new StringBuilder("GeoPolygonFilter(");
+        StringBuilder sb = new StringBuilder("GeoPolygonQuery(");
         sb.append(indexFieldData.getFieldNames().indexName());
         sb.append(", ").append(Arrays.toString(points)).append(')');
         return sb.toString();


### PR DESCRIPTION
Minor typo in the two queries toString() method. They were former filters the toString() seems to have been forgotten while renaming.
