### PR TITLE
 Add fromXContent method to HighlightBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/highlight/AbstractHighlighterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/AbstractHighlighterBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.highlight;
 
 import org.apache.lucene.search.highlight.SimpleFragmenter;
 import org.apache.lucene.search.highlight.SimpleSpanFragmenter;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -36,6 +37,28 @@ import java.util.Objects;
  * and provides the common setters, equality, hashCode calculation and common serialization
  */
 public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterBuilder> {
+
+    public static final ParseField PRE_TAGS_FIELD = new ParseField("pre_tags");
+    public static final ParseField POST_TAGS_FIELD = new ParseField("post_tags");
+    public static final ParseField FIELDS_FIELD = new ParseField("fields");
+    public static final ParseField ORDER_FIELD = new ParseField("order");
+    public static final ParseField TAGS_SCHEMA_FIELD = new ParseField("tags_schema");
+    public static final ParseField HIGHLIGHT_FILTER_FIELD = new ParseField("highlight_filter");
+    public static final ParseField FRAGMENT_SIZE_FIELD = new ParseField("fragment_size");
+    public static final ParseField FRAGMENT_OFFSET_FIELD = new ParseField("fragment_offset");
+    public static final ParseField NUMBER_OF_FRAGMENTS_FIELD = new ParseField("number_of_fragments");
+    public static final ParseField ENCODER_FIELD = new ParseField("encoder");
+    public static final ParseField REQUIRE_FIELD_MATCH_FIELD = new ParseField("require_field_match");
+    public static final ParseField BOUNDARY_MAX_SCAN_FIELD = new ParseField("boundary_max_scan");
+    public static final ParseField BOUNDARY_CHARS_FIELD = new ParseField("boundary_chars");
+    public static final ParseField TYPE_FIELD = new ParseField("type");
+    public static final ParseField FRAGMENTER_FIELD = new ParseField("fragmenter");
+    public static final ParseField NO_MATCH_SIZE_FIELD = new ParseField("no_match_size");
+    public static final ParseField FORCE_SOURCE_FIELD = new ParseField("force_source");
+    public static final ParseField PHRASE_LIMIT_FIELD = new ParseField("phrase_limit");
+    public static final ParseField OPTIONS_FIELD = new ParseField("options");
+    public static final ParseField HIGHLIGHT_QUERY_FIELD = new ParseField("highlight_query");
+    public static final ParseField MATCHED_FIELDS_FIELD = new ParseField("matched_fields");
 
     protected String[] preTags;
 
@@ -347,52 +370,52 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
 
     void commonOptionsToXContent(XContentBuilder builder) throws IOException {
         if (preTags != null) {
-            builder.array("pre_tags", preTags);
+            builder.array(PRE_TAGS_FIELD.getPreferredName(), preTags);
         }
         if (postTags != null) {
-            builder.array("post_tags", postTags);
+            builder.array(POST_TAGS_FIELD.getPreferredName(), postTags);
         }
         if (fragmentSize != null) {
-            builder.field("fragment_size", fragmentSize);
+            builder.field(FRAGMENT_SIZE_FIELD.getPreferredName(), fragmentSize);
         }
         if (numOfFragments != null) {
-            builder.field("number_of_fragments", numOfFragments);
+            builder.field(NUMBER_OF_FRAGMENTS_FIELD.getPreferredName(), numOfFragments);
         }
         if (highlighterType != null) {
-            builder.field("type", highlighterType);
+            builder.field(TYPE_FIELD.getPreferredName(), highlighterType);
         }
         if (fragmenter != null) {
-            builder.field("fragmenter", fragmenter);
+            builder.field(FRAGMENTER_FIELD.getPreferredName(), fragmenter);
         }
         if (highlightQuery != null) {
-            builder.field("highlight_query", highlightQuery);
+            builder.field(HIGHLIGHT_QUERY_FIELD.getPreferredName(), highlightQuery);
         }
         if (order != null) {
-            builder.field("order", order);
+            builder.field(ORDER_FIELD.getPreferredName(), order);
         }
         if (highlightFilter != null) {
-            builder.field("highlight_filter", highlightFilter);
+            builder.field(HIGHLIGHT_FILTER_FIELD.getPreferredName(), highlightFilter);
         }
         if (boundaryMaxScan != null) {
-            builder.field("boundary_max_scan", boundaryMaxScan);
+            builder.field(BOUNDARY_MAX_SCAN_FIELD.getPreferredName(), boundaryMaxScan);
         }
         if (boundaryChars != null) {
-            builder.field("boundary_chars", new String(boundaryChars));
+            builder.field(BOUNDARY_CHARS_FIELD.getPreferredName(), new String(boundaryChars));
         }
         if (options != null && options.size() > 0) {
-            builder.field("options", options);
+            builder.field(OPTIONS_FIELD.getPreferredName(), options);
         }
         if (forceSource != null) {
-            builder.field("force_source", forceSource);
+            builder.field(FORCE_SOURCE_FIELD.getPreferredName(), forceSource);
         }
         if (requireFieldMatch != null) {
-            builder.field("require_field_match", requireFieldMatch);
+            builder.field(REQUIRE_FIELD_MATCH_FIELD.getPreferredName(), requireFieldMatch);
         }
         if (noMatchSize != null) {
-            builder.field("no_match_size", noMatchSize);
+            builder.field(NO_MATCH_SIZE_FIELD.getPreferredName(), noMatchSize);
         }
         if (phraseLimit != null) {
-            builder.field("phrase_limit", phraseLimit);
+            builder.field(PHRASE_LIMIT_FIELD.getPreferredName(), phraseLimit);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/highlight/AbstractHighlighterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/AbstractHighlighterBuilder.java
@@ -377,7 +377,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
             builder.field("boundary_max_scan", boundaryMaxScan);
         }
         if (boundaryChars != null) {
-            builder.field("boundary_chars", boundaryChars);
+            builder.field("boundary_chars", new String(boundaryChars));
         }
         if (options != null && options.size() > 0) {
             builder.field("options", options);

--- a/core/src/main/java/org/elasticsearch/search/highlight/AbstractHighlighterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/AbstractHighlighterBuilder.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * This abstract class holds parameters shared by {@link HighlightBuilder} and {@link HighlightBuilder.Field}
  * and provides the common setters, equality, hashCode calculation and common serialization
  */
-public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterBuilder> {
+public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterBuilder<?>> {
 
     public static final ParseField PRE_TAGS_FIELD = new ParseField("pre_tags");
     public static final ParseField POST_TAGS_FIELD = new ParseField("post_tags");
@@ -72,7 +72,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
 
     protected String fragmenter;
 
-    protected QueryBuilder highlightQuery;
+    protected QueryBuilder<?> highlightQuery;
 
     protected String order;
 
@@ -198,7 +198,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
      * Sets a query to be used for highlighting instead of the search query.
      */
     @SuppressWarnings("unchecked")
-    public HB highlightQuery(QueryBuilder highlightQuery) {
+    public HB highlightQuery(QueryBuilder<?> highlightQuery) {
         this.highlightQuery = highlightQuery;
         return (HB) this;
     }
@@ -206,7 +206,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
     /**
      * @return the value set by {@link #highlightQuery(QueryBuilder)}
      */
-    public QueryBuilder highlightQuery() {
+    public QueryBuilder<?> highlightQuery() {
         return this.highlightQuery;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
@@ -45,6 +45,8 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
 
     public static final HighlightBuilder PROTOTYPE = new HighlightBuilder();
 
+    public static final String HIGHLIGHT_ELEMENT_NAME = "highlight";
+
     private final List<Field> fields = new ArrayList<>();
 
     private String encoder;
@@ -166,7 +168,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject("highlight");
+        builder.startObject(HIGHLIGHT_ELEMENT_NAME);
         innerXContent(builder);
         builder.endObject();
         return builder;
@@ -192,19 +194,19 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
             if (token == XContentParser.Token.FIELD_NAME) {
                 topLevelFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if ("pre_tags".equals(topLevelFieldName) || "preTags".equals(topLevelFieldName)) {
+                if (parseContext.parseFieldMatcher().match(topLevelFieldName, PRE_TAGS_FIELD)) {
                     List<String> preTagsList = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         preTagsList.add(parser.text());
                     }
                     highlightBuilder.preTags(preTagsList.toArray(new String[preTagsList.size()]));
-                } else if ("post_tags".equals(topLevelFieldName) || "postTags".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, POST_TAGS_FIELD)) {
                     List<String> postTagsList = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         postTagsList.add(parser.text());
                     }
                     highlightBuilder.postTags(postTagsList.toArray(new String[postTagsList.size()]));
-                } else if ("fields".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, FIELDS_FIELD)) {
                     highlightBuilder.useExplicitFieldOrder(true);
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token == XContentParser.Token.START_OBJECT) {
@@ -225,39 +227,40 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
                     }
                 }
             } else if (token.isValue()) {
-                if ("order".equals(topLevelFieldName)) {
+                if (parseContext.parseFieldMatcher().match(topLevelFieldName, ORDER_FIELD)) {
                     highlightBuilder.order(parser.text());
-                } else if ("tags_schema".equals(topLevelFieldName) || "tagsSchema".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, TAGS_SCHEMA_FIELD)) {
                     highlightBuilder.tagsSchema(parser.text());
-                } else if ("highlight_filter".equals(topLevelFieldName) || "highlightFilter".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, HIGHLIGHT_FILTER_FIELD)) {
                     highlightBuilder.highlightFilter(parser.booleanValue());
-                } else if ("fragment_size".equals(topLevelFieldName) || "fragmentSize".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, FRAGMENT_SIZE_FIELD)) {
                     highlightBuilder.fragmentSize(parser.intValue());
-                } else if ("number_of_fragments".equals(topLevelFieldName) || "numberOfFragments".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, NUMBER_OF_FRAGMENTS_FIELD)) {
                     highlightBuilder.numOfFragments(parser.intValue());
-                } else if ("encoder".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, ENCODER_FIELD)) {
                     highlightBuilder.encoder(parser.text());
-                } else if ("require_field_match".equals(topLevelFieldName) || "requireFieldMatch".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, REQUIRE_FIELD_MATCH_FIELD)) {
                     highlightBuilder.requireFieldMatch(parser.booleanValue());
-                } else if ("boundary_max_scan".equals(topLevelFieldName) || "boundaryMaxScan".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, BOUNDARY_MAX_SCAN_FIELD)) {
                     highlightBuilder.boundaryMaxScan(parser.intValue());
-                } else if ("boundary_chars".equals(topLevelFieldName) || "boundaryChars".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, BOUNDARY_CHARS_FIELD)) {
                     highlightBuilder.boundaryChars(parser.text().toCharArray());
-                } else if ("type".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, TYPE_FIELD)) {
                     highlightBuilder.highlighterType(parser.text());
-                } else if ("fragmenter".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, FRAGMENTER_FIELD)) {
                     highlightBuilder.fragmenter(parser.text());
-                } else if ("no_match_size".equals(topLevelFieldName) || "noMatchSize".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, NO_MATCH_SIZE_FIELD)) {
                     highlightBuilder.noMatchSize(parser.intValue());
-                } else if ("force_source".equals(topLevelFieldName) || "forceSource".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, FORCE_SOURCE_FIELD)) {
                     highlightBuilder.forceSource(parser.booleanValue());
-                } else if ("phrase_limit".equals(topLevelFieldName) || "phraseLimit".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, PHRASE_LIMIT_FIELD)) {
                     highlightBuilder.phraseLimit(parser.intValue());
                 }
