### PR TITLE
Mapper parsers should not check for a `tokenized` property.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/TypeParsers.java
@@ -197,9 +197,6 @@ public class TypeParsers {
             } else if (propName.equals("index")) {
                 parseIndex(name, propNode.toString(), builder);
                 iterator.remove();
-            } else if (propName.equals("tokenized")) {
-                builder.tokenized(nodeBooleanValue(propNode));
-                iterator.remove();
             } else if (propName.equals(DOC_VALUES)) {
                 builder.docValues(nodeBooleanValue(propNode));
                 iterator.remove();


### PR DESCRIPTION
I don't recall of this property of any of our field mappers and it's not in our
docs so I suspect it's very old. The removal of this property will not fail
version upgrades since none of the field mappers use it in toXContent.
