### PR TITLE
Processing pending deletes should rely on index UUID instead of index name

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/MultiDataPathUpgrader.java
+++ b/core/src/main/java/org/elasticsearch/common/util/MultiDataPathUpgrader.java
@@ -323,7 +323,7 @@ public class MultiDataPathUpgrader {
 
             for (String index : allIndices) {
                 for (ShardId shardId : findAllShardIds(nodeEnv.indexPaths(new Index(index)))) {
-                    try (ShardLock lock = nodeEnv.shardLock(shardId, 0)) {
+                    try (ShardLock lock = nodeEnv.shardLock(shardId, null, 0)) {
                         if (upgrader.needsUpgrading(shardId)) {
                             final ShardPath shardPath = upgrader.pickShardPath(shardId);
                             upgrader.upgrade(shardId, shardPath);

--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -233,7 +233,7 @@ public final class IndexService extends AbstractIndexComponent implements IndexC
         boolean success = false;
         Store store = null;
         IndexShard indexShard = null;
-        final ShardLock lock = nodeEnv.shardLock(shardId, TimeUnit.SECONDS.toMillis(5));
+        final ShardLock lock = nodeEnv.shardLock(shardId, this.indexSettings.getUUID(), TimeUnit.SECONDS.toMillis(5));
         try {
             eventListener.beforeIndexShardCreated(shardId, indexSettings);
             ShardPath path;

--- a/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -164,21 +164,21 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         assertAcked(client().admin().indices().prepareClose("test"));
         assertTrue(path.exists());
 
-        assertEquals(indicesService.numPendingDeletes(test.index()), numPending);
+        assertEquals(indicesService.numPendingDeletes(test.indexUUID()), numPending);
 
         // shard lock released... we can now delete
         indicesService.processPendingDeletes(test.index(), test.getIndexSettings(), new TimeValue(0, TimeUnit.MILLISECONDS));
-        assertEquals(indicesService.numPendingDeletes(test.index()), 0);
+        assertEquals(indicesService.numPendingDeletes(test.indexUUID()), 0);
         assertFalse(path.exists());
 
         if (randomBoolean()) {
             indicesService.addPendingDelete(new ShardId(test.index(), 0), test.getIndexSettings());
             indicesService.addPendingDelete(new ShardId(test.index(), 1), test.getIndexSettings());
             indicesService.addPendingDelete(new ShardId("bogus", 1), test.getIndexSettings());
-            assertEquals(indicesService.numPendingDeletes(test.index()), 2);
+            assertEquals(indicesService.numPendingDeletes(test.indexUUID()), 2);
             // shard lock released... we can now delete
             indicesService.processPendingDeletes(test.index(), test.getIndexSettings(), new TimeValue(0, TimeUnit.MILLISECONDS));
-            assertEquals(indicesService.numPendingDeletes(test.index()), 0);
+            assertEquals(indicesService.numPendingDeletes(test.indexUUID()), 0);
         }
         assertAcked(client().admin().indices().prepareOpen("test"));
 

--- a/test-framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1864,7 +1864,7 @@ public final class InternalTestCluster extends TestCluster {
             Set<ShardId> shardIds = env.lockedShards();
             for (ShardId id : shardIds) {
                 try {
-                    env.shardLock(id, TimeUnit.SECONDS.toMillis(5)).close();
+                    env.shardLock(id, null, TimeUnit.SECONDS.toMillis(5)).close();
                 } catch (IOException ex) {
                     fail("Shard " + id + " is still locked after 5 sec waiting");
                 }


### PR DESCRIPTION
Relates to #14932 which shows that processing pending deletes can block shard initialization for 30 minutes. The core issue is that processing pending deletes (which is an asynchronous operation) is based on index name instead of UUID. If a new index with same name has been recreated in the meantime, we run into some issues.

As a fix, I suggest the following changes:
- Pass index UUID when requesting ShardLock. If uuid do not match with uuid of currently held ShardLock for that shard, throw LockObtainFailedException. We use the special wildcard "null" to match any uuid. This is useful if we don't know what the index UUID is (fallback to the old behavior).
- pendingDeletes map is indexed by index uuid, not index name anymore. This means that we process only the pending deletes for the specific UUID.
- processPendingDeletes should not request all, but as many ShardLocks as possible. If only subset is locked, then index directory should NOT be deleted. Same as before, it should only delete directories for which it has lock.

Note that it is still unsafe in the following case: Let's assume we recreate index with more shards. If the given machine only gets the shard with number higher than any number in old index, then processPendingDeletes might still delete the index directory.
