### PR TITLE
Fail fast when executing master level write operations via a tribe node

### DIFF
--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.tribe;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterService;
@@ -104,6 +105,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
             sb.put("cluster.name", "tribe_" + Strings.randomBase64UUID()); // make sure it won't join other tribe nodes in the same JVM
         }
         sb.put(TransportMasterNodeReadAction.FORCE_LOCAL_SETTING, true);
+        sb.put(TransportMasterNodeAction.REQUIRE_LOCAL_SETTING, true);
         return sb.build();
     }
 

--- a/core/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -244,6 +244,19 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         listener.get();
     }
 
+    public void testForbiddenNonLocalOperation() throws InterruptedException {
+        Request request = new Request();
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+
+        clusterService.setState(ClusterStateCreationUtils.state(localNode, remoteNode, allNodes));
+
+        new Action(Settings.builder().put(TransportMasterNodeAction.REQUIRE_LOCAL_SETTING, "true").build(),
+            "testAction", transportService, clusterService, threadPool).execute(request, listener);
+
+        assertTrue(listener.isDone());
+        assertListenerThrows("IllegalStateException should be thrown", listener, IllegalStateException.class);
+    }
+
     public void testMasterNotAvailable() throws ExecutionException, InterruptedException {
         Request request = new Request().masterNodeTimeout(TimeValue.timeValueSeconds(0));
         clusterService.setState(ClusterStateCreationUtils.state(localNode, null, allNodes));

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -50,9 +50,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -181,6 +179,12 @@ public class TribeIT extends ESIntegTestCase {
         } catch (ClusterBlockException e) {
             // all is well!
         }
+    }
+
+    public void testFailOnNonLocalMasterNodeAction() throws Exception {
+        setupTribeNode(Settings.EMPTY);
+
+        assertThrows(tribeClient.admin().indices().prepareCreate("test"), IllegalStateException.class);
     }
 
     public void testIndexWriteBlocks() throws Exception {


### PR DESCRIPTION
Currently, executing master level write operations against a tribe node leads to MasterNotDiscoveredException after a 1 minute timeout. This PR adds a new mode to TransportMasterNodeAction to fail fast if the action does not specify to always execute locally.

Closes #13290