-            } else if (token == XContentParser.Token.START_OBJECT && "options".equals(topLevelFieldName)) {
+            } else if (token == XContentParser.Token.START_OBJECT && topLevelFieldName != null &&
+                    parseContext.parseFieldMatcher().match(topLevelFieldName, OPTIONS_FIELD)) {
                 highlightBuilder.options(parser.map());
-            } else if (token == XContentParser.Token.START_OBJECT) {
-                if ("fields".equals(topLevelFieldName)) {
+            } else if (token == XContentParser.Token.START_OBJECT && topLevelFieldName != null) {
+                if (parseContext.parseFieldMatcher().match(topLevelFieldName, FIELDS_FIELD)) {
                     String highlightFieldName = null;
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         if (token == XContentParser.Token.FIELD_NAME) {
@@ -266,7 +269,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
                             highlightBuilder.field(Field.fromXContent(highlightFieldName, parseContext));
                         }
                     }
-                } else if ("highlight_query".equals(topLevelFieldName) || "highlightQuery".equals(topLevelFieldName)) {
+                } else if (parseContext.parseFieldMatcher().match(topLevelFieldName, HIGHLIGHT_QUERY_FIELD)) {
                     highlightBuilder.highlightQuery(parseContext.parseInnerQueryBuilder());
                 }
             }
