### PR TITLE
[Ingest] throw exception when invalid locale is provided to the date processor

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/processor/DateProcessor.java
+++ b/core/src/main/java/org/elasticsearch/ingest/processor/DateProcessor.java
@@ -27,6 +27,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.ArrayList;
+import java.util.IllformedLocaleException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -121,7 +122,14 @@ public final class DateProcessor implements Processor {
             String timezoneString = ConfigurationUtils.readOptionalStringProperty(config, "timezone");
             DateTimeZone timezone = timezoneString == null ? DateTimeZone.UTC : DateTimeZone.forID(timezoneString);
             String localeString = ConfigurationUtils.readOptionalStringProperty(config, "locale");
-            Locale locale = localeString == null ? Locale.ENGLISH : Locale.forLanguageTag(localeString);
+            Locale locale = Locale.ENGLISH;
+            if (localeString != null) {
+                try {
+                    locale = (new Locale.Builder()).setLanguageTag(localeString).build();
+                } catch (IllformedLocaleException e) {
+                    throw new IllegalArgumentException("Invalid language tag specified: " + localeString);
+                }
+            }
             List<String> matchFormats = ConfigurationUtils.readList(config, "match_formats");
             return new DateProcessor(timezone, locale, matchField, matchFormats, targetField);
         }

--- a/core/src/test/java/org/elasticsearch/ingest/processor/DateProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/DateProcessorFactoryTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.ingest.processor;
 
-import org.elasticsearch.ingest.processor.DateProcessor;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTimeZone;
 
@@ -95,6 +94,21 @@ public class DateProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getLocale().toLanguageTag(), equalTo(locale.toLanguageTag()));
     }
 
+    public void testParseInvalidLocale() throws Exception {
+        DateProcessor.Factory factory = new DateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        config.put("match_field", sourceField);
+        config.put("match_formats", Collections.singletonList("dd/MM/yyyyy"));
+        config.put("locale", "invalid_locale");
+        try {
+            factory.create(config);
+            fail("should fail with invalid locale");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("Invalid language tag specified: invalid_locale"));
+        }
+    }
+
     public void testParseTimezone() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
@@ -106,6 +120,21 @@ public class DateProcessorFactoryTests extends ESTestCase {
         config.put("timezone", timezone.getID());
         DateProcessor processor = factory.create(config);
         assertThat(processor.getTimezone(), equalTo(timezone));
+    }
+
+    public void testParseInvalidTimezone() throws Exception {
+        DateProcessor.Factory factory = new DateProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        config.put("match_field", sourceField);
+        config.put("match_formats", Collections.singletonList("dd/MM/yyyyy"));
+        config.put("timezone", "invalid_timezone");
+        try {
+            factory.create(config);
+            fail("invalid timezone should fail");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("The datetime zone id 'invalid_timezone' is not recognised"));
+        }
     }
 
     //we generate a timezone out of the available ones in joda, some available in the jdk are not available in joda by default


### PR DESCRIPTION
We should throw an exception when `locale` is not valid. Currently, this is silently ignored and set to the `""` locale. by switching to the `Locale.Builder`, an exception is thrown and can be caught.
