### PR TITLE
[WIP] Make FieldSortBuilder serializable

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.unit;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
 
@@ -32,7 +33,7 @@ import java.io.IOException;
  * the earth ellipsoid defined in {@link GeoUtils}. The default unit used within
  * this project is <code>METERS</code> which is defined by <code>DEFAULT</code>
  */
-public enum DistanceUnit {
+public enum DistanceUnit implements Writeable<DistanceUnit> {
     INCH(0.0254, "in", "inch"),
     YARD(0.9144, "yd", "yards"),
     FEET(0.3048, "ft", "feet"),
@@ -321,5 +322,25 @@ public enum DistanceUnit {
             }
             return new Distance(Double.parseDouble(distance), defaultUnit);
         }
+    }
+
+    private static final DistanceUnit PROTOTYPE = DEFAULT;
+
+    @Override
+    public DistanceUnit readFrom(StreamInput in) throws IOException {
+        int ordinal = in.readVInt();
+        if (ordinal < 0 || ordinal >= values().length) {
+            throw new IOException("Unknown DistanceUnit ordinal [" + ordinal + "]");
+        }
+        return values()[ordinal];
+    }
+
+    public static DistanceUnit readUnitFrom(StreamInput in) throws IOException {
+        return PROTOTYPE.readFrom(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(this.ordinal());
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
@@ -67,6 +67,8 @@ public final class Fuzziness implements ToXContent, Writeable<Fuzziness> {
 
     /**
      * Creates a {@link Fuzziness} instance from an edit distance. The value must be one of <tt>[0, 1, 2]</tt>
+     * 
+     * Note: Using this method only makes sense if the field you are applying Fuzziness to is some sort of string.
      */
     public static Fuzziness fromEdits(int edits) {
         return new Fuzziness(edits);

--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -48,7 +48,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
 
     private final String[] types;
 
-    static final IdsQueryBuilder PROTOTYPE = new IdsQueryBuilder();
+    public static final IdsQueryBuilder PROTOTYPE = new IdsQueryBuilder();
 
     /**
      * Creates a new IdsQueryBuilder without providing the types of the documents to look for

--- a/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchAllQueryBuilder.java
@@ -34,7 +34,7 @@ public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuil
 
     public static final String NAME = "match_all";
 
-    static final MatchAllQueryBuilder PROTOTYPE = new MatchAllQueryBuilder();
+    public static final MatchAllQueryBuilder PROTOTYPE = new MatchAllQueryBuilder();
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
 
     public static final String NAME = "term";
-    static final TermQueryBuilder PROTOTYPE = new TermQueryBuilder("name", "value");
+    public static final TermQueryBuilder PROTOTYPE = new TermQueryBuilder("name", "value");
 
     /** @see BaseTermQueryBuilder#BaseTermQueryBuilder(String, String) */
     public TermQueryBuilder(String fieldName, String value) {

--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -19,7 +19,10 @@
 
 package org.elasticsearch.search.sort;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
@@ -27,8 +30,10 @@ import java.io.IOException;
 /**
  * A sort builder to sort based on a document field.
  */
-public class FieldSortBuilder extends SortBuilder {
+public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
 
+    static final FieldSortBuilder PROTOTYPE = new FieldSortBuilder("");
+ 
     private final String fieldName;
 
     private SortOrder order;
@@ -155,5 +160,24 @@ public class FieldSortBuilder extends SortBuilder {
         }
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+    }
+
+    @Override
+    public FieldSortBuilder readFrom(StreamInput in) throws IOException {
+        return null;
+    }
+
+    @Override
+    public FieldSortBuilder fromXContent(XContentParser parser) throws IOException {
+        return null;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -235,7 +235,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     public int hashCode() {
         return Objects.hash(this.fieldName, this.nestedFilter, this.nestedPath,
                 this.missing, this.order, this.sortMode, this.unmappedType);
-    };
+    }
 
     @Override
     public String getWriteableName() {
@@ -291,7 +291,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     }
 
     @Override
-    public FieldSortBuilder fromXContent(QueryParseContext context) throws IOException {
+    public FieldSortBuilder fromXContent(QueryParseContext context, String elementName) throws IOException {
         XContentParser parser = context.parser();
 
         String fieldName = null;

--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -19,28 +19,40 @@
 
 package org.elasticsearch.search.sort;
 
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A sort builder to sort based on a document field.
  */
 public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
-
+    public static final String NAME = "field_sort";
     static final FieldSortBuilder PROTOTYPE = new FieldSortBuilder("");
+
+    public static final ParseField NESTED_PATH = new ParseField("nested_path");
+    public static final ParseField NESTED_FILTER = new ParseField("nested_filter");
+    public static final ParseField MISSING = new ParseField("missing");
+    public static final ParseField ORDER = new ParseField("order");
+    public static final ParseField SORT_MODE = new ParseField("mode");    
+    public static final ParseField UNMAPPED_TYPE = new ParseField("unmapped_type");
+
  
     private final String fieldName;
 
     private SortOrder order;
 
     private Object missing;
-
-    private Boolean ignoreUnmapped;
 
     private String unmappedType;
 
@@ -50,6 +62,16 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
 
     private String nestedPath;
 
+    /** Copy constructor. */
+    public FieldSortBuilder(FieldSortBuilder template) {
+        this(template.fieldName);
+        this.order(template.order());
+        this.missing(template.missing());
+        this.unmappedType(template.unmappedType());
+        this.sortMode(template.sortMode());
+        this.setNestedFilter(template.getNestedFilter());
+        this.setNestedPath(template.getNestedPath());
+    }
     /**
      * Constructs a new sort based on a document field.
      *
@@ -61,6 +83,11 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         }
         this.fieldName = fieldName;
     }
+    
+    /** Returns the document field this sort should be based on. */
+    public String getFieldName() {
+        return this.fieldName;
+    }
 
     /**
      * The order of sorting. Defaults to {@link SortOrder#ASC}.
@@ -71,25 +98,28 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         return this;
     }
 
+    /** Returns the order of sorting. */
+    public SortOrder order() {
+        return this.order;
+    }
+
     /**
      * Sets the value when a field is missing in a doc. Can also be set to <tt>_last</tt> or
      * <tt>_first</tt> to sort missing last or first respectively.
      */
     @Override
     public FieldSortBuilder missing(Object missing) {
-        this.missing = missing;
+        if (missing instanceof String) {
+            this.missing = BytesRefs.toBytesRef(missing);
+        } else {
+            this.missing = missing;
+        }
         return this;
     }
 
-    /**
-     * Sets if the field does not exists in the index, it should be ignored and not sorted by or not. Defaults
-     * to <tt>false</tt> (not ignoring).
-     * @deprecated Use {@link #unmappedType(String)} instead.
-     */
-    @Deprecated
-    public FieldSortBuilder ignoreUnmapped(boolean ignoreUnmapped) {
-        this.ignoreUnmapped = ignoreUnmapped;
-        return this;
+    /** Returns the value used when a field is missing in a doc. */
+    public Object missing() {
+        return this.missing;
     }
 
     /**
@@ -104,9 +134,16 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         return this;
     }
 
+    /** Returns the type to use in case the current field is not mapped in an index. */
+    public String unmappedType() {
+        return this.unmappedType;
+    }
+
     /**
      * Defines what values to pick in the case a document contains multiple values for the targeted sort field.
      * Possible values: min, max, sum and avg
+     * 
+     * TODO would love to see an enum here
      * <p>
      * The last two values are only applicable for number based fields.
      */
@@ -115,15 +152,26 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         return this;
     }
 
+    /** Returns what values to pick in the case a document contains multiple values for the targeted sort field. */
+    public String sortMode() {
+        return this.sortMode;
+    }
     /**
      * Sets the nested filter that the nested objects should match with in order to be taken into account
      * for sorting.
+     * 
+     * TODO should the above getters and setters be deprecated/ changed in favour of real getters and setters?
      */
     public FieldSortBuilder setNestedFilter(QueryBuilder nestedFilter) {
         this.nestedFilter = nestedFilter;
         return this;
     }
 
+    /** Returns the nested filter that the nested objects should match with in order to be taken into account
+     * for sorting. */
+    public QueryBuilder getNestedFilter() {
+        return this.nestedFilter;
+    }
 
     /**
      * Sets the nested path if sorting occurs on a field that is inside a nested object. By default when sorting on a
@@ -134,50 +182,188 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         return this;
     }
 
+    /** Returns the nested path if sorting occurs in a field that is inside a nested object. */
+    public String getNestedPath() {
+        return this.nestedPath;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(fieldName);
         if (order != null) {
-            builder.field("order", order.toString());
+            builder.field(ORDER.getPreferredName(), order.toString());
         }
         if (missing != null) {
-            builder.field("missing", missing);
-        }
-        if (ignoreUnmapped != null) {
-            builder.field(SortParseElement.IGNORE_UNMAPPED.getPreferredName(), ignoreUnmapped);
+            if (missing instanceof BytesRef) {
+                builder.field(MISSING.getPreferredName(), ((BytesRef) missing).utf8ToString());
+            } else {
+                builder.field(MISSING.getPreferredName(), missing);
+            }
         }
         if (unmappedType != null) {
-            builder.field(SortParseElement.UNMAPPED_TYPE.getPreferredName(), unmappedType);
+            builder.field(UNMAPPED_TYPE.getPreferredName(), unmappedType);
         }
         if (sortMode != null) {
-            builder.field("mode", sortMode);
+            builder.field(SORT_MODE.getPreferredName(), sortMode);
         }
         if (nestedFilter != null) {
-            builder.field("nested_filter", nestedFilter, params);
+            builder.field(NESTED_FILTER.getPreferredName(), nestedFilter, params);
         }
         if (nestedPath != null) {
-            builder.field("nested_path", nestedPath);
+            builder.field(NESTED_PATH.getPreferredName(), nestedPath);
         }
         builder.endObject();
         return builder;
     }
 
     @Override
+    public boolean equals(Object other) {
+        if (! (other instanceof FieldSortBuilder)) {
+            return false;
+        }
+        FieldSortBuilder builder = (FieldSortBuilder) other;
+        return (Objects.equals(this.fieldName, builder.fieldName) &&
+                Objects.equals(this.nestedFilter, builder.nestedFilter) &&
+                Objects.equals(this.nestedPath, builder.nestedPath) &&
+                Objects.equals(this.missing, builder.missing) &&
+                Objects.equals(this.order, builder.order) &&
+                Objects.equals(this.sortMode, builder.sortMode) &&
+                Objects.equals(this.unmappedType, builder.unmappedType));
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.fieldName, this.nestedFilter, this.nestedPath,
+                this.missing, this.order, this.sortMode, this.unmappedType);
+    };
+
+    @Override
     public String getWriteableName() {
-        return null;
+        return NAME;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(this.fieldName);
+        if (this.nestedFilter != null) {
+            out.writeBoolean(true);
+            out.writeQuery(this.nestedFilter);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalString(this.nestedPath);
+        if (this.missing != null) {
+            out.writeBoolean(true);
+            out.writeGenericValue(this.missing);
+        } else {
+            out.writeBoolean(false);
+        }
+        
+        if (this.order != null) {
+            out.writeBoolean(true);
+            this.order.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        
+        out.writeOptionalString(this.sortMode);
+        out.writeOptionalString(this.unmappedType);
     }
 
     @Override
     public FieldSortBuilder readFrom(StreamInput in) throws IOException {
-        return null;
+        String fieldName = in.readString();
+        FieldSortBuilder result = new FieldSortBuilder(fieldName);
+        if (in.readBoolean()) {
+            QueryBuilder query = in.readQuery();
+            result.setNestedFilter(query);
+        }
+        result.setNestedPath(in.readOptionalString());
+        if (in.readBoolean()) {
+            result.missing(in.readGenericValue());
+        }
+        if (in.readBoolean()) {
+            result.order(SortOrder.readOrderFrom(in));
+        }
+        result.sortMode(in.readOptionalString());
+        result.unmappedType(in.readOptionalString());
+        return result;
     }
 
     @Override
-    public FieldSortBuilder fromXContent(XContentParser parser) throws IOException {
-        return null;
+    public FieldSortBuilder fromXContent(QueryParseContext context) throws IOException {
+        XContentParser parser = context.parser();
+
+        String fieldName = null;
+        QueryBuilder nestedFilter = null;
+        String nestedPath = null;
+        Object missing = null;
+        SortOrder order = null;
+        String sortMode = null;
+        String unmappedType = null;
+        
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+                if (fieldName != null) {
+                    throw new ParsingException(parser.getTokenLocation(),
+                            "[term] query does not support different field names, use [bool] query instead");
+                } else {
+                    fieldName = currentFieldName;
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                        if (token == XContentParser.Token.FIELD_NAME) {
+                            currentFieldName = parser.currentName();
+                        } else if (token == XContentParser.Token.START_OBJECT) {
+                            if (context.parseFieldMatcher().match(currentFieldName, NESTED_FILTER)) {
+                                nestedFilter = context.parseInnerQueryBuilder();
+                            }
+                        } else if (token.isValue()) {
+                            if (context.parseFieldMatcher().match(currentFieldName, NESTED_PATH)) {
+                                nestedPath = parser.text();
+                            } else if (context.parseFieldMatcher().match(currentFieldName, MISSING)) {
+                                missing = parser.objectBytes();
+                            } else if (context.parseFieldMatcher().match(currentFieldName, ORDER)) {
+                                String sortOrder = parser.text();
+                                if ("asc".equals(sortOrder)) {
+                                    order = SortOrder.ASC;
+                                } else if ("desc".equals(sortOrder)) {
+                                    order = SortOrder.DESC;
+                                } else {
+                                    throw new IllegalStateException("Sort order " + sortOrder + " not supported.");
+                                }
+                            } else if (context.parseFieldMatcher().match(currentFieldName, SORT_MODE)) {
+                                sortMode = parser.text();
+                            } else if (context.parseFieldMatcher().match(currentFieldName, UNMAPPED_TYPE)) {
+                                unmappedType = parser.text();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        FieldSortBuilder builder = new FieldSortBuilder(fieldName);
+        if (nestedFilter != null) {
+            builder.setNestedFilter(nestedFilter);
+        }
+        if (nestedPath != null) {
+            builder.setNestedPath(nestedPath);
+        }
+        if (missing != null) {
+            builder.missing(missing);
+        }
+        if (order != null) {
+            builder.order(order);
+        }
+        if (sortMode != null) {
+            builder.sortMode(sortMode);
+        }
+        if (unmappedType != null) {
+            builder.unmappedType(unmappedType);
+        }
+        return builder;
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -22,9 +22,12 @@ package org.elasticsearch.search.sort;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryParseContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,7 +38,7 @@ import java.util.Locale;
 /**
  * A geo distance based sorting on a geo point like field.
  */
-public class GeoDistanceSortBuilder extends SortBuilder {
+public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> {
 
     final String fieldName;
     private final List<GeoPoint> points = new ArrayList<>();
@@ -202,5 +205,24 @@ public class GeoDistanceSortBuilder extends SortBuilder {
 
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+    }
+
+    @Override
+    public GeoDistanceSortBuilder readFrom(StreamInput in) throws IOException {
+        return null;
+    }
+
+    @Override
+    public GeoDistanceSortBuilder fromXContent(QueryParseContext context) throws IOException {
+        return null;
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -54,7 +54,7 @@ import java.util.List;
 /**
  *
  */
-public class GeoDistanceSortParser implements SortParser {
+public class GeoDistanceSortParser implements SortParserTemp {
 
     @Override
     public String[] names() {

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortParser.java
@@ -72,8 +72,8 @@ public class GeoDistanceSortParser implements SortParserTemp {
         NestedInnerQueryParseSupport nestedHelper = null;
 
         final boolean indexCreatedBeforeV2_0 = context.indexShard().getIndexSettings().getIndexVersionCreated().before(Version.V_2_0_0);
-        boolean coerce = false;
-        boolean ignoreMalformed = false;
+        boolean coerce = GeoDistanceSortBuilder.DEFAULT_COERCE;
+        boolean ignoreMalformed = GeoDistanceSortBuilder.DEFAULT_IGNORE_MALFORMED;
 
         XContentParser.Token token;
         String currentName = parser.currentName();

--- a/core/src/main/java/org/elasticsearch/search/sort/ParameterParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ParameterParser.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.search.sort;
 
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 
@@ -31,11 +29,11 @@ public interface ParameterParser<T extends ToXContent> {
      * Creates a new item from the json held by the {@link ParameterParser}
      * in {@link org.elasticsearch.common.xcontent.XContent} format
      *
-     * @param parseContext
+     * @param context
      *            the input parse context. The state on the parser contained in
      *            this context will be changed as a side effect of this method
      *            call
      * @return the new item
      */
-    T fromXContent(QueryParseContext context) throws IOException;
+    T fromXContent(QueryParseContext context, String elementName) throws IOException;
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/ParameterParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ParameterParser.java
@@ -21,6 +21,8 @@ package org.elasticsearch.search.sort;
 
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 
@@ -35,5 +37,5 @@ public interface ParameterParser<T extends ToXContent> {
      *            call
      * @return the new item
      */
-    T fromXContent(XContentParser parser) throws IOException;
+    T fromXContent(QueryParseContext context) throws IOException;
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/ParameterParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ParameterParser.java
@@ -19,20 +19,21 @@
 
 package org.elasticsearch.search.sort;
 
-import org.elasticsearch.action.support.ToXContentToBytes;
-import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentParser;
 
-public abstract class SortBuilder<S extends ToXContent> extends ToXContentToBytes implements NamedWriteable<S>, ParameterParser<S> {
+import java.io.IOException;
 
+public interface ParameterParser<T extends ToXContent> {
     /**
-     * The order of sorting. Defaults to {@link SortOrder#ASC}.
+     * Creates a new item from the json held by the {@link ParameterParser}
+     * in {@link org.elasticsearch.common.xcontent.XContent} format
+     *
+     * @param parseContext
+     *            the input parse context. The state on the parser contained in
+     *            this context will be changed as a side effect of this method
+     *            call
+     * @return the new item
      */
-    public abstract SortBuilder<S> order(SortOrder order);
-
-    /**
-     * Sets the value when a field is missing in a doc. Can also be set to <tt>_last</tt> or
-     * <tt>_first</tt> to sort missing last or first respectively.
-     */
-    public abstract SortBuilder<S> missing(Object missing);
+    T fromXContent(XContentParser parser) throws IOException;
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ScriptSortParser.java
@@ -57,7 +57,7 @@ import java.util.Map;
 /**
  *
  */
-public class ScriptSortParser implements SortParser {
+public class ScriptSortParser implements SortParserTemp {
 
     private static final String STRING_SORT_TYPE = "string";
     private static final String NUMBER_SORT_TYPE = "number";

--- a/core/src/main/java/org/elasticsearch/search/sort/SortOrder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/SortOrder.java
@@ -19,13 +19,9 @@
 
 package org.elasticsearch.search.sort;
 
-import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.BooleanClause;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.util.CollectionUtils;
-import org.elasticsearch.index.query.Operator;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -55,13 +51,14 @@ public enum SortOrder implements Writeable<SortOrder> {
         }
     };
     
-    private static final SortOrder PROTOTYPE = ASC;
+    public static final SortOrder DEFAULT = DESC;
+    private static final SortOrder PROTOTYPE = DEFAULT;
 
     @Override
     public SortOrder readFrom(StreamInput in) throws IOException {
         int ordinal = in.readVInt();
         if (ordinal < 0 || ordinal >= values().length) {
-            throw new IOException("Unknown Operator ordinal [" + ordinal + "]");
+            throw new IOException("Unknown SortOrder ordinal [" + ordinal + "]");
         }
         return values()[ordinal];
     }
@@ -78,10 +75,4 @@ public enum SortOrder implements Writeable<SortOrder> {
     public static SortOrder fromString(String op) {
         return valueOf(op.toUpperCase(Locale.ROOT));
     }
-
-    private static IllegalArgumentException newSortOrderException(String op) {
-        return new IllegalArgumentException("SortOrder needs to be either " + CollectionUtils.arrayAsArrayList(values()) + ", but not [" + op + "]");
-    }
-   
-
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/SortOrder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/SortOrder.java
@@ -19,12 +19,23 @@
 
 package org.elasticsearch.search.sort;
 
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.BooleanClause;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.query.Operator;
+
+import java.io.IOException;
+import java.util.Locale;
+
 /**
  * A sorting order.
  *
  *
  */
-public enum SortOrder {
+public enum SortOrder implements Writeable<SortOrder> {
     /**
      * Ascending order.
      */
@@ -42,5 +53,35 @@ public enum SortOrder {
         public String toString() {
             return "desc";
         }
+    };
+    
+    private static final SortOrder PROTOTYPE = ASC;
+
+    @Override
+    public SortOrder readFrom(StreamInput in) throws IOException {
+        int ordinal = in.readVInt();
+        if (ordinal < 0 || ordinal >= values().length) {
+            throw new IOException("Unknown Operator ordinal [" + ordinal + "]");
+        }
+        return values()[ordinal];
     }
+
+    public static SortOrder readOrderFrom(StreamInput in) throws IOException {
+        return PROTOTYPE.readFrom(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(this.ordinal());
+    }
+
+    public static SortOrder fromString(String op) {
+        return valueOf(op.toUpperCase(Locale.ROOT));
+    }
+
+    private static IllegalArgumentException newSortOrderException(String op) {
+        return new IllegalArgumentException("SortOrder needs to be either " + CollectionUtils.arrayAsArrayList(values()) + ", but not [" + op + "]");
+    }
+   
+
 }

--- a/core/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -45,9 +45,6 @@ import java.util.Map;
 
 import static java.util.Collections.unmodifiableMap;
 
-/**
- *
- */
 public class SortParseElement implements SearchParseElement {
 
     public static final SortField SORT_SCORE = new SortField(null, SortField.Type.SCORE);
@@ -61,16 +58,16 @@ public class SortParseElement implements SearchParseElement {
     public static final String SCORE_FIELD_NAME = "_score";
     public static final String DOC_FIELD_NAME = "_doc";
 
-    private static final Map<String, SortParser> PARSERS;
+    private static final Map<String, SortParserTemp> PARSERS;
 
     static {
-        Map<String, SortParser> parsers = new HashMap<>();
+        Map<String, SortParserTemp> parsers = new HashMap<>();
         addParser(parsers, new ScriptSortParser());
         addParser(parsers, new GeoDistanceSortParser());
         PARSERS = unmodifiableMap(parsers);
     }
 
-    private static void addParser(Map<String, SortParser> parsers, SortParser parser) {
+    private static void addParser(Map<String, SortParserTemp> parsers, SortParserTemp parser) {
         for (String name : parser.names()) {
             parsers.put(name, parser);
         }

--- a/core/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/SortParseElement.java
@@ -53,7 +53,6 @@ public class SortParseElement implements SearchParseElement {
     private static final SortField SORT_DOC_REVERSE = new SortField(null, SortField.Type.DOC, true);
 
     public static final ParseField IGNORE_UNMAPPED = new ParseField("ignore_unmapped");
-    public static final ParseField UNMAPPED_TYPE = new ParseField("unmapped_type");
 
     public static final String SCORE_FIELD_NAME = "_score";
     public static final String DOC_FIELD_NAME = "_doc";
@@ -159,7 +158,7 @@ public class SortParseElement implements SearchParseElement {
                                             && parser.booleanValue()) {
                                         unmappedType = LongFieldMapper.CONTENT_TYPE;
                                     }
-                                } else if (context.parseFieldMatcher().match(innerJsonName, UNMAPPED_TYPE)) {
+                                } else if (context.parseFieldMatcher().match(innerJsonName, FieldSortBuilder.UNMAPPED_TYPE)) {
                                     unmappedType = parser.textOrNull();
                                 } else if ("mode".equals(innerJsonName)) {
                                     sortMode = MultiValueMode.fromString(parser.text());

--- a/core/src/main/java/org/elasticsearch/search/sort/SortParserTemp.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/SortParserTemp.java
@@ -19,20 +19,16 @@
 
 package org.elasticsearch.search.sort;
 
-import org.elasticsearch.action.support.ToXContentToBytes;
-import org.elasticsearch.common.io.stream.NamedWriteable;
-import org.elasticsearch.common.xcontent.ToXContent;
+import org.apache.lucene.search.SortField;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.internal.SearchContext;
 
-public abstract class SortBuilder<S extends ToXContent> extends ToXContentToBytes implements NamedWriteable<S>, ParameterParser<S> {
+/**
+ *
+ */
+public interface SortParserTemp {
 
-    /**
-     * The order of sorting. Defaults to {@link SortOrder#ASC}.
-     */
-    public abstract SortBuilder<S> order(SortOrder order);
+    String[] names();
 
-    /**
-     * Sets the value when a field is missing in a doc. Can also be set to <tt>_last</tt> or
-     * <tt>_first</tt> to sort missing last or first respectively.
-     */
-    public abstract SortBuilder<S> missing(Object missing);
+    SortField parse(XContentParser parser, SearchContext context) throws Exception;
 }

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -808,12 +808,6 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
     }
 
     protected static Fuzziness randomFuzziness(String fieldName) {
-        if (randomBoolean()) {
-            return Fuzziness.fromEdits(randomIntBetween(0, 2));
-        }
-        if (randomBoolean()) {
-            return Fuzziness.AUTO;
-        }
         switch (fieldName) {
             case INT_FIELD_NAME:
                 return Fuzziness.build(randomIntBetween(3, 100));
@@ -822,6 +816,9 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             case DATE_FIELD_NAME:
                 return Fuzziness.build(randomTimeValue());
             default:
+                if (randomBoolean()) {
+                    return Fuzziness.fromEdits(randomIntBetween(0, 2));
+                }
                 return Fuzziness.AUTO;
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSearchSourceItemTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSearchSourceItemTestCase.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.sort;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.*;
+
+//TODO maybe merge with AbstractShapeBuilderTestCase once #14933 is in?
+public abstract class AbstractSearchSourceItemTestCase<T extends NamedWriteable<T> & ToXContent & ParameterParser<T>> extends ESTestCase {
+
+    private static final int NUMBER_OF_TESTBUILDERS = 20;
+    private NamedWriteableRegistry namedWriteableRegistry;
+
+    public class RegistryItem {
+        public Class<T> type;
+        public T prototype;
+
+        public RegistryItem(Class<T> type, T prototype) {
+            this.type = type;
+            this.prototype = prototype;
+        }
+    }
+
+    @Before
+    public void setup() {
+        namedWriteableRegistry = new NamedWriteableRegistry();
+        RegistryItem item = getPrototype();
+        namedWriteableRegistry.registerPrototype(item.type, item.prototype);
+    }
+
+    @After
+    public void afterClass() throws Exception {
+        namedWriteableRegistry = null;
+    }
+
+    /** Returns the prototype of the named writable under test. */
+    protected abstract RegistryItem getPrototype();
+
+    /** Returns random shape that is put under test */
+    protected abstract T createTestItem();
+
+    /** Returns mutated version of original so the returned shape is different in terms of equals/hashcode */
+    protected abstract T mutate(T original) throws IOException;
+
+    protected abstract ParameterParser<T> getItemParser();
+
+    /**
+     * Test that creates new shape from a random test shape and checks both for equality
+     */
+    public void testFromXContent() throws IOException {
+        for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
+            T testItem = createTestItem();
+            XContentBuilder contentBuilder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+            if (randomBoolean()) {
+                contentBuilder.prettyPrint();
+            }
+            XContentBuilder builder = testItem.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
+            XContentParser itemParser = XContentHelper.createParser(builder.bytes());
+            XContentHelper.createParser(builder.bytes());
+            itemParser.nextToken();
+            NamedWriteable<T> parsedItem= getItemParser().fromXContent(itemParser);
+            assertNotSame(testItem, parsedItem);
+            assertEquals(testItem, parsedItem);
+            assertEquals(testItem.hashCode(), parsedItem.hashCode());
+        }
+    }
+
+    /**
+     * Test serialization and deserialization of the test shape.
+     */
+    public void testSerialization() throws IOException {
+        for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
+            T testShape = createTestItem();
+            T deserializedShape = copyItem(testShape);
+            assertEquals(deserializedShape, testShape);
+            assertEquals(deserializedShape.hashCode(), testShape.hashCode());
+            assertNotSame(deserializedShape, testShape);
+        }
+    }
+
+    /**
+     * Test equality and hashCode properties
+     */
+    public void testEqualsAndHashcode() throws IOException {
+        for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
+            T firstShape = createTestItem();
+            assertFalse("shape is equal to null", firstShape.equals(null));
+            assertFalse("shape is equal to incompatible type", firstShape.equals(""));
+            assertTrue("shape is not equal to self", firstShape.equals(firstShape));
+            assertThat("same shape's hashcode returns different values if called multiple times", firstShape.hashCode(),
+                    equalTo(firstShape.hashCode()));
+            assertThat("different shapes should not be equal", mutate(firstShape), not(equalTo(firstShape)));
+            assertThat("different shapes should have different hashcode", mutate(firstShape).hashCode(), not(equalTo(firstShape.hashCode())));
+
+            T secondShape = copyItem(firstShape);
+            assertTrue("shape is not equal to self", secondShape.equals(secondShape));
+            assertTrue("shape is not equal to its copy", firstShape.equals(secondShape));
+            assertTrue("equals is not symmetric", secondShape.equals(firstShape));
+            assertThat("shape copy's hashcode is different from original hashcode", secondShape.hashCode(), equalTo(firstShape.hashCode()));
+
+            T thirdShape = copyItem(secondShape);
+            assertTrue("shape is not equal to self", thirdShape.equals(thirdShape));
+            assertTrue("shape is not equal to its copy", secondShape.equals(thirdShape));
+            assertThat("shape copy's hashcode is different from original hashcode", secondShape.hashCode(), equalTo(thirdShape.hashCode()));
+            assertTrue("equals is not transitive", firstShape.equals(thirdShape));
+            assertThat("shape copy's hashcode is different from original hashcode", firstShape.hashCode(), equalTo(thirdShape.hashCode()));
+            assertTrue("equals is not symmetric", thirdShape.equals(secondShape));
+            assertTrue("equals is not symmetric", thirdShape.equals(firstShape));
+        }
+    }
+
+    protected T copyItem(T original) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            original.writeTo(output);
+            try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
+                @SuppressWarnings("unchecked")
+                T prototype = (T) namedWriteableRegistry.getPrototype(getPrototype().type, original.getWriteableName());
+                T copy = (T) prototype.readFrom(in);
+                return copy;
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
+x * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
  * ownership. Elasticsearch licenses this file to you under
@@ -19,16 +19,29 @@
 
 package org.elasticsearch.search.sort;
 
-import org.apache.lucene.search.SortField;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.search.internal.SearchContext;
+import java.io.IOException;
 
-/**
- *
- */
-public interface SortParser {
+public class FieldSortBuilderTest extends AbstractSearchSourceItemTestCase<FieldSortBuilder> {
 
-    String[] names();
+    @Override
+    protected RegistryItem getPrototype() {
+        return new RegistryItem(FieldSortBuilder.class, FieldSortBuilder.PROTOTYPE);
+    }
 
-    SortField parse(XContentParser parser, SearchContext context) throws Exception;
+    @Override
+    protected FieldSortBuilder createTestItem() {
+        return null;
+    }
+
+    @Override
+    protected FieldSortBuilder mutate(FieldSortBuilder original) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected ParameterParser<FieldSortBuilder> getItemParser() {
+        return null;
+    }
+
+
 }

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTest.java
@@ -19,12 +19,6 @@ x * Licensed to Elasticsearch under one or more contributor
 
 package org.elasticsearch.search.sort;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.query.IdsQueryBuilder;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
-
 import java.io.IOException;
 
 public class FieldSortBuilderTest extends AbstractSearchSourceItemTestCase<FieldSortBuilder> {
@@ -39,117 +33,30 @@ public class FieldSortBuilderTest extends AbstractSearchSourceItemTestCase<Field
         String fieldName = randomAsciiOfLengthBetween(1, 10);
         FieldSortBuilder builder = new FieldSortBuilder(fieldName);
         if (randomBoolean()) {
-            order(builder);
+            builder.order(RandomSortDataGenerator.order(builder.order()));
         }
 
         if (randomBoolean()) {
-            missing(builder);
+            builder.missing(RandomSortDataGenerator.missing(builder.missing()));
         }
 
         if (randomBoolean()) {
-            unmappedType(builder);
+            builder.unmappedType(RandomSortDataGenerator.randomAscii(builder.unmappedType()));
         }
 
         if (randomBoolean()) {
-            modes(builder);
+            builder.sortMode(RandomSortDataGenerator.mode(builder.sortMode()));
         }
 
         if (randomBoolean()) {
-            nestedFilter(builder);
+            builder.setNestedFilter(RandomSortDataGenerator.nestedFilter(builder.getNestedFilter()));
         }
 
         if (randomBoolean()) {
-            nestedPath(builder);
+            builder.setNestedPath(RandomSortDataGenerator.randomAscii(builder.getNestedPath()));
         }
         
         return builder;
-    }
-
-    private void nestedFilter(FieldSortBuilder builder) {
-        @SuppressWarnings("rawtypes")
-        QueryBuilder nested = null;
-        while (nested == null || nested.equals(builder.getNestedFilter())) {
-            switch (randomInt(2)) {
-            case 0:
-                nested = new MatchAllQueryBuilder();
-                break;
-            case 1:
-                nested = new IdsQueryBuilder();
-                break;
-            default:
-            case 2:
-                nested = new TermQueryBuilder(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10));
-                break;
-            }
-            nested.boost((float) randomDoubleBetween(0, 10, false));
-        }
-        builder.setNestedFilter(nested);
-    }
-
-    private void nestedPath(FieldSortBuilder builder) {
-        String nestedPath = randomAsciiOfLengthBetween(1, 10);
-        while (nestedPath.equals(builder.getNestedPath())) {
-            nestedPath = randomAsciiOfLengthBetween(1, 10);
-        }
-        builder.setNestedPath(nestedPath);
-    }
-
-    private void modes(FieldSortBuilder builder) {
-        String[] modes = {"min", "max", "avg", "sum"};
-        String mode = randomFrom(modes);
-        while (mode.equals(builder.sortMode())) {
-            mode = randomFrom(modes);
-        }
-        builder.sortMode(mode);
-    }
-    
-    private void missing(FieldSortBuilder builder) {
-        Object missing = null;
-        Object otherMissing = null;
-        if (builder.missing() instanceof BytesRef) {
-            otherMissing = ((BytesRef) builder.missing()).utf8ToString();
-        } else {
-            otherMissing = builder.missing();
-        }
-
-        while (missing == null || missing.equals(otherMissing)) {
-          int missingId = randomIntBetween(0, 3);
-          switch (missingId) {
-          case 0:
-              missing = ("_last");
-              break;
-          case 1:
-              missing = ("_first");
-              break;
-          case 2:
-              missing = randomAsciiOfLength(10);
-              break;
-          case 3:
-              missing = randomInt();
-              break;
-          default:
-              throw new IllegalStateException("Unknown missing type.");
-              
-          }
-        }
-        builder.missing(missing);
-    }
-    
-    public void unmappedType(FieldSortBuilder builder) {
-        String type = randomAsciiOfLengthBetween(1, 10);
-        while (type.equals(builder.unmappedType())) {
-            type = randomAsciiOfLengthBetween(1, 10);
-        }
-        builder.unmappedType(type);
-    }
-    
-    public void order(FieldSortBuilder builder) {
-        SortOrder order = SortOrder.ASC;
-        if (order.equals(builder.order())) {
-            builder.order(SortOrder.DESC);
-        } else {
-            builder.order(SortOrder.ASC);
-        }
     }
 
     @Override
@@ -158,27 +65,26 @@ public class FieldSortBuilderTest extends AbstractSearchSourceItemTestCase<Field
         int parameter = randomIntBetween(0, 5);
         switch (parameter) {
         case 0:
-            nestedPath(mutated);
+            mutated.setNestedPath(RandomSortDataGenerator.randomAscii(mutated.getNestedPath()));
             break;
         case 1:
-            nestedFilter(mutated);
+            mutated.setNestedFilter(RandomSortDataGenerator.nestedFilter(mutated.getNestedFilter()));
             break;
         case 2:
-            modes(mutated);
+            mutated.sortMode(RandomSortDataGenerator.mode(mutated.sortMode()));
             break;
         case 3:
-            unmappedType(mutated);
+            mutated.unmappedType(RandomSortDataGenerator.randomAscii(mutated.unmappedType()));
             break;
         case 4:
-            missing(mutated);
+            mutated.missing(RandomSortDataGenerator.missing(mutated.missing()));
             break;
         case 5:
-            order(mutated);
+            mutated.order(RandomSortDataGenerator.order(mutated.order()));
             break;
         default:
             throw new IllegalStateException("Unsupported mutation.");
         }
         return mutated;
-        
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTest.java
@@ -19,29 +19,166 @@ x * Licensed to Elasticsearch under one or more contributor
 
 package org.elasticsearch.search.sort;
 
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.query.IdsQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+
 import java.io.IOException;
 
 public class FieldSortBuilderTest extends AbstractSearchSourceItemTestCase<FieldSortBuilder> {
 
-    @Override
-    protected RegistryItem getPrototype() {
-        return new RegistryItem(FieldSortBuilder.class, FieldSortBuilder.PROTOTYPE);
+    @SuppressWarnings("unchecked")
+    public Class<FieldSortBuilder> getPrototype() {
+        return (Class<FieldSortBuilder>) FieldSortBuilder.PROTOTYPE.getClass();
     }
 
     @Override
     protected FieldSortBuilder createTestItem() {
-        return null;
+        String fieldName = randomAsciiOfLengthBetween(1, 10);
+        FieldSortBuilder builder = new FieldSortBuilder(fieldName);
+        if (randomBoolean()) {
+            order(builder);
+        }
+
+        if (randomBoolean()) {
+            missing(builder);
+        }
+
+        if (randomBoolean()) {
+            unmappedType(builder);
+        }
+
+        if (randomBoolean()) {
+            modes(builder);
+        }
+
+        if (randomBoolean()) {
+            nestedFilter(builder);
+        }
+
+        if (randomBoolean()) {
+            nestedPath(builder);
+        }
+        
+        return builder;
+    }
+
+    private void nestedFilter(FieldSortBuilder builder) {
+        @SuppressWarnings("rawtypes")
+        QueryBuilder nested = null;
+        while (nested == null || nested.equals(builder.getNestedFilter())) {
+            switch (randomInt(2)) {
+            case 0:
+                nested = new MatchAllQueryBuilder();
+                break;
+            case 1:
+                nested = new IdsQueryBuilder();
+                break;
+            default:
+            case 2:
+                nested = new TermQueryBuilder(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10));
+                break;
+            }
+            nested.boost((float) randomDoubleBetween(0, 10, false));
+        }
+        builder.setNestedFilter(nested);
+    }
+
+    private void nestedPath(FieldSortBuilder builder) {
+        String nestedPath = randomAsciiOfLengthBetween(1, 10);
+        while (nestedPath.equals(builder.getNestedPath())) {
+            nestedPath = randomAsciiOfLengthBetween(1, 10);
+        }
+        builder.setNestedPath(nestedPath);
+    }
+
+    private void modes(FieldSortBuilder builder) {
+        String[] modes = {"min", "max", "avg", "sum"};
+        String mode = randomFrom(modes);
+        while (mode.equals(builder.sortMode())) {
+            mode = randomFrom(modes);
+        }
+        builder.sortMode(mode);
+    }
+    
+    private void missing(FieldSortBuilder builder) {
+        Object missing = null;
+        Object otherMissing = null;
+        if (builder.missing() instanceof BytesRef) {
+            otherMissing = ((BytesRef) builder.missing()).utf8ToString();
+        } else {
+            otherMissing = builder.missing();
+        }
+
+        while (missing == null || missing.equals(otherMissing)) {
+          int missingId = randomIntBetween(0, 3);
+          switch (missingId) {
+          case 0:
+              missing = ("_last");
+              break;
+          case 1:
+              missing = ("_first");
+              break;
+          case 2:
+              missing = randomAsciiOfLength(10);
+              break;
+          case 3:
+              missing = randomInt();
+              break;
+          default:
+              throw new IllegalStateException("Unknown missing type.");
+              
+          }
+        }
+        builder.missing(missing);
+    }
+    
+    public void unmappedType(FieldSortBuilder builder) {
+        String type = randomAsciiOfLengthBetween(1, 10);
+        while (type.equals(builder.unmappedType())) {
+            type = randomAsciiOfLengthBetween(1, 10);
+        }
+        builder.unmappedType(type);
+    }
+    
+    public void order(FieldSortBuilder builder) {
+        SortOrder order = SortOrder.ASC;
+        if (order.equals(builder.order())) {
+            builder.order(SortOrder.DESC);
+        } else {
+            builder.order(SortOrder.ASC);
+        }
     }
 
     @Override
     protected FieldSortBuilder mutate(FieldSortBuilder original) throws IOException {
-        return null;
+        FieldSortBuilder mutated = new FieldSortBuilder(original);
+        int parameter = randomIntBetween(0, 5);
+        switch (parameter) {
+        case 0:
+            nestedPath(mutated);
+            break;
+        case 1:
+            nestedFilter(mutated);
+            break;
+        case 2:
+            modes(mutated);
+            break;
+        case 3:
+            unmappedType(mutated);
+            break;
+        case 4:
+            missing(mutated);
+            break;
+        case 5:
+            order(mutated);
+            break;
+        default:
+            throw new IllegalStateException("Unsupported mutation.");
+        }
+        return mutated;
+        
     }
-
-    @Override
-    protected ParameterParser<FieldSortBuilder> getItemParser() {
-        return null;
-    }
-
-
 }

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortParserTest.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortParserTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.sort;
+
+import org.apache.lucene.search.Sort;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TestSearchContext;
+import org.junit.Test;
+
+public class FieldSortParserTest extends ESTestCase {
+
+    private SearchContext createSearchContext() {
+        SearchContext context = new TestSearchContext();
+        return context;
+    }
+    
+    public Sort parseSortElement(XContentParser parser) throws Exception {
+        SearchContext context = createSearchContext();
+        SortParseElement element = new SortParseElement();
+        element.parse(parser, context);
+        return context.sort();
+    }
+    
+    @Test
+    public void test() throws Exception {
+        String element = 
+                "{\n" + 
+                "    \"sort\" : [\n" + 
+                "        { \"post_date\" : {\"order\" : \"asc\"}},\n" + 
+                "        \"user\",\n" + 
+                "        { \"name\" : \"desc\" },\n" + 
+                "        { \"age\" : \"desc\" },\n" + 
+                "        \"_score\"\n" + 
+                "    ]" + 
+                "}";
+        XContentParser parser = XContentFactory.xContent(element).createParser(element);
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        parseSortElement(parser);
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTest.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.sort;
+
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.geo.GeoDistance;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.geo.RandomGeoGenerator;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class GeoDistanceSortBuilderTest extends AbstractSearchSourceItemTestCase<GeoDistanceSortBuilder> {
+
+    @Override
+    protected GeoDistanceSortBuilder createTestItem() {
+        String fieldName = randomAsciiOfLengthBetween(1, 10);
+        GeoDistanceSortBuilder result = new GeoDistanceSortBuilder(fieldName);
+
+        int id = randomIntBetween(0, 2);
+        switch(id) {
+            case 0:
+                int count = randomIntBetween(1, 10);
+                String[] geohashes = new String[count];
+                for (int i = 0; i < count; i++) {
+                    geohashes[i] = RandomGeoGenerator.randomPoint(getRandom()).geohash();
+                }
+
+                result.geohashes(geohashes);
+                break;
+            case 1:
+                GeoPoint pt = RandomGeoGenerator.randomPoint(getRandom());
+                result.point(pt.getLat(), pt.getLon());
+                break;
+            case 2:
+                result.points(points(result.points()));
+                break;
+            default:
+                throw new IllegalStateException("one of three geo initialisation strategies must be used");
+           
+        }
+        if (randomBoolean()) {
+            result.geoDistance(geoDistance(result.geoDistance()));
+        }
+        if (randomBoolean()) {
+            result.unit(unit(result.unit()));
+        }
+        if (randomBoolean()) {
+            result.order(RandomSortDataGenerator.order(result.order()));
+        }
+        if (randomBoolean()) {
+            result.sortMode(mode(result.sortMode()));
+        }
+        if (randomBoolean()) {
+            result.setNestedFilter(RandomSortDataGenerator.nestedFilter(result.getNestedFilter()));
+        }
+        if (randomBoolean()) {
+            result.setNestedPath(RandomSortDataGenerator.randomAscii(result.getNestedPath()));
+        }
+        if (randomBoolean()) {
+            result.coerce(! result.coerce());
+        }
+        if (randomBoolean()) {
+            result.ignoreMalformed(! result.ignoreMalformed());
+        }
+        
+        return result;
+    }
+
+    private static String mode(String original) {
+        String[] modes = {"MIN", "MAX", "AVG"};
+        String mode = ESTestCase.randomFrom(modes);
+        while (mode.equals(original)) {
+            mode = ESTestCase.randomFrom(modes);
+        }
+        return mode;
+    }
+
+    private DistanceUnit unit(DistanceUnit original) {
+        int id = -1;
+        while (id == -1 || (original != null && original.ordinal() == id)) {
+            id = randomIntBetween(0, DistanceUnit.values().length - 1);
+        }
+        return DistanceUnit.values()[id];
+    }
+
+    private GeoPoint[] points(GeoPoint[] original) {
+        GeoPoint[] result = null;
+        while (result == null || Arrays.deepEquals(original, result)) {
+            int count = randomIntBetween(1, 10);
+            result = new GeoPoint[count];
+            for (int i = 0; i < count; i++) {
+                result[i] = RandomGeoGenerator.randomPoint(getRandom());
+            }
+        }
+        return result;
+    }
+
+    private GeoDistance geoDistance(GeoDistance original) {
+        int id = -1;
+        while (id == -1 || (original != null && original.ordinal() == id)) {
+            id = randomIntBetween(0, GeoDistance.values().length - 1);
+        }
+        return GeoDistance.values()[id];
+    }
+
+    @Override
+    protected GeoDistanceSortBuilder mutate(GeoDistanceSortBuilder original) throws IOException {
+        GeoDistanceSortBuilder result = new GeoDistanceSortBuilder(original);
+        int parameter = randomIntBetween(0, 9);
+        switch (parameter) {
+        case 0:
+            while (Arrays.deepEquals(original.points(), result.points())) {
+                GeoPoint pt = RandomGeoGenerator.randomPoint(getRandom());
+                result.point(pt.getLat(), pt.getLon());
+            }
+            break;
+        case 1:
+            result.points(points(original.points()));
+            break;
+        case 2:
+            result.geoDistance(geoDistance(original.geoDistance()));
+            break;
+        case 3:
+            result.unit(unit(original.unit()));
+            break;
+        case 4:
+            result.order(RandomSortDataGenerator.order(original.order()));
+            break;
+        case 5:
+            result.sortMode(mode(original.sortMode()));
+            break;
+        case 6:
+            result.setNestedFilter(RandomSortDataGenerator.nestedFilter(original.getNestedFilter()));
+            break;
+        case 7:
+            result.setNestedPath(RandomSortDataGenerator.randomAscii(original.getNestedPath()));
+            break;
+        case 8:
+            result.coerce(! original.coerce());
+            break;
+        case 9:
+            // ignore malformed will only be set if coerce is set to true
+            result.coerce(false);
+            result.ignoreMalformed(! original.ignoreMalformed());
+            break;
+        }
+        return result;
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Class<GeoDistanceSortBuilder> getPrototype() {
+        return (Class<GeoDistanceSortBuilder>) GeoDistanceSortBuilder.PROTOTYPE.getClass();
+    }
+
+    public void testSortModeSumIsRejectedInSetter() {
+        GeoDistanceSortBuilder builder = new GeoDistanceSortBuilder("testname");
+        GeoPoint point = RandomGeoGenerator.randomPoint(getRandom());
+        builder.point(point.getLat(), point.getLon());
+        try {
+            builder.sortMode("SUM");
+            fail("sort mode sum should not be supported");
+          } catch (IllegalArgumentException e) {
+              // all good
+          }
+    }
+    
+    public void testSortModeSumIsRejectedInJSON() throws IOException {
+        String json = "{\n" + 
+                "  \"testname\" : [ {\n" + 
+                "    \"lat\" : -6.046997540714173,\n" + 
+                "    \"lon\" : -51.94128329747579\n" + 
+                "  } ],\n" + 
+                "  \"unit\" : \"m\",\n" + 
+                "  \"distance_type\" : \"sloppy_arc\",\n" + 
+                "  \"reverse\" : true,\n" + 
+                "  \"mode\" : \"SUM\",\n" + 
+                "  \"coerce\" : false,\n" + 
+                "  \"ignore_malformed\" : false\n" + 
+                "}";
+        XContentParser itemParser = XContentHelper.createParser(new BytesArray(json));
+        itemParser.nextToken();
+        
+        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry);
+        context.reset(itemParser);
+
+        try {
+          GeoDistanceSortBuilder.PROTOTYPE.fromXContent(context, "");
+          fail("sort mode sum should not be supported");
+        } catch (IllegalArgumentException e) {
+            // all good
+        }
+    }
+    
+    public void testMissingPointsRejectedToXContent() throws IOException {
+        GeoDistanceSortBuilder testItem = new GeoDistanceSortBuilder("teststring");
+        XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+        if (randomBoolean()) {
+            builder.prettyPrint();
+        }
+        builder.startObject();
+        try {
+            testItem.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            fail("Converting w/o any points should be forbidden.");
+        } catch (ElasticsearchParseException e) { 
+            // all good
+        }
+    }
+    
+    // TODO
+    public void testMissingPointsRejectedToSort() {
+        
+    }
+
+    public void testGeoDistanceSortCanBeParsedFromGeoHash() throws IOException {
+        String json = "{\n" + 
+                "    \"VDcvDuFjE\" : [ \"7umzzv8eychg\", \"dmdgmt5z13uw\", \"ezu09wxw6v4c\", \"kc7s3515p6k6\", \"jgeuvjwrmfzn\", \"kcpcfj7ruyf8\" ],\n" + 
+                "    \"unit\" : \"m\",\n" + 
+                "    \"distance_type\" : \"sloppy_arc\",\n" + 
+                "    \"reverse\" : true,\n" + 
+                "    \"mode\" : \"MAX\",\n" + 
+                "    \"nested_filter\" : {\n" + 
+                "      \"ids\" : {\n" + 
+                "        \"type\" : [ ],\n" + 
+                "        \"values\" : [ ],\n" + 
+                "        \"boost\" : 5.711116\n" + 
+                "      }\n" + 
+                "    },\n" + 
+                "    \"coerce\" : false,\n" + 
+                "    \"ignore_malformed\" : true\n" + 
+                "  }";
+        XContentParser itemParser = XContentHelper.createParser(new BytesArray(json));
+        itemParser.nextToken();
+        
+        QueryParseContext context = new QueryParseContext(indicesQueriesRegistry);
+        context.reset(itemParser);
+
+        GeoDistanceSortBuilder result = GeoDistanceSortBuilder.PROTOTYPE.fromXContent(context, json);
+        assertEquals("[-19.700583312660456, -2.8225036337971687, "
+                + "31.537466906011105, -74.63590376079082, "
+                + "43.71844606474042, -5.548660643398762, "
+                + "-37.20467280596495, 38.71751043945551, "
+                + "-69.44606635719538, 84.25200328230858, "
+                + "-39.03717711567879, 44.74099852144718]", Arrays.toString(result.points()));                
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/sort/RandomSortDataGenerator.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/RandomSortDataGenerator.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.sort;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.query.IdsQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+public class RandomSortDataGenerator {
+    private RandomSortDataGenerator() {
+        // this is a helper class only, doesn't need a constructor
+    }
+
+    public static QueryBuilder nestedFilter(QueryBuilder original) {
+        @SuppressWarnings("rawtypes")
+        QueryBuilder nested = null;
+        while (nested == null || nested.equals(original)) {
+            switch (ESTestCase.randomInt(2)) {
+            case 0:
+                nested = new MatchAllQueryBuilder();
+                break;
+            case 1:
+                nested = new IdsQueryBuilder();
+                break;
+            default:
+            case 2:
+                nested = new TermQueryBuilder(ESTestCase.randomAsciiOfLengthBetween(1, 10), ESTestCase.randomAsciiOfLengthBetween(1, 10));
+                break;
+            }
+            nested.boost((float) ESTestCase.randomDoubleBetween(0, 10, false));
+        }
+        return nested;
+    }
+
+    public static String randomAscii(String original) {
+        String nestedPath = ESTestCase.randomAsciiOfLengthBetween(1, 10);
+        while (nestedPath.equals(original)) {
+            nestedPath = ESTestCase.randomAsciiOfLengthBetween(1, 10);
+        }
+        return nestedPath;
+    }
+
+    public static String mode(String original) {
+        String[] modes = {"min", "max", "avg", "sum"};
+        String mode = ESTestCase.randomFrom(modes);
+        while (mode.equals(original)) {
+            mode = ESTestCase.randomFrom(modes);
+        }
+        return mode;
+    }
+    
+    public static Object missing(Object original) {
+        Object missing = null;
+        Object otherMissing = null;
+        if (original instanceof BytesRef) {
+            otherMissing = ((BytesRef) original).utf8ToString();
+        } else {
+            otherMissing = original;
+        }
+
+        while (missing == null || missing.equals(otherMissing)) {
+          int missingId = ESTestCase.randomIntBetween(0, 3);
+          switch (missingId) {
+          case 0:
+              missing = ("_last");
+              break;
+          case 1:
+              missing = ("_first");
+              break;
+          case 2:
+              missing = ESTestCase.randomAsciiOfLength(10);
+              break;
+          case 3:
+              missing = ESTestCase.randomInt();
+              break;
+          default:
+              throw new IllegalStateException("Unknown missing type.");
+              
+          }
+        }
+        return missing;
+    }
+    
+    public static SortOrder order(SortOrder original) {
+        SortOrder order = SortOrder.ASC;
+        if (order.equals(original)) {
+            return SortOrder.DESC;
+        } else {
+            return SortOrder.ASC;
+        }
+    }
+
+}


### PR DESCRIPTION
Warning: This is early work in progress posted for feedback.

Final goal as described in #15178 is to make all sorting serializable. The initial state of this PR however only adds the Writable interface to SortBuilder, fixes FieldSortBuilder and adds a roundtrip serialisation test (mostly inspir^Wcopied from the highlighter refactoring) for it.

What's missing: 
- Fix other classes implementing SortBuilder and add respective unit tests.
- Migrate the logic that generates the actual Lucene sort objects over from SortParseElement and friends.

@cbuescher if you have time for feedback (as in "yeah, that looks like a good way forward" or as in "no, stop - before going out and changing another handful of classes let's fix issues x, y, and z with the general approach first") that would be appreciated.
