### PR TITLE
[Ingest] ingest on failure

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/CompoundProcessor.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/ingest/processor/CompoundProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.elasticsearch.ingest.processor;
+
+import org.elasticsearch.ingest.IngestDocument;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A Processor that executes a list of other "processors". It executes a separate list of
+ * "onFailureProcessors" when any of the processors throw an {@link Exception}.
+ */
+public class CompoundProcessor implements Processor {
+
+    private final List<Processor> processors;
+    private final List<Processor> onFailureProcessors;
+
+    public CompoundProcessor(Processor... processor) {
+        this(Arrays.asList(processor), Collections.emptyList());
+    }
+    public CompoundProcessor(List<Processor> processors, List<Processor> onFailureProcessors) {
+        this.processors = processors;
+        this.onFailureProcessors = onFailureProcessors;
+    }
+
+    public List<Processor> getOnFailureProcessors() {
+        return onFailureProcessors;
+    }
+
+    public List<Processor> getProcessors() {
+        return processors;
+    }
+
+    @Override
+    public String getType() {
+        return "compound[" + processors.stream().map(p -> p.getType()).collect(Collectors.joining(",")) + "]";
+    }
+
+    @Override
+    public void execute(IngestDocument ingestDocument) throws Exception {
+        try {
+            for (Processor processor : processors) {
+                processor.execute(ingestDocument);
+            }
+        } catch (Exception e) {
+            if (onFailureProcessors.isEmpty()) {
+                throw e;
+            } else {
+                executeOnFailure(ingestDocument);
+            }
+        }
+
+    }
+
+    void executeOnFailure(IngestDocument ingestDocument) throws Exception {
+        for (Processor processor : onFailureProcessors) {
+            processor.execute(ingestDocument);
+        }
+    }
+}

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/PipelineFactoryTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/PipelineFactoryTests.java
@@ -52,6 +52,29 @@ public class PipelineFactoryTests extends ESTestCase {
         assertThat(pipeline.getProcessors().get(0).getType(), equalTo("test-processor"));
     }
 
+    public void testCreateWithPipelineOnFailure() throws Exception {
+        Map<String, Object> processorConfig = new HashMap<>();
+        Map<String, Object> pipelineConfig = new HashMap<>();
+        pipelineConfig.put("description", "_description");
+        pipelineConfig.put("processors", Collections.singletonList(Collections.singletonMap("test-processor", processorConfig)));
+        pipelineConfig.put("on_failure", Collections.singletonList(Collections.singletonMap("test-processor", processorConfig)));
+        Pipeline.Factory factory = new Pipeline.Factory();
+        Map<String, Processor.Factory> processorRegistry = new HashMap<>();
+        Processor processor = mock(Processor.class);
+        when(processor.getType()).thenReturn("test-processor");
+        Processor.Factory processorFactory = mock(Processor.Factory.class);
+        when(processorFactory.create(processorConfig)).thenReturn(processor);
+        processorRegistry.put("test-processor", processorFactory);
+
+        Pipeline pipeline = factory.create("_id", pipelineConfig, processorRegistry);
+        assertThat(pipeline.getId(), equalTo("_id"));
+        assertThat(pipeline.getDescription(), equalTo("_description"));
+        assertThat(pipeline.getProcessors().size(), equalTo(1));
+        assertThat(pipeline.getProcessors().get(0).getType(), equalTo("test-processor"));
+        assertThat(pipeline.getOnFailureProcessors().size(), equalTo(1));
+        assertThat(pipeline.getOnFailureProcessors().get(0).getType(), equalTo("test-processor"));
+    }
+
     public void testCreateUnusedProcessorOptions() throws Exception {
         Map<String, Object> processorConfig = new HashMap<>();
         processorConfig.put("unused", "value");
@@ -70,5 +93,27 @@ public class PipelineFactoryTests extends ESTestCase {
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), equalTo("processor [test] doesn't support one or more provided configuration parameters [unused]"));
         }
