### PR TITLE
Cli tools: Use verbose flag for printing stack trace instead of a system property

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/cli/Terminal.java
+++ b/core/src/main/java/org/elasticsearch/common/cli/Terminal.java
@@ -31,16 +31,14 @@ import java.util.Locale;
 @SuppressForbidden(reason = "System#out")
 public abstract class Terminal {
 
-    public static final String DEBUG_SYSTEM_PROPERTY = "es.cli.debug";
-
     public static final Terminal DEFAULT = ConsoleTerminal.supported() ? new ConsoleTerminal() : new SystemTerminal();
 
-    public static enum Verbosity {
+    public enum Verbosity {
         SILENT(0), NORMAL(1), VERBOSE(2);
 
         private final int level;
 
-        private Verbosity(int level) {
+        Verbosity(int level) {
             this.level = level;
         }
 
@@ -60,7 +58,6 @@ public abstract class Terminal {
     }
 
     private Verbosity verbosity = Verbosity.NORMAL;
-    private final boolean isDebugEnabled;
 
     public Terminal() {
         this(Verbosity.NORMAL);
@@ -68,7 +65,6 @@ public abstract class Terminal {
 
     public Terminal(Verbosity verbosity) {
         this.verbosity = verbosity;
-        this.isDebugEnabled = "true".equals(System.getProperty(DEBUG_SYSTEM_PROPERTY, "false"));
     }
 
     public void verbosity(Verbosity verbosity) {
@@ -116,9 +112,12 @@ public abstract class Terminal {
     }
 
     public void printError(Throwable t) {
-        printError("%s", t.toString());
-        if (isDebugEnabled) {
+
+        if (this.verbosity.enabled(Verbosity.VERBOSE)) {
             printStackTrace(t);
+        } else {
+            printError(t.toString());
+            printError("The stacktrace was omitted. Use -v to see it.");
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/common/cli/TerminalTests.java
+++ b/core/src/test/java/org/elasticsearch/common/cli/TerminalTests.java
@@ -26,9 +26,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-/**
- *
- */
 public class TerminalTests extends CliToolTestCase {
     public void testVerbosity() throws Exception {
         CaptureOutputTerminal terminal = new CaptureOutputTerminal(Terminal.Verbosity.SILENT);
@@ -58,10 +55,17 @@ public class TerminalTests extends CliToolTestCase {
             assertFalse(output.isEmpty());
             assertTrue(output.get(0), output.get(0).contains("NoSuchFileException")); // exception class
             assertTrue(output.get(0), output.get(0).contains("/path/to/some/file")); // message
-            assertEquals(1, output.size());
+            assertEquals("missing stacktrace warning", 2, output.size());
+            assertTrue(output.get(1).contains("The stacktrace was omitted"));
 
-            // TODO: we should test stack trace is printed in debug mode...except debug is a sysprop instead of
-            // a command line param...maybe it should be VERBOSE instead of a separate debug prop?
+            terminal = new CaptureOutputTerminal(Terminal.Verbosity.VERBOSE);
+            terminal.printError(e);
+            output = terminal.getTerminalOutput();
+            assertFalse(output.isEmpty());
+            assertTrue(output.get(0), output.get(0).contains("NoSuchFileException")); // exception class
+            assertTrue(output.get(0), output.get(0).contains("/path/to/some/file")); // message
+            assertTrue(output.get(0), output.get(0).contains(TerminalTests.class.getPackage().getName()));
+            assertEquals(1, output.size()); // stack trace shows up in one "line" (just one string in the capture list)
         }
     }
 


### PR DESCRIPTION
Cli tools currently have a special system property the look for to
indicate whether error should have their stack trace printed. It is the
only use of this "debug" property, and confusing (and more work for the
user to set it). This change reuses the existing verbose mode for
printing stack traces, and removes the debug property. If someone says
they want verbose output, that includes stack traces.