@@ -285,13 +288,13 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
         commonOptionsToXContent(builder);
         // special options for top-level highlighter
         if (encoder != null) {
-            builder.field("encoder", encoder);
+            builder.field(ENCODER_FIELD.getPreferredName(), encoder);
         }
         if (fields.size() > 0) {
             if (useExplicitFieldOrder) {
-                builder.startArray("fields");
+                builder.startArray(FIELDS_FIELD.getPreferredName());
             } else {
-                builder.startObject("fields");
+                builder.startObject(FIELDS_FIELD.getPreferredName());
             }
             for (Field field : fields) {
                 if (useExplicitFieldOrder) {
@@ -396,10 +399,10 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
             commonOptionsToXContent(builder);
             // write special field-highlighter options
             if (fragmentOffset != -1) {
-                builder.field("fragment_offset", fragmentOffset);
+                builder.field(FRAGMENT_OFFSET_FIELD.getPreferredName(), fragmentOffset);
             }
             if (matchedFields != null) {
-                builder.field("matched_fields", matchedFields);
+                builder.field(MATCHED_FIELDS_FIELD.getPreferredName(), matchedFields);
             }
             builder.endObject();
         }
@@ -414,19 +417,19 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (token == XContentParser.Token.START_ARRAY) {
-                    if ("pre_tags".equals(currentFieldName) || "preTags".equals(currentFieldName)) {
+                    if (parseContext.parseFieldMatcher().match(currentFieldName, PRE_TAGS_FIELD)) {
                         List<String> preTagsList = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             preTagsList.add(parser.text());
                         }
                         field.preTags(preTagsList.toArray(new String[preTagsList.size()]));
-                    } else if ("post_tags".equals(currentFieldName) || "postTags".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, POST_TAGS_FIELD)) {
                         List<String> postTagsList = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             postTagsList.add(parser.text());
                         }
                         field.postTags(postTagsList.toArray(new String[postTagsList.size()]));
-                    } else if ("matched_fields".equals(currentFieldName) || "matchedFields".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, MATCHED_FIELDS_FIELD)) {
                         List<String> matchedFields = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             matchedFields.add(parser.text());
@@ -434,37 +437,37 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
                         field.matchedFields(matchedFields.toArray(new String[matchedFields.size()]));
                     }
                 } else if (token.isValue()) {
-                    if ("fragment_size".equals(currentFieldName) || "fragmentSize".equals(currentFieldName)) {
+                    if (parseContext.parseFieldMatcher().match(currentFieldName, FRAGMENT_SIZE_FIELD)) {
                         field.fragmentSize(parser.intValue());
-                    } else if ("number_of_fragments".equals(currentFieldName) || "numberOfFragments".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, NUMBER_OF_FRAGMENTS_FIELD)) {
                         field.numOfFragments(parser.intValue());
-                    } else if ("fragment_offset".equals(currentFieldName) || "fragmentOffset".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, FRAGMENT_OFFSET_FIELD)) {
                         field.fragmentOffset(parser.intValue());
-                    } else if ("highlight_filter".equals(currentFieldName) || "highlightFilter".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, HIGHLIGHT_FILTER_FIELD)) {
                         field.highlightFilter(parser.booleanValue());
-                    } else if ("order".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, ORDER_FIELD)) {
                         field.order(parser.text());
-                    } else if ("require_field_match".equals(currentFieldName) || "requireFieldMatch".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, REQUIRE_FIELD_MATCH_FIELD)) {
                         field.requireFieldMatch(parser.booleanValue());
-                    } else if ("boundary_max_scan".equals(currentFieldName) || "boundaryMaxScan".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, BOUNDARY_MAX_SCAN_FIELD)) {
                         field.boundaryMaxScan(parser.intValue());
-                    } else if ("boundary_chars".equals(currentFieldName) || "boundaryChars".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, BOUNDARY_CHARS_FIELD)) {
                         field.boundaryChars(parser.text().toCharArray());
-                    } else if ("type".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, TYPE_FIELD)) {
                         field.highlighterType(parser.text());
-                    } else if ("fragmenter".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, FRAGMENTER_FIELD)) {
                         field.fragmenter(parser.text());
-                    } else if ("no_match_size".equals(currentFieldName) || "noMatchSize".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, NO_MATCH_SIZE_FIELD)) {
                         field.noMatchSize(parser.intValue());
-                    } else if ("force_source".equals(currentFieldName) || "forceSource".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, FORCE_SOURCE_FIELD)) {
                         field.forceSource(parser.booleanValue());
-                    } else if ("phrase_limit".equals(currentFieldName) || "phraseLimit".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, PHRASE_LIMIT_FIELD)) {
                         field.phraseLimit(parser.intValue());
                     }
