### PR TITLE
Speed up CodecTests.

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingBackwardCompatibilityTests.java
@@ -53,6 +53,10 @@ public class RoutingBackwardCompatibilityTests extends ESTestCase {
 
                 OperationRouting operationRouting = new OperationRouting(Settings.EMPTY, null);
                 for (Version version : VersionUtils.allVersions()) {
+                    if (version.onOrAfter(Version.V_2_0_0) == false) {
+                        // unsupported version, no need to test
+                        continue;
+                    }
                     final Settings settings = settings(version).build();
                     IndexMetaData indexMetaData = IndexMetaData.builder(index).settings(settings).numberOfShards(numberOfShards).numberOfReplicas(randomInt(3)).build();
                     MetaData.Builder metaData = MetaData.builder().put(indexMetaData, false);

--- a/core/src/test/java/org/elasticsearch/codecs/CodecTests.java
+++ b/core/src/test/java/org/elasticsearch/codecs/CodecTests.java
@@ -44,6 +44,10 @@ public class CodecTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
         int i = 0;
         for (Version v : VersionUtils.allVersions()) {
+            if (v.onOrAfter(Version.V_2_0_0) == false) {
+                // no need to test, we don't support upgrading from these versions
+                continue;
+            }
             IndexService indexService = createIndex("test-" + i++, Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, v).build());
             DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
             try {
@@ -67,6 +71,10 @@ public class CodecTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
         int i = 0;
         for (Version v : VersionUtils.allVersions()) {
+            if (v.onOrAfter(Version.V_2_0_0) == false) {
+                // no need to test, we don't support upgrading from these versions
+                continue;
+            }
             IndexService indexService = createIndex("test-" + i++, Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, v).build());
             DocumentMapperParser parser = indexService.mapperService().documentMapperParser();
             try {


### PR DESCRIPTION
Some tests, but in particular CodecTests, are slow because they test all
versions that ever existed even though they should only test supported
versions.
