### PR TITLE
Preserve existing mappings on batch mapping updates

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -234,14 +234,14 @@ public class MetaDataMappingService extends AbstractComponent {
                                 final IndexMetaData indexMetaData = currentState.metaData().index(index);
                                 IndexService indexService;
                                 if (indicesService.hasIndex(index) == false) {
-                                    indexService = indicesService.createIndex(nodeServicesProvider, indexMetaData, Collections.EMPTY_LIST);
                                     indicesToClose.add(index);
+                                    indexService = indicesService.createIndex(nodeServicesProvider, indexMetaData, Collections.EMPTY_LIST);
+                                    // make sure to add custom default mapping if exists
+                                    if (indexMetaData.getMappings().containsKey(MapperService.DEFAULT_MAPPING)) {
+                                        indexService.mapperService().merge(MapperService.DEFAULT_MAPPING, indexMetaData.getMappings().get(MapperService.DEFAULT_MAPPING).source(), false, request.updateAllTypes());
+                                    }
                                 } else {
                                     indexService = indicesService.indexService(index);
-                                }
-                                // make sure to add custom default mapping if exists
-                                if (indexMetaData.getMappings().containsKey(MapperService.DEFAULT_MAPPING)) {
-                                    indexService.mapperService().merge(MapperService.DEFAULT_MAPPING, indexMetaData.getMappings().get(MapperService.DEFAULT_MAPPING).source(), false, request.updateAllTypes());
                                 }
                                 // only add the current relevant mapping (if exists)
                                 if (indexMetaData.getMappings().containsKey(request.type())) {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -243,8 +243,9 @@ public class MetaDataMappingService extends AbstractComponent {
                                 } else {
                                     indexService = indicesService.indexService(index);
                                 }
-                                // only add the current relevant mapping (if exists)
-                                if (indexMetaData.getMappings().containsKey(request.type())) {
+                                // only add the current relevant mapping (if exists and not yet added)
+                                if (indexMetaData.getMappings().containsKey(request.type()) &&
+                                        !indexService.mapperService().hasMapping(request.type())) {
                                     indexService.mapperService().merge(request.type(), indexMetaData.getMappings().get(request.type()).source(), false, request.updateAllTypes());
                                 }
                             }

--- a/core/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -51,7 +51,6 @@ import static org.hamcrest.Matchers.*;
 @ClusterScope(randomDynamicTemplates = false)
 public class UpdateMappingIntegrationIT extends ESIntegTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/15129")
     public void testDynamicUpdates() throws Exception {
         client().admin().indices().prepareCreate("test")
                 .setSettings(


### PR DESCRIPTION
This commit addresses an issues introduced in #14899 to apply mapping
updates in batches. The issue is that an existing mapping for a type
could be lost if that type came in a batch that already contained a
mapping update for another type on the same index. The underlying issue
was that the existing mapping would not be merged in because the merging
logic was only tripped once per index, rather than for all types seeing
updates for each index. Resolving this issue is simply a matter of
ensuring that all existing types seeing updates are merged in.

Closes #15129