-                } else if (token == XContentParser.Token.START_OBJECT) {
-                    if ("highlight_query".equals(currentFieldName) || "highlightQuery".equals(currentFieldName)) {
+                } else if (token == XContentParser.Token.START_OBJECT && currentFieldName != null) {
+                    if (parseContext.parseFieldMatcher().match(currentFieldName, HIGHLIGHT_QUERY_FIELD)) {
                         field.highlightQuery(parseContext.parseInnerQueryBuilder());
-                    } else if ("options".equals(currentFieldName)) {
+                    } else if (parseContext.parseFieldMatcher().match(currentFieldName, OPTIONS_FIELD)) {
                         field.options(parser.map());
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/HighlightBuilder.java
@@ -278,6 +278,8 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "cannot parse object with name [{}]", topLevelFieldName);
                 }
+            } else if (topLevelFieldName != null) {
+                throw new ParsingException(parser.getTokenLocation(), "unexpected token [{}] after [{}]", token, topLevelFieldName);
             }
         }
 
@@ -482,6 +484,8 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
                     } else {
                         throw new ParsingException(parser.getTokenLocation(), "cannot parse object with name [{}]", currentFieldName);
                     }
+                } else if (currentFieldName != null) {
+                    throw new ParsingException(parser.getTokenLocation(), "unexpected token [{}] after [{}]", token, currentFieldName);
                 }
             }
             return field;

