### PR TITLE
Make MetaData parsing less lenient.

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -1074,14 +1074,20 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
                 if (token == XContentParser.Token.START_OBJECT) {
                     // move to the field name (meta-data)
                     token = parser.nextToken();
+                    if (token != XContentParser.Token.FIELD_NAME) {
+                        throw new IllegalArgumentException("Expected a field name but got " + token);
+                    }
                     // move to the next object
                     token = parser.nextToken();
                 }
                 currentFieldName = parser.currentName();
-                if (token == null) {
-                    // no data...
-                    return builder.build();
-                }
+            }
+
+            if (!"meta-data".equals(parser.currentName())) {
+                throw new IllegalArgumentException("Expected [meta-data] as a field name but got " + currentFieldName);
+            }
+            if (token != XContentParser.Token.START_OBJECT) {
+                throw new IllegalArgumentException("Expected a START_OBJECT but got " + token);
             }
 
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -1114,7 +1120,11 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
                         builder.version = parser.longValue();
                     } else if ("cluster_uuid".equals(currentFieldName) || "uuid".equals(currentFieldName)) {
                         builder.clusterUUID = parser.text();
+                    } else {
+                        throw new IllegalArgumentException("Unexpected field [" + currentFieldName + "]");
                     }
+                } else {
+                    throw new IllegalArgumentException("Unexpected token " + token);
                 }
             }
             return builder.build();

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -20,8 +20,14 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -108,6 +114,38 @@ public class MetaDataTests extends ESTestCase {
             fail("should fail");
         } catch (IllegalArgumentException ex) {
             assertThat(ex.getMessage(), is("index/alias [alias2] provided with routing value [1,2] that resolved to several routing values, rejecting operation"));
+        }
+    }
+
+    public void testUnknownFieldClusterMetaData() throws IOException {
+        BytesReference metadata = JsonXContent.contentBuilder()
+            .startObject()
+                .startObject("meta-data")
+                    .field("random", "value")
+                .endObject()
+            .endObject().bytes();
+        XContentParser parser = JsonXContent.jsonXContent.createParser(metadata);
+        try {
+            MetaData.Builder.fromXContent(parser);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Unexpected field [random]", e.getMessage());
+        }
+    }
+
+    public void testUnknownFieldIndexMetaData() throws IOException {
+        BytesReference metadata = JsonXContent.contentBuilder()
+            .startObject()
+                .startObject("index_name")
+                    .field("random", "value")
+                .endObject()
+            .endObject().bytes();
+        XContentParser parser = JsonXContent.jsonXContent.createParser(metadata);
+        try {
+            IndexMetaData.Builder.fromXContent(parser);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Unexpected field [random]", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Today this simply ignores everything that is not recognized.
