### PR TITLE
Improve network docs

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -137,8 +137,7 @@ public class NetworkService extends AbstractComponent {
      * Resolves {@code publishHosts} to a single publish address. The fact that it returns
      * only one address is just a current limitation.
      * <p>
-     * If {@code publishHosts} resolves to more than one address, <b>then one is selected with magic</b>,
-     * and the user is warned (they can always just be more specific).
+     * If {@code publishHosts} resolves to more than one address, <b>then one is selected with magic</b>
      * @param publishHosts list of hosts to publish as. this may contain special pseudo-hostnames
      *                     such as _local_ (see the documentation). if it is null, it will be populated
      *                     based on global default settings.
@@ -186,13 +185,12 @@ public class NetworkService extends AbstractComponent {
             }
         }
         
-        // 3. warn user if we end out with multiple publish addresses
+        // 3. if we end out with multiple publish addresses, select by preference.
+        // don't warn the user, or they will get confused by bind_host vs publish_host etc.
         if (addresses.length > 1) {
             List<InetAddress> sorted = new ArrayList<>(Arrays.asList(addresses));
             NetworkUtils.sortAddresses(sorted);
             addresses = new InetAddress[] { sorted.get(0) };
-            logger.warn("publish host: {} resolves to multiple addresses, auto-selecting {{}} as single publish address", 
-                    Arrays.toString(publishHosts), NetworkAddress.format(addresses[0]));
         }
         return addresses[0];
     }

--- a/distribution/src/main/resources/config/elasticsearch.yml
+++ b/distribution/src/main/resources/config/elasticsearch.yml
@@ -60,18 +60,7 @@
 # For more information, see the documentation at:
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
 #
-# ---------------------------------- Gateway -----------------------------------
-#
-# Block initial recovery after a full cluster restart until N nodes are started:
-#
-# gateway.recover_after_nodes: 3
-#
-# For more information, see the documentation at:
-# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
-#
 # --------------------------------- Discovery ----------------------------------
-#
-# Elasticsearch nodes will find each other via unicast, by default.
 #
 # Pass an initial list of hosts to perform discovery when new node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
@@ -84,6 +73,15 @@
 #
 # For more information, see the documentation at:
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+# gateway.recover_after_nodes: 3
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
 #
 # ---------------------------------- Various -----------------------------------
 #

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -360,6 +360,22 @@ are:
 `s`::   Second
 `ms`::  Milli-second
 
+[[size-units]]
+[float]
+=== Data size units
+
+Whenever the size of data needs to be specified, eg when setting a buffer size
+parameter, the value must specify the unit, like `10kb` for 10 kilobytes.  The
+supported units are:
+
+[horizontal]
+`b`::   Bytes
+`kb`::  Kilobytes
+`mb`::  Megabytes
+`gb`::  Gigabytes
+`tb`::  Terabytes
+`pb`::  Petabytes
+
 [[distance-units]]
 [float]
 === Distance Units

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -7,6 +7,7 @@
 :jdk:           1.8.0_25
 :defguide:      https://www.elastic.co/guide/en/elasticsearch/guide/current
 :plugins:       https://www.elastic.co/guide/en/elasticsearch/plugins/master
+:javaclient:    https://www.elastic.co/guide/en/elasticsearch/client/java-api/master/
 :issue:         https://github.com/elastic/elasticsearch/issues/
 :pull:          https://github.com/elastic/elasticsearch/pull/
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -1,102 +1,175 @@
 [[modules-network]]
-== Basic Settings
+== Network Settings
 
-Commonly used network settings:
+Elasticsearch binds to localhost only by default.  This is sufficient for you
+to run a local development server (or even a development cluster, if you start
+multiple nodes on the same machine), but you will need to configure some
+<<common-network-settings,basic network settings>> in order to run a real
+production cluster across multiple servers.
 
