### PR TITLE
Add sub-fields support to `bool` fields.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/BooleanFieldMapper.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 import static org.elasticsearch.index.mapper.MapperBuilders.booleanField;
 import static org.elasticsearch.index.mapper.core.TypeParsers.parseField;
+import static org.elasticsearch.index.mapper.core.TypeParsers.parseMultiField;
 
 /**
  * A field mapper for boolean fields.
@@ -106,6 +107,8 @@ public class BooleanFieldMapper extends FieldMapper {
                         throw new MapperParsingException("Property [null_value] cannot be null.");
                     }
                     builder.nullValue(nodeBooleanValue(propNode));
+                    iterator.remove();
+                } else if (parseMultiField(builder, name, parserContext, propName, propNode)) {
                     iterator.remove();
                 }
             }

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/BooleanFieldMapperTests.java
@@ -28,6 +28,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -109,5 +110,28 @@ public class BooleanFieldMapperTests extends ESSingleNodeTestCase {
         mapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         assertEquals("{\"field\":{\"type\":\"boolean\",\"doc_values\":false,\"null_value\":true}}", builder.string());
+    }
+
+    public void testMultiFields() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "boolean")
+                        .startObject("fields")
+                            .startObject("as_string")
+                                .field("type", "string")
+                                .field("index", "not_analyzed")
+                            .endObject()
+                        .endObject()
+                    .endObject().endObject()
+                .endObject().endObject().string();
+        DocumentMapper mapper = indexService.mapperService().merge("type", new CompressedXContent(mapping), true, false);
+        assertEquals(mapping, mapper.mappingSource().toString());
+        BytesReference source = XContentFactory.jsonBuilder()
+                .startObject()
+                    .field("field", false)
+                .endObject().bytes();
+        ParsedDocument doc = mapper.parse("test", "type", "1", source);
+        assertNotNull(doc.rootDoc().getField("field.as_string"));
     }
 }


### PR DESCRIPTION
`bool` is our only core mapper that does not support sub fields.

Close #6587
