### PR TITLE
Catch tragic even inside the checkpoint method rather than on the caller side

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/BufferingTranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/BufferingTranslogWriter.java
@@ -129,12 +129,7 @@ public final class BufferingTranslogWriter extends TranslogWriter {
                 // we can do this outside of the write lock but we have to protect from
                 // concurrent syncs
                 ensureOpen(); // just for kicks - the checkpoint happens or not either way
-                try {
-                    checkpoint(offsetToSync, opsCounter, channelReference);
-                } catch (Throwable ex) {
-                    closeWithTragicEvent(ex);
-                    throw ex;
-                }
+                checkpoint(offsetToSync, opsCounter, channelReference);
                 lastSyncedOffset = offsetToSync;
             } finally {
                 channelReference.decRef();

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -296,8 +296,13 @@ public class TranslogWriter extends TranslogReader {
     }
 
     protected synchronized void checkpoint(long lastSyncPosition, int operationCounter, ChannelReference channelReference) throws IOException {
-        channelReference.getChannel().force(false);
-        writeCheckpoint(lastSyncPosition, operationCounter, channelReference.getPath().getParent(), channelReference.getGeneration(), StandardOpenOption.WRITE);
+        try {
+            channelReference.getChannel().force(false);
+            writeCheckpoint(lastSyncPosition, operationCounter, channelReference.getPath().getParent(), channelReference.getGeneration(), StandardOpenOption.WRITE);
+        } catch (Throwable ex) {
+            closeWithTragicEvent(ex);
+            throw ex;
+        }
     }
 
     private static void writeCheckpoint(long syncPosition, int numOperations, Path translogFile, long generation, OpenOption... options) throws IOException {


### PR DESCRIPTION
We call this method in the buffered and unbuffered writer but never catch tragic
event exceptions on the unbuffered one. This change moves the check into the checkpoint method
to streamline the tragic event handling.

Note this is not a problem in master since it has only one impl
