### PR TITLE
Support wildcards for getting repositories and snapshots

### DIFF
--- a/core/src/test/java/org/elasticsearch/snapshots/RepositoriesIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/RepositoriesIT.java
@@ -94,7 +94,8 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         assertThat(repositoriesMetaData.repository("test-repo-2").type(), equalTo("fs"));
 
         logger.info("--> check that both repositories can be retrieved by getRepositories query");
-        GetRepositoriesResponse repositoriesResponse = client.admin().cluster().prepareGetRepositories().get();
+        GetRepositoriesResponse repositoriesResponse = client.admin().cluster()
+            .prepareGetRepositories(randomFrom("_all", "*", "test-repo-*")).get();
         assertThat(repositoriesResponse.repositories().size(), equalTo(2));
         assertThat(findRepository(repositoriesResponse.repositories(), "test-repo-1"), notNullValue());
         assertThat(findRepository(repositoriesResponse.repositories(), "test-repo-2"), notNullValue());

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -149,7 +149,10 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
-        SnapshotInfo snapshotInfo = client.admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-snap").get().getSnapshots().get(0);
+        List<SnapshotInfo> snapshotInfos = client.admin().cluster().prepareGetSnapshots("test-repo")
+            .setSnapshots(randomFrom("test-snap", "_all", "*", "*-snap", "test*")).get().getSnapshots();
+        assertThat(snapshotInfos.size(), equalTo(1));
+        SnapshotInfo snapshotInfo = snapshotInfos.get(0);
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
         assertThat(snapshotInfo.version(), equalTo(Version.CURRENT));
 

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -45,6 +45,15 @@ which returns:
 }
 -----------------------------------
 
+Information about multiple repositories can be fetched in one go by using a comma-delimited list of repository names.
+Star wildcards are supported as well. For example, information about repositories that start with `repo` or that contain `backup`
+can be obtained using the following command:
+
+[source,js]
+-----------------------------------
+GET /_snapshot/repo*,*backup*
+-----------------------------------
+
 If a repository name is not specified, or `_all` is used as repository name Elasticsearch will return information about
 all repositories currently registered in the cluster:
 
@@ -248,6 +257,14 @@ Once a snapshot is created information about this snapshot can be obtained using
 [source,sh]
 -----------------------------------
 GET /_snapshot/my_backup/snapshot_1
+-----------------------------------
+// AUTOSENSE
+
+Similar as for repositories, information about multiple snapshots can be queried in one go, supporting wildcards as well:
+
+[source,sh]
+-----------------------------------
+GET /_snapshot/my_backup/snapshot_*,some_other_snapshot
 -----------------------------------
 // AUTOSENSE
 


### PR DESCRIPTION
Supports the following:

```
GET /_snapshot/*
GET /_snapshot/repo*
GET /_snapshot/repo/*
GET /_snapshot/repo/prefix*
```

What is not supported:

```
GET /_snapshot/*/snap
GET /_snapshot/repo*/snap*
```

Relates to #4758
