### PR TITLE
getKeyAsString and key_as_string should be the same for terms aggregation on boolean field

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -91,7 +91,7 @@ public class LongTerms extends InternalTerms<LongTerms, LongTerms.Bucket> {
 
         @Override
         public String getKeyAsString() {
-            return String.valueOf(term);
+            return formatter.format(term);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
@@ -99,20 +99,22 @@ public class BooleanTermsIT extends ESIntegTestCase {
         final int bucketCount = numSingleFalses > 0 && numSingleTrues > 0 ? 2 : numSingleFalses + numSingleTrues > 0 ? 1 : 0;
         assertThat(terms.getBuckets().size(), equalTo(bucketCount));
 
-        Terms.Bucket bucket = terms.getBucketByKey("0");
+        Terms.Bucket bucket = terms.getBucketByKey("false");
         if (numSingleFalses == 0) {
             assertNull(bucket);
         } else {
             assertNotNull(bucket);
             assertEquals(numSingleFalses, bucket.getDocCount());
+            assertEquals("false", bucket.getKeyAsString());
         }
 
-        bucket = terms.getBucketByKey("1");
+        bucket = terms.getBucketByKey("true");
         if (numSingleTrues == 0) {
             assertNull(bucket);
         } else {
             assertNotNull(bucket);
             assertEquals(numSingleTrues, bucket.getDocCount());
+            assertEquals("true", bucket.getKeyAsString());
         }
     }
 
@@ -131,20 +133,22 @@ public class BooleanTermsIT extends ESIntegTestCase {
         final int bucketCount = numMultiFalses > 0 && numMultiTrues > 0 ? 2 : numMultiFalses + numMultiTrues > 0 ? 1 : 0;
         assertThat(terms.getBuckets().size(), equalTo(bucketCount));
 
-        Terms.Bucket bucket = terms.getBucketByKey("0");
+        Terms.Bucket bucket = terms.getBucketByKey("false");
         if (numMultiFalses == 0) {
             assertNull(bucket);
         } else {
             assertNotNull(bucket);
             assertEquals(numMultiFalses, bucket.getDocCount());
+            assertEquals("false", bucket.getKeyAsString());
         }
 
-        bucket = terms.getBucketByKey("1");
+        bucket = terms.getBucketByKey("true");
         if (numMultiTrues == 0) {
             assertNull(bucket);
         } else {
             assertNotNull(bucket);
             assertEquals(numMultiTrues, bucket.getDocCount());
+            assertEquals("true", bucket.getKeyAsString());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
@@ -423,10 +423,10 @@ public class NestedIT extends ESIntegTestCase {
 
         Terms startDate = response.getAggregations().get("startDate");
         assertThat(startDate.getBuckets().size(), equalTo(2));
-        Terms.Bucket bucket = startDate.getBucketByKey("1414800000000"); // 2014-11-01T00:00:00.000Z
+        Terms.Bucket bucket = startDate.getBucketByKey("2014-11-01T00:00:00.000Z");
         assertThat(bucket.getDocCount(), equalTo(1l));
         Terms endDate = bucket.getAggregations().get("endDate");
-        bucket = endDate.getBucketByKey("1417305600000"); // 2014-11-30T00:00:00.000Z
+        bucket = endDate.getBucketByKey("2014-11-30T00:00:00.000Z");
         assertThat(bucket.getDocCount(), equalTo(1l));
         Terms period = bucket.getAggregations().get("period");
         bucket = period.getBucketByKey("2014-11");
@@ -440,10 +440,10 @@ public class NestedIT extends ESIntegTestCase {
         Terms tags = nestedTags.getAggregations().get("tag");
         assertThat(tags.getBuckets().size(), equalTo(0)); // and this must be empty
 
-        bucket = startDate.getBucketByKey("1417392000000"); // 2014-12-01T00:00:00.000Z
+        bucket = startDate.getBucketByKey("2014-12-01T00:00:00.000Z");
         assertThat(bucket.getDocCount(), equalTo(1l));
         endDate = bucket.getAggregations().get("endDate");
-        bucket = endDate.getBucketByKey("1419984000000"); // 2014-12-31T00:00:00.000Z
+        bucket = endDate.getBucketByKey("2014-12-31T00:00:00.000Z");
         assertThat(bucket.getDocCount(), equalTo(1l));
         period = bucket.getAggregations().get("period");
         bucket = period.getBucketByKey("2014-12");


### PR DESCRIPTION
LongTerms.Bucket.getKeyAsString now returns "false" or "true" for boolean fields
in order to be consistent with the json response field `key_as_string` of the terms aggregation.
The downside is that getBucketByKey("0") needs to be changed with getBucketByKey("false") when dealing with booleans.
