### PR TITLE
Fix rpm and deb generated poms to have correct artifactId

### DIFF
--- a/distribution/deb/build.gradle
+++ b/distribution/deb/build.gradle
@@ -19,6 +19,7 @@
 
 task buildDeb(type: Deb) {
   dependsOn dependencyFiles, preparePackagingFiles
+  baseName 'elasticsearch' // this is what pom generation uses for artifactId
   // Follow elasticsearch's deb file naming convention
   archiveName "${packageName}-${project.version}.deb"
   packageGroup 'web'

--- a/distribution/rpm/build.gradle
+++ b/distribution/rpm/build.gradle
@@ -19,6 +19,7 @@
 
 task buildRpm(type: Rpm) {
   dependsOn dependencyFiles, preparePackagingFiles
+  baseName 'elasticsearch' // this is what pom generation uses for artifactId
   // Follow elasticsearch's rpm file naming convention
   archiveName = "${packageName}-${project.version}.rpm"
   packageGroup 'Application/Internet'


### PR DESCRIPTION
For all our distributions, we use "elasticsearch" as the artifactId.
This fixes the id for the generated poms of rpm and deb distributions.
