### PR TITLE
fix nested multi-value query

### DIFF
--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -55,7 +55,7 @@ GET my_index/_search
     "bool": {
       "must": [
         { "match": { "user.first": "Alice" }},
-        { "match": { "user.last":  "White" }}
+        { "match": { "user.last":  "Smith" }}
       ]
     }
   }


### PR DESCRIPTION
The doc has a typo. It currently says 

> This document would incorrectly match a query for alice AND smith:

and the query is for alice AND white.
