### PR TITLE
Write log entries of external nodes to console

### DIFF
--- a/qa/backwards/shared/src/main/java/org/elasticsearch/test/ExternalNodeServiceClient.java
+++ b/qa/backwards/shared/src/main/java/org/elasticsearch/test/ExternalNodeServiceClient.java
@@ -53,7 +53,7 @@ public class ExternalNodeServiceClient {
     }
 
     public int start(final String args) {
-        return Integer.parseInt(interact("start " + args, "bound to \\[localhost:(\\d+)\\]").group(1), 10);
+        return Integer.parseInt(interact("start " + args, "pid \\[(\\d+)\\]").group(1), 10);
     }
 
     public void stop(int esPort) {

--- a/qa/backwards/shared/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -31,6 +31,7 @@ import org.elasticsearch.client.FilterClient;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -83,7 +84,7 @@ public class CompositeTestCluster extends TestCluster {
         this.client = new ExternalClient();
         if (size() > 0) {
             logger.debug("Waiting for {} nodes", size());
-            client().admin().cluster().prepareHealth().setWaitForNodes(">=" + Integer.toString(this.size())).get();
+            client().admin().cluster().prepareHealth().setWaitForNodes(">=" + Integer.toString(this.size())).setTimeout(TimeValue.timeValueSeconds(60)).get();
         }
     }
 

--- a/qa/backwards/shared/src/test/java/org/elasticsearch/test/ExternalNode.java
+++ b/qa/backwards/shared/src/test/java/org/elasticsearch/test/ExternalNode.java
@@ -106,10 +106,6 @@ final class ExternalNode implements Closeable {
         externaNodeSettingsBuilder.put("path.data", dataPath());
         externaNodeSettingsBuilder.put("path.logs", logPath());
         externaNodeSettingsBuilder.put("pidfile", pidPath());
-        // we have to delete the pid file which might be leftover from previous tests in the same suite
-        // otherwise the ExternalNodeService reads the old pid file and later tries to stop the wrong process
-        Files.deleteIfExists(pidPath());
-
 
         for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
             String found = externaNodeSettingsBuilder.get(entry.getKey());


### PR DESCRIPTION
Before external nodes wrote logs only to a file which makes it tricky to debug
test failures.
This also removes the port information which we cannot get anymore because
we do not scan the output. But is was not needed anyway.

A side effect seems to be that now on windows one has to press Ctrl+C several times instead of only once to interrupt the bwc tests. Not sure how much of a problem that is. I did not find a workaround for that. 

If this is too bad than we can still go for #15028
