### PR TITLE
Add simple EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig: http://editorconfig.org/
+
+root = true
+
+[*.java]
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
The [EditorConfig](http://editorconfig.org/) file applies the formatting rules described in `CONTRIBUTING.md`.

Many IDEs and text editors support the EditorConfig standard to apply formatting rules, e. g. IntelliJ IDEA: http://editorconfig.org/#download
