### PR TITLE
Use egrep instead of grep -E for Solaris

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -132,7 +132,7 @@ HOSTNAME=`hostname | cut -d. -f1`
 export HOSTNAME
 
 # manual parsing to find out, if process should be detached
-daemonized=`echo $* | grep -E -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`
+daemonized=`echo $* | egrep -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`
 if [ -z "$daemonized" ] ; then
     exec "$JAVA" $JAVA_OPTS $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" \
           org.elasticsearch.bootstrap.Elasticsearch start "$@"


### PR DESCRIPTION
/usr/bin/grep on Solaris doesn't support -E.  /usr/xpg4/bin/grep does support -E, but it was considered cleaner to use egrep which corresponds to grep -E on Linux and supports enough of the same regex syntax on Solaris.  egrep also works on Mac OS X.

Closes #15628
