### PR TITLE
Fix toXContent() for mapper attachments field

### DIFF
--- a/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
+++ b/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
@@ -625,7 +625,7 @@ public class AttachmentMapper extends FieldMapper {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(name());
+        builder.startObject(simpleName());
         builder.field("type", CONTENT_TYPE);
         if (indexCreatedBefore2x) {
             builder.field("path", pathType.name().toLowerCase(Locale.ROOT));

--- a/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/SimpleAttachmentMapperTests.java
+++ b/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/SimpleAttachmentMapperTests.java
@@ -22,10 +22,14 @@ package org.elasticsearch.mapper.attachments;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.junit.Test;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.StreamsUtils.copyToBytesFromClasspath;
@@ -105,6 +109,35 @@ public class SimpleAttachmentMapperTests extends AttachmentUnitTestCase {
         assertThat(doc.get(docMapper.mappers().getMapper("file.content_type").fieldType().names().indexName()), startsWith("application/xhtml+xml"));
         assertThat(doc.get(docMapper.mappers().getMapper("file.title").fieldType().names().indexName()), equalTo("XHTML test document"));
         assertThat(doc.get(docMapper.mappers().getMapper("file.content").fieldType().names().indexName()), containsString("This document tests the ability of Apache Tika to extract content"));
+    }
+
+    /**
+     * See issue https://github.com/elastic/elasticsearch-mapper-attachments/issues/169
+     * Mapping should not contain field names with dot.
+     */
+    @Test
+    public void testMapperErrorWithDotTwoLevels169() throws Exception {
+        XContentBuilder mappingBuilder = jsonBuilder();
+        mappingBuilder.startObject()
+                .startObject("mail")
+                .startObject("properties")
+                .startObject("attachments")
+                .startObject("properties")
+                .startObject("innerfield")
+                .field("type", "attachment")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+
+        byte[] mapping = mappingBuilder.bytes().toBytes();
+        MapperService mapperService = MapperTestUtils.newMapperService(createTempDir(), Settings.EMPTY);
+        DocumentMapper docMapper = mapperService.parse("mail", new CompressedXContent(mapping), true);
+        // this should not throw an exception
+        mapperService.parse("mail", new CompressedXContent(docMapper.mapping().toString()), true);
+        // the mapping may not contain a field name with a dot
+        assertFalse(docMapper.mapping().toString().contains("."));
     }
 
 }


### PR DESCRIPTION
We must use simpleName() instead of name() because otherwise when the mapping
is generated as a string the field name will be the full path with dots
and that is illegal from es 2.0 on.

closes https://github.com/elastic/elasticsearch-mapper-attachments/issues/169
