### PR TITLE
Add workaround for JDK-6427854

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -80,6 +80,10 @@ grant {
   // TODO: look into this and decide if users should simply set the actual sysprop?!
   permission java.util.PropertyPermission "org.jboss.netty.epollBugWorkaround", "write";
 
+  // Netty SelectorUtil wants to change this, because of https://bugs.openjdk.java.net/browse/JDK-6427854
+  // the bug says it only happened rarely, and that its fixed, but apparently it still happens rarely!
+  permission java.util.PropertyPermission "sun.nio.ch.bugLevel", "write";
+
   // needed by lucene SPI currently 
   permission java.lang.RuntimePermission "getClassLoader";
 


### PR DESCRIPTION
See e.g. http://build-us-00.elastic.co/job/es_feature_ingest/2831/consoleFull

The bug can still happen, so we should let netty do this workaround
