### PR TITLE
Fix indent in example

### DIFF
--- a/docs/reference/aggregations/bucket/filters-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/filters-aggregation.asciidoc
@@ -46,19 +46,18 @@ Response:
       "buckets" : {
         "errors" : {
           "doc_count" : 34,
-            "monthly" : {
-              "buckets" : [
-                ... // the histogram monthly breakdown
-              ]
-            }
-          },
-          "warnings" : {
-            "doc_count" : 439,
-            "monthly" : {
-              "buckets" : [
-                 ... // the histogram monthly breakdown
-              ]
-            }
+          "monthly" : {
+            "buckets" : [
+              ... // the histogram monthly breakdown
+            ]
+          }
+        },
+        "warnings" : {
+          "doc_count" : 439,
+          "monthly" : {
+            "buckets" : [
+               ... // the histogram monthly breakdown
+            ]
           }
         }
       }


### PR DESCRIPTION
Previously it would look like if `warnings` key is nested under `errors`.
