### PR TITLE
Wait for new master when failing shard

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -31,6 +31,8 @@ import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
+import org.elasticsearch.cluster.MasterNodeChangePredicate;
+import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -42,6 +44,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
@@ -76,6 +79,7 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -882,14 +886,27 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
                             if (ignoreReplicaException(exp)) {
                                 onReplicaFailure(nodeId, exp);
                             } else {
-                                logger.warn("{} failed to perform {} on node {}", exp, shardId, transportReplicaAction, node);
-                                shardStateAction.shardFailed(clusterService.state(), shard, indexUUID, "failed to perform " + transportReplicaAction + " on replica on node " + node, exp, shardFailedTimeout, new ReplicationFailedShardStateListener(nodeId, exp));
+                                ClusterStateObserver observer = new ClusterStateObserver(clusterService, null, logger);
+                                String message = String.format(Locale.ROOT, "failed to perform %s on replica on node %s", transportReplicaAction, node);
+                                ReplicationFailedShardStateListener listener = new ReplicationFailedShardStateListener(observer, shard, exp, message, nodeId);
+                                shardFailed(observer.observedState(), shard, exp, message, listener);
                             }
                         }
                     }
             );
         }
 
+        private void shardFailed(ClusterState clusterState, ShardRouting shard, TransportException exp, String message, ShardStateAction.Listener listener) {
+            logger.warn("{} {}", exp, shardId, message);
+            shardStateAction.shardFailed(
+                clusterState,
+                shard,
+                indexUUID,
+                message,
+                exp,
+                shardFailedTimeout,
+                listener);
+        }
 
         void onReplicaFailure(String nodeId, @Nullable Throwable e) {
             // Only version conflict should be ignored from being put into the _shards header?
@@ -957,30 +974,86 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         }
 
         public class ReplicationFailedShardStateListener implements ShardStateAction.Listener {
+            private final ClusterStateObserver observer;
+            private final ShardRouting shard;
+            private final TransportException exp;
+            private final String message;
             private final String nodeId;
-            private Throwable failure;
 
-            public ReplicationFailedShardStateListener(String nodeId, Throwable failure) {
+            public ReplicationFailedShardStateListener(
+                ClusterStateObserver observer, ShardRouting shard, TransportException exp,
+                String message,
+                String nodeId) {
+                this.observer = observer;
+                this.shard = shard;
+                this.exp = exp;
+                this.message = message;
                 this.nodeId = nodeId;
-                this.failure = failure;
             }
 
             @Override
             public void onSuccess() {
-                onReplicaFailure(nodeId, failure);
+                // TODO: validate the cluster state and retry?
+                onReplicaFailure(nodeId, exp);
             }
 
             @Override
             public void onShardFailedNoMaster() {
-                onReplicaFailure(nodeId, failure);
+                waitForNewMasterAndRetry();
             }
 
             @Override
             public void onShardFailedFailure(DiscoveryNode master, TransportException e) {
                 if (e instanceof ReceiveTimeoutTransportException) {
                     logger.trace("timeout sending shard failure to master [{}]", e, master);
+                    // TODO: recheck the cluster state and retry indefinitely?
+                    onReplicaFailure(nodeId, exp);
+                } else if (e.getCause() instanceof NotMasterException) {
+                    waitForNewMasterAndRetry();
                 }
-                onReplicaFailure(nodeId, failure);
+            }
+
+            private void waitForNewMasterAndRetry() {
+                observer.waitForNextChange(new ClusterStateObserver.Listener() {
+                    @Override
+                    public void onNewClusterState(ClusterState state) {
+                        retry(state);
+                    }
+
+                    @Override
+                    public void onClusterServiceClose() {
+                        logger.error("{} node closed while handling failed shard [{}]", exp, shard.shardId(), shard);
+                        forceFinishAsFailed(new NodeClosedException(clusterService.localNode()));
+                    }
+
+                    @Override
+                    public void onTimeout(TimeValue timeout) {
+                        // we wait indefinitely for a new master
+                        assert false;
+                    }
+                }, MasterNodeChangePredicate.INSTANCE);
+            }
+
+            private void retry(ClusterState clusterState) {
+                if (!isFailed(shard, clusterState)) {
+                    shardFailed(clusterState, shard, exp, message, this);
+                } else {
+                    // the shard has already been failed, so just signal replica failure
+                    onReplicaFailure(nodeId, exp);
+                }
+            }
+
+            private boolean isFailed(ShardRouting shardRouting, ClusterState clusterState) {
+                // verify that the shard we requested to fail is no longer in the cluster state
+                RoutingNode routingNode = clusterState.getRoutingNodes().node(shardRouting.currentNodeId());
+                if (routingNode == null) {
+                    // the node left
+                    return true;
+                } else {
+                    // the same shard is gone
+                    ShardRouting sr = routingNode.get(shardRouting.getId());
+                    return sr == null || !sr.isSameAllocation(shardRouting);
+                }
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -111,6 +111,7 @@ public class ShardStateAction extends AbstractComponent {
 
                     @Override
                     public void handleException(TransportException exp) {
+                        assert exp.getCause() != null : exp;
                         if (isMasterChannelException(exp.getCause())) {
                             waitForNewMasterAndRetry(observer, shardRoutingEntry, listener);
                         } else {

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -377,6 +377,21 @@ public class ShardStateAction extends AbstractComponent {
         default void onSuccess() {
         }
 
+        /**
+         * Notification for non-channel exceptions that are not handled
+         * by {@link ShardStateAction}.
+         *
+         * The exceptions that are handled by {@link ShardStateAction}
+         * are:
+         *  - {@link NotMasterException}
+         *  - {@link NodeDisconnectedException}
+         *  - {@link Discovery.FailedToCommitClusterStateException}
+         *
+         * Any other exception is communicated to the requester via
+         * this notification.
+         *
+         * @param e the unexpected cause of the failure on the master
+         */
         default void onShardFailedFailure(final Exception e) {
         }
     }

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -137,12 +137,15 @@ public class ShardStateAction extends AbstractComponent {
         observer.waitForNextChange(new ClusterStateObserver.Listener() {
             @Override
             public void onNewClusterState(ClusterState state) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("new cluster state [{}] after waiting for master election to fail shard [{}]", shardRoutingEntry.getShardRouting().shardId(), state.prettyPrint(), shardRoutingEntry);
+                }
                 sendShardFailed(observer, shardRoutingEntry, listener);
             }
 
             @Override
             public void onClusterServiceClose() {
-                logger.error("{} node closed while handling failed shard [{}]", shardRoutingEntry.failure, shardRoutingEntry.getShardRouting().getId(), shardRoutingEntry.getShardRouting());
+                logger.warn("{} node closed while handling failed shard [{}]", shardRoutingEntry.failure, shardRoutingEntry.getShardRouting().getId(), shardRoutingEntry.getShardRouting());
                 listener.onShardFailedFailure(new NodeClosedException(clusterService.localNode()));
             }
 

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
@@ -121,7 +122,12 @@ public class ShardStateAction extends AbstractComponent {
         }
     }
 
-    private static Set<Class<?>> MASTER_CHANNEL_EXCEPTIONS = new HashSet<>(Arrays.asList(NotMasterException.class, NodeDisconnectedException.class));
+    private static Set<Class<?>> MASTER_CHANNEL_EXCEPTIONS =
+        new HashSet<>(Arrays.asList(
+            NotMasterException.class,
+            NodeDisconnectedException.class,
+            Discovery.FailedToCommitClusterStateException.class
+        ));
     private static boolean isMasterChannelException(Throwable cause) {
         return MASTER_CHANNEL_EXCEPTIONS.contains(cause.getClass());
     }

--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -458,7 +458,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
             if (!indexService.hasShard(shardId) && shardRouting.started()) {
                 if (failedShards.containsKey(shardRouting.shardId())) {
                     if (nodes.masterNode() != null) {
-                        shardStateAction.resendShardFailed(event.state(), shardRouting, indexMetaData.getIndexUUID(),
+                        shardStateAction.resendShardFailed(shardRouting, indexMetaData.getIndexUUID(),
                                 "master " + nodes.masterNode() + " marked shard as started, but shard has previous failed. resending shard failure.", null, SHARD_STATE_ACTION_LISTENER);
                     }
                 } else {
@@ -590,7 +590,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         if (!indexService.hasShard(shardId)) {
             if (failedShards.containsKey(shardRouting.shardId())) {
                 if (nodes.masterNode() != null) {
-                    shardStateAction.resendShardFailed(state, shardRouting, indexMetaData.getIndexUUID(),
+                    shardStateAction.resendShardFailed(shardRouting, indexMetaData.getIndexUUID(),
                             "master " + nodes.masterNode() + " marked shard as initializing, but shard is marked as failed, resend shard failure", null, SHARD_STATE_ACTION_LISTENER);
                 }
                 return;
@@ -788,7 +788,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         try {
             logger.warn("[{}] marking and sending shard failed due to [{}]", failure, shardRouting.shardId(), message);
             failedShards.put(shardRouting.shardId(), new FailedShard(shardRouting.version()));
-            shardStateAction.shardFailed(clusterService.state(), shardRouting, indexUUID, message, failure, SHARD_STATE_ACTION_LISTENER);
+            shardStateAction.shardFailed(shardRouting, indexUUID, message, failure, SHARD_STATE_ACTION_LISTENER);
         } catch (Throwable e1) {
             logger.warn("[{}][{}] failed to mark shard as failed (because of [{}])", e1, shardRouting.getIndex(), shardRouting.getId(), message);
         }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -489,7 +489,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         TransportReplicationAction<Request, Request, Response>.ReplicationPhase replicationPhase =
                 action.new ReplicationPhase(request,
                         new Response(),
-                        request.shardId(), createTransportChannel(listener), reference, null);
+                        request.shardId(), createTransportChannel(listener), reference);
 
         assertThat(replicationPhase.totalShards(), equalTo(totalShards));
         assertThat(replicationPhase.pending(), equalTo(assignedReplicas));

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -566,8 +566,7 @@ public class TransportReplicationActionTests extends ESTestCase {
                             // force a new cluster state to simulate a new master having been elected
                             clusterService.setState(ClusterState.builder(clusterService.state()));
                             transport.handleResponse(currentRequest.requestId, new NotMasterException("shard-failed-test"));
-                            CapturingTransport.CapturedRequest[] retryRequests = transport.capturedRequests();
-                            transport.clear();
+                            CapturingTransport.CapturedRequest[] retryRequests = transport.getCapturedRequestsAndClear();
                             assertEquals(1, retryRequests.length);
                             currentRequest = retryRequests[0];
                         }

--- a/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
@@ -58,7 +58,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class ShardStateActionTests extends ESTestCase {
     private static ThreadPool THREAD_POOL;
 
-    private AtomicBoolean timeout;
     private TestShardStateAction shardStateAction;
     private CapturingTransport transport;
     private TransportService transportService;
@@ -102,7 +101,6 @@ public class ShardStateActionTests extends ESTestCase {
         clusterService = new TestClusterService(THREAD_POOL);
         transportService = new TransportService(transport, THREAD_POOL);
         transportService.start();
-        this.timeout = new AtomicBoolean();
         shardStateAction = new TestShardStateAction(Settings.EMPTY, clusterService, transportService, null, null);
         shardStateAction.setOnBeforeWaitForNewMasterAndRetry(() -> {});
         shardStateAction.setOnAfterWaitForNewMasterAndRetry(() -> {});

--- a/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
@@ -140,6 +140,13 @@ public class ShardStateActionTests extends ESTestCase {
                 success.set(true);
                 latch.countDown();
             }
+
+            @Override
+            public void onShardFailedFailure(Exception e) {
+                success.set(false);
+                latch.countDown();
+                assert false;
+            }
         });
 
         CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
@@ -180,6 +187,13 @@ public class ShardStateActionTests extends ESTestCase {
             public void onSuccess() {
                 success.set(true);
                 latch.countDown();
+            }
+
+            @Override
+            public void onShardFailedFailure(Exception e) {
+                success.set(false);
+                latch.countDown();
+                assert false;
             }
         });
 
@@ -224,6 +238,7 @@ public class ShardStateActionTests extends ESTestCase {
                 success.set(false);
                 exception.set(e);
                 latch.countDown();
+                assert false;
             }
         });
 
@@ -251,6 +266,7 @@ public class ShardStateActionTests extends ESTestCase {
         shardStateAction.shardFailed(getRandomShardRouting(index), indexUUID, "test", getSimulatedFailure(), new ShardStateAction.Listener() {
             @Override
             public void onSuccess() {
+                failure.set(false);
                 assert false;
             }
 

--- a/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
@@ -182,8 +182,7 @@ public class ShardStateActionTests extends ESTestCase {
             }
         });
 
-        final CapturingTransport.CapturedRequest[] capturedRequests = transport.capturedRequests();
-        transport.clear();
+        final CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
         assertThat(capturedRequests.length, equalTo(1));
         assertFalse(success.get());
         List<Exception> possibleExceptions = new ArrayList<>();
@@ -243,8 +242,7 @@ public class ShardStateActionTests extends ESTestCase {
         invoked.set(true);
 
         // assert a retry request was sent
-        final CapturingTransport.CapturedRequest[] capturedRequests = transport.capturedRequests();
-        transport.clear();
+        final CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
         retried.set(capturedRequests.length == 1);
         if (retried.get()) {
             // finish the request


### PR DESCRIPTION
This commit handles the situation when we are failing a shard and either
no master is known, or the known master left while failing the shard. We
handle this situation by waiting for a new master to be reelected, and
then sending the shard failed request to the new master.

Relates #14252
