### PR TITLE
Remove some raw from ActionRequest subclasses

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionRequest.java
@@ -28,13 +28,13 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class ActionRequest<T extends ActionRequest> extends TransportRequest {
+public abstract class ActionRequest<Self extends ActionRequest<Self>> extends TransportRequest {
 
     public ActionRequest() {
         super();
     }
 
-    protected ActionRequest(ActionRequest request) {
+    protected ActionRequest(ActionRequest<?> request) {
         super(request);
         // this does not set the listenerThreaded API, if needed, its up to the caller to set it
         // since most times, we actually want it to not be threaded...

--- a/core/src/main/java/org/elasticsearch/action/ActionRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionRequest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class ActionRequest<Self extends ActionRequest<Self>> extends TransportRequest {
+public abstract class ActionRequest<Request extends ActionRequest<Request>> extends TransportRequest {
 
     public ActionRequest() {
         super();

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -146,7 +146,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
         public Request() {
         }
 
-        public Request(ActionRequest request, String[] nodesIds) {
+        public Request(ActionRequest<?> request, String[] nodesIds) {
             super(request, nodesIds);
         }
 
@@ -180,6 +180,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
             this.failures = failures;
         }
 
+        @Override
         public FailedNodeException[] failures() {
             return failures;
         }

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class BroadcastRequest<T extends BroadcastRequest> extends ActionRequest<T> implements IndicesRequest.Replaceable {
+public class BroadcastRequest<Self extends BroadcastRequest<Self>> extends ActionRequest<Self> implements IndicesRequest.Replaceable {
 
     protected String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
@@ -40,7 +40,7 @@ public class BroadcastRequest<T extends BroadcastRequest> extends ActionRequest<
 
     }
 
-    protected BroadcastRequest(ActionRequest originalRequest) {
+    protected BroadcastRequest(ActionRequest<?> originalRequest) {
         super(originalRequest);
     }
 
@@ -55,9 +55,9 @@ public class BroadcastRequest<T extends BroadcastRequest> extends ActionRequest<
 
     @SuppressWarnings("unchecked")
     @Override
-    public final T indices(String... indices) {
+    public final Self indices(String... indices) {
         this.indices = indices;
-        return (T) this;
+        return (Self) this;
     }
 
     @Override
@@ -71,9 +71,9 @@ public class BroadcastRequest<T extends BroadcastRequest> extends ActionRequest<
     }
 
     @SuppressWarnings("unchecked")
-    public final T indicesOptions(IndicesOptions indicesOptions) {
+    public final Self indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = indicesOptions;
-        return (T) this;
+        return (Self) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public class BroadcastRequest<Self extends BroadcastRequest<Self>> extends ActionRequest<Self> implements IndicesRequest.Replaceable {
+public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends ActionRequest<Request> implements IndicesRequest.Replaceable {
 
     protected String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
@@ -55,9 +55,9 @@ public class BroadcastRequest<Self extends BroadcastRequest<Self>> extends Actio
 
     @SuppressWarnings("unchecked")
     @Override
-    public final Self indices(String... indices) {
+    public final Request indices(String... indices) {
         this.indices = indices;
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override
@@ -71,9 +71,9 @@ public class BroadcastRequest<Self extends BroadcastRequest<Self>> extends Actio
     }
 
     @SuppressWarnings("unchecked")
-    public final Self indicesOptions(IndicesOptions indicesOptions) {
+    public final Request indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = indicesOptions;
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  * Abstract class that allows to mark action requests that support acknowledgements.
  * Facilitates consistency across different api.
  */
-public abstract class AcknowledgedRequest<T extends MasterNodeRequest> extends MasterNodeRequest<T> implements AckedRequest {
+public abstract class AcknowledgedRequest<Self extends MasterNodeRequest<Self>> extends MasterNodeRequest<Self> implements AckedRequest {
 
     public static final TimeValue DEFAULT_ACK_TIMEOUT = timeValueSeconds(30);
 
@@ -42,7 +42,7 @@ public abstract class AcknowledgedRequest<T extends MasterNodeRequest> extends M
     protected AcknowledgedRequest() {
     }
 
-    protected AcknowledgedRequest(ActionRequest request) {
+    protected AcknowledgedRequest(ActionRequest<?> request) {
         super(request);
     }
 
@@ -52,9 +52,9 @@ public abstract class AcknowledgedRequest<T extends MasterNodeRequest> extends M
      * @return the request itself
      */
     @SuppressWarnings("unchecked")
-    public final T timeout(String timeout) {
+    public final Self timeout(String timeout) {
         this.timeout = TimeValue.parseTimeValue(timeout, this.timeout, getClass().getSimpleName() + ".timeout");
-        return (T)this;
+        return (Self)this;
     }
 
     /**
@@ -63,9 +63,9 @@ public abstract class AcknowledgedRequest<T extends MasterNodeRequest> extends M
      * @return the request itself
      */
     @SuppressWarnings("unchecked")
-    public final T timeout(TimeValue timeout) {
+    public final Self timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (T) this;
+        return (Self) this;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  * Abstract class that allows to mark action requests that support acknowledgements.
  * Facilitates consistency across different api.
  */
-public abstract class AcknowledgedRequest<Self extends MasterNodeRequest<Self>> extends MasterNodeRequest<Self> implements AckedRequest {
+public abstract class AcknowledgedRequest<Request extends MasterNodeRequest<Request>> extends MasterNodeRequest<Request> implements AckedRequest {
 
     public static final TimeValue DEFAULT_ACK_TIMEOUT = timeValueSeconds(30);
 
@@ -52,9 +52,9 @@ public abstract class AcknowledgedRequest<Self extends MasterNodeRequest<Self>> 
      * @return the request itself
      */
     @SuppressWarnings("unchecked")
-    public final Self timeout(String timeout) {
+    public final Request timeout(String timeout) {
         this.timeout = TimeValue.parseTimeValue(timeout, this.timeout, getClass().getSimpleName() + ".timeout");
-        return (Self)this;
+        return (Request)this;
     }
 
     /**
@@ -63,9 +63,9 @@ public abstract class AcknowledgedRequest<Self extends MasterNodeRequest<Self>> 
      * @return the request itself
      */
     @SuppressWarnings("unchecked")
-    public final Self timeout(TimeValue timeout) {
+    public final Request timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (Self) this;
+        return (Request) this;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadRequest.java
@@ -27,14 +27,14 @@ import java.io.IOException;
 /**
  * Base request for master based read operations that allows to read the cluster state from the local node if needed
  */
-public abstract class MasterNodeReadRequest<T extends MasterNodeReadRequest> extends MasterNodeRequest<T> {
+public abstract class MasterNodeReadRequest<Self extends MasterNodeReadRequest<Self>> extends MasterNodeRequest<Self> {
 
     protected boolean local = false;
 
     @SuppressWarnings("unchecked")
-    public final T local(boolean local) {
+    public final Self local(boolean local) {
         this.local = local;
-        return (T) this;
+        return (Self) this;
     }
 
     public final boolean local() {

--- a/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeReadRequest.java
@@ -27,14 +27,14 @@ import java.io.IOException;
 /**
  * Base request for master based read operations that allows to read the cluster state from the local node if needed
  */
-public abstract class MasterNodeReadRequest<Self extends MasterNodeReadRequest<Self>> extends MasterNodeRequest<Self> {
+public abstract class MasterNodeReadRequest<Request extends MasterNodeReadRequest<Request>> extends MasterNodeRequest<Request> {
 
     protected boolean local = false;
 
     @SuppressWarnings("unchecked")
-    public final Self local(boolean local) {
+    public final Request local(boolean local) {
         this.local = local;
-        return (Self) this;
+        return (Request) this;
     }
 
     public final boolean local() {

--- a/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * A based request for master based operation.
  */
-public abstract class MasterNodeRequest<T extends MasterNodeRequest> extends ActionRequest<T> {
+public abstract class MasterNodeRequest<Self extends MasterNodeRequest<Self>> extends ActionRequest<Self> {
 
     public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);
 
@@ -39,7 +39,7 @@ public abstract class MasterNodeRequest<T extends MasterNodeRequest> extends Act
 
     }
 
-    protected MasterNodeRequest(ActionRequest request) {
+    protected MasterNodeRequest(ActionRequest<?> request) {
         super(request);
     }
 
@@ -47,15 +47,15 @@ public abstract class MasterNodeRequest<T extends MasterNodeRequest> extends Act
      * A timeout value in case the master has not been discovered yet or disconnected.
      */
     @SuppressWarnings("unchecked")
-    public final T masterNodeTimeout(TimeValue timeout) {
+    public final Self masterNodeTimeout(TimeValue timeout) {
         this.masterNodeTimeout = timeout;
-        return (T) this;
+        return (Self) this;
     }
 
     /**
      * A timeout value in case the master has not been discovered yet or disconnected.
      */
-    public final T masterNodeTimeout(String timeout) {
+    public final Self masterNodeTimeout(String timeout) {
         return masterNodeTimeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".masterNodeTimeout"));
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * A based request for master based operation.
  */
-public abstract class MasterNodeRequest<Self extends MasterNodeRequest<Self>> extends ActionRequest<Self> {
+public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Request>> extends ActionRequest<Request> {
 
     public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);
 
@@ -47,15 +47,15 @@ public abstract class MasterNodeRequest<Self extends MasterNodeRequest<Self>> ex
      * A timeout value in case the master has not been discovered yet or disconnected.
      */
     @SuppressWarnings("unchecked")
-    public final Self masterNodeTimeout(TimeValue timeout) {
+    public final Request masterNodeTimeout(TimeValue timeout) {
         this.masterNodeTimeout = timeout;
-        return (Self) this;
+        return (Request) this;
     }
 
     /**
      * A timeout value in case the master has not been discovered yet or disconnected.
      */
-    public final Self masterNodeTimeout(String timeout) {
+    public final Request masterNodeTimeout(String timeout) {
         return masterNodeTimeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".masterNodeTimeout"));
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
@@ -30,30 +30,30 @@ import java.io.IOException;
 
 /**
  */
-public abstract class ClusterInfoRequest<T extends ClusterInfoRequest> extends MasterNodeReadRequest<T> implements IndicesRequest.Replaceable {
+public abstract class ClusterInfoRequest<Self extends ClusterInfoRequest<Self>> extends MasterNodeReadRequest<Self> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;
 
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
-    @SuppressWarnings("unchecked")
     @Override
-    public T indices(String... indices) {
+    @SuppressWarnings("unchecked")
+    public Self indices(String... indices) {
         this.indices = indices;
-        return (T) this;
+        return (Self) this;
     }
 
     @SuppressWarnings("unchecked")
-    public T types(String... types) {
+    public Self types(String... types) {
         this.types = types;
-        return (T) this;
+        return (Self) this;
     }
 
     @SuppressWarnings("unchecked")
-    public T indicesOptions(IndicesOptions indicesOptions) {
+    public Self indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = indicesOptions;
-        return (T) this;
+        return (Self) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 
 /**
  */
-public abstract class ClusterInfoRequest<Self extends ClusterInfoRequest<Self>> extends MasterNodeReadRequest<Self> implements IndicesRequest.Replaceable {
+public abstract class ClusterInfoRequest<Request extends ClusterInfoRequest<Request>> extends MasterNodeReadRequest<Request> implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] types = Strings.EMPTY_ARRAY;
@@ -39,21 +39,21 @@ public abstract class ClusterInfoRequest<Self extends ClusterInfoRequest<Self>> 
 
     @Override
     @SuppressWarnings("unchecked")
-    public Self indices(String... indices) {
+    public Request indices(String... indices) {
         this.indices = indices;
-        return (Self) this;
+        return (Request) this;
     }
 
     @SuppressWarnings("unchecked")
-    public Self types(String... types) {
+    public Request types(String... types) {
         this.types = types;
-        return (Self) this;
+        return (Request) this;
     }
 
     @SuppressWarnings("unchecked")
-    public Self indicesOptions(IndicesOptions indicesOptions) {
+    public Request indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = indicesOptions;
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class BaseNodesRequest<Self extends BaseNodesRequest<Self>> extends ActionRequest<Self> {
+public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>> extends ActionRequest<Request> {
 
     public static String[] ALL_NODES = Strings.EMPTY_ARRAY;
 
@@ -57,9 +57,9 @@ public abstract class BaseNodesRequest<Self extends BaseNodesRequest<Self>> exte
     }
 
     @SuppressWarnings("unchecked")
-    public final Self nodesIds(String... nodesIds) {
+    public final Request nodesIds(String... nodesIds) {
         this.nodesIds = nodesIds;
-        return (Self) this;
+        return (Request) this;
     }
 
     public TimeValue timeout() {
@@ -67,15 +67,15 @@ public abstract class BaseNodesRequest<Self extends BaseNodesRequest<Self>> exte
     }
 
     @SuppressWarnings("unchecked")
-    public final Self timeout(TimeValue timeout) {
+    public final Request timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (Self) this;
+        return (Request) this;
     }
 
     @SuppressWarnings("unchecked")
-    public final Self timeout(String timeout) {
+    public final Request timeout(String timeout) {
         this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class BaseNodesRequest<T extends BaseNodesRequest> extends ActionRequest<T> {
+public abstract class BaseNodesRequest<Self extends BaseNodesRequest<Self>> extends ActionRequest<Self> {
 
     public static String[] ALL_NODES = Strings.EMPTY_ARRAY;
 
@@ -43,7 +43,7 @@ public abstract class BaseNodesRequest<T extends BaseNodesRequest> extends Actio
 
     }
 
-    protected BaseNodesRequest(ActionRequest request, String... nodesIds) {
+    protected BaseNodesRequest(ActionRequest<?> request, String... nodesIds) {
         super(request);
         this.nodesIds = nodesIds;
     }
@@ -57,9 +57,9 @@ public abstract class BaseNodesRequest<T extends BaseNodesRequest> extends Actio
     }
 
     @SuppressWarnings("unchecked")
-    public final T nodesIds(String... nodesIds) {
+    public final Self nodesIds(String... nodesIds) {
         this.nodesIds = nodesIds;
-        return (T) this;
+        return (Self) this;
     }
 
     public TimeValue timeout() {
@@ -67,15 +67,15 @@ public abstract class BaseNodesRequest<T extends BaseNodesRequest> extends Actio
     }
 
     @SuppressWarnings("unchecked")
-    public final T timeout(TimeValue timeout) {
+    public final Self timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (T) this;
+        return (Self) this;
     }
 
     @SuppressWarnings("unchecked")
-    public final T timeout(String timeout) {
+    public final Self timeout(String timeout) {
         this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (T) this;
+        return (Self) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -38,7 +38,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  *
  */
-public class ReplicationRequest<Self extends ReplicationRequest<Self>> extends ActionRequest<Self> implements IndicesRequest {
+public class ReplicationRequest<Request extends ReplicationRequest<Request>> extends ActionRequest<Request> implements IndicesRequest {
 
     public static final TimeValue DEFAULT_TIMEOUT = new TimeValue(1, TimeUnit.MINUTES);
 
@@ -77,7 +77,7 @@ public class ReplicationRequest<Self extends ReplicationRequest<Self>> extends A
     /**
      * Copy constructor that creates a new request that is a copy of the one provided as an argument.
      */
-    protected ReplicationRequest(Self request) {
+    protected ReplicationRequest(Request request) {
         this(request, request);
     }
 
@@ -85,7 +85,7 @@ public class ReplicationRequest<Self extends ReplicationRequest<Self>> extends A
      * Copy constructor that creates a new request that is a copy of the one provided as an argument.
      * The new request will inherit though headers and context from the original request that caused it.
      */
-    protected ReplicationRequest(Self request, ActionRequest<?> originalRequest) {
+    protected ReplicationRequest(Request request, ActionRequest<?> originalRequest) {
         super(originalRequest);
         this.timeout = request.timeout();
         this.index = request.index();
@@ -96,15 +96,15 @@ public class ReplicationRequest<Self extends ReplicationRequest<Self>> extends A
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
     @SuppressWarnings("unchecked")
-    public final Self timeout(TimeValue timeout) {
+    public final Request timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (Self) this;
+        return (Request) this;
     }
 
     /**
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
-    public final Self timeout(String timeout) {
+    public final Request timeout(String timeout) {
         return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
     }
 
@@ -117,9 +117,9 @@ public class ReplicationRequest<Self extends ReplicationRequest<Self>> extends A
     }
 
     @SuppressWarnings("unchecked")
-    public final Self index(String index) {
+    public final Request index(String index) {
         this.index = index;
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override
@@ -150,9 +150,9 @@ public class ReplicationRequest<Self extends ReplicationRequest<Self>> extends A
      * Sets the consistency level of write. Defaults to {@link org.elasticsearch.action.WriteConsistencyLevel#DEFAULT}
      */
     @SuppressWarnings("unchecked")
-    public final Self consistencyLevel(WriteConsistencyLevel consistencyLevel) {
+    public final Request consistencyLevel(WriteConsistencyLevel consistencyLevel) {
         this.consistencyLevel = consistencyLevel;
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override
@@ -196,9 +196,9 @@ public class ReplicationRequest<Self extends ReplicationRequest<Self>> extends A
      * index/delete request is resolved by the transport action
      */
     @SuppressWarnings("unchecked")
-    public Self setShardId(ShardId shardId) {
+    public Request setShardId(ShardId shardId) {
         this.shardId = shardId;
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -38,7 +38,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  *
  */
-public class ReplicationRequest<T extends ReplicationRequest> extends ActionRequest<T> implements IndicesRequest {
+public class ReplicationRequest<Self extends ReplicationRequest<Self>> extends ActionRequest<Self> implements IndicesRequest {
 
     public static final TimeValue DEFAULT_TIMEOUT = new TimeValue(1, TimeUnit.MINUTES);
 
@@ -61,14 +61,14 @@ public class ReplicationRequest<T extends ReplicationRequest> extends ActionRequ
     /**
      * Creates a new request that inherits headers and context from the request provided as argument.
      */
-    public ReplicationRequest(ActionRequest request) {
+    public ReplicationRequest(ActionRequest<?> request) {
         super(request);
     }
 
     /**
      * Creates a new request with resolved shard id
      */
-    public ReplicationRequest(ActionRequest request, ShardId shardId) {
+    public ReplicationRequest(ActionRequest<?> request, ShardId shardId) {
         super(request);
         this.index = shardId.getIndex();
         this.shardId = shardId;
@@ -77,7 +77,7 @@ public class ReplicationRequest<T extends ReplicationRequest> extends ActionRequ
     /**
      * Copy constructor that creates a new request that is a copy of the one provided as an argument.
      */
-    protected ReplicationRequest(T request) {
+    protected ReplicationRequest(Self request) {
         this(request, request);
     }
 
@@ -85,7 +85,7 @@ public class ReplicationRequest<T extends ReplicationRequest> extends ActionRequ
      * Copy constructor that creates a new request that is a copy of the one provided as an argument.
      * The new request will inherit though headers and context from the original request that caused it.
      */
-    protected ReplicationRequest(T request, ActionRequest originalRequest) {
+    protected ReplicationRequest(Self request, ActionRequest<?> originalRequest) {
         super(originalRequest);
         this.timeout = request.timeout();
         this.index = request.index();
@@ -96,15 +96,15 @@ public class ReplicationRequest<T extends ReplicationRequest> extends ActionRequ
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
     @SuppressWarnings("unchecked")
-    public final T timeout(TimeValue timeout) {
+    public final Self timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (T) this;
+        return (Self) this;
     }
 
     /**
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
-    public final T timeout(String timeout) {
+    public final Self timeout(String timeout) {
         return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
     }
 
@@ -117,9 +117,9 @@ public class ReplicationRequest<T extends ReplicationRequest> extends ActionRequ
     }
 
     @SuppressWarnings("unchecked")
-    public final T index(String index) {
+    public final Self index(String index) {
         this.index = index;
-        return (T) this;
+        return (Self) this;
     }
 
     @Override
@@ -150,9 +150,9 @@ public class ReplicationRequest<T extends ReplicationRequest> extends ActionRequ
      * Sets the consistency level of write. Defaults to {@link org.elasticsearch.action.WriteConsistencyLevel#DEFAULT}
      */
     @SuppressWarnings("unchecked")
-    public final T consistencyLevel(WriteConsistencyLevel consistencyLevel) {
+    public final Self consistencyLevel(WriteConsistencyLevel consistencyLevel) {
         this.consistencyLevel = consistencyLevel;
-        return (T) this;
+        return (Self) this;
     }
 
     @Override
@@ -195,9 +195,10 @@ public class ReplicationRequest<T extends ReplicationRequest> extends ActionRequ
      * Sets the target shard id for the request. The shard id is set when a
      * index/delete request is resolved by the transport action
      */
-    public T setShardId(ShardId shardId) {
+    @SuppressWarnings("unchecked")
+    public Self setShardId(ShardId shardId) {
         this.shardId = shardId;
-        return (T) this;
+        return (Self) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
@@ -34,7 +34,8 @@ import java.util.concurrent.TimeUnit;
 /**
  *
  */
-public abstract class InstanceShardOperationRequest<Self extends InstanceShardOperationRequest<Self>> extends ActionRequest<Self> implements IndicesRequest {
+public abstract class InstanceShardOperationRequest<Request extends InstanceShardOperationRequest<Request>> extends ActionRequest<Request>
+        implements IndicesRequest {
 
     public static final TimeValue DEFAULT_TIMEOUT = new TimeValue(1, TimeUnit.MINUTES);
 
@@ -77,9 +78,9 @@ public abstract class InstanceShardOperationRequest<Self extends InstanceShardOp
     }
 
     @SuppressWarnings("unchecked")
-    public final Self index(String index) {
+    public final Request index(String index) {
         this.index = index;
-        return (Self) this;
+        return (Request) this;
     }
 
     public TimeValue timeout() {
@@ -90,15 +91,15 @@ public abstract class InstanceShardOperationRequest<Self extends InstanceShardOp
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
     @SuppressWarnings("unchecked")
-    public final Self timeout(TimeValue timeout) {
+    public final Request timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (Self) this;
+        return (Request) this;
     }
 
     /**
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
-    public final Self timeout(String timeout) {
+    public final Request timeout(String timeout) {
         return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 /**
  *
  */
-public abstract class InstanceShardOperationRequest<T extends InstanceShardOperationRequest> extends ActionRequest<T> implements IndicesRequest {
+public abstract class InstanceShardOperationRequest<Self extends InstanceShardOperationRequest<Self>> extends ActionRequest<Self> implements IndicesRequest {
 
     public static final TimeValue DEFAULT_TIMEOUT = new TimeValue(1, TimeUnit.MINUTES);
 
@@ -77,9 +77,9 @@ public abstract class InstanceShardOperationRequest<T extends InstanceShardOpera
     }
 
     @SuppressWarnings("unchecked")
-    public final T index(String index) {
+    public final Self index(String index) {
         this.index = index;
-        return (T) this;
+        return (Self) this;
     }
 
     public TimeValue timeout() {
@@ -90,15 +90,15 @@ public abstract class InstanceShardOperationRequest<T extends InstanceShardOpera
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
     @SuppressWarnings("unchecked")
-    public final T timeout(TimeValue timeout) {
+    public final Self timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (T) this;
+        return (Self) this;
     }
 
     /**
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
-    public final T timeout(String timeout) {
+    public final Self timeout(String timeout) {
         return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class SingleShardRequest<Self extends SingleShardRequest<Self>> extends ActionRequest<Self> implements IndicesRequest {
+public abstract class SingleShardRequest<Request extends SingleShardRequest<Request>> extends ActionRequest<Request> implements IndicesRequest {
 
     public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.strictSingleIndexNoExpandForbidClosed();
 
@@ -91,9 +91,9 @@ public abstract class SingleShardRequest<Self extends SingleShardRequest<Self>> 
      * Sets the index.
      */
     @SuppressWarnings("unchecked")
-    public final Self index(String index) {
+    public final Request index(String index) {
         this.index = index;
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override
@@ -117,9 +117,9 @@ public abstract class SingleShardRequest<Self extends SingleShardRequest<Self>> 
      * Controls if the operation will be executed on a separate thread when executed locally.
      */
     @SuppressWarnings("unchecked")
-    public final Self operationThreaded(boolean threadedOperation) {
+    public final Request operationThreaded(boolean threadedOperation) {
         this.threadedOperation = threadedOperation;
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  *
  */
-public abstract class SingleShardRequest<T extends SingleShardRequest> extends ActionRequest<T> implements IndicesRequest {
+public abstract class SingleShardRequest<Self extends SingleShardRequest<Self>> extends ActionRequest<Self> implements IndicesRequest {
 
     public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.strictSingleIndexNoExpandForbidClosed();
 
@@ -56,11 +56,11 @@ public abstract class SingleShardRequest<T extends SingleShardRequest> extends A
         this.index = index;
     }
 
-    protected SingleShardRequest(ActionRequest request) {
+    protected SingleShardRequest(ActionRequest<?> request) {
         super(request);
     }
 
-    protected SingleShardRequest(ActionRequest request, String index) {
+    protected SingleShardRequest(ActionRequest<?> request, String index) {
         super(request);
         this.index = index;
     }
@@ -91,9 +91,9 @@ public abstract class SingleShardRequest<T extends SingleShardRequest> extends A
      * Sets the index.
      */
     @SuppressWarnings("unchecked")
-    public final T index(String index) {
+    public final Self index(String index) {
         this.index = index;
-        return (T) this;
+        return (Self) this;
     }
 
     @Override
@@ -117,9 +117,9 @@ public abstract class SingleShardRequest<T extends SingleShardRequest> extends A
      * Controls if the operation will be executed on a separate thread when executed locally.
      */
     @SuppressWarnings("unchecked")
-    public final T operationThreaded(boolean threadedOperation) {
+    public final Self operationThreaded(boolean threadedOperation) {
         this.threadedOperation = threadedOperation;
-        return (T) this;
+        return (Self) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  * A base class for task requests
  */
-public class BaseTasksRequest<T extends BaseTasksRequest> extends ActionRequest<T> {
+public class BaseTasksRequest<Self extends BaseTasksRequest<Self>> extends ActionRequest<Self> {
 
 
     public static final String[] ALL_ACTIONS = Strings.EMPTY_ARRAY;
@@ -65,7 +65,7 @@ public class BaseTasksRequest<T extends BaseTasksRequest> extends ActionRequest<
      * Get information about tasks from nodes based on the nodes ids specified.
      * If none are passed, information for all nodes will be returned.
      */
-    public BaseTasksRequest(ActionRequest request, String... nodesIds) {
+    public BaseTasksRequest(ActionRequest<?> request, String... nodesIds) {
         super(request);
         this.nodesIds = nodesIds;
     }
@@ -82,9 +82,9 @@ public class BaseTasksRequest<T extends BaseTasksRequest> extends ActionRequest<
      * Sets the list of action masks for the actions that should be returned
      */
     @SuppressWarnings("unchecked")
-    public final T actions(String... actions) {
+    public final Self actions(String... actions) {
         this.actions = actions;
-        return (T) this;
+        return (Self) this;
     }
 
     /**
@@ -99,9 +99,9 @@ public class BaseTasksRequest<T extends BaseTasksRequest> extends ActionRequest<
     }
 
     @SuppressWarnings("unchecked")
-    public final T nodesIds(String... nodesIds) {
+    public final Self nodesIds(String... nodesIds) {
         this.nodesIds = nodesIds;
-        return (T) this;
+        return (Self) this;
     }
 
     /**
@@ -112,9 +112,9 @@ public class BaseTasksRequest<T extends BaseTasksRequest> extends ActionRequest<
     }
 
     @SuppressWarnings("unchecked")
-    public T parentNode(String parentNode) {
+    public Self parentNode(String parentNode) {
         this.parentNode = parentNode;
-        return (T) this;
+        return (Self) this;
     }
 
     /**
@@ -125,9 +125,9 @@ public class BaseTasksRequest<T extends BaseTasksRequest> extends ActionRequest<
     }
 
     @SuppressWarnings("unchecked")
-    public T parentTaskId(long parentTaskId) {
+    public Self parentTaskId(long parentTaskId) {
         this.parentTaskId = parentTaskId;
-        return (T) this;
+        return (Self) this;
     }
 
 
@@ -136,15 +136,15 @@ public class BaseTasksRequest<T extends BaseTasksRequest> extends ActionRequest<
     }
 
     @SuppressWarnings("unchecked")
-    public final T timeout(TimeValue timeout) {
+    public final Self timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (T) this;
+        return (Self) this;
     }
 
     @SuppressWarnings("unchecked")
-    public final T timeout(String timeout) {
+    public final Self timeout(String timeout) {
         this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (T) this;
+        return (Self) this;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  * A base class for task requests
  */
-public class BaseTasksRequest<Self extends BaseTasksRequest<Self>> extends ActionRequest<Self> {
+public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends ActionRequest<Request> {
 
 
     public static final String[] ALL_ACTIONS = Strings.EMPTY_ARRAY;
@@ -82,9 +82,9 @@ public class BaseTasksRequest<Self extends BaseTasksRequest<Self>> extends Actio
      * Sets the list of action masks for the actions that should be returned
      */
     @SuppressWarnings("unchecked")
-    public final Self actions(String... actions) {
+    public final Request actions(String... actions) {
         this.actions = actions;
-        return (Self) this;
+        return (Request) this;
     }
 
     /**
@@ -99,9 +99,9 @@ public class BaseTasksRequest<Self extends BaseTasksRequest<Self>> extends Actio
     }
 
     @SuppressWarnings("unchecked")
-    public final Self nodesIds(String... nodesIds) {
+    public final Request nodesIds(String... nodesIds) {
         this.nodesIds = nodesIds;
-        return (Self) this;
+        return (Request) this;
     }
 
     /**
@@ -112,9 +112,9 @@ public class BaseTasksRequest<Self extends BaseTasksRequest<Self>> extends Actio
     }
 
     @SuppressWarnings("unchecked")
-    public Self parentNode(String parentNode) {
+    public Request parentNode(String parentNode) {
         this.parentNode = parentNode;
-        return (Self) this;
+        return (Request) this;
     }
 
     /**
@@ -125,9 +125,9 @@ public class BaseTasksRequest<Self extends BaseTasksRequest<Self>> extends Actio
     }
 
     @SuppressWarnings("unchecked")
-    public Self parentTaskId(long parentTaskId) {
+    public Request parentTaskId(long parentTaskId) {
         this.parentTaskId = parentTaskId;
-        return (Self) this;
+        return (Request) this;
     }
 
 
@@ -136,15 +136,15 @@ public class BaseTasksRequest<Self extends BaseTasksRequest<Self>> extends Actio
     }
 
     @SuppressWarnings("unchecked")
-    public final Self timeout(TimeValue timeout) {
+    public final Request timeout(TimeValue timeout) {
         this.timeout = timeout;
-        return (Self) this;
+        return (Request) this;
     }
 
     @SuppressWarnings("unchecked")
-    public final Self timeout(String timeout) {
+    public final Request timeout(String timeout) {
         this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (Self) this;
+        return (Request) this;
     }
 
     @Override


### PR DESCRIPTION
Renames "T" used in many subclasses of ActionRequest to "Self" and tightens
the type bounds.
