### PR TITLE
Remove and forbid use of IndexWriter#isLocked

### DIFF
--- a/buildSrc/src/main/resources/forbidden/all-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/all-signatures.txt
@@ -45,6 +45,7 @@ org.apache.lucene.search.NumericRangeFilter
 org.apache.lucene.search.PrefixFilter
 org.apache.lucene.search.QueryWrapperFilter
 org.apache.lucene.search.join.BitDocIdSetCachingWrapperFilter
+org.apache.lucene.index.IndexWriter#isLocked(org.apache.lucene.store.Directory)
 
 java.nio.file.Paths @ Use org.elasticsearch.common.io.PathUtils.get() instead.
 java.nio.file.FileSystems#getDefault() @ use org.elasticsearch.common.io.PathUtils.getDefaultFileSystem() instead.

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -959,8 +959,7 @@ public class InternalEngine extends Engine {
             });
             return new IndexWriter(store.directory(), iwc);
         } catch (LockObtainFailedException ex) {
-            boolean isLocked = IndexWriter.isLocked(store.directory());
-            logger.warn("Could not lock IndexWriter isLocked [{}]", ex, isLocked);
+            logger.warn("could not lock IndexWriter", ex);
             throw ex;
         }
     }

--- a/core/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
@@ -56,7 +56,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -292,7 +291,6 @@ public class VersionsTests extends ESTestCase {
         }
 
         iw.close();
-        assertThat(IndexWriter.isLocked(iw.getDirectory()), is(false));
         ir.close();
         dir.close();
     }


### PR DESCRIPTION
This commit removes and now forbids use of
`org.apache.lucene.index.IndexWriter#isLocked` as this method was
deprecated in [LUCENE-6508](https://issues.apache.org/jira/browse/LUCENE-6508). The deprecation is due to the fact that
checking if a lock is held before acquiring that lock is subject to a
[time-of-check-to-time-of-use race condition](https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use). There were three uses of
`IndexWriter#isLocked` in the code base:
- a logging statement in `o.e.i.e.InternalEngine` where we are already in
  an exceptional condition that the lock was held; in this case,
  logging whether or not the directory is locked is superfluous
- in `o.e.c.l.u.VersionsTests` where we were verifying that a write lock
  is released upon closing an `IndexWriter`; in this case, the check is
  not needed as successfully closing an `IndexWriter` releases its
  write lock
- in `o.e.t.s.MockFSDirectoryService` where we were verifying that a
  directory is not write-locked before (implicitly) trying to obtain
  such a write lock in `org.apache.lucene.index.CheckIndex#<init>` (this
  is the exact type of a situation that is subject to a race
  condition); in this case we can proceed by just (implicitly) trying
  to obtain the write lock and failing if we encounter a
  `LockObtainFailedException`

Closes #15846
