### PR TITLE
If we can't get a MAC address for the node, use a dummy one

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/MacAddressProvider.java
+++ b/core/src/main/java/org/elasticsearch/common/MacAddressProvider.java
@@ -65,8 +65,8 @@ public class MacAddressProvider {
         byte[] address = null;
         try {
             address = getMacAddress();
-        } catch( SocketException se ) {
-            logger.warn("Unable to get mac address, will use a dummy address", se);
+        } catch (Throwable t) {
+            logger.warn("Unable to get mac address, will use a dummy address", t);
             // address will be set below
         }
 


### PR DESCRIPTION
We already use a dummy MAC address if we hit a `SocketException` while trying; this PR just widens that to any `Throwable`.

Closes #10099 
