### PR TITLE
serialize os name, arch and version too

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
@@ -111,6 +111,11 @@ public class OsInfo implements Streamable, ToXContent {
         if (in.getVersion().onOrAfter(Version.V_2_1_0)) {
             allocatedProcessors = in.readInt();
         }
+        if (in.getVersion().onOrAfter(Version.V_2_2_0)) {
+            name = in.readOptionalString();
+            arch = in.readOptionalString();
+            version = in.readOptionalString();
+        }
     }
 
     @Override
@@ -119,6 +124,11 @@ public class OsInfo implements Streamable, ToXContent {
         out.writeInt(availableProcessors);
         if (out.getVersion().onOrAfter(Version.V_2_1_0)) {
             out.writeInt(allocatedProcessors);
+        }
+        if (out.getVersion().onOrAfter(Version.V_2_2_0)) {
+            out.writeOptionalString(name);
+            out.writeOptionalString(arch);
+            out.writeOptionalString(version);
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/core/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -74,6 +74,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
         assertExpectedUnchanged(nodeInfo, readNodeInfo);
 
         comparePluginsAndModulesOnOrAfter2_2_0(nodeInfo, readNodeInfo);
+        compareOSOnOrAfter2_2_0(nodeInfo, readNodeInfo);
 
         // test version before V_2_2_0
         version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_1_1);
@@ -87,6 +88,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
         assertExpectedUnchanged(nodeInfo, readNodeInfo);
 
         comparePluginsAndModulesBefore2_2_0(nodeInfo, readNodeInfo);
+        compareOSOnOrBefore2_2_0(nodeInfo, readNodeInfo);
     }
 
     // checks all properties that are expected to be unchanged. Once we start changing them between versions this method has to be changed as well
@@ -101,8 +103,6 @@ public class NodeInfoStreamingTests extends ESTestCase {
         }
         compareJsonOutput(nodeInfo.getHttp(), readNodeInfo.getHttp());
         compareJsonOutput(nodeInfo.getJvm(), readNodeInfo.getJvm());
-        // see issue https://github.com/elastic/elasticsearch/issues/15422
-        // compareJsonOutput(nodeInfo.getOs(), readNodeInfo.getOs());
         compareJsonOutput(nodeInfo.getProcess(), readNodeInfo.getProcess());
         compareJsonOutput(nodeInfo.getSettings(), readNodeInfo.getSettings());
         compareJsonOutput(nodeInfo.getThreadPool(), readNodeInfo.getThreadPool());
@@ -140,6 +140,19 @@ public class NodeInfoStreamingTests extends ESTestCase {
         param1.toXContent(param1Builder, params);
         param2.toXContent(param2Builder, params);
         assertThat(param1Builder.string(), equalTo(param2Builder.string()));
+    }
+
+    // see https://github.com/elastic/elasticsearch/issues/15422
+    private void compareOSOnOrBefore2_2_0(NodeInfo nodeInfo, NodeInfo readNodeInfo) {
+        OsInfo osInfo = nodeInfo.getOs();
+        OsInfo readOsInfo = readNodeInfo.getOs();
+        assertThat(osInfo.getAllocatedProcessors(), equalTo(readOsInfo.getAllocatedProcessors()));
+        assertThat(osInfo.getAvailableProcessors(), equalTo(readOsInfo.getAvailableProcessors()));
+        assertThat(osInfo.getRefreshInterval(), equalTo(readOsInfo.getRefreshInterval()));
+    }
+
+    private void compareOSOnOrAfter2_2_0(NodeInfo nodeInfo, NodeInfo readNodeInfo) throws IOException {
+        compareJsonOutput(nodeInfo.getOs(), readNodeInfo.getOs());
     }
 
     private NodeInfo createNodeInfo() {


### PR DESCRIPTION
These three properties are build in the JSON response but were not
transported when a node sends the response.

closes #15422
