### PR TITLE
Filter classes loaded by scripts

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/ClassPermission.java
+++ b/core/src/main/java/org/elasticsearch/script/ClassPermission.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import java.security.BasicPermission;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Checked by scripting engines to allow loading a java class.
+ * <p>
+ * Examples:
+ * <p>
+ * Allow permission to {@code java.util.List}
+ * <pre>permission org.elasticsearch.script.ClassPermission "java.util.List";</pre>
+ * Allow permission to classes underneath {@code java.util} (and its subpackages such as {@code java.util.zip})
+ * <pre>permission org.elasticsearch.script.ClassPermission "java.util.*";</pre>
+ * Allow permission to standard predefined list of basic classes (see list below)
+ * <pre>permission org.elasticsearch.script.ClassPermission "&lt;&lt;STANDARD&gt;&gt;";</pre>
+ * Allow permission to all classes
+ * <pre>permission org.elasticsearch.script.ClassPermission "*";</pre>
+ * <p>
+ * Set of classes (allowed by special value <code>&lt;&lt;STANDARD&gt;&gt;</code>):
+ * <ul>
+ *   <li>{@link java.lang.Boolean}</li>
+ *   <li>{@link java.lang.Byte}</li>
+ *   <li>{@link java.lang.Character}</li>
+ *   <li>{@link java.lang.Double}</li>
+ *   <li>{@link java.lang.Integer}</li>
+ *   <li>{@link java.lang.Long}</li>
+ *   <li>{@link java.lang.Math}</li>
+ *   <li>{@link java.lang.Object}</li>
+ *   <li>{@link java.lang.Short}</li>
+ *   <li>{@link java.lang.String}</li>
+ *   <li>{@link java.math.BigDecimal}</li>
+ *   <li>{@link java.util.ArrayList}</li>
+ *   <li>{@link java.util.Arrays}</li>
+ *   <li>{@link java.util.Date}</li>
+ *   <li>{@link java.util.HashMap}</li>
+ *   <li>{@link java.util.HashSet}</li>
+ *   <li>{@link java.util.Iterator}</li>
+ *   <li>{@link java.util.List}</li>
+ *   <li>{@link java.util.Map}</li>
+ *   <li>{@link java.util.Set}</li>
+ *   <li>{@link java.util.UUID}</li>
+ *   <li>{@link org.joda.time.DateTime}</li>
+ *   <li>{@link org.joda.time.DateTimeUtils}</li>
+ *   <li>{@link org.joda.time.DateTimeZone}</li>
+ *   <li>{@link org.joda.time.Instant}</li>
+ * </ul>
+ */
+public final class ClassPermission extends BasicPermission {
+    private static final long serialVersionUID = 3530711429252193884L;
+
+    public static final String STANDARD = "<<STANDARD>>";
+    /** Typical set of classes for scripting: basic data types, math, dates, and simple collections */
+    // this is the list from the old grovy sandbox impl (+ some things like String, Iterator, etc that were missing)
+    public static final Set<String> STANDARD_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            // jdk classes
+            java.lang.Boolean.class.getName(),
+            java.lang.Byte.class.getName(),
+            java.lang.Character.class.getName(),
+            java.lang.Double.class.getName(),
+            java.lang.Integer.class.getName(),
+            java.lang.Long.class.getName(),
+            java.lang.Math.class.getName(),
+            java.lang.Object.class.getName(),
+            java.lang.Short.class.getName(),
+            java.lang.String.class.getName(),
+            java.math.BigDecimal.class.getName(),
+            java.util.ArrayList.class.getName(),
+            java.util.Arrays.class.getName(),
+            java.util.Date.class.getName(),
+            java.util.HashMap.class.getName(),
+            java.util.HashSet.class.getName(),
+            java.util.Iterator.class.getName(),
+            java.util.List.class.getName(),
+            java.util.Map.class.getName(),
+            java.util.Set.class.getName(),
+            java.util.UUID.class.getName(),
+            // joda-time
+            org.joda.time.DateTime.class.getName(),
+            org.joda.time.DateTimeUtils.class.getName(),
+            org.joda.time.DateTimeZone.class.getName(),
+            org.joda.time.Instant.class.getName()
+     )));
+
+    /**
+     * Creates a new ClassPermission object.
+     * 
+     * @param name class to grant permission to
+     */
+    public ClassPermission(String name) {
+        super(name);
+    }
+    
+    /**
+     * Creates a new ClassPermission object.
+     * This constructor exists for use by the {@code Policy} object to instantiate new Permission objects.
+     * 
+     * @param name class to grant permission to
+     * @param actions ignored
+     */
+    public ClassPermission(String name, String actions) {
+        this(name);
+    }
+
+    @Override
+    public boolean implies(Permission p) {
+        // check for a special value of STANDARD to imply the basic set
+        if (p != null && p.getClass() == getClass()) {
+            ClassPermission other = (ClassPermission) p;
+            if (STANDARD.equals(getName()) && STANDARD_CLASSES.contains(other.getName())) {
+                return true;
+            }
+        }
+        return super.implies(p);
+    }
+
+    @Override
+    public PermissionCollection newPermissionCollection() {
+        // BasicPermissionCollection only handles wildcards, we expand <<STANDARD>> here
+        PermissionCollection impl = super.newPermissionCollection();
+        return new PermissionCollection() {
+            private static final long serialVersionUID = 6792220143549780002L;
+            
+            @Override
+            public void add(Permission permission) {
+                if (permission instanceof ClassPermission && STANDARD.equals(permission.getName())) {
+                    for (String clazz : STANDARD_CLASSES) {
+                        impl.add(new ClassPermission(clazz));
+                    }
+                } else {
+                    impl.add(permission);
+                }
+            }
+            
+            @Override
+            public boolean implies(Permission permission) {
+                return impl.implies(permission);
+            }
+            
+            @Override
+            public Enumeration<Permission> elements() {
+                return impl.elements();
+            }
+        };
+    }
+}