+    }
+
+    public void testCreateProcessorsWithOnFailureProperties() throws Exception {
+        Map<String, Object> processorConfig = new HashMap<>();
+        processorConfig.put("on_failure", Collections.singletonList(Collections.singletonMap("test", new HashMap<>())));
+
+        Map<String, Object> pipelineConfig = new HashMap<>();
+        pipelineConfig.put("description", "_description");
+        pipelineConfig.put("processors", Collections.singletonList(Collections.singletonMap("test", processorConfig)));
+        Pipeline.Factory factory = new Pipeline.Factory();
+        Map<String, Processor.Factory> processorFactoryStore = new HashMap<>();
+        Processor processor = mock(Processor.class);
+        when(processor.getType()).thenReturn("test-processor");
+        Processor.Factory processorFactory = mock(Processor.Factory.class);
+        when(processorFactory.create(processorConfig)).thenReturn(processor);
+        processorFactoryStore.put("test", processorFactory);
+
+        Pipeline pipeline = factory.create("_id", pipelineConfig, processorFactoryStore);
+        assertThat(pipeline.getId(), equalTo("_id"));
+        assertThat(pipeline.getDescription(), equalTo("_description"));
+        assertThat(pipeline.getProcessors().size(), equalTo(1));
+        assertThat(pipeline.getProcessors().get(0).getType(), equalTo("compound[test-processor]"));
     }
 }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/CompoundProcessorTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/processor/CompoundProcessorTests.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.ingest.processor;
+
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static org.elasticsearch.mock.orig.Mockito.verify;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+
+public class CompoundProcessorTests extends ESTestCase {
+    private IngestDocument ingestDocument;
+
+    @Before
+    public void init() {
+        ingestDocument = new IngestDocument(new HashMap<>(), new HashMap<>());
+    }
+
+    public void testEmpty() throws Exception {
+        CompoundProcessor processor = new CompoundProcessor();
+        assertThat(processor.getProcessors().isEmpty(), is(true));
+        assertThat(processor.getOnFailureProcessors().isEmpty(), is(true));
+        processor.execute(ingestDocument);
+    }
+
+    public void testSingleProcessor() throws Exception {
+        Processor processor = mock(Processor.class);
+        CompoundProcessor compoundProcessor = new CompoundProcessor(processor);
+        assertThat(compoundProcessor.getProcessors().size(), equalTo(1));
+        assertThat(compoundProcessor.getProcessors().get(0), equalTo(processor));
+        assertThat(compoundProcessor.getOnFailureProcessors().isEmpty(), is(true));
+        compoundProcessor.execute(ingestDocument);
+        verify(processor, times(1)).execute(ingestDocument);
+    }
+
+    public void testSingleProcessorWithException() throws Exception {
+        Processor processor = mock(Processor.class);
+        doThrow(new RuntimeException("error")).doNothing().when(processor).execute(ingestDocument);
+        CompoundProcessor compoundProcessor = new CompoundProcessor(processor);
+        assertThat(compoundProcessor.getProcessors().size(), equalTo(1));
+        assertThat(compoundProcessor.getProcessors().get(0), equalTo(processor));
+        assertThat(compoundProcessor.getOnFailureProcessors().isEmpty(), is(true));
+        try {
+            compoundProcessor.execute(ingestDocument);
+            fail("should throw exception");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), equalTo("error"));
+        }
+        verify(processor, times(1)).execute(ingestDocument);
+    }
+
+    public void testSingleProcessorWithOnFailureProcessor() throws Exception {
+        Processor processor = mock(Processor.class);
+        doThrow(new RuntimeException("error")).doNothing().when(processor).execute(ingestDocument);
+        Processor processorNext = mock(Processor.class);
+        CompoundProcessor compoundProcessor = new CompoundProcessor(Arrays.asList(processor), Arrays.asList(processorNext));
+        assertThat(compoundProcessor.getProcessors().size(), equalTo(1));
+        assertThat(compoundProcessor.getProcessors().get(0), equalTo(processor));
+        assertThat(compoundProcessor.getOnFailureProcessors().size(), equalTo(1));
+        assertThat(compoundProcessor.getOnFailureProcessors().get(0), equalTo(processorNext));
+        compoundProcessor.execute(ingestDocument);
+        verify(processor, times(1)).execute(ingestDocument);
+        verify(processorNext, times(1)).execute(ingestDocument);
+    }
+
+    public void testSingleProcessorWithNestedFailures() throws Exception {
+        Processor processor = mock(Processor.class);
+        doThrow(new RuntimeException("error")).doNothing().when(processor).execute(ingestDocument);
+        Processor processorToFail = mock(Processor.class);
+        doThrow(new RuntimeException("error")).doNothing().when(processorToFail).execute(ingestDocument);
+        Processor lastProcessor = mock(Processor.class);
+
+        CompoundProcessor innerCompoundOnFailProcessor = new CompoundProcessor(Arrays.asList(processorToFail), Arrays.asList(lastProcessor));
+        CompoundProcessor compoundOnFailProcessor = spy(innerCompoundOnFailProcessor);
+
+        CompoundProcessor innerCompoundProcessor = new CompoundProcessor(Arrays.asList(processor), Arrays.asList(compoundOnFailProcessor));
+        CompoundProcessor compoundProcessor = spy(innerCompoundProcessor);
+
+        assertThat(compoundProcessor.getProcessors().size(), equalTo(1));
+        assertThat(compoundProcessor.getProcessors().get(0), equalTo(processor));
+        assertThat(compoundProcessor.getOnFailureProcessors().size(), equalTo(1));
+        assertThat(compoundProcessor.getOnFailureProcessors().get(0), equalTo(compoundOnFailProcessor));
+        compoundProcessor.execute(ingestDocument);
+        verify(processor, times(1)).execute(ingestDocument);
+        verify(compoundProcessor, times(1)).executeOnFailure(ingestDocument);
+        verify(compoundOnFailProcessor, times(1)).execute(ingestDocument);
+        verify(processorToFail, times(1)).execute(ingestDocument);
+        verify(compoundOnFailProcessor, times(1)).executeOnFailure(ingestDocument);
+        verify(lastProcessor, times(1)).execute(ingestDocument);
+    }
+}

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilterTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/IngestActionFilterTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Pipeline;
+import org.elasticsearch.ingest.processor.CompoundProcessor;
 import org.elasticsearch.ingest.processor.Processor;
 import org.elasticsearch.plugin.ingest.IngestBootstrapper;
 import org.elasticsearch.plugin.ingest.IngestPlugin;
