### PR TITLE
change S3 repository link to elastic/elasticsearch@2.0

### DIFF
--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -150,7 +150,7 @@ shared file system repository.
 
 Other repository backends are available in these official plugins:
 
-* https://github.com/elasticsearch/elasticsearch-cloud-aws#s3-repository[AWS Cloud Plugin] for S3 repositories
+* https://github.com/elastic/elasticsearch/tree/2.0/plugins/cloud-aws[AWS Cloud Plugin] for S3 repositories
 * https://github.com/elasticsearch/elasticsearch-hadoop/tree/master/repository-hdfs[HDFS Plugin] for Hadoop environments
 * https://github.com/elasticsearch/elasticsearch-cloud-azure#azure-repository[Azure Cloud Plugin] for Azure storage repositories
 


### PR DESCRIPTION
The previous link went to the outdated repo for ES < 2.0. Two things:
- Not sure if it's smart to link current-docs with something like tree/2.0, or if tree/2.x would be better
- Not sure if it wouldn't be better to link to the plugin doc page anyway, which would be https://www.elastic.co/guide/en/elasticsearch/plugins/current/cloud-aws.html. Would have to change the other 2 links (HDFS and Azure plugins) too for consistency.
