### PR TITLE
Refactor master node change predicate for reuse

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/MasterNodeChangePredicate.java
+++ b/core/src/main/java/org/elasticsearch/cluster/MasterNodeChangePredicate.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster;
+
+public enum MasterNodeChangePredicate implements ClusterStateObserver.ChangePredicate {
+    INSTANCE;
+
+    @Override
+    public boolean apply(
+        ClusterState previousState,
+        ClusterState.ClusterStateStatus previousStatus,
+        ClusterState newState,
+        ClusterState.ClusterStateStatus newStatus) {
+        // checking if the masterNodeId changed is insufficient as the
+        // same master node might get re-elected after a disruption
+        return newState.nodes().masterNodeId() != null && newState != previousState;
+    }
+
+    @Override
+    public boolean apply(ClusterChangedEvent changedEvent) {
+        return changedEvent.nodesDelta().masterNodeChanged();
+    }
+}


### PR DESCRIPTION
This commit migrates a ClusterStateObserver.ChangePredicate for
detecting a master node change into a separate class for reuse
elsewhere.
