### PR TITLE
Introduce Local checkpoints

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
@@ -30,6 +29,7 @@ import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.health.ClusterStateHealth;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
@@ -105,7 +105,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
             for (IndexShard indexShard : indexService) {
                 if (indexShard.routingEntry() != null && indexShard.routingEntry().active()) {
                     // only report on fully started shards
-                    shardsStats.add(new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), new CommonStats(indexShard, SHARD_STATS_FLAGS), indexShard.commitStats()));
+                    shardsStats.add(new ShardStats(indexShard.routingEntry(), indexShard.shardPath(),
+                            new CommonStats(indexShard, SHARD_STATS_FLAGS), indexShard.commitStats(), indexShard.seqNoStats()));
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -227,7 +227,6 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         RequestCache("request_cache"),
         Recovery("recovery");
 
-
         private final String restName;
 
         Flag(String restName) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -107,7 +107,7 @@ public class ShardStats implements Streamable, ToXContent {
         statePath = in.readString();
         dataPath = in.readString();
         isCustomDataPath = in.readBoolean();
-        seqNoStats = in.readOptionalStreamable(SeqNoStats.PROTOTYPE);
+        seqNoStats = in.readOptionalStreamableReader(SeqNoStats.PROTOTYPE);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -118,7 +118,7 @@ public class ShardStats implements Streamable, ToXContent {
         out.writeString(statePath);
         out.writeString(dataPath);
         out.writeBoolean(isCustomDataPath);
-        out.writeOptionalStreamable(seqNoStats);
+        out.writeOptionalWritable(seqNoStats);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -107,7 +107,7 @@ public class ShardStats implements Streamable, ToXContent {
         statePath = in.readString();
         dataPath = in.readString();
         isCustomDataPath = in.readBoolean();
-        seqNoStats = in.readOptionalStreamableReader(SeqNoStats.PROTOTYPE);
+        seqNoStats = in.readOptionalStreamableReader(SeqNoStats::new);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 import org.elasticsearch.index.engine.CommitStats;
-import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.shard.ShardPath;
 
 import java.io.IOException;
@@ -42,6 +42,8 @@ public class ShardStats implements Streamable, ToXContent {
     private CommonStats commonStats;
     @Nullable
     private CommitStats commitStats;
+    @Nullable
+    private SeqNoStats seqNoStats;
     private String dataPath;
     private String statePath;
     private boolean isCustomDataPath;
@@ -49,13 +51,14 @@ public class ShardStats implements Streamable, ToXContent {
     ShardStats() {
     }
 
-    public ShardStats(ShardRouting routing, ShardPath shardPath, CommonStats commonStats, CommitStats commitStats) {
+    public ShardStats(ShardRouting routing, ShardPath shardPath, CommonStats commonStats, CommitStats commitStats, SeqNoStats seqNoStats) {
         this.shardRouting = routing;
         this.dataPath = shardPath.getRootDataPath().toString();
         this.statePath = shardPath.getRootStatePath().toString();
         this.isCustomDataPath = shardPath.isCustomDataPath();
         this.commitStats = commitStats;
         this.commonStats = commonStats;
+        this.seqNoStats = seqNoStats;
     }
 
     /**
@@ -71,6 +74,11 @@ public class ShardStats implements Streamable, ToXContent {
 
     public CommitStats getCommitStats() {
         return this.commitStats;
+    }
+
+    @Nullable
+    public SeqNoStats getSeqNoStats() {
+        return this.seqNoStats;
     }
 
     public String getDataPath() {
@@ -99,6 +107,7 @@ public class ShardStats implements Streamable, ToXContent {
         statePath = in.readString();
         dataPath = in.readString();
         isCustomDataPath = in.readBoolean();
+        seqNoStats = in.readOptionalStreamable(SeqNoStats.PROTOTYPE);
     }
 
     @Override
@@ -109,6 +118,7 @@ public class ShardStats implements Streamable, ToXContent {
         out.writeString(statePath);
         out.writeString(dataPath);
         out.writeBoolean(isCustomDataPath);
+        out.writeOptionalStreamable(seqNoStats);
     }
 
     @Override
@@ -123,6 +133,9 @@ public class ShardStats implements Streamable, ToXContent {
         commonStats.toXContent(builder, params);
         if (commitStats != null) {
             commitStats.toXContent(builder, params);
+        }
+        if (seqNoStats != null) {
+            seqNoStats.toXContent(builder, params);
         }
         builder.startObject(Fields.SHARD_PATH);
         builder.field(Fields.STATE_PATH, statePath);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -162,6 +162,7 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
             flags.set(CommonStatsFlags.Flag.Recovery);
         }
 
-        return new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), new CommonStats(indexShard, flags), indexShard.commitStats());
+        return new ShardStats(indexShard.routingEntry(), indexShard.shardPath(),
+                new CommonStats(indexShard, flags), indexShard.commitStats(), indexShard.seqNoStats());
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
@@ -30,6 +29,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.seqno.LocalCheckpointService;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 
@@ -116,42 +116,43 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
 
     /** All known byte-sized settings for an index. */
     public static final Set<String> INDEX_BYTES_SIZE_SETTINGS = unmodifiableSet(newHashSet(
-                                    "index.merge.policy.floor_segment",
-                                    "index.merge.policy.max_merged_segment",
-                                    "index.merge.policy.max_merge_size",
-                                    "index.merge.policy.min_merge_size",
-                                    "index.shard.recovery.file_chunk_size",
-                                    "index.shard.recovery.translog_size",
-                                    "index.store.throttle.max_bytes_per_sec",
-                                    "index.translog.flush_threshold_size",
-                                    "index.translog.fs.buffer_size",
-                                    "index.version_map_size"));
+            "index.merge.policy.floor_segment",
+            "index.merge.policy.max_merged_segment",
+            "index.merge.policy.max_merge_size",
+            "index.merge.policy.min_merge_size",
+            "index.shard.recovery.file_chunk_size",
+            "index.shard.recovery.translog_size",
+            "index.store.throttle.max_bytes_per_sec",
+            "index.translog.flush_threshold_size",
+            "index.translog.fs.buffer_size",
+            "index.version_map_size"));
 
     /** All known time settings for an index. */
     public static final Set<String> INDEX_TIME_SETTINGS = unmodifiableSet(newHashSet(
-                                    "index.gateway.wait_for_mapping_update_post_recovery",
-                                    "index.shard.wait_for_mapping_update_post_recovery",
-                                    "index.gc_deletes",
-                                    "index.indexing.slowlog.threshold.index.debug",
-                                    "index.indexing.slowlog.threshold.index.info",
-                                    "index.indexing.slowlog.threshold.index.trace",
-                                    "index.indexing.slowlog.threshold.index.warn",
-                                    "index.refresh_interval",
-                                    "index.search.slowlog.threshold.fetch.debug",
-                                    "index.search.slowlog.threshold.fetch.info",
-                                    "index.search.slowlog.threshold.fetch.trace",
-                                    "index.search.slowlog.threshold.fetch.warn",
-                                    "index.search.slowlog.threshold.query.debug",
-                                    "index.search.slowlog.threshold.query.info",
-                                    "index.search.slowlog.threshold.query.trace",
-                                    "index.search.slowlog.threshold.query.warn",
-                                    "index.shadow.wait_for_initial_commit",
-                                    "index.store.stats_refresh_interval",
-                                    "index.translog.flush_threshold_period",
-                                    "index.translog.interval",
-                                    "index.translog.sync_interval",
-                                    "index.shard.inactive_time",
-                                    UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING));
+            "index.gateway.wait_for_mapping_update_post_recovery",
+            "index.shard.wait_for_mapping_update_post_recovery",
+            "index.gc_deletes",
+            "index.indexing.slowlog.threshold.index.debug",
+            "index.indexing.slowlog.threshold.index.info",
+            "index.indexing.slowlog.threshold.index.trace",
+            "index.indexing.slowlog.threshold.index.warn",
+            "index.refresh_interval",
+            "index.search.slowlog.threshold.fetch.debug",
+            "index.search.slowlog.threshold.fetch.info",
+            "index.search.slowlog.threshold.fetch.trace",
+            "index.search.slowlog.threshold.fetch.warn",
+            "index.search.slowlog.threshold.query.debug",
+            "index.search.slowlog.threshold.query.info",
+            "index.search.slowlog.threshold.query.trace",
+            "index.search.slowlog.threshold.query.warn",
+            "index.shadow.wait_for_initial_commit",
+            "index.store.stats_refresh_interval",
+            "index.translog.flush_threshold_period",
+            "index.translog.interval",
+            "index.translog.sync_interval",
+            "index.shard.inactive_time",
+            LocalCheckpointService.SETTINGS_INDEX_LAG_MAX_WAIT,
+            UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING));
 
     /**
      * Elasticsearch 2.0 requires units on byte/memory and time settings; this method adds the default unit to any such settings that are
@@ -163,7 +164,7 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
             // Created lazily if we find any settings that are missing units:
             Settings settings = indexMetaData.getSettings();
             Settings.Builder newSettings = null;
-            for(String byteSizeSetting : INDEX_BYTES_SIZE_SETTINGS) {
+            for (String byteSizeSetting : INDEX_BYTES_SIZE_SETTINGS) {
                 String value = settings.get(byteSizeSetting);
                 if (value != null) {
                     try {
@@ -180,7 +181,7 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
                     newSettings.put(byteSizeSetting, value + "b");
                 }
             }
-            for(String timeSetting : INDEX_TIME_SETTINGS) {
+            for (String timeSetting : INDEX_TIME_SETTINGS) {
                 String value = settings.get(timeSetting);
                 if (value != null) {
                     try {
@@ -200,9 +201,9 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
             if (newSettings != null) {
                 // At least one setting was changed:
                 return IndexMetaData.builder(indexMetaData)
-                    .version(indexMetaData.getVersion())
-                    .settings(newSettings.build())
-                    .build();
+                        .version(indexMetaData.getVersion())
+                        .settings(newSettings.build())
+                        .build();
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -151,7 +151,7 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
             "index.translog.interval",
             "index.translog.sync_interval",
             "index.shard.inactive_time",
-            LocalCheckpointService.SETTINGS_INDEX_LAG_MAX_WAIT,
+        LocalCheckpointService.SETTINGS_BIT_ARRAY_CHUNK_SIZE,
             UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING));
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -151,7 +151,7 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
             "index.translog.interval",
             "index.translog.sync_interval",
             "index.shard.inactive_time",
-        LocalCheckpointService.SETTINGS_BIT_ARRAY_CHUNK_SIZE,
+        LocalCheckpointService.SETTINGS_BIT_ARRAYS_SIZE,
             UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING));
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -93,8 +93,8 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
     private void checkSupportedVersion(IndexMetaData indexMetaData) {
         if (indexMetaData.getState() == IndexMetaData.State.OPEN && isSupportedVersion(indexMetaData) == false) {
             throw new IllegalStateException("The index [" + indexMetaData.getIndex() + "] was created before v2.0.0.beta1 and wasn't upgraded."
-                    + " This index should be open using a version before " + Version.CURRENT.minimumCompatibilityVersion()
-                    + " and upgraded using the upgrade API.");
+                + " This index should be open using a version before " + Version.CURRENT.minimumCompatibilityVersion()
+                + " and upgraded using the upgrade API.");
         }
     }
 
@@ -107,7 +107,7 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
             return true;
         }
         if (indexMetaData.getMinimumCompatibleVersion() != null &&
-                indexMetaData.getMinimumCompatibleVersion().onOrAfter(org.apache.lucene.util.Version.LUCENE_5_0_0)) {
+            indexMetaData.getMinimumCompatibleVersion().onOrAfter(org.apache.lucene.util.Version.LUCENE_5_0_0)) {
             //The index was upgraded we can work with it
             return true;
         }
@@ -116,43 +116,43 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
 
     /** All known byte-sized settings for an index. */
     public static final Set<String> INDEX_BYTES_SIZE_SETTINGS = unmodifiableSet(newHashSet(
-            "index.merge.policy.floor_segment",
-            "index.merge.policy.max_merged_segment",
-            "index.merge.policy.max_merge_size",
-            "index.merge.policy.min_merge_size",
-            "index.shard.recovery.file_chunk_size",
-            "index.shard.recovery.translog_size",
-            "index.store.throttle.max_bytes_per_sec",
-            "index.translog.flush_threshold_size",
-            "index.translog.fs.buffer_size",
-            "index.version_map_size"));
+        "index.merge.policy.floor_segment",
+        "index.merge.policy.max_merged_segment",
+        "index.merge.policy.max_merge_size",
+        "index.merge.policy.min_merge_size",
+        "index.shard.recovery.file_chunk_size",
+        "index.shard.recovery.translog_size",
+        "index.store.throttle.max_bytes_per_sec",
+        "index.translog.flush_threshold_size",
+        "index.translog.fs.buffer_size",
+        "index.version_map_size"));
 
     /** All known time settings for an index. */
     public static final Set<String> INDEX_TIME_SETTINGS = unmodifiableSet(newHashSet(
-            "index.gateway.wait_for_mapping_update_post_recovery",
-            "index.shard.wait_for_mapping_update_post_recovery",
-            "index.gc_deletes",
-            "index.indexing.slowlog.threshold.index.debug",
-            "index.indexing.slowlog.threshold.index.info",
-            "index.indexing.slowlog.threshold.index.trace",
-            "index.indexing.slowlog.threshold.index.warn",
-            "index.refresh_interval",
-            "index.search.slowlog.threshold.fetch.debug",
-            "index.search.slowlog.threshold.fetch.info",
-            "index.search.slowlog.threshold.fetch.trace",
-            "index.search.slowlog.threshold.fetch.warn",
-            "index.search.slowlog.threshold.query.debug",
-            "index.search.slowlog.threshold.query.info",
-            "index.search.slowlog.threshold.query.trace",
-            "index.search.slowlog.threshold.query.warn",
-            "index.shadow.wait_for_initial_commit",
-            "index.store.stats_refresh_interval",
-            "index.translog.flush_threshold_period",
-            "index.translog.interval",
-            "index.translog.sync_interval",
-            "index.shard.inactive_time",
+        "index.gateway.wait_for_mapping_update_post_recovery",
+        "index.shard.wait_for_mapping_update_post_recovery",
+        "index.gc_deletes",
+        "index.indexing.slowlog.threshold.index.debug",
+        "index.indexing.slowlog.threshold.index.info",
+        "index.indexing.slowlog.threshold.index.trace",
+        "index.indexing.slowlog.threshold.index.warn",
+        "index.refresh_interval",
+        "index.search.slowlog.threshold.fetch.debug",
+        "index.search.slowlog.threshold.fetch.info",
+        "index.search.slowlog.threshold.fetch.trace",
+        "index.search.slowlog.threshold.fetch.warn",
+        "index.search.slowlog.threshold.query.debug",
+        "index.search.slowlog.threshold.query.info",
+        "index.search.slowlog.threshold.query.trace",
+        "index.search.slowlog.threshold.query.warn",
+        "index.shadow.wait_for_initial_commit",
+        "index.store.stats_refresh_interval",
+        "index.translog.flush_threshold_period",
+        "index.translog.interval",
+        "index.translog.sync_interval",
+        "index.shard.inactive_time",
         LocalCheckpointService.SETTINGS_BIT_ARRAYS_SIZE,
-            UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING));
+        UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING));
 
     /**
      * Elasticsearch 2.0 requires units on byte/memory and time settings; this method adds the default unit to any such settings that are
@@ -201,9 +201,9 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
             if (newSettings != null) {
                 // At least one setting was changed:
                 return IndexMetaData.builder(indexMetaData)
-                        .version(indexMetaData.getVersion())
-                        .settings(newSettings.build())
-                        .build();
+                    .version(indexMetaData.getVersion())
+                    .settings(newSettings.build())
+                    .build();
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -40,19 +40,9 @@ import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-import java.io.ByteArrayInputStream;
-import java.io.EOFException;
-import java.io.FileNotFoundException;
-import java.io.FilterInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.NoSuchFileException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.ElasticsearchException.readException;
@@ -538,6 +528,17 @@ public abstract class StreamInput extends InputStream {
             T streamable = supplier.get();
             streamable.readFrom(this);
             return streamable;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Serializes a potential null value.
+     */
+    public <T extends StreamableReader<T>> T readOptionalStreamable(StreamableReader<T> streamableReader) throws IOException {
+        if (readBoolean()) {
+            return streamableReader.readFrom(this);
         } else {
             return null;
         }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -536,7 +536,7 @@ public abstract class StreamInput extends InputStream {
     /**
      * Serializes a potential null value.
      */
-    public <T extends StreamableReader<T>> T readOptionalStreamable(StreamableReader<T> streamableReader) throws IOException {
+    public <T extends StreamableReader<T>> T readOptionalStreamableReader(StreamableReader<T> streamableReader) throws IOException {
         if (readBoolean()) {
             return streamableReader.readFrom(this);
         } else {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -536,7 +536,7 @@ public abstract class StreamInput extends InputStream {
     /**
      * Serializes a potential null value.
      */
-    public <T extends StreamableReader<T>> T readOptionalStreamableReader(StreamableReader<T> streamableReader) throws IOException {
+    public <T> T readOptionalStreamableReader(StreamableReader<T> streamableReader) throws IOException {
         if (readBoolean()) {
             return streamableReader.readFrom(this);
         } else {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -40,9 +40,19 @@ import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.NoSuchFileException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.ElasticsearchException.readException;
@@ -133,7 +143,7 @@ public abstract class StreamInput extends InputStream {
      */
     public int readInt() throws IOException {
         return ((readByte() & 0xFF) << 24) | ((readByte() & 0xFF) << 16)
-                | ((readByte() & 0xFF) << 8) | (readByte() & 0xFF);
+            | ((readByte() & 0xFF) << 8) | (readByte() & 0xFF);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -506,7 +506,7 @@ public abstract class StreamOutput extends OutputStream {
     /**
      * Serializes a potential null value.
      */
-    public void writeOptionalStreamable(@Nullable Writeable writeable) throws IOException {
+    public void writeOptionalWritable(@Nullable Writeable writeable) throws IOException {
         if (writeable != null) {
             writeBoolean(true);
             writeable.writeTo(this);

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -503,6 +503,18 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
+    /**
+     * Serializes a potential null value.
+     */
+    public void writeOptionalStreamable(@Nullable Writeable writeable) throws IOException {
+        if (writeable != null) {
+            writeBoolean(true);
+            writeable.writeTo(this);
+        } else {
+            writeBoolean(false);
+        }
+    }
+
     public void writeThrowable(Throwable throwable) throws IOException {
         if (throwable == null) {
             writeBoolean(false);

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/EsRejectedExecutionException.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/EsRejectedExecutionException.java
@@ -31,13 +31,17 @@ import java.io.IOException;
 public class EsRejectedExecutionException extends ElasticsearchException {
     private final boolean isExecutorShutdown;
 
-    public EsRejectedExecutionException(String message, boolean isExecutorShutdown) {
-        super(message);
+    public EsRejectedExecutionException(String message, boolean isExecutorShutdown, Object... args) {
+        super(message, args);
         this.isExecutorShutdown = isExecutorShutdown;
     }
 
-    public EsRejectedExecutionException(String message) {
-        this(message, false);
+    public EsRejectedExecutionException(String message, Object... args) {
+        this(message, false, args);
+    }
+
+    public EsRejectedExecutionException(String message, boolean isExecutorShutdown) {
+        this(message, isExecutorShutdown, new Object[0]);
     }
 
     public EsRejectedExecutionException() {

--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -45,6 +45,7 @@ import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.merge.MergeStats;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.Store;
@@ -324,6 +325,9 @@ public abstract class Engine implements Closeable {
     public CommitStats commitStats() {
         return new CommitStats(getLastCommittedSegmentInfos());
     }
+
+    /** get sequence number related stats */
+    public abstract SeqNoStats seqNoStats();
 
     /**
      * Read the last segments info from the commit pointed to by the searcher manager

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -50,6 +50,7 @@ import org.elasticsearch.index.indexing.ShardIndexingService;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.merge.OnGoingMerge;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.ElasticsearchMergePolicy;
 import org.elasticsearch.index.shard.MergeSchedulerConfig;
@@ -348,10 +349,6 @@ public class InternalEngine extends Engine {
         } catch (OutOfMemoryError | IllegalStateException | IOException t) {
             maybeFailEngine("index", t);
             throw new IndexFailedEngineException(shardId, index.type(), index.id(), t);
-        } finally {
-            if (index.seqNo() != SequenceNumbersService.UNASSIGNED_SEQ_NO) {
-                seqNoService.markSeqNoAsCompleted(index.seqNo());
-            }
         }
         checkVersionMapRefresh();
         return created;
@@ -359,7 +356,7 @@ public class InternalEngine extends Engine {
 
     private boolean innerIndex(Index index) throws IOException {
         synchronized (dirtyLock(index.uid())) {
-            lastWriteNanos  = index.startTime();
+            lastWriteNanos = index.startTime();
             final long currentVersion;
             final boolean deleted;
             VersionValue versionValue = versionMap.getUnderLock(index.uid().bytes());
@@ -388,37 +385,47 @@ public class InternalEngine extends Engine {
 
             final boolean created;
             index.updateVersion(updatedVersion);
+            final long seqNo;
             if (index.origin() == Operation.Origin.PRIMARY) {
-                index.updateSeqNo(seqNoService.generateSeqNo());
-            }
-
-            if (currentVersion == Versions.NOT_FOUND) {
-                // document does not exists, we can optimize for create
-                created = true;
-                if (index.docs().size() > 1) {
-                    indexWriter.addDocuments(index.docs());
-                } else {
-                    indexWriter.addDocument(index.docs().get(0));
-                }
+                seqNo = seqNoService.generateSeqNo();
             } else {
-                if (versionValue != null) {
-                    created = versionValue.delete(); // we have a delete which is not GC'ed...
-                } else {
-                    created = false;
-                }
-                if (index.docs().size() > 1) {
-                    indexWriter.updateDocuments(index.uid(), index.docs());
-                } else {
-                    indexWriter.updateDocument(index.uid(), index.docs().get(0));
-                }
+                seqNo = index.seqNo();
+                seqNoService.markSeqNoAsStarted(seqNo);
             }
-            Translog.Location translogLocation = translog.add(new Translog.Index(index));
+            try {
+                if (index.origin() == Operation.Origin.PRIMARY) {
+                    index.updateSeqNo(seqNo);
+                }
+                if (currentVersion == Versions.NOT_FOUND) {
+                    // document does not exists, we can optimize for create
+                    created = true;
+                    if (index.docs().size() > 1) {
+                        indexWriter.addDocuments(index.docs());
+                    } else {
+                        indexWriter.addDocument(index.docs().get(0));
+                    }
+                } else {
+                    if (versionValue != null) {
+                        created = versionValue.delete(); // we have a delete which is not GC'ed...
+                    } else {
+                        created = false;
+                    }
+                    if (index.docs().size() > 1) {
+                        indexWriter.updateDocuments(index.uid(), index.docs());
+                    } else {
+                        indexWriter.updateDocument(index.uid(), index.docs().get(0));
+                    }
+                }
+                Translog.Location translogLocation = translog.add(new Translog.Index(index));
 
-            versionMap.putUnderLock(index.uid().bytes(), new VersionValue(updatedVersion, translogLocation));
-            index.setTranslogLocation(translogLocation);
+                versionMap.putUnderLock(index.uid().bytes(), new VersionValue(updatedVersion, translogLocation));
+                index.setTranslogLocation(translogLocation);
 
-            indexingService.postIndexUnderLock(index);
-            return created;
+                indexingService.postIndexUnderLock(index);
+                return created;
+            } finally {
+                seqNoService.markSeqNoAsCompleted(seqNo);
+            }
         }
     }
 
@@ -458,10 +465,6 @@ public class InternalEngine extends Engine {
         } catch (OutOfMemoryError | IllegalStateException | IOException t) {
             maybeFailEngine("delete", t);
             throw new DeleteFailedEngineException(shardId, delete, t);
-        } finally {
-            if (delete.seqNo() != SequenceNumbersService.UNASSIGNED_SEQ_NO) {
-                seqNoService.markSeqNoAsCompleted(delete.seqNo());
-            }
         }
 
         maybePruneDeletedTombstones();
@@ -506,28 +509,39 @@ public class InternalEngine extends Engine {
             }
             updatedVersion = delete.versionType().updateVersion(currentVersion, expectedVersion);
 
+            final long seqNo;
             if (delete.origin() == Operation.Origin.PRIMARY) {
-                delete.updateSeqNo(seqNoService.generateSeqNo());
-            }
-
-            final boolean found;
-            if (currentVersion == Versions.NOT_FOUND) {
-                // doc does not exist and no prior deletes
-                found = false;
-            } else if (versionValue != null && versionValue.delete()) {
-                // a "delete on delete", in this case, we still increment the version, log it, and return that version
-                found = false;
+                seqNo = seqNoService.generateSeqNo();
             } else {
-                // we deleted a currently existing document
-                indexWriter.deleteDocuments(delete.uid());
-                found = true;
+                seqNo = delete.seqNo();
+                seqNoService.markSeqNoAsStarted(seqNo);
             }
+            try {
+                if (delete.origin() == Operation.Origin.PRIMARY) {
+                    delete.updateSeqNo(seqNo);
+                }
 
-            delete.updateVersion(updatedVersion, found);
-            Translog.Location translogLocation = translog.add(new Translog.Delete(delete));
-            versionMap.putUnderLock(delete.uid().bytes(), new DeleteVersionValue(updatedVersion, engineConfig.getThreadPool().estimatedTimeInMillis(), translogLocation));
-            delete.setTranslogLocation(translogLocation);
-            indexingService.postDeleteUnderLock(delete);
+                final boolean found;
+                if (currentVersion == Versions.NOT_FOUND) {
+                    // doc does not exist and no prior deletes
+                    found = false;
+                } else if (versionValue != null && versionValue.delete()) {
+                    // a "delete on delete", in this case, we still increment the version, log it, and return that version
+                    found = false;
+                } else {
+                    // we deleted a currently existing document
+                    indexWriter.deleteDocuments(delete.uid());
+                    found = true;
+                }
+
+                delete.updateVersion(updatedVersion, found);
+                Translog.Location translogLocation = translog.add(new Translog.Delete(delete));
+                versionMap.putUnderLock(delete.uid().bytes(), new DeleteVersionValue(updatedVersion, engineConfig.getThreadPool().estimatedTimeInMillis(), translogLocation));
+                delete.setTranslogLocation(translogLocation);
+                indexingService.postDeleteUnderLock(delete);
+            } finally {
+                seqNoService.markSeqNoAsCompleted(seqNo);
+            }
         }
     }
 
@@ -988,7 +1002,7 @@ public class InternalEngine extends Engine {
         @Override
         public IndexSearcher newSearcher(IndexReader reader, IndexReader previousReader) throws IOException {
             IndexSearcher searcher = super.newSearcher(reader, previousReader);
-            if (reader instanceof LeafReader && isMergedSegment((LeafReader)reader)) {
+            if (reader instanceof LeafReader && isMergedSegment((LeafReader) reader)) {
                 // we call newSearcher from the IndexReaderWarmer which warms segments during merging
                 // in that case the reader is a LeafReader and all we need to do is to build a new Searcher
                 // and return it since it does it's own warming for that particular reader.
@@ -1177,5 +1191,10 @@ public class InternalEngine extends Engine {
 
     public MergeStats getMergeStats() {
         return mergeScheduler.stats();
+    }
+
+    @Override
+    public SeqNoStats seqNoStats() {
+        return seqNoService.stats();
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.translog.Translog;
 
 import java.io.IOException;
@@ -230,5 +231,10 @@ public class ShadowEngine extends Engine {
     public long indexWriterRAMBytesUsed() {
         // No IndexWriter
         throw new UnsupportedOperationException("ShadowEngine has no IndexWriter");
+    }
+
+    @Override
+    public SeqNoStats seqNoStats() {
+        throw new UnsupportedOperationException("ShadowEngine doesn't track sequence numbers");
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.seqno;
+
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.shard.AbstractIndexShardComponent;
+import org.elasticsearch.index.shard.ShardId;
+
+public class LocalCheckpointService extends AbstractIndexShardComponent {
+
+    public static String SETTINGS_INDEX_LAG_THRESHOLD = "index.seq_no.index_lag.threshold";
+    public static String SETTINGS_INDEX_LAG_MAX_WAIT = "index.seq_no.index_lag.max_wait";
+
+    final Object mutex = new Object();
+    final FixedBitSet processedSeqNo;
+    final int indexLagThreshold;
+    final TimeValue indexLagMaxWait;
+
+
+    volatile long nextSeqNo = 0;
+    volatile long checkpoint = -1;
+
+    public LocalCheckpointService(ShardId shardId, IndexSettings indexSettings) {
+        super(shardId, indexSettings);
+        indexLagThreshold = indexSettings.getSettings().getAsInt(SETTINGS_INDEX_LAG_THRESHOLD, 1024);
+        indexLagMaxWait = indexSettings.getSettings().getAsTime(SETTINGS_INDEX_LAG_MAX_WAIT, TimeValue.timeValueSeconds(30));
+        processedSeqNo = new FixedBitSet(indexLagThreshold);
+
+    }
+
+    public long generateSeqNo() {
+        synchronized (mutex) {
+            // we have to keep checking when ensure capacity returns because it release the lock and nextSeqNo may change
+            while (hasCapacity(nextSeqNo) == false) {
+                ensureCapacity(nextSeqNo);
+            }
+            return nextSeqNo++;
+        }
+    }
+
+    public void markSeqNoAsStarted(long seqNo) {
+        synchronized (mutex) {
+            // make sure we track highest seen seqNo
+            if (seqNo >= nextSeqNo) {
+                nextSeqNo = seqNo + 1;
+            }
+            if (seqNo <= checkpoint) {
+                // this is possible during recover where we might replay an op that was also replicated
+                return;
+            }
+            ensureCapacity(seqNo);
+            assert processedSeqNo.get(seqNoToOffset(seqNo)) == false : "expected [" + seqNo + "] not to be marked as started";
+        }
+    }
+
+    public long markSeqNoAsCompleted(long seqNo) {
+        synchronized (mutex) {
+            if (seqNo <= checkpoint) {
+                // this is possible during recover where we might replay an op that was also replicated
+                return checkpoint;
+            }
+            // just to be safe (previous calls to generateSeqNo/markSeqNoAsStarted should ensure this is OK)
+            ensureCapacity(seqNo);
+            int offset = seqNoToOffset(seqNo);
+            processedSeqNo.set(offset);
+            if (seqNo == checkpoint + 1) {
+                do {
+                    // clear the flag as we are making it free for future operations. do se before we expose it
+                    // by moving the checkpoint
+                    processedSeqNo.clear(offset);
+                    checkpoint++;
+                    offset = seqNoToOffset(checkpoint + 1);
+                } while (processedSeqNo.get(offset));
+                mutex.notifyAll();
+            }
+        }
+        return checkpoint;
+    }
+
+    public long getCheckpoint() {
+        return checkpoint;
+    }
+
+    public long getMaxSeqNo() {
+        return nextSeqNo - 1;
+    }
+
+
+    private boolean hasCapacity(long seqNo) {
+        assert Thread.holdsLock(mutex);
+        return (seqNo - checkpoint) < indexLagThreshold;
+    }
+
+    private void ensureCapacity(long seqNo) {
+        assert Thread.holdsLock(mutex);
+        long retry = 0;
+        final long maxRetries = indexLagMaxWait.seconds();
+        while (hasCapacity(seqNo) == false) {
+            try {
+                if (retry > maxRetries) {
+                    ElasticsearchException e = new EsRejectedExecutionException("indexing lag exceeds [{}] (seq# requested [{}], local checkpoint [{}]",
+                            indexLagThreshold, seqNo, checkpoint);
+                    e.setShard(shardId());
+                    throw e;
+                }
+
+                // this temporary releases the lock on mutex
+                mutex.wait(Math.min(1000, indexLagMaxWait.millis() - retry * 1000));
+                retry++;
+            } catch (InterruptedException ie) {
+                ElasticsearchException exp = new ElasticsearchException("interrupted while waiting on index lag");
+                exp.setShard(shardId());
+                throw exp;
+            }
+        }
+    }
+
+    private int seqNoToOffset(long seqNo) {
+        assert seqNo - checkpoint < indexLagThreshold;
+        assert seqNo > checkpoint;
+        return (int) (seqNo % indexLagThreshold);
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointService.java
@@ -26,20 +26,43 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
 
+/**
+ * This class generates sequences numbers and keeps track of the so called local checkpoint - the highest number for which
+ * all previous seqNo have been processed (including)
+ */
 public class LocalCheckpointService extends AbstractIndexShardComponent {
 
+    /** sets the maximum spread between lowest and highest seq no in flight */
     public static String SETTINGS_INDEX_LAG_THRESHOLD = "index.seq_no.index_lag.threshold";
+
+    /**
+     * how long should an incoming indexing request which violates {@link #SETTINGS_INDEX_LAG_THRESHOLD } should wait
+     * before being rejected
+     */
     public static String SETTINGS_INDEX_LAG_MAX_WAIT = "index.seq_no.index_lag.max_wait";
+
+    /** default value for {@link #SETTINGS_INDEX_LAG_THRESHOLD} */
     final static int DEFAULT_INDEX_LAG_THRESHOLD = 1024;
+
+    /** default value for {@link #SETTINGS_INDEX_LAG_MAX_WAIT} */
     final static TimeValue DEFAULT_INDEX_LAG_MAX_WAIT = TimeValue.timeValueSeconds(30);
 
+    /** protects changes to all internal state and signals changes in {@link #checkpoint} */
     final Object mutex = new Object();
+
+    /** each bits maps to a seqNo in round robin fashion. a set bit means the seqNo has been processed */
     final FixedBitSet processedSeqNo;
+
+    /** value of {@link #SETTINGS_INDEX_LAG_THRESHOLD } */
     final int indexLagThreshold;
+    /** value of {#link #SETTINGS_INDEX_LAG_THRESHOLD } */
     final TimeValue indexLagMaxWait;
 
 
+    /** the next available seqNo - used for seqNo generation */
     volatile long nextSeqNo = 0;
+
+    /** the current local checkpoint, i.e., all seqNo lower<= this number have been completed */
     volatile long checkpoint = -1;
 
     public LocalCheckpointService(ShardId shardId, IndexSettings indexSettings) {
@@ -50,6 +73,11 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
 
     }
 
+    /**
+     * issue the next sequence number
+     *
+     * Note that this method can block to honour maximum indexing lag . See {@link #SETTINGS_INDEX_LAG_THRESHOLD }
+     **/
     public long generateSeqNo() {
         synchronized (mutex) {
             // we have to keep checking when ensure capacity returns because it release the lock and nextSeqNo may change
@@ -60,6 +88,10 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
         }
     }
 
+    /**
+     * marks the processing of the given seqNo have been completed
+     * Note that this method can block to honour maximum indexing lag . See {@link #SETTINGS_INDEX_LAG_THRESHOLD }
+     **/
     public long markSeqNoAsCompleted(long seqNo) {
         synchronized (mutex) {
             // make sure we track highest seen seqNo
@@ -88,20 +120,24 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
         return checkpoint;
     }
 
+    /** get's the current check point */
     public long getCheckpoint() {
         return checkpoint;
     }
 
+    /** get's the maximum seqno seen so far */
     public long getMaxSeqNo() {
         return nextSeqNo - 1;
     }
 
 
+    /** checks if seqNo violates {@link #SETTINGS_INDEX_LAG_THRESHOLD } */
     private boolean hasCapacity(long seqNo) {
         assert Thread.holdsLock(mutex);
         return (seqNo - checkpoint) <= indexLagThreshold;
     }
 
+    /** blocks until {@link #SETTINGS_INDEX_LAG_THRESHOLD } is honoured or raises {@link EsRejectedExecutionException }*/
     private void ensureCapacity(long seqNo) {
         assert Thread.holdsLock(mutex);
         long retry = 0;
@@ -126,6 +162,7 @@ public class LocalCheckpointService extends AbstractIndexShardComponent {
         }
     }
 
+    /** maps the given seqNo to a position in {@link #processedSeqNo} */
     private int seqNoToOffset(long seqNo) {
         assert seqNo - checkpoint <= indexLagThreshold;
         assert seqNo > checkpoint;

--- a/core/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
@@ -39,10 +39,12 @@ public class SeqNoStats implements ToXContent, Writeable<SeqNoStats> {
         this.localCheckpoint = localCheckpoint;
     }
 
+    /** the maximum sequence number seen so far */
     public long getMaxSeqNo() {
         return maxSeqNo;
     }
 
+    /** the maximum sequence number for which all previous operations (including) have been completed */
     public long getLocalCheckpoint() {
         return localCheckpoint;
     }

--- a/core/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
@@ -29,14 +29,16 @@ import java.io.IOException;
 
 public class SeqNoStats implements ToXContent, Writeable<SeqNoStats> {
 
-    public static final SeqNoStats PROTOTYPE = new SeqNoStats(0, 0);
-
     final long maxSeqNo;
     final long localCheckpoint;
 
     public SeqNoStats(long maxSeqNo, long localCheckpoint) {
         this.maxSeqNo = maxSeqNo;
         this.localCheckpoint = localCheckpoint;
+    }
+
+    public SeqNoStats(StreamInput in) throws IOException {
+        this(in.readZLong(), in.readZLong());
     }
 
     /** the maximum sequence number seen so far */
@@ -56,8 +58,8 @@ public class SeqNoStats implements ToXContent, Writeable<SeqNoStats> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeLong(maxSeqNo);
-        out.writeLong(localCheckpoint);
+        out.writeZLong(maxSeqNo);
+        out.writeZLong(localCheckpoint);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SeqNoStats.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.seqno;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilderString;
+
+import java.io.IOException;
+
+public class SeqNoStats implements ToXContent, Writeable<SeqNoStats> {
+
+    public static final SeqNoStats PROTOTYPE = new SeqNoStats(0, 0);
+
+    final long maxSeqNo;
+    final long localCheckpoint;
+
+    public SeqNoStats(long maxSeqNo, long localCheckpoint) {
+        this.maxSeqNo = maxSeqNo;
+        this.localCheckpoint = localCheckpoint;
+    }
+
+    public long getMaxSeqNo() {
+        return maxSeqNo;
+    }
+
+    public long getLocalCheckpoint() {
+        return localCheckpoint;
+    }
+
+    @Override
+    public SeqNoStats readFrom(StreamInput in) throws IOException {
+        return new SeqNoStats(in.readLong(), in.readLong());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(maxSeqNo);
+        out.writeLong(localCheckpoint);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.SEQ_NO);
+        builder.field(Fields.MAX_SEQ_NO, maxSeqNo);
+        builder.field(Fields.LOCAL_CHECKPOINT, localCheckpoint);
+        builder.endObject();
+        return builder;
+    }
+
+
+    static final class Fields {
+        static final XContentBuilderString SEQ_NO = new XContentBuilderString("seq_no");
+        static final XContentBuilderString MAX_SEQ_NO = new XContentBuilderString("max");
+        static final XContentBuilderString LOCAL_CHECKPOINT = new XContentBuilderString("local_checkpoint");
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -42,11 +42,6 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
         return localCheckpointService.generateSeqNo();
     }
 
-    public void markSeqNoAsStarted(long seqNo) {
-        localCheckpointService.markSeqNoAsStarted(seqNo);
-
-    }
-
     public void markSeqNoAsCompleted(long seqNo) {
         localCheckpointService.markSeqNoAsCompleted(seqNo);
     }

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -22,39 +22,36 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.ShardId;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 /** a very light weight implementation. will be replaced with proper machinery later */
 public class SequenceNumbersService extends AbstractIndexShardComponent {
 
     public final static long UNASSIGNED_SEQ_NO = -1L;
-
-    AtomicLong seqNoGenerator = new AtomicLong();
+    final LocalCheckpointService localCheckpointService;
 
     public SequenceNumbersService(ShardId shardId, IndexSettings indexSettings) {
         super(shardId, indexSettings);
+        localCheckpointService = new LocalCheckpointService(shardId, indexSettings);
     }
 
     /**
      * generates a new sequence number.
      * Note: you must call {@link #markSeqNoAsCompleted(long)} after the operation for which this seq# was generated
-     * was completed (whether successfully or with a failure
+     * was completed (whether successfully or with a failure)
      */
     public long generateSeqNo() {
-        return seqNoGenerator.getAndIncrement();
+        return localCheckpointService.generateSeqNo();
+    }
+
+    public void markSeqNoAsStarted(long seqNo) {
+        localCheckpointService.markSeqNoAsStarted(seqNo);
+
     }
 
     public void markSeqNoAsCompleted(long seqNo) {
-        // this is temporary to make things semi sane on primary promotion and recovery. will be replaced with better machinery
-        boolean success;
-        do {
-            long maxSeqNo = seqNoGenerator.get();
-            if (seqNo > maxSeqNo) {
-                success = seqNoGenerator.compareAndSet(maxSeqNo, seqNo);
-            } else {
-                success = true;
-            }
-        } while (success == false);
+        localCheckpointService.markSeqNoAsCompleted(seqNo);
     }
 
+    public SeqNoStats stats() {
+        return new SeqNoStats(localCheckpointService.getMaxSeqNo(), localCheckpointService.getCheckpoint());
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -42,10 +42,17 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
         return localCheckpointService.generateSeqNo();
     }
 
+    /**
+     * marks the given seqNo as completed. See {@link LocalCheckpointService#markSeqNoAsCompleted(long)}
+     * more details
+     */
     public void markSeqNoAsCompleted(long seqNo) {
         localCheckpointService.markSeqNoAsCompleted(seqNo);
     }
 
+    /**
+     * Gets sequence number related stats
+     */
     public SeqNoStats stats() {
         return new SeqNoStats(localCheckpointService.getMaxSeqNo(), localCheckpointService.getCheckpoint());
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -79,6 +79,7 @@ import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
 import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.search.stats.ShardSearchStats;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.snapshots.IndexShardRepository;
@@ -589,6 +590,15 @@ public class IndexShard extends AbstractIndexShardComponent {
     public CommitStats commitStats() {
         Engine engine = getEngineOrNull();
         return engine == null ? null : engine.commitStats();
+    }
+
+    /**
+     * @return {@link SeqNoStats} if engine is open, otherwise null
+     */
+    @Nullable
+    public SeqNoStats seqNoStats() {
+        Engine engine = getEngineOrNull();
+        return engine == null ? null : engine.seqNoStats();
     }
 
     public IndexingStats indexingStats(String... types) {

--- a/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShadowIndexShard.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.index.shard;
 
-import java.io.IOException;
-
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.IndexSettings;
@@ -31,9 +29,12 @@ import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.merge.MergeStats;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.TranslogStats;
+
+import java.io.IOException;
 
 /**
  * ShadowIndexShard extends {@link IndexShard} to add file synchronization
@@ -65,6 +66,11 @@ public final class ShadowIndexShard extends IndexShard {
     @Override
     public MergeStats mergeStats() {
         return new MergeStats();
+    }
+
+    @Override
+    public SeqNoStats seqNoStats() {
+        return null;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -198,7 +198,9 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                     if (indexShard.routingEntry() == null) {
                         continue;
                     }
-                    IndexShardStats indexShardStats = new IndexShardStats(indexShard.shardId(), new ShardStats[] { new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), new CommonStats(indexShard, flags), indexShard.commitStats()) });
+                    IndexShardStats indexShardStats = new IndexShardStats(indexShard.shardId(),
+                            new ShardStats[]{new ShardStats(indexShard.routingEntry(), indexShard.shardPath(),
+                                    new CommonStats(indexShard, flags), indexShard.commitStats(), indexShard.seqNoStats())});
                     if (!statsByShard.containsKey(indexService.index())) {
                         statsByShard.put(indexService.index(), arrayAsArrayList(indexShardStats));
                     } else {

--- a/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -104,8 +104,8 @@ public class DiskUsageTests extends ESTestCase {
         CommonStats commonStats1 = new CommonStats();
         commonStats1.store = new StoreStats(1000, 1);
         ShardStats[] stats = new ShardStats[]{
-                new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, "0xdeadbeef", test_0.shardId()), commonStats0, null),
-                new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, "0xdeadbeef", test_1.shardId()), commonStats1, null)
+                new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, "0xdeadbeef", test_0.shardId()), commonStats0, null, null),
+                new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, "0xdeadbeef", test_1.shardId()), commonStats1, null, null)
         };
         ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<ShardRouting, String> routingToPath = ImmutableOpenMap.builder();

--- a/core/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointServiceTests.java
@@ -50,7 +50,7 @@ public class LocalCheckpointServiceTests extends ESTestCase {
             new ShardId("test", 0),
             IndexSettingsModule.newIndexSettings("test",
                 Settings.builder()
-                    .put(LocalCheckpointService.SETTINGS_BIT_ARRAY_CHUNK_SIZE, SMALL_CHUNK_SIZE)
+                    .put(LocalCheckpointService.SETTINGS_BIT_ARRAYS_SIZE, SMALL_CHUNK_SIZE)
                     .build()
             ));
     }

--- a/core/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointServiceTests.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.seqno;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LocalCheckpointServiceTests extends ESTestCase {
+
+    LocalCheckpointService checkpointService;
+
+    final int SMALL_INDEX_LAG_THRESHOLD = 10;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        checkpointService = getCheckpointService(SMALL_INDEX_LAG_THRESHOLD, LocalCheckpointService.DEFAULT_INDEX_LAG_MAX_WAIT);
+    }
+
+    protected LocalCheckpointService getCheckpointService(int thresholdLag, TimeValue thresholdDelay) {
+        return new LocalCheckpointService(
+                new ShardId("test", 0),
+                IndexSettingsModule.newIndexSettings("test",
+                        Settings.builder()
+                                .put(LocalCheckpointService.SETTINGS_INDEX_LAG_THRESHOLD, thresholdLag)
+                                .put(LocalCheckpointService.SETTINGS_INDEX_LAG_MAX_WAIT, thresholdDelay)
+                                .build()
+                ));
+    }
+
+    public void testSimplePrimary() {
+        long seqNo1, seqNo2;
+        assertThat(checkpointService.getCheckpoint(), equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
+        seqNo1 = checkpointService.generateSeqNo();
+        assertThat(seqNo1, equalTo(0L));
+        checkpointService.markSeqNoAsCompleted(seqNo1);
+        assertThat(checkpointService.getCheckpoint(), equalTo(0L));
+        seqNo1 = checkpointService.generateSeqNo();
+        seqNo2 = checkpointService.generateSeqNo();
+        assertThat(seqNo1, equalTo(1L));
+        assertThat(seqNo2, equalTo(2L));
+        checkpointService.markSeqNoAsCompleted(seqNo2);
+        assertThat(checkpointService.getCheckpoint(), equalTo(0L));
+        checkpointService.markSeqNoAsCompleted(seqNo1);
+        assertThat(checkpointService.getCheckpoint(), equalTo(2L));
+    }
+
+    public void testSimpleReplica() {
+        assertThat(checkpointService.getCheckpoint(), equalTo(SequenceNumbersService.UNASSIGNED_SEQ_NO));
+        checkpointService.markSeqNoAsCompleted(0L);
+        assertThat(checkpointService.getCheckpoint(), equalTo(0L));
+        checkpointService.markSeqNoAsCompleted(2L);
+        assertThat(checkpointService.getCheckpoint(), equalTo(0L));
+        checkpointService.markSeqNoAsCompleted(1L);
+        assertThat(checkpointService.getCheckpoint(), equalTo(2L));
+    }
+
+    public void testIndexThrottleSuccessPrimary() throws Exception {
+        LocalCheckpointService checkpoint = getCheckpointService(3, TimeValue.timeValueHours(1));
+        final long seq1 = checkpoint.generateSeqNo();
+        final long seq2 = checkpoint.generateSeqNo();
+        final long seq3 = checkpoint.generateSeqNo();
+        final CountDownLatch threadStarted = new CountDownLatch(1);
+        final AtomicBoolean threadDone = new AtomicBoolean(false);
+        Thread backgroundThread = new Thread(() -> {
+            threadStarted.countDown();
+            checkpoint.generateSeqNo();
+            threadDone.set(true);
+        }, "testIndexDelayPrimary");
+        backgroundThread.start();
+        logger.info("--> waiting for thread to start");
+        threadStarted.await();
+        assertFalse("background thread finished but should have waited", threadDone.get());
+        checkpoint.markSeqNoAsCompleted(seq2);
+        assertFalse("background thread finished but should have waited (seq2 completed)", threadDone.get());
+        checkpoint.markSeqNoAsCompleted(seq1);
+        logger.info("--> waiting for thread to stop");
+        assertBusy(() -> {
+            assertTrue("background thread should finished after finishing seq1", threadDone.get());
+        });
+    }
+
+    public void testIndexThrottleTimeoutPrimary() throws Exception {
+        LocalCheckpointService checkpoint = getCheckpointService(2, TimeValue.timeValueMillis(100));
+        checkpoint.generateSeqNo();
+        checkpoint.generateSeqNo();
+        try {
+            checkpoint.generateSeqNo();
+            fail("index operation should time out due to a large lag");
+        } catch (EsRejectedExecutionException e) {
+            // OK!
+        }
+    }
+
+    public void testIndexThrottleSuccessReplica() throws Exception {
+        LocalCheckpointService checkpoint = getCheckpointService(3, TimeValue.timeValueHours(1));
+        final CountDownLatch threadStarted = new CountDownLatch(1);
+        final AtomicBoolean threadDone = new AtomicBoolean(false);
+        checkpoint.markSeqNoAsCompleted(1);
+        Thread backgroundThread = new Thread(() -> {
+            threadStarted.countDown();
+            checkpoint.markSeqNoAsCompleted(3);
+            threadDone.set(true);
+        }, "testIndexDelayReplica");
+        backgroundThread.start();
+        logger.info("--> waiting for thread to start");
+        threadStarted.await();
+        assertFalse("background thread finished but should have waited", threadDone.get());
+        checkpoint.markSeqNoAsCompleted(0);
+        logger.info("--> waiting for thread to stop");
+        assertBusy(() -> {
+            assertTrue("background thread should finished after finishing seq1", threadDone.get());
+        });
+    }
+
+    public void testIndexThrottleTimeoutReplica() throws Exception {
+        LocalCheckpointService checkpoint = getCheckpointService(1, TimeValue.timeValueMillis(100));
+        try {
+            checkpoint.markSeqNoAsCompleted(1L);
+            fail("index operation should time out due to a large lag");
+        } catch (EsRejectedExecutionException e) {
+            // OK!
+        }
+        checkpoint.markSeqNoAsCompleted(0L);
+        try {
+            checkpoint.markSeqNoAsCompleted(2L);
+            fail("index operation should time out due to a large lag");
+        } catch (EsRejectedExecutionException e) {
+            // OK!
+        }
+
+    }
+
+    public void testConcurrentPrimary() throws InterruptedException {
+        Thread[] threads = new Thread[randomIntBetween(2, 5)];
+        final int opsPerThread = randomIntBetween(10, 20);
+        final int maxOps = opsPerThread * threads.length;
+        final long unFinisshedSeq = randomIntBetween(maxOps - SMALL_INDEX_LAG_THRESHOLD, maxOps - 2); // make sure we won't be blocked
+        logger.info("--> will run [{}] threads, maxOps [{}], unfinished seq no [{}]", threads.length, maxOps, unFinisshedSeq);
+        final CyclicBarrier barrier = new CyclicBarrier(threads.length);
+        for (int t = 0; t < threads.length; t++) {
+            final int threadId = t;
+            threads[t] = new Thread(new AbstractRunnable() {
+                @Override
+                public void onFailure(Throwable t) {
+                    throw new ElasticsearchException("failure in background thread", t);
+                }
+
+                @Override
+                protected void doRun() throws Exception {
+                    barrier.await();
+                    for (int i = 0; i < opsPerThread; i++) {
+                        long seqNo = checkpointService.generateSeqNo();
+                        logger.info("[t{}] started   [{}]", threadId, seqNo);
+                        if (seqNo != unFinisshedSeq) {
+                            checkpointService.markSeqNoAsCompleted(seqNo);
+                            logger.info("[t{}] completed [{}]", threadId, seqNo);
+                        }
+                    }
+                }
+            }, "testConcurrentPrimary_" + threadId);
+            threads[t].start();
+        }
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        assertThat(checkpointService.getMaxSeqNo(), equalTo(maxOps - 1L));
+        assertThat(checkpointService.getCheckpoint(), equalTo(unFinisshedSeq - 1L));
+        checkpointService.markSeqNoAsCompleted(unFinisshedSeq);
+        assertThat(checkpointService.getCheckpoint(), equalTo(maxOps - 1L));
+    }
+
+    public void testConcurrentReplica() throws InterruptedException {
+        Thread[] threads = new Thread[randomIntBetween(2, 5)];
+        final int opsPerThread = randomIntBetween(10, 20);
+        final int maxOps = opsPerThread * threads.length;
+        final long unFinisshedSeq = randomIntBetween(maxOps - SMALL_INDEX_LAG_THRESHOLD, maxOps - 2); // make sure we won't be blocked
+        Set<Integer> seqNoList = new HashSet<>();
+        for (int i = 0; i < maxOps; i++) {
+            seqNoList.add(i);
+        }
+
+        final Integer[][] seqNoPerThread = new Integer[threads.length][];
+        for (int t = 0; t < threads.length - 1; t++) {
+            int size = Math.min(seqNoList.size(), randomIntBetween(opsPerThread - 4, opsPerThread + 4));
+            seqNoPerThread[t] = randomSubsetOf(size, seqNoList).toArray(new Integer[size]);
+            Arrays.sort(seqNoPerThread[t]);
+            seqNoList.removeAll(Arrays.asList(seqNoPerThread[t]));
+        }
+        seqNoPerThread[threads.length - 1] = seqNoList.toArray(new Integer[seqNoList.size()]);
+        logger.info("--> will run [{}] threads, maxOps [{}], unfinished seq no [{}]", threads.length, maxOps, unFinisshedSeq);
+        final CyclicBarrier barrier = new CyclicBarrier(threads.length);
+        for (int t = 0; t < threads.length; t++) {
+            final int threadId = t;
+            threads[t] = new Thread(new AbstractRunnable() {
+                @Override
+                public void onFailure(Throwable t) {
+                    throw new ElasticsearchException("failure in background thread", t);
+                }
+
+                @Override
+                protected void doRun() throws Exception {
+                    barrier.await();
+                    Integer[] ops = seqNoPerThread[threadId];
+                    for (int seqNo : ops) {
+                        if (seqNo != unFinisshedSeq) {
+                            checkpointService.markSeqNoAsCompleted(seqNo);
+                            logger.info("[t{}] completed [{}]", threadId, seqNo);
+                        }
+                    }
+                }
+            }, "testConcurrentPrimary_" + threadId);
+            threads[t].start();
+        }
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        assertThat(checkpointService.getMaxSeqNo(), equalTo(maxOps - 1L));
+        assertThat(checkpointService.getCheckpoint(), equalTo(unFinisshedSeq - 1L));
+        checkpointService.markSeqNoAsCompleted(unFinisshedSeq);
+        assertThat(checkpointService.getCheckpoint(), equalTo(maxOps - 1L));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -591,7 +591,8 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexService test = indicesService.indexService("test");
         IndexShard shard = test.getShardOrNull(0);
-        ShardStats stats = new ShardStats(shard.routingEntry(), shard.shardPath(), new CommonStats(shard, new CommonStatsFlags()), shard.commitStats());
+        ShardStats stats = new ShardStats(shard.routingEntry(), shard.shardPath(), new CommonStats(shard, new CommonStatsFlags()),
+                shard.commitStats(), shard.seqNoStats());
         assertEquals(shard.shardPath().getRootDataPath().toString(), stats.getDataPath());
         assertEquals(shard.shardPath().getRootStatePath().toString(), stats.getStatePath());
         assertEquals(shard.shardPath().isCustomDataPath(), stats.isCustomDataPath());

--- a/test-framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -555,12 +555,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * Returns size random values
      */
     public static <T> List<T> randomSubsetOf(int size, T... values) {
-        if (size > values.length) {
-            throw new IllegalArgumentException("Can\'t pick " + size + " random objects from a list of " + values.length + " objects");
-        }
-        List<T> list = arrayAsArrayList(values);
-        Collections.shuffle(list);
-        return list.subList(0, size);
+        return randomSubsetOf(size, Arrays.asList(values));
     }
 
     /**
@@ -571,7 +566,7 @@ public abstract class ESTestCase extends LuceneTestCase {
             throw new IllegalArgumentException("Can\'t pick " + size + " random objects from a list of " + values.size() + " objects");
         }
         List<T> list = new ArrayList<>(values);
-        Collections.shuffle(list);
+        Collections.shuffle(list, random());
         return list.subList(0, size);
     }
 
@@ -621,7 +616,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         sb.append("]");
         assertThat(count + " files exist that should have been cleaned:\n" + sb.toString(), count, equalTo(0));
     }
-    
+
     /** Returns the suite failure marker: internal use only! */
     public static TestRuleMarkFailure getSuiteFailureMarker() {
         return suiteFailureMarker;

--- a/test-framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -29,14 +29,12 @@ import com.carrotsearch.randomizedtesting.generators.RandomInts;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import com.carrotsearch.randomizedtesting.rules.TestRuleAdapter;
-
 import org.apache.lucene.uninverting.UninvertingReader;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.util.TestRuleMarkFailure;
 import org.apache.lucene.util.TestUtil;
 import org.apache.lucene.util.TimeUnits;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.BootstrapForTesting;
 import org.elasticsearch.cache.recycler.MockPageCacheRecycler;
@@ -50,7 +48,6 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -58,11 +55,7 @@ import org.elasticsearch.search.MockSearchService;
 import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.junit.*;
 import org.junit.rules.RuleChain;
 
 import java.io.IOException;
@@ -569,6 +562,19 @@ public abstract class ESTestCase extends LuceneTestCase {
         Collections.shuffle(list);
         return list.subList(0, size);
     }
+
+    /**
+     * Returns size random values
+     */
+    public static <T> List<T> randomSubsetOf(int size, Collection<T> values) {
+        if (size > values.size()) {
+            throw new IllegalArgumentException("Can\'t pick " + size + " random objects from a list of " + values.size() + " objects");
+        }
+        List<T> list = new ArrayList<>(values);
+        Collections.shuffle(list);
+        return list.subList(0, size);
+    }
+
 
     /**
      * Returns true iff assertions for elasticsearch packages are enabled

--- a/test-framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test-framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -55,21 +55,29 @@ import org.elasticsearch.search.MockSearchService;
 import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.rules.RuleChain;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
-import static org.elasticsearch.common.util.CollectionUtils.arrayAsArrayList;
 import static org.hamcrest.Matchers.equalTo;
 
 /**


### PR DESCRIPTION
This PR introduces the notion of a local checkpoint on the shard level. A local check point is defined as a the highest sequence number for which all previous operations (i.e. with a lower seq#) have been processed.

The current implementation is based on a fixed in memory bit array which is used in a round robin fashion. This introduces a limit to the spread between inflight indexing operation. We are still discussing options to work around this, but I think we should move forward toward a working system and optimize from there (and either remove this limitation or better understand it's implications).

relates to #10708

replaces #15111 
