### PR TITLE
Add test that cluster state update tasks are executed in order

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/ClusterServiceIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterServiceIT.java
@@ -806,13 +806,13 @@ public class ClusterServiceIT extends ESIntegTestCase {
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
 
         class TaskExecutor implements ClusterStateTaskExecutor<Integer> {
-            int tracking = -1;
+            int tracking = 0;
 
             @Override
             public BatchResult<Integer> execute(ClusterState currentState, List<Integer> tasks) throws Exception {
                 for (Integer task : tasks) {
                     try {
-                        assertEquals("task was executed out of order", tracking + 1, (int)task);
+                        assertEquals("task was executed out of order", tracking, (int)task);
                         tracking++;
                     } catch (AssertionError e) {
                         return BatchResult.<Integer>builder().failures(tasks, e).build(currentState);
@@ -886,7 +886,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         assertFalse(failure.get());
 
         for (int i = 0; i < numberOfThreads; i++) {
-            assertEquals(tasksSubmittedPerThread - 1, executors[i].tracking);
+            assertEquals(tasksSubmittedPerThread, executors[i].tracking);
         }
     }
 


### PR DESCRIPTION
This commit adds a test that ensures that cluster state update tasks
are executed in order from the perspective of a single thread.

Closes #15483 
