### PR TITLE
Fix integration tests and 'gradle run' to work on windoze

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -285,11 +285,8 @@ class ClusterFormationTasks {
     /** Adds a task to start an elasticsearch node with the given configuration */
     static Task configureStartTask(String name, Project project, Task setup, NodeInfo node) {
         String executable
-        List<String> esArgs = []
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             executable = 'cmd'
-            esArgs.add('/C')
-            esArgs.add('call')
         } else {
             executable = 'sh'
         }
@@ -326,6 +323,9 @@ class ClusterFormationTasks {
 
             ant.exec(executable: executable, spawn: node.config.daemonize, dir: node.cwd, taskname: 'elasticsearch') {
                 node.env.each { key, value -> env(key: key, value: value) }
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                  arg(value: '/C')
+                }
                 arg(value: script)
                 node.args.each { arg(value: it) }
             }


### PR DESCRIPTION
`esArgs` was being completely ignored, meaning we were just running `cmd.exe` with no parameters. This is why things would just hang.

I know jenkins is failing, but I really do not want to push this fix until #15092 at least is addressed, ideally #15091 too. It was hellacious to debug and I do not wish to go through the pain again.

Closes #15084
