### PR TITLE
IngestDocument to support accessing and modifying list items

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/rename/RenameProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/rename/RenameProcessor.java
@@ -47,8 +47,8 @@ public class RenameProcessor implements Processor {
     @Override
     public void execute(IngestDocument document) {
         for(Map.Entry<String, String> entry : fields.entrySet()) {
-            if (document.hasFieldValue(entry.getKey())) {
-                if (document.hasFieldValue(entry.getKey()) == false) {
+            if (document.hasField(entry.getKey())) {
+                if (document.hasField(entry.getKey()) == false) {
                     throw new IllegalArgumentException("field [" + entry.getKey() + "] doesn't exist");
                 }
                 Object oldValue = document.getFieldValue(entry.getKey(), Object.class);

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -22,9 +22,7 @@ package org.elasticsearch.ingest;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.Matchers.*;
 
@@ -40,8 +38,16 @@ public class IngestDocumentTests extends ESTestCase {
         Map<String, Object> innerObject = new HashMap<>();
         innerObject.put("buzz", "hello world");
         innerObject.put("foo_null", null);
+        innerObject.put("1", "bar");
         document.put("fizz", innerObject);
+        List<Map<String, Object>> list = new ArrayList<>();
+        Map<String, Object> value = new HashMap<>();
+        value.put("field", "value");
+        list.add(value);
+        list.add(null);
+        document.put("list", list);
         ingestDocument = new IngestDocument("index", "type", "id", document);
+        assertThat(ingestDocument.isSourceModified(), equalTo(false));
     }
 
     public void testSimpleGetFieldValue() {
@@ -71,46 +77,127 @@ public class IngestDocumentTests extends ESTestCase {
 
     public void testNestedGetFieldValue() {
         assertThat(ingestDocument.getFieldValue("fizz.buzz", String.class), equalTo("hello world"));
+        assertThat(ingestDocument.getFieldValue("fizz.1", String.class), equalTo("bar"));
+    }
+
+    public void testNestedGetFieldValueTypeMismatch() {
+        try {
+            ingestDocument.getFieldValue("foo.foo.bar", String.class);
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("cannot resolve [foo] from object of type [java.lang.String] as part of path [foo.foo.bar]"));
+        }
+    }
+
+    public void testListGetFieldValue() {
+        assertThat(ingestDocument.getFieldValue("list.0.field", String.class), equalTo("value"));
+    }
+
+    public void testListGetFieldValueNull() {
+        assertThat(ingestDocument.getFieldValue("list.1", String.class), nullValue());
+    }
+
+    public void testListGetFieldValueIndexNotNumeric() {
+        try {
+            ingestDocument.getFieldValue("list.test.field", String.class);
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("[test] is not an integer, cannot be used as an index as part of path [list.test.field]"));
+        }
+    }
+
+    public void testListGetFieldValueIndexOutOfBounds() {
+        try {
+            ingestDocument.getFieldValue("list.10.field", String.class);
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("[10] is out of bounds for array with length [2] as part of path [list.10.field]"));
+        }
     }
 
     public void testGetFieldValueNotFound() {
-        assertThat(ingestDocument.getFieldValue("not.here", String.class), nullValue());
+        try {
+            ingestDocument.getFieldValue("not.here", String.class);
+            fail("get field value should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("field [not] not present as part of path [not.here]"));
+        }
+    }
+
+    public void testGetFieldValueNotFoundNullParent() {
+        try {
+            ingestDocument.getFieldValue("fizz.foo_null.not_there", String.class);
+            fail("get field value should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("cannot resolve [not_there] from null as part of path [fizz.foo_null.not_there]"));
+        }
     }
 
     public void testGetFieldValueNull() {
-        assertNull(ingestDocument.getFieldValue(null, String.class));
+        try {
+            ingestDocument.getFieldValue(null, String.class);
+            fail("get field value should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("path cannot be null nor empty"));
+        }
     }
 
     public void testGetFieldValueEmpty() {
-        assertNull(ingestDocument.getFieldValue("", String.class));
+        try {
+            ingestDocument.getFieldValue("", String.class);
+            fail("get field value should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("path cannot be null nor empty"));
+        }
     }
 
-    public void testHasFieldValue() {
-        assertTrue(ingestDocument.hasFieldValue("fizz"));
+    public void testHasField() {
+        assertTrue(ingestDocument.hasField("fizz"));
     }
 
-    public void testHasFieldValueNested() {
-        assertTrue(ingestDocument.hasFieldValue("fizz.buzz"));
+    public void testHasFieldNested() {
+        assertTrue(ingestDocument.hasField("fizz.buzz"));
     }
 
-    public void testHasFieldValueNotFound() {
-        assertFalse(ingestDocument.hasFieldValue("doesnotexist"));
+    public void testListHasField() {
+        assertTrue(ingestDocument.hasField("list.0.field"));
     }
 
-    public void testHasFieldValueNestedNotFound() {
-        assertFalse(ingestDocument.hasFieldValue("fizz.doesnotexist"));
+    public void testListHasFieldNull() {
+        assertTrue(ingestDocument.hasField("list.1"));
     }
 
-    public void testHasFieldValueNull() {
-        assertFalse(ingestDocument.hasFieldValue(null));
+    public void testListHasFieldIndexOutOfBounds() {
+        assertFalse(ingestDocument.hasField("list.10"));
     }
 
-    public void testHasFieldValueNullValue() {
-        assertTrue(ingestDocument.hasFieldValue("fizz.foo_null"));
+    public void testListHasFieldIndexNotNumeric() {
+        assertFalse(ingestDocument.hasField("list.test"));
     }
 
-    public void testHasFieldValueEmpty() {
-        assertFalse(ingestDocument.hasFieldValue(""));
+    public void testNestedHasFieldTypeMismatch() {
+        assertFalse(ingestDocument.hasField("foo.foo.bar"));
+    }
+
+    public void testHasFieldNotFound() {
+        assertFalse(ingestDocument.hasField("not.here"));
+    }
+
+    public void testHasFieldNotFoundNullParent() {
+        assertFalse(ingestDocument.hasField("fizz.foo_null.not_there"));
+    }
+
+    public void testHasFieldNestedNotFound() {
+        assertFalse(ingestDocument.hasField("fizz.doesnotexist"));
+    }
+
+    public void testHasFieldNull() {
+        assertFalse(ingestDocument.hasField(null));
+    }
+
+    public void testHasFieldNullValue() {
+        assertTrue(ingestDocument.hasField("fizz.foo_null"));
+    }
+
+    public void testHasFieldEmpty() {
+        assertFalse(ingestDocument.hasField(""));
     }
 
     public void testSimpleSetFieldValue() {
@@ -162,7 +249,7 @@ public class IngestDocumentTests extends ESTestCase {
             ingestDocument.setFieldValue("fizz.buzz.new", "bar");
             fail("add field should have failed");
         } catch(IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("cannot add field to parent [buzz] of type [java.lang.String], [java.util.Map] expected instead."));
+            assertThat(e.getMessage(), equalTo("cannot set [new] with parent object of type [java.lang.String] as part of path [fizz.buzz.new]"));
             assertThat(ingestDocument.isSourceModified(), equalTo(false));
         }
     }
@@ -172,7 +259,7 @@ public class IngestDocumentTests extends ESTestCase {
             ingestDocument.setFieldValue("fizz.foo_null.test", "bar");
             fail("add field should have failed");
         } catch(IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("cannot add field to null parent, [java.util.Map] expected instead."));
+            assertThat(e.getMessage(), equalTo("cannot set [test] with null parent as part of path [fizz.foo_null.test]"));
             assertThat(ingestDocument.isSourceModified(), equalTo(false));
         }
     }
@@ -182,7 +269,85 @@ public class IngestDocumentTests extends ESTestCase {
             ingestDocument.setFieldValue(null, "bar");
             fail("add field should have failed");
         } catch(IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("cannot add null or empty field"));
+            assertThat(e.getMessage(), equalTo("path cannot be null nor empty"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
+    }
+
+    public void testListSetFieldValueNoIndexProvided() {
+        ingestDocument.setFieldValue("list", "value");
+        assertThat(ingestDocument.isSourceModified(), equalTo(true));
+        Object object = ingestDocument.getSource().get("list");
+        assertThat(object, instanceOf(String.class));
+        assertThat(object, equalTo("value"));
+    }
+
+    public void testListAppendFieldValue() {
+        ingestDocument.appendFieldValue("list", "new_value");
+        assertThat(ingestDocument.isSourceModified(), equalTo(true));
+        Object object = ingestDocument.getSource().get("list");
+        assertThat(object, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<Object> list = (List<Object>) object;
+        assertThat(list.size(), equalTo(3));
+        assertThat(list.get(0), equalTo(Collections.singletonMap("field", "value")));
+        assertThat(list.get(1), nullValue());
+        assertThat(list.get(2), equalTo("new_value"));
+    }
+
+    public void testListSetFieldValueIndexProvided() {
+        ingestDocument.setFieldValue("list.1", "value");
+        assertThat(ingestDocument.isSourceModified(), equalTo(true));
+        Object object = ingestDocument.getSource().get("list");
+        assertThat(object, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<Object> list = (List<Object>) object;
+        assertThat(list.size(), equalTo(3));
+        assertThat(list.get(0), equalTo(Collections.singletonMap("field", "value")));
+        assertThat(list.get(1), equalTo("value"));
+        assertThat(list.get(2), nullValue());
+    }
+
+    public void testSetFieldValueListAsPartOfPath() {
+        ingestDocument.setFieldValue("list.0.field", "new_value");
+        assertThat(ingestDocument.isSourceModified(), equalTo(true));
+        Object object = ingestDocument.getSource().get("list");
+        assertThat(object, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<Object> list = (List<Object>) object;
+        assertThat(list.size(), equalTo(2));
+        assertThat(list.get(0), equalTo(Collections.singletonMap("field", "new_value")));
+        assertThat(list.get(1), nullValue());
+    }
+
+    public void testListSetFieldValueIndexNotNumeric() {
+        try {
+            ingestDocument.setFieldValue("list.test", "value");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("[test] is not an integer, cannot be used as an index as part of path [list.test]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
+
+        try {
+            ingestDocument.setFieldValue("list.test.field", "new_value");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("[test] is not an integer, cannot be used as an index as part of path [list.test.field]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
+    }
+
+    public void testListSetFieldValueIndexOutOfBounds() {
+        try {
+            ingestDocument.setFieldValue("list.10", "value");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("[10] is out of bounds for array with length [2] as part of path [list.10]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
+
+        try {
+            ingestDocument.setFieldValue("list.10.field", "value");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("[10] is out of bounds for array with length [2] as part of path [list.10.field]"));
             assertThat(ingestDocument.isSourceModified(), equalTo(false));
         }
     }
@@ -192,7 +357,7 @@ public class IngestDocumentTests extends ESTestCase {
             ingestDocument.setFieldValue("", "bar");
             fail("add field should have failed");
         } catch(IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("cannot add null or empty field"));
+            assertThat(e.getMessage(), equalTo("path cannot be null nor empty"));
             assertThat(ingestDocument.isSourceModified(), equalTo(false));
         }
     }
@@ -200,48 +365,127 @@ public class IngestDocumentTests extends ESTestCase {
     public void testRemoveField() {
         ingestDocument.removeField("foo");
         assertThat(ingestDocument.isSourceModified(), equalTo(true));
-        assertThat(ingestDocument.getSource().size(), equalTo(2));
+        assertThat(ingestDocument.getSource().size(), equalTo(3));
         assertThat(ingestDocument.getSource().containsKey("foo"), equalTo(false));
     }
 
     public void testRemoveInnerField() {
         ingestDocument.removeField("fizz.buzz");
-        assertThat(ingestDocument.getSource().size(), equalTo(3));
+        assertThat(ingestDocument.getSource().size(), equalTo(4));
         assertThat(ingestDocument.getSource().get("fizz"), instanceOf(Map.class));
         @SuppressWarnings("unchecked")
         Map<String, Object> map = (Map<String, Object>) ingestDocument.getSource().get("fizz");
-        assertThat(map.size(), equalTo(1));
+        assertThat(map.size(), equalTo(2));
         assertThat(map.containsKey("buzz"), equalTo(false));
 
         ingestDocument.removeField("fizz.foo_null");
+        assertThat(map.size(), equalTo(1));
+        assertThat(ingestDocument.getSource().size(), equalTo(4));
+        assertThat(ingestDocument.getSource().containsKey("fizz"), equalTo(true));
+        assertThat(ingestDocument.isSourceModified(), equalTo(true));
+
+        ingestDocument.removeField("fizz.1");
         assertThat(map.size(), equalTo(0));
-        assertThat(ingestDocument.getSource().size(), equalTo(3));
+        assertThat(ingestDocument.getSource().size(), equalTo(4));
         assertThat(ingestDocument.getSource().containsKey("fizz"), equalTo(true));
         assertThat(ingestDocument.isSourceModified(), equalTo(true));
     }
 
     public void testRemoveNonExistingField() {
-        ingestDocument.removeField("does_not_exist");
-        assertThat(ingestDocument.isSourceModified(), equalTo(false));
-        assertThat(ingestDocument.getSource().size(), equalTo(3));
+        try {
+            ingestDocument.removeField("does_not_exist");
+            fail("remove field should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("field [does_not_exist] not present as part of path [does_not_exist]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
     }
 
     public void testRemoveExistingParentTypeMismatch() {
-        ingestDocument.removeField("foo.test");
-        assertThat(ingestDocument.isSourceModified(), equalTo(false));
-        assertThat(ingestDocument.getSource().size(), equalTo(3));
+        try {
+            ingestDocument.removeField("foo.foo.bar");
+            fail("remove field should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("cannot resolve [foo] from object of type [java.lang.String] as part of path [foo.foo.bar]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
+    }
+
+    public void testListRemoveField() {
+        ingestDocument.removeField("list.0.field");
+        assertThat(ingestDocument.isSourceModified(), equalTo(true));
+        assertThat(ingestDocument.getSource().size(), equalTo(4));
+        assertThat(ingestDocument.getSource().containsKey("list"), equalTo(true));
+        Object object = ingestDocument.getSource().get("list");
+        assertThat(object, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<Object> list = (List<Object>) object;
+        assertThat(list.size(), equalTo(2));
+        object = list.get(0);
+        assertThat(object, instanceOf(Map.class));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) object;
+        assertThat(map.size(), equalTo(0));
+        ingestDocument.removeField("list.0");
+        assertThat(list.size(), equalTo(1));
+        assertThat(list.get(0), nullValue());
+    }
+
+    public void testRemoveFieldValueNotFoundNullParent() {
+        try {
+            ingestDocument.removeField("fizz.foo_null.not_there");
+            fail("get field value should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("cannot remove [not_there] from null as part of path [fizz.foo_null.not_there]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
+    }
+
+    public void testNestedRemoveFieldTypeMismatch() {
+        try {
+            ingestDocument.removeField("fizz.1.bar");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("cannot remove [bar] from object of type [java.lang.String] as part of path [fizz.1.bar]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
+    }
+
+    public void testListRemoveFieldIndexNotNumeric() {
+        try {
+            ingestDocument.removeField("list.test");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("[test] is not an integer, cannot be used as an index as part of path [list.test]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
+    }
+
+    public void testListRemoveFieldIndexOutOfBounds() {
+        try {
+            ingestDocument.removeField("list.10");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("[10] is out of bounds for array with length [2] as part of path [list.10]"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
     }
 
     public void testRemoveNullField() {
-        ingestDocument.removeField(null);
-        assertThat(ingestDocument.isSourceModified(), equalTo(false));
-        assertThat(ingestDocument.getSource().size(), equalTo(3));
+        try {
+            ingestDocument.removeField(null);
+            fail("remove field should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("path cannot be null nor empty"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
     }
 
     public void testRemoveEmptyField() {
-        ingestDocument.removeField("");
-        assertThat(ingestDocument.isSourceModified(), equalTo(false));
-        assertThat(ingestDocument.getSource().size(), equalTo(3));
+        try {
+            ingestDocument.removeField("");
+            fail("remove field should have failed");
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("path cannot be null nor empty"));
+            assertThat(ingestDocument.isSourceModified(), equalTo(false));
+        }
     }
 
     public void testEqualsAndHashcode() throws Exception {
@@ -289,9 +533,11 @@ public class IngestDocumentTests extends ESTestCase {
         } else {
             assertThat(ingestDocument, equalTo(otherIngestDocument));
             assertThat(otherIngestDocument, equalTo(ingestDocument));
+            assertThat(ingestDocument.hashCode(), equalTo(otherIngestDocument.hashCode()));
             IngestDocument thirdIngestDocument = new IngestDocument(index, type, id, Collections.singletonMap(fieldName, fieldValue));
             assertThat(thirdIngestDocument, equalTo(ingestDocument));
             assertThat(ingestDocument, equalTo(thirdIngestDocument));
+            assertThat(ingestDocument.hashCode(), equalTo(thirdIngestDocument.hashCode()));
         }
     }
 }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/AbstractStringProcessorTestCase.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/AbstractStringProcessorTestCase.java
@@ -23,12 +23,12 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class AbstractStringProcessorTestCase extends ESTestCase {
@@ -57,7 +57,7 @@ public abstract class AbstractStringProcessorTestCase extends ESTestCase {
         }
     }
 
-    public void testNullValue() throws Exception {
+    public void testFieldNotFound() throws Exception {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         Processor processor = newProcessor(Collections.singletonList(fieldName));
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
@@ -65,7 +65,18 @@ public abstract class AbstractStringProcessorTestCase extends ESTestCase {
             processor.execute(ingestDocument);
             fail("processor should have failed");
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("field [" + fieldName + "] is null, cannot process it."));
+            assertThat(e.getMessage(), containsString("not present as part of path [" + fieldName + "]"));
+        }
+    }
+
+    public void testNullValue() throws Exception {
+        Processor processor = newProcessor(Collections.singletonList("field"));
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
+        try {
+            processor.execute(ingestDocument);
+            fail("processor should have failed");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("field [field] is null, cannot process it."));
         }
     }
 

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/add/AddProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/add/AddProcessorTests.java
@@ -24,8 +24,9 @@ import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.ingest.processor.Processor;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -44,7 +45,7 @@ public class AddProcessorTests extends ESTestCase {
         processor.execute(ingestDocument);
 
         for (Map.Entry<String, Object> field : fields.entrySet()) {
-            assertThat(ingestDocument.hasFieldValue(field.getKey()), equalTo(true));
+            assertThat(ingestDocument.hasField(field.getKey()), equalTo(true));
             assertThat(ingestDocument.getFieldValue(field.getKey(), Object.class), equalTo(field.getValue()));
         }
     }
@@ -63,7 +64,7 @@ public class AddProcessorTests extends ESTestCase {
         Processor processor = new AddProcessor(fields);
         processor.execute(ingestDocument);
         for (Map.Entry<String, Object> field : fields.entrySet()) {
-            assertThat(ingestDocument.hasFieldValue(field.getKey()), equalTo(true));
+            assertThat(ingestDocument.hasField(field.getKey()), equalTo(true));
             assertThat(ingestDocument.getFieldValue(field.getKey(), Object.class), equalTo(field.getValue()));
         }
     }
@@ -76,7 +77,7 @@ public class AddProcessorTests extends ESTestCase {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
         } catch(IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("cannot add field to parent [field] of type [java.lang.String], [java.util.Map] expected instead."));
+            assertThat(e.getMessage(), equalTo("cannot set [inner] with parent object of type [java.lang.String] as part of path [field.inner]"));
         }
     }
 }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/join/JoinProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/join/JoinProcessorTests.java
@@ -24,9 +24,9 @@ import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.ingest.processor.Processor;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.IOException;
 import java.util.*;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class JoinProcessorTests extends ESTestCase {
@@ -111,7 +111,17 @@ public class JoinProcessorTests extends ESTestCase {
         try {
             processor.execute(ingestDocument);
         } catch(IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("field [" + fieldName + "] is null, cannot join."));
+            assertThat(e.getMessage(), containsString("not present as part of path [" + fieldName + "]"));
+        }
+    }
+
+    public void testJoinNullValue() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
+        Processor processor = new JoinProcessor(Collections.singletonMap("field", "-"));
+        try {
+            processor.execute(ingestDocument);
+        } catch(IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("field [field] is null, cannot join."));
         }
     }
 }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/rename/RenameProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/rename/RenameProcessorTests.java
@@ -70,8 +70,8 @@ public class RenameProcessorTests extends ESTestCase {
         String newFieldName = RandomDocumentPicks.randomFieldName(random());
         Processor processor = new RenameProcessor(Collections.singletonMap(fieldName, newFieldName));
         processor.execute(ingestDocument);
-        assertThat(ingestDocument.hasFieldValue(fieldName), equalTo(false));
-        assertThat(ingestDocument.hasFieldValue(newFieldName), equalTo(true));
+        assertThat(ingestDocument.hasField(fieldName), equalTo(false));
+        assertThat(ingestDocument.hasField(newFieldName), equalTo(true));
         assertThat(ingestDocument.getFieldValue(newFieldName, Object.class), nullValue());
     }
 }


### PR DESCRIPTION
When reading, through #getFieldValue and #hasField, and a list is encountered, the next element in the path is treated as the index of the item that the path points to (e.g. `list.0.key`). If the index is not a number or out of bounds, an exception gets thrown.
# removeField supports now removing a specific element of a list, by specifying its index. (e.g. field.list.0)
# setFieldValue supports now lists while resolving the path same as described above for reading and remove. It also now allows to add a value to a list at a specific position by doing `setFieldValue("field.list.1", value);`. That said when the last element in the path is a list, e.g. field.list, the set will replace the list with the new value.

Added #appendFieldValue method that has the same behaviour as setFieldValue, but when a list is the last element in the path, instead of replacing the whole list it will simply add a new element to the existing list. This method is currently unused, we have to decide whether the set processor or a new processor should use it.

A few other changes made:
- Renamed hasFieldValue to hasField, as this method is not really about values but only keys. It will return true if a key is there but its value is null, while it returns false only when a field is not there at all.
- Changed null semantic in getFieldValue. null gets returned only when it was an actual value in the source, an exception is thrown otherwise when trying to access a non existing field, so that null != field not present.
- Made getFieldValue stricter about the input path. Throw error if null or empty rather than returning null.
- Made remove stricter about non existing fields. Throws error when trying to remove a non existing field. This is more consistent with the other methods in IngestDocument which are strict about fields that are not present.

Relates to #14324
