### PR TITLE
Fixed broken link on from-size documentation page

### DIFF
--- a/docs/reference/search/request/from-size.asciidoc
+++ b/docs/reference/search/request/from-size.asciidoc
@@ -21,6 +21,5 @@ defaults to `10`.
 --------------------------------------------------
 
 Note that `from` + `size` can not be more than the `index.max_result_window`
-index setting which defaults to 10,000. See the
-{ref}/search-request-scroll.html[Scroll] api for more efficient ways to do deep
-scrolling.
+index setting which defaults to 10,000. See the <<search-request-scroll,Scroll>>
+API for more efficient ways to do deep scrolling.


### PR DESCRIPTION
See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html for the current bug.

<img width="870" alt="from___size" src="https://cloud.githubusercontent.com/assets/9599/12183613/bdac0186-b544-11e5-99ec-a306ae7b69e6.png">
