### PR TITLE
Enable copy_to in multi_fields

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -312,9 +312,6 @@ class DocumentParser implements Closeable {
         } else {
             FieldMapper fieldMapper = (FieldMapper)mapper;
             Mapper update = fieldMapper.parse(context);
-            if (fieldMapper.copyTo() != null) {
-                parseCopyFields(context, fieldMapper, fieldMapper.copyTo().copyToFields());
-            }
             return update;
         }
     }
@@ -683,7 +680,7 @@ class DocumentParser implements Closeable {
     }
 
     /** Creates instances of the fields that the current field should be copied to */
-    private static void parseCopyFields(ParseContext context, FieldMapper fieldMapper, List<String> copyToFields) throws IOException {
+    public static void parseCopyFields(ParseContext context, FieldMapper fieldMapper, List<String> copyToFields) throws IOException {
         if (!context.isWithinCopyTo() && copyToFields.isEmpty() == false) {
             context = context.createCopyToContext();
             for (String field : copyToFields) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -339,6 +339,9 @@ public abstract class FieldMapper extends Mapper {
             throw new MapperParsingException("failed to parse [" + fieldType().names().fullName() + "]", e);
         }
         multiFields.parse(this, context);
+        if (copyTo() != null) {
+            DocumentParser.parseCopyFields(context, this, this.copyTo().copyToFields());
+        }
         return null;
     }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/copyto/CopyToMapperTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper.copyto;
 
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -40,6 +41,7 @@ import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.junit.Test;
 
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -358,4 +360,21 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
         assertArrayEquals(expected, actual);
     }
 
+    @Test
+    public void testCopyToInMultiFields() throws Exception {
+        String mapping = jsonBuilder().startObject().startObject("type").startObject("properties")
+                .startObject("copy_test")
+                .field("type", "string")
+                .startObject("fields")
+                .startObject("raw")
+                .field("type", "string")
+                .field("copy_to", "another_field")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject().endObject().endObject().string();
+        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse(mapping);
+        ParsedDocument doc = docMapper.parse("test", "type", "1", new BytesArray("{\"copy_test\":\"foo bar\"}"));
+        assertThat(doc.docs().get(0).getFields("another_field")[0].stringValue(), equalTo("foo bar"));
+    }
 }


### PR DESCRIPTION
This is just a poc for #14946 . I am opening this pull request so that we can discuss better. 

I tried re enabling `copy_to` functionality for `multi_fields` and it seems to me this is just a matter of shifting three lines. I have not thought about it much though yet and might be missing something. However, tests with this branch pass.
