### PR TITLE
set RLIMIT_NPROC = 0 on bsd/os X systems.

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/JNACLibrary.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JNACLibrary.java
@@ -66,6 +66,7 @@ final class JNACLibrary {
     }
     
     static native int getrlimit(int resource, Rlimit rlimit);
+    static native int setrlimit(int resource, Rlimit rlimit);
     
     static native String strerror(int errno);
 


### PR DESCRIPTION
This BSD-specific limit prevents child process creation.

Windows has something that appears similar, I will look into it.

Tested on OS X, FreeBSD, and OpenBSD.
