### PR TITLE
Remove the `format` option of the `_source` field.

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/source/DefaultSourceMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/source/DefaultSourceMappingTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.*;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,25 +64,16 @@ public class DefaultSourceMappingTests extends ESSingleNodeTestCase {
         assertThat(XContentFactory.xContentType(doc.source()), equalTo(XContentType.SMILE));
     }
 
-    public void testJsonFormat() throws Exception {
+    public void testFormatBackCompat() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("_source").field("format", "json").endObject()
                 .endObject().endObject().string();
+        Settings settings = Settings.builder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_2_0))
+                .build();
 
-        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
-        DocumentMapper documentMapper = parser.parse(mapping);
-        ParsedDocument doc = documentMapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
-                .field("field", "value")
-                .endObject().bytes());
-
-        assertThat(XContentFactory.xContentType(doc.source()), equalTo(XContentType.JSON));
-
-        documentMapper = parser.parse(mapping);
-        doc = documentMapper.parse("test", "type", "1", XContentFactory.smileBuilder().startObject()
-            .field("field", "value")
-            .endObject().bytes());
-
-        assertThat(XContentFactory.xContentType(doc.source()), equalTo(XContentType.JSON));
+        DocumentMapperParser parser = createIndex("test", settings).mapperService().documentMapperParser();
+        parser.parse(mapping); // no exception
     }
 
     public void testIncludes() throws Exception {

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -213,6 +213,13 @@ float by default instead of a double. The reasoning is that floats should be
 more than enough for most cases but would decrease storage requirements
 significantly.
 
+==== `_source`'s `format` option
+
+The `_source` mapping does not support the `format` option anymore. This option
+will still be accepted for indices created before the upgrade to 3.0 for backward
+compatibility, but it will have no effect. Indices created on or after 3.0 will
+reject this option.
+
 [[breaking_30_plugins]]
 === Plugin changes
 


### PR DESCRIPTION
This option allows to force the xcontent type to use to store the `_source`
document. The default is to use the same format as the input format.

This commit makes this option ignored for 2.x indices and rejected for 3.0
indices.
