### PR TITLE
Fix Windows service installation failure

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -93,7 +93,7 @@ set JAVA_OPTS=%JAVA_OPTS% -Djna.nosys=true
 
 REM check in case a user was using this mechanism
 if "%ES_CLASSPATH%" == "" (
-set ES_CLASSPATH=%ES_HOME%/lib/elasticsearch-${project.version}.jar;%ES_HOME%/lib/*
+set ES_CLASSPATH=!ES_HOME!/lib/elasticsearch-${project.version}.jar;!ES_HOME!/lib/*
 ) else (
 ECHO Error: Don't modify the classpath with ES_CLASSPATH, Best is to add 1>&2
 ECHO additional elements via the plugin mechanism, or if code must really be 1>&2

--- a/distribution/src/main/resources/bin/service.bat
+++ b/distribution/src/main/resources/bin/service.bat
@@ -1,5 +1,5 @@
 @echo off
-SETLOCAL
+SETLOCAL enabledelayedexpansion
 
 TITLE Elasticsearch Service ${project.version}
 


### PR DESCRIPTION
When ES_HOME contains parentheses, parsing of the if statement around ES_CLASSPATH is thrown off.  This fix enables delayed expansion in service.bat (already enabled in elasticsearch.bat).

Closes #15349
