### PR TITLE
Don't treat _default_ as a regular type.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -351,7 +351,7 @@ public class DocumentMapper implements ToXContent {
         this.fieldMappers = this.fieldMappers.copyAndAllAll(fieldMappers);
 
         // finally update for the entire index
-        mapperService.addMappers(objectMappers, fieldMappers);
+        mapperService.addMappers(type, objectMappers, fieldMappers);
     }
 
     public MergeResult merge(Mapping mapping, boolean simulate, boolean updateAllTypes) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -79,6 +79,10 @@ class DocumentParser implements Closeable {
     }
 
     private ParsedDocument innerParseDocument(SourceToParse source) throws MapperParsingException {
+        if (docMapper.type().equals(MapperService.DEFAULT_MAPPING)) {
+            throw new IllegalArgumentException("It is forbidden to index into the default mapping [" + MapperService.DEFAULT_MAPPING + "]");
+        }
+
         ParseContext.InternalParseContext context = cache.get();
 
         final Mapping mapping = docMapper.mapping();

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -56,7 +57,11 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
      * from the provided fields. If a field already exists, the field type will be updated
      * to use the new mappers field type.
      */
-    public FieldTypeLookup copyAndAddAll(Collection<FieldMapper> newFieldMappers) {
+    public FieldTypeLookup copyAndAddAll(String type, Collection<FieldMapper> newFieldMappers) {
+        Objects.requireNonNull(type, "type must not be null");
+        if (MapperService.DEFAULT_MAPPING.equals(type)) {
+            throw new IllegalArgumentException("Default mappings should not be added to the lookup");
+        }
         CopyOnWriteHashMap<String, MappedFieldTypeReference> fullName = this.fullNameToFieldType;
         CopyOnWriteHashMap<String, MappedFieldTypeReference> indexName = this.indexNameToFieldType;
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -30,6 +32,11 @@ import static org.elasticsearch.test.VersionUtils.getPreviousVersion;
 import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
 
 public class MapperServiceTests extends ESSingleNodeTestCase {
     @Rule
@@ -81,5 +88,57 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
                 .addMapping(type, field, "type=string")
                 .execute()
                 .actionGet();
+    }
+
+    public void testTypes() throws Exception {
+        IndexService indexService1 = createIndex("index1");
+        MapperService mapperService = indexService1.mapperService();
+        assertEquals(Collections.emptySet(), mapperService.types());
+
+        mapperService.merge("type1", new CompressedXContent("{\"type1\":{}}"), true, false);
+        assertNull(mapperService.documentMapper(MapperService.DEFAULT_MAPPING));
+        assertEquals(Collections.singleton("type1"), mapperService.types());
+
+        mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent("{\"_default_\":{}}"), true, false);
+        assertNotNull(mapperService.documentMapper(MapperService.DEFAULT_MAPPING));
+        assertEquals(Collections.singleton("type1"), mapperService.types());
+
+        mapperService.merge("type2", new CompressedXContent("{\"type2\":{}}"), true, false);
+        assertNotNull(mapperService.documentMapper(MapperService.DEFAULT_MAPPING));
+        assertEquals(new HashSet<>(Arrays.asList("type1", "type2")), mapperService.types());
+    }
+
+    public void testIndexIntoDefaultMapping() throws Throwable {
+        // 1. test implicit index creation
+        try {
+            client().prepareIndex("index1", MapperService.DEFAULT_MAPPING, "1").setSource("{").execute().get();
+            fail();
+        } catch (Throwable t) {
+            if (t instanceof ExecutionException) {
+                t = ((ExecutionException) t).getCause();
+            }
+            if (t instanceof IllegalArgumentException) {
+                assertEquals("It is forbidden to index into the default mapping [_default_]", t.getMessage());
+            } else {
+                throw t;
+            }
+        }
+
+        // 2. already existing index
+        IndexService indexService = createIndex("index2");
+        try {
+            client().prepareIndex("index2", MapperService.DEFAULT_MAPPING, "2").setSource().execute().get();
+            fail();
+        } catch (Throwable t) {
+            if (t instanceof ExecutionException) {
+                t = ((ExecutionException) t).getCause();
+            }
+            if (t instanceof IllegalArgumentException) {
+                assertEquals("It is forbidden to index into the default mapping [_default_]", t.getMessage());
+            } else {
+                throw t;
+            }
+        }
+        assertFalse(indexService.mapperService().hasMapping(MapperService.DEFAULT_MAPPING));
     }
 }


### PR DESCRIPTION
This adds safety that you can't index into the `_default_` type (it was possible
before), and can't add default mappers to the field type lookups (was not
happening in tests but I think this is still a good check).

Also MapperService.types() now excludes `_default` so that eg. the `ids` query
does not try to search on this type anymore.

Related to #15049
