### PR TITLE
Updated links on scripting reference

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -78,8 +78,8 @@ supported scripting languages:
 |expression |yes       |built-in
 |mustache   |yes       |built-in
 |mvel       |no        |https://github.com/elastic/elasticsearch-lang-mvel[elasticsearch-lang-mvel]
-|javascript |no        |https://github.com/elastic/elasticsearch-lang-javascript[elasticsearch-lang-javascript]
-|python     |no        |https://github.com/elastic/elasticsearch-lang-python[elasticsearch-lang-python]
+|javascript |no        |https://github.com/elastic/elasticsearch/tree/master/plugins/lang-javascript[elasticsearch-lang-javascript]
+|python     |no        |https://github.com/elastic/elasticsearch/tree/master/plugins/lang-python[elasticsearch-lang-python]
 |=======================================================================
 
 To increase security, Elasticsearch does not allow you to specify scripts for


### PR DESCRIPTION
The links in https://www.elastic.co/guide/en/elasticsearch/reference/2.1/modules-scripting.html seem to point to deprecated repos (it is noted that they will only receive bug fixes).

I've changed them to point to their current locations.

This pull in my opinion is unfinished as there are a few questions on #15883 which could do with thinking on first.
