### PR TITLE
Close recovered translog readers if createWriter fails

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogReader.java
@@ -138,7 +138,7 @@ public abstract class TranslogReader implements Closeable, Comparable<TranslogRe
     abstract protected void readBytes(ByteBuffer buffer, long position) throws IOException;
 
     @Override
-    public void close() throws IOException {
+    public final void close() throws IOException {
         if (closed.compareAndSet(false, true)) {
             channelReference.decRef();
         }


### PR DESCRIPTION
If we fail to create a writer all recovered translog readers are not
closed today which causes all open files to leak.

Closes #15754

@jasontedor @mikemccand can you take a look
