### PR TITLE
Expose query/fetch timing to IndexEventListener

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/CompositeIndexEventListener.java
+++ b/core/src/main/java/org/elasticsearch/index/CompositeIndexEventListener.java
@@ -270,4 +270,28 @@ final class CompositeIndexEventListener implements IndexEventListener {
             }
         }
     }
+
+    @Override
+    public void onQueryPhase(IndexShard indexShard, long tookInNanos) {
+        for (IndexEventListener listener  : listeners) {
+            try {
+                listener.onQueryPhase(indexShard, tookInNanos);
+            } catch (Throwable t) {
+                logger.warn("failed to invoke on query phase callback", t);
+                throw t;
+            }
+        }
+    }
+
+    @Override
+    public void onFetchPhase(IndexShard indexShard, long tookInNanos) {
+        for (IndexEventListener listener  : listeners) {
+            try {
+                listener.onFetchPhase(indexShard, tookInNanos);
+            } catch (Throwable t) {
+                logger.warn("failed to invoke on fetch phase callback", t);
+                throw t;
+            }
+        }
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
+++ b/core/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.util.HashMap;
@@ -39,10 +40,12 @@ public final class ShardSearchStats {
     private final SearchSlowLog slowLogSearchService;
     private final StatsHolder totalStats = new StatsHolder();
     private final CounterMetric openContexts = new CounterMetric();
+    private final IndexEventListener indexEventListener;
     private volatile Map<String, StatsHolder> groupsStats = emptyMap();
 
-    public ShardSearchStats(Settings indexSettings) {
+    public ShardSearchStats(Settings indexSettings, IndexEventListener indexEventListener) {
         this.slowLogSearchService = new SearchSlowLog(indexSettings);
+        this.indexEventListener = indexEventListener;
     }
 
     /**
@@ -99,6 +102,7 @@ public final class ShardSearchStats {
             }
         }
         slowLogSearchService.onQueryPhase(searchContext, tookInNanos);
+        indexEventListener.onQueryPhase(searchContext.indexShard(), tookInNanos);
     }
 
     public void onPreFetchPhase(SearchContext searchContext) {
@@ -130,6 +134,7 @@ public final class ShardSearchStats {
             }
         }
         slowLogSearchService.onFetchPhase(searchContext, tookInNanos);
+        indexEventListener.onFetchPhase(searchContext.indexShard(), tookInNanos);
     }
 
     public void clear() {

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
@@ -185,4 +185,16 @@ public interface IndexEventListener {
      */
     default void beforeIndexAddedToCluster(Index index, Settings indexSettings) {
     }
+
+    /**
+     * Called after a query phase has completed.
+     */
+    default void onQueryPhase(IndexShard indexShard, long tookInNanos) {
+    }
+
+    /**
+     * Called after a fetch phase has completed.
+     */
+    default void onFetchPhase(IndexShard indexShard, long tookInNanos) {
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -220,7 +220,7 @@ public class IndexShard extends AbstractIndexShardComponent {
         this.indexingService = new ShardIndexingService(shardId, indexSettings);
         this.getService = new ShardGetService(indexSettings, this, mapperService);
         this.termVectorsService = provider.getTermVectorsService();
-        this.searchService = new ShardSearchStats(settings);
+        this.searchService = new ShardSearchStats(settings, indexEventListener);
         this.shardWarmerService = new ShardIndexWarmerService(shardId, indexSettings);
         this.indicesQueryCache = provider.getIndicesQueryCache();
         this.shardQueryCache = new ShardRequestCache(shardId, indexSettings);


### PR DESCRIPTION
Elasticsearch collects a limited number of stats that can be collected in a very
performant manner. Other stats, such as latency percentiles, are perhaps out of
scope of the main elasticsearch project. This allows plugins to add their own
stat collection routines to the existing shard stats collection.

Closes #15412