@@ -186,7 +187,7 @@ public class IngestActionFilterTests extends ESTestCase {
                 return null;
             }
         };
-        when(store.get("_id")).thenReturn(new Pipeline("_id", "_description", Collections.singletonList(processor)));
+        when(store.get("_id")).thenReturn(new Pipeline("_id", "_description", new CompoundProcessor(processor)));
         executionService = new PipelineExecutionService(store, threadPool);
         IngestBootstrapper bootstrapper = mock(IngestBootstrapper.class);
         when(bootstrapper.getPipelineExecutionService()).thenReturn(executionService);

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateExecutionServiceTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulateExecutionServiceTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.ingest.RandomDocumentPicks;
-import org.elasticsearch.ingest.processor.Processor;
+import org.elasticsearch.ingest.processor.CompoundProcessor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -47,7 +47,7 @@ public class SimulateExecutionServiceTests extends ESTestCase {
     private ThreadPool threadPool;
     private SimulateExecutionService executionService;
     private Pipeline pipeline;
-    private Processor processor;
+    private CompoundProcessor processor;
     private IngestDocument ingestDocument;
 
     @Before
@@ -58,10 +58,9 @@ public class SimulateExecutionServiceTests extends ESTestCase {
                         .build()
         );
         executionService = new SimulateExecutionService(threadPool);
-        processor = mock(Processor.class);
+        processor = mock(CompoundProcessor.class);
         when(processor.getType()).thenReturn("mock");
-        pipeline = new Pipeline("_id", "_description", Arrays.asList(processor, processor));
-        //ingestDocument = new IngestDocument("_index", "_type", "_id", Collections.singletonMap("foo", "bar"));
+        pipeline = new Pipeline("_id", "_description", new CompoundProcessor(processor, processor));
         ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
     }
 

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/20_crud.yaml
@@ -72,3 +72,53 @@
               }
             ]
           }
