### PR TITLE
Remove backwards from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,5 @@ html_docs
 
 # random old stuff that we should look at the necessity of...
 /tmp/
-backwards/
 
 


### PR DESCRIPTION
backwards was the canonical name for the directory to which to download
the bwc version. Its no longer needed because we now download it using
maven into a target directory.
