### PR TITLE
disable_allocation was replaced by enable

### DIFF
--- a/docs/reference/setup/backup.asciidoc
+++ b/docs/reference/setup/backup.asciidoc
@@ -50,7 +50,7 @@ while the backup is in process:
 PUT /_cluster/settings
 {
   "transient": {
-    "cluster.routing.allocation.disable_allocation": "true"
+    "cluster.routing.allocation.enable": "none"
   }
 }
 -----------------------------------
@@ -79,7 +79,7 @@ PUT /_all/_settings
 PUT /_cluster/settings
 {
   "transient": {
-    "cluster.routing.allocation.disable_allocation": "false"
+    "cluster.routing.allocation.enable": "all"
   }
 }
 -----------------------------------


### PR DESCRIPTION
The cluster.routing.allocation settings (disable_allocation, disable_new_allocation and disable_replica_location) have been replaced by the single setting
