### PR TITLE
Remove `GET` option for /_forcemerge

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/forcemerge/RestForceMergeAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/forcemerge/RestForceMergeAction.java
@@ -45,9 +45,6 @@ public class RestForceMergeAction extends BaseRestHandler {
         super(settings, controller, client);
         controller.registerHandler(POST, "/_forcemerge", this);
         controller.registerHandler(POST, "/{index}/_forcemerge", this);
-
-        controller.registerHandler(GET, "/_forcemerge", this);
-        controller.registerHandler(GET, "/{index}/_forcemerge", this);
     }
 
     @Override

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -90,6 +90,9 @@ The search exists api has been removed in favour of using the search api with
 The deprecated `/_optimize` endpoint has been removed. The `/_forcemerge`
 endpoint should be used in lieu of optimize.
 
+The `GET` HTTP verb for `/_forcemerge` is no longer supported, please use the
+`POST` HTTP verb.
+
 ==== Deprecated queries removed
 
 The following deprecated queries have been removed:

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -1,7 +1,7 @@
 {
   "indices.forcemerge": {
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html",
-    "methods": ["POST", "GET"],
+    "methods": ["POST"],
     "url": {
       "path": "/_forcemerge",
       "paths": ["/_forcemerge", "/{index}/_forcemerge"],


### PR DESCRIPTION
POST should be used to indicate this is not just a retrieval operation.

Resolves #15165
