### PR TITLE
Deprecate the `missing` query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryBuilder.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 /**
  * Constructs a filter that only match on documents that the field has a value in them.
+ * @deprecated Use {@link ExistsQueryBuilder} inside a {@link BoolQueryBuilder#mustNot(QueryBuilder)} clause instead.
  */
 public class MissingQueryBuilder extends QueryBuilder {
 

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -766,8 +766,7 @@ public abstract class QueryBuilders {
 
     /**
      * A filter to filter only documents where a field does not exists in them.
-     *
-     * @param name The name of the field
+     * @deprecated Use {@link #existsQuery(String)} inside a {@link BoolQueryBuilder#mustNot(QueryBuilder)} clause instead.
      */
     public static MissingQueryBuilder missingQuery(String name) {
         return new MissingQueryBuilder(name);
@@ -792,7 +791,7 @@ public abstract class QueryBuilders {
 
     /**
      * Create a new {@link AndQueryBuilder} composed of the given filters.
-     * @deprecated Use {@link #boolQuery()} instead
+     * @deprecated Use {@link #boolQuery().mustNot()} instead
      */
     @Deprecated
     public static AndQueryBuilder andQuery(QueryBuilder... filters) {

--- a/docs/java-api/query-dsl/missing-query.asciidoc
+++ b/docs/java-api/query-dsl/missing-query.asciidoc
@@ -1,6 +1,8 @@
 [[java-query-dsl-missing-query]]
 ==== Missing Query
 
+deprecated[2.2.0, Use `exists` query inside a `must_not` clause instead]
+
 See {ref}/query-dsl-missing-query.html[Missing Query]
 
 [source,java]

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -70,3 +70,19 @@ no values in the `user` field and thus would not match the `exists` filter:
 { "foo": "bar" }
 --------------------------------------------------
 
+===== `missing` query
+
+The exists query can advantageously replace the `missing` query when used inside a must_not clause as follows:
+
+[source,js]
+--------------------------------------------------
+"bool": {
+    "must_not": {
+        "exists": {
+            "field": "user"
+        }
+    }
+}
+--------------------------------------------------
+
+This query returns documents that have no value in the user field.

--- a/docs/reference/query-dsl/missing-query.asciidoc
+++ b/docs/reference/query-dsl/missing-query.asciidoc
@@ -1,6 +1,8 @@
 [[query-dsl-missing-query]]
 === Missing Query
 
+deprecated[2.2.0, Use `exists` query inside a `must_not` clause instead]
+
 Returns documents that have only `null` values or no value in the original field:
 
 [source,js]


### PR DESCRIPTION
Deprecate the missing filter in favour of using an exists filter, which works also in a nested context, where the user can place the negation where appropriate.
Fixes #14112
