### PR TITLE
Improve / Fix Inaccurate Transport Sniffing Docs

### DIFF
--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -175,17 +175,19 @@ Or using `elasticsearch.yml` file as shown in <<node-client>>
 
 The Transport client comes with a cluster sniffing feature which
 allows it to dynamically add new hosts and remove old ones.
-When sniffing is enabled the nodes specified during client construction via
-addTransportAddress are connected to first. After this, the client will search
-the cluster state for available data nodes, replacing its internal node list
-with only those data nodes. This list is refreshed every five seconds by default.
-Note that the IP addresses the sniffer connects to are the ones that the
-other nodes were started with (the "publish" address).
+When sniffing is enabled the the transport client will connect to the nodes in its
+internal node list, which is built via calls to addTransportAddres.
+After this, the client will call the internal cluster state API on those nodes
+to discover available data nodes. The internal node list of the client will
+be replaced with those data nodes only. This list is refreshed every five seconds by default.
+Note that the IP addresses the sniffer connects to are the ones declared as the 'publish'
+address in those node's elasticsearch config.
 
 Keep in mind that list might possibly not include the original node it connected to
 if that node is not a data node. If, for instance, you initially connect to a
 master node, after sniffing no further requests will go to that master node,
-but rather to any data nodes instead.
+but rather to any data nodes instead. The reason the transport excludes non-data
+nodes is to avoid sending search traffic to master only nodes.
 
 In order to enable sniffing, set `client.transport.sniff` to `true`:
 

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -173,11 +173,21 @@ Client client = TransportClient.builder().settings(settings).build();
 
 Or using `elasticsearch.yml` file as shown in <<node-client>>
 
-The client allows sniffing the rest of the cluster, which adds data nodes
-into its list of machines to use. In this case, note that the IP addresses
-used will be the ones that the other nodes were started with (the
-"publish" address). In order to enable it, set the
-`client.transport.sniff` to `true`:
+The Transport client comes with a cluster sniffing feature which
+allows it to dynamically add new hosts and remove old ones.
+When sniffing is enabled the nodes specified during client construction via
+addTransportAddress are connected to first. After this, the client will search
+the cluster state for available data nodes, replacing its internal node list
+with only those data nodes. This list is refreshed every five seconds by default.
+Note that the IP addresses the sniffer connects to are the ones that the
+other nodes were started with (the "publish" address).
+
+Keep in mind that list might possibly not include the original node it connected to
+if that node is not a data node. If, for instance, you initially connect to a
+master node, after sniffing no further requests will go to that master node,
+but rather to any data nodes instead.
+
+In order to enable sniffing, set `client.transport.sniff` to `true`:
 
 [source,java]
 --------------------------------------------------

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -176,7 +176,7 @@ Or using `elasticsearch.yml` file as shown in <<node-client>>
 The Transport client comes with a cluster sniffing feature which
 allows it to dynamically add new hosts and remove old ones.
 When sniffing is enabled the the transport client will connect to the nodes in its
-internal node list, which is built via calls to addTransportAddres.
+internal node list, which is built via calls to addTransportAddress.
 After this, the client will call the internal cluster state API on those nodes
 to discover available data nodes. The internal node list of the client will
 be replaced with those data nodes only. This list is refreshed every five seconds by default.


### PR DESCRIPTION
The current transport sniffing docs imply that sniffing only adds nodes to the current node list. After discussing this with @ywelsch and @polyfractal it appears that is incorrect, and that the node list is fully replaced with data nodes. This new documentation reflects that.

I have yet to functionally verify that this works as described, but the [code](https://github.com/elastic/elasticsearch/blob/2.1/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java#L483) @ywelsch linked me to seems to clearly replace the values.
