### PR TITLE
Improve network docs

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -137,8 +137,7 @@ public class NetworkService extends AbstractComponent {
      * Resolves {@code publishHosts} to a single publish address. The fact that it returns
      * only one address is just a current limitation.
      * <p>
-     * If {@code publishHosts} resolves to more than one address, <b>then one is selected with magic</b>,
-     * and the user is warned (they can always just be more specific).
+     * If {@code publishHosts} resolves to more than one address, <b>then one is selected with magic</b>
      * @param publishHosts list of hosts to publish as. this may contain special pseudo-hostnames
      *                     such as _local_ (see the documentation). if it is null, it will be populated
      *                     based on global default settings.
@@ -186,13 +185,12 @@ public class NetworkService extends AbstractComponent {
             }
         }
         
-        // 3. warn user if we end out with multiple publish addresses
+        // 3. if we end out with multiple publish addresses, select by preference.
+        // don't warn the user, or they will get confused by bind_host vs publish_host etc.
         if (addresses.length > 1) {
             List<InetAddress> sorted = new ArrayList<>(Arrays.asList(addresses));
             NetworkUtils.sortAddresses(sorted);
             addresses = new InetAddress[] { sorted.get(0) };
-            logger.warn("publish host: {} resolves to multiple addresses, auto-selecting {{}} as single publish address", 
-                    Arrays.toString(publishHosts), NetworkAddress.format(addresses[0]));
         }
         return addresses[0];
     }

--- a/distribution/src/main/resources/config/elasticsearch.yml
+++ b/distribution/src/main/resources/config/elasticsearch.yml
@@ -60,18 +60,7 @@
 # For more information, see the documentation at:
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
 #
-# ---------------------------------- Gateway -----------------------------------
-#
-# Block initial recovery after a full cluster restart until N nodes are started:
-#
-# gateway.recover_after_nodes: 3
-#
-# For more information, see the documentation at:
-# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
-#
 # --------------------------------- Discovery ----------------------------------
-#
-# Elasticsearch nodes will find each other via unicast, by default.
 #
 # Pass an initial list of hosts to perform discovery when new node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
@@ -84,6 +73,15 @@
 #
 # For more information, see the documentation at:
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+# gateway.recover_after_nodes: 3
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
 #
 # ---------------------------------- Various -----------------------------------
 #

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -36,7 +36,7 @@ to the public internet.
 
 These special values will work over both IPv4 and IPv6 by default,
 but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers. For 
-example, `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
+example, `_en0:ipv4_` would only bind to the IPv4 addresses of interface `en0`.
 
 When the `discovery-ec2` plugin is installed, you can use
 {plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -1,15 +1,52 @@
 [[modules-network]]
-== Network Settings
+== Basic Settings
 
-There are several modules within a Node that use network based
-configuration, for example, the
-<<modules-transport,transport>> and
-<<modules-http,http>> modules. Node level
-network settings allows to set common settings that will be shared among
-all network based modules (unless explicitly overridden in each module).
+Commonly used network settings:
 
-Be careful with host configuration! Never expose an unprotected instance
+[cols="<,<",options="header",]
+|=======================================================================
+|Name |Description
+|`network.host` |Host to bind and publish to other nodes. Can be set to an IP address, hostname, or special value (see table below). Defaults to `_local_`.
+
+|`discovery.zen.ping.unicast.hosts`|Initial list other nodes. Can be set to IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
+
+|`http.port` |Port to bind for incoming http requests. Can be set to a single value or a range. Defaults to `9200-9300`.
+
+|`transport.tcp.port` |Port to bind for communication between nodes. Can be set to a single value or a range. Defaults to `9300-9400`.
+
+Be careful with network configuration! Never expose an unprotected instance
 to the public internet.
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Special Host Value |Description
+|`_[networkInterface]_` |Resolves to the addresses of the provided
+network interface. For example `_en0_`.
+
+|`_local_` |Will be resolved to loopback addresses (e.g. 127.0.0.1)
+
+|`_site_` |Will be resolved to site-local addresses (e.g. 192.168.0.1)
+
+|`_global_` |Will be resolved to globally-scoped addresses (e.g. 8.8.8.8)
+
+These special values will work over both IPv4 and IPv6 by default,
+but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers, for 
+example `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
+
+|=======================================================================
+
+When the `discovery-ec2` plugin is installed, you can use
+{plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].
+
+When the `discovery-gce` plugin is installed, you can use
+{plugins}/discovery-gce-network-host.html[gce specific host settings].
+
+[float]
+[[advanced]]
+=== Advanced network settings
+
+`network.bind_host` and `network.publish_host` can be set instead of `network.host` 
+for advanced cases such as when behind a proxy server.
 
 The `network.bind_host` setting allows to control the host different network
 components will bind on. By default, the bind host will be `_local_`