-[cols="<,<",options="header",]
-|=======================================================================
-|Name |Description
-|`network.host` |Host to bind and publish to other nodes. Accepts an IP address, hostname, or special value (see table below). Defaults to `_local_`.
-
-|`discovery.zen.ping.unicast.hosts`|Initial list of other nodes. Accepts IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
-
-|`http.port` |Port to bind for incoming http requests. Accepts a single value or a range. Defaults to `9200-9300`.
-
-|`transport.tcp.port` |Port to bind for communication between nodes. Accepts a single value or a range. Defaults to `9300-9400`.
-|=======================================================================
-
-Be careful with network configuration! Never expose an unprotected instance
-to the public internet.
+[WARNING]
+.Be careful with the network configuration!
+=============================
+Never expose an unprotected node to the public internet.
+=============================
 
 [float]
-[[special-values]]
+[[common-network-settings]]
+=== Commonly Used Network Settings
+
+`network.host`::
+
+The node will bind to this hostname or IP address and _publish_ (advertise)
+this host to other nodes in the cluster. Accepts an IP address, hostname, or a
+<<network-interface-values,special value>>.
++
+Defaults to `_local_`.
+
+`discovery.zen.ping.unicast.hosts`::
+
+In order to join a cluster, a node needs to know the hostname or IP address of
+at least some of the other nodes in the cluster.  This settting provides the
+initial list of other nodes that this node will try to contact. Accepts IP
+addresses or hostnames.
++
+Defaults to `["127.0.0.1", "[::1]"]`.
+
+`http.port`::
+
+Port to bind to for incoming HTTP requests. Accepts a single value or a range.
+If a range is specified, the node will bind to the first available port in the
+range.
++
+Defaults to `9200-9300`.
+
+`transport.tcp.port`::
+
+Port to bind for communication between nodes. Accepts a single value or a
+range. If a range is specified, the node will bind to the first available port
+in the range.
++
+Defaults to `9300-9400`.
+
+[float]
+[[network-interface-values]]
 === Special values for `network.host`
 
-[cols="<,<",options="header",]
-|=======================================================================
-|Special Host Value |Description
-|`_[networkInterface]_` |Addresses of a network interface, for example `_en0_`.
+The following special values may be passed to `network.host`:
 
-|`_local_` |Any loopback addresses on the system, for example `127.0.0.1`.
+[horizontal]
+`_[networkInterface]_`::
 
-|`_site_` |Any site-local addresses on the system, for example `192.168.0.1`.
+  Addresses of a network interface, for example `_en0_`.
 
-|`_global_` |Any globally-scoped addresses on the system, for example `8.8.8.8`.
-|=======================================================================
+`_local_`::
 
-These special values will work over both IPv4 and IPv6 by default,
-but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers. For 
-example, `_en0:ipv4_` would only bind to the IPv4 addresses of interface `en0`.
+  Any loopback addresses on the system, for example `127.0.0.1`.
 
-When the `discovery-ec2` plugin is installed, you can use
-{plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].
+`_site_`::
 
-When the `discovery-gce` plugin is installed, you can use
-{plugins}/discovery-gce-network-host.html[gce specific host settings].
+  Any site-local addresses on the system, for example `192.168.0.1`.
+
+`_global_`::
+
+  Any globally-scoped addresses on the system, for example `8.8.8.8`.
+
 
 [float]
