### PR TITLE
Simpler using compressed oops flag representation

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -296,10 +296,10 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
     }
 
     private void maybeLogHeapDetails() {
-        ByteSizeValue maxHeapSize = JvmInfo.jvmInfo().getMem().getHeapMax();
-        Boolean usingCompressedOops = JvmInfo.jvmInfo().usingCompressedOops();
-        String usingCompressedOopsStatus = usingCompressedOops == null ? "unknown" : Boolean.toString(usingCompressedOops);
-        logger.info("heap size [{}], compressed ordinary object pointers [{}]", maxHeapSize, usingCompressedOopsStatus);
+        JvmInfo jvmInfo = JvmInfo.jvmInfo();
+        ByteSizeValue maxHeapSize = jvmInfo.getMem().getHeapMax();
+        String useCompressedOops = jvmInfo.useCompressedOops();
+        logger.info("heap size [{}], compressed ordinary object pointers [{}]", maxHeapSize, useCompressedOops);
     }
 
     private static String toString(Collection<String> items) {

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -375,7 +375,7 @@ public class JvmInfo implements Streamable, ToXContent {
         mem.readFrom(in);
         gcCollectors = in.readStringArray();
         memoryPools = in.readStringArray();
-        useCompressedOops = in.readOptionalString();
+        useCompressedOops = in.readString();
     }
 
     @Override
@@ -400,7 +400,7 @@ public class JvmInfo implements Streamable, ToXContent {
         mem.writeTo(out);
         out.writeStringArray(gcCollectors);
         out.writeStringArray(memoryPools);
-        out.writeOptionalString(useCompressedOops);
+        out.writeString(useCompressedOops);
     }
 
     public static class Mem implements Streamable {


### PR DESCRIPTION
This commit modifies the internal representation of the JVM flag
UseCompressedOops to just be a String. This means we can just store the
value of the flag or "unknown" directly so that we do not have to engage
in shenanigans with three-valued logic around a boxed boolean.

Relates #15489
