### PR TITLE
sync translog to disk after recovery from primary

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/TranslogRecoveryPerformer.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/TranslogRecoveryPerformer.java
@@ -70,6 +70,7 @@ public class TranslogRecoveryPerformer {
                 performRecoveryOperation(engine, operation, false);
                 numOps++;
             }
+            engine.getTranslog().sync();
         } catch (Throwable t) {
             throw new BatchOperationException(shardId, "failed to apply batch translog operation", numOps, t);
         }


### PR DESCRIPTION
Otherwise if that node is shutdown and restarted it might will have lost all operations
that were in the translog.

This might be responsible for build failures in the bwc tests like here: http://build-us-00.elastic.co/job/es_core_2x_window-2008/437/consoleText
