### PR TITLE
AllTermQuery's scorer should skip segments that never saw the requested term

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/all/AllTermQuery.java
@@ -149,6 +149,10 @@ public final class AllTermQuery extends Query {
                     return null;
                 }
                 final TermState state = termStates.get(context.ord);
+                if (state == null) {
+                    // Term does not exist in this segment
+                    return null;
+                }
                 termsEnum.seekExact(term.bytes(), state);
                 PostingsEnum docs = termsEnum.postings(null, PostingsEnum.PAYLOADS);
                 assert docs != null;


### PR DESCRIPTION
Spinoff from this user's issue: https://discuss.elastic.co/t/2-1-0-nullpointerexception-not-sure-where-to-start/37419

When a segment never indexed the requested term, it has a null `TermState`, which means we should skip scoring that segment, and not cause an NPE.
