### PR TITLE
Simplify shard inactive logging

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1034,7 +1034,7 @@ public class IndexShard extends AbstractIndexShardComponent {
             boolean wasActive = active.getAndSet(false);
             if (wasActive) {
                 updateBufferSize(IndexingMemoryController.INACTIVE_SHARD_INDEXING_BUFFER, IndexingMemoryController.INACTIVE_SHARD_TRANSLOG_BUFFER);
-                logger.debug("shard is now inactive");
+                logger.debug("marking shard as inactive (inactive_time=[{}]) indexing wise", inactiveTime);
                 indexEventListener.onShardInactive(this);
             }
         }

--- a/core/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
+++ b/core/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
@@ -292,13 +292,7 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
      */
     protected boolean checkIdle(IndexShard shard) {
         try {
-            boolean idle = shard.checkIdle();
-            if (idle && logger.isDebugEnabled()) {
-                logger.debug("marking shard {} as inactive (inactive_time[{}]) indexing wise",
-                    shard.shardId(),
-                    shard.getInactiveTime());
-            }
-            return idle;
+            return shard.checkIdle();
         } catch (EngineClosedException | FlushNotAllowedEngineException e) {
             logger.trace("ignore [{}] while marking shard {} as inactive", e.getClass().getSimpleName(), shard.shardId());
             return true;

--- a/core/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
+++ b/core/src/main/java/org/elasticsearch/indices/memory/IndexingMemoryController.java
@@ -254,7 +254,6 @@ public class IndexingMemoryController extends AbstractLifecycleComponent<Indexin
             // is actually using (using IW.ramBytesUsed), so that small indices (e.g. Marvel) would not
             // get the same indexing buffer as large indices.  But it quickly gets tricky...
             if (activeShardCount == 0) {
-                logger.debug("no active shards");
                 return;
             }
 


### PR DESCRIPTION
This commit simplifies shard inactive debug logging to only log when the
physical shard is marked as inactive. This eliminates duplicate logging
that existed in IndexShard#checkIdle and
IndexingMemoryController#checkIdle, and eliminates excessive logging
that was occurring when the shard was already inactive as a result of
the work in #15252.
