### PR TITLE
Sanity check for Gradle esplugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@
 import com.bmuschko.gradle.nexus.NexusPlugin
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
+apply plugin: 'base' // basic lifecycle for root project
+
 // common maven publishing configuration
 subprojects {
   group = 'org.elasticsearch'
@@ -272,3 +274,10 @@ task run(type: Run) {
   group = 'Verification'
   impliesSubProjects = true
 }
+
+task buildSrcIntegTest(type: GradleBuild) {
+  buildFile = 'buildSrc/build.gradle'
+  tasks = ['integTest']
+}
+
+check.dependsOn buildSrcIntegTest

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -64,6 +64,8 @@ dependencies {
   compile 'de.thetaphi:forbiddenapis:2.0'
   compile 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   compile 'org.apache.rat:apache-rat:0.11'
+
+  testCompile gradleTestKit()
 }
 
 processResources {
@@ -91,3 +93,33 @@ tasks.cleanEclipse {
   delete '.settings'
 }
 tasks.eclipse.dependsOn(cleanEclipse, copyEclipseSettings)
+
+// Write the plugin's classpath to a file to share with the tests
+def generatedResourcesOutputDir = file("$projectDir/generated-resources")
+task createPluginClasspathManifest {
+  inputs.files sourceSets.main.runtimeClasspath
+  outputs.dir generatedResourcesOutputDir
+
+  doLast {
+    generatedResourcesOutputDir.mkdirs()
+    file("$generatedResourcesOutputDir/plugin-classpath.txt").setText(sourceSets.main.runtimeClasspath.join('\n'), 'UTF-8')
+  }
+}
+
+// Add the classpath file to the test runtime classpath
+dependencies {
+  testRuntime files(createPluginClasspathManifest)
+}
+
+project.sourceSets.test.output.dir(generatedResourcesOutputDir, builtBy: createPluginClasspathManifest)
+
+test {
+  exclude '**/*IT.class'
+}
+
+task integTest(type: Test) {
+  include '**/*IT.class'
+  ignoreFailures = true
+}
+
+project.idea.module.singleEntryLibraries= ['TEST': [project.file(generatedResourcesOutputDir)]]

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
@@ -87,6 +87,7 @@ class RandomizedTestingTask extends DefaultTask {
         outputs.upToDateWhen {false} // randomized tests are never up to date
         listenersConfig.listeners.add(new TestProgressLogger(factory: getProgressLoggerFactory()))
         listenersConfig.listeners.add(new TestReportLogger(logger: logger, config: testLoggingConfig))
+        onlyIf { testClassesDir.exists() }
     }
 
     @Inject

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestSpecHack.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestSpecHack.groovy
@@ -62,10 +62,12 @@ public class RestSpecHack {
             }
             into project.sourceSets.test.output.resourcesDir
         }
-        project.idea {
-            module {
-                if (scopes.TEST != null) {
-                    scopes.TEST.plus.add(project.configurations.restSpec)
+        if (project.hasProperty('idea')) {
+            project.idea {
+                module {
+                    if (scopes.TEST != null) {
+                        scopes.TEST.plus.add(project.configurations.restSpec)
+                    }
                 }
             }
         }

--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/SimplePluginIT.groovy
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/SimplePluginIT.groovy
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertEquals
+
+class SimplePluginIT {
+
+    @Rule
+    public TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File buildFile
+    List<File> pluginClasspath
+
+    @Before
+    public void setup() throws IOException {
+        buildFile = testProjectDir.newFile("build.gradle")
+        URL pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")
+        if (pluginClasspathResource == null) {
+            throw new IllegalStateException("Plugin classpath resource not found, run `createPluginClasspathManifest` task in buildSrc.")
+        }
+        pluginClasspath = pluginClasspathResource.readLines("UTF-8").collect { new File(it) }
+    }
+
+    @Test
+    public void testSimplePlugin() throws IOException {
+        buildFile.setText("""
+
+            plugins {
+                id 'elasticsearch.esplugin'
+            }
+
+            esplugin {
+                description 'Dummy description.'
+                classname 'org.elasticsearch.plugin.dummy.DummyPlugin'
+            }
+
+            """, 'UTF-8');
+
+        BuildResult result = GradleRunner.create()
+            .withPluginClasspath(pluginClasspath)
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments("assemble")
+            .build()
+
+        assertTrue(result.getOutput().contains("Elasticsearch Build Hamster says Hello!"))
+        assertEquals(result.task(":assemble").getOutcome(), TaskOutcome.SUCCESS)
+    }
+
+}


### PR DESCRIPTION
During development of a plugin based on the Gradle `elasticsearch.esplugin`, @beiske noticed a dependency of `RestSpecHack` on the `idea` plugin (which was not explicitly applied in his project). There are currently no sanity checks in place in our infrastructure to check whether the plugin functionality properly works for future third-party plugins based on `elasticsearch.esplugin`.

This PR adds the most simple sanity check, an integration test that applies `elasticsearch.esplugin` against the following sample plugin project:

```
plugins {
  id 'elasticsearch.esplugin'
}

esplugin {
  description 'Dummy description.'
  classname 'org.elasticsearch.plugin.dummy.DummyPlugin'
}
```
