### PR TITLE
Fixed example query for Native Java plugin

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -425,7 +425,7 @@ curl -XPOST localhost:9200/_search -d '{
         {
           "script_score": {
             "script": {
-                "id": "my_script",
+                "inline": "my_script",
                 "lang" : "native"
             }
           }

--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -409,7 +409,7 @@ public class MyNativeScriptPlugin extends Plugin {
 --------------------------------------------------
 
 You can execute the script by specifying its `lang` as `native`, and the name
-of the script as the `id`:
+of the script as the `inline`:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Based on Elasticsearch v2.1.1 source code, the correct way to use a custom native Java plugin is to use "inline" in the query instead of "id".

E.g.:

```
GET _search
{
    "fields": [
       "_boost"
    ], 
  "query": {
    "function_score": {
      "query": {
        "match_all": {}
      },
      "functions": [
        {
          "script_score": {
            "script": {
                "inline": "my_script",
                "lang" : "native"
            }
          }
        }
      ]
    }
  }
}
```
