### PR TITLE
Faster terms filter when cached

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -481,11 +481,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
             // bit set
             return termFilter(values.get(0), context);
         default:
-            BytesRef[] bytesRefs = new BytesRef[values.size()];
-            for (int i = 0; i < bytesRefs.length; i++) {
-                bytesRefs[i] = indexedValueForSearch(values.get(i));
-            }
-            return new DeferredTermsFilter(names.indexName(), bytesRefs);
+            return new DeferredTermsFilter(names.indexName(), values, this);
             
         }
     }

--- a/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/core/AbstractFieldMapper.java
@@ -31,7 +31,6 @@ import org.apache.lucene.index.FieldInfo.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.queries.TermFilter;
-import org.apache.lucene.queries.TermsFilter;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
@@ -58,6 +57,7 @@ import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.mapper.internal.AllFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.search.DeferredTermsFilter;
 import org.elasticsearch.index.search.FieldDataTermsFilter;
 import org.elasticsearch.index.similarity.SimilarityLookupService;
 import org.elasticsearch.index.similarity.SimilarityProvider;
@@ -485,7 +485,7 @@ public abstract class AbstractFieldMapper<T> implements FieldMapper<T> {
             for (int i = 0; i < bytesRefs.length; i++) {
                 bytesRefs[i] = indexedValueForSearch(values.get(i));
             }
-            return new TermsFilter(names.indexName(), bytesRefs);
+            return new DeferredTermsFilter(names.indexName(), bytesRefs);
             
         }
     }

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -188,9 +188,12 @@ public class TermsFilterParser implements FilterParser {
 
             // external lookup, use it
             TermsLookup termsLookup = new TermsLookup(lookupIndex, lookupType, lookupId, lookupRouting, lookupPath, parseContext, SearchContext.current());
+            // We always pass null as the cacheKey here:  Using the cache key for the overall filter generally leads
+            // to redundant lookup caching:  The overall filter needs to be keyed off the field being filtered +
+            // the lookup options.  Whereas the lookup only needs to be keyed off the lookup options.
             // Note that we avoid a copy here and just assign to the looked-up terms.  This is safe so long as
             // terms is never modified.
-            terms = termsFilterCache.terms(termsLookup, lookupCache, cacheKey);
+            terms = termsFilterCache.terms(termsLookup, lookupCache, null);
         }
 
         if (terms.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
+++ b/src/main/java/org/elasticsearch/index/query/TermsFilterParser.java
@@ -188,7 +188,9 @@ public class TermsFilterParser implements FilterParser {
 
             // external lookup, use it
             TermsLookup termsLookup = new TermsLookup(lookupIndex, lookupType, lookupId, lookupRouting, lookupPath, parseContext, SearchContext.current());
-            terms.addAll(termsFilterCache.terms(termsLookup, lookupCache, cacheKey));
+            // Note that we avoid a copy here and just assign to the looked-up terms.  This is safe so long as
+            // terms is never modified.
+            terms = termsFilterCache.terms(termsLookup, lookupCache, cacheKey);
         }
 
         if (terms.isEmpty()) {

--- a/src/main/java/org/elasticsearch/index/search/DeferredTermsFilter.java
+++ b/src/main/java/org/elasticsearch/index/search/DeferredTermsFilter.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.search;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.queries.TermsFilter;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+
+/**
+ * Avoid the expense of the TermsFilter constructor unless absolutely necessary.
+ *
+ * It turns out that the TermsFilter constructor is pretty expensive.  (See the source.)
+ * Much of the time, the TermsFilter is not useful since we use the cached bitset anyway,
+ * so defer instantiating the TermsFilter until needed.
+ */
+public class DeferredTermsFilter extends Filter {
+    private final String field;
+    private final BytesRef[] bytesRefs;
+
+    // TODO: consider setting this to null to allow GC if we end up using the cached (through a public method)
+    private TermsFilter filter;
+
+    public DeferredTermsFilter(String field, BytesRef[] bytesRefs) {
+        this.field = field;
+        this.bytesRefs = bytesRefs;
+    }
+
+    private synchronized void ensureFilter() {
+        if (this.filter == null) {
+            this.filter = new TermsFilter(field, bytesRefs);
+        }
+    }
+
+    @Override
+    public DocIdSet getDocIdSet(AtomicReaderContext atomicReaderContext, Bits bits) throws IOException {
+        ensureFilter();
+        return this.filter.getDocIdSet(atomicReaderContext, bits);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof DeferredTermsFilter)) return false;
+        ensureFilter();
+        return this.filter.equals(((DeferredTermsFilter) obj).filter);
+    }
+
+    @Override
+    public int hashCode() {
+        ensureFilter();
+        return this.filter.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        ensureFilter();
+        return this.filter.toString();
+    }
+}


### PR DESCRIPTION
Our ES queries using terms lookups with many security labels are slow.  In theory query performance (with a cached filter) shouldn't vary with the number of looked-up terms, especially since in our tests we fill the terms with bogus terms that don't match any documents.  (So the resulting bitset should be identical to the one generated from the original terms list.)

The slowdown results from incidental / accidental bits in the code.  The parsing code implements the terms lookup.  It basically works as follows:
(1) Fetch the terms by lookup or from cache.
(2) Instantiate the TermsFilter.
(3) Fetch the cached filter (if cached, otherwise use the filter from step (2)).

(The query execution code is not an issue.)

In theory steps (1) and (3) should be instantaneous when cached, which turns out to be true for (3) and mostly true for (1).  Of course, step (2) is totally redundant when step (3) is cached.

Is step (2) fast?  It turns out not.  The TermsFilter constructor turns out to be horribly slow when the terms array is large.  It copies the array, sorts it, and iterates over it.  There are some other copies that happen outside the constructor, etc.  So as mentioned we can eliminate step (2) entirely.  Or really, defer it until step (3) gets a cache miss.

Eliminating step (2) fixes 90% of the problem (makes the query say 5 - 10x faster).  Then it turns out there's another copy in step (1) that we can also eliminate, which makes the query another 5 - 10x faster.  I'll re-run some numbers locally but if I recall correctly I had a 13-second query with 200k lookups down to under 100 ms.

Two other related items:
- The terms lookup cache needs to be bigger say 4 gb.  There's another big slowdown without that.
- The developer can specify a cache key to the terms filter (to any filter actually).  The terms lookups are cached using the same key.  This leads to redundant caching of the lookups because the lookups should be keyed by the lookup parameters (lookup table, type, id, and field).  But the terms filter itself should generally be keyed by the field being filtered on + the lookup parameters.  If you are filtering against 50 different fields using the same lookup, as we do, then you end up with 50 copies of the lookup in the lookup cache.  We should use the default lookup cache key (which is just the lookup options) instead, allowing the lookup cache to cache 50x more lookups.  That's also in this PR.
