### PR TITLE
Only fail the relocation target when a replication request on it fails

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -844,11 +844,11 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
                 // we never execute replication operation locally as primary operation has already completed locally
                 // hence, we ignore any local shard for replication
                 if (nodes.localNodeId().equals(shard.currentNodeId()) == false) {
-                    performOnReplica(shard, shard.currentNodeId());
+                    performOnReplica(shard);
                 }
                 // send operation to relocating shard
                 if (shard.relocating()) {
-                    performOnReplica(shard, shard.relocatingNodeId());
+                    performOnReplica(shard.buildTargetRelocatingShard());
                 }
             }
         }
@@ -856,9 +856,10 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
         /**
          * send replica operation to target node
          */
-        void performOnReplica(final ShardRouting shard, final String nodeId) {
+        void performOnReplica(final ShardRouting shard) {
             // if we don't have that node, it means that it might have failed and will be created again, in
             // this case, we don't have to do the operation, and just let it failover
+            String nodeId = shard.currentNodeId();
             if (!nodes.nodeExists(nodeId)) {
                 logger.trace("failed to send action [{}] on replica [{}] for request [{}] due to unknown node [{}]", transportReplicaAction, shard.shardId(), replicaRequest, nodeId);
                 onReplicaFailure(nodeId, null);

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -302,6 +302,10 @@ public class ShardStateAction extends AbstractComponent {
             this.failure = failure;
         }
 
+        public ShardRouting getShardRouting() {
+            return shardRouting;
+        }
+
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -492,7 +492,6 @@ public class TransportReplicationActionTests extends ESTestCase {
         final CapturingTransport.CapturedRequest[] capturedRequests = transport.capturedRequests();
         transport.clear();
 
-        assertThat(capturedRequests.length, equalTo(assignedReplicas));
         HashMap<String, Request> nodesSentTo = new HashMap<>();
         boolean executeOnReplica =
             action.shouldExecuteReplication(clusterService.state().getMetaData().index(shardId.getIndex()).getSettings());

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -65,9 +65,9 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -76,10 +76,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.state;
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithStartedPrimary;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -490,34 +493,37 @@ public class TransportReplicationActionTests extends ESTestCase {
         transport.clear();
 
         assertThat(capturedRequests.length, equalTo(assignedReplicas));
-        Set<String> nodesSentTo = new HashSet<>();
+        HashMap<String, Request> nodesSentTo = new HashMap<>();
         boolean executeOnReplica =
             action.shouldExecuteReplication(clusterService.state().getMetaData().index(shardId.getIndex()).getSettings());
         for (CapturingTransport.CapturedRequest capturedRequest : capturedRequests) {
             // no duplicate requests
-            assertTrue(nodesSentTo.add(capturedRequest.node.getId()));
+            Request replicationRequest = (Request) capturedRequest.request;
+            assertNull(nodesSentTo.put(capturedRequest.node.getId(), replicationRequest));
             // the request is hitting the correct shard
-            Request replicationRequest = (Request)capturedRequest.request;
             assertEquals(request.shardId, replicationRequest.shardId);
         }
 
+        // no request was sent to the local node
+        assertThat(nodesSentTo.keySet(), not(hasItem(clusterService.state().getNodes().localNodeId())));
+
         // requests were sent to the correct shard copies
-        List<ShardRouting> shards =
-            clusterService.state().getRoutingTable().index(shardId.getIndex()).shard(shardId.id()).shards();
-        for (ShardRouting shard : shards) {
-            if (!shard.primary() && !executeOnReplica) {
+        for (ShardRouting shard : clusterService.state().getRoutingTable().shardRoutingTable(shardId.getIndex(), shardId.id())) {
+            if (shard.primary() == false && executeOnReplica == false) {
                 continue;
             }
             if (shard.unassigned()) {
                 continue;
             }
-            if (!clusterService.state().getNodes().localNodeId().equals(shard.currentNodeId())) {
-                assertThat(nodesSentTo, hasItem(shard.currentNodeId()));
+            if (shard.primary() == false) {
+                nodesSentTo.remove(shard.currentNodeId());
             }
             if (shard.relocating()) {
-                assertThat(nodesSentTo, hasItem(shard.relocatingNodeId()));
+                nodesSentTo.remove(shard.relocatingNodeId());
             }
         }
+
+        assertThat(nodesSentTo.entrySet(), is(empty()));
 
         if (assignedReplicas > 0) {
             assertThat("listener is done, but there are outstanding replicas", listener.isDone(), equalTo(false));
@@ -548,7 +554,7 @@ public class TransportReplicationActionTests extends ESTestCase {
                     // and the shard that was requested to be failed
                     ShardStateAction.ShardRoutingEntry shardRoutingEntry = (ShardStateAction.ShardRoutingEntry)shardFailedRequest.request;
                     // the shard the request was sent to and the shard to be failed should be the same
-                    assertTrue(shardRoutingEntry.getShardRouting().isSameAllocation(routing));
+                    assertEquals(shardRoutingEntry.getShardRouting(), routing);
                     failures.add(shardFailedRequest);
                     transport.handleResponse(shardFailedRequest.requestId, TransportResponse.Empty.INSTANCE);
                 }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -418,7 +418,6 @@ public class TransportReplicationActionTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/15790")
     public void testReplication() throws ExecutionException, InterruptedException {
         final String index = "test";
         final ShardId shardId = new ShardId(index, 0);
@@ -442,7 +441,6 @@ public class TransportReplicationActionTests extends ESTestCase {
         runReplicateTest(shardRoutingTable, assignedReplicas, totalShards);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/15790")
     public void testReplicationWithShadowIndex() throws ExecutionException, InterruptedException {
         final String index = "test";
         final ShardId shardId = new ShardId(index, 0);


### PR DESCRIPTION
This commit addresses an issue when handling a failed replication
request against a relocating target shard. Namely, if a replication
request fails against the target of a relocation we currently fail both
the source and the target. This leads to an unnecessary
recovery. Instead, only the target of the relocation should be failed.

Closes #15790