@@ -21,54 +58,13 @@ Currently an elasticsearch node may be bound to multiple addresses, but only
 publishes one.  If not specified, this defaults to the "best" address from 
 `network.bind_host`, sorted by IPv4/IPv6 stack preference, then by reachability.
 
-The `network.host` setting is a simple setting to automatically set both
-`network.bind_host` and `network.publish_host` to the same host value.
-
 Both settings allows to be configured with either explicit host address(es)
 or host name(s). The settings also accept logical setting value(s) explained
 in the following table:
 
-[cols="<,<",options="header",]
-|=======================================================================
-|Logical Host Setting Value |Description
-|`_local_` |Will be resolved to loopback addresses
-
-|`_local:ipv4_` |Will be resolved to loopback IPv4 addresses (e.g. 127.0.0.1)
-
-|`_local:ipv6_` |Will be resolved to loopback IPv6 addresses (e.g. ::1)
-
-|`_site_` |Will be resolved to site-local addresses ("private network")
-
-|`_site:ipv4_` |Will be resolved to site-local IPv4 addresses (e.g. 192.168.0.1)
-
-|`_site:ipv6_` |Will be resolved to site-local IPv6 addresses (e.g. fec0::1)
-
-|`_global_` |Will be resolved to globally-scoped addresses ("publicly reachable")
-
-|`_global:ipv4_` |Will be resolved to globally-scoped IPv4 addresses (e.g. 8.8.8.8)
-
-|`_global:ipv6_` |Will be resolved to globally-scoped IPv6 addresses (e.g. 2001:4860:4860::8888)
-
-|`_[networkInterface]_` |Resolves to the addresses of the provided
-network interface. For example `_en0_`.
-
-|`_[networkInterface]:ipv4_` |Resolves to the ipv4 addresses of the
-provided network interface. For example `_en0:ipv4_`.
-
-|`_[networkInterface]:ipv6_` |Resolves to the ipv6 addresses of the
-provided network interface. For example `_en0:ipv6_`.
-|=======================================================================
-
-When the `discovery-ec2` plugin is installed, you can use
-{plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].
-
-When the `discovery-gce` plugin is installed, you can use
-{plugins}/discovery-gce-network-host.html[gce specific host settings].
-
-
 [float]
 [[tcp-settings]]
-=== TCP Settings
+=== Advanced TCP Settings
 
 Any component that uses TCP (like the HTTP, Transport and Memcached)
 share the following allowed settings:
@@ -91,4 +87,15 @@ Defaults to `true` on non-windows machines.
 |`network.tcp.receive_buffer_size` |The size of the tcp receive buffer
 size (in size setting format). By default not explicitly set.
 |=======================================================================
+
+[float]
+[[module-settings]]
+=== Module-specific Settings
+
+There are several modules within a Node that use network based
+configuration, for example, the
+<<modules-transport,transport>> and
+<<modules-http,http>> modules. Node level
+network settings allows to set common settings that will be shared among
+all network based modules (unless explicitly overridden in each module).
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -6,13 +6,13 @@ Commonly used network settings:
 [cols="<,<",options="header",]
 |=======================================================================
 |Name |Description
-|`network.host` |Host to bind and publish to other nodes. Can be set to an IP address, hostname, or special value (see table below). Defaults to `_local_`.
+|`network.host` |Host to bind and publish to other nodes. Accepts an IP address, hostname, or special value (see table below). Defaults to `_local_`.
 
-|`discovery.zen.ping.unicast.hosts`|Initial list of other nodes. Can be set to IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
+|`discovery.zen.ping.unicast.hosts`|Initial list of other nodes. Accepts IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
 
-|`http.port` |Port to bind for incoming http requests. Can be set to a single value or a range. Defaults to `9200-9300`.
+|`http.port` |Port to bind for incoming http requests. Accepts a single value or a range. Defaults to `9200-9300`.
 
-|`transport.tcp.port` |Port to bind for communication between nodes. Can be set to a single value or a range. Defaults to `9300-9400`.
+|`transport.tcp.port` |Port to bind for communication between nodes. Accepts a single value or a range. Defaults to `9300-9400`.
 |=======================================================================
 
 Be careful with network configuration! Never expose an unprotected instance
@@ -25,19 +25,18 @@ to the public internet.
 [cols="<,<",options="header",]
 |=======================================================================
 |Special Host Value |Description
