### PR TITLE
RangeQueryParser should accept `_name` in inner field

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryParser.java
@@ -104,6 +104,8 @@ public class RangeQueryParser implements QueryParser {
                             timeZone = DateTimeZone.forID(parser.text());
                         } else if ("format".equals(currentFieldName)) {
                             forcedDateParser = new DateMathParser(Joda.forPattern(parser.text()));
+                        } else if ("_name".equals(currentFieldName)) {
+                            queryName = parser.text();
                         } else {
                             throw new QueryParsingException(parseContext, "[range] query does not support [" + currentFieldName + "]");
                         }

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -800,6 +800,23 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         assertThat(rangeQuery.includesMax(), equalTo(false));
     }
 
+    /**
+     * test that "_name" gets parsed on field level and on query level
+     */
+    @Test
+    public void testNamedRangeQuery() throws IOException {
+        IndexQueryParserService queryParser = queryParser();
+        String query = "{ range: { age: { gte:\"23\", lt:\"54\", _name:\"middle_aged\"}}}";
+        ParsedQuery parsedQuery = queryParser.parse(query);
+        assertThat(parsedQuery.query(), instanceOf(NumericRangeQuery.class));
+        assertThat(parsedQuery.namedFilters().keySet(), contains("middle_aged"));
+
+        query = "{ range: { age: { gte:\"23\", lt:\"54\"}, _name:\"middle_aged_toplevel\"}}";
+        parsedQuery = queryParser.parse(query);
+        assertThat(parsedQuery.query(), instanceOf(NumericRangeQuery.class));
+        assertThat(parsedQuery.namedFilters().keySet(), contains("middle_aged_toplevel"));
+    }
+
     @Test
     public void testRangeFilteredQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();


### PR DESCRIPTION
This re-introduces support for the "_name" parameter in range queries on the field level that was droped while transitioning to 2.x but was allowed up to 1.7 and is the prefered location on master.
Also keeps parsing "_name" on the top level but deprecating it via use of ParseField.

Closes #15306 
