### PR TITLE
Fix minor issues in delimited payload token filter docs

### DIFF
--- a/docs/reference/analysis/tokenfilters/delimited-payload-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/delimited-payload-tokenfilter.asciidoc
@@ -3,9 +3,7 @@
 
 Named `delimited_payload_filter`. Splits tokens into tokens and payload whenever a delimiter character is found.
 
-Example: "the|1 quick|2 fox|3" is split per default int to tokens `fox`, `quick` and `the` with payloads `1`, `2` and `3` respectively.
-
-
+Example: "the|1 quick|2 fox|3" is split by default into tokens `the`, `quick`, and `fox` with payloads `1`, `2`, and `3` respectively.
 
 Parameters:
 


### PR DESCRIPTION
This commit addresses a few minor issues in the delimited payload token
filter docs:
- the provided example reversed the payloads associated with the
  tokens "the" and "fox"
- two additional typos in the same sentence
  - "per default" -> "by default"
  - "default int to" -> "default into"
- adds two serial commas
