### PR TITLE
fix SnapshotBackwardsCompatibilityIT to not use wildcards with 2.0

### DIFF
--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotSharedTest.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotSharedTest.java
@@ -114,8 +114,14 @@ public class SnapshotSharedTest {
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
 
+        String snapshotName;
+        if (ESIntegTestCase.getMinimumVersionInCluster().onOrAfter(Version.V_2_2_0)) {
+            snapshotName = randomFrom("test-snap", "_all", "*", "*-snap", "test*");
+        } else {
+            snapshotName = "test-snap";
+        }
         SnapshotInfo snapshotInfo = client().admin().cluster().prepareGetSnapshots("test-repo")
-            .setSnapshots(randomFrom("test-snap", "_all", "*", "*-snap", "test*")).get().getSnapshots().get(0);
+            .setSnapshots(snapshotName).get().getSnapshots().get(0);
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
         assertThat(snapshotInfo.version(), snapshotVersion);
 

--- a/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -33,6 +33,7 @@ import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -1912,6 +1913,18 @@ public abstract class ESIntegTestCase extends ESTestCase {
             }
         }
         return nodes;
+    }
+
+    // returns the minimum Version of all nodes in the current cluster
+    public static Version getMinimumVersionInCluster() {
+        NodesInfoResponse nodesInfoResponse = client().admin().cluster().prepareNodesInfo().get();
+        Version minimumVersionInCluster = Version.CURRENT;
+        for (NodeInfo nodeInfo : nodesInfoResponse) {
+            if (nodeInfo.getVersion().before(minimumVersionInCluster)) {
+                minimumVersionInCluster = nodeInfo.getVersion();
+            }
+        }
+        return minimumVersionInCluster;
     }
 
     protected static class NumShards {


### PR DESCRIPTION
This was only introduced in 2.2 with #15151 so we must not use
wildcards when running with 2.0 nodes.
