### PR TITLE
Remove Plugin.onIndexService.

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -71,12 +71,6 @@ public abstract class Plugin {
     }
 
     /**
-     * Called once the given {@link IndexService} is fully constructed but not yet published.
-     * This is used to initialize plugin services that require acess to index level resources
-     */
-    public void onIndexService(IndexService indexService) {}
-
-    /**
      * Called before a new index is created on a node. The given module can be used to regsiter index-leve
      * extensions.
      */

--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -247,14 +247,6 @@ public class PluginsService extends AbstractComponent {
         for (Tuple<PluginInfo, Plugin> plugin : plugins) {
             plugin.v2().onIndexModule(indexModule);
         }
-        indexModule.addIndexEventListener(new IndexEventListener() {
-            @Override
-            public void afterIndexCreated(IndexService indexService) {
-                for (Tuple<PluginInfo, Plugin> plugin : plugins) {
-                    plugin.v2().onIndexService(indexService);
-                }
-            }
-        });
     }
     /**
      * Get information about plugins (jvm and site plugins).


### PR DESCRIPTION
Now that field mappers are registered at the node level (#14896), this method
is not necessary anymore.
