### PR TITLE
Make rename processor less error prone

### DIFF
--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -33,7 +33,8 @@ Removes one or more existing fields. If a field doesn't exist, nothing will happ
 --------------------------------------------------
 
 ==== Rename processor
-Renames one or more existing fields. If a field doesn't exist, an exception will be thrown.
+Renames one or more existing fields. If a field doesn't exist, an exception will be thrown. Also the new field
+name must not exist.
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Rename processor now checks whether the field to rename exists and throws exception if it doesn't. It also checks that the new field to rename to doesn't exist yet, and throws exception otherwise. Also we make sure that the rename operation is atomic, otherwise things may break between the remove and the set and we'd leave the document in an inconsistent state.

Note that the requirement for the new field name to not exist simplifies the usecase for e.g. { "rename" : { "list.1": "list.2"} } as such a rename wouldn't be accepted if list is actually a list given that either list.2 already exists or the index is out of bounds for the existing list. If one really wants to replace an existing field, that field needs to be removed first through remove processor and then rename can be used.
