### PR TITLE
[Ingest] Change ExecutionService to process multiple request at a time

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineExecutionService.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/PipelineExecutionService.java
@@ -54,12 +54,11 @@ public class PipelineExecutionService {
         });
     }
 
-    public void execute(Iterable<ActionRequest> indexRequests, String pipelineId,
+    public void execute(Iterable<ActionRequest> actionRequests, String pipelineId,
                         Consumer<Throwable> itemFailureHandler, Consumer<Boolean> completionHandler) {
         Pipeline pipeline = getPipeline(pipelineId);
         threadPool.executor(THREAD_POOL_NAME).execute(() -> {
-            Throwable lastThrowable = null;
-            for (ActionRequest actionRequest : indexRequests) {
+            for (ActionRequest actionRequest : actionRequests) {
                 if ((actionRequest instanceof IndexRequest) == false) {
                     continue;
                 }
@@ -68,13 +67,12 @@ public class PipelineExecutionService {
                 try {
                     innerExecute(indexRequest, pipeline);
                 } catch (Throwable e) {
-                    lastThrowable = e;
                     if (itemFailureHandler != null) {
                         itemFailureHandler.accept(e);
                     }
                 }
             }
-            completionHandler.accept(lastThrowable == null);
+            completionHandler.accept(true);
         });
     }
 

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -44,10 +45,7 @@ import org.elasticsearch.plugin.ingest.transport.simulate.SimulatePipelineRespon
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -146,39 +144,48 @@ public class IngestClientIT extends ESIntegTestCase {
         assertThat(simulateDocumentSimpleResult.getFailure(), nullValue());
     }
 
-    public void testBulkWithIngestFailures() {
+    public void testBulkWithIngestFailures() throws Exception {
         createIndex("index");
+
+        new PutPipelineRequestBuilder(client(), PutPipelineAction.INSTANCE)
+            .setId("_id")
+            .setSource(jsonBuilder().startObject()
+                .field("description", "my_pipeline")
+                .startArray("processors")
+                .startObject()
+                .startObject("join")
+                .field("field", "field1")
+                .field("separator", "|")
+                .endObject()
+                .endObject()
+                .endArray()
+                .endObject().bytes())
+            .get();
 
         int numRequests = scaledRandomIntBetween(32, 128);
         BulkRequest bulkRequest = new BulkRequest();
-        bulkRequest.putHeader(IngestPlugin.PIPELINE_ID_PARAM, "_none_existing_id");
+        bulkRequest.putHeader(IngestPlugin.PIPELINE_ID_PARAM, "_id");
         for (int i = 0; i < numRequests; i++) {
+            IndexRequest indexRequest = new IndexRequest("index", "type", Integer.toString(i));
             if (i % 2 == 0) {
-                UpdateRequest updateRequest = new UpdateRequest("index", "type", Integer.toString(i));
-                updateRequest.upsert("field", "value");
-                updateRequest.doc(new HashMap());
-                bulkRequest.add(updateRequest);
+                indexRequest.source("field1", Arrays.asList("value1", "value2"));
             } else {
-                IndexRequest indexRequest = new IndexRequest("index", "type", Integer.toString(i));
-                indexRequest.source("field1", "value1");
-                bulkRequest.add(indexRequest);
+                indexRequest.source("field2", Arrays.asList("value1", "value2"));
             }
+            bulkRequest.add(indexRequest);
         }
 
         BulkResponse response = client().bulk(bulkRequest).actionGet();
         assertThat(response.getItems().length, equalTo(bulkRequest.requests().size()));
         for (int i = 0; i < bulkRequest.requests().size(); i++) {
-            ActionRequest request = bulkRequest.requests().get(i);
             BulkItemResponse itemResponse = response.getItems()[i];
-            if (request instanceof IndexRequest) {
-                BulkItemResponse.Failure failure = itemResponse.getFailure();
-                assertThat(failure.getMessage(), equalTo("java.lang.IllegalArgumentException: pipeline with id [_none_existing_id] does not exist"));
-            } else if (request instanceof UpdateRequest) {
-                UpdateResponse updateResponse = itemResponse.getResponse();
-                assertThat(updateResponse.getId(), equalTo(Integer.toString(i)));
-                assertThat(updateResponse.isCreated(), is(true));
+            if (i % 2 == 0) {
+                IndexResponse indexResponse = itemResponse.getResponse();
+                assertThat(indexResponse.getId(), equalTo(Integer.toString(i)));
+                assertThat(indexResponse.isCreated(), is(true));
             } else {
-                fail("unexpected request item [" + request + "]");
+                BulkItemResponse.Failure failure = itemResponse.getFailure();
+                assertThat(failure.getMessage(), equalTo("java.lang.IllegalArgumentException: field [field1] not present as part of path [field1]"));
             }
         }
     }

--- a/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.ingest;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -27,8 +26,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
-import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.plugin.ingest.IngestPlugin;
 import org.elasticsearch.plugin.ingest.transport.delete.DeletePipelineAction;
@@ -45,7 +42,11 @@ import org.elasticsearch.plugin.ingest.transport.simulate.SimulatePipelineRespon
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Collections;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineExecutionServiceTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/PipelineExecutionServiceTests.java
@@ -227,7 +227,7 @@ public class PipelineExecutionServiceTests extends ESTestCase {
         executionService.execute(bulkRequest.requests(), pipelineId, requestItemErrorHandler, completionHandler);
 
         verify(requestItemErrorHandler, times(numIndexRequests)).accept(error);
-        verify(completionHandler, times(1)).accept(false);
+        verify(completionHandler, times(1)).accept(true);
     }
 
     public void testBulkRequestExecution() throws Exception {

--- a/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/BulkRequestModifierTests.java
+++ b/plugins/ingest/src/test/java/org/elasticsearch/plugin/ingest/transport/BulkRequestModifierTests.java
@@ -1,0 +1,101 @@
+package org.elasticsearch.plugin.ingest.transport;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class BulkRequestModifierTests extends ESTestCase {
+
+    public void testPipelineFailures() {
+        BulkRequest originalBulkRequest = new BulkRequest();
+        for (int i = 0; i < 32; i++) {
+            originalBulkRequest.add(new IndexRequest("index", "type", String.valueOf(i)));
+        }
+
+        IngestActionFilter.BulkRequestModifier modifier = new IngestActionFilter.BulkRequestModifier(originalBulkRequest);
+        for (int i = 0; modifier.hasNext(); i++) {
+            modifier.next();
+            if (i % 2 == 0) {
+                modifier.markCurrentItemAsFailed(new RuntimeException());
+            }
+        }
+
+        // So half of the requests have "failed", so only the successful requests are left:
+        BulkRequest bulkRequest = modifier.getBulkRequest();
+        assertThat(bulkRequest.requests().size(), Matchers.equalTo(16));
+
+        List<BulkItemResponse> responses = new ArrayList<>();
+        ActionListener<BulkResponse> bulkResponseListener = modifier.wrapActionListenerIfNeeded(new ActionListener<BulkResponse>() {
+            @Override
+            public void onResponse(BulkResponse bulkItemResponses) {
+                responses.addAll(Arrays.asList(bulkItemResponses.getItems()));
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+            }
+        });
+
+        List<BulkItemResponse> originalResponses = new ArrayList<>();
+        for (ActionRequest actionRequest : bulkRequest.requests()) {
+            IndexRequest indexRequest = (IndexRequest) actionRequest;
+            IndexResponse indexResponse = new IndexResponse(new ShardId("index", 0), indexRequest.type(), indexRequest.id(), 1, true);
+            originalResponses.add(new BulkItemResponse(Integer.parseInt(indexRequest.id()), indexRequest.opType().lowercase(), indexResponse));
+        }
+        bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[0]), 0));
+
+        assertThat(responses.size(), Matchers.equalTo(32));
+        for (int i = 0; i < 32; i++) {
+            assertThat(responses.get(i).getId(), Matchers.equalTo(String.valueOf(i)));
+        }
+    }
+
+    public void testNoFailures() {
+        BulkRequest originalBulkRequest = new BulkRequest();
+        for (int i = 0; i < 32; i++) {
+            originalBulkRequest.add(new IndexRequest("index", "type", String.valueOf(i)));
+        }
+
+        IngestActionFilter.BulkRequestModifier modifier = new IngestActionFilter.BulkRequestModifier(originalBulkRequest);
+        for (int i = 0; modifier.hasNext(); i++) {
+            modifier.next();
+        }
+
+        BulkRequest bulkRequest = modifier.getBulkRequest();
+        assertThat(bulkRequest, Matchers.sameInstance(originalBulkRequest));
+        ActionListener<BulkResponse> actionListener = Mockito.mock(ActionListener.class);
+        assertThat(modifier.wrapActionListenerIfNeeded(actionListener), Matchers.sameInstance(actionListener));
+    }
+
+}


### PR DESCRIPTION
ExecutionService should be able to process multiple index requests at a time. This change is important for the when ingest is enabled for the bulk api, so that we don't use a head per bulk item, but instead use a threed per bulk request.
