### PR TITLE
Standardize some methods on varargs

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/AliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/AliasesRequest.java
@@ -35,7 +35,7 @@ public interface AliasesRequest extends IndicesRequest.Replaceable {
     /**
      * Sets the array of aliases that the action relates to
      */
-    AliasesRequest aliases(String[] aliases);
+    AliasesRequest aliases(String... aliases);
 
     /**
      * Returns true if wildcards expressions among aliases should be resolved, false otherwise

--- a/core/src/main/java/org/elasticsearch/action/IndicesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/IndicesRequest.java
@@ -41,9 +41,9 @@ public interface IndicesRequest {
     IndicesOptions indicesOptions();
 
     static interface Replaceable extends IndicesRequest {
-        /*
-         * Sets the array of indices that the action relates to
+        /**
+         * Sets the indices that the action relates to.
          */
-        IndicesRequest indices(String[] indices);
+        IndicesRequest indices(String... indices);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -61,7 +61,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
     }
 
     @Override
-    public ClusterHealthRequest indices(String[] indices) {
+    public ClusterHealthRequest indices(String... indices) {
         this.indices = indices;
         return this;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/exists/indices/IndicesExistsRequest.java
@@ -51,7 +51,7 @@ public class IndicesExistsRequest extends MasterNodeReadRequest<IndicesExistsReq
     }
 
     @Override
-    public IndicesExistsRequest indices(String[] indices) {
+    public IndicesExistsRequest indices(String... indices) {
         this.indices = indices;
         return this;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/exists/types/TypesExistsRequest.java
@@ -52,7 +52,7 @@ public class TypesExistsRequest extends MasterNodeReadRequest<TypesExistsRequest
     }
 
     @Override
-    public TypesExistsRequest indices(String[] indices) {
+    public TypesExistsRequest indices(String... indices) {
         this.indices = indices;
         return this;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.mapping.put;
 
 import com.carrotsearch.hppc.ObjectHashSet;
+
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
@@ -96,7 +97,7 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
      * Sets the indices this put mapping operation will execute on.
      */
     @Override
-    public PutMappingRequest indices(String[] indices) {
+    public PutMappingRequest indices(String... indices) {
         this.indices = indices;
         return this;
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/warmer/put/PutWarmerRequest.java
@@ -111,7 +111,7 @@ public class PutWarmerRequest extends AcknowledgedRequest<PutWarmerRequest> impl
     }
 
     @Override
-    public IndicesRequest indices(String[] indices) {
+    public IndicesRequest indices(String... indices) {
         if (searchRequest == null) {
             throw new IllegalStateException("unable to set indices, search request is null");
         }

--- a/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
+++ b/plugins/delete-by-query/src/main/java/org/elasticsearch/action/deletebyquery/DeleteByQueryRequest.java
@@ -105,7 +105,7 @@ public class DeleteByQueryRequest extends ActionRequest<DeleteByQueryRequest> im
     }
 
     @Override
-    public DeleteByQueryRequest indices(String[] indices) {
+    public DeleteByQueryRequest indices(String... indices) {
         this.indices = indices;
         return this;
     }


### PR DESCRIPTION
Right now we define the same sort of methods as taking String arrays and
string varargs. We should standardize on one and varargs is easier to
call so lets use varargs!
