### PR TITLE
Introduce a common base response class to all single doc write ops

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.io.IOException;
+
+/**
+ * A base class for the response of a write operation that involves a single doc
+ */
+public abstract class DocWriteResponse extends ReplicationResponse implements ToXContent {
+
+    private ShardId shardId;
+    private String id;
+    private String type;
+    private long version;
+
+    public DocWriteResponse(ShardId shardId, String type, String id, long version) {
+        this.shardId = shardId;
+        this.type = type;
+        this.id = id;
+        this.version = version;
+    }
+
+    // needed for deserialization
+    protected DocWriteResponse() {
+    }
+
+    /**
+     * The index the document was changed in.
+     */
+    public String getIndex() {
+        return this.shardId.getIndex();
+    }
+
+
+    /**
+     * The exact shard the document was changed in.
+     */
+    public ShardId getShardId() {
+        return this.shardId;
+    }
+
+    /**
+     * The type of the document changed.
+     */
+    public String getType() {
+        return this.type;
+    }
+
+    /**
+     * The id of the document changed.
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Returns the current version of the doc.
+     */
+    public long getVersion() {
+        return this.version;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        shardId = ShardId.readShardId(in);
+        type = in.readString();
+        id = in.readString();
+        version = in.readZLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        shardId.writeTo(out);
+        out.writeString(type);
+        out.writeString(id);
+        out.writeZLong(version);
+    }
+
+    static final class Fields {
+        static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
+        static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
+        static final XContentBuilderString _ID = new XContentBuilderString("_id");
+        static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        ReplicationResponse.ShardInfo shardInfo = getShardInfo();
+        builder.field(Fields._INDEX, getIndex())
+            .field(Fields._TYPE, getType())
+            .field(Fields._ID, getId())
+            .field(Fields._VERSION, getVersion());
+        shardInfo.toXContent(builder, params);
+        return builder;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -120,10 +120,10 @@ public abstract class DocWriteResponse extends ReplicationResponse implements St
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         ReplicationResponse.ShardInfo shardInfo = getShardInfo();
-        builder.field(Fields._INDEX, getIndex())
-            .field(Fields._TYPE, getType())
-            .field(Fields._ID, getId())
-            .field(Fields._VERSION, getVersion());
+        builder.field(Fields._INDEX, shardId.getIndex())
+            .field(Fields._TYPE, type)
+            .field(Fields._ID, id)
+            .field(Fields._VERSION, version);
         shardInfo.toXContent(builder, params);
         return builder;
     }

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -20,17 +20,19 @@ package org.elasticsearch.action;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.StatusToXContent;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
 /**
  * A base class for the response of a write operation that involves a single doc
  */
-public abstract class DocWriteResponse extends ReplicationResponse implements ToXContent {
+public abstract class DocWriteResponse extends ReplicationResponse implements StatusToXContent {
 
     private ShardId shardId;
     private String id;
@@ -83,6 +85,12 @@ public abstract class DocWriteResponse extends ReplicationResponse implements To
     public long getVersion() {
         return this.version;
     }
+
+    /** returns the rest status for this response (based on {@link ShardInfo#status()} */
+    public RestStatus status() {
+        return getShardInfo().status();
+    }
+
 
     @Override
     public void readFrom(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/action/ReplicationResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/ReplicationResponse.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.bootstrap.Elasticsearch;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -30,25 +29,23 @@ import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
-import java.util.Collections;
 
 /**
  * Base class for write action responses.
  */
-public class ActionWriteResponse extends ActionResponse {
+public class ReplicationResponse extends ActionResponse {
 
-    public final static ActionWriteResponse.ShardInfo.Failure[] EMPTY = new ActionWriteResponse.ShardInfo.Failure[0];
+    public final static ReplicationResponse.ShardInfo.Failure[] EMPTY = new ReplicationResponse.ShardInfo.Failure[0];
 
     private ShardInfo shardInfo;
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        shardInfo = ActionWriteResponse.ShardInfo.readShardInfo(in);
+        shardInfo = ReplicationResponse.ShardInfo.readShardInfo(in);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportBroadcastReplicationAction;
@@ -36,7 +36,7 @@ import java.util.List;
 /**
  * Flush Action.
  */
-public class TransportFlushAction extends TransportBroadcastReplicationAction<FlushRequest, FlushResponse, ShardFlushRequest, ActionWriteResponse> {
+public class TransportFlushAction extends TransportBroadcastReplicationAction<FlushRequest, FlushResponse, ShardFlushRequest, ReplicationResponse> {
 
     @Inject
     public TransportFlushAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
@@ -47,8 +47,8 @@ public class TransportFlushAction extends TransportBroadcastReplicationAction<Fl
     }
 
     @Override
-    protected ActionWriteResponse newShardResponse() {
-        return new ActionWriteResponse();
+    protected ReplicationResponse newShardResponse() {
+        return new ReplicationResponse();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.ClusterService;
@@ -39,7 +39,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  *
  */
-public class TransportShardFlushAction extends TransportReplicationAction<ShardFlushRequest, ShardFlushRequest, ActionWriteResponse> {
+public class TransportShardFlushAction extends TransportReplicationAction<ShardFlushRequest, ShardFlushRequest, ReplicationResponse> {
 
     public static final String NAME = FlushAction.NAME + "[s]";
 
@@ -53,16 +53,16 @@ public class TransportShardFlushAction extends TransportReplicationAction<ShardF
     }
 
     @Override
-    protected ActionWriteResponse newResponseInstance() {
-        return new ActionWriteResponse();
+    protected ReplicationResponse newResponseInstance() {
+        return new ReplicationResponse();
     }
 
     @Override
-    protected Tuple<ActionWriteResponse, ShardFlushRequest> shardOperationOnPrimary(MetaData metaData, ShardFlushRequest shardRequest) throws Throwable {
+    protected Tuple<ReplicationResponse, ShardFlushRequest> shardOperationOnPrimary(MetaData metaData, ShardFlushRequest shardRequest) throws Throwable {
         IndexShard indexShard = indicesService.indexServiceSafe(shardRequest.shardId().getIndex()).getShard(shardRequest.shardId().id());
         indexShard.flush(shardRequest.getRequest());
         logger.trace("{} flush request executed on primary", indexShard.shardId());
-        return new Tuple<>(new ActionWriteResponse(), shardRequest);
+        return new Tuple<>(new ReplicationResponse(), shardRequest);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.refresh;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * Refresh action.
  */
-public class TransportRefreshAction extends TransportBroadcastReplicationAction<RefreshRequest, RefreshResponse, ReplicationRequest, ActionWriteResponse> {
+public class TransportRefreshAction extends TransportBroadcastReplicationAction<RefreshRequest, RefreshResponse, ReplicationRequest, ReplicationResponse> {
 
     @Inject
     public TransportRefreshAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
@@ -48,8 +48,8 @@ public class TransportRefreshAction extends TransportBroadcastReplicationAction<
     }
 
     @Override
-    protected ActionWriteResponse newShardResponse() {
-        return new ActionWriteResponse();
+    protected ReplicationResponse newShardResponse() {
+        return new ReplicationResponse();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.refresh;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
@@ -41,7 +41,7 @@ import org.elasticsearch.transport.TransportService;
 /**
  *
  */
-public class TransportShardRefreshAction extends TransportReplicationAction<ReplicationRequest, ReplicationRequest, ActionWriteResponse> {
+public class TransportShardRefreshAction extends TransportReplicationAction<ReplicationRequest, ReplicationRequest, ReplicationResponse> {
 
     public static final String NAME = RefreshAction.NAME + "[s]";
 
@@ -55,16 +55,16 @@ public class TransportShardRefreshAction extends TransportReplicationAction<Repl
     }
 
     @Override
-    protected ActionWriteResponse newResponseInstance() {
-        return new ActionWriteResponse();
+    protected ReplicationResponse newResponseInstance() {
+        return new ReplicationResponse();
     }
 
     @Override
-    protected Tuple<ActionWriteResponse, ReplicationRequest> shardOperationOnPrimary(MetaData metaData, ReplicationRequest shardRequest) throws Throwable {
+    protected Tuple<ReplicationResponse, ReplicationRequest> shardOperationOnPrimary(MetaData metaData, ReplicationRequest shardRequest) throws Throwable {
         IndexShard indexShard = indicesService.indexServiceSafe(shardRequest.shardId().getIndex()).getShard(shardRequest.shardId().id());
         indexShard.refresh("api");
         logger.trace("{} refresh request executed on primary", indexShard.shardId());
-        return new Tuple<>(new ActionWriteResponse(), shardRequest);
+        return new Tuple<>(new ReplicationResponse(), shardRequest);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -19,15 +19,18 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.StatusToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -36,7 +39,39 @@ import java.io.IOException;
  * Represents a single item response for an action executed as part of the bulk API. Holds the index/type/id
  * of the relevant action, and if it has failed or not (with the failure message incase it failed).
  */
-public class BulkItemResponse implements Streamable {
+public class BulkItemResponse implements Streamable, StatusToXContent {
+
+    @Override
+    public RestStatus status() {
+        return failure == null ? response.status() : failure.getStatus();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(opType);
+        if (failure == null) {
+            response.toXContent(builder, params);
+            builder.field(Fields.STATUS, response.status());
+        } else {
+            builder.field(Fields._INDEX, failure.getIndex());
+            builder.field(Fields._TYPE, failure.getType());
+            builder.field(Fields._ID, failure.getId());
+            builder.field(Fields.STATUS, failure.getStatus());
+            builder.startObject(Fields.ERROR);
+            ElasticsearchException.toXContent(builder, params, failure.getCause());
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    static final class Fields {
+        static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
+        static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
+        static final XContentBuilderString _ID = new XContentBuilderString("_id");
+        static final XContentBuilderString STATUS = new XContentBuilderString("status");
+        static final XContentBuilderString ERROR = new XContentBuilderString("error");
+    }
 
     /**
      * Represents a failure.

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -20,7 +20,8 @@
 package org.elasticsearch.action.bulk;
 
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.update.UpdateResponse;
@@ -99,7 +100,7 @@ public class BulkItemResponse implements Streamable {
 
     private String opType;
 
-    private ActionWriteResponse response;
+    private DocWriteResponse response;
 
     private Failure failure;
 
@@ -107,7 +108,7 @@ public class BulkItemResponse implements Streamable {
 
     }
 
-    public BulkItemResponse(int id, String opType, ActionWriteResponse response) {
+    public BulkItemResponse(int id, String opType, DocWriteResponse response) {
         this.id = id;
         this.opType = opType;
         this.response = response;
@@ -140,14 +141,7 @@ public class BulkItemResponse implements Streamable {
         if (failure != null) {
             return failure.getIndex();
         }
-        if (response instanceof IndexResponse) {
-            return ((IndexResponse) response).getIndex();
-        } else if (response instanceof DeleteResponse) {
-            return ((DeleteResponse) response).getIndex();
-        } else if (response instanceof UpdateResponse) {
-            return ((UpdateResponse) response).getIndex();
-        }
-        return null;
+        return response.getIndex();
     }
 
     /**
@@ -157,14 +151,7 @@ public class BulkItemResponse implements Streamable {
         if (failure != null) {
             return failure.getType();
         }
-        if (response instanceof IndexResponse) {
-            return ((IndexResponse) response).getType();
-        } else if (response instanceof DeleteResponse) {
-            return ((DeleteResponse) response).getType();
-        } else if (response instanceof UpdateResponse) {
-            return ((UpdateResponse) response).getType();
-        }
-        return null;
+        return response.getType();
     }
 
     /**
@@ -174,14 +161,7 @@ public class BulkItemResponse implements Streamable {
         if (failure != null) {
             return failure.getId();
         }
-        if (response instanceof IndexResponse) {
-            return ((IndexResponse) response).getId();
-        } else if (response instanceof DeleteResponse) {
-            return ((DeleteResponse) response).getId();
-        } else if (response instanceof UpdateResponse) {
-            return ((UpdateResponse) response).getId();
-        }
-        return null;
+        return response.getId();
     }
 
     /**
@@ -191,21 +171,14 @@ public class BulkItemResponse implements Streamable {
         if (failure != null) {
             return -1;
         }
-        if (response instanceof IndexResponse) {
-            return ((IndexResponse) response).getVersion();
-        } else if (response instanceof DeleteResponse) {
-            return ((DeleteResponse) response).getVersion();
-        } else if (response instanceof UpdateResponse) {
-            return ((UpdateResponse) response).getVersion();
-        }
-        return -1;
+        return response.getVersion();
     }
 
     /**
      * The actual response ({@link IndexResponse} or {@link DeleteResponse}). <tt>null</tt> in
      * case of failure.
      */
-    public <T extends ActionWriteResponse> T getResponse() {
+    public <T extends DocWriteResponse> T getResponse() {
         return (T) response;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.action.bulk;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  *
  */
-public class BulkShardResponse extends ActionWriteResponse {
+public class BulkShardResponse extends ReplicationResponse {
 
     private ShardId shardId;
     private BulkItemResponse[] responses;

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -204,7 +204,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                                 BytesReference indexSourceAsBytes = indexRequest.source();
                                 // add the response
                                 IndexResponse indexResponse = result.response();
-                                UpdateResponse updateResponse = new UpdateResponse(indexResponse.getShardInfo(), indexResponse.getIndex(), indexResponse.getType(), indexResponse.getId(), indexResponse.getVersion(), indexResponse.isCreated());
+                                UpdateResponse updateResponse = new UpdateResponse(indexResponse.getShardInfo(), indexResponse.getShardId(), indexResponse.getType(), indexResponse.getId(), indexResponse.getVersion(), indexResponse.isCreated());
                                 if (updateRequest.fields() != null && updateRequest.fields().length > 0) {
                                     Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(indexSourceAsBytes, true);
                                     updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), indexResponse.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), indexSourceAsBytes));
@@ -216,7 +216,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
                                 WriteResult<DeleteResponse> writeResult = updateResult.writeResult;
                                 DeleteResponse response = writeResult.response();
                                 DeleteRequest deleteRequest = updateResult.request();
-                                updateResponse = new UpdateResponse(response.getShardInfo(), response.getIndex(), response.getType(), response.getId(), response.getVersion(), false);
+                                updateResponse = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), false);
                                 updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), response.getVersion(), updateResult.result.updatedSourceAsMap(), updateResult.result.updateSourceContentType(), null));
                                 // Replace the update request to the translated delete request to execute on the replica.
                                 item = request.items()[requestIndex] = new BulkItemRequest(request.items()[requestIndex].id(), deleteRequest);

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -20,10 +20,12 @@
 package org.elasticsearch.action.delete;
 
 import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
@@ -64,5 +66,37 @@ public class DeleteResponse extends DocWriteResponse {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBoolean(found);
+    }
+
+    @Override
+    public RestStatus status() {
+        if (found == false) {
+            return RestStatus.NOT_FOUND;
+        }
+        return super.status();
+    }
+
+    static final class Fields {
+        static final XContentBuilderString FOUND = new XContentBuilderString("found");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(Fields.FOUND, isFound());
+        super.toXContent(builder, params);
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("DeleteResponse[");
+        builder.append("index=").append(getIndex());
+        builder.append(",type=").append(getType());
+        builder.append(",id=").append(getId());
+        builder.append(",version=").append(getVersion());
+        builder.append(",found=").append(found);
+        builder.append(",shards=").append(getShardInfo());
+        return builder.append("]").toString();
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.action.delete;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -31,53 +33,19 @@ import java.io.IOException;
  * @see org.elasticsearch.action.delete.DeleteRequest
  * @see org.elasticsearch.client.Client#delete(DeleteRequest)
  */
-public class DeleteResponse extends ActionWriteResponse {
+public class DeleteResponse extends DocWriteResponse {
 
-    private String index;
-    private String id;
-    private String type;
-    private long version;
     private boolean found;
 
     public DeleteResponse() {
 
     }
 
-    public DeleteResponse(String index, String type, String id, long version, boolean found) {
-        this.index = index;
-        this.id = id;
-        this.type = type;
-        this.version = version;
+    public DeleteResponse(ShardId shardId, String type, String id, long version, boolean found) {
+        super(shardId, type, id, version);
         this.found = found;
     }
 
-    /**
-     * The index the document was deleted from.
-     */
-    public String getIndex() {
-        return this.index;
-    }
-
-    /**
-     * The type of the document deleted.
-     */
-    public String getType() {
-        return this.type;
-    }
-
-    /**
-     * The id of the document deleted.
-     */
-    public String getId() {
-        return this.id;
-    }
-
-    /**
-     * The version of the delete operation.
-     */
-    public long getVersion() {
-        return this.version;
-    }
 
     /**
      * Returns <tt>true</tt> if a doc was found to delete.
@@ -89,20 +57,12 @@ public class DeleteResponse extends ActionWriteResponse {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        index = in.readString();
-        type = in.readString();
-        id = in.readString();
-        version = in.readLong();
         found = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(index);
-        out.writeString(type);
-        out.writeString(id);
-        out.writeLong(version);
         out.writeBoolean(found);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/TransportDeleteAction.java
@@ -140,7 +140,7 @@ public class TransportDeleteAction extends TransportReplicationAction<DeleteRequ
 
         assert request.versionType().validateVersionForWrites(request.version());
         return new WriteResult<>(
-            new DeleteResponse(indexShard.shardId().getIndex(), request.type(), request.id(), delete.version(), delete.found()),
+            new DeleteResponse(indexShard.shardId(), request.type(), request.id(), delete.version(), delete.found()),
             delete.getTranslogLocation());
     }
 

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
@@ -52,6 +53,14 @@ public class IndexResponse extends DocWriteResponse {
      */
     public boolean isCreated() {
         return this.created;
+    }
+
+    @Override
+    public RestStatus status() {
+        if (created) {
+            return RestStatus.CREATED;
+        }
+        return super.status();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -19,9 +19,12 @@
 
 package org.elasticsearch.action.index;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -31,52 +34,17 @@ import java.io.IOException;
  * @see org.elasticsearch.action.index.IndexRequest
  * @see org.elasticsearch.client.Client#index(IndexRequest)
  */
-public class IndexResponse extends ActionWriteResponse {
+public class IndexResponse extends DocWriteResponse {
 
-    private String index;
-    private String id;
-    private String type;
-    private long version;
     private boolean created;
 
     public IndexResponse() {
 
     }
 
-    public IndexResponse(String index, String type, String id, long version, boolean created) {
-        this.index = index;
-        this.id = id;
-        this.type = type;
-        this.version = version;
+    public IndexResponse(ShardId shardId, String type, String id, long version, boolean created) {
+        super(shardId, type, id, version);
         this.created = created;
-    }
-
-    /**
-     * The index the document was indexed into.
-     */
-    public String getIndex() {
-        return this.index;
-    }
-
-    /**
-     * The type of the document indexed.
-     */
-    public String getType() {
-        return this.type;
-    }
-
-    /**
-     * The id of the document indexed.
-     */
-    public String getId() {
-        return this.id;
-    }
-
-    /**
-     * Returns the current version of the doc indexed.
-     */
-    public long getVersion() {
-        return this.version;
     }
 
     /**
@@ -89,20 +57,12 @@ public class IndexResponse extends ActionWriteResponse {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        index = in.readString();
-        type = in.readString();
-        id = in.readString();
-        version = in.readLong();
         created = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(index);
-        out.writeString(type);
-        out.writeString(id);
-        out.writeLong(version);
         out.writeBoolean(created);
     }
 
@@ -110,12 +70,23 @@ public class IndexResponse extends ActionWriteResponse {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("IndexResponse[");
-        builder.append("index=").append(index);
-        builder.append(",type=").append(type);
-        builder.append(",id=").append(id);
-        builder.append(",version=").append(version);
+        builder.append("index=").append(getIndex());
+        builder.append(",type=").append(getType());
+        builder.append(",id=").append(getId());
+        builder.append(",version=").append(getVersion());
         builder.append(",created=").append(created);
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();
+    }
+
+    static final class Fields {
+        static final XContentBuilderString CREATED = new XContentBuilderString("created");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        super.toXContent(builder, params);
+        builder.field(Fields.CREATED, isCreated());
+        return builder;
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -222,7 +222,7 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
 
         assert request.versionType().validateVersionForWrites(request.version());
 
-        return new WriteResult<>(new IndexResponse(shardId.getIndex(), request.type(), request.id(), request.version(), created), operation.getTranslogLocation());
+        return new WriteResult<>(new IndexResponse(shardId, request.type(), request.id(), request.version(), created), operation.getTranslogLocation());
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
@@ -22,9 +22,8 @@ package org.elasticsearch.action.support.replication;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -53,7 +52,7 @@ import java.util.function.Supplier;
  * Base class for requests that should be executed on all shards of an index or several indices.
  * This action sends shard requests to all primary shards of the indices and they are then replicated like write requests
  */
-public abstract class TransportBroadcastReplicationAction<Request extends BroadcastRequest, Response extends BroadcastResponse, ShardRequest extends ReplicationRequest, ShardResponse extends ActionWriteResponse> extends HandledTransportAction<Request, Response> {
+public abstract class TransportBroadcastReplicationAction<Request extends BroadcastRequest, Response extends BroadcastResponse, ShardRequest extends ReplicationRequest, ShardResponse extends ReplicationResponse> extends HandledTransportAction<Request, Response> {
 
     private final TransportReplicationAction replicatedBroadcastShardAction;
     private final ClusterService clusterService;
@@ -91,15 +90,15 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
                     logger.trace("{}: got failure from {}", actionName, shardId);
                     int totalNumCopies = clusterState.getMetaData().index(shardId.index().getName()).getNumberOfReplicas() + 1;
                     ShardResponse shardResponse = newShardResponse();
-                    ActionWriteResponse.ShardInfo.Failure[] failures;
+                    ReplicationResponse.ShardInfo.Failure[] failures;
                     if (TransportActions.isShardNotAvailableException(e)) {
-                        failures = new ActionWriteResponse.ShardInfo.Failure[0];
+                        failures = new ReplicationResponse.ShardInfo.Failure[0];
                     } else {
-                        ActionWriteResponse.ShardInfo.Failure failure = new ActionWriteResponse.ShardInfo.Failure(shardId.index().name(), shardId.id(), null, e, ExceptionsHelper.status(e), true);
-                        failures = new ActionWriteResponse.ShardInfo.Failure[totalNumCopies];
+                        ReplicationResponse.ShardInfo.Failure failure = new ReplicationResponse.ShardInfo.Failure(shardId.index().name(), shardId.id(), null, e, ExceptionsHelper.status(e), true);
+                        failures = new ReplicationResponse.ShardInfo.Failure[totalNumCopies];
                         Arrays.fill(failures, failure);
                     }
-                    shardResponse.setShardInfo(new ActionWriteResponse.ShardInfo(totalNumCopies, 0, failures));
+                    shardResponse.setShardInfo(new ReplicationResponse.ShardInfo(totalNumCopies, 0, failures));
                     shardsResponses.add(shardResponse);
                     if (responsesCountDown.countDown()) {
                         finishAndNotifyListener(listener, shardsResponses);
@@ -142,7 +141,7 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
         int totalNumCopies = 0;
         List<ShardOperationFailedException> shardFailures = null;
         for (int i = 0; i < shardsResponses.size(); i++) {
-            ActionWriteResponse shardResponse = shardsResponses.get(i);
+            ReplicationResponse shardResponse = shardsResponses.get(i);
             if (shardResponse == null) {
                 // non active shard, ignore
             } else {
@@ -152,7 +151,7 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
                 if (shardFailures == null) {
                     shardFailures = new ArrayList<>();
                 }
-                for (ActionWriteResponse.ShardInfo.Failure failure : shardResponse.getShardInfo().getFailures()) {
+                for (ReplicationResponse.ShardInfo.Failure failure : shardResponse.getShardInfo().getFailures()) {
                     shardFailures.add(new DefaultShardOperationFailedException(new BroadcastShardOperationFailedException(new ShardId(failure.index(), failure.shardId()), failure.getCause())));
                 }
             }

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -175,7 +175,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 indexAction.execute(upsertRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getIndex(), response.getType(), response.getId(), response.getVersion(), response.isCreated());
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.isCreated());
                         if (request.fields() != null && request.fields().length > 0) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(upsertSourceBytes, true);
                             update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), upsertSourceBytes));
@@ -212,7 +212,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 indexAction.execute(indexRequest, new ActionListener<IndexResponse>() {
                     @Override
                     public void onResponse(IndexResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getIndex(), response.getType(), response.getId(), response.getVersion(), response.isCreated());
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), response.isCreated());
                         update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
                         listener.onResponse(update);
                     }
@@ -240,7 +240,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 deleteAction.execute(deleteRequest, new ActionListener<DeleteResponse>() {
                     @Override
                     public void onResponse(DeleteResponse response) {
-                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getIndex(), response.getType(), response.getId(), response.getVersion(), false);
+                        UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), false);
                         update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));
                         listener.onResponse(update);
                     }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
@@ -70,6 +71,14 @@ public class UpdateResponse extends DocWriteResponse {
     }
 
     @Override
+    public RestStatus status() {
+        if (created) {
+            return RestStatus.CREATED;
+        }
+        return super.status();
+    }
+
+    @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         created = in.readBoolean();
@@ -105,4 +114,18 @@ public class UpdateResponse extends DocWriteResponse {
         }
         return builder;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("UpdateResponse[");
+        builder.append("index=").append(getIndex());
+        builder.append(",type=").append(getType());
+        builder.append(",id=").append(getId());
+        builder.append(",version=").append(getVersion());
+        builder.append(",created=").append(created);
+        builder.append(",shards=").append(getShardInfo());
+        return builder.append("]").toString();
+    }
+
 }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -19,21 +19,20 @@
 
 package org.elasticsearch.action.update;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
 /**
  */
-public class UpdateResponse extends ActionWriteResponse {
+public class UpdateResponse extends DocWriteResponse {
 
-    private String index;
-    private String id;
-    private String type;
-    private long version;
     private boolean created;
     private GetResult getResult;
 
@@ -44,45 +43,14 @@ public class UpdateResponse extends ActionWriteResponse {
      * Constructor to be used when a update didn't translate in a write.
      * For example: update script with operation set to none
      */
-    public UpdateResponse(String index, String type, String id, long version, boolean created) {
-        this(new ShardInfo(0, 0), index, type, id, version, created);
+    public UpdateResponse(ShardId shardId, String type, String id, long version, boolean created) {
+        this(new ShardInfo(0, 0), shardId, type, id, version, created);
     }
 
-    public UpdateResponse(ShardInfo shardInfo, String index, String type, String id, long version, boolean created) {
+    public UpdateResponse(ShardInfo shardInfo, ShardId shardId, String type, String id, long version, boolean created) {
+        super(shardId, type, id, version);
         setShardInfo(shardInfo);
-        this.index = index;
-        this.id = id;
-        this.type = type;
-        this.version = version;
         this.created = created;
-    }
-
-    /**
-     * The index the document was indexed into.
-     */
-    public String getIndex() {
-        return this.index;
-    }
-
-    /**
-     * The type of the document indexed.
-     */
-    public String getType() {
-        return this.type;
-    }
-
-    /**
-     * The id of the document indexed.
-     */
-    public String getId() {
-        return this.id;
-    }
-
-    /**
-     * Returns the current version of the doc indexed.
-     */
-    public long getVersion() {
-        return this.version;
     }
 
     public void setGetResult(GetResult getResult) {
@@ -104,10 +72,6 @@ public class UpdateResponse extends ActionWriteResponse {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        index = in.readString();
-        type = in.readString();
-        id = in.readString();
-        version = in.readLong();
         created = in.readBoolean();
         if (in.readBoolean()) {
             getResult = GetResult.readGetResult(in);
@@ -117,10 +81,6 @@ public class UpdateResponse extends ActionWriteResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(index);
-        out.writeString(type);
-        out.writeString(id);
-        out.writeLong(version);
         out.writeBoolean(created);
         if (getResult == null) {
             out.writeBoolean(false);
@@ -128,5 +88,21 @@ public class UpdateResponse extends ActionWriteResponse {
             out.writeBoolean(true);
             getResult.writeTo(out);
         }
+    }
+
+
+    static final class Fields {
+        static final XContentBuilderString GET = new XContentBuilderString("get");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        super.toXContent(builder, params);
+        if (getGetResult() != null) {
+            builder.startObject(Fields.GET);
+            getGetResult().toXContentEmbedded(builder, params);
+            builder.endObject();
+        }
+        return builder;
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.rest.action.bulk;
 
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -93,22 +91,7 @@ public class RestBulkAction extends BaseRestHandler {
                 builder.startArray(Fields.ITEMS);
                 for (BulkItemResponse itemResponse : response) {
                     builder.startObject();
-                    builder.startObject(itemResponse.getOpType());
-                    if (itemResponse.isFailed()) {
-                        builder.field(Fields._INDEX, itemResponse.getIndex());
-                        builder.field(Fields._TYPE, itemResponse.getType());
-                        builder.field(Fields._ID, itemResponse.getId());
-                        builder.field(Fields.STATUS, itemResponse.getFailure().getStatus().getStatus());
-                        builder.startObject(Fields.ERROR);
-                        ElasticsearchException.toXContent(builder, request, itemResponse.getFailure().getCause());
-                        builder.endObject();
-                    } else {
-                        final DocWriteResponse docResponse = itemResponse.getResponse();
-                        docResponse.toXContent(builder, request);
-                        RestStatus status = docResponse.status();
-                        builder.field(Fields.STATUS, status.getStatus());
-                    }
-                    builder.endObject();
+                    itemResponse.toXContent(builder, request);
                     builder.endObject();
                 }
                 builder.endArray();
@@ -122,11 +105,6 @@ public class RestBulkAction extends BaseRestHandler {
     static final class Fields {
         static final XContentBuilderString ITEMS = new XContentBuilderString("items");
         static final XContentBuilderString ERRORS = new XContentBuilderString("errors");
-        static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
-        static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
-        static final XContentBuilderString _ID = new XContentBuilderString("_id");
-        static final XContentBuilderString STATUS = new XContentBuilderString("status");
-        static final XContentBuilderString ERROR = new XContentBuilderString("error");
         static final XContentBuilderString TOOK = new XContentBuilderString("took");
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -21,15 +21,11 @@ package org.elasticsearch.rest.action.bulk;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.bulk.BulkShardRequest;
-import org.elasticsearch.action.delete.DeleteResponse;
-import org.elasticsearch.action.index.IndexResponse;
-import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.Strings;
@@ -109,23 +105,7 @@ public class RestBulkAction extends BaseRestHandler {
                     } else {
                         final DocWriteResponse docResponse = itemResponse.getResponse();
                         docResponse.toXContent(builder, request);
-                        RestStatus status = docResponse.getShardInfo().status();
-                        if (docResponse instanceof DeleteResponse) {
-                            DeleteResponse deleteResponse = (DeleteResponse) docResponse;
-                            if (deleteResponse.isFound() == false) {
-                                status = RestStatus.NOT_FOUND;
-                            }
-                        } else if (docResponse instanceof IndexResponse) {
-                            IndexResponse indexResponse = (IndexResponse) docResponse;
-                            if (indexResponse.isCreated()) {
-                                status = RestStatus.CREATED;
-                            }
-                        } else if (docResponse instanceof UpdateResponse) {
-                            UpdateResponse updateResponse = (UpdateResponse) docResponse;
-                            if (updateResponse.isCreated()) {
-                                status = RestStatus.CREATED;
-                            }
-                        }
+                        RestStatus status = docResponse.status();
                         builder.field(Fields.STATUS, status.getStatus());
                     }
                     builder.endObject();

--- a/core/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -20,7 +20,8 @@
 package org.elasticsearch.rest.action.bulk;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -97,49 +98,35 @@ public class RestBulkAction extends BaseRestHandler {
                 for (BulkItemResponse itemResponse : response) {
                     builder.startObject();
                     builder.startObject(itemResponse.getOpType());
-                    builder.field(Fields._INDEX, itemResponse.getIndex());
-                    builder.field(Fields._TYPE, itemResponse.getType());
-                    builder.field(Fields._ID, itemResponse.getId());
-                    long version = itemResponse.getVersion();
-                    if (version != -1) {
-                        builder.field(Fields._VERSION, itemResponse.getVersion());
-                    }
                     if (itemResponse.isFailed()) {
+                        builder.field(Fields._INDEX, itemResponse.getIndex());
+                        builder.field(Fields._TYPE, itemResponse.getType());
+                        builder.field(Fields._ID, itemResponse.getId());
                         builder.field(Fields.STATUS, itemResponse.getFailure().getStatus().getStatus());
                         builder.startObject(Fields.ERROR);
                         ElasticsearchException.toXContent(builder, request, itemResponse.getFailure().getCause());
                         builder.endObject();
                     } else {
-                        ActionWriteResponse.ShardInfo shardInfo = itemResponse.getResponse().getShardInfo();
-                        shardInfo.toXContent(builder, request);
-                        if (itemResponse.getResponse() instanceof DeleteResponse) {
-                            DeleteResponse deleteResponse = itemResponse.getResponse();
-                            if (deleteResponse.isFound()) {
-                                builder.field(Fields.STATUS, shardInfo.status().getStatus());
-                            } else {
-                                builder.field(Fields.STATUS, RestStatus.NOT_FOUND.getStatus());
+                        final DocWriteResponse docResponse = itemResponse.getResponse();
+                        docResponse.toXContent(builder, request);
+                        RestStatus status = docResponse.getShardInfo().status();
+                        if (docResponse instanceof DeleteResponse) {
+                            DeleteResponse deleteResponse = (DeleteResponse) docResponse;
+                            if (deleteResponse.isFound() == false) {
+                                status = RestStatus.NOT_FOUND;
                             }
-                            builder.field(Fields.FOUND, deleteResponse.isFound());
-                        } else if (itemResponse.getResponse() instanceof IndexResponse) {
-                            IndexResponse indexResponse = itemResponse.getResponse();
+                        } else if (docResponse instanceof IndexResponse) {
+                            IndexResponse indexResponse = (IndexResponse) docResponse;
                             if (indexResponse.isCreated()) {
-                                builder.field(Fields.STATUS, RestStatus.CREATED.getStatus());
-                            } else {
-                                builder.field(Fields.STATUS, shardInfo.status().getStatus());
+                                status = RestStatus.CREATED;
                             }
-                        } else if (itemResponse.getResponse() instanceof UpdateResponse) {
-                            UpdateResponse updateResponse = itemResponse.getResponse();
+                        } else if (docResponse instanceof UpdateResponse) {
+                            UpdateResponse updateResponse = (UpdateResponse) docResponse;
                             if (updateResponse.isCreated()) {
-                                builder.field(Fields.STATUS, RestStatus.CREATED.getStatus());
-                            } else {
-                                builder.field(Fields.STATUS, shardInfo.status().getStatus());
-                            }
-                            if (updateResponse.getGetResult() != null) {
-                                builder.startObject(Fields.GET);
-                                updateResponse.getGetResult().toXContentEmbedded(builder, request);
-                                builder.endObject();
+                                status = RestStatus.CREATED;
                             }
                         }
+                        builder.field(Fields.STATUS, status.getStatus());
                     }
                     builder.endObject();
                     builder.endObject();
@@ -161,9 +148,6 @@ public class RestBulkAction extends BaseRestHandler {
         static final XContentBuilderString STATUS = new XContentBuilderString("status");
         static final XContentBuilderString ERROR = new XContentBuilderString("error");
         static final XContentBuilderString TOOK = new XContentBuilderString("took");
-        static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
-        static final XContentBuilderString FOUND = new XContentBuilderString("found");
-        static final XContentBuilderString GET = new XContentBuilderString("get");
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.rest.action.delete;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -65,28 +65,15 @@ public class RestDeleteAction extends BaseRestHandler {
         client.delete(deleteRequest, new RestBuilderListener<DeleteResponse>(channel) {
             @Override
             public RestResponse buildResponse(DeleteResponse result, XContentBuilder builder) throws Exception {
-                ActionWriteResponse.ShardInfo shardInfo = result.getShardInfo();
-                builder.startObject().field(Fields.FOUND, result.isFound())
-                        .field(Fields._INDEX, result.getIndex())
-                        .field(Fields._TYPE, result.getType())
-                        .field(Fields._ID, result.getId())
-                        .field(Fields._VERSION, result.getVersion())
-                        .value(shardInfo)
-                        .endObject();
-                RestStatus status = shardInfo.status();
+                builder.startObject();
+                result.toXContent(builder, request);
+                builder.endObject();
+                RestStatus status = result.getShardInfo().status();
                 if (!result.isFound()) {
                     status = NOT_FOUND;
                 }
                 return new BytesRestResponse(status, builder);
             }
         });
-    }
-
-    static final class Fields {
-        static final XContentBuilderString FOUND = new XContentBuilderString("found");
-        static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
-        static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
-        static final XContentBuilderString _ID = new XContentBuilderString("_id");
-        static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/delete/RestDeleteAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.delete;
 
-import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -27,14 +26,13 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
+import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
-import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 
 /**
  *
@@ -62,18 +60,6 @@ public class RestDeleteAction extends BaseRestHandler {
             deleteRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
 
-        client.delete(deleteRequest, new RestBuilderListener<DeleteResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(DeleteResponse result, XContentBuilder builder) throws Exception {
-                builder.startObject();
-                result.toXContent(builder, request);
-                builder.endObject();
-                RestStatus status = result.getShardInfo().status();
-                if (!result.isFound()) {
-                    status = NOT_FOUND;
-                }
-                return new BytesRestResponse(status, builder);
-            }
-        });
+        client.delete(deleteRequest, new RestStatusToXContentListener<>(channel));
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.rest.action.index;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
@@ -103,15 +103,9 @@ public class RestIndexAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(IndexResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                ActionWriteResponse.ShardInfo shardInfo = response.getShardInfo();
-                builder.field(Fields._INDEX, response.getIndex())
-                        .field(Fields._TYPE, response.getType())
-                        .field(Fields._ID, response.getId())
-                        .field(Fields._VERSION, response.getVersion());
-                shardInfo.toXContent(builder, request);
-                builder.field(Fields.CREATED, response.isCreated());
+                response.toXContent(builder, request);
                 builder.endObject();
-                RestStatus status = shardInfo.status();
+                RestStatus status = response.getShardInfo().status();
                 if (response.isCreated()) {
                     status = CREATED;
                 }
@@ -119,13 +113,4 @@ public class RestIndexAction extends BaseRestHandler {
             }
         });
     }
-
-    static final class Fields {
-        static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
-        static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
-        static final XContentBuilderString _ID = new XContentBuilderString("_id");
-        static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
-        static final XContentBuilderString CREATED = new XContentBuilderString("created");
-    }
-
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/index/RestIndexAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.index;
 
-import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
@@ -27,11 +26,11 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
+import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 
 import java.io.IOException;
 
@@ -99,18 +98,6 @@ public class RestIndexAction extends BaseRestHandler {
         if (consistencyLevel != null) {
             indexRequest.consistencyLevel(WriteConsistencyLevel.fromString(consistencyLevel));
         }
-        client.index(indexRequest, new RestBuilderListener<IndexResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(IndexResponse response, XContentBuilder builder) throws Exception {
-                builder.startObject();
-                response.toXContent(builder, request);
-                builder.endObject();
-                RestStatus status = response.getShardInfo().status();
-                if (response.isCreated()) {
-                    status = CREATED;
-                }
-                return new BytesRestResponse(status, builder);
-            }
-        });
+        client.index(indexRequest, new RestStatusToXContentListener<>(channel));
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.rest.action.update;
 
-import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -29,7 +28,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -40,6 +38,7 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.support.RestActions;
 import org.elasticsearch.rest.action.support.RestBuilderListener;
+import org.elasticsearch.rest.action.support.RestStatusToXContentListener;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptParameterParser;
 import org.elasticsearch.script.ScriptParameterParser.ScriptParameterValue;
@@ -48,7 +47,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.CREATED;
 
 /**
  */
@@ -123,18 +121,6 @@ public class RestUpdateAction extends BaseRestHandler {
             }
         }
 
-        client.update(updateRequest, new RestBuilderListener<UpdateResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(UpdateResponse response, XContentBuilder builder) throws Exception {
-                builder.startObject();
-                response.toXContent(builder, request);
-                builder.endObject();
-                RestStatus status = response.getShardInfo().status();
-                if (response.isCreated()) {
-                    status = CREATED;
-                }
-                return new BytesRestResponse(status, builder);
-            }
-        });
+        client.update(updateRequest, new RestStatusToXContentListener<>(channel));
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/update/RestUpdateAction.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.rest.action.update;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -127,34 +127,14 @@ public class RestUpdateAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(UpdateResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
-                ActionWriteResponse.ShardInfo shardInfo = response.getShardInfo();
-                builder.field(Fields._INDEX, response.getIndex())
-                        .field(Fields._TYPE, response.getType())
-                        .field(Fields._ID, response.getId())
-                        .field(Fields._VERSION, response.getVersion());
-
-                shardInfo.toXContent(builder, request);
-                if (response.getGetResult() != null) {
-                    builder.startObject(Fields.GET);
-                    response.getGetResult().toXContentEmbedded(builder, request);
-                    builder.endObject();
-                }
-
+                response.toXContent(builder, request);
                 builder.endObject();
-                RestStatus status = shardInfo.status();
+                RestStatus status = response.getShardInfo().status();
                 if (response.isCreated()) {
                     status = CREATED;
                 }
                 return new BytesRestResponse(status, builder);
             }
         });
-    }
-
-    static final class Fields {
-        static final XContentBuilderString _INDEX = new XContentBuilderString("_index");
-        static final XContentBuilderString _TYPE = new XContentBuilderString("_type");
-        static final XContentBuilderString _ID = new XContentBuilderString("_id");
-        static final XContentBuilderString _VERSION = new XContentBuilderString("_version");
-        static final XContentBuilderString GET = new XContentBuilderString("get");
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -20,7 +20,7 @@ package org.elasticsearch.action.support.replication;
 
 import org.apache.lucene.index.CorruptIndexException;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.support.ActionFilter;
@@ -521,7 +521,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
         assertThat(listener.isDone(), equalTo(true));
         Response response = listener.get();
-        final ActionWriteResponse.ShardInfo shardInfo = response.getShardInfo();
+        final ReplicationResponse.ShardInfo shardInfo = response.getShardInfo();
         assertThat(shardInfo.getFailed(), equalTo(criticalFailures));
         assertThat(shardInfo.getFailures(), arrayWithSize(criticalFailures));
         assertThat(shardInfo.getSuccessful(), equalTo(successful));
@@ -703,7 +703,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
     }
 
-    static class Response extends ActionWriteResponse {
+    static class Response extends ReplicationResponse {
     }
 
     class Action extends TransportReplicationAction<Request, Request, Response> {

--- a/core/src/test/java/org/elasticsearch/document/ShardInfoIT.java
+++ b/core/src/test/java/org/elasticsearch/document/ShardInfoIT.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.document;
 
-import org.elasticsearch.action.ActionWriteResponse;
+import org.elasticsearch.action.ReplicationResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -117,11 +117,11 @@ public class ShardInfoIT extends ESIntegTestCase {
         }
     }
 
-    private void assertShardInfo(ActionWriteResponse response) {
+    private void assertShardInfo(ReplicationResponse response) {
         assertShardInfo(response, numCopies, numNodes);
     }
 
-    private void assertShardInfo(ActionWriteResponse response, int expectedTotal, int expectedSuccessful) {
+    private void assertShardInfo(ReplicationResponse response, int expectedTotal, int expectedSuccessful) {
         assertThat(response.getShardInfo().getTotal(), greaterThanOrEqualTo(expectedTotal));
         assertThat(response.getShardInfo().getSuccessful(), greaterThanOrEqualTo(expectedSuccessful));
     }

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.update;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -39,24 +38,12 @@ import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.shard.MergePolicyConfig;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.script.CompiledScript;
-import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptEngineService;
-import org.elasticsearch.script.ScriptModule;
-import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.SearchScript;
+import org.elasticsearch.script.*;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
@@ -65,14 +52,7 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 public class UpdateIT extends ESIntegTestCase {
 
@@ -107,7 +87,7 @@ public class UpdateIT extends ESIntegTestCase {
 
         @Override
         public String[] types() {
-            return new String[] { NAME };
+            return new String[]{NAME};
         }
 
         @Override
@@ -205,7 +185,7 @@ public class UpdateIT extends ESIntegTestCase {
 
         @Override
         public String[] types() {
-            return new String[] { NAME };
+            return new String[]{NAME};
         }
 
         @Override
@@ -296,7 +276,7 @@ public class UpdateIT extends ESIntegTestCase {
 
         @Override
         public String[] types() {
-            return new String[] { NAME };
+            return new String[]{NAME};
         }
 
         @Override
@@ -387,7 +367,7 @@ public class UpdateIT extends ESIntegTestCase {
 
         @Override
         public String[] types() {
-            return new String[] { NAME };
+            return new String[]{NAME};
         }
 
         @Override
@@ -451,23 +431,23 @@ public class UpdateIT extends ESIntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(
-                PutFieldValuesScriptPlugin.class,
-                FieldIncrementScriptPlugin.class,
-                ScriptedUpsertScriptPlugin.class,
-                ExtractContextInSourceScriptPlugin.class);
+            PutFieldValuesScriptPlugin.class,
+            FieldIncrementScriptPlugin.class,
+            ScriptedUpsertScriptPlugin.class,
+            ExtractContextInSourceScriptPlugin.class);
     }
 
     private void createTestIndex() throws Exception {
         logger.info("--> creating index test");
 
         assertAcked(prepareCreate("test").addAlias(new Alias("alias"))
-                .addMapping("type1", XContentFactory.jsonBuilder()
-                        .startObject()
-                        .startObject("type1")
-                        .startObject("_timestamp").field("enabled", true).endObject()
-                        .startObject("_ttl").field("enabled", true).endObject()
-                        .endObject()
-                        .endObject()));
+            .addMapping("type1", XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("type1")
+                .startObject("_timestamp").field("enabled", true).endObject()
+                .startObject("_ttl").field("enabled", true).endObject()
+                .endObject()
+                .endObject()));
     }
 
     public void testUpsert() throws Exception {
@@ -475,9 +455,9 @@ public class UpdateIT extends ESIntegTestCase {
         ensureGreen();
 
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
-                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
-                .execute().actionGet();
+            .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
+            .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+            .execute().actionGet();
         assertTrue(updateResponse.isCreated());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
@@ -487,9 +467,9 @@ public class UpdateIT extends ESIntegTestCase {
         }
 
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
-                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
-                .execute().actionGet();
+            .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
+            .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+            .execute().actionGet();
         assertFalse(updateResponse.isCreated());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
@@ -507,7 +487,7 @@ public class UpdateIT extends ESIntegTestCase {
         // 1) New accounts take balance from "balance" in upsert doc and first payment is charged at 50%
         // 2) Existing accounts subtract full payment from balance stored in elasticsearch
 
-        int openingBalance=10;
+        int openingBalance = 10;
 
         Map<String, Object> params = new HashMap<>();
         params.put("payment", 2);
@@ -515,10 +495,10 @@ public class UpdateIT extends ESIntegTestCase {
         // Pay money from what will be a new account and opening balance comes from upsert doc
         // provided by client
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setUpsert(XContentFactory.jsonBuilder().startObject().field("balance", openingBalance).endObject())
-                .setScriptedUpsert(true)
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "scripted_upsert", params))
-                .execute().actionGet();
+            .setUpsert(XContentFactory.jsonBuilder().startObject().field("balance", openingBalance).endObject())
+            .setScriptedUpsert(true)
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "scripted_upsert", params))
+            .execute().actionGet();
         assertTrue(updateResponse.isCreated());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
@@ -529,10 +509,10 @@ public class UpdateIT extends ESIntegTestCase {
 
         // Now pay money for an existing account where balance is stored in es
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setUpsert(XContentFactory.jsonBuilder().startObject().field("balance", openingBalance).endObject())
-                .setScriptedUpsert(true)
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "scripted_upsert", params))
-                .execute().actionGet();
+            .setUpsert(XContentFactory.jsonBuilder().startObject().field("balance", openingBalance).endObject())
+            .setScriptedUpsert(true)
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "scripted_upsert", params))
+            .execute().actionGet();
         assertFalse(updateResponse.isCreated());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
@@ -547,10 +527,10 @@ public class UpdateIT extends ESIntegTestCase {
         ensureGreen();
 
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setDoc(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
-                .setDocAsUpsert(true)
-                .setFields("_source")
-                .execute().actionGet();
+            .setDoc(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
+            .setDocAsUpsert(true)
+            .setFields("_source")
+            .execute().actionGet();
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
         assertThat(updateResponse.getGetResult().getIndex(), equalTo("test"));
@@ -563,10 +543,10 @@ public class UpdateIT extends ESIntegTestCase {
         ensureGreen();
 
         assertThrows(client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setDoc(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
-                .setDocAsUpsert(false)
-                .setFields("_source")
-                .execute(), DocumentMissingException.class);
+            .setDoc(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
+            .setDocAsUpsert(false)
+            .setFields("_source")
+            .execute(), DocumentMissingException.class);
     }
 
     public void testUpsertFields() throws Exception {
@@ -574,10 +554,10 @@ public class UpdateIT extends ESIntegTestCase {
         ensureGreen();
 
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("extra", "foo")))
-                .setFields("_source")
-                .execute().actionGet();
+            .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("extra", "foo")))
+            .setFields("_source")
+            .execute().actionGet();
 
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
@@ -586,10 +566,10 @@ public class UpdateIT extends ESIntegTestCase {
         assertThat(updateResponse.getGetResult().sourceAsMap().get("extra"), nullValue());
 
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("extra", "foo")))
-                .setFields("_source")
-                .execute().actionGet();
+            .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("extra", "foo")))
+            .setFields("_source")
+            .execute().actionGet();
 
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
@@ -605,40 +585,40 @@ public class UpdateIT extends ESIntegTestCase {
         index("test", "type", "1", "text", "value"); // version is now 1
 
         assertThrows(client().prepareUpdate(indexOrAlias(), "type", "1")
-                        .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(2)
-                        .execute(),
-                VersionConflictEngineException.class);
+                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(2)
+                .execute(),
+            VersionConflictEngineException.class);
 
         client().prepareUpdate(indexOrAlias(), "type", "1")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(1).get();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(1).get();
         assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(2l));
 
         // and again with a higher version..
         client().prepareUpdate(indexOrAlias(), "type", "1")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v3"))).setVersion(2).get();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v3"))).setVersion(2).get();
 
         assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(3l));
 
         // after delete
         client().prepareDelete("test", "type", "1").get();
         assertThrows(client().prepareUpdate("test", "type", "1")
-                        .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(3)
-                        .execute(),
-                DocumentMissingException.class);
+                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(3)
+                .execute(),
+            DocumentMissingException.class);
 
         // external versioning
         client().prepareIndex("test", "type", "2").setSource("text", "value").setVersion(10).setVersionType(VersionType.EXTERNAL).get();
 
         assertThrows(client().prepareUpdate(indexOrAlias(), "type", "2")
-                        .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(2)
-                        .setVersionType(VersionType.EXTERNAL).execute(),
-                ActionRequestValidationException.class);
+                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(2)
+                .setVersionType(VersionType.EXTERNAL).execute(),
+            ActionRequestValidationException.class);
 
 
         // With force version
         client().prepareUpdate(indexOrAlias(), "type", "2")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE,  "put_values", Collections.singletonMap("text", "v10")))
-                .setVersion(10).setVersionType(VersionType.FORCE).get();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v10")))
+            .setVersion(10).setVersionType(VersionType.FORCE).get();
 
         GetResponse get = get("test", "type", "2");
         assertThat(get.getVersion(), equalTo(10l));
@@ -648,8 +628,8 @@ public class UpdateIT extends ESIntegTestCase {
 
         // With internal versions, tt means "if object is there with version X, update it or explode. If it is not there, index.
         client().prepareUpdate(indexOrAlias(), "type", "3")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2")))
-                .setVersion(10).setUpsert("{ \"text\": \"v0\" }").get();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2")))
+            .setVersion(10).setUpsert("{ \"text\": \"v0\" }").get();
         get = get("test", "type", "3");
         assertThat(get.getVersion(), equalTo(1l));
         assertThat((String) get.getSource().get("text"), equalTo("v0"));
@@ -660,10 +640,10 @@ public class UpdateIT extends ESIntegTestCase {
 
     public void testIndexAutoCreation() throws Exception {
         UpdateResponse updateResponse = client().prepareUpdate("test", "type1", "1")
-                .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("extra", "foo")))
-                .setFields("_source")
-                .execute().actionGet();
+            .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("extra", "foo")))
+            .setFields("_source")
+            .execute().actionGet();
 
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
@@ -678,7 +658,7 @@ public class UpdateIT extends ESIntegTestCase {
 
         try {
             client().prepareUpdate(indexOrAlias(), "type1", "1")
-                    .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
+                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
             fail();
         } catch (DocumentMissingException e) {
             // all is well
@@ -687,7 +667,7 @@ public class UpdateIT extends ESIntegTestCase {
         client().prepareIndex("test", "type1", "1").setSource("field", 1).execute().actionGet();
 
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
+            .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(2L));
         assertFalse(updateResponse.isCreated());
         assertThat(updateResponse.getIndex(), equalTo("test"));
@@ -700,7 +680,7 @@ public class UpdateIT extends ESIntegTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("inc", 3);
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", params)).execute().actionGet();
+            .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", params)).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(3L));
         assertFalse(updateResponse.isCreated());
         assertThat(updateResponse.getIndex(), equalTo("test"));
@@ -712,7 +692,7 @@ public class UpdateIT extends ESIntegTestCase {
 
         // check noop
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("op", "none")))).execute().actionGet();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("op", "none")))).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(3L));
         assertFalse(updateResponse.isCreated());
         assertThat(updateResponse.getIndex(), equalTo("test"));
@@ -724,7 +704,7 @@ public class UpdateIT extends ESIntegTestCase {
 
         // check delete
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("op", "delete")))).execute().actionGet();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("op", "delete")))).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(4L));
         assertFalse(updateResponse.isCreated());
         assertThat(updateResponse.getIndex(), equalTo("test"));
@@ -740,14 +720,14 @@ public class UpdateIT extends ESIntegTestCase {
         long ttl = ((Number) getResponse.getField("_ttl").getValue()).longValue();
         assertThat(ttl, greaterThan(0L));
         client().prepareUpdate(indexOrAlias(), "type1", "2")
-                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
+            .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).execute().actionGet();
         getResponse = client().prepareGet("test", "type1", "2").setFields("_ttl").execute().actionGet();
         ttl = ((Number) getResponse.getField("_ttl").getValue()).longValue();
         assertThat(ttl, greaterThan(0L));
 
         // check TTL update
         client().prepareUpdate(indexOrAlias(), "type1", "2")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("_ttl", 3600000)))).execute().actionGet();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("_ttl", 3600000)))).execute().actionGet();
         getResponse = client().prepareGet("test", "type1", "2").setFields("_ttl").execute().actionGet();
         ttl = ((Number) getResponse.getField("_ttl").getValue()).longValue();
         assertThat(ttl, greaterThan(0L));
@@ -756,8 +736,8 @@ public class UpdateIT extends ESIntegTestCase {
         // check timestamp update
         client().prepareIndex("test", "type1", "3").setSource("field", 1).setRefresh(true).execute().actionGet();
         client().prepareUpdate(indexOrAlias(), "type1", "3")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("_timestamp", "2009-11-15T14:12:12")))).execute()
-                .actionGet();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("_ctx", Collections.singletonMap("_timestamp", "2009-11-15T14:12:12")))).execute()
+            .actionGet();
         getResponse = client().prepareGet("test", "type1", "3").setFields("_timestamp").execute().actionGet();
         long timestamp = ((Number) getResponse.getField("_timestamp").getValue()).longValue();
         assertThat(timestamp, equalTo(1258294332000L));
@@ -765,8 +745,8 @@ public class UpdateIT extends ESIntegTestCase {
         // check fields parameter
         client().prepareIndex("test", "type1", "1").setSource("field", 1).execute().actionGet();
         updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1")
-                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).setFields("_source", "field")
-                .execute().actionGet();
+            .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null)).setFields("_source", "field")
+            .execute().actionGet();
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
         assertThat(updateResponse.getGetResult().getIndex(), equalTo("test"));
@@ -824,9 +804,9 @@ public class UpdateIT extends ESIntegTestCase {
 
         try {
             client().prepareUpdate(indexOrAlias(), "type1", "1")
-                    .setDoc(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
-                    .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
-                    .execute().actionGet();
+                .setDoc(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
+                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+                .execute().actionGet();
             fail("Should have thrown ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
             assertThat(e.validationErrors().size(), equalTo(1));
@@ -840,9 +820,9 @@ public class UpdateIT extends ESIntegTestCase {
         ensureGreen();
         try {
             client().prepareUpdate(indexOrAlias(), "type1", "1")
-                    .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
-                    .setDocAsUpsert(true)
-                    .execute().actionGet();
+                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+                .setDocAsUpsert(true)
+                .execute().actionGet();
             fail("Should have thrown ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
             assertThat(e.validationErrors().size(), equalTo(1));
@@ -853,51 +833,51 @@ public class UpdateIT extends ESIntegTestCase {
 
     public void testContextVariables() throws Exception {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias"))
-                        .addMapping("type1", XContentFactory.jsonBuilder()
-                                .startObject()
-                                .startObject("type1")
-                                .startObject("_timestamp").field("enabled", true).endObject()
-                                .startObject("_ttl").field("enabled", true).endObject()
-                                .endObject()
-                                .endObject())
-                        .addMapping("subtype1", XContentFactory.jsonBuilder()
-                                .startObject()
-                                .startObject("subtype1")
-                                .startObject("_parent").field("type", "type1").endObject()
-                                .startObject("_timestamp").field("enabled", true).endObject()
-                                .startObject("_ttl").field("enabled", true).endObject()
-                                .endObject()
-                                .endObject())
+                .addMapping("type1", XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("type1")
+                    .startObject("_timestamp").field("enabled", true).endObject()
+                    .startObject("_ttl").field("enabled", true).endObject()
+                    .endObject()
+                    .endObject())
+                .addMapping("subtype1", XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("subtype1")
+                    .startObject("_parent").field("type", "type1").endObject()
+                    .startObject("_timestamp").field("enabled", true).endObject()
+                    .startObject("_ttl").field("enabled", true).endObject()
+                    .endObject()
+                    .endObject())
         );
         ensureGreen();
 
         // Index some documents
         long timestamp = System.currentTimeMillis();
         client().prepareIndex()
-                .setIndex("test")
-                .setType("type1")
-                .setId("parentId1")
-                .setTimestamp(String.valueOf(timestamp-1))
-                .setSource("field1", 0, "content", "bar")
-                .execute().actionGet();
+            .setIndex("test")
+            .setType("type1")
+            .setId("parentId1")
+            .setTimestamp(String.valueOf(timestamp - 1))
+            .setSource("field1", 0, "content", "bar")
+            .execute().actionGet();
 
         long ttl = 10000;
         client().prepareIndex()
-                .setIndex("test")
-                .setType("subtype1")
-                .setId("id1")
-                .setParent("parentId1")
-                .setRouting("routing1")
-                .setTimestamp(String.valueOf(timestamp))
-                .setTTL(ttl)
-                .setSource("field1", 1, "content", "foo")
-                .execute().actionGet();
+            .setIndex("test")
+            .setType("subtype1")
+            .setId("id1")
+            .setParent("parentId1")
+            .setRouting("routing1")
+            .setTimestamp(String.valueOf(timestamp))
+            .setTTL(ttl)
+            .setSource("field1", 1, "content", "foo")
+            .execute().actionGet();
 
         // Update the first object and note context variables values
         UpdateResponse updateResponse = client().prepareUpdate("test", "subtype1", "id1")
-                .setRouting("routing1")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "extract_ctx", null))
-                .execute().actionGet();
+            .setRouting("routing1")
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "extract_ctx", null))
+            .execute().actionGet();
 
         assertEquals(2, updateResponse.getVersion());
 
@@ -909,12 +889,12 @@ public class UpdateIT extends ESIntegTestCase {
         assertEquals(1, updateContext.get("_version"));
         assertEquals("parentId1", updateContext.get("_parent"));
         assertEquals("routing1", updateContext.get("_routing"));
-        assertThat(((Integer) updateContext.get("_ttl")).longValue(), allOf(greaterThanOrEqualTo(ttl-3000), lessThanOrEqualTo(ttl)));
+        assertThat(((Integer) updateContext.get("_ttl")).longValue(), allOf(greaterThanOrEqualTo(ttl - 3000), lessThanOrEqualTo(ttl)));
 
         // Idem with the second object
         updateResponse = client().prepareUpdate("test", "type1", "parentId1")
-                .setScript(new Script("", ScriptService.ScriptType.INLINE, "extract_ctx", null))
-                .execute().actionGet();
+            .setScript(new Script("", ScriptService.ScriptType.INLINE, "extract_ctx", null))
+            .execute().actionGet();
 
         assertEquals(2, updateResponse.getVersion());
 
@@ -934,7 +914,7 @@ public class UpdateIT extends ESIntegTestCase {
         createTestIndex();
         ensureGreen();
 
-        int numberOfThreads = scaledRandomIntBetween(2,5);
+        int numberOfThreads = scaledRandomIntBetween(2, 5);
         final CountDownLatch latch = new CountDownLatch(numberOfThreads);
         final CountDownLatch startLatch = new CountDownLatch(1);
         final int numberOfUpdatesPerThread = scaledRandomIntBetween(100, 500);
@@ -952,16 +932,16 @@ public class UpdateIT extends ESIntegTestCase {
                             }
                             if (useBulkApi) {
                                 UpdateRequestBuilder updateRequestBuilder = client().prepareUpdate(indexOrAlias(), "type1", Integer.toString(i))
-                                        .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
-                                        .setRetryOnConflict(Integer.MAX_VALUE)
-                                        .setUpsert(jsonBuilder().startObject().field("field", 1).endObject());
+                                    .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+                                    .setRetryOnConflict(Integer.MAX_VALUE)
+                                    .setUpsert(jsonBuilder().startObject().field("field", 1).endObject());
                                 client().prepareBulk().add(updateRequestBuilder).execute().actionGet();
                             } else {
                                 client().prepareUpdate(indexOrAlias(), "type1", Integer.toString(i))
-                                        .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
-                                        .setRetryOnConflict(Integer.MAX_VALUE)
-                                        .setUpsert(jsonBuilder().startObject().field("field", 1).endObject())
-                                        .execute().actionGet();
+                                    .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+                                    .setRetryOnConflict(Integer.MAX_VALUE)
+                                    .setUpsert(jsonBuilder().startObject().field("field", 1).endObject())
+                                    .execute().actionGet();
                             }
                         }
                         logger.info("Client [{}] issued all [{}] requests.", Thread.currentThread().getName(), numberOfUpdatesPerThread);
@@ -1000,30 +980,30 @@ public class UpdateIT extends ESIntegTestCase {
     public void testStressUpdateDeleteConcurrency() throws Exception {
         //We create an index with merging disabled so that deletes don't get merged away
         assertAcked(prepareCreate("test")
-                .addMapping("type1", XContentFactory.jsonBuilder()
-                        .startObject()
-                        .startObject("type1")
-                        .startObject("_timestamp").field("enabled", true).endObject()
-                        .startObject("_ttl").field("enabled", true).endObject()
-                        .endObject()
-                        .endObject())
-                .setSettings(Settings.builder().put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)));
+            .addMapping("type1", XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("type1")
+                .startObject("_timestamp").field("enabled", true).endObject()
+                .startObject("_ttl").field("enabled", true).endObject()
+                .endObject()
+                .endObject())
+            .setSettings(Settings.builder().put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)));
         ensureGreen();
 
-        final int numberOfThreads = scaledRandomIntBetween(3,5);
-        final int numberOfIdsPerThread = scaledRandomIntBetween(3,10);
-        final int numberOfUpdatesPerId = scaledRandomIntBetween(10,100);
-        final int retryOnConflict = randomIntBetween(0,1);
+        final int numberOfThreads = scaledRandomIntBetween(3, 5);
+        final int numberOfIdsPerThread = scaledRandomIntBetween(3, 10);
+        final int numberOfUpdatesPerId = scaledRandomIntBetween(10, 100);
+        final int retryOnConflict = randomIntBetween(0, 1);
         final CountDownLatch latch = new CountDownLatch(numberOfThreads);
         final CountDownLatch startLatch = new CountDownLatch(1);
         final List<Throwable> failures = new CopyOnWriteArrayList<>();
 
         final class UpdateThread extends Thread {
-            final Map<Integer,Integer> failedMap = new HashMap<>();
+            final Map<Integer, Integer> failedMap = new HashMap<>();
             final int numberOfIds;
             final int updatesPerId;
-            final int maxUpdateRequests = numberOfIdsPerThread*numberOfUpdatesPerId;
-            final int maxDeleteRequests = numberOfIdsPerThread*numberOfUpdatesPerId;
+            final int maxUpdateRequests = numberOfIdsPerThread * numberOfUpdatesPerId;
+            final int maxDeleteRequests = numberOfIdsPerThread * numberOfUpdatesPerId;
             private final Semaphore updateRequestsOutstanding = new Semaphore(maxUpdateRequests);
             private final Semaphore deleteRequestsOutstanding = new Semaphore(maxDeleteRequests);
 
@@ -1076,7 +1056,7 @@ public class UpdateIT extends ESIntegTestCase {
             }
 
             @Override
-            public void run(){
+            public void run() {
                 try {
                     startLatch.await();
                     boolean hasWaitedForNoNode = false;
@@ -1085,10 +1065,10 @@ public class UpdateIT extends ESIntegTestCase {
                             updateRequestsOutstanding.acquire();
                             try {
                                 UpdateRequest ur = client().prepareUpdate("test", "type1", Integer.toString(j))
-                                        .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
-                                        .setRetryOnConflict(retryOnConflict)
-                                        .setUpsert(jsonBuilder().startObject().field("field", 1).endObject())
-                                        .request();
+                                    .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+                                    .setRetryOnConflict(retryOnConflict)
+                                    .setUpsert(jsonBuilder().startObject().field("field", 1).endObject())
+                                    .request();
                                 client().update(ur, new UpdateListener(j));
                             } catch (NoNodeAvailableException nne) {
                                 updateRequestsOutstanding.release();
@@ -1135,7 +1115,7 @@ public class UpdateIT extends ESIntegTestCase {
                 }
             }
 
-            private void incrementMapValue(int j, Map<Integer,Integer> map) {
+            private void incrementMapValue(int j, Map<Integer, Integer> map) {
                 if (!map.containsKey(j)) {
                     map.put(j, 0);
                 }
@@ -1146,15 +1126,15 @@ public class UpdateIT extends ESIntegTestCase {
                 long start = System.currentTimeMillis();
                 do {
                     long msRemaining = timeOut.getMillis() - (System.currentTimeMillis() - start);
-                    logger.info("[{}] going to try and acquire [{}] in [{}]ms [{}] available to acquire right now",name, maxRequests,msRemaining, requestsOutstanding.availablePermits());
+                    logger.info("[{}] going to try and acquire [{}] in [{}]ms [{}] available to acquire right now", name, maxRequests, msRemaining, requestsOutstanding.availablePermits());
                     try {
-                        requestsOutstanding.tryAcquire(maxRequests, msRemaining, TimeUnit.MILLISECONDS );
+                        requestsOutstanding.tryAcquire(maxRequests, msRemaining, TimeUnit.MILLISECONDS);
                         return;
                     } catch (InterruptedException ie) {
                         //Just keep swimming
                     }
                 } while ((System.currentTimeMillis() - start) < timeOut.getMillis());
-                throw new ElasticsearchTimeoutException("Requests were still outstanding after the timeout [" + timeOut + "] for type [" + name + "]" );
+                throw new ElasticsearchTimeoutException("Requests were still outstanding after the timeout [" + timeOut + "] for type [" + name + "]");
             }
         }
         final List<UpdateThread> threads = new ArrayList<>();
@@ -1168,7 +1148,7 @@ public class UpdateIT extends ESIntegTestCase {
         startLatch.countDown();
         latch.await();
 
-        for (UpdateThread ut : threads){
+        for (UpdateThread ut : threads) {
             ut.join(); //Threads should have finished because of the latch.await
         }
 
@@ -1185,7 +1165,7 @@ public class UpdateIT extends ESIntegTestCase {
         //All the previous operations should be complete or failed at this point
         for (int i = 0; i < numberOfIdsPerThread; ++i) {
             UpdateResponse ur = client().prepareUpdate("test", "type1", Integer.toString(i))
-                    .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
+                .setScript(new Script("field", ScriptService.ScriptType.INLINE, "field_inc", null))
                 .setRetryOnConflict(Integer.MAX_VALUE)
                 .setUpsert(jsonBuilder().startObject().field("field", 1).endObject())
                 .execute().actionGet();
@@ -1208,9 +1188,9 @@ public class UpdateIT extends ESIntegTestCase {
                 logger.error("Actual version [{}] Expected version [{}] Total failures [{}]", response.getVersion(), expectedVersion, totalFailures);
                 assertThat(response.getVersion(), equalTo((long) expectedVersion));
                 assertThat(response.getVersion() + totalFailures,
-                        equalTo(
-                                (long)((numberOfUpdatesPerId * numberOfThreads * 2) + 1)
-                ));
+                    equalTo(
+                        (long) ((numberOfUpdatesPerId * numberOfThreads * 2) + 1)
+                    ));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.update;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;

--- a/plugins/delete-by-query/src/test/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryActionTests.java
+++ b/plugins/delete-by-query/src/test/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryActionTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.text.StringText;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.InternalSearchHit;
@@ -225,7 +226,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
                 } else {
                     deleted++;
                 }
-                items[i] = new BulkItemResponse(i, "delete", new DeleteResponse("test", "type", String.valueOf(i), 1, delete));
+                items[i] = new BulkItemResponse(i, "delete", new DeleteResponse(new ShardId("test", 0), "type", String.valueOf(i), 1, delete));
             } else {
                 items[i] = new BulkItemResponse(i, "delete", new BulkItemResponse.Failure("test", "type", String.valueOf(i), new Throwable("item failed")));
                 failed++;
@@ -281,7 +282,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
                     deleted[0] = deleted[0] + 1;
                     deleted[index] = deleted[index] + 1;
                 }
-                items[i] = new BulkItemResponse(i, "delete", new DeleteResponse("test-" + index, "type", String.valueOf(i), 1, delete));
+                items[i] = new BulkItemResponse(i, "delete", new DeleteResponse(new ShardId("test-" + index, 0), "type", String.valueOf(i), 1, delete));
             } else {
                 items[i] = new BulkItemResponse(i, "delete", new BulkItemResponse.Failure("test-" + index, "type", String.valueOf(i), new Throwable("item failed")));
                 failed[0] = failed[0] + 1;


### PR DESCRIPTION
IndexResponse, DeleteResponse and UpdateResponse share some logic. This can be unified to a single DocWriteResponse base class. On top, some replication actions are now not about write operations anymore. This commit renames ActionWriteResponse to ReplicationResponse

Last some toXContent is moved from the Rest layer to the actual response classes, for more code re-sharing.

This is ported over from the `feature/seq_no` branch to make maintaining that branch simpler