--- a/core/src/main/resources/org/elasticsearch/bootstrap/untrusted.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/untrusted.policy
@@ -34,5 +34,6 @@ grant {
   permission java.util.PropertyPermission "rhino.stack.style", "read";
 
   // needed IndyInterface selectMethod (setCallSiteTarget)
+  // TODO: clean this up / only give it to engines that really must have it
   permission java.lang.RuntimePermission "getClassLoader";
 };

--- a/core/src/test/java/org/elasticsearch/script/ClassPermissionTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ClassPermissionTests.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.security.AllPermission;
+import java.security.PermissionCollection;
+
+/** Very simple sanity checks for {@link ClassPermission} */
+public class ClassPermissionTests extends ESTestCase {
+
+    public void testEquals() {
+        assertEquals(new ClassPermission("pkg.MyClass"), new ClassPermission("pkg.MyClass"));
+        assertFalse(new ClassPermission("pkg.MyClass").equals(new AllPermission()));
+    }
+
+    public void testImplies() {
+        assertTrue(new ClassPermission("pkg.MyClass").implies(new ClassPermission("pkg.MyClass")));
+        assertFalse(new ClassPermission("pkg.MyClass").implies(new ClassPermission("pkg.MyOtherClass")));
+        assertFalse(new ClassPermission("pkg.MyClass").implies(null));
+        assertFalse(new ClassPermission("pkg.MyClass").implies(new AllPermission()));
+    }
+
+    public void testStandard() {
+        assertTrue(new ClassPermission("<<STANDARD>>").implies(new ClassPermission("java.lang.Math")));
+        assertFalse(new ClassPermission("<<STANDARD>>").implies(new ClassPermission("pkg.MyClass")));
+    }
+ 
+    public void testPermissionCollection() {
+        ClassPermission math = new ClassPermission("java.lang.Math");
+        PermissionCollection collection = math.newPermissionCollection();
+        collection.add(math);
+        assertTrue(collection.implies(new ClassPermission("java.lang.Math")));
+        assertFalse(collection.implies(new ClassPermission("pkg.MyClass")));
+    }
+    
+    public void testPermissionCollectionStandard() {
+        ClassPermission standard = new ClassPermission("<<STANDARD>>");
+        PermissionCollection collection = standard.newPermissionCollection();
+        collection.add(standard);
+        assertTrue(collection.implies(new ClassPermission("java.lang.Math")));
+        assertFalse(collection.implies(new ClassPermission("pkg.MyClass")));
+    }
+
+    /** not recommended but we test anyway */
+    public void testWildcards() {
+        assertTrue(new ClassPermission("*").implies(new ClassPermission("pkg.MyClass")));
+        assertTrue(new ClassPermission("pkg.*").implies(new ClassPermission("pkg.MyClass")));
+        assertTrue(new ClassPermission("pkg.*").implies(new ClassPermission("pkg.sub.MyClass")));
+        assertFalse(new ClassPermission("pkg.My*").implies(new ClassPermission("pkg.MyClass")));
+        assertFalse(new ClassPermission("pkg*").implies(new ClassPermission("pkg.MyClass")));        
+    }
+    
+    public void testPermissionCollectionWildcards() {
+        ClassPermission lang = new ClassPermission("java.lang.*");
+        PermissionCollection collection = lang.newPermissionCollection();
+        collection.add(lang);
+        assertTrue(collection.implies(new ClassPermission("java.lang.Math")));
+        assertFalse(collection.implies(new ClassPermission("pkg.MyClass")));
+    }
+}

