### PR TITLE
Remove -Xlint:-deprecation from all but core

### DIFF
--- a/modules/lang-groovy/build.gradle
+++ b/modules/lang-groovy/build.gradle
@@ -26,8 +26,8 @@ dependencies {
   compile 'org.codehaus.groovy:groovy:2.4.4:indy'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-rawtypes,-unchecked,-cast,-deprecation'
-compileTestJava.options.compilerArgs << '-Xlint:-rawtypes,-unchecked,-cast,-deprecation'
+compileJava.options.compilerArgs << '-Xlint:-rawtypes,-unchecked,-cast'
+compileTestJava.options.compilerArgs << '-Xlint:-rawtypes,-unchecked,-cast'
 
 integTest {
   cluster {

--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -30,6 +30,3 @@ dependencies {
 dependencyLicenses {
   mapping from: /lucene-.*/, to: 'lucene'
 }
-
-compileJava.options.compilerArgs << "-Xlint:-deprecation"
-

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuCollationTokenFilterFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuCollationTokenFilterFactory.java
@@ -19,18 +19,19 @@
 
 package org.elasticsearch.index.analysis;
 
-import com.ibm.icu.text.Collator;
-import com.ibm.icu.text.RuleBasedCollator;
-import com.ibm.icu.util.ULocale;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+
 import org.apache.lucene.analysis.TokenStream;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
+import com.ibm.icu.text.Collator;
+import com.ibm.icu.text.RuleBasedCollator;
+import com.ibm.icu.util.ULocale;
 
 /**
  * An ICU based collation token filter. There are two ways to configure collation:
@@ -45,6 +46,7 @@ public class IcuCollationTokenFilterFactory extends AbstractTokenFilterFactory {
 
     private final Collator collator;
 
+    @SuppressWarnings("deprecation") // Intentionally sets deprecated options for backwards compatibility
     public IcuCollationTokenFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(indexSettings, name, settings);
 
@@ -165,6 +167,7 @@ public class IcuCollationTokenFilterFactory extends AbstractTokenFilterFactory {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Constructs a deprecated filter for backwards compatibility
     public TokenStream create(TokenStream tokenStream) {
         return new ICUCollationKeyFilter(tokenStream, collator);
     }

--- a/plugins/discovery-azure/build.gradle
+++ b/plugins/discovery-azure/build.gradle
@@ -57,8 +57,6 @@ dependencyLicenses {
 }
 
 compileJava.options.compilerArgs << '-Xlint:-path,-serial,-unchecked'
-// TODO: why is deprecation needed here but not in maven....?
-compileJava.options.compilerArgs << '-Xlint:-deprecation'
 
 thirdPartyAudit.excludes = [
   // classes are missing

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -42,8 +42,6 @@ dependencyLicenses {
   mapping from: /jackson-.*/, to: 'jackson'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-rawtypes,-deprecation'
-
 test {
   // this is needed for insecure plugins, remove if possible!
   systemProperty 'tests.artifact', project.name 

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cloud.aws;
 
 import com.amazonaws.services.ec2.AmazonEC2;
+
 import org.elasticsearch.common.component.LifecycleComponent;
 
 public interface AwsEc2Service extends LifecycleComponent<AwsEc2Service> {
@@ -33,10 +34,6 @@ public interface AwsEc2Service extends LifecycleComponent<AwsEc2Service> {
         public static final String PROXY_PASSWORD = "cloud.aws.proxy.password";
         public static final String SIGNER = "cloud.aws.signer";
         public static final String REGION = "cloud.aws.region";
-        @Deprecated
-        public static final String DEPRECATED_PROXY_HOST = "cloud.aws.proxy_host";
-        @Deprecated
-        public static final String DEPRECATED_PROXY_PORT = "cloud.aws.proxy_port";
     }
 
     final class CLOUD_EC2 {
@@ -49,10 +46,6 @@ public interface AwsEc2Service extends LifecycleComponent<AwsEc2Service> {
         public static final String PROXY_PASSWORD = "cloud.aws.ec2.proxy.password";
         public static final String SIGNER = "cloud.aws.ec2.signer";
         public static final String ENDPOINT = "cloud.aws.ec2.endpoint";
-        @Deprecated
-        public static final String DEPRECATED_PROXY_HOST = "cloud.aws.ec2.proxy_host";
-        @Deprecated
-        public static final String DEPRECATED_PROXY_PORT = "cloud.aws.ec2.proxy_port";
     }
 
     final class DISCOVERY_EC2 {

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
@@ -73,7 +73,6 @@ public class AwsEc2ServiceImpl extends AbstractLifecycleComponent<AwsEc2Service>
     }
 
     @Override
-    @SuppressWarnings("deprecation") // Supports deprecated parameters for backwards compatibility
     public synchronized AmazonEC2 client() {
         if (client != null) {
             return client;
@@ -94,11 +93,11 @@ public class AwsEc2ServiceImpl extends AbstractLifecycleComponent<AwsEc2Service>
         String account = settings.get(CLOUD_EC2.KEY, settings.get(CLOUD_AWS.KEY));
         String key = settings.get(CLOUD_EC2.SECRET, settings.get(CLOUD_AWS.SECRET));
 
-        String proxyHost = settings.get(CLOUD_AWS.PROXY_HOST, settings.get(CLOUD_AWS.DEPRECATED_PROXY_HOST));
-        proxyHost = settings.get(CLOUD_EC2.PROXY_HOST, settings.get(CLOUD_EC2.DEPRECATED_PROXY_HOST, proxyHost));
+        String proxyHost = settings.get(CLOUD_AWS.PROXY_HOST);
+        proxyHost = settings.get(CLOUD_EC2.PROXY_HOST, proxyHost);
         if (proxyHost != null) {
-            String portString = settings.get(CLOUD_AWS.PROXY_PORT, settings.get(CLOUD_AWS.DEPRECATED_PROXY_PORT, "80"));
-            portString = settings.get(CLOUD_EC2.PROXY_PORT, settings.get(CLOUD_EC2.DEPRECATED_PROXY_PORT, portString));
+            String portString = settings.get(CLOUD_AWS.PROXY_PORT, "80");
+            portString = settings.get(CLOUD_EC2.PROXY_PORT, portString);
             Integer proxyPort;
             try {
                 proxyPort = Integer.parseInt(portString, 10);

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/cloud/aws/AwsEc2ServiceImpl.java
@@ -33,6 +33,7 @@ import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cloud.aws.network.Ec2NameResolver;
 import org.elasticsearch.cloud.aws.node.Ec2CustomNodeAttributes;
@@ -71,6 +72,8 @@ public class AwsEc2ServiceImpl extends AbstractLifecycleComponent<AwsEc2Service>
         discoveryNodeService.addCustomAttributeProvider(new Ec2CustomNodeAttributes(settings));
     }
 
+    @Override
+    @SuppressWarnings("deprecation") // Supports deprecated parameters for backwards compatibility
     public synchronized AmazonEC2 client() {
         if (client != null) {
             return client;
@@ -135,7 +138,7 @@ public class AwsEc2ServiceImpl extends AbstractLifecycleComponent<AwsEc2Service>
                                                      int retriesAttempted) {
                         // with 10 retries the max delay time is 320s/320000ms (10 * 2^5 * 1 * 1000)
                         logger.warn("EC2 API request failed, retry again. Reason was:", exception);
-                        return 1000L * (long) (10d * Math.pow(2, ((double) retriesAttempted) / 2.0d) * (1.0d + rand.nextDouble()));
+                        return 1000L * (long) (10d * Math.pow(2, retriesAttempted / 2.0d) * (1.0d + rand.nextDouble()));
                     }
                 },
                 10,

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/plugin/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -19,6 +19,11 @@
 
 package org.elasticsearch.plugin.discovery.ec2;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.cloud.aws.AwsEc2ServiceImpl;
 import org.elasticsearch.cloud.aws.Ec2Module;
@@ -32,16 +37,11 @@ import org.elasticsearch.discovery.ec2.AwsEc2UnicastHostsProvider;
 import org.elasticsearch.discovery.ec2.Ec2Discovery;
 import org.elasticsearch.plugins.Plugin;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collection;
-
 /**
  *
  */
 public class Ec2DiscoveryPlugin extends Plugin {
-  
+
     // ClientConfiguration clinit has some classloader problems
     // TODO: fix that
     static {
@@ -87,6 +87,7 @@ public class Ec2DiscoveryPlugin extends Plugin {
     }
 
     @Override
+    @SuppressWarnings("rawtypes") // Supertype uses rawtype
     public Collection<Class<? extends LifecycleComponent>> nodeServices() {
         Collection<Class<? extends LifecycleComponent>> services = new ArrayList<>();
         services.add(AwsEc2ServiceImpl.class);

--- a/plugins/discovery-multicast/build.gradle
+++ b/plugins/discovery-multicast/build.gradle
@@ -21,5 +21,3 @@ esplugin {
   description 'The Multicast Discovery plugin allows discovery other nodes using multicast requests'
   classname 'org.elasticsearch.plugin.discovery.multicast.MulticastDiscoveryPlugin'
 }
-
-compileJava.options.compilerArgs << "-Xlint:-deprecation"

--- a/plugins/mapper-attachments/build.gradle
+++ b/plugins/mapper-attachments/build.gradle
@@ -61,7 +61,7 @@ dependencies {
   compile 'org.apache.commons:commons-compress:1.10'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-cast,-deprecation,-rawtypes'
+compileJava.options.compilerArgs << '-Xlint:-cast,-rawtypes'
 
 forbiddenPatterns {
   exclude '**/*.docx'

--- a/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
+++ b/plugins/mapper-attachments/src/main/java/org/elasticsearch/mapper/attachments/AttachmentMapper.java
@@ -100,6 +100,7 @@ public class AttachmentMapper extends FieldMapper {
             super(ref);
         }
 
+        @Override
         public AttachmentMapper.AttachmentFieldType clone() {
             return new AttachmentMapper.AttachmentFieldType(this);
         }
@@ -109,6 +110,7 @@ public class AttachmentMapper extends FieldMapper {
             return CONTENT_TYPE;
         }
 
+        @Override
         public String value(Object value) {
             return value == null?null:value.toString();
         }
@@ -292,7 +294,7 @@ public class AttachmentMapper extends FieldMapper {
                 type = "string";
             }
             Mapper.TypeParser typeParser = parserContext.typeParser(type);
-            Mapper.Builder<?, ?> mapperBuilder = typeParser.parse(propName, (Map<String, Object>) propNode, parserContext);
+            Mapper.Builder<?, ?> mapperBuilder = typeParser.parse(propName, propNode, parserContext);
 
             return mapperBuilder;
         }
@@ -414,6 +416,7 @@ public class AttachmentMapper extends FieldMapper {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // https://github.com/elastic/elasticsearch/issues/15843
     public Mapper parse(ParseContext context) throws IOException {
         byte[] content = null;
         String contentType = null;

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -35,6 +35,5 @@ dependencyLicenses {
   mapping from: /stax-.*/, to: 'stax'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-deprecation,-serial'
-compileTestJava.options.compilerArgs << '-Xlint:-deprecation'
+compileJava.options.compilerArgs << '-Xlint:-serial'
 

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.LocationMode;
 import com.microsoft.azure.storage.StorageException;
+
 import org.elasticsearch.common.blobstore.BlobMetaData;
 
 import java.io.InputStream;
@@ -36,10 +37,6 @@ public interface AzureStorageService {
 
     final class Storage {
         public static final String PREFIX = "cloud.azure.storage.";
-        @Deprecated
-        public static final String ACCOUNT_DEPRECATED = "cloud.azure.storage.account";
-        @Deprecated
-        public static final String KEY_DEPRECATED = "cloud.azure.storage.key";
 
         public static final String TIMEOUT = "cloud.azure.storage.timeout";
 

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettings.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettings.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.cloud.azure.storage;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.logging.ESLogger;
@@ -27,9 +30,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.repositories.RepositorySettings;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class AzureStorageSettings {
     private static ESLogger logger = ESLoggerFactory.getLogger(AzureStorageSettings.class.getName());
@@ -78,6 +78,7 @@ public class AzureStorageSettings {
      * @param settings settings to parse
      * @return A tuple with v1 = primary storage and v2 = secondary storage
      */
+    @SuppressWarnings("deprecation") // Supports deprecated settings
     public static Tuple<AzureStorageSettings, Map<String, AzureStorageSettings>> parse(Settings settings) {
         AzureStorageSettings primaryStorage = null;
         Map<String, AzureStorageSettings> secondaryStorage = new HashMap<>();

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettings.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageSettings.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.cloud.azure.storage;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.logging.ESLogger;
@@ -30,6 +27,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.repositories.RepositorySettings;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class AzureStorageSettings {
     private static ESLogger logger = ESLoggerFactory.getLogger(AzureStorageSettings.class.getName());
@@ -78,57 +78,46 @@ public class AzureStorageSettings {
      * @param settings settings to parse
      * @return A tuple with v1 = primary storage and v2 = secondary storage
      */
-    @SuppressWarnings("deprecation") // Supports deprecated settings
     public static Tuple<AzureStorageSettings, Map<String, AzureStorageSettings>> parse(Settings settings) {
         AzureStorageSettings primaryStorage = null;
         Map<String, AzureStorageSettings> secondaryStorage = new HashMap<>();
 
-        // We check for deprecated settings
-        String account = settings.get(Storage.ACCOUNT_DEPRECATED);
-        String key = settings.get(Storage.KEY_DEPRECATED);
-
         TimeValue globalTimeout = settings.getAsTime(Storage.TIMEOUT, TimeValue.timeValueMinutes(5));
 
-        if (account != null) {
-            logger.warn("[{}] and [{}] have been deprecated. Use now [{}xxx.account] and [{}xxx.key] where xxx is any name",
-                    Storage.ACCOUNT_DEPRECATED, Storage.KEY_DEPRECATED, Storage.PREFIX, Storage.PREFIX);
-            primaryStorage = new AzureStorageSettings(null, account, key, globalTimeout);
-        } else {
-            Settings storageSettings = settings.getByPrefix(Storage.PREFIX);
-            if (storageSettings != null) {
-                Map<String, Object> asMap = storageSettings.getAsStructuredMap();
-                for (Map.Entry<String, Object> storage : asMap.entrySet()) {
-                    if (storage.getValue() instanceof Map) {
-                        @SuppressWarnings("unchecked")
-                        Map<String, String> map = (Map) storage.getValue();
-                        TimeValue timeout = TimeValue.parseTimeValue(map.get("timeout"), globalTimeout, Storage.PREFIX + storage.getKey() + ".timeout");
-                        AzureStorageSettings current = new AzureStorageSettings(storage.getKey(), map.get("account"), map.get("key"), timeout);
-                        boolean activeByDefault = Boolean.parseBoolean(map.getOrDefault("default", "false"));
-                        if (activeByDefault) {
-                            if (primaryStorage == null) {
-                                primaryStorage = current;
-                            } else {
-                                logger.warn("default storage settings has already been defined. You can not define it to [{}]", storage.getKey());
-                                secondaryStorage.put(storage.getKey(), current);
-                            }
+        Settings storageSettings = settings.getByPrefix(Storage.PREFIX);
+        if (storageSettings != null) {
+            Map<String, Object> asMap = storageSettings.getAsStructuredMap();
+            for (Map.Entry<String, Object> storage : asMap.entrySet()) {
+                if (storage.getValue() instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> map = (Map) storage.getValue();
+                    TimeValue timeout = TimeValue.parseTimeValue(map.get("timeout"), globalTimeout, Storage.PREFIX + storage.getKey() + ".timeout");
+                    AzureStorageSettings current = new AzureStorageSettings(storage.getKey(), map.get("account"), map.get("key"), timeout);
+                    boolean activeByDefault = Boolean.parseBoolean(map.getOrDefault("default", "false"));
+                    if (activeByDefault) {
+                        if (primaryStorage == null) {
+                            primaryStorage = current;
                         } else {
+                            logger.warn("default storage settings has already been defined. You can not define it to [{}]", storage.getKey());
                             secondaryStorage.put(storage.getKey(), current);
                         }
+                    } else {
+                        secondaryStorage.put(storage.getKey(), current);
                     }
                 }
-                // If we did not set any default storage, we should complain and define it
-                if (primaryStorage == null && secondaryStorage.isEmpty() == false) {
-                    Map.Entry<String, AzureStorageSettings> fallback = secondaryStorage.entrySet().iterator().next();
-                    // We only warn if the number of secondary storage if > to 1
-                    // If the user defined only one storage account, that's fine. We know it's the default one.
-                    if (secondaryStorage.size() > 1) {
-                        logger.warn("no default storage settings has been defined. " +
-                                "Add \"default\": true to the settings you want to activate by default. " +
-                                "Forcing default to [{}].", fallback.getKey());
-                    }
-                    primaryStorage = fallback.getValue();
-                    secondaryStorage.remove(fallback.getKey());
+            }
+            // If we did not set any default storage, we should complain and define it
+            if (primaryStorage == null && secondaryStorage.isEmpty() == false) {
+                Map.Entry<String, AzureStorageSettings> fallback = secondaryStorage.entrySet().iterator().next();
+                // We only warn if the number of secondary storage if > to 1
+                // If the user defined only one storage account, that's fine. We know it's the default one.
+                if (secondaryStorage.size() > 1) {
+                    logger.warn("no default storage settings has been defined. " +
+                            "Add \"default\": true to the settings you want to activate by default. " +
+                            "Forcing default to [{}].", fallback.getKey());
                 }
+                primaryStorage = fallback.getValue();
+                secondaryStorage.remove(fallback.getKey());
             }
         }
 

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.cloud.azure;
 
-import java.net.URISyntaxException;
-import java.util.Collection;
+import com.microsoft.azure.storage.LocationMode;
+import com.microsoft.azure.storage.StorageException;
 
 import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
@@ -34,8 +34,8 @@ import org.elasticsearch.test.store.MockFSDirectoryService;
 import org.junit.After;
 import org.junit.Before;
 
-import com.microsoft.azure.storage.LocationMode;
-import com.microsoft.azure.storage.StorageException;
+import java.net.URISyntaxException;
+import java.util.Collection;
 
 public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzureTestCase {
 
@@ -77,15 +77,9 @@ public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzu
     }
 
     @Override
-    @SuppressWarnings("deprecation") // Supports deprecated settings for testing backwards compatibility
     protected Settings nodeSettings(int nodeOrdinal) {
         Settings.Builder builder = Settings.settingsBuilder()
                 .put(Storage.CONTAINER, "snapshots");
-
-        // We use sometime deprecated settings in tests
-        builder.put(Storage.ACCOUNT_DEPRECATED, "mock_azure_account")
-                .put(Storage.KEY_DEPRECATED, "mock_azure_key");
-
         return builder.build();
     }
 

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
@@ -19,8 +19,9 @@
 
 package org.elasticsearch.cloud.azure;
 
-import com.microsoft.azure.storage.LocationMode;
-import com.microsoft.azure.storage.StorageException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
 import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.cloud.azure.storage.AzureStorageServiceMock;
@@ -33,8 +34,8 @@ import org.elasticsearch.test.store.MockFSDirectoryService;
 import org.junit.After;
 import org.junit.Before;
 
-import java.net.URISyntaxException;
-import java.util.Collection;
+import com.microsoft.azure.storage.LocationMode;
+import com.microsoft.azure.storage.StorageException;
 
 public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzureTestCase {
 
@@ -76,6 +77,7 @@ public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzu
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Supports deprecated settings for testing backwards compatibility
     protected Settings nodeSettings(int nodeOrdinal) {
         Settings.Builder builder = Settings.settingsBuilder()
                 .put(Storage.CONTAINER, "snapshots");

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSettingsParserTest.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSettingsParserTest.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.repositories.azure;
 
+import java.util.Map;
+
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.cloud.azure.storage.AzureStorageSettings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
-
-import java.util.Map;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -67,6 +67,7 @@ public class AzureSettingsParserTest extends LuceneTestCase {
     }
 
     public void testDeprecatedSettings() {
+        @SuppressWarnings("deprecation")
         Settings settings = Settings.builder()
                 .put(Storage.ACCOUNT_DEPRECATED, "myaccount1")
                 .put(Storage.KEY_DEPRECATED, "mykey1")

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSettingsParserTest.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSettingsParserTest.java
@@ -19,13 +19,12 @@
 
 package org.elasticsearch.repositories.azure;
 
-import java.util.Map;
-
 import org.apache.lucene.util.LuceneTestCase;
-import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.cloud.azure.storage.AzureStorageSettings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
+
+import java.util.Map;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -57,20 +56,6 @@ public class AzureSettingsParserTest extends LuceneTestCase {
         Settings settings = Settings.builder()
                 .put("cloud.azure.storage.azure1.account", "myaccount1")
                 .put("cloud.azure.storage.azure1.key", "mykey1")
-                .build();
-
-        Tuple<AzureStorageSettings, Map<String, AzureStorageSettings>> tuple = AzureStorageSettings.parse(settings);
-        assertThat(tuple.v1(), notNullValue());
-        assertThat(tuple.v1().getAccount(), is("myaccount1"));
-        assertThat(tuple.v1().getKey(), is("mykey1"));
-        assertThat(tuple.v2().keySet(), hasSize(0));
-    }
-
-    public void testDeprecatedSettings() {
-        @SuppressWarnings("deprecation")
-        Settings settings = Settings.builder()
-                .put(Storage.ACCOUNT_DEPRECATED, "myaccount1")
-                .put(Storage.KEY_DEPRECATED, "mykey1")
                 .build();
 
         Tuple<AzureStorageSettings, Map<String, AzureStorageSettings>> tuple = AzureStorageSettings.parse(settings);

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -96,8 +96,6 @@ integTest {
   }
 }
 
-compileJava.options.compilerArgs << '-Xlint:-deprecation,-rawtypes'
-
 thirdPartyAudit.excludes = [
   // classes are missing, because we added hadoop jars one by one until tests pass.
   'com.google.gson.stream.JsonReader', 

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -43,8 +43,6 @@ dependencyLicenses {
   mapping from: /jackson-.*/, to: 'jackson'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-deprecation,-rawtypes'
-
 test {
   // this is needed for insecure plugins, remove if possible!
   systemProperty 'tests.artifact', project.name 

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cloud.aws;
 
 import com.amazonaws.services.s3.AmazonS3;
+
 import org.elasticsearch.common.component.LifecycleComponent;
 
 /**
@@ -37,10 +38,6 @@ public interface AwsS3Service extends LifecycleComponent<AwsS3Service> {
         public static final String PROXY_PASSWORD = "cloud.aws.proxy.password";
         public static final String SIGNER = "cloud.aws.signer";
         public static final String REGION = "cloud.aws.region";
-        @Deprecated
-        public static final String DEPRECATED_PROXY_HOST = "cloud.aws.proxy_host";
-        @Deprecated
-        public static final String DEPRECATED_PROXY_PORT = "cloud.aws.proxy_port";
     }
 
     final class CLOUD_S3 {
@@ -53,10 +50,6 @@ public interface AwsS3Service extends LifecycleComponent<AwsS3Service> {
         public static final String PROXY_PASSWORD = "cloud.aws.s3.proxy.password";
         public static final String SIGNER = "cloud.aws.s3.signer";
         public static final String ENDPOINT = "cloud.aws.s3.endpoint";
-        @Deprecated
-        public static final String DEPRECATED_PROXY_HOST = "cloud.aws.s3.proxy_host";
-        @Deprecated
-        public static final String DEPRECATED_PROXY_PORT = "cloud.aws.s3.proxy_port";
     }
 
     final class REPOSITORY_S3 {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -31,6 +31,7 @@ import com.amazonaws.http.IdleConnectionReaper;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -94,7 +95,7 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
         return getClient(endpoint, protocol, account, key, maxRetries);
     }
 
-
+    @SuppressWarnings("deprecation") // Handles deprecated settings.
     private synchronized AmazonS3 getClient(String endpoint, String protocol, String account, String key, Integer maxRetries) {
         Tuple<String, String> clientDescriptor = new Tuple<String, String>(endpoint, account);
         AmazonS3Client client = clients.get(clientDescriptor);

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -95,7 +95,6 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
         return getClient(endpoint, protocol, account, key, maxRetries);
     }
 
-    @SuppressWarnings("deprecation") // Handles deprecated settings.
     private synchronized AmazonS3 getClient(String endpoint, String protocol, String account, String key, Integer maxRetries) {
         Tuple<String, String> clientDescriptor = new Tuple<String, String>(endpoint, account);
         AmazonS3Client client = clients.get(clientDescriptor);
@@ -120,11 +119,11 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
             throw new IllegalArgumentException("No protocol supported [" + protocol + "], can either be [http] or [https]");
         }
 
-        String proxyHost = settings.get(CLOUD_AWS.PROXY_HOST, settings.get(CLOUD_AWS.DEPRECATED_PROXY_HOST));
-        proxyHost = settings.get(CLOUD_S3.PROXY_HOST, settings.get(CLOUD_S3.DEPRECATED_PROXY_HOST, proxyHost));
+        String proxyHost = settings.get(CLOUD_AWS.PROXY_HOST);
+        proxyHost = settings.get(CLOUD_S3.PROXY_HOST, proxyHost);
         if (proxyHost != null) {
-            String portString = settings.get(CLOUD_AWS.PROXY_PORT, settings.get(CLOUD_AWS.DEPRECATED_PROXY_PORT, "80"));
-            portString = settings.get(CLOUD_S3.PROXY_PORT, settings.get(CLOUD_S3.DEPRECATED_PROXY_PORT, portString));
+            String portString = settings.get(CLOUD_AWS.PROXY_PORT, "80");
+            portString = settings.get(CLOUD_S3.PROXY_PORT, portString);
             Integer proxyPort;
             try {
                 proxyPort = Integer.parseInt(portString, 10);

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/plugin/repository/s3/S3RepositoryPlugin.java
@@ -77,6 +77,7 @@ public class S3RepositoryPlugin extends Plugin {
     }
 
     @Override
+    @SuppressWarnings("rawtypes") // Supertype declaration has raw types
     public Collection<Class<? extends LifecycleComponent>> nodeServices() {
         return Collections.<Class<? extends LifecycleComponent>>singleton(S3Module.getS3ServiceImpl());
     }

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   compile 'org.elasticsearch:securemock:1.2'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-cast,-deprecation,-rawtypes,-serial,-try,-unchecked'
+compileJava.options.compilerArgs << '-Xlint:-cast,-rawtypes,-serial,-try,-unchecked'
 compileTestJava.options.compilerArgs << '-Xlint:-rawtypes'
 
 // the main files are actually test files, so use the appopriate forbidden api sigs

--- a/test/framework/src/main/java/org/elasticsearch/common/io/PathUtilsForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/io/PathUtilsForTesting.java
@@ -23,21 +23,22 @@ import org.apache.lucene.util.LuceneTestCase;
 
 import java.nio.file.FileSystem;
 
-/** 
- * Exposes some package private stuff in PathUtils for framework purposes only! 
+/**
+ * Exposes some package private stuff in PathUtils for framework purposes only!
  */
 public class PathUtilsForTesting {
-    
+
     /** Sets a new default filesystem for testing */
+    @SuppressWarnings("deprecation") // https://github.com/elastic/elasticsearch/issues/15845
     public static void setup() {
         installMock(LuceneTestCase.getBaseTempDirForTestClass().getFileSystem());
     }
-    
+
     /** Installs a mock filesystem for testing */
     public static void installMock(FileSystem mock) {
         PathUtils.DEFAULT = mock;
     }
-    
+
     /** Resets filesystem back to the real system default */
     public static void teardown() {
         PathUtils.DEFAULT = PathUtils.ACTUAL_DEFAULT;

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -24,6 +24,7 @@ import com.carrotsearch.randomizedtesting.SysGlobals;
 import com.carrotsearch.randomizedtesting.generators.RandomInts;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+
 import org.apache.lucene.store.StoreRateLimiting;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ElasticsearchException;
@@ -117,7 +118,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static junit.framework.Assert.fail;
 import static org.apache.lucene.util.LuceneTestCase.TEST_NIGHTLY;
 import static org.apache.lucene.util.LuceneTestCase.rarely;
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
@@ -127,6 +127,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * InternalTestCluster manages a set of JVM private nodes and allows convenient access to them.
@@ -1045,6 +1046,7 @@ public final class InternalTestCluster extends TestCluster {
         }
     }
 
+    @SuppressWarnings("deprecation") // https://github.com/elastic/elasticsearch/issues/15844
     private void randomlyResetClients() throws IOException {
         // only reset the clients on nightly tests, it causes heavy load...
         if (RandomizedTest.isNightly() && rarely(random)) {

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruption.java
@@ -75,6 +75,7 @@ public class LongGCDisruption extends SingleNodeDisruption {
         return TimeValue.timeValueMillis(0);
     }
 
+    @SuppressWarnings("deprecation") // stops/resumes threads intentionally
     @SuppressForbidden(reason = "stops/resumes threads intentionally")
     protected boolean stopNodeThreads(String node, Set<Thread> nodeThreads) {
         Thread[] allThreads = null;
@@ -118,6 +119,7 @@ public class LongGCDisruption extends SingleNodeDisruption {
         return stopped;
     }
 
+    @SuppressWarnings("deprecation") // stops/resumes threads intentionally
     @SuppressForbidden(reason = "stops/resumes threads intentionally")
     protected void resumeThreads(Set<Thread> threads) {
         for (Thread thread : threads) {

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -513,9 +513,9 @@ public class ElasticsearchAssertions {
     public static <T extends Query> T assertBooleanSubQuery(Query query, Class<T> subqueryType, int i) {
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery q = (BooleanQuery) query;
-        assertThat(q.getClauses().length, greaterThan(i));
-        assertThat(q.getClauses()[i].getQuery(), instanceOf(subqueryType));
-        return (T) q.getClauses()[i].getQuery();
+        assertThat(q.clauses().size(), greaterThan(i));
+        assertThat(q.clauses().get(i).getQuery(), instanceOf(subqueryType));
+        return subqueryType.cast(q.clauses().get(i).getQuery());
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/store/MockFSDirectoryService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/store/MockFSDirectoryService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.test.store;
 
 import com.carrotsearch.randomizedtesting.SeedUtils;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+
 import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.store.BaseDirectoryWrapper;
@@ -105,6 +106,7 @@ public class MockFSDirectoryService extends FsDirectoryService {
         throw new UnsupportedOperationException();
     }
 
+    @SuppressWarnings("deprecation") // https://github.com/elastic/elasticsearch/issues/15846
     public static void checkIndex(ESLogger logger, Store store, ShardId shardId) {
         if (store.tryIncRef()) {
             logger.info("start check index");


### PR DESCRIPTION
Gets a few other Xlints while I'm in there but mostly just deprecation. For the most part I isolate the deprecation and leave a comment. Either the comment is an admission of why we still need to use the deprecated method or a link to an issue.

Closes #15829