+
+---
+"Test basic pipeline with on_failure in processor":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "field2",
+                  "value": "_value",
+                  "on_failure": [
+                    {
+                      "set" : {
+                        "field" : "field2",
+                        "value" : "_failed_value"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+  - match: { _index: ".ingest" }
+  - match: { _type: "pipeline" }
+  - match: { _version: 1 }
+  - match: { _id: "my_pipeline" }
+
+  - do:
+      ingest.get_pipeline:
+        id: "my_pipeline"
+  - match: { my_pipeline._source.description: "_description" }
+  - match: { my_pipeline._version: 1 }
+
+  - do:
+      ingest.delete_pipeline:
+        id: "my_pipeline"
+  - match: { _index: ".ingest" }
+  - match: { _type: "pipeline" }
+  - match: { _version: 2 }
+  - match: { _id: "my_pipeline" }
+  - match: { found: true }
+
+  - do:
+      catch: missing
+      ingest.get_pipeline:
+        id: "my_pipeline"

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/70_simulate.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/70_simulate.yaml
@@ -70,6 +70,48 @@
   - length: { docs: 1 }
 
 ---
+"Test simulate with provided pipeline definition with on_failure block":
+  - do:
+      ingest.simulate:
+        body: >
+          {
+            "pipeline": {
+              "description": "_description",
+              "processors": [
+                {
+                  "rename" : {
+                    "field" : "does_not_exist",
+                    "to" : "field2",
+                    "on_failure" : [
+                      {
+                        "set" : {
+                          "field" : "field2",
+                          "value" : "_value"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "docs": [
+              {
+                "_index": "index",
+                "_type": "type",
+                "_id": "id",
+                "_source": {
+                  "foo": "bar"
+                }
+              }
+            ]
+          }
+  - length: { docs: 1 }
+  - match: { docs.0.doc._source.foo: "bar" }
+  - match: { docs.0.doc._source.field2: "_value" }
+  - length: { docs.0.doc._ingest: 1 }
+  - is_true: docs.0.doc._ingest.timestamp
+
+---
 "Test simulate with no provided pipeline or pipeline_id":
   - do:
       catch: request

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/80_on_failure.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/80_on_failure.yaml
@@ -1,0 +1,122 @@
+---
+"Test Pipeline With On Failure Block":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "rename" : {
+                  "field" : "foofield",
+                  "to" : "field1"
+                }
+              },
+              {
+                "grok" : {
+                  "field" : "field1",
+                  "pattern" : "%{NUMBER:val} %{NUMBER:status} <%{WORD:msg}>"
+                }
+              }
+            ],
+            "on_failure" : [
+              {
+                "grok" : {
+                  "field" : "field1",
+                  "pattern" : "%{NUMBER:val:float} %{NUMBER:status:int} <%{WORD:msg}>"
+                }
+              },
+              {
+                "set" : {
+                  "field" : "_failed",
+                  "value" : true
+                }
+              }
+            ]
+          }
+  - match: { _id: "my_pipeline" }
+
+  - do:
+      ingest.index:
+        index: test
+        type: test
+        id: 1
+        pipeline_id: "my_pipeline"
+        body: {field1: "123.42 400 <foo>"}
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.val: 123.42 }
+  - match: { _source.status: 400 }
+  - match: { _source.msg: "foo" }
+  - match: { _source._failed: true }
+
+---
+"Test Pipeline With Nested Processor On Failures":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "grok" : {
+                  "field" : "field1",
+                  "pattern" : "%{NUMBER:val:float} %{NUMBER:status:int} <%{WORD:msg}>"
+                }
+              },
+              {
+                "rename" : {
+                  "field" : "foofield",
+                  "to" : "field1",
+                  "on_failure" : [
+                    {
+                      "set" : {
+                        "field" : "foofield",
+                        "value" : "exists"
+                      }
+                    },
+                    {
+                      "rename" : {
+                        "field" : "foofield2",
+                        "to" : "field1",
+                        "on_failure" : [
+                          {
+                            "set" : {
+                            "field" : "foofield2",
+                            "value" : "ran"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+  - match: { _id: "my_pipeline" }
+
+  - do:
+      ingest.index:
+        index: test
+        type: test
+        id: 1
+        pipeline_id: "my_pipeline"
+        body: {field1: "123.42 400 <foo>"}
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.val: 123.42 }
+  - match: { _source.msg: "foo" }
+  - match: { _source.status: 400 }
+  - match: { _source.foofield: "exists" }
+  - match: { _source.foofield2: "ran" }


### PR DESCRIPTION
After some discussion, a sort of consensus around an `on_failure` block for all processors to have was decided on, instead of a `continue_on_failure` flag described by this issue.

An example of this is as follows:

```
{
  description: "my pipeline with on_failure",
  processors: [
    {
      "grok" : {
          ...
          on_failure : [
            { "set" : { "grok.failed" : true } },
            { "meta": { "_index" : "failed-index" } }
          ]
      }
    },
    {
       "date" : {
         ...
       }
    }
  ]
}
```

an `on_failure` will also be added to a pipeline as a whole:

```
{
   "description" : "...",
   "processors" : [ ... ],
   "on_failure" : [ ... ]
}
```

processors without an `on_failure` parameter defined will throw an exception and exit the pipeline immediately. processors with `on_failure` defined will catch the exception and allow for further processors to run. Exceptions within the `on_failure` block will be treated the same as the top-level.

If a user wishes to handle a failure, and still exit the pipeline immediately, a `fail` processor will be introduced. This processor will do nothing but throw an exception so that the pipeline exits.

Closes: #14548
