### PR TITLE
Remove Xlint:-override,-fallthrough,-static

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -102,8 +102,8 @@ if (isEclipse) {
   }
 }
 
-compileJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-fallthrough,-overrides,-rawtypes,-serial,-try,-unchecked"
-compileTestJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-fallthrough,-overrides,-rawtypes,-serial,-try,-unchecked"
+compileJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-rawtypes,-serial,-try,-unchecked"
+compileTestJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-rawtypes,-serial,-try,-unchecked"
 
 forbiddenPatterns {
   exclude '**/*.json'

--- a/core/src/main/java/org/elasticsearch/common/hash/MurmurHash3.java
+++ b/core/src/main/java/org/elasticsearch/common/hash/MurmurHash3.java
@@ -59,6 +59,7 @@ public enum MurmurHash3 {
      * Note, this hashing function might be used to persist hashes, so if the way hashes are computed
      * changes for some reason, it needs to be addressed (like in BloomFilter and MurmurHashField).
      */
+    @SuppressWarnings("fallthrough") // Intentionally uses fallthrough to implement a well known hashing algorithm
     public static Hash128 hash128(byte[] key, int offset, int length, long seed, Hash128 hash) {
         long h1 = seed;
         long h2 = seed;

--- a/core/src/main/java/org/elasticsearch/common/inject/assistedinject/FactoryProvider2.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/assistedinject/FactoryProvider2.java
@@ -258,6 +258,12 @@ public final class FactoryProvider2<F> implements InvocationHandler, Provider<F>
         return o == this || o == factory;
     }
 
+    @Override
+    public int hashCode() {
+        // This way both this and its factory hash to the same spot, making hashCode consistent.
+        return factory.hashCode();
+    }
+
     /**
      * Returns true if {@code thrown} can be thrown by {@code invoked} without wrapping.
      */

--- a/core/src/main/java/org/elasticsearch/common/util/BloomFilter.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BloomFilter.java
@@ -519,6 +519,7 @@ public class BloomFilter {
         return k;
     }
 
+    @SuppressWarnings("fallthrough") // Uses fallthrough to implement a well know hashing algorithm
     public static long hash3_x64_128(byte[] key, int offset, int length, long seed) {
         final int nblocks = length >> 4; // Process as 128-bit blocks.
 
@@ -598,7 +599,7 @@ public class BloomFilter {
             case 2:
                 k1 ^= ((long) key[offset + 1]) << 8;
             case 1:
-                k1 ^= ((long) key[offset]);
+                k1 ^= (key[offset]);
                 k1 *= c1;
                 k1 = rotl64(k1, 31);
                 k1 *= c2;

--- a/core/src/main/java/org/elasticsearch/index/fieldvisitor/SingleFieldsVisitor.java
+++ b/core/src/main/java/org/elasticsearch/index/fieldvisitor/SingleFieldsVisitor.java
@@ -58,11 +58,16 @@ public class SingleFieldsVisitor extends FieldsVisitor {
 
     public void postProcess(MappedFieldType fieldType) {
         if (uid != null) {
-            // TODO: this switch seems very wrong...either each case should be breaking, or this should not be a switch
             switch (field) {
-                case UidFieldMapper.NAME: addValue(field, uid.toString());
-                case IdFieldMapper.NAME: addValue(field, uid.id());
-                case TypeFieldMapper.NAME: addValue(field, uid.type());
+            case UidFieldMapper.NAME:
+                addValue(field, uid.toString());
+                break;
+            case IdFieldMapper.NAME:
+                addValue(field, uid.id());
+                break;
+            case TypeFieldMapper.NAME:
+                addValue(field, uid.type());
+                break;
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -151,18 +151,10 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
 
         for (int i = 0; i < numSearches; i++) {
             SearchRequestBuilder searchRequestBuilder = client().prepareSearch().setQuery(QueryBuilders.matchAllQuery());
-            switch (randomIntBetween(0, 5)) {
-                case 5:
-                case 4:
-                case 3:
-                    searchRequestBuilder.addSort("test-str", SortOrder.ASC);
-                    // fall through - sometimes get both fields
-                case 2:
-                case 1:
-                default:
-                    searchRequestBuilder.addSort("test-num", SortOrder.ASC);
-
+            if (random().nextBoolean()) {
+                searchRequestBuilder.addSort("test-str", SortOrder.ASC);
             }
+            searchRequestBuilder.addSort("test-num", SortOrder.ASC);
             boolean success = false;
             try {
                 // Sort by the string and numeric fields, to load them into field data
@@ -249,6 +241,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
                         if (random.nextDouble() < topLevelRatio) {
                             throw new IOException("Forced top level Exception on [" + flag.name() + "]");
                         }
+                        break;
                     case Intersect:
                         break;
                     case Norms:

--- a/plugins/discovery-azure/build.gradle
+++ b/plugins/discovery-azure/build.gradle
@@ -56,11 +56,9 @@ dependencyLicenses {
   mapping from: /jaxb-.*/, to: 'jaxb'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-path,-serial,-static,-unchecked'
+compileJava.options.compilerArgs << '-Xlint:-path,-serial,-unchecked'
 // TODO: why is deprecation needed here but not in maven....?
 compileJava.options.compilerArgs << '-Xlint:-deprecation'
-// TODO: and why does this static not show up in maven...
-compileTestJava.options.compilerArgs << '-Xlint:-static'
 
 thirdPartyAudit.excludes = [
   // classes are missing

--- a/plugins/discovery-azure/src/main/java/org/elasticsearch/cloud/azure/AzureDiscoveryModule.java
+++ b/plugins/discovery-azure/src/main/java/org/elasticsearch/cloud/azure/AzureDiscoveryModule.java
@@ -47,11 +47,7 @@ public class AzureDiscoveryModule extends AbstractModule {
     private Settings settings;
 
     // pkg private so it is settable by tests
-    static Class<? extends AzureComputeService> computeServiceImpl = AzureComputeServiceImpl.class;
-
-    public static Class<? extends AzureComputeService> getComputeServiceImpl() {
-        return computeServiceImpl;
-    }
+    Class<? extends AzureComputeService> computeServiceImpl = AzureComputeServiceImpl.class;
 
     @Inject
     public AzureDiscoveryModule(Settings settings) {

--- a/plugins/lang-plan-a/build.gradle
+++ b/plugins/lang-plan-a/build.gradle
@@ -35,7 +35,7 @@ dependencyLicenses {
   mapping from: /asm-.*/, to: 'asm'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-cast,-fallthrough,-rawtypes'
+compileJava.options.compilerArgs << '-Xlint:-cast,-rawtypes'
 compileTestJava.options.compilerArgs << '-Xlint:-unchecked'
 
 // regeneration logic, comes in via ant right now

--- a/plugins/lang-plan-a/src/main/java/org/elasticsearch/plan/a/Analyzer.java
+++ b/plugins/lang-plan-a/src/main/java/org/elasticsearch/plan/a/Analyzer.java
@@ -2223,12 +2223,15 @@ class Analyzer extends PlanAParserBaseVisitor<Void> {
                 case LONG:
                     incremd.preConst = positive ? 1L : -1L;
                     incremd.from = definition.longType;
+                    break;
                 case FLOAT:
                     incremd.preConst = positive ? 1.0F : -1.0F;
                     incremd.from = definition.floatType;
+                    break;
                 case DOUBLE:
                     incremd.preConst = positive ? 1.0 : -1.0;
                     incremd.from = definition.doubleType;
+                    break;
                 default:
                     incremd.preConst = positive ? 1 : -1;
                     incremd.from = definition.intType;

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   compile 'org.elasticsearch:securemock:1.2'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-cast,-deprecation,-fallthrough,-overrides,-rawtypes,-serial,-try,-unchecked'
+compileJava.options.compilerArgs << '-Xlint:-cast,-deprecation,-rawtypes,-serial,-try,-unchecked'
 compileTestJava.options.compilerArgs << '-Xlint:-rawtypes'
 
 // the main files are actually test files, so use the appopriate forbidden api sigs


### PR DESCRIPTION
Adds `@SuppressWarnings("fallthrough")` in two places where the fallthrough
is used to implement well known hashing algorithms.
