### PR TITLE
Add update parameter to bin/plugin, for easier updating of plugins

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginManagerCliParser.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManagerCliParser.java
@@ -180,39 +180,6 @@ public class PluginManagerCliParser extends CliTool {
     }
 
     /**
-     * Update a plugin
-     */
-    static class Update extends CliTool.Command {
-
-        private static final String NAME = "update";
-
-        private static final CliToolConfig.Cmd CMD = cmd(NAME, Update.class).build();
-        private final Command remove;
-        private final Command install;
-
-        public static Command parse(Terminal terminal, CommandLine cli) {
-            Command remove = Remove.parse(terminal, cli);
-            Command install = Install.parse(terminal, cli);
-            return new Update(terminal, remove, install);
-        }
-
-        Update(Terminal terminal, Command remove, Command install) {
-            super(terminal);
-            this.remove = remove;
-            this.install = install;
-        }
-
-        @Override
-        public ExitStatus execute(Settings settings, Environment env) throws Exception {
-            ExitStatus status = remove.execute(settings, env);
-            if (status != ExitStatus.OK) {
-                return status;
-            }
-            return install.execute(settings, env);
-        }
-    }
-
-    /**
      * Installs a plugin
      */
     static class Install extends Command {
@@ -286,6 +253,39 @@ public class PluginManagerCliParser extends CliTool {
             }
             pluginManager.downloadAndExtract(name, terminal, batch);
             return ExitStatus.OK;
+        }
+    }
+
+    /**
+     * Update a plugin
+     */
+    static class Update extends CliTool.Command {
+
+        private static final String NAME = "update";
+
+        private static final CliToolConfig.Cmd CMD = cmd(NAME, Update.class).build();
+        private final Command remove;
+        private final Command install;
+
+        public static Command parse(Terminal terminal, CommandLine cli) {
+            Command remove = Remove.parse(terminal, cli);
+            Command install = Install.parse(terminal, cli);
+            return new Update(terminal, remove, install);
+        }
+
+        Update(Terminal terminal, Command remove, Command install) {
+            super(terminal);
+            this.remove = remove;
+            this.install = install;
+        }
+
+        @Override
+        public ExitStatus execute(Settings settings, Environment env) throws Exception {
+            ExitStatus status = remove.execute(settings, env);
+            if (status != ExitStatus.OK) {
+                return status;
+            }
+            return install.execute(settings, env);
         }
     }
 }

--- a/core/src/main/resources/org/elasticsearch/plugins/plugin-update.help
+++ b/core/src/main/resources/org/elasticsearch/plugins/plugin-update.help
@@ -1,0 +1,12 @@
+NAME
+
+    update - Update a plugin
+
+SYNOPSIS
+
+    plugin update <name>
+
+DESCRIPTION
+
+    This command removes an elasticsearch plugin and installs it again.
+

--- a/core/src/main/resources/org/elasticsearch/plugins/plugin.help
+++ b/core/src/main/resources/org/elasticsearch/plugins/plugin.help
@@ -16,6 +16,8 @@ COMMANDS
 
     remove     Remove a plugin
 
+    update     Update a plugin
+
     list       List installed plugins
 
 NOTES

--- a/core/src/test/java/org/elasticsearch/plugins/PluginManagerCliTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginManagerCliTests.java
@@ -52,6 +52,11 @@ public class PluginManagerCliTests extends CliToolTestCase {
         terminal.getTerminalOutput().clear();
         assertThat(new PluginManagerCliParser(terminal).execute(args("list -h")), is(OK_AND_EXIT));
         assertTerminalOutputContainsHelpFile(terminal, "/org/elasticsearch/plugins/plugin-list.help");
+
+        terminal.getTerminalOutput().clear();
+        assertThat(new PluginManagerCliParser(terminal).execute(args("update --help")), is(OK_AND_EXIT));
+        assertTerminalOutputContainsHelpFile(terminal, "/org/elasticsearch/plugins/plugin-update.help");
+
     }
 
     public void testUrlSpacesInPath() throws MalformedURLException {

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -141,6 +141,18 @@ sudo bin/plugin remove [pluginname]
 
 After a Java plugin has been removed, you will need to restart the node to complete the removal process.
 
+[float]
+=== Updating plugins
+
+Plugins can be updated using `update` option:
+
+[source,shell]
+-----------------------------------
+sudo bin/plugin update [pluginname]
+-----------------------------------
+
+After a Java plugin has been updated, you will need to restart the node to complete the update process.
+
 === Other command line parameters
 
 The `plugin` scripts supports a number of other command line parameters:


### PR DESCRIPTION
With the frequent release cycle (and the need to update every elastic plugin), it would be nice to add an `update` parameter to `bin/plugin`, that does `bin/plugin remove ...` and `bin/plugin install ...` in one step.

Closes #15000.
