### PR TITLE
Remove `index.merge.scheduler.notify_on_failure` and default to `true`

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1129,20 +1129,18 @@ public class InternalEngine extends Engine {
         @Override
         protected void handleMergeException(final Directory dir, final Throwable exc) {
             logger.error("failed to merge", exc);
-            if (config().getMergeSchedulerConfig().isNotifyOnMergeFailure()) {
-                engineConfig.getThreadPool().generic().execute(new AbstractRunnable() {
-                    @Override
-                    public void onFailure(Throwable t) {
-                        logger.debug("merge failure action rejected", t);
-                    }
+            engineConfig.getThreadPool().generic().execute(new AbstractRunnable() {
+                @Override
+                public void onFailure(Throwable t) {
+                    logger.debug("merge failure action rejected", t);
+                }
 
-                    @Override
-                    protected void doRun() throws Exception {
-                        MergePolicy.MergeException e = new MergePolicy.MergeException(exc, dir);
-                        failEngine("merge failed", e);
-                    }
-                });
-            }
+                @Override
+                protected void doRun() throws Exception {
+                    MergePolicy.MergeException e = new MergePolicy.MergeException(exc, dir);
+                    failEngine("merge failed", e);
+                }
+            });
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/MergeSchedulerConfig.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/MergeSchedulerConfig.java
@@ -29,19 +29,19 @@ import org.elasticsearch.index.IndexSettings;
  * merge operations once they are needed (according to the merge policy).  Merges
  * run in separate threads, and when the maximum number of threads is reached,
  * further merges will wait until a merge thread becomes available.
- * 
+ *
  * <p>The merge scheduler supports the following <b>dynamic</b> settings:
- * 
+ *
  * <ul>
  * <li> <code>index.merge.scheduler.max_thread_count</code>:
- * 
+ *
  *     The maximum number of threads that may be merging at once. Defaults to
  *     <code>Math.max(1, Math.min(4, Runtime.getRuntime().availableProcessors() / 2))</code>
  *     which works well for a good solid-state-disk (SSD).  If your index is on
  *     spinning platter drives instead, decrease this to 1.
- * 
+ *
  * <li><code>index.merge.scheduler.auto_throttle</code>:
- * 
+ *
  *     If this is true (the default), then the merge scheduler will rate-limit IO
  *     (writes) for merges to an adaptive value depending on how many merges are
  *     requested over time.  An application with a low indexing rate that
@@ -55,19 +55,16 @@ public final class MergeSchedulerConfig {
     public static final String MAX_THREAD_COUNT = "index.merge.scheduler.max_thread_count";
     public static final String MAX_MERGE_COUNT = "index.merge.scheduler.max_merge_count";
     public static final String AUTO_THROTTLE = "index.merge.scheduler.auto_throttle";
-    public static final String NOTIFY_ON_MERGE_FAILURE = "index.merge.scheduler.notify_on_failure"; // why would we not wanna do this?
 
     private volatile boolean autoThrottle;
     private volatile int maxThreadCount;
     private volatile int maxMergeCount;
-    private final boolean notifyOnMergeFailure;
 
     public MergeSchedulerConfig(IndexSettings indexSettings) {
         final Settings settings = indexSettings.getSettings();
         maxThreadCount = settings.getAsInt(MAX_THREAD_COUNT, Math.max(1, Math.min(4, EsExecutors.boundedNumberOfProcessors(settings) / 2)));
         maxMergeCount = settings.getAsInt(MAX_MERGE_COUNT, maxThreadCount + 5);
         this.autoThrottle = settings.getAsBoolean(AUTO_THROTTLE, true);
-        notifyOnMergeFailure = settings.getAsBoolean(NOTIFY_ON_MERGE_FAILURE, true);
     }
 
     /**
@@ -113,12 +110,5 @@ public final class MergeSchedulerConfig {
      */
     public void setMaxMergeCount(int maxMergeCount) {
         this.maxMergeCount = maxMergeCount;
-    }
-
-    /**
-     * Returns <code>true</code> iff we fail the engine on a merge failure. Default is <code>true</code>
-     */
-    public boolean isNotifyOnMergeFailure() {
-        return notifyOnMergeFailure;
     }
 }


### PR DESCRIPTION
This setting was undocumented and should not be set by any user. We should
fail the shard instead.

Closes  #15570
