### PR TITLE
CancellableThreads should also treat ThreadInterruptedException as InterruptedException

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/CancellableThreads.java
+++ b/core/src/main/java/org/elasticsearch/common/util/CancellableThreads.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.common.util;
 
+import org.apache.lucene.util.ThreadInterruptedException;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.Nullable;
@@ -84,7 +85,7 @@ public class CancellableThreads {
         RuntimeException throwable = null;
         try {
             interruptable.run();
-        } catch (InterruptedException e) {
+        } catch (InterruptedException | ThreadInterruptedException e) {
             // assume this is us and ignore
         } catch (RuntimeException t) {
             throwable = t;


### PR DESCRIPTION
RecoverySource uses the RateLimiter under a cancelable thread. The SimpleRateLimiter used in throws   ThreadInterruptedException on interruption. We should treat it as InterruptedException
