### PR TITLE
Fail and close translog hard if writing to disk fails

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -782,9 +782,13 @@ public class InternalEngine extends Engine {
             // but we are double-checking it's failed and closed
             if (indexWriter.isOpen() == false && indexWriter.getTragicException() != null) {
                 failEngine("already closed by tragic event", indexWriter.getTragicException());
+            } else if (translog.isOpen() == false && translog.getTragicException() != null) {
+                failEngine("already closed by tragic event", translog.getTragicException());
             }
             return true;
-        } else if (t != null && indexWriter.isOpen() == false && indexWriter.getTragicException() == t) {
+        } else if (t != null &&
+            ((indexWriter.isOpen() == false && indexWriter.getTragicException() == t)
+                || (translog.isOpen() == false && translog.getTragicException() == t))) {
             // this spot on - we are handling the tragic event exception here so we have to fail the engine
             // right away
             failEngine(source, t);

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -781,9 +781,9 @@ public class InternalEngine extends Engine {
             // we need to fail the engine. it might have already been failed before
             // but we are double-checking it's failed and closed
             if (indexWriter.isOpen() == false && indexWriter.getTragicException() != null) {
-                failEngine("already closed by tragic event", indexWriter.getTragicException());
+                failEngine("already closed by tragic event on the index writer", indexWriter.getTragicException());
             } else if (translog.isOpen() == false && translog.getTragicException() != null) {
-                failEngine("already closed by tragic event", translog.getTragicException());
+                failEngine("already closed by tragic event on the translog", translog.getTragicException());
             }
             return true;
         } else if (t != null &&

--- a/core/src/main/java/org/elasticsearch/index/translog/BufferingTranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/BufferingTranslogWriter.java
@@ -128,10 +128,10 @@ public final class BufferingTranslogWriter extends TranslogWriter {
                 }
                 // we can do this outside of the write lock but we have to protect from
                 // concurrent syncs
+                ensureOpen(); // just for kicks - the checkpoint happens or not either way
                 try {
-                    ensureOpen(); // just for kicks - the checkpoint happens or not either way
                     checkpoint(offsetToSync, opsCounter, channelReference);
-                } catch (IOException ex) {
+                } catch (Throwable ex) {
                     closeWithTragicEvent(ex);
                     throw ex;
                 }

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -542,6 +542,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
     public boolean ensureSynced(Location location) throws IOException {
         try (ReleasableLock lock = readLock.acquire()) {
             if (location.generation == current.generation) { // if we have a new one it's already synced
+                ensureOpen();
                 return current.syncUpTo(location.translogLocation + location.size);
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
@@ -140,16 +140,16 @@ public abstract class TranslogReader implements Closeable, Comparable<TranslogRe
     @Override
     public void close() throws IOException {
         if (closed.compareAndSet(false, true)) {
-            doClose();
+            channelReference.decRef();
         }
     }
 
-    protected void doClose() throws IOException {
-        channelReference.decRef();
+    protected final boolean isClosed() {
+        return closed.get();
     }
 
     protected void ensureOpen() {
-        if (closed.get()) {
+        if (isClosed()) {
             throw new AlreadyClosedException("translog [" + getGeneration() + "] is already closed");
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -130,12 +130,10 @@ public class TranslogWriter extends TranslogReader {
 
     protected final void closeWithTragicEvent(Throwable throwable) throws IOException {
         try (ReleasableLock lock = writeLock.acquire()) {
-            if (throwable != null) {
-                if (tragedy == null) {
-                    tragedy = throwable;
-                } else {
-                    tragedy.addSuppressed(throwable);
-                }
+            if (tragedy == null) {
+                tragedy = throwable;
+            } else {
+                tragedy.addSuppressed(throwable);
             }
             close();
         }

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -173,10 +173,8 @@ public class TranslogWriter extends TranslogReader {
         if (syncNeeded()) {
             try (ReleasableLock lock = writeLock.acquire()) {
                 ensureOpen();
-                final long offset = writtenOffset;
-                final int opsCount = operationCounter;
-                checkpoint(offset, opsCount, channelReference);
-                lastSyncedOffset = offset;
+                checkpoint(writtenOffset, operationCounter, channelReference);
+                lastSyncedOffset = writtenOffset;
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/translog/BufferedTranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/BufferedTranslogTests.java
@@ -34,13 +34,12 @@ import java.nio.file.Path;
 public class BufferedTranslogTests extends TranslogTests {
 
     @Override
-    protected Translog create(Path path) throws IOException {
+    protected TranslogConfig getTranslogConfig(Path path) {
         Settings build = Settings.settingsBuilder()
                 .put("index.translog.fs.type", TranslogWriter.Type.BUFFERED.name())
                 .put("index.translog.fs.buffer_size", 10 + randomInt(128 * 1024), ByteSizeUnit.BYTES)
                 .put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT)
                 .build();
-        TranslogConfig translogConfig = new TranslogConfig(shardId, path, IndexSettingsModule.newIndexSettings(shardId.index(), build), Translog.Durabilty.REQUEST, BigArrays.NON_RECYCLING_INSTANCE, null);
-        return new Translog(translogConfig);
+        return new TranslogConfig(shardId, path, IndexSettingsModule.newIndexSettings(shardId.index(), build), Translog.Durabilty.REQUEST, BigArrays.NON_RECYCLING_INSTANCE, null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1310,7 +1310,7 @@ public class TranslogTests extends ESTestCase {
                                         super.write(src);
                                         src.position(pos);
                                         src.limit(limit);
-                                        throw new IOException("no space left on device");
+                                        throw new IOException("__FAKE__ no space left on device");
                                     }
                                 }
                                 return super.write(src);
@@ -1334,7 +1334,7 @@ public class TranslogTests extends ESTestCase {
             } catch (IOException ex) {
                 failed = true;
                 assertFalse(translog.isOpen());
-                assertEquals("no space left on device", ex.getMessage());
+                assertEquals("__FAKE__ no space left on device", ex.getMessage());
              }
             simulateDiskFull.set(randomBoolean());
         }
@@ -1345,7 +1345,7 @@ public class TranslogTests extends ESTestCase {
                 fail("we are already closed");
             } catch (AlreadyClosedException ex) {
                 assertNotNull(ex.getCause());
-                assertEquals(ex.getCause().getMessage(), "no space left on device");
+                assertEquals(ex.getCause().getMessage(), "__FAKE__ no space left on device");
             }
 
         }


### PR DESCRIPTION
Today we are super lenient (how could I missed that for f**k sake) with failing
/ closing the translog writer when we hit an exception. It's actually worse, we allow
to further write to it and don't care what has been already written to disk and what hasn't.
We keep the buffer in memory and try to write it again on the next operation.

When we hit a disk-full expcetion due to for instance a big merge we are likely adding document to the
translog but fail to write them to disk. Once the merge failed and freed up it's diskspace (note this is
a small window when concurrently indexing and failing the shard due to out of space exceptions) we will
allow in-flight operations to add to the translog and then once we fail the shard fsync it. These operations
are written to disk and fsynced which is fine but the previous buffer flush might have written some bytes
to disk which are not corrupting the translog. That wouldn't be an issue if we prevented the fsync.

Closes #15333
