### PR TITLE
Fix initial sizing of BytesStreamOutput.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
@@ -39,10 +39,12 @@ public class BytesStreamOutput extends StreamOutput implements BytesStream {
     protected int count;
 
     /**
-     * Create a non recycling {@link BytesStreamOutput} with 1 initial page acquired.
+     * Create a non recycling {@link BytesStreamOutput} with an initial capacity of 0.
      */
     public BytesStreamOutput() {
-        this(BigArrays.PAGE_SIZE_IN_BYTES);
+        // since this impl is not recycling anyway, don't bother aligning to
+        // the page size, this will even save memory
+        this(0);
     }
 
     /**


### PR DESCRIPTION
It currently tries to align to the page size (16KB) by default. However, this
might waste a significant memory (if many BytesStreamOutputs are allocated)
and is also useless given that BytesStreamOutput does not recycle (on the
contrary to ReleasableBytesStreamOutput). So the initial size has been changed
to 0.

Closes #15789
