### PR TITLE
punch thru symlinks when loading plugins/modules

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -316,7 +316,8 @@ public class PluginsService extends AbstractComponent {
                 // gather urls for jar files
                 try (DirectoryStream<Path> jarStream = Files.newDirectoryStream(module, "*.jar")) {
                     for (Path jar : jarStream) {
-                        bundle.urls.add(jar.toUri().toURL());
+                        // normalize with toRealPath to get symlinks out of our hair
+                        bundle.urls.add(jar.toRealPath().toUri().toURL());
                     }
                 }
                 bundles.add(bundle);
@@ -357,7 +358,8 @@ public class PluginsService extends AbstractComponent {
                     // a jvm plugin: gather urls for jar files
                     try (DirectoryStream<Path> jarStream = Files.newDirectoryStream(plugin, "*.jar")) {
                         for (Path jar : jarStream) {
-                            urls.add(jar.toUri().toURL());
+                            // normalize with toRealPath to get symlinks out of our hair
+                            urls.add(jar.toRealPath().toUri().toURL());
                         }
                     }
                 }


### PR DESCRIPTION
this ensures the codebase URL matches the permission grant (see matching toRealPath in Security.java) in the case of symlinks or other shenanigans.

this is best effort, if we really want to support symlinks in any way, we need
e.g. qa or vagrant tests that configure a bunch of symlinks for things and ensure that in jenkins.
this should be easier to do with gradle, as we can just create a symlink'd home if we want