-|`_[networkInterface]_` |Resolves to the addresses of the provided
-network interface. For example `_en0_`.
+|`_[networkInterface]_` |Addresses of a network interface, for example `_en0_`.
 
-|`_local_` |Will be resolved to loopback addresses (e.g. 127.0.0.1)
+|`_local_` |Any loopback addresses on the system, for example `127.0.0.1`.
 
-|`_site_` |Will be resolved to site-local addresses (e.g. 192.168.0.1)
+|`_site_` |Any site-local addresses on the system, for example `192.168.0.1`.
 
-|`_global_` |Will be resolved to globally-scoped addresses (e.g. 8.8.8.8)
+|`_global_` |Any globally-scoped addresses on the system, for example `8.8.8.8`.
 |=======================================================================
 
 These special values will work over both IPv4 and IPv6 by default,
-but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers, for 
-example `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
+but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers. For 
+example, `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
 
 When the `discovery-ec2` plugin is installed, you can use
 {plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].
@@ -52,19 +51,17 @@ When the `discovery-gce` plugin is installed, you can use
 `network.bind_host` and `network.publish_host` can be set instead of `network.host` 
 for advanced cases such as when behind a proxy server.
 
-The `network.bind_host` setting allows to control the host different network
-components will bind on. By default, the bind host will be `_local_`
-(loopback addresses such as `127.0.0.1`, `::1`).
+`network.bind_host` sets the host different network
+components will bind on.
 
-The `network.publish_host` setting allows to control the host the node will
+`network.publish_host` sets the host the node will
 publish itself within the cluster so other nodes will be able to connect to it.
 Currently an elasticsearch node may be bound to multiple addresses, but only
 publishes one.  If not specified, this defaults to the "best" address from 
 `network.bind_host`, sorted by IPv4/IPv6 stack preference, then by reachability.
 
-Both settings allows to be configured with either explicit host address(es)
-or host name(s). The settings also accept logical setting value(s) explained
-in the following table:
+Both settings can be configured just like `network.host`: they accept ip
+addresses, host names, and special values.
 
 [float]
 [[tcp-settings]]

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -18,6 +18,10 @@ Commonly used network settings:
 Be careful with network configuration! Never expose an unprotected instance
 to the public internet.
 
+[float]
+[[special-values]]
+=== Special values for `network.host`
+
 [cols="<,<",options="header",]
 |=======================================================================
 |Special Host Value |Description

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -8,7 +8,7 @@ Commonly used network settings:
 |Name |Description
 |`network.host` |Host to bind and publish to other nodes. Can be set to an IP address, hostname, or special value (see table below). Defaults to `_local_`.
 
-|`discovery.zen.ping.unicast.hosts`|Initial list other nodes. Can be set to IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
+|`discovery.zen.ping.unicast.hosts`|Initial list of other nodes. Can be set to IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
 
 |`http.port` |Port to bind for incoming http requests. Can be set to a single value or a range. Defaults to `9200-9300`.
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -13,6 +13,7 @@ Commonly used network settings:
 |`http.port` |Port to bind for incoming http requests. Can be set to a single value or a range. Defaults to `9200-9300`.
 
 |`transport.tcp.port` |Port to bind for communication between nodes. Can be set to a single value or a range. Defaults to `9300-9400`.
+|=======================================================================
 
 Be careful with network configuration! Never expose an unprotected instance
 to the public internet.
@@ -28,12 +29,11 @@ network interface. For example `_en0_`.
 |`_site_` |Will be resolved to site-local addresses (e.g. 192.168.0.1)
 
 |`_global_` |Will be resolved to globally-scoped addresses (e.g. 8.8.8.8)
+|=======================================================================
 
 These special values will work over both IPv4 and IPv6 by default,
 but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers, for 
 example `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
-
-|=======================================================================
 
 When the `discovery-ec2` plugin is installed, you can use
 {plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].


### PR DESCRIPTION
This makes some minor improvements (does not fix all problems!)

It reorders unicast disco in elasticsearch.yml to be right after the network host,
for better locality.

It removes the warning (unreleased) about publish addresses, lets try to really discourage setting
that unless you need to (behind a proxy server). Most people should be fine with `network.host`

Finally it reorganizes the network docs page a bit:

We add a table of 4 "basic" settings at the very beginning:
- network.host
- discovery.zen.ping.unicast.hosts
- http.port
- transport.tcp.port

The first two being the most important, which addresses to bind and talk to, and the other two
being the port numbers.

The rest of the stuff I tried to simplify and reorder under "advanced" headers.

This is just a quick stab, I still think we need more effort into this thing, but we gotta start somewhere.
