### PR TITLE
Remove a trailing comma from an example data of JSON

### DIFF
--- a/docs/reference/search/request/post-filter.asciidoc
+++ b/docs/reference/search/request/post-filter.asciidoc
@@ -78,7 +78,7 @@ curl -XGET localhost:9200/shirts/_search -d '
   },
   "aggs": {
     "colors": {
-      "terms": { "field": "color" }, <2>
+      "terms": { "field": "color" } <2>
     },
     "color_red": {
       "filter": {


### PR DESCRIPTION
This PR fixes a JSON-formatted fault in [post-filter.asciidoc](https://github.com/elastic/elasticsearch/blob/148265bd164cd5a614cd020fb480d5974f523d81/docs/reference/search/request/post-filter.asciidoc) due to a trailing comma.
