### PR TITLE
make index type and id optional in simulate api

### DIFF
--- a/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulatePipelineRequest.java
+++ b/plugins/ingest/src/main/java/org/elasticsearch/plugin/ingest/transport/simulate/SimulatePipelineRequest.java
@@ -147,9 +147,9 @@ public class SimulatePipelineRequest extends ActionRequest {
         List<IngestDocument> ingestDocumentList = new ArrayList<>();
         for (Map<String, Object> dataMap : docs) {
             Map<String, Object> document = ConfigurationUtils.readMap(dataMap, Fields.SOURCE);
-            IngestDocument ingestDocument = new IngestDocument(ConfigurationUtils.readStringProperty(dataMap, MetaData.INDEX.getFieldName()),
-                    ConfigurationUtils.readStringProperty(dataMap, MetaData.TYPE.getFieldName()),
-                    ConfigurationUtils.readStringProperty(dataMap, MetaData.ID.getFieldName()),
+            IngestDocument ingestDocument = new IngestDocument(ConfigurationUtils.readStringProperty(dataMap, MetaData.INDEX.getFieldName(), "_index"),
+                    ConfigurationUtils.readStringProperty(dataMap, MetaData.TYPE.getFieldName(), "_type"),
+                    ConfigurationUtils.readStringProperty(dataMap, MetaData.ID.getFieldName(), "_id"),
                     ConfigurationUtils.readOptionalStringProperty(dataMap, MetaData.ROUTING.getFieldName()),
                     ConfigurationUtils.readOptionalStringProperty(dataMap, MetaData.PARENT.getFieldName()),
                     ConfigurationUtils.readOptionalStringProperty(dataMap, MetaData.TIMESTAMP.getFieldName()),

--- a/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/70_simulate.yaml
+++ b/plugins/ingest/src/test/resources/rest-api-spec/test/ingest/70_simulate.yaml
@@ -70,6 +70,33 @@
   - length: { docs: 1 }
 
 ---
+"Test simulate without index type and id":
+  - do:
+      ingest.simulate:
+        body: >
+          {
+            "pipeline": {
+              "description": "_description",
+              "processors": [
+                {
+                  "set" : {
+                    "field" : "field2",
+                    "value" : "_value"
+                  }
+                }
+              ]
+            },
+            "docs": [
+              {
+                "_source": {
+                  "foo": "bar"
+                }
+              }
+            ]
+          }
+  - length: { docs: 1 }
+
+---
 "Test simulate with provided pipeline definition with on_failure block":
   - do:
       ingest.simulate:


### PR DESCRIPTION
Default values are _index, _type and _id.

Closes #15711