--- a/modules/lang-expression/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/lang-expression/src/main/plugin-metadata/plugin-security.policy
@@ -22,4 +22,13 @@ grant {
   permission java.lang.RuntimePermission "createClassLoader";
   // needed because of security problems in JavascriptCompiler
   permission java.lang.RuntimePermission "getClassLoader";
+  
+  // expression runtime
+  permission org.elasticsearch.script.ClassPermission "java.lang.String";
+  permission org.elasticsearch.script.ClassPermission "org.apache.lucene.expressions.Expression";
+  permission org.elasticsearch.script.ClassPermission "org.apache.lucene.queries.function.FunctionValues";
+  // available functions
+  permission org.elasticsearch.script.ClassPermission "java.lang.Math";
+  permission org.elasticsearch.script.ClassPermission "org.apache.lucene.util.MathUtil";
+  permission org.elasticsearch.script.ClassPermission "org.apache.lucene.util.SloppyMath";
 };

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/MoreExpressionTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/MoreExpressionTests.java
@@ -97,6 +97,16 @@ public class MoreExpressionTests extends ESIntegTestCase {
         assertEquals(1, rsp.getHits().getTotalHits());
         assertEquals(5.0, rsp.getHits().getAt(0).field("foo").getValue(), 0.0D);
     }
