### PR TITLE
Fix CreateIndexIT#testCreateAndDeleteIndexConcurrently

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java
@@ -206,8 +206,12 @@ public class InternalClusterService extends AbstractLifecycleComponent<ClusterSe
     protected void doStop() {
         FutureUtils.cancel(this.reconnectToNodes);
         for (NotifyTimeout onGoingTimeout : onGoingTimeouts) {
-            onGoingTimeout.cancel();
-            onGoingTimeout.listener.onClose();
+            try {
+                onGoingTimeout.cancel();
+                onGoingTimeout.listener.onClose();
+            } catch (Exception ex) {
+                logger.debug("failed to notify listeners on shutdown", ex);
+            }
         }
         ThreadPool.terminate(updateTasksExecutor, 10, TimeUnit.SECONDS);
         remove(localNodeMasterListeners);


### PR DESCRIPTION
The test fails in different ways since we can hit timeouts and shards not being available on retry
which we simply didn't expect before but are valid.

Closes #15312
Closes #14512
