### PR TITLE
Specify custom char_filters/tokenizer/token_filters in the analyze API

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
@@ -21,6 +21,8 @@ package org.elasticsearch.action.admin.indices.analyze;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 
+import java.util.Map;
+
 /**
  *
  */
@@ -54,7 +56,7 @@ public class AnalyzeRequestBuilder extends SingleShardOperationRequestBuilder<An
     }
 
     /**
-     * Instead of setting the analyzer, sets the tokenizer that will be used as part of a custom
+     * Instead of setting the analyzer, sets the tokenizer as name that will be used as part of a custom
      * analyzer.
      */
     public AnalyzeRequestBuilder setTokenizer(String tokenizer) {
@@ -63,18 +65,43 @@ public class AnalyzeRequestBuilder extends SingleShardOperationRequestBuilder<An
     }
 
     /**
-     * Sets token filters that will be used on top of a tokenizer provided.
+     * Instead of setting the analyzer, sets the tokenizer using custom settings that will be used as part of a custom
+     * analyzer.
      */
-    public AnalyzeRequestBuilder setTokenFilters(String... tokenFilters) {
-        request.tokenFilters(tokenFilters);
+    public AnalyzeRequestBuilder setTokenizer(Map<String, ?> tokenizer) {
+        request.tokenizer(tokenizer);
         return this;
     }
 
     /**
-     * Sets char filters that will be used before the tokenizer.
+     * Add token filter setting that will be used on top of a tokenizer provided.
      */
-    public AnalyzeRequestBuilder setCharFilters(String... charFilters) {
-        request.charFilters(charFilters);
+    public AnalyzeRequestBuilder addTokenFilter(Map<String, ?> tokenFilter) {
+        request.addTokenFilter(tokenFilter);
+        return this;
+    }
+
+    /**
+     * Add a name of token filter that will be used on top of a tokenizer provided.
+     */
+    public AnalyzeRequestBuilder addTokenFilter(String tokenFilter) {
+        request.addTokenFilter(tokenFilter);
+        return this;
+    }
+
+    /**
+     * Add char filter setting that will be used on top of a tokenizer provided.
+     */
+    public AnalyzeRequestBuilder addCharFilter(Map<String, ?> charFilter) {
+        request.addCharFilter(charFilter);
+        return this;
+    }
+
+    /**
+     * Add a name of char filter that will be used before the tokenizer.
+     */
+    public AnalyzeRequestBuilder addCharFilter(String tokenFilter) {
+        request.addCharFilter(tokenFilter);
         return this;
     }
 

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -73,7 +73,8 @@ public class TransportAnalyzeActionTests extends ESTestCase {
 
         request.analyzer(null);
         request.tokenizer("whitespace");
-        request.tokenFilters("lowercase", "word_delimiter");
+        request.addTokenFilter("lowercase");
+        request.addTokenFilter("word_delimiter");
         request.text("the qu1ck brown fox");
         analyze = TransportAnalyzeAction.analyze(request, AllFieldMapper.NAME, null, randomBoolean() ? analysisService : null, registry, environment);
         tokens = analyze.getTokens();
@@ -84,8 +85,9 @@ public class TransportAnalyzeActionTests extends ESTestCase {
 
         request.analyzer(null);
         request.tokenizer("whitespace");
-        request.charFilters("html_strip");
-        request.tokenFilters("lowercase", "word_delimiter");
+        request.addCharFilter("html_strip");
+        request.addTokenFilter("lowercase");
+        request.addTokenFilter("word_delimiter");
         request.text("<p>the qu1ck brown fox</p>");
         analyze = TransportAnalyzeAction.analyze(request, AllFieldMapper.NAME, null, randomBoolean() ? analysisService : null, registry, environment);
         tokens = analyze.getTokens();
@@ -155,7 +157,8 @@ public class TransportAnalyzeActionTests extends ESTestCase {
 
         request.analyzer(null);
         request.tokenizer("whitespace");
-        request.tokenFilters("lowercase", "wordDelimiter");
+        request.addTokenFilter("lowercase");
+        request.addTokenFilter("wordDelimiter");
         request.text("the qu1ck brown fox-dog");
         analyze = TransportAnalyzeAction.analyze(request, AllFieldMapper.NAME, null, analysisService, registry, environment);
         tokens = analyze.getTokens();
@@ -211,7 +214,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         try {
             AnalyzeRequest request = new AnalyzeRequest();
             request.tokenizer("whitespace");
-            request.tokenFilters("foobar");
+            request.addTokenFilter("foobar");
             request.text("the qu1ck brown fox");
             TransportAnalyzeAction.analyze(request, AllFieldMapper.NAME, null, notGlobal ? analysisService : null, registry, environment);
             fail("no such analyzer");
@@ -226,8 +229,8 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         try {
             AnalyzeRequest request = new AnalyzeRequest();
             request.tokenizer("whitespace");
-            request.tokenFilters("lowercase");
-            request.charFilters("foobar");
+            request.addTokenFilter("lowercase");
+            request.addCharFilter("foobar");
             request.text("the qu1ck brown fox");
             TransportAnalyzeAction.analyze(request, AllFieldMapper.NAME, null, notGlobal ? analysisService : null, registry, environment);
             fail("no such analyzer");

--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -51,6 +51,18 @@ curl -XGET 'localhost:9200/_analyze' -d '
 
 deprecated[5.0.0, Use `filter`/`token_filter`/`char_filter` instead of `filters`/`token_filters`/`char_filters`]
 
+Custom tokenizers, token filters, and character filters can be specified in the request body as follows:
+
+[source,js]
+--------------------------------------------------
+curl -XGET 'localhost:9200/_analyze' -d '
+{
+  "tokenizer" : "whitespace",
+  "filter" : ["lowercase", {"type": "stop", "stopwords": ["a", "is", "this"]}],
+  "text" : "this is a test"
+}'
+--------------------------------------------------
+
 It can also run against a specific index:
 
 [source,js]

--- a/docs/reference/migration/migrate_5_0/java.asciidoc
+++ b/docs/reference/migration/migrate_5_0/java.asciidoc
@@ -324,4 +324,12 @@ The Render Search Template Java API including `RenderSearchTemplateAction`, `Ren
  This Search Template API is now included in the `lang-mustache` module and the `simulate` flag must be set on the
  `SearchTemplateRequest` object.
 
+==== AnalyzeRequest
 
+The `tokenFilters(String...)` and `charFilters(String...)` methods have been removed
+in favor of using `addTokenFilter(String)`/`addTokenFilter(Map)` and `addCharFilter(String)`/`addCharFilter(Map)` each filters
+
+==== AnalyzeRequestBuilder
+
+The `setTokenFilters(String...)` and `setCharFilters(String...)` methods have been removed
+in favor of using `addTokenFilter(String)`/`addTokenFilter(Map)` and `addCharFilter(String)`/`addCharFilter(Map)` each filters

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
@@ -95,3 +95,39 @@ setup:
     - match:     { detail.tokenfilters.0.tokens.2.token: troubl }
     - match:     { detail.tokenfilters.0.tokens.2.keyword: false }
 
+---
+"Custom filter in request":
+    - do:
+        indices.analyze:
+          body: { "text": "Foo Bar Buzz", "filter": ["lowercase",   {     "type": "stop", "stopwords": ["foo", "buzz"]}], "tokenizer": whitespace, "explain": true }
+    - length: {detail.tokenizer.tokens: 3 }
+    - length: {detail.tokenfilters.0.tokens: 3 }
+    - length: {detail.tokenfilters.1.tokens: 1 }
+    - match:     { detail.tokenizer.name: whitespace }
+    - match:     { detail.tokenizer.tokens.0.token: Foo }
+    - match:     { detail.tokenizer.tokens.1.token: Bar }
+    - match:     { detail.tokenizer.tokens.2.token: Buzz }
+    - match:     { detail.tokenfilters.0.name: lowercase }
+    - match:     { detail.tokenfilters.0.tokens.0.token: foo }
+    - match:     { detail.tokenfilters.0.tokens.1.token: bar }
+    - match:     { detail.tokenfilters.0.tokens.2.token: buzz }
+    - match:     { detail.tokenfilters.1.name: "_anonymous_tokenfilter_[1]" }
+    - match:     { detail.tokenfilters.1.tokens.0.token: bar }
+---
+"Custom char_filter in request":
+    - do:
+        indices.analyze:
+          body: { "text": "jeff quit phish", "char_filter": [{"type": "mapping", "mappings": ["ph => f", "qu => q"]}], "tokenizer": keyword }
+    - length: {tokens: 1 }
+    - match:     { tokens.0.token: "jeff qit fish" }
+
+---
+"Custom tokenizer in request":
+    - do:
+        indices.analyze:
+          body: { "text": "good", "tokenizer": {"type": "nGram", "min_gram": 2, "max_gram": 2}, "explain": true }
+    - length: {detail.tokenizer.tokens: 3 }
+    - match:     { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:     { detail.tokenizer.tokens.0.token: go }
+    - match:     { detail.tokenizer.tokens.1.token: oo }
+    - match:     { detail.tokenizer.tokens.2.token: od }


### PR DESCRIPTION
Add parser for custom char_filters/tokenizer/token_filters in analyze API request.

You don't need to create temporary index to analyze a text with new char_filter/tokenizer/token_filter settings.
Example: 

```
curl -XGET 'localhost:9200/_analyze' -d '
{
  "tokenizer" : "whitespace",
  "filters" : ["lowercase", {"type": "stop", "stopwords": ["a", "is", "this"]}],
  "text" : "this is a test"
}'
```

Closed #8878
