### PR TITLE
Fix build to run correctly on FreeBSD

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.monitor.jvm;
 
 import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.unit.TimeValue;
@@ -130,6 +131,11 @@ public class HotThreads {
 
     private String innerDetect() throws Exception {
         StringBuilder sb = new StringBuilder();
+
+        if (Constants.FREE_BSD) {
+            sb.append("hot_threads is not supported on FreeBSD");
+            return sb.toString();
+        }
 
         sb.append("Hot threads at ");
         sb.append(DATE_TIME_FORMATTER.printer().print(System.currentTimeMillis()));

--- a/core/src/test/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.action.admin;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodeHotThreads;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRequestBuilder;
@@ -40,6 +41,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.lessThan;
 
 public class HotThreadsIT extends ESIntegTestCase {
+
     public void testHotThreadsDontFail() throws ExecutionException, InterruptedException {
         /**
          * This test just checks if nothing crashes or gets stuck etc.
@@ -125,6 +127,7 @@ public class HotThreadsIT extends ESIntegTestCase {
     }
 
     public void testIgnoreIdleThreads() throws ExecutionException, InterruptedException {
+        assumeTrue("no support for hot_threads on FreeBSD", Constants.FREE_BSD == false);
 
         // First time, don't ignore idle threads:
         NodesHotThreadsRequestBuilder builder = client().admin().cluster().prepareNodesHotThreads();
@@ -158,12 +161,19 @@ public class HotThreadsIT extends ESIntegTestCase {
 
         NodesHotThreadsResponse response = client().admin().cluster().prepareNodesHotThreads().execute().get();
 
-        for (NodeHotThreads node : response.getNodesMap().values()) {
-            String result = node.getHotThreads();
-            assertTrue(result.indexOf("Hot threads at") != -1);
-            assertTrue(result.indexOf("interval=500ms") != -1);
-            assertTrue(result.indexOf("busiestThreads=3") != -1);
-            assertTrue(result.indexOf("ignoreIdleThreads=true") != -1);
+        if (Constants.FREE_BSD) {
+            for (NodeHotThreads node : response.getNodesMap().values()) {
+                String result = node.getHotThreads();
+                assertTrue(result.indexOf("hot_threads is not supported") != -1);
+            }
+        } else {
+            for (NodeHotThreads node : response.getNodesMap().values()) {
+                String result = node.getHotThreads();
+                assertTrue(result.indexOf("Hot threads at") != -1);
+                assertTrue(result.indexOf("interval=500ms") != -1);
+                assertTrue(result.indexOf("busiestThreads=3") != -1);
+                assertTrue(result.indexOf("ignoreIdleThreads=true") != -1);
+            }
         }
     }
 }

--- a/plugins/discovery-multicast/src/test/java/org/elasticsearch/plugin/discovery/multicast/MulticastZenPingTests.java
+++ b/plugins/discovery-multicast/src/test/java/org/elasticsearch/plugin/discovery/multicast/MulticastZenPingTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.plugin.discovery.multicast;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -45,6 +46,7 @@ import java.net.InetAddress;
 import java.net.MulticastSocket;
 
 public class MulticastZenPingTests extends ESTestCase {
+
     private Settings buildRandomMulticast(Settings settings) {
         Settings.Builder builder = Settings.builder().put(settings);
         builder.put("discovery.zen.ping.multicast.group", "224.2.3." + randomIntBetween(0, 255));
@@ -57,6 +59,7 @@ public class MulticastZenPingTests extends ESTestCase {
     }
 
     public void testSimplePings() throws InterruptedException {
+        assumeTrue("https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=193246", Constants.FREE_BSD == false);
         Settings settings = Settings.EMPTY;
         settings = buildRandomMulticast(settings);
         Thread.sleep(30000);
@@ -129,8 +132,16 @@ public class MulticastZenPingTests extends ESTestCase {
         }
     }
 
+    // This test is here because when running on FreeBSD, if no tests are
+    // executed for the 'multicast' project it will assume everything
+    // failed, so we need to have at least one test that runs.
+    public void testAlwaysRun() throws Exception {
+        assertTrue(true);
+    }
+
     @SuppressForbidden(reason = "I bind to wildcard addresses. I am a total nightmare")
     public void testExternalPing() throws Exception {
+        assumeTrue("https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=193246", Constants.FREE_BSD == false);
         Settings settings = Settings.EMPTY;
         settings = buildRandomMulticast(settings);
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yaml
@@ -6,8 +6,8 @@
 
   - match:
       $body: |
-               /  #host       ip                          heap.percent        ram.percent     cpu     load                node.role        master          name
-               ^  (\S+   \s+  (\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+ \d* \s+ (-)?\d*(\.\d+)?    \s+  [-dc]       \s+  [-*mx]    \s+   (\S+\s?)+     \n)+  $/
+               /  #host       ip                          heap.percent        ram.percent     cpu         load                    node.role        master          name
+               ^  (\S+   \s+  (\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+ (-)?\d* \s+ (-)?\d*(\.\d+)?    \s+  [-dc]       \s+  [-*mx]    \s+   (\S+\s?)+     \n)+  $/
 
   - do:
       cat.nodes:
@@ -15,8 +15,8 @@
 
   - match:
       $body: |
-               /^  host  \s+  ip                     \s+  heap\.percent   \s+  ram\.percent \s+ cpu \s+ load           \s+  node\.role   \s+  master   \s+   name  \n
-                  (\S+   \s+  (\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+ \d* \s+ (-)?\d*(\.\d+)?    \s+  [-dc]        \s+  [-*mx]    \s+   (\S+\s?)+     \n)+  $/
+               /^  host  \s+  ip                     \s+  heap\.percent   \s+  ram\.percent \s+ cpu      \s+ load           \s+  node\.role   \s+  master   \s+   name  \n
+                  (\S+   \s+  (\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+ (-)?\d* \s+ (-)?\d*(\.\d+)?    \s+  [-dc]        \s+  [-*mx]    \s+   (\S+\s?)+     \n)+  $/
 
   - do:
       cat.nodes:


### PR DESCRIPTION
This adds the required changes/checks so that the build can run on
FreeBSD.

There are a few things that differ between FreeBSD and Linux:
- CPU probes return -1 for CPU usage
- `hot_threads` cannot be supported on FreeBSD

From OpenJDK's `os_bsd.cpp`:

``` c++
bool os::is_thread_cpu_time_supported() {
  #ifdef __APPLE__
  return true;
  #else
  return false;
  #endif
}
```

So this API now returns (for each FreeBSD node):

```
curl -s localhost:9200/_nodes/hot_threads
::: {Devil Hunter Gabriel}{q8OJnKCcQS6EB9fygU4R4g}{127.0.0.1}{127.0.0.1:9300}
   hot_threads is not supported on FreeBSD
```
- multicast fails in native `join` method - known bug:
  https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=193246

Which causes:

```
1> Caused by: java.net.SocketException: Invalid argument
1>    at java.net.PlainDatagramSocketImpl.join(Native Method)
1>    at java.net.AbstractPlainDatagramSocketImpl.join(AbstractPlainDatagramSocketImpl.java:179)
1>    at java.net.MulticastSocket.joinGroup(MulticastSocket.java:323)
1>    at org.elasticsearch.plugin.discovery.multicast.MulticastChannel$Plain.buildMulticastSocket(MulticastChannel.java:309)
```

So these tests are skipped on FreeBSD.

Resolves #15562
