### PR TITLE
Fix NPE in TestClusterService when waiting indefinitely

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/cluster/TestClusterService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/cluster/TestClusterService.java
@@ -184,9 +184,11 @@ public class TestClusterService implements ClusterService {
         if (threadPool == null) {
             throw new UnsupportedOperationException("TestClusterService wasn't initialized with a thread pool");
         }
-        NotifyTimeout notifyTimeout = new NotifyTimeout(listener, timeout);
-        notifyTimeout.future = threadPool.schedule(timeout, ThreadPool.Names.GENERIC, notifyTimeout);
-        onGoingTimeouts.add(notifyTimeout);
+        if (timeout != null) {
+            NotifyTimeout notifyTimeout = new NotifyTimeout(listener, timeout);
+            notifyTimeout.future = threadPool.schedule(timeout, ThreadPool.Names.GENERIC, notifyTimeout);
+            onGoingTimeouts.add(notifyTimeout);
+        }
         listeners.add(listener);
         listener.postAdded();
     }


### PR DESCRIPTION
When waiting indefinitely for a new cluster state in a test,
TestClusterService#add will throw a NullPointerException if the timeout
is null. Instead, TestClusterService#add should guard against a null
timeout and not even attempt to add a notification for the timeout
expiring. Note that the usage of null is the agreed upon contract for
specifying an indefinite wait from ClusterStateObserver.
