### PR TITLE
Fix delayed extra config file checks to be right before copy

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -185,7 +185,8 @@ class ClusterFormationTasks {
         Copy copyConfig = project.tasks.create(name: name, type: Copy, dependsOn: setup)
         copyConfig.into(new File(node.homeDir, 'config')) // copy must always have a general dest dir, even though we don't use it
         for (Map.Entry<String,Object> extraConfigFile : node.config.extraConfigFiles.entrySet()) {
-            Closure delayedSrc = {
+            copyConfig.doFirst {
+                // make sure the copy won't be a no-op or act on a directory
                 File srcConfigFile = project.file(extraConfigFile.getValue())
                 if (srcConfigFile.isDirectory()) {
                     throw new GradleException("Source for extraConfigFile must be a file: ${srcConfigFile}")
@@ -193,11 +194,10 @@ class ClusterFormationTasks {
                 if (srcConfigFile.exists() == false) {
                     throw new GradleException("Source file for extraConfigFile does not exist: ${srcConfigFile}")
                 }
-                return srcConfigFile
             }
             File destConfigFile = new File(node.homeDir, 'config/' + extraConfigFile.getKey())
-            copyConfig.from(delayedSrc)
-                      .into(destConfigFile.canonicalFile.parentFile)
+            copyConfig.into(destConfigFile.canonicalFile.parentFile)
+                      .from({ extraConfigFile.getValue() }) // wrap in closure to delay resolution to execution time
                       .rename { destConfigFile.name }
         }
         return copyConfig


### PR DESCRIPTION
The current delay waits until later after normal configuration, but
still just after resolution (ie when paths would be known for
dependencies but not actual execution). This delays the checks further
to be done right before we actually execute the copy task.

closes #15068