-[[advanced]]
+==== IPv4 vs IPv6
+
+These special values will work over both IPv4 and IPv6 by default, but you can
+also limit this with the use of `:ipv4` of `:ipv6` specifiers. For example,
+`_en0:ipv4_` would only bind to the IPv4 addresses of interface `en0`.
+
+[TIP]
+.Discovery in the cloud
+================================
+
+More special settings are available when running in the cloud with either the
+{plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[EC2 discovery plugin] or the
+{plugins}/discovery-gce-network-host.html#discovery-gce-network-host[Google Compute Engine discovery plugin]
+installed.
+
+================================
+
+[float]
+[[advanced-network-settings]]
 === Advanced network settings
 
-`network.bind_host` and `network.publish_host` can be set instead of `network.host` 
-for advanced cases such as when behind a proxy server.
+The `network.host` setting explained in <<common-network-settings,Commonly used network settings>>
+is a shortcut which sets the _bind host_ and the _publish host_ at the same
+time. In advanced used cases, such as when running behind a proxy server, you
+may need to set these settings to different values:
 
-`network.bind_host` sets the host different network
-components will bind on.
+`network.bind_host`::
 
-`network.publish_host` sets the host the node will
-publish itself within the cluster so other nodes will be able to connect to it.
-Currently an elasticsearch node may be bound to multiple addresses, but only
-publishes one.  If not specified, this defaults to the "best" address from 
-`network.bind_host`, sorted by IPv4/IPv6 stack preference, then by reachability.
+This specifies which network interface(s) a node should bind to in order to
+listen for incoming requests.  A node can bind to multiple interfaces, e.g.
+two network cards, or a site-local address and a local address. Defaults to
+`network.host`.
 
-Both settings can be configured just like `network.host`: they accept ip
-addresses, host names, and special values.
+`network.publish_host`::
+
+The publish host is the single interface that the node advertises to other
+nodes in the cluster, so that those nodes can connect to it.   Currently an
+elasticsearch node may be bound to multiple addresses, but only publishes one.
+If not specified, this defaults to the ``best'' address from
+`network.bind_host`, sorted by IPv4/IPv6 stack preference, then by
+reachability.
+
+Both of the above settings can be configured just like `network.host` -- they
+accept IP addresses, host names, and
+<<network-interface-values,special values>>.
 
 [float]
 [[tcp-settings]]
 === Advanced TCP Settings
 
-Any component that uses TCP (like the HTTP, Transport and Memcached)
-share the following allowed settings:
+Any component that uses TCP (like the <<modules-http,HTTP>> and
+<<modules-transport,Transport>> modules) share the following settings:
 
-[cols="<,<",options="header",]
-|=======================================================================
-|Setting |Description
-|`network.tcp.no_delay` |Enable or disable tcp no delay setting.
+[horizontal]
+`network.tcp.no_delay`::
+
+Enable or disable the https://en.wikipedia.org/wiki/Nagle%27s_algorithm[TCP no delay]
+setting. Defaults to `true`.
+
+`network.tcp.keep_alive`::
+
+Enable or disable https://en.wikipedia.org/wiki/Keepalive[TCP keep alive].
 Defaults to `true`.
 
-|`network.tcp.keep_alive` |Enable or disable tcp keep alive. Defaults
-to `true`.
+`network.tcp.reuse_address`::
 
-|`network.tcp.reuse_address` |Should an address be reused or not.
-Defaults to `true` on non-windows machines.
+Should an address be reused or not. Defaults to `true` on non-windows
+machines.
 
-|`network.tcp.send_buffer_size` |The size of the tcp send buffer size
-(in size setting format). By default not explicitly set.
+`network.tcp.send_buffer_size`::
 
-|`network.tcp.receive_buffer_size` |The size of the tcp receive buffer
-size (in size setting format). By default not explicitly set.
-|=======================================================================
+The size of the TCP send buffer (specified with <<size-units,size units>>).
+By default not explicitly set.
+
+`network.tcp.receive_buffer_size`::
+
+The size of the TCP receive buffer (specified with <<size-units,size units>>).
+By default not explicitly set.
 
 [float]
-[[module-settings]]
-=== Module-specific Settings
+=== Transport and HTTP protocols
 
-There are several modules within a Node that use network based
-configuration, for example, the
-<<modules-transport,transport>> and
-<<modules-http,http>> modules. Node level
-network settings allows to set common settings that will be shared among
-all network based modules (unless explicitly overridden in each module).
+An Elasticsearch node exposes two network protocols which inherit the above
+settings, but may be further configured independently:
+
+TCP Transport::
+
+Used for communication between nodes in the cluster and by the Java
+{javaclient}/node-client.html[Node client],
+{javaclient}/transport-client.html[Transport client], and by the
+<<modules-tribe,Tribe node>>.  See the <<modules-transport,Transport module>>
+for more information.
+
+HTTP::
+
+Exposes the JSON-over-HTTP interface used by all clients other than the Java
+clients. See the <<modules-http,HTTP module>> for more information.
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -36,7 +36,7 @@ to the public internet.
 
 These special values will work over both IPv4 and IPv6 by default,
 but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers. For 
-example, `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
+example, `_en0:ipv4_` would only bind to the IPv4 addresses of interface `en0`.
 
 When the `discovery-ec2` plugin is installed, you can use
 {plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -1,15 +1,52 @@
 [[modules-network]]
-== Network Settings
+== Basic Settings
 
-There are several modules within a Node that use network based
-configuration, for example, the
-<<modules-transport,transport>> and
-<<modules-http,http>> modules. Node level
-network settings allows to set common settings that will be shared among
-all network based modules (unless explicitly overridden in each module).
+Commonly used network settings:
 
-Be careful with host configuration! Never expose an unprotected instance
+[cols="<,<",options="header",]
+|=======================================================================
+|Name |Description
+|`network.host` |Host to bind and publish to other nodes. Can be set to an IP address, hostname, or special value (see table below). Defaults to `_local_`.
+
+|`discovery.zen.ping.unicast.hosts`|Initial list other nodes. Can be set to IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
+
+|`http.port` |Port to bind for incoming http requests. Can be set to a single value or a range. Defaults to `9200-9300`.
+
+|`transport.tcp.port` |Port to bind for communication between nodes. Can be set to a single value or a range. Defaults to `9300-9400`.
+
+Be careful with network configuration! Never expose an unprotected instance
 to the public internet.
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Special Host Value |Description
+|`_[networkInterface]_` |Resolves to the addresses of the provided
+network interface. For example `_en0_`.
+
+|`_local_` |Will be resolved to loopback addresses (e.g. 127.0.0.1)
+
+|`_site_` |Will be resolved to site-local addresses (e.g. 192.168.0.1)
+
+|`_global_` |Will be resolved to globally-scoped addresses (e.g. 8.8.8.8)
+
+These special values will work over both IPv4 and IPv6 by default,
+but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers, for 
+example `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
+
+|=======================================================================
+
+When the `discovery-ec2` plugin is installed, you can use
+{plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].
+
+When the `discovery-gce` plugin is installed, you can use
+{plugins}/discovery-gce-network-host.html[gce specific host settings].
+
+[float]
+[[advanced]]
+=== Advanced network settings
+
+`network.bind_host` and `network.publish_host` can be set instead of `network.host` 
+for advanced cases such as when behind a proxy server.
 
 The `network.bind_host` setting allows to control the host different network
 components will bind on. By default, the bind host will be `_local_`
@@ -21,54 +58,13 @@ Currently an elasticsearch node may be bound to multiple addresses, but only
 publishes one.  If not specified, this defaults to the "best" address from 
 `network.bind_host`, sorted by IPv4/IPv6 stack preference, then by reachability.
 
-The `network.host` setting is a simple setting to automatically set both
-`network.bind_host` and `network.publish_host` to the same host value.
-
 Both settings allows to be configured with either explicit host address(es)
 or host name(s). The settings also accept logical setting value(s) explained
 in the following table:
 
-[cols="<,<",options="header",]
-|=======================================================================
-|Logical Host Setting Value |Description
-|`_local_` |Will be resolved to loopback addresses
-
-|`_local:ipv4_` |Will be resolved to loopback IPv4 addresses (e.g. 127.0.0.1)
-
-|`_local:ipv6_` |Will be resolved to loopback IPv6 addresses (e.g. ::1)
-
-|`_site_` |Will be resolved to site-local addresses ("private network")
-
-|`_site:ipv4_` |Will be resolved to site-local IPv4 addresses (e.g. 192.168.0.1)
-
-|`_site:ipv6_` |Will be resolved to site-local IPv6 addresses (e.g. fec0::1)
-
-|`_global_` |Will be resolved to globally-scoped addresses ("publicly reachable")
-
-|`_global:ipv4_` |Will be resolved to globally-scoped IPv4 addresses (e.g. 8.8.8.8)
-
-|`_global:ipv6_` |Will be resolved to globally-scoped IPv6 addresses (e.g. 2001:4860:4860::8888)
-
-|`_[networkInterface]_` |Resolves to the addresses of the provided
-network interface. For example `_en0_`.
-
-|`_[networkInterface]:ipv4_` |Resolves to the ipv4 addresses of the
-provided network interface. For example `_en0:ipv4_`.
-
-|`_[networkInterface]:ipv6_` |Resolves to the ipv6 addresses of the
-provided network interface. For example `_en0:ipv6_`.
-|=======================================================================
-
-When the `discovery-ec2` plugin is installed, you can use
-{plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].
-
-When the `discovery-gce` plugin is installed, you can use
-{plugins}/discovery-gce-network-host.html[gce specific host settings].
-
-
 [float]
 [[tcp-settings]]
-=== TCP Settings
+=== Advanced TCP Settings
 
 Any component that uses TCP (like the HTTP, Transport and Memcached)
 share the following allowed settings:
@@ -91,4 +87,15 @@ Defaults to `true` on non-windows machines.
 |`network.tcp.receive_buffer_size` |The size of the tcp receive buffer
 size (in size setting format). By default not explicitly set.
 |=======================================================================
+
+[float]
+[[module-settings]]
+=== Module-specific Settings
+
+There are several modules within a Node that use network based
+configuration, for example, the
+<<modules-transport,transport>> and
+<<modules-http,http>> modules. Node level
+network settings allows to set common settings that will be shared among
+all network based modules (unless explicitly overridden in each module).
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -6,13 +6,13 @@ Commonly used network settings:
 [cols="<,<",options="header",]
 |=======================================================================
 |Name |Description
-|`network.host` |Host to bind and publish to other nodes. Can be set to an IP address, hostname, or special value (see table below). Defaults to `_local_`.
+|`network.host` |Host to bind and publish to other nodes. Accepts an IP address, hostname, or special value (see table below). Defaults to `_local_`.
 
-|`discovery.zen.ping.unicast.hosts`|Initial list of other nodes. Can be set to IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
+|`discovery.zen.ping.unicast.hosts`|Initial list of other nodes. Accepts IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
 
-|`http.port` |Port to bind for incoming http requests. Can be set to a single value or a range. Defaults to `9200-9300`.
+|`http.port` |Port to bind for incoming http requests. Accepts a single value or a range. Defaults to `9200-9300`.
 
-|`transport.tcp.port` |Port to bind for communication between nodes. Can be set to a single value or a range. Defaults to `9300-9400`.
+|`transport.tcp.port` |Port to bind for communication between nodes. Accepts a single value or a range. Defaults to `9300-9400`.
 |=======================================================================
 
 Be careful with network configuration! Never expose an unprotected instance
@@ -25,19 +25,18 @@ to the public internet.
 [cols="<,<",options="header",]
 |=======================================================================
 |Special Host Value |Description
-|`_[networkInterface]_` |Resolves to the addresses of the provided
-network interface. For example `_en0_`.
+|`_[networkInterface]_` |Addresses of a network interface, for example `_en0_`.
 
-|`_local_` |Will be resolved to loopback addresses (e.g. 127.0.0.1)
+|`_local_` |Any loopback addresses on the system, for example `127.0.0.1`.
 
-|`_site_` |Will be resolved to site-local addresses (e.g. 192.168.0.1)
+|`_site_` |Any site-local addresses on the system, for example `192.168.0.1`.
 
-|`_global_` |Will be resolved to globally-scoped addresses (e.g. 8.8.8.8)
+|`_global_` |Any globally-scoped addresses on the system, for example `8.8.8.8`.
 |=======================================================================
 
 These special values will work over both IPv4 and IPv6 by default,
-but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers, for 
-example `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
+but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers. For 
+example, `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
 
 When the `discovery-ec2` plugin is installed, you can use
 {plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].
@@ -52,19 +51,17 @@ When the `discovery-gce` plugin is installed, you can use
 `network.bind_host` and `network.publish_host` can be set instead of `network.host` 
 for advanced cases such as when behind a proxy server.
 
-The `network.bind_host` setting allows to control the host different network
-components will bind on. By default, the bind host will be `_local_`
-(loopback addresses such as `127.0.0.1`, `::1`).
+`network.bind_host` sets the host different network
+components will bind on.
 
-The `network.publish_host` setting allows to control the host the node will
+`network.publish_host` sets the host the node will
 publish itself within the cluster so other nodes will be able to connect to it.
 Currently an elasticsearch node may be bound to multiple addresses, but only
 publishes one.  If not specified, this defaults to the "best" address from 
 `network.bind_host`, sorted by IPv4/IPv6 stack preference, then by reachability.
 
-Both settings allows to be configured with either explicit host address(es)
-or host name(s). The settings also accept logical setting value(s) explained
-in the following table:
+Both settings can be configured just like `network.host`: they accept ip
+addresses, host names, and special values.
 
 [float]
 [[tcp-settings]]

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -18,6 +18,10 @@ Commonly used network settings:
 Be careful with network configuration! Never expose an unprotected instance
 to the public internet.
 
+[float]
+[[special-values]]
+=== Special values for `network.host`
+
 [cols="<,<",options="header",]
 |=======================================================================
 |Special Host Value |Description

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -8,7 +8,7 @@ Commonly used network settings:
 |Name |Description
 |`network.host` |Host to bind and publish to other nodes. Can be set to an IP address, hostname, or special value (see table below). Defaults to `_local_`.
 
-|`discovery.zen.ping.unicast.hosts`|Initial list other nodes. Can be set to IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
+|`discovery.zen.ping.unicast.hosts`|Initial list of other nodes. Can be set to IP addresses or hostnames. Defaults to `["127.0.0.1", "[::1]"]`.
 
 |`http.port` |Port to bind for incoming http requests. Can be set to a single value or a range. Defaults to `9200-9300`.
 

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -13,6 +13,7 @@ Commonly used network settings:
 |`http.port` |Port to bind for incoming http requests. Can be set to a single value or a range. Defaults to `9200-9300`.
 
 |`transport.tcp.port` |Port to bind for communication between nodes. Can be set to a single value or a range. Defaults to `9300-9400`.
+|=======================================================================
 
 Be careful with network configuration! Never expose an unprotected instance
 to the public internet.
@@ -28,12 +29,11 @@ network interface. For example `_en0_`.
 |`_site_` |Will be resolved to site-local addresses (e.g. 192.168.0.1)
 
 |`_global_` |Will be resolved to globally-scoped addresses (e.g. 8.8.8.8)
+|=======================================================================
 
 These special values will work over both IPv4 and IPv6 by default,
 but you can also limit this with the use of `:ipv4` of `:ipv6` specifiers, for 
 example `_en0:ipv4_` would only bind to the ipv4 addresses of interface `en0`.
-
-|=======================================================================
 
 When the `discovery-ec2` plugin is installed, you can use
 {plugins}/discovery-ec2-discovery.html#discovery-ec2-network-host[ec2 specific host settings].


### PR DESCRIPTION
This makes some minor improvements (does not fix all problems!)

It reorders unicast disco in elasticsearch.yml to be right after the network host,
for better locality.

It removes the warning (unreleased) about publish addresses, lets try to really discourage setting
that unless you need to (behind a proxy server). Most people should be fine with `network.host`

Finally it reorganizes the network docs page a bit:

We add a table of 4 "basic" settings at the very beginning:
- network.host
- discovery.zen.ping.unicast.hosts
- http.port
- transport.tcp.port

The first two being the most important, which addresses to bind and talk to, and the other two
being the port numbers.

The rest of the stuff I tried to simplify and reorder under "advanced" headers.

This is just a quick stab, I still think we need more effort into this thing, but we gotta start somewhere.

Closes #15343
