### PR TITLE
Plugin: List commercial plugins that can be installed by referring to…

### DIFF
--- a/core/src/main/resources/org/elasticsearch/plugins/plugin-install.help
+++ b/core/src/main/resources/org/elasticsearch/plugins/plugin-install.help
@@ -53,6 +53,10 @@ OFFICIAL PLUGINS
     - repository-azure
     - repository-s3
     - store-smb
+    - license
+    - marvel
+    - shield
+    - watcher
 
 
 OPTIONS


### PR DESCRIPTION
… their name as well.

This is listed when running `bin/plugin install -h`...
