### PR TITLE
Rename `add` processor to `set` processor

### DIFF
--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -3,14 +3,14 @@
 
 === Processors
 
-==== Add processor
-Adds one or more fields and associates them with the specified values. If a field already exists,
+==== Set processor
+Sets one or more fields and associates them with the specified values. If a field already exists,
 its value will be replaced with the provided one.
 
 [source,js]
 --------------------------------------------------
 {
-  "add": {
+  "set": {
     "fields": {
       "field": 582.1
     }

--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/set/SetProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/set/SetProcessor.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.ingest.processor.add;
+package org.elasticsearch.ingest.processor.set;
 
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.processor.ConfigurationUtils;
@@ -31,13 +31,13 @@ import java.util.Map;
  * Processor that adds new fields with their corresponding values. If the field is already present, its value
  * will be replaced with the provided one.
  */
-public class AddProcessor implements Processor {
+public class SetProcessor implements Processor {
 
-    public static final String TYPE = "add";
+    public static final String TYPE = "set";
 
     private final Map<String, Object> fields;
 
-    AddProcessor(Map<String, Object> fields) {
+    SetProcessor(Map<String, Object> fields) {
         this.fields = fields;
     }
 
@@ -57,11 +57,11 @@ public class AddProcessor implements Processor {
         return TYPE;
     }
 
-    public static final class Factory implements Processor.Factory<AddProcessor> {
+    public static final class Factory implements Processor.Factory<SetProcessor> {
         @Override
-        public AddProcessor create(Map<String, Object> config) throws IOException {
+        public SetProcessor create(Map<String, Object> config) throws IOException {
             Map<String, Object> fields = ConfigurationUtils.readMap(config, "fields");
-            return new AddProcessor(Collections.unmodifiableMap(fields));
+            return new SetProcessor(Collections.unmodifiableMap(fields));
         }
     }
 }

--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestModule.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/IngestModule.java
@@ -22,7 +22,7 @@ package org.elasticsearch.plugin.ingest;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
 import org.elasticsearch.ingest.processor.Processor;
-import org.elasticsearch.ingest.processor.add.AddProcessor;
+import org.elasticsearch.ingest.processor.set.SetProcessor;
 import org.elasticsearch.ingest.processor.convert.ConvertProcessor;
 import org.elasticsearch.ingest.processor.date.DateProcessor;
 import org.elasticsearch.ingest.processor.geoip.GeoIpProcessor;
@@ -56,7 +56,7 @@ public class IngestModule extends AbstractModule {
         addProcessor(GeoIpProcessor.TYPE, new GeoIpProcessor.Factory());
         addProcessor(GrokProcessor.TYPE, new GrokProcessor.Factory());
         addProcessor(DateProcessor.TYPE, new DateProcessor.Factory());
-        addProcessor(AddProcessor.TYPE, new AddProcessor.Factory());
+        addProcessor(SetProcessor.TYPE, new SetProcessor.Factory());
         addProcessor(RenameProcessor.TYPE, new RenameProcessor.Factory());
         addProcessor(RemoveProcessor.TYPE, new RemoveProcessor.Factory());
         addProcessor(SplitProcessor.TYPE, new SplitProcessor.Factory());

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/set/SetProcessorFactoryTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/set/SetProcessorFactoryTests.java
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-package org.elasticsearch.ingest.processor.add;
+package org.elasticsearch.ingest.processor.set;
 
-import org.elasticsearch.ingest.processor.join.JoinProcessor;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -29,19 +28,19 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class AddProcessorFactoryTests extends ESTestCase {
+public class SetProcessorFactoryTests extends ESTestCase {
 
     public void testCreate() throws IOException {
-        AddProcessor.Factory factory = new AddProcessor.Factory();
+        SetProcessor.Factory factory = new SetProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
         Map<String, String> fields = Collections.singletonMap("field1", "value1");
         config.put("fields", fields);
-        AddProcessor addProcessor = factory.create(config);
-        assertThat(addProcessor.getFields(), equalTo(fields));
+        SetProcessor setProcessor = factory.create(config);
+        assertThat(setProcessor.getFields(), equalTo(fields));
     }
 
     public void testCreateMissingFields() throws IOException {
-        AddProcessor.Factory factory = new AddProcessor.Factory();
+        SetProcessor.Factory factory = new SetProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
         try {
             factory.create(config);

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/set/SetProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/set/SetProcessorTests.java
@@ -17,22 +17,20 @@
  * under the License.
  */
 
-package org.elasticsearch.ingest.processor.add;
+package org.elasticsearch.ingest.processor.set;
 
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.ingest.processor.Processor;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class AddProcessorTests extends ESTestCase {
+public class SetProcessorTests extends ESTestCase {
 
-    public void testAddExistingFields() throws Exception {
+    public void testSetExistingFields() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         int numFields = randomIntBetween(1, 5);
         Map<String, Object> fields = new HashMap<>();
@@ -41,7 +39,7 @@ public class AddProcessorTests extends ESTestCase {
             Object fieldValue = RandomDocumentPicks.randomFieldValue(random());
             fields.put(fieldName, fieldValue);
         }
-        Processor processor = new AddProcessor(fields);
+        Processor processor = new SetProcessor(fields);
         processor.execute(ingestDocument);
 
         for (Map.Entry<String, Object> field : fields.entrySet()) {
@@ -50,7 +48,7 @@ public class AddProcessorTests extends ESTestCase {
         }
     }
 
-    public void testAddNewFields() throws Exception {
+    public void testSetNewFields() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         //used to verify that there are no conflicts between subsequent fields going to be added
         IngestDocument testIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
@@ -61,7 +59,7 @@ public class AddProcessorTests extends ESTestCase {
             String fieldName = RandomDocumentPicks.addRandomField(random(), testIngestDocument, fieldValue);
             fields.put(fieldName, fieldValue);
         }
-        Processor processor = new AddProcessor(fields);
+        Processor processor = new SetProcessor(fields);
         processor.execute(ingestDocument);
         for (Map.Entry<String, Object> field : fields.entrySet()) {
             assertThat(ingestDocument.hasField(field.getKey()), equalTo(true));
@@ -69,10 +67,10 @@ public class AddProcessorTests extends ESTestCase {
         }
     }
 
-    public void testAddFieldsTypeMismatch() throws Exception {
+    public void testSetFieldsTypeMismatch() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         ingestDocument.setFieldValue("field", "value");
-        Processor processor = new AddProcessor(Collections.singletonMap("field.inner", "value"));
+        Processor processor = new SetProcessor(Collections.singletonMap("field.inner", "value"));
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
@@ -12,7 +12,7 @@
             "description": "_description",
             "processors": [
               {
-                "add" : {
+                "set" : {
                   "fields" : {
                     "field2": "_value"
                   }

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/60_mutate.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/60_mutate.yaml
@@ -12,7 +12,7 @@
             "description": "_description",
             "processors": [
               {
-                "add" : {
+                "set" : {
                   "fields" : {
                     "new_field": "new_value"
                   }

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/80_simulate.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/80_simulate.yaml
@@ -12,7 +12,7 @@
             "description": "_description",
             "processors": [
               {
-                "add" : {
+                "set" : {
                   "fields" : {
                     "field2" : "_value"
                   }
@@ -66,7 +66,7 @@
               "description": "_description",
               "processors": [
                 {
-                  "add" : {
+                  "set" : {
                     "fields" : {
                       "field2" : "_value"
                     }
@@ -129,14 +129,14 @@
               "description": "_description",
               "processors": [
                 {
-                  "add" : {
+                  "set" : {
                     "fields" : {
                       "field2" : "_value"
                     }
                   }
                 },
                 {
-                  "add" : {
+                  "set" : {
                     "fields" : {
                       "field3" : "third_val"
                     }
@@ -157,7 +157,7 @@
           }
   - length: { docs: 1 }
   - length: { docs.0.processor_results: 2 }
-  - match: { docs.0.processor_results.0.processor_id: "processor[add]-0" }
+  - match: { docs.0.processor_results.0.processor_id: "processor[set]-0" }
   - is_true: docs.0.processor_results.0.doc.modified
   - length: { docs.0.processor_results.0.doc._source: 2 }
   - match: { docs.0.processor_results.0.doc._source.foo: "bar" }


### PR DESCRIPTION
This name makes more sense, because if a field already exists it overwrites it.
