### PR TITLE
Set -Dsun.jnu.encoding=UTF-8 in elasticsearch.in.sh

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -86,7 +86,7 @@ REM Disables explicit GC
 set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
 
 REM Ensure UTF-8 encoding by default (e.g. filenames)
-set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
+set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8
 
 REM Use our provided JNA always versus the system one
 set JAVA_OPTS=%JAVA_OPTS% -Djna.nosys=true

--- a/distribution/src/main/resources/bin/elasticsearch.in.sh
+++ b/distribution/src/main/resources/bin/elasticsearch.in.sh
@@ -82,7 +82,7 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 
 # Ensure UTF-8 encoding by default (e.g. filenames)
-JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
 
 # Use our provided JNA always versus the system one
 JAVA_OPTS="$JAVA_OPTS -Djna.nosys=true"


### PR DESCRIPTION
Currently we set `-Dfile.encoding=UTF-8` in elasticsearch.in.sh (which affects the content of a file) but not the dual `sun.jnu.encoding` which affects the creation of file names. The value of `sun.jnu.encoding` is usually determined on Unix systems by the `LANG` environment variable.

With UTF-8 index names, this can lead to interesting issues. I have observed this first when setting up my build server as the REST test `rest-api-spec/src/main/resources/rest-api-spec/test/index/10_with_id.yaml` failed. This test creates an index with name `test-weird-index-中文`.

To reproduce:
- Change the following line in elasticsearch.in.sh:
  `JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"` to `JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=ANSI_X3.4-1968"`
- start elasticsearch
- Execute `curl -XPOST localhost:9200/test-weird-index-中文`
- see an endless stream of exceptions fly by

```
[2015-12-18 22:04:27,637][WARN ][gateway                  ] [One Above All] [test-weird-index-￤ﾸﾭ￦ﾖﾇ][4]: failed to list shard for shard_started on node [0SZxDwUvSoSdMLkVhBRsUQ]
FailedNodeException[Failed node [0SZxDwUvSoSdMLkVhBRsUQ]]; nested: RemoteTransportException[[One Above All][127.0.0.1:9300][internal:gateway/local/started_shards[n]]]; nested: ElasticsearchException[failed to load started shards]; nested: InvalidPathException[Malformed input or input contains unmappable characters: test-weird-index-￤ﾸﾭ￦ﾖﾇ];
    at org.elasticsearch.action.support.nodes.TransportNodesAction$AsyncAction.onFailure(TransportNodesAction.java:187)
    at org.elasticsearch.action.support.nodes.TransportNodesAction$AsyncAction.access$700(TransportNodesAction.java:94)
    at org.elasticsearch.action.support.nodes.TransportNodesAction$AsyncAction$2.handleException(TransportNodesAction.java:160)
    at org.elasticsearch.transport.TransportService$DirectResponseChannel.processException(TransportService.java:821)
    at org.elasticsearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:799)
    at org.elasticsearch.transport.TransportService$4.onFailure(TransportService.java:361)
    at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:42)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
Caused by: RemoteTransportException[[One Above All][127.0.0.1:9300][internal:gateway/local/started_shards[n]]]; nested: ElasticsearchException[failed to load started shards]; nested: InvalidPathException[Malformed input or input contains unmappable characters: test-weird-index-￤ﾸﾭ￦ﾖﾇ];
Caused by: ElasticsearchException[failed to load started shards]; nested: InvalidPathException[Malformed input or input contains unmappable characters: test-weird-index-￤ﾸﾭ￦ﾖﾇ];
    at org.elasticsearch.gateway.TransportNodesListGatewayStartedShards.nodeOperation(TransportNodesListGatewayStartedShards.java:154)
    at org.elasticsearch.gateway.TransportNodesListGatewayStartedShards.nodeOperation(TransportNodesListGatewayStartedShards.java:59)
    at org.elasticsearch.action.support.nodes.TransportNodesAction$NodeTransportHandler.messageReceived(TransportNodesAction.java:211)
    at org.elasticsearch.action.support.nodes.TransportNodesAction$NodeTransportHandler.messageReceived(TransportNodesAction.java:207)
    at org.elasticsearch.transport.TransportService$4.doRun(TransportService.java:350)
    at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: test-weird-index-￤ﾸﾭ￦ﾖﾇ
    at sun.nio.fs.UnixPath.encode(UnixPath.java:147)
    at sun.nio.fs.UnixPath.<init>(UnixPath.java:71)
    at sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:281)
    at sun.nio.fs.AbstractPath.resolve(AbstractPath.java:53)
    at org.elasticsearch.env.NodeEnvironment$NodePath.resolve(NodeEnvironment.java:91)
    at org.elasticsearch.env.NodeEnvironment$NodePath.resolve(NodeEnvironment.java:84)
    at org.elasticsearch.env.NodeEnvironment.availableShardPaths(NodeEnvironment.java:634)
    at org.elasticsearch.gateway.TransportNodesListGatewayStartedShards.nodeOperation(TransportNodesListGatewayStartedShards.java:125)
    ... 8 more
``
```
