### PR TITLE
Speed improvements for BalancedShardsAllocator

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -260,14 +260,6 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         }
 
         /**
-         * Returns the global average of primaries per node
-         */
-        public float avgPrimariesPerNode() {
-            return ((float) metaData.numberOfShards()) / nodes.size();
-        }
-
-
-        /**
          * Returns a new {@link NodeSorter} that sorts the nodes based on their
          * current weight with respect to the index passed to the sorter. The
          * returned sorter is not sorted. Use {@link NodeSorter#reset(String)}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -228,6 +228,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
 
         private final float threshold;
         private final MetaData metaData;
+        private final float avgShardsPerNode;
 
         private final Predicate<ShardRouting> assignedFilter = shard -> shard.assignedToNode();
 
@@ -241,6 +242,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                 nodes.put(node.nodeId(), new ModelNode(node.nodeId()));
             }
             metaData = routingNodes.metaData();
+            avgShardsPerNode = ((float) metaData.totalNumberOfShards()) / nodes.size();
         }
 
         /**
@@ -261,7 +263,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
          * Returns the global average of shards per node
          */
         public float avgShardsPerNode() {
-            return ((float) metaData.totalNumberOfShards()) / nodes.size();
+            return avgShardsPerNode;
         }
 
         /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -892,7 +892,6 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
     static final class ModelIndex {
         private final String id;
         private final Map<ShardRouting, Decision> shards = new HashMap<>();
-        private int numPrimaries = -1;
         private int highestPrimary = -1;
 
         public ModelIndex(String id) {
@@ -924,26 +923,13 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
             return shards.keySet();
         }
 
-        public int numPrimaries() {
-            if (numPrimaries == -1) {
-                int num = 0;
-                for (ShardRouting shard : shards.keySet()) {
-                    if (shard.primary()) {
-                        num++;
-                    }
-                }
-                return numPrimaries = num;
-            }
-            return numPrimaries;
-        }
-
         public Decision removeShard(ShardRouting shard) {
-            highestPrimary = numPrimaries = -1;
+            highestPrimary = -1;
             return shards.remove(shard);
         }
 
         public void addShard(ShardRouting shard, Decision decision) {
-            highestPrimary = numPrimaries = -1;
+            highestPrimary = -1;
             assert decision != null;
             assert !shards.containsKey(shard) : "Shard already allocated on current node: " + shards.get(shard) + " " + shard;
             shards.put(shard, decision);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -332,7 +332,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
             if (onlyAssign == false && changed == false && allocation.deciders().canRebalance(allocation).type() == Type.YES) {
                 NodeSorter sorter = newNodeSorter();
                 if (nodes.size() > 1) { /* skip if we only have one node */
-                    for (String index : buildWeightOrderedIndidces(sorter)) {
+                    for (String index : buildWeightOrderedIndices(sorter)) {
                         sorter.reset(index);
                         final float[] weights = sorter.weights;
                         final ModelNode[] modelNodes = sorter.modelNodes;
@@ -423,7 +423,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
          * average. To re-balance we need to move shards back eventually likely
          * to the nodes we relocated them from.
          */
-        private String[] buildWeightOrderedIndidces(NodeSorter sorter) {
+        private String[] buildWeightOrderedIndices(NodeSorter sorter) {
             final String[] indices = this.indices.toArray(new String[this.indices.size()]);
             final float[] deltas = new float[indices.length];
             for (int i = 0; i < deltas.length; i++) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -856,14 +856,6 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
             return index == null ? 0 : index.numShards();
         }
 
-        public Collection<ShardRouting> shards() {
-            Collection<ShardRouting> result = new ArrayList<>();
-            for (ModelIndex index : indices.values()) {
-                result.addAll(index.getAllShards());
-            }
-            return result;
-        }
-
         public int highestPrimary(String index) {
             ModelIndex idx = indices.get(index);
             if (idx != null) {
@@ -939,10 +931,6 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
 
         public String getIndexId() {
             return id;
-        }
-
-        public Decision getDecicion(ShardRouting shard) {
-            return shards.get(shard);
         }
 
         public int numShards() {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -173,7 +173,8 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
 
         private final float indexBalance;
         private final float shardBalance;
-        private final float[] theta;
+        private final float theta0;
+        private final float theta1;
 
 
         public WeightFunction(float indexBalance, float shardBalance) {
@@ -181,7 +182,8 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
             if (sum <= 0.0f) {
                 throw new IllegalArgumentException("Balance factors must sum to a value > 0 but was: " + sum);
             }
-            theta = new float[]{shardBalance / sum, indexBalance / sum};
+            theta0 = shardBalance / sum;
+            theta1 = indexBalance / sum;
             this.indexBalance = indexBalance;
             this.shardBalance = shardBalance;
         }
@@ -189,8 +191,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         public float weight(Operation operation, Balancer balancer, ModelNode node, String index) {
             final float weightShard = (node.numShards() - balancer.avgShardsPerNode());
             final float weightIndex = (node.numShards(index) - balancer.avgShardsPerNode(index));
-            assert theta != null;
-            return theta[0] * weightShard + theta[1] * weightIndex;
+            return theta0 * weightShard + theta1 * weightIndex;
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -70,6 +71,14 @@ public abstract class AllocationDecider extends AbstractComponent {
      * {@link RoutingAllocation}. The default is {@link Decision#ALWAYS}.
      */
     public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    /**
+     * Returns a {@link Decision} whether the given shard routing can be allocated at all at this state of the
+     * {@link RoutingAllocation}. The default is {@link Decision#ALWAYS}.
+     */
+    public Decision canAllocate(IndexMetaData indexMetaData, RoutingNode node, RoutingAllocation allocation) {
         return Decision.ALWAYS;
     }
 


### PR DESCRIPTION
This PR contains some speed improvements for `BalancedShardsAllocator` (relates to #6372):
- Removal of the pattern `node.addShard() -> calculate weight -> node.removeShard()` which is expensive as, beside map lookups, it invalidates caching of precomputed values in `ModelNode` and `ModelIndex`. Replaced by adding an additional parameter to the weight function which accounts for the added / removed shard.
- For rebalancing an index, only consider nodes that currently have a shard of that index or where the index can be allocated. This allows to prune a large number of nodes in case of hot/warm setup. Implemented by adding allocation decider rule based on `IndexMetaData`.
- Removed some dead code
- Some caching (avoid reresolving values in map all the time) / simplification of code

I made smaller commits for each improvement to simplify the review process.
