### PR TITLE
Translog base flushes can be disabled after replication relocation or slow recovery

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogService.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogService.java
@@ -25,10 +25,17 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.index.engine.EngineClosedException;
 import org.elasticsearch.index.engine.FlushNotAllowedEngineException;
 import org.elasticsearch.index.settings.IndexSettingsService;
-import org.elasticsearch.index.shard.*;
+import org.elasticsearch.index.shard.AbstractIndexShardComponent;
+import org.elasticsearch.index.shard.IllegalIndexShardStateException;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardState;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
@@ -41,7 +48,7 @@ public class TranslogService extends AbstractIndexShardComponent implements Clos
     public static final String INDEX_TRANSLOG_FLUSH_INTERVAL = "index.translog.interval";
     public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS = "index.translog.flush_threshold_ops";
     public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE = "index.translog.flush_threshold_size";
-    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_PERIOD =  "index.translog.flush_threshold_period";
+    public static final String INDEX_TRANSLOG_FLUSH_THRESHOLD_PERIOD = "index.translog.flush_threshold_period";
     public static final String INDEX_TRANSLOG_DISABLE_FLUSH = "index.translog.disable_flush";
 
     private final ThreadPool threadPool;
@@ -82,7 +89,6 @@ public class TranslogService extends AbstractIndexShardComponent implements Clos
     }
 
 
-
     class ApplySettings implements IndexSettingsService.Listener {
         @Override
         public void onRefreshSettings(Settings settings) {
@@ -118,37 +124,64 @@ public class TranslogService extends AbstractIndexShardComponent implements Clos
         return new TimeValue(interval.millis() + (ThreadLocalRandom.current().nextLong(interval.millis())));
     }
 
-    private class TranslogBasedFlush implements Runnable {
+    // public for testing
+    public TranslogBasedFlush createTranslogBasedFlush() {
+        return new TranslogBasedFlush();
+    }
+
+    public class TranslogBasedFlush extends AbstractRunnable {
 
         private volatile long lastFlushTime = System.currentTimeMillis();
 
+        // prevent construction
+        private TranslogBasedFlush() {}
+
         @Override
-        public void run() {
+        public void onFailure(Throwable t) {
+            if (t instanceof EsRejectedExecutionException) {
+                logger.trace("ignoring EsRejectedExecutionException, shutting down", t);
+            } else {
+                logger.warn("unexpected error while checking whether the translog needs a flush. rescheduling", t);
+                reschedule();
+            }
+        }
+
+        @Override
+        protected void doRun() throws Exception {
+            maybeFlushAndReschedule();
+        }
+
+        /** checks if we need to flush and reschedules a new check. returns true if a new check was scheduled */
+        public boolean maybeFlushAndReschedule() {
             if (indexShard.state() == IndexShardState.CLOSED) {
-                return;
+                return false;
             }
 
             // flush is disabled, but still reschedule
             if (disableFlush) {
                 reschedule();
-                return;
+                return true;
             }
-            Translog translog = indexShard.engine().getTranslog();
-            if (translog == null) {
+            final Translog translog;
+            try {
+                translog = indexShard.engine().getTranslog();
+            } catch (EngineClosedException e) {
+                // we're still recovering
                 reschedule();
-                return;
+                return true;
             }
+
             int currentNumberOfOperations = translog.totalOperations();
             if (currentNumberOfOperations == 0) {
                 reschedule();
-                return;
+                return true;
             }
 
             if (flushThresholdOperations > 0) {
                 if (currentNumberOfOperations > flushThresholdOperations) {
                     logger.trace("flushing translog, operations [{}], breached [{}]", currentNumberOfOperations, flushThresholdOperations);
                     asyncFlushAndReschedule();
-                    return;
+                    return true;
                 }
             }
 
@@ -157,7 +190,7 @@ public class TranslogService extends AbstractIndexShardComponent implements Clos
                 if (sizeInBytes > flushThresholdSize.bytes()) {
                     logger.trace("flushing translog, size [{}], breached [{}]", new ByteSizeValue(sizeInBytes), flushThresholdSize);
                     asyncFlushAndReschedule();
-                    return;
+                    return true;
                 }
             }
 
@@ -165,11 +198,11 @@ public class TranslogService extends AbstractIndexShardComponent implements Clos
                 if ((threadPool.estimatedTimeInMillis() - lastFlushTime) > flushThresholdPeriod.millis()) {
                     logger.trace("flushing translog, last_flush_time [{}], breached [{}]", lastFlushTime, flushThresholdPeriod);
                     asyncFlushAndReschedule();
-                    return;
+                    return true;
                 }
             }
-
             reschedule();
+            return true;
         }
 
         private void reschedule() {


### PR DESCRIPTION
#10624 decoupled translog flush from ongoing recoveries. In the process, the translog creation was delayed to moment the engine is created (during recovery, after copying files from the primary). On the other side, TranslogService, in charge of translog based flushes, starts a background checker as soon as the shard is allocated. That checker performs it's first check after 5s expected the translog to be there. However, if the file copying phase of the recovery takes >5s (likely!) or local recovery is slow, the check can run into an exception and never recover. The end result is that the translog based flush is completely disabled.

Note that this is mitigated but shard inactivity which triggers synced flush after 5m of no indexing.

Also - this is already fixed in master, where we don't have this background check,

Closes #15814
