### PR TITLE
Allow `_gce_` network when not using discovery gce

### DIFF
--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceComputeService.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceComputeService.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cloud.gce;
 import com.google.api.services.compute.model.Instance;
 import org.elasticsearch.common.component.LifecycleComponent;
 
-import java.io.IOException;
 import java.util.Collection;
 
 /**

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceComputeServiceImpl.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceComputeServiceImpl.java
@@ -21,9 +21,6 @@ package org.elasticsearch.cloud.gce;
 
 import com.google.api.client.googleapis.compute.ComputeCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
@@ -32,31 +29,26 @@ import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.InstanceList;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.cloud.gce.network.GceNameResolver;
+import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.discovery.gce.RetryHttpInitializerWrapper;
 
 import java.io.IOException;
-import java.net.URL;
 import java.security.AccessController;
 import java.security.GeneralSecurityException;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.common.util.CollectionUtils.eagerTransform;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.util.*;
 
 /**
  *

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceMetadataService.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceMetadataService.java
@@ -19,30 +19,27 @@
 
 package org.elasticsearch.cloud.gce;
 
-import com.google.api.services.compute.model.Instance;
 import org.elasticsearch.common.component.LifecycleComponent;
 
 import java.io.IOException;
-import java.util.Collection;
 
 /**
- *
+ * Access Google Compute Engine metadata
  */
