### PR TITLE
Add nicer error message when a plugin descriptor is missing

### DIFF
--- a/core/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -26,6 +26,8 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.test.ESTestCase;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 public class PluginsServiceTests extends ESTestCase {
@@ -121,6 +123,17 @@ public class PluginsServiceTests extends ESTestCase {
         } catch (ElasticsearchException ex) {
             assertEquals("failed to invoke onModule", ex.getMessage());
             assertEquals("boom", ex.getCause().getCause().getMessage());
+        }
+    }
+
+    public void testExistingPluginMissingDescriptor() throws Exception {
+        Path pluginsDir = createTempDir();
+        Files.createDirectory(pluginsDir.resolve("plugin-missing-descriptor"));
+        try {
+            PluginsService.getPluginBundles(pluginsDir);
+            fail();
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("[plugin-missing-descriptor] missing plugin descriptor"));
         }
     }
 }


### PR DESCRIPTION
Currently, when a user tries to install an old plugin (pre 2.x) on a 2.x
node, the error message is cryptic (just printing the file path that was
missing, when looking for the descriptor). This improves the message to
be more explicit that the descriptor is missing, and suggests the
problem might be the plugin was built before 2.0.

closes #15197