+    
+    public void testFunction() throws Exception {
+        createIndex("test");
+        ensureGreen("test");
+        client().prepareIndex("test", "doc", "1").setSource("foo", 4).setRefresh(true).get();
+        SearchResponse rsp = buildRequest("doc['foo'] + abs(1)").get();
+        assertSearchResponse(rsp);
+        assertEquals(1, rsp.getHits().getTotalHits());
+        assertEquals(5.0, rsp.getHits().getAt(0).field("foo").getValue(), 0.0D);
+    }
 
     public void testBasicUsingDotValue() throws Exception {
         createIndex("test");

--- a/modules/lang-groovy/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/lang-groovy/src/main/plugin-metadata/plugin-security.policy
@@ -28,4 +28,24 @@ grant {
   permission java.lang.RuntimePermission "closeClassLoader";
   // Allow executing groovy scripts with codesource of /untrusted
   permission groovy.security.GroovyCodeSourcePermission "/untrusted";
+
+  // Standard set of classes
+  permission org.elasticsearch.script.ClassPermission "<<STANDARD>>";
+  // groovy runtime (TODO: clean these up if possible)
+  permission org.elasticsearch.script.ClassPermission "groovy.grape.GrabAnnotationTransformation";
+  permission org.elasticsearch.script.ClassPermission "groovy.json.JsonOutput";
+  permission org.elasticsearch.script.ClassPermission "groovy.lang.Binding";
+  permission org.elasticsearch.script.ClassPermission "groovy.lang.GroovyObject";
+  permission org.elasticsearch.script.ClassPermission "groovy.lang.GString";
+  permission org.elasticsearch.script.ClassPermission "groovy.lang.Script";
+  permission org.elasticsearch.script.ClassPermission "groovy.util.GroovyCollections";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.ast.builder.AstBuilderTransformation";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.reflection.ClassInfo";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.GStringImpl";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.powerassert.ValueRecorder";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.powerassert.AssertionRenderer";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.ScriptBytecodeAdapter";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.vmplugin.v7.IndyInterface";
+  permission org.elasticsearch.script.ClassPermission "sun.reflect.ConstructorAccessorImpl";
 };

--- a/plugins/lang-javascript/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/lang-javascript/src/main/plugin-metadata/plugin-security.policy
@@ -20,4 +20,15 @@
 grant {
   // needed to generate runtime classes
   permission java.lang.RuntimePermission "createClassLoader";
+  
+  // Standard set of classes
+  permission org.elasticsearch.script.ClassPermission "<<STANDARD>>";
+  // rhino runtime (TODO: clean these up if possible)
+  permission org.elasticsearch.script.ClassPermission "org.mozilla.javascript.ContextFactory";
+  permission org.elasticsearch.script.ClassPermission "org.mozilla.javascript.Callable";
+  permission org.elasticsearch.script.ClassPermission "org.mozilla.javascript.NativeFunction";
+  permission org.elasticsearch.script.ClassPermission "org.mozilla.javascript.Script";
+  permission org.elasticsearch.script.ClassPermission "org.mozilla.javascript.ScriptRuntime";
+  permission org.elasticsearch.script.ClassPermission "org.mozilla.javascript.Undefined";
+  permission org.elasticsearch.script.ClassPermission "org.mozilla.javascript.optimizer.OptRuntime";
 };

--- a/plugins/lang-python/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/lang-python/src/main/plugin-metadata/plugin-security.policy
@@ -22,4 +22,6 @@ grant {
   permission java.lang.RuntimePermission "createClassLoader";
   // needed by PySystemState init (TODO: see if we can avoid this)
   permission java.lang.RuntimePermission "getClassLoader";
+  // Standard set of classes
+  permission org.elasticsearch.script.ClassPermission "<<STANDARD>>";
 };

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonSecurityTests.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/PythonSecurityTests.java
@@ -25,7 +25,9 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTestCase;
 import org.python.core.PyException;
 
+import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -66,12 +68,12 @@ public class PythonSecurityTests extends ESTestCase {
             doTest(script);
             fail("did not get expected exception");
         } catch (PyException expected) {
-            Throwable cause = expected.getCause();
             // TODO: fix jython localization bugs: https://github.com/elastic/elasticsearch/issues/13967
-            // this is the correct assert:
-            // assertNotNull("null cause for exception: " + expected, cause);
-            assertNotNull("null cause for exception", cause);
-            assertTrue("unexpected exception: " + cause, cause instanceof SecurityException);
+            // we do a gross hack for now
+            DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.getDefault());
+            if (symbols.getZeroDigit() == '0') {
+                assertTrue(expected.toString().contains("cannot import"));
+            }
         }
     }
     
@@ -90,5 +92,17 @@ public class PythonSecurityTests extends ESTestCase {
         assertFailure("from java.net import Socket\nSocket(\"localhost\", 1024)");
         // no files
         assertFailure("from java.io import File\nFile.createTempFile(\"test\", \"tmp\")");
+    }
+    
+    /** Test again from a new thread, python has complex threadlocal configuration */
+    public void testNotOKFromSeparateThread() throws Exception {
+        Thread t = new Thread() {
+            @Override
+            public void run() {
+                assertFailure("from java.lang import Runtime\nRuntime.availableProcessors()");
+            }
+        };
+        t.start();
+        t.join();
     }
 }


### PR DESCRIPTION
Since 2.2 we run all scripts with minimal privileges, similar to applets in your browser.
The problem is, they have unrestricted access to other things they can muck with (ES, JDK, whatever).
So they can still easily do tons of bad things.

This PR restricts what classes scripts can load via the classloader mechanism, to make life more difficult.
The "standard" list was populated from the old list used for the groovy sandbox: though
a few more were needed for tests to pass (java.lang.String, java.util.Iterator, nothing scary there).

Additionally, each scripting engine typically needs permissions to some runtime stuff.
That is the downside of this "good old classloader" approach, but I like the transparency and simplicity,
and I don't want to waste my time with any feature provided by the engine itself for this, I don't trust them.

This is not perfect and the engines are not perfect but you gotta start somewhere. For expert users that
need to tweak the permissions, we already support that via the standard java security configuration files, the specification is simple, supports wildcards, etc (though we do not use them ourselves).
