### PR TITLE
fix bwc for NodeInfo, plugins and modules streaming was changed only …

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.info;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -57,7 +58,7 @@ public class PluginsAndModules implements Streamable, ToXContent {
         });
         return plugins;
     }
-    
+
     /**
      * Returns an ordered list based on modules name
      */
@@ -75,7 +76,7 @@ public class PluginsAndModules implements Streamable, ToXContent {
     public void addPlugin(PluginInfo info) {
         plugins.add(info);
     }
-    
+
     public void addModule(PluginInfo info) {
         modules.add(info);
     }
@@ -89,21 +90,34 @@ public class PluginsAndModules implements Streamable, ToXContent {
         for (int i = 0; i < plugins_size; i++) {
             plugins.add(PluginInfo.readFromStream(in));
         }
-        int modules_size = in.readInt();
-        for (int i = 0; i < modules_size; i++) {
-            modules.add(PluginInfo.readFromStream(in));
+        if (in.getVersion().onOrAfter(Version.V_2_2_0)) {
+            int modules_size = in.readInt();
+            for (int i = 0; i < modules_size; i++) {
+                modules.add(PluginInfo.readFromStream(in));
+            }
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeInt(plugins.size());
-        for (PluginInfo plugin : getPluginInfos()) {
-            plugin.writeTo(out);
+        if (out.getVersion().before(Version.V_2_2_0)) {
+            out.writeInt(plugins.size() + modules.size());
+            for (PluginInfo plugin : getPluginInfos()) {
+                plugin.writeTo(out);
+            }
+            for (PluginInfo module : getModuleInfos()) {
+                module.writeTo(out);
+            }
         }
-        out.writeInt(modules.size());
-        for (PluginInfo module : getModuleInfos()) {
-            module.writeTo(out);
+        else {
+            out.writeInt(plugins.size());
+            for (PluginInfo plugin : getPluginInfos()) {
+                plugin.writeTo(out);
+            }
+            out.writeInt(modules.size());
+            for (PluginInfo module : getModuleInfos()) {
+                module.writeTo(out);
+            }
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/monitor/os/DummyOsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/DummyOsInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.monitor.os;
+
+public class DummyOsInfo extends OsInfo {
+
+    DummyOsInfo() {
+        refreshInterval = 0;
+        availableProcessors = 0;
+        allocatedProcessors = 0;
+        name = "dummy_name";
+        arch = "dummy_arch";
+        version = "dummy_version";
+    }
+
+    public static final DummyOsInfo INSTANCE = new DummyOsInfo();
+}

--- a/core/src/main/java/org/elasticsearch/plugins/DummyPluginInfo.java
+++ b/core/src/main/java/org/elasticsearch/plugins/DummyPluginInfo.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.plugins;
+
+public class DummyPluginInfo extends PluginInfo {
+
+    private DummyPluginInfo(String name, String description, boolean site, String version, boolean jvm, String classname, boolean isolated) {
+        super(name, description, site, version, jvm, classname, isolated);
+    }
+
+    public static final DummyPluginInfo INSTANCE = new DummyPluginInfo("dummy_plugin_name", "dummy plugin description", true, "dummy_plugin_version", true, "DummyPluginName", true);
+}

--- a/core/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/core/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.nodesinfo;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.http.HttpInfo;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.monitor.os.DummyOsInfo;
+import org.elasticsearch.monitor.os.OsInfo;
+import org.elasticsearch.monitor.process.ProcessInfo;
+import org.elasticsearch.plugins.DummyPluginInfo;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolInfo;
+import org.elasticsearch.transport.TransportInfo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ *
+ */
+public class NodeInfoStreamingTests extends ESTestCase {
+
+    public void testNodeInfoStreaming() throws IOException {
+        NodeInfo nodeInfo = createNodeInfo();
+
+        // test version on or after V_2_2_0
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_2_0, Version.CURRENT);
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(version);
+        nodeInfo.writeTo(out);
+        out.close();
+        StreamInput in = StreamInput.wrap(out.bytes());
+        in.setVersion(version);
+        NodeInfo readNodeInfo = NodeInfo.readNodeInfo(in);
+        assertExpectedUnchanged(nodeInfo, readNodeInfo);
+
+        comparePluginsAndModulesOnOrAfter2_2_0(nodeInfo, readNodeInfo);
+
+        // test version before V_2_2_0
+        version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_1_1);
+        out = new BytesStreamOutput();
+        out.setVersion(version);
+        nodeInfo.writeTo(out);
+        out.close();
+        in = StreamInput.wrap(out.bytes());
+        in.setVersion(version);
+        readNodeInfo = NodeInfo.readNodeInfo(in);
+        assertExpectedUnchanged(nodeInfo, readNodeInfo);
+
+        comparePluginsAndModulesBefore2_2_0(nodeInfo, readNodeInfo);
+    }
+
+    // checks all properties that are expected to be unchanged. Once we start changing them between versions this method has to be changed as well
+    private void assertExpectedUnchanged(NodeInfo nodeInfo, NodeInfo readNodeInfo) throws IOException {
+        assertThat(nodeInfo.getBuild().toString(), equalTo(readNodeInfo.getBuild().toString()));
+        assertThat(nodeInfo.getHostname(), equalTo(readNodeInfo.getHostname()));
+        assertThat(nodeInfo.getVersion(), equalTo(readNodeInfo.getVersion()));
+        assertThat(nodeInfo.getServiceAttributes().size(), equalTo(readNodeInfo.getServiceAttributes().size()));
+        for (Map.Entry<String, String> entry : nodeInfo.getServiceAttributes().entrySet()) {
+            assertNotNull(readNodeInfo.getServiceAttributes().get(entry.getKey()));
+            assertThat(readNodeInfo.getServiceAttributes().get(entry.getKey()), equalTo(entry.getValue()));
+        }
+        compareJsonOutput(nodeInfo.getHttp(), readNodeInfo.getHttp());
+        compareJsonOutput(nodeInfo.getJvm(), readNodeInfo.getJvm());
+        // see issue https://github.com/elastic/elasticsearch/issues/15422
+        // compareJsonOutput(nodeInfo.getOs(), readNodeInfo.getOs());
+        compareJsonOutput(nodeInfo.getProcess(), readNodeInfo.getProcess());
+        compareJsonOutput(nodeInfo.getSettings(), readNodeInfo.getSettings());
+        compareJsonOutput(nodeInfo.getThreadPool(), readNodeInfo.getThreadPool());
+        compareJsonOutput(nodeInfo.getTransport(), readNodeInfo.getTransport());
+        compareJsonOutput(nodeInfo.getNode(), readNodeInfo.getNode());
+    }
+
+    private void comparePluginsAndModulesBefore2_2_0(NodeInfo nodeInfo, NodeInfo readNodeInfo) throws IOException {
+        assertThat(readNodeInfo.getPlugins().getPluginInfos().size(), equalTo(nodeInfo.getPlugins().getModuleInfos().size() + nodeInfo.getPlugins().getPluginInfos().size()));
+        for (int i = 0; i < nodeInfo.getPlugins().getPluginInfos().size(); i++) {
+            compareJsonOutput(readNodeInfo.getPlugins().getPluginInfos().get(i), nodeInfo.getPlugins().getPluginInfos().get(i));
+        }
+        for (int i = 0; i < nodeInfo.getPlugins().getPluginInfos().size(); i++) {
+            compareJsonOutput(readNodeInfo.getPlugins().getPluginInfos().get(i + nodeInfo.getPlugins().getPluginInfos().size()), nodeInfo.getPlugins().getModuleInfos().get(i));
+        }
+    }
+
+    private void comparePluginsAndModulesOnOrAfter2_2_0(NodeInfo nodeInfo, NodeInfo readNodeInfo) throws IOException {
+        ToXContent.Params params = ToXContent.EMPTY_PARAMS;
+        XContentBuilder pluginsAndModules = jsonBuilder();
+        pluginsAndModules.startObject();
+        nodeInfo.getPlugins().toXContent(pluginsAndModules, params);
+        pluginsAndModules.endObject();
+        XContentBuilder readPluginsAndModules = jsonBuilder();
+        readPluginsAndModules.startObject();
+        readNodeInfo.getPlugins().toXContent(readPluginsAndModules, params);
+        readPluginsAndModules.endObject();
+        assertThat(pluginsAndModules.string(), equalTo(readPluginsAndModules.string()));
+    }
+
+    private void compareJsonOutput(ToXContent param1, ToXContent param2) throws IOException {
+        ToXContent.Params params = ToXContent.EMPTY_PARAMS;
+        XContentBuilder param1Builder = jsonBuilder();
+        XContentBuilder param2Builder = jsonBuilder();
+        param1.toXContent(param1Builder, params);
+        param2.toXContent(param2Builder, params);
+        assertThat(param1Builder.string(), equalTo(param2Builder.string()));
+    }
+
+    private NodeInfo createNodeInfo() {
+        Build build = Build.CURRENT;
+        DiscoveryNode node = new DiscoveryNode("test_node", DummyTransportAddress.INSTANCE, VersionUtils.randomVersion(random()));
+        ImmutableMap<String, String> serviceAttributes = ImmutableMap.of("test", "attribute");
+        Settings settings = Settings.builder().put("test", "setting").build();
+        OsInfo osInfo = DummyOsInfo.INSTANCE;
+        ProcessInfo process = new ProcessInfo(randomInt(), randomBoolean());
+        JvmInfo jvm = JvmInfo.jvmInfo();
+        List<ThreadPool.Info> threadPoolInfos = new ArrayList<>();
+        threadPoolInfos.add(new ThreadPool.Info("test_threadpool", ThreadPool.ThreadPoolType.FIXED, 5));
+        ThreadPoolInfo threadPoolInfo = new ThreadPoolInfo(threadPoolInfos);
+        Map<String, BoundTransportAddress> profileAddresses = new HashMap<>();
+        BoundTransportAddress dummyBoundTransportAddress = new BoundTransportAddress(new TransportAddress[]{DummyTransportAddress.INSTANCE}, DummyTransportAddress.INSTANCE);
+        profileAddresses.put("test_address", dummyBoundTransportAddress);
+        TransportInfo transport = new TransportInfo(dummyBoundTransportAddress, profileAddresses);
+        HttpInfo htttpInfo = new HttpInfo(dummyBoundTransportAddress, randomLong());
+        PluginsAndModules plugins = new PluginsAndModules();
+        plugins.addModule(DummyPluginInfo.INSTANCE);
+        plugins.addPlugin(DummyPluginInfo.INSTANCE);
+        return new NodeInfo(VersionUtils.randomVersion(random()), build, node, serviceAttributes, settings, osInfo, process, jvm, threadPoolInfo, transport, htttpInfo, plugins);
+    }
+}


### PR DESCRIPTION
…in 2.2

see #15303 

While at it, I found two more things: 
- #15422, see comment in the test
- the bwc tests still don't all pass (edit: now made a pr here: #15453). I get a failure when I run `mvn verify -Pdev -Dskip.unit.tests -pl org.elasticsearch.qa.backwards:2.0.0 -Dtests.seed=96FBCE4CB2B7B1EC -Dtests.class=org.elasticsearch.bwcompat.SnapshotBackwardsCompatibilityIT -Dtests.method="testBasicWorkflow" -Des.logger.level=DEBUG -Dtests.assertion.disabled=false -Dtests.security.manager=true -Dtests.heap.size=512m -Dtests.locale=hi_IN -Dtests.timezone=SystemV/CST6CDT` but it is a different failure and seems unrelated.

I'd like to fix these two things after this is pushed.
