### PR TITLE
Change link for HDFS support to plugins docs

### DIFF
--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -160,7 +160,7 @@ shared file system repository.
 Other repository backends are available in these official plugins:
 
 * {plugins}/repository-s3.html[repository-s3] for S3 repository support
-* {plugins}/repository-s3.html[repository-hdfs] for HDFS repository support in Hadoop environments
+* {plugins}/repository-hdfs.html[repository-hdfs] for HDFS repository support in Hadoop environments
 * {plugins}/repository-azure.html[repository-azure] for Azure storage repositories
 
 [float]

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -160,7 +160,7 @@ shared file system repository.
 Other repository backends are available in these official plugins:
 
 * {plugins}/repository-s3.html[repository-s3] for S3 repository support
-* https://github.com/elasticsearch/elasticsearch-hadoop/tree/master/repository-hdfs[HDFS Plugin] for Hadoop environments
+* {plugins}/repository-s3.html[repository-hdfs] for HDFS repository support in Hadoop environments
 * {plugins}/repository-azure.html[repository-azure] for Azure storage repositories
 
 [float]


### PR DESCRIPTION
I came to this change when I read https://github.com/elastic/elasticsearch/pull/15591

HDFS plugin link has not been updated when we moved HDFS to elasticsearch repository (#15192).