--- a/core/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -58,7 +58,7 @@ public class HighlighterParseElement implements SearchParseElement {
     public static final boolean DEFAULT_REQUIRE_FIELD_MATCH = true;
     /** default for whether <tt>fvh</tt> should provide highlighting on filter clauses */
     public static final boolean DEFAULT_HIGHLIGHT_FILTER = false;
-    /** default for highlight fragments being ordered by score */ 
+    /** default for highlight fragments being ordered by score */
     public static final boolean DEFAULT_SCORE_ORDERED = false;
     /** the default encoder setting */
     public static final String DEFAULT_ENCODER = "default";
@@ -74,7 +74,7 @@ public class HighlighterParseElement implements SearchParseElement {
     public static final String[] DEFAULT_PRE_TAGS = new String[]{"<em>"};
     /** the default closing tag  */
     public static final String[] DEFAULT_POST_TAGS = new String[]{"</em>"};
-    
+
     /** the default opening tags when <tt>tag_schema = "styled"</tt>  */
     public static final String[] STYLED_PRE_TAG = {
             "<em class=\"hlt1\">", "<em class=\"hlt2\">", "<em class=\"hlt3\">",
@@ -94,7 +94,7 @@ public class HighlighterParseElement implements SearchParseElement {
         }
     }
 
-    public static SearchContextHighlight parse(XContentParser parser, QueryShardContext queryShardContext) throws IOException {
+    public SearchContextHighlight parse(XContentParser parser, QueryShardContext queryShardContext) throws IOException {
         XContentParser.Token token;
         String topLevelFieldName = null;
         final List<Tuple<String, SearchContextHighlight.FieldOptions.Builder>> fieldsOptions = new ArrayList<>();

--- a/core/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -94,7 +94,7 @@ public class HighlighterParseElement implements SearchParseElement {
         }
     }
 
-    public SearchContextHighlight parse(XContentParser parser, QueryShardContext queryShardContext) throws IOException {
+    public static SearchContextHighlight parse(XContentParser parser, QueryShardContext queryShardContext) throws IOException {
         XContentParser.Token token;
         String topLevelFieldName = null;
         final List<Tuple<String, SearchContextHighlight.FieldOptions.Builder>> fieldsOptions = new ArrayList<>();
@@ -211,7 +211,7 @@ public class HighlighterParseElement implements SearchParseElement {
         return new SearchContextHighlight(fields);
     }
 
-    protected SearchContextHighlight.FieldOptions.Builder parseFields(XContentParser parser, QueryShardContext queryShardContext) throws IOException {
+    private static SearchContextHighlight.FieldOptions.Builder parseFields(XContentParser parser, QueryShardContext queryShardContext) throws IOException {
         XContentParser.Token token;
 
         final SearchContextHighlight.FieldOptions.Builder fieldOptionsBuilder = new SearchContextHighlight.FieldOptions.Builder();

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.highlight;
 
+import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -130,6 +131,7 @@ public class HighlightBuilderTests extends ESTestCase {
      */
     public void testFromXContent() throws IOException {
         QueryParseContext context = new QueryParseContext(indicesQueriesRegistry);
+        context.parseFieldMatcher(new ParseFieldMatcher(Settings.EMPTY));
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
             HighlightBuilder highlightBuilder = randomHighlighterBuilder();
             XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
@@ -155,6 +157,7 @@ public class HighlightBuilderTests extends ESTestCase {
      */
     public void testParsingTagsSchema() throws IOException {
         QueryParseContext context = new QueryParseContext(indicesQueriesRegistry);
+        context.parseFieldMatcher(new ParseFieldMatcher(Settings.EMPTY));
         String highlightElement = "{\n" +
                 "    \"tags_schema\" : \"styled\"\n" +
                 "}\n";

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
@@ -23,10 +23,23 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.IdsQueryBuilder;
+import org.elasticsearch.index.query.IdsQueryParser;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryParser;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryParser;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.query.TermQueryParser;
+import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.search.highlight.HighlightBuilder.Field;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.AfterClass;
@@ -35,8 +48,10 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -45,23 +60,26 @@ public class HighlightBuilderTests extends ESTestCase {
 
     private static final int NUMBER_OF_TESTBUILDERS = 20;
     private static NamedWriteableRegistry namedWriteableRegistry;
+    private static IndicesQueriesRegistry indicesQueriesRegistry;
 
     /**
      * setup for the whole base test class
      */
     @BeforeClass
     public static void init() {
-        if (namedWriteableRegistry == null) {
-            namedWriteableRegistry = new NamedWriteableRegistry();
-            namedWriteableRegistry.registerPrototype(QueryBuilder.class, new MatchAllQueryBuilder());
-            namedWriteableRegistry.registerPrototype(QueryBuilder.class, new IdsQueryBuilder());
-            namedWriteableRegistry.registerPrototype(QueryBuilder.class, new TermQueryBuilder("field", "value"));
-        }
+        namedWriteableRegistry = new NamedWriteableRegistry();
+        @SuppressWarnings("rawtypes")
+        Set<QueryParser> injectedQueryParsers = new HashSet<>();
+        injectedQueryParsers.add(new MatchAllQueryParser());
+        injectedQueryParsers.add(new IdsQueryParser());
+        injectedQueryParsers.add(new TermQueryParser());
+        indicesQueriesRegistry = new IndicesQueriesRegistry(Settings.settingsBuilder().build(), injectedQueryParsers, namedWriteableRegistry);
     }
 
     @AfterClass
     public static void afterClass() throws Exception {
         namedWriteableRegistry = null;
+        indicesQueriesRegistry = null;
     }
 
     /**
@@ -108,6 +126,83 @@ public class HighlightBuilderTests extends ESTestCase {
     }
 
     /**
+     * Generic test that creates new highlighter from the test highlighter and checks both for equality
+     */
+    public void testFromXContent() throws IOException {
+        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry);
+        for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
+            HighlightBuilder highlightBuilder = randomHighlighterBuilder();
+            XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+            if (randomBoolean()) {
+                builder.prettyPrint();
+            }
+            builder.startObject();
+            highlightBuilder.innerXContent(builder);
+            builder.endObject();
+
+            XContentParser parser = XContentHelper.createParser(builder.bytes());
+            context.reset(parser);
+            HighlightBuilder secondHighlightBuilder = HighlightBuilder.fromXContent(context);
+            assertNotSame(highlightBuilder, secondHighlightBuilder);
+            assertEquals(highlightBuilder, secondHighlightBuilder);
+            assertEquals(highlightBuilder.hashCode(), secondHighlightBuilder.hashCode());
+        }
+    }
+
+    /**
+     * `tags_schema` is not produced by toXContent in the builder but should be parseable, so this
+     * adds a simple json test for this.
+     */
+    public void testParsingTagsSchema() throws IOException {
+        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry);
+        String highlightElement = "{\n" +
+                "    \"tags_schema\" : \"styled\"\n" +
+                "}\n";
+        XContentParser parser = XContentFactory.xContent(highlightElement).createParser(highlightElement);
+
+        context.reset(parser);
+        HighlightBuilder highlightBuilder = HighlightBuilder.fromXContent(context);
+        assertArrayEquals("setting tags_schema 'styled' should alter pre_tags", HighlighterParseElement.STYLED_PRE_TAG,
+                highlightBuilder.preTags());
+        assertArrayEquals("setting tags_schema 'styled' should alter post_tags", HighlighterParseElement.STYLED_POST_TAGS,
+                highlightBuilder.postTags());
+
+        highlightElement = "{\n" +
+                "    \"tags_schema\" : \"default\"\n" +
+                "}\n";
+        parser = XContentFactory.xContent(highlightElement).createParser(highlightElement);
+
+        context.reset(parser);
+        highlightBuilder = HighlightBuilder.fromXContent(context);
+        assertArrayEquals("setting tags_schema 'default' should alter pre_tags", HighlighterParseElement.DEFAULT_PRE_TAGS,
+                highlightBuilder.preTags());
+        assertArrayEquals("setting tags_schema 'default' should alter post_tags", HighlighterParseElement.DEFAULT_POST_TAGS,
+                highlightBuilder.postTags());
+
+        highlightElement = "{\n" +
+                "    \"tags_schema\" : \"somthing_else\"\n" +
+                "}\n";
+        parser = XContentFactory.xContent(highlightElement).createParser(highlightElement);
+
+        context.reset(parser);
+        try {
+            highlightBuilder = HighlightBuilder.fromXContent(context);
+            fail("setting unknown tag schema should throw exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Unknown tag schema [somthing_else]", e.getMessage());
+        }
+    }
+
+    protected static XContentBuilder toXContent(HighlightBuilder highlight, XContentType contentType) throws IOException {
+        XContentBuilder builder = XContentFactory.contentBuilder(contentType);
+        if (randomBoolean()) {
+            builder.prettyPrint();
+        }
+        highlight.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return builder;
+    }
+
+    /**
      * create random shape that is put under test
      */
     private static HighlightBuilder randomHighlighterBuilder() {
@@ -132,11 +227,11 @@ public class HighlightBuilderTests extends ESTestCase {
         return testHighlighter;
     }
 
+    @SuppressWarnings("rawtypes")
     private static void setRandomCommonOptions(AbstractHighlighterBuilder highlightBuilder) {
         if (randomBoolean()) {
+            // need to set this together, otherwise parsing will complain
             highlightBuilder.preTags(randomStringArray(0, 3));
-        }
-        if (randomBoolean()) {
             highlightBuilder.postTags(randomStringArray(0, 3));
         }
         if (randomBoolean()) {
@@ -213,7 +308,7 @@ public class HighlightBuilderTests extends ESTestCase {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private static void mutateCommonOptions(AbstractHighlighterBuilder highlightBuilder) {
         switch (randomIntBetween(1, 16)) {
         case 1:
@@ -242,6 +337,7 @@ public class HighlightBuilderTests extends ESTestCase {
             break;
         case 9:
             highlightBuilder.highlightFilter(toggleOrSet(highlightBuilder.highlightFilter()));
+            break;
         case 10:
             highlightBuilder.forceSource(toggleOrSet(highlightBuilder.forceSource()));
             break;
@@ -316,6 +412,7 @@ public class HighlightBuilderTests extends ESTestCase {
                             fieldToChange.matchedFields(randomStringArray(5, 10));
                         }
                     }
+                    break;
             }
         }
         return mutation;


### PR DESCRIPTION
For the search refactoring the HighlightBuilder needs a way to create new instances by parsing xContent. For bwc this PR start by moving over and slightly modifying the parsing from HighlighterParseElement and keeps parsing for top level highlighter and field options separate. Also adding tests for roundtrip of random builder (rendering it to xContent and parsing it and making sure the original builder properties are preserved).
