### PR TITLE
[Ingest] The geoip processor should only try to read *.mmdb files from the geoip config directory

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/geoip/GeoIpProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/geoip/GeoIpProcessor.java
@@ -35,15 +35,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.*;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.ingest.processor.ConfigurationUtils.readList;
 import static org.elasticsearch.ingest.processor.ConfigurationUtils.readOptionalList;
 import static org.elasticsearch.ingest.processor.ConfigurationUtils.readStringProperty;
 
@@ -231,11 +228,12 @@ public final class GeoIpProcessor implements Processor {
 
             try (Stream<Path> databaseFiles = Files.list(geoIpConfigDirectory)) {
                 Map<String, DatabaseReader> databaseReaders = new HashMap<>();
+                PathMatcher pathMatcher = geoIpConfigDirectory.getFileSystem().getPathMatcher("glob:**.mmdb");
                 // Use iterator instead of forEach otherwise IOException needs to be caught twice...
                 Iterator<Path> iterator = databaseFiles.iterator();
                 while (iterator.hasNext()) {
                     Path databasePath = iterator.next();
-                    if (Files.isRegularFile(databasePath)) {
+                    if (Files.isRegularFile(databasePath) && pathMatcher.matches(databasePath)) {
                         try (InputStream inputStream = Files.newInputStream(databasePath, StandardOpenOption.READ)) {
                             databaseReaders.put(databasePath.getFileName().toString(), new DatabaseReader.Builder(inputStream).build());
                         }


### PR DESCRIPTION
This build failure is caused by the fact this processor tries to read all files in the config directory:
http://build-us-00.elastic.co/job/es_feature_ingest/2948/

The test framework adds extra files in temp directories to see if code is able to handle that. This is common on certain operation systems (like: .DS_Store, thumbs.db, .nfsXXX files). (see ExtrasFS)
