### PR TITLE
Enable es_include at init

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -107,6 +107,7 @@ export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
 export ES_GC_LOG_FILE
 export JAVA_HOME
+export ES_INCLUDE
 
 # Check DAEMON exists
 test -x $DAEMON || exit 0

--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -66,6 +66,7 @@ export ES_JAVA_OPTS
 export ES_GC_LOG_FILE
 export ES_STARTUP_SLEEP_TIME
 export JAVA_HOME
+export ES_INCLUDE
 
 lockfile=/var/lock/subsys/$prog
 


### PR DESCRIPTION
`es_include` is not exported at init so it is not loaded from the right /etc/default/elasticsearch when users have custom default files causing gc.log file not to load. 
