### PR TITLE
check if tmpfile exists before delete it

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -231,7 +231,10 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             }
             if (tempFileRenamed == false) {
                 try {
-                    Files.delete(tempFile);
+                    if (Files.exists(tempFile)) {
+                        Files.delete(tempFile);
+                    }
+                    
                 } catch (IOException ex) {
                     logger.warn("failed to delete temp file {}", ex, tempFile);
                 }


### PR DESCRIPTION
I think it's better to check if a tmpfile exista before we delete it
