### PR TITLE
Gradle idea plugin does not properly mark resources directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,30 @@ gradle.projectsEvaluated {
 // intellij configuration
 allprojects {
   apply plugin: 'idea'
+
+  idea {
+    module {
+      // same as for the IntelliJ Gradle tooling integration
+      inheritOutputDirs = false
+      outputDir = file('build/classes/main')
+      testOutputDir = file('build/classes/test')
+
+      iml {
+        // fix so that Gradle idea plugin properly generates support for resource folders
+        // see also https://issues.gradle.org/browse/GRADLE-2975
+        withXml {
+          it.asNode().component.content.sourceFolder.findAll { it.@url == 'file://$MODULE_DIR$/src/main/resources' }.each {
+            it.attributes().remove('isTestSource')
+            it.attributes().put('type', 'java-resource')
+          }
+          it.asNode().component.content.sourceFolder.findAll { it.@url == 'file://$MODULE_DIR$/src/test/resources' }.each {
+            it.attributes().remove('isTestSource')
+            it.attributes().put('type', 'java-test-resource')
+          }
+        }
+      }
+    }
+  }
 }
 
 idea {


### PR DESCRIPTION
Using `gradle cleanIdea idea` I have the issue that resource directories (`src/main/resources` and `src/test/resources`) are not properly marked as resource directories (but only as normal source directories). When I then build the project in IDEA, I get exceptions from the Groovy compiler (as it finds Groovy sources under our `src/test/resources`. 

The issue seems to be an well-known one.
https://discuss.gradle.org/t/idea-plugin-resource-folders-support/5692/2
https://discuss.gradle.org/t/the-idea-plugin-breaks-the-new-intellij-13-iml-configuration/2456
https://issues.gradle.org/browse/GRADLE-2975

Note that by applying the [Intellij Gradle integration](https://www.jetbrains.com/idea/help/gradle.html) (import as Gradle project), resource directories are properly marked and the issue disappears.
