### PR TITLE
DOC - field name is changed

### DIFF
--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -137,7 +137,7 @@ GET my_index/my_type/_search
 {
   "query": {
     "term": {
-      "exact_value": "foxes" <3>
+      "full_text": "foxes" <3>
     }
   }
 }


### PR DESCRIPTION
`exact_value` is changed to `full_text` at the second (3) example.