-public interface GceComputeService extends LifecycleComponent<GceComputeService> {
-    final class Fields {
-        public static final String PROJECT = "cloud.gce.project_id";
-        public static final String ZONE = "cloud.gce.zone";
-        public static final String REFRESH = "cloud.gce.refresh_interval";
-        public static final String TAGS = "discovery.gce.tags";
-        public static final String VERSION = "Elasticsearch/GceCloud/1.0";
-
-        public static final String RETRY = "cloud.gce.retry";
-        public static final String MAXWAIT = "cloud.gce.max_wait";
-    }
+public interface GceMetadataService extends LifecycleComponent<GceMetadataService> {
 
     /**
-     * Return a collection of running instances within the same GCE project
-     * @return a collection of running instances within the same GCE project
+     * <p>Gets metadata on the current running machine (call to
+     * http://metadata.google.internal/computeMetadata/v1/instance/xxx).</p>
+     * <p>For example, you can retrieve network information by replacing xxx with:</p>
+     * <ul>
+     *     <li>`hostname` when we need to resolve the host name</li>
+     *     <li>`network-interfaces/0/ip` when we need to resolve private IP</li>
+     * </ul>
+     * @see org.elasticsearch.cloud.gce.network.GceNameResolver for bindings
+     * @param metadataPath path to metadata information
+     * @return extracted information (for example a hostname or an IP address)
+     * @throws IOException in case metadata URL is not accessible
      */
-    Collection<Instance> instances();
+    String metadata(String metadataPath) throws IOException;
 }

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceMetadataServiceImpl.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceMetadataServiceImpl.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.gce;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpTransport;
+import org.elasticsearch.cloud.gce.network.GceNameResolver;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.IOException;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.GeneralSecurityException;
+import java.security.PrivilegedExceptionAction;
+
+public class GceMetadataServiceImpl extends AbstractLifecycleComponent<GceMetadataService>
+    implements GceMetadataService {
+
+    // Forcing Google Token API URL as set in GCE SDK to
+    //      http://metadata/computeMetadata/v1/instance/service-accounts/default/token
+    // See https://developers.google.com/compute/docs/metadata#metadataserver
+    public static final String GCE_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/instance";
+    public static final String TOKEN_SERVER_ENCODED_URL = GCE_METADATA_URL + "/service-accounts/default/token";
+
+    /** Global instance of the HTTP transport. */
+    private HttpTransport gceHttpTransport;
+
+    @Inject
+    public GceMetadataServiceImpl(Settings settings, NetworkService networkService) {
+        super(settings);
+        networkService.addCustomNameResolver(new GceNameResolver(settings, this));
+    }
+
+    protected synchronized HttpTransport getGceHttpTransport() throws GeneralSecurityException, IOException {
+        if (gceHttpTransport == null) {
+            gceHttpTransport = GoogleNetHttpTransport.newTrustedTransport();
+        }
+        return gceHttpTransport;
+    }
+
+    @Override
+    public String metadata(String metadataPath) throws IOException {
+        String urlMetadataNetwork = GCE_METADATA_URL + "/" + metadataPath;
+        logger.debug("get metadata from [{}]", urlMetadataNetwork);
+        URL url = new URL(urlMetadataNetwork);
+        HttpHeaders headers;
+        try {
+            // hack around code messiness in GCE code
+            // TODO: get this fixed
+            headers = AccessController.doPrivileged(new PrivilegedExceptionAction<HttpHeaders>() {
+                @Override
+                public HttpHeaders run() throws IOException {
+                    return new HttpHeaders();
+                }
+            });
+
+            // This is needed to query meta data: https://cloud.google.com/compute/docs/metadata
+            headers.put("Metadata-Flavor", "Google");
+            HttpResponse response;
+            response = getGceHttpTransport().createRequestFactory()
+                .buildGetRequest(new GenericUrl(url))
+                .setHeaders(headers)
+                .execute();
+            String metadata = response.parseAsString();
+            logger.debug("metadata found [{}]", metadata);
+            return metadata;
+        } catch (Exception e) {
+            throw new IOException("failed to fetch metadata from [" + urlMetadataNetwork + "]", e);
+        }
+    }
+
+
+    @Override
+    protected void doStart() {
+
+    }
+
+    @Override
+    protected void doStop() {
+        if (gceHttpTransport != null) {
+            try {
+                gceHttpTransport.shutdown();
+            } catch (IOException e) {
+                logger.warn("unable to shutdown GCE Http Transport", e);
+            }
+            gceHttpTransport = null;
+        }
+    }
+
+    @Override
+    protected void doClose() {
+
+    }
+}

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceModule.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceModule.java
@@ -21,18 +21,37 @@ package org.elasticsearch.cloud.gce;
 
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+
+import static org.elasticsearch.plugin.cloud.gce.CloudGcePlugin.isDiscoveryAlive;
 
 public class GceModule extends AbstractModule {
     // pkg private so tests can override with mock
     static Class<? extends GceComputeService> computeServiceImpl = GceComputeServiceImpl.class;
+    static Class<? extends GceMetadataService> metadataServiceImpl = GceMetadataServiceImpl.class;
+
+    protected final Settings settings;
+    protected final ESLogger logger = Loggers.getLogger(GceModule.class);
+
+    public GceModule(Settings settings) {
+        this.settings = settings;
+    }
 
     public static Class<? extends GceComputeService> getComputeServiceImpl() {
         return computeServiceImpl;
     }
 
+    public static Class<? extends GceMetadataService> getMetadataServiceImpl() {
+        return metadataServiceImpl;
+    }
+
     @Override
     protected void configure() {
-        bind(GceComputeService.class).to(computeServiceImpl).asEagerSingleton();
+        if (isDiscoveryAlive(settings, logger)) {
+            bind(GceComputeService.class).to(computeServiceImpl).asEagerSingleton();
+        }
+        bind(GceMetadataService.class).to(metadataServiceImpl).asEagerSingleton();
     }
 }

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceModule.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/GceModule.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.cloud.gce;
 
 import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/network/GceNameResolver.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/network/GceNameResolver.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cloud.gce.network;
 
 import org.elasticsearch.cloud.gce.GceComputeService;
+import org.elasticsearch.cloud.gce.GceMetadataService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.network.NetworkService.CustomNameResolver;
@@ -40,7 +41,7 @@ import java.net.InetAddress;
  */
 public class GceNameResolver extends AbstractComponent implements CustomNameResolver {
 
-    private final GceComputeService gceComputeService;
+    private final GceMetadataService gceMetadataService;
 
     /**
      * enum that can be added to over time with more meta-data types
@@ -72,9 +73,9 @@ public class GceNameResolver extends AbstractComponent implements CustomNameReso
     /**
      * Construct a {@link CustomNameResolver}.
      */
-    public GceNameResolver(Settings settings, GceComputeService gceComputeService) {
+    public GceNameResolver(Settings settings, GceMetadataService gceMetadataService) {
         super(settings);
-        this.gceComputeService = gceComputeService;
+        this.gceMetadataService = gceMetadataService;
     }
 
     /**
@@ -105,7 +106,7 @@ public class GceNameResolver extends AbstractComponent implements CustomNameReso
         }
 
         try {
-            String metadataResult = gceComputeService.metadata(gceMetadataPath);
+            String metadataResult = gceMetadataService.metadata(gceMetadataPath);
             if (metadataResult == null || metadataResult.length() == 0) {
                 throw new IOException("no gce metadata returned from [" + gceMetadataPath + "] for [" + value + "]");
             }

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/network/GceNameResolver.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/cloud/gce/network/GceNameResolver.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cloud.gce.network;
 
-import org.elasticsearch.cloud.gce.GceComputeService;
 import org.elasticsearch.cloud.gce.GceMetadataService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractComponent;

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
@@ -22,7 +22,6 @@ package org.elasticsearch.discovery.gce;
 import com.google.api.services.compute.model.AccessConfig;
 import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.NetworkInterface;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.cloud.gce.GceComputeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/plugin/cloud/gce/CloudGcePlugin.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/plugin/cloud/gce/CloudGcePlugin.java
@@ -21,7 +21,6 @@ package org.elasticsearch.plugin.cloud.gce;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.util.ClassInfo;
-
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.cloud.gce.GceComputeService;
 import org.elasticsearch.cloud.gce.GceModule;

--- a/plugins/cloud-gce/src/main/java/org/elasticsearch/plugin/cloud/gce/CloudGcePlugin.java
+++ b/plugins/cloud-gce/src/main/java/org/elasticsearch/plugin/cloud/gce/CloudGcePlugin.java
@@ -88,9 +88,7 @@ public class CloudGcePlugin extends Plugin {
     @Override
     public Collection<Module> nodeModules() {
         List<Module> modules = new ArrayList<>();
-        if (isDiscoveryAlive(settings, logger)) {
-            modules.add(new GceModule());
-        }
+        modules.add(new GceModule(settings));
         return modules;
     }
 
@@ -100,6 +98,7 @@ public class CloudGcePlugin extends Plugin {
         if (isDiscoveryAlive(settings, logger)) {
             services.add(GceModule.getComputeServiceImpl());
         }
+        services.add(GceModule.getMetadataServiceImpl());
         return services;
     }
 
@@ -122,9 +121,9 @@ public class CloudGcePlugin extends Plugin {
             return false;
         }
 
-        if (checkProperty(GceComputeService.Fields.PROJECT, settings.get(GceComputeService.Fields.PROJECT), logger) == false ||
-                checkProperty(GceComputeService.Fields.ZONE, settings.getAsArray(GceComputeService.Fields.ZONE), logger) == false) {
-            logger.debug("one or more gce discovery settings are missing. " +
+        if (checkProperty(settings.get(GceComputeService.Fields.PROJECT)) == false ||
+                checkProperty(settings.getAsArray(GceComputeService.Fields.ZONE)) == false) {
+            logger.warn("one or more gce discovery settings are missing. " +
                             "Check elasticsearch.yml file. Should have [{}] and [{}].",
                     GceComputeService.Fields.PROJECT,
                     GceComputeService.Fields.ZONE);
@@ -136,20 +135,12 @@ public class CloudGcePlugin extends Plugin {
         return true;
     }
 
-    private static boolean checkProperty(String name, String value, ESLogger logger) {
-        if (!Strings.hasText(value)) {
-            logger.warn("{} is not set.", name);
-            return false;
-        }
-        return true;
+    private static boolean checkProperty(String value) {
+        return Strings.hasText(value);
     }
 
-    private static boolean checkProperty(String name, String[] values, ESLogger logger) {
-        if (values == null || values.length == 0) {
-            logger.warn("{} is not set.", name);
-            return false;
-        }
-        return true;
+    private static boolean checkProperty(String[] values) {
+        return !(values == null || values.length == 0);
     }
 
 }

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceComputeServiceMock.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceComputeServiceMock.java
@@ -20,23 +20,10 @@
 package org.elasticsearch.discovery.gce;
 
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.LowLevelHttpRequest;
-import com.google.api.client.http.LowLevelHttpResponse;
-import com.google.api.client.json.Json;
-import com.google.api.client.testing.http.MockHttpTransport;
-import com.google.api.client.testing.http.MockLowLevelHttpRequest;
-import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import org.elasticsearch.cloud.gce.GceComputeServiceImpl;
-import org.elasticsearch.cloud.gce.GceMetadataServiceImpl;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.Callback;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.security.GeneralSecurityException;
 
 /**

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoverySettingsTests.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoverySettingsTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.discovery.gce;
 
-import org.elasticsearch.cloud.gce.GceModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugin.cloud.gce.CloudGcePlugin;
 import org.elasticsearch.test.ESTestCase;

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoveryTests.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoveryTests.java
@@ -119,7 +119,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.PROJECT, projectName)
                 .put(GceComputeService.Fields.ZONE, "europe-west1-b")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(2));
     }
@@ -131,7 +131,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.ZONE, "europe-west1-b")
                 .putArray(GceComputeService.Fields.TAGS, "elasticsearch")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(1));
         assertThat(discoveryNodes.get(0).getId(), is("#cloud-test2-0"));
@@ -144,7 +144,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.ZONE, "europe-west1-b")
                 .putArray(GceComputeService.Fields.TAGS, "elasticsearch", "dev")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(1));
         assertThat(discoveryNodes.get(0).getId(), is("#cloud-test2-0"));
@@ -156,7 +156,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.PROJECT, projectName)
                 .put(GceComputeService.Fields.ZONE, "europe-west1-b")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(2));
     }
@@ -168,7 +168,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.ZONE, "europe-west1-b")
                 .putArray(GceComputeService.Fields.TAGS, "elasticsearch")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(2));
     }
@@ -180,7 +180,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.ZONE, "europe-west1-b")
                 .putArray(GceComputeService.Fields.TAGS, "elasticsearch", "dev")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(2));
     }
@@ -191,7 +191,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.PROJECT, projectName)
                 .putArray(GceComputeService.Fields.ZONE, "us-central1-a", "europe-west1-b")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(2));
     }
@@ -202,7 +202,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.PROJECT, projectName)
                 .putArray(GceComputeService.Fields.ZONE, "us-central1-a", "europe-west1-b")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(2));
     }
@@ -216,7 +216,7 @@ public class GceDiscoveryTests extends ESTestCase {
                 .put(GceComputeService.Fields.PROJECT, projectName)
                 .putArray(GceComputeService.Fields.ZONE, "us-central1-a", "us-central1-b")
                 .build();
-        mock = new GceComputeServiceMock(nodeSettings, networkService);
+        mock = new GceComputeServiceMock(nodeSettings);
         List<DiscoveryNode> discoveryNodes = buildDynamicNodes(mock, nodeSettings);
         assertThat(discoveryNodes, hasSize(0));
     }

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceMetadataServiceMock.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceMetadataServiceMock.java
@@ -20,23 +20,11 @@
 package org.elasticsearch.discovery.gce;
 
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.LowLevelHttpRequest;
-import com.google.api.client.http.LowLevelHttpResponse;
-import com.google.api.client.json.Json;
-import com.google.api.client.testing.http.MockHttpTransport;
-import com.google.api.client.testing.http.MockLowLevelHttpRequest;
-import com.google.api.client.testing.http.MockLowLevelHttpResponse;
-import org.elasticsearch.cloud.gce.GceComputeServiceImpl;
 import org.elasticsearch.cloud.gce.GceMetadataServiceImpl;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.Callback;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.security.GeneralSecurityException;
 
 /**

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceMetadataServiceMock.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceMetadataServiceMock.java
@@ -40,14 +40,14 @@ import java.net.URL;
 import java.security.GeneralSecurityException;
 
 /**
- *
+ * Mock for GCE Metadata Service
  */
-public class GceComputeServiceMock extends GceComputeServiceImpl {
+public class GceMetadataServiceMock extends GceMetadataServiceImpl {
 
     protected HttpTransport mockHttpTransport;
 
-    public GceComputeServiceMock(Settings settings) {
-        super(settings);
+    public GceMetadataServiceMock(Settings settings, NetworkService networkService) {
+        super(settings, networkService);
         this.mockHttpTransport = GceMockUtils.configureMock();
     }
 

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceMockUtils.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceMockUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.gce;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.Json;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import org.elasticsearch.cloud.gce.GceMetadataServiceImpl;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.util.Callback;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class GceMockUtils {
+    protected final static ESLogger logger = Loggers.getLogger(GceMockUtils.class);
+
+    protected static HttpTransport configureMock() {
+        return new MockHttpTransport() {
+            @Override
+            public LowLevelHttpRequest buildRequest(String method, final String url) throws IOException {
+                return new MockLowLevelHttpRequest() {
+                    @Override
+                    public LowLevelHttpResponse execute() throws IOException {
+                        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+                        response.setStatusCode(200);
+                        response.setContentType(Json.MEDIA_TYPE);
+                        if (url.startsWith(GceMetadataServiceImpl.GCE_METADATA_URL)) {
+                            logger.info("--> Simulate GCE Auth/Metadata response for [{}]", url);
+                            response.setContent(GceMockUtils.readGoogleInternalJsonResponse(url));
+                        } else {
+                            logger.info("--> Simulate GCE API response for [{}]", url);
+                            response.setContent(GceMockUtils.readGoogleApiJsonResponse(url));
+                        }
+
+                        return response;
+                    }
+                };
+            }
+        };
+    }
+
+    public static String readGoogleInternalJsonResponse(String url) throws IOException {
+        return readJsonResponse(url, "http://metadata.google.internal/");
+    }
+
+    public static String readGoogleApiJsonResponse(String url) throws IOException {
+        return readJsonResponse(url, "https://www.googleapis.com/");
+    }
+
+    public static String readJsonResponse(String url, String urlRoot) throws IOException {
+        // We extract from the url the mock file path we want to use
+        String mockFileName = Strings.replace(url, urlRoot, "");
+
+        logger.debug("--> read mock file from [{}]", mockFileName);
+        URL resource = GceMockUtils.class.getResource(mockFileName);
+        if (resource == null) {
+            throw new IOException("can't read [" + url + "] in src/test/resources/org/elasticsearch/discovery/gce");
+        }
+        try (InputStream is = resource.openStream()) {
+            final StringBuilder sb = new StringBuilder();
+            Streams.readAllLines(is, new Callback<String>() {
+                @Override
+                public void handle(String s) {
+                    sb.append(s);
+                }
+            });
+            String response = sb.toString();
+            logger.trace("{}", response);
+            return response;
+        }
+    }
+}

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceNetworkTests.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceNetworkTests.java
@@ -111,7 +111,7 @@ public class GceNetworkTests extends ESTestCase {
                 .build();
 
         NetworkService networkService = new NetworkService(nodeSettings);
-        GceComputeServiceMock mock = new GceComputeServiceMock(nodeSettings, networkService);
+        GceMetadataServiceMock mock = new GceMetadataServiceMock(nodeSettings, networkService);
         networkService.addCustomNameResolver(new GceNameResolver(nodeSettings, mock));
         try {
             InetAddress[] addresses = networkService.resolveBindHostAddresses(null);

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/RetryHttpInitializerWrapperTests.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/RetryHttpInitializerWrapperTests.java
@@ -34,7 +34,6 @@ import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.client.testing.util.MockSleeper;
 import com.google.api.services.compute.Compute;
-
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;


### PR DESCRIPTION
For now we support `_gce_` only if discovery is set to `gce` and all information about GCE is provided (project_id and zone).
But in some cases, people would like to only bind to `_gce_` on a single node (without any elasticsearch cluster).

They could access the machine then from other machines running inside the same project.

This commit adds a new GceMetadataService which is started as soon as the plugin is started so GceNameResolver can use it to resolve `_gce`.

Closes #15724.
