### PR TITLE
Cli tools: Use toString instead of getMessage for exceptions

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/cli/Terminal.java
+++ b/core/src/main/java/org/elasticsearch/common/cli/Terminal.java
@@ -116,7 +116,7 @@ public abstract class Terminal {
     }
 
     public void printError(Throwable t) {
-        printError("%s", t.getMessage());
+        printError("%s", t.toString());
         if (isDebugEnabled) {
             printStackTrace(t);
         }

--- a/core/src/test/java/org/elasticsearch/common/cli/TerminalTests.java
+++ b/core/src/test/java/org/elasticsearch/common/cli/TerminalTests.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.common.cli;
 
+import java.nio.file.NoSuchFileException;
+import java.util.List;
+
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -44,10 +47,28 @@ public class TerminalTests extends CliToolTestCase {
         assertPrinted(terminal, Terminal.Verbosity.VERBOSE, "text");
     }
 
+    public void testError() throws Exception {
+        try {
+            // actually throw so we have a stacktrace
+            throw new NoSuchFileException("/path/to/some/file");
+        } catch (NoSuchFileException e) {
+            CaptureOutputTerminal terminal = new CaptureOutputTerminal(Terminal.Verbosity.NORMAL);
+            terminal.printError(e);
+            List<String> output = terminal.getTerminalOutput();
+            assertFalse(output.isEmpty());
+            assertTrue(output.get(0), output.get(0).contains("NoSuchFileException")); // exception class
+            assertTrue(output.get(0), output.get(0).contains("/path/to/some/file")); // message
+            assertEquals(1, output.size());
+
+            // TODO: we should test stack trace is printed in debug mode...except debug is a sysprop instead of
+            // a command line param...maybe it should be VERBOSE instead of a separate debug prop?
+        }
+    }
+
     private void assertPrinted(CaptureOutputTerminal logTerminal, Terminal.Verbosity verbosity, String text) {
         logTerminal.print(verbosity, text);
         assertThat(logTerminal.getTerminalOutput(), hasSize(1));
-        assertThat(logTerminal.getTerminalOutput(), hasItem(is("text")));
+        assertThat(logTerminal.getTerminalOutput(), hasItem(text));
         logTerminal.terminalOutput.clear();
     }
 


### PR DESCRIPTION
When not in debug mode, we currently only print the message of an
exception. However, this is not usually useful without knowing what the
exception type was. This change makes cli tools use toString() on the
exception so we get the type + message.
