### PR TITLE
Ordering term aggregation based on scripted metric.

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -127,7 +127,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
         public Aggregator createInternal(AggregationContext context, Aggregator parent, boolean collectsFromSingleBucket,
                 List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
             if (collectsFromSingleBucket == false) {
-                return asMultiBucketAggregator(this, context, parent);
+                return asMultiBucketAggregator(this, context, parent, reduceScript);
             }
             Map<String, Object> params = this.params;
             if (params != null) {


### PR DESCRIPTION
Hi,

Scripted metrics have been introduced to compute complex computations based on a map/reduce approach. Unfortunately the usage of scripted metrics is limited because they can't be used in the 'order' clause of an aggregation. See this discussion for a full description of the issue. 

https://discuss.elastic.co/t/ordering-terms-aggregation-based-on-pipeline-metric/31839

This pull-request is an attempt to fix this issue for scripted metrics returning a number as the result of their reduce method (probably more than 90% of use cases).

That's my first contribution to ES, so there is probably room for improvements and even may be mistakes here and there. Don't hesitate to guide me in the right direction in order to make this pull request a success.

Thanks

Laurent 
