### PR TITLE
Geo: Fix small error in distance normalization in test

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoDistanceQueryBuilderTests.java
@@ -204,6 +204,7 @@ public class GeoDistanceQueryBuilderTests extends AbstractQueryTestCase<GeoDista
         double distance = queryBuilder.distance();
         if (queryBuilder.geoDistance() != null) {
             distance = queryBuilder.geoDistance().normalize(distance, DistanceUnit.DEFAULT);
+            distance = org.elasticsearch.common.geo.GeoUtils.maxRadialDistance(queryBuilder.point(), distance);
             assertThat(geoQuery.getRadiusMeters(), closeTo(distance, GeoUtils.TOLERANCE));
         }
     }


### PR DESCRIPTION
A CI test failure at http://build-us-00.elastic.co/job/es_core_master_suse/2731/ caught my attention and I did some digging. The test failure is:

```
java.lang.AssertionError: 
Expected: a numeric value within <1.0E-6> of <1055.6179277598308>
     but: <849.7492361579754> differed by <205.8686906018554>
    at __randomizedtesting.SeedInfo.seed([C512CE5226BF19E6:32E9CC6C573CDC0C]:0)
    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
    at org.junit.Assert.assertThat(Assert.java:865)
    at org.junit.Assert.assertThat(Assert.java:832)
    at org.elasticsearch.index.query.GeoDistanceQueryBuilderTests.assertGeoPointQuery(GeoDistanceQueryBuilderTests.java:206)
```

The query causing it is 

```
  "geo_distance" : {
    "mapped_geo_point" : [ -35.05150139609236, -89.99617044659995 ],
    "distance" : 1055.6179277598308,
    "distance_type" : "sloppy_arc",
    "optimize_bbox" : "memory",
    "validation_method" : "STRICT",
    "boost" : 0.10526316,
    "_name" : "pw8"
  }
}
```

It looks like for this particular setting, the code generating the lucene query applies some additional normalization to the distance via `GeoUtils.maxRadialDistance(center, normDistance)` which was currently not reflected in the test code. Added this line to the test. @nknize could you check if this is okay or maybe this is a strange glitch in the code generating the lucene query that need further investigation?
