### PR TITLE
#14719  url params parsing should not be lenient

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestController.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.path.PathTrie;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.http.HttpException;
 import org.elasticsearch.rest.support.RestUtils;
 
 import java.io.IOException;
@@ -209,7 +210,13 @@ public class RestController extends AbstractLifecycleComponent<RestController> {
     void executeHandler(RestRequest request, RestChannel channel) throws Exception {
         final RestHandler handler = getHandler(request);
         if (handler != null) {
-            handler.handleRequest(request, channel);
+                handler.handleRequest(request, channel);
+
+            //Just validate params to READ operations
+            if(RestRequest.Method.GET.equals(request.method()) && !request.allParamsConsumed()){
+                channel.sendResponse(new BytesRestResponse(BAD_REQUEST, "There are wrong parameters"));
+            }
+
         } else {
             if (request.method() == RestRequest.Method.OPTIONS) {
                 // when we have OPTIONS request, simply send OK by default (with the Access Control Origin header which gets automatically added)

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -88,6 +88,8 @@ public abstract class RestRequest extends ContextAndHeaderHolder implements ToXC
 
     public abstract Map<String, String> params();
 
+    public abstract boolean allParamsConsumed();
+
     public float paramAsFloat(String key, float defaultValue) {
         String sValue = param(key);
         if (sValue == null) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsAggregator.java
@@ -43,7 +43,7 @@ import java.util.Map;
 /**
  *
  */
-public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
+public class StatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     final ValuesSource.Numeric valuesSource;
     final ValueFormatter formatter;
@@ -54,10 +54,10 @@ public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
     DoubleArray maxes;
 
 
-    public StatsAggegator(String name, ValuesSource.Numeric valuesSource, ValueFormatter formatter,
- AggregationContext context,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metaData) throws IOException {
+    public StatsAggregator(String name, ValuesSource.Numeric valuesSource, ValueFormatter formatter,
+                           AggregationContext context,
+                           Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+                           Map<String, Object> metaData) throws IOException {
         super(name, context, parent, pipelineAggregators, metaData);
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
@@ -164,14 +164,14 @@ public class StatsAggegator extends NumericMetricsAggregator.MultiValue {
         @Override
         protected Aggregator createUnmapped(AggregationContext aggregationContext, Aggregator parent,
                 List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
-            return new StatsAggegator(name, null, config.formatter(), aggregationContext, parent, pipelineAggregators, metaData);
+            return new StatsAggregator(name, null, config.formatter(), aggregationContext, parent, pipelineAggregators, metaData);
         }
 
         @Override
         protected Aggregator doCreateInternal(ValuesSource.Numeric valuesSource, AggregationContext aggregationContext, Aggregator parent,
                 boolean collectsFromSingleBucket, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData)
                 throws IOException {
-            return new StatsAggegator(name, valuesSource, config.formatter(), aggregationContext, parent, pipelineAggregators, metaData);
+            return new StatsAggregator(name, valuesSource, config.formatter(), aggregationContext, parent, pipelineAggregators, metaData);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/StatsParser.java
@@ -34,6 +34,6 @@ public class StatsParser extends NumericValuesSourceMetricsAggregatorParser<Inte
 
     @Override
     protected AggregatorFactory createFactory(String aggregationName, ValuesSourceConfig<ValuesSource.Numeric> config) {
-        return new StatsAggegator.Factory(aggregationName, config);
+        return new StatsAggregator.Factory(aggregationName, config);
     }
 }

--- a/core/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -95,6 +95,11 @@ public class RestRequestTests extends ESTestCase {
         }
 
         @Override
+        public boolean allParamsConsumed() {
+            return true;
+        }
+
+        @Override
         public Map<String, String> params() {
             return null;
         }

--- a/test-framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -23,13 +23,17 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.rest.RestRequest;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class FakeRestRequest extends RestRequest {
 
     private final Map<String, String> headers;
 
     private final Map<String, String> params;
+
+    private final Set<String> consumedParams;
 
     public FakeRestRequest() {
         this(new HashMap<String, String>(), new HashMap<String, String>());
@@ -41,6 +45,7 @@ public class FakeRestRequest extends RestRequest {
             putInContext(entry.getKey(), entry.getValue());
         }
         this.params = new HashMap<>();
+        this.consumedParams = new HashSet<>(params().size());
     }
 
     @Override
@@ -85,17 +90,25 @@ public class FakeRestRequest extends RestRequest {
 
     @Override
     public String param(String key) {
+        this.consumedParams.add(key);
         return params.get(key);
     }
 
     @Override
     public String param(String key, String defaultValue) {
+        this.consumedParams.add(key);
         String value = params.get(key);
         if (value == null) {
             return defaultValue;
         }
         return value;
     }
+
+    @Override
+    public boolean allParamsConsumed() {
+        return this.consumedParams.containsAll(this.params().keySet());
+    }
+
 
     @Override
     public Map<String, String> params() {


### PR DESCRIPTION
There is my initial commit with a generic and centralized parameter validation.

This validation is being done just for GET requests. Validation on the other methods will have to be done en every single rest request.
