### PR TITLE
Ignore RejectedExecutionException in NodesFaultDetection

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/fd/NodesFaultDetection.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
@@ -41,7 +42,7 @@ import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.new
 public class NodesFaultDetection extends FaultDetection {
 
     public static final String PING_ACTION_NAME = "internal:discovery/zen/fd/ping";
-    
+
     public abstract static class Listener {
 
         public void onNodeFailure(DiscoveryNode node, String reason) {}
@@ -145,14 +146,18 @@ public class NodesFaultDetection extends FaultDetection {
     }
 
     private void notifyNodeFailure(final DiscoveryNode node, final String reason) {
-        threadPool.generic().execute(new Runnable() {
-            @Override
-            public void run() {
-                for (Listener listener : listeners) {
-                    listener.onNodeFailure(node, reason);
+        try {
+            threadPool.generic().execute(new Runnable() {
+                @Override
+                public void run() {
+                    for (Listener listener : listeners) {
+                        listener.onNodeFailure(node, reason);
+                    }
                 }
-            }
-        });
+            });
+        } catch (EsRejectedExecutionException ex) {
+            logger.trace("[node  ] [{}] ignoring node failure (reason [{}]). Local node is shutting down", ex, node, reason);
+        }
     }
 
     private void notifyPingReceived(final PingRequest pingRequest) {


### PR DESCRIPTION
Test failure: http://build-us-00.elastic.co/job/es_core_master_strong/5680/

Interesting log lines:

```
WARNING: Uncaught exception in thread: Thread[elasticsearch[node_t0][generic][T#4],5,TGRP-RareClusterStateIT]
EsRejectedExecutionException[rejected execution of org.elasticsearch.discovery.zen.fd.NodesFaultDetection$1@406bad99 on EsThreadPoolExecutor[generic, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@51f591fd[Shutting down, pool size = 3, active threads = 3, queued tasks = 0, completed tasks = 42]]]
    at __randomizedtesting.SeedInfo.seed([A9A984299976420]:0)
    at org.elasticsearch.common.util.concurrent.EsAbortPolicy.rejectedExecution(EsAbortPolicy.java:50)
    at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:823)
    at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1369)
    at org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor.execute(EsThreadPoolExecutor.java:85)
    at org.elasticsearch.discovery.zen.fd.NodesFaultDetection.notifyNodeFailure(NodesFaultDetection.java:148)
    at org.elasticsearch.discovery.zen.fd.NodesFaultDetection.handleTransportDisconnect(NodesFaultDetection.java:143)
    at org.elasticsearch.discovery.zen.fd.NodesFaultDetection$NodeFD$1.handleException(NodesFaultDetection.java:213)
    at org.elasticsearch.transport.TransportService$3.run(TransportService.java:327)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)

dets 02, 2015 3:53:09 PM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
```

Reason: Race between threadpools shutting down and NodesFaultDetection still receiving node disconnect event. It's not an issue for production. Test infrastructure just complains that exception was not caught.

How to reproduce error: Add Thread.sleep(1000) as first statement to `NodesFaultDetection.notifyNodeFailure()`.
