### PR TITLE
Ban Serializable

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -309,9 +309,10 @@ class BuildPlugin implements Plugin<Project> {
                 /*
                  * -path because gradle will send in paths that don't always exist.
                  * -missing because we have tons of missing @returns and @param.
+                 * -serial because we don't use java serialization.
                  */
                 // don't even think about passing args with -J-xxx, oracle will ask you to submit a bug report :)
-                options.compilerArgs << '-Werror' << '-Xlint:all,-path' << '-Xdoclint:all' << '-Xdoclint:-missing'
+                options.compilerArgs << '-Werror' << '-Xlint:all,-path,-serial' << '-Xdoclint:all' << '-Xdoclint:-missing'
                 // compile with compact 3 profile by default
                 // NOTE: this is just a compile time check: does not replace testing with a compact3 JRE
                 if (project.compactProfile != 'full') {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.groovy
@@ -62,6 +62,9 @@ public class ForbiddenPatternsTask extends DefaultTask {
         patterns.put('nocommit', /nocommit/)
         patterns.put('tab', /\t/)
         patterns.put('wildcard imports', /^\s*import.*\.\*/)
+        // We don't use Java serialization so we fail if it looks like we're trying to.
+        patterns.put('declares serialVersionUID', /serialVersionUID/)
+        patterns.put('references Serializable', /java\.io\.Serializable/)
 
         inputs.property("excludes", filesFilter.excludes)
         inputs.property("rules", patterns)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -102,8 +102,8 @@ if (isEclipse) {
   }
 }
 
-compileJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-rawtypes,-serial,-try,-unchecked"
-compileTestJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-rawtypes,-serial,-try,-unchecked"
+compileJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-rawtypes,-try,-unchecked"
+compileTestJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-rawtypes,-try,-unchecked"
 
 forbiddenPatterns {
   exclude '**/*.json'

--- a/core/src/main/java/org/elasticsearch/SpecialPermission.java
+++ b/core/src/main/java/org/elasticsearch/SpecialPermission.java
@@ -22,15 +22,15 @@ package org.elasticsearch;
 import java.security.BasicPermission;
 
 /**
- * Elasticsearch-specific permission to check before entering 
- * {@code AccessController.doPrivileged()} blocks. 
+ * Elasticsearch-specific permission to check before entering
+ * {@code AccessController.doPrivileged()} blocks.
  * <p>
- * We try to avoid these blocks in our code and keep security simple, 
- * but we need them for a few special places to contain hacks for third 
+ * We try to avoid these blocks in our code and keep security simple,
+ * but we need them for a few special places to contain hacks for third
  * party code, or dangerous things used by scripting engines.
  * <p>
  * All normal code has this permission, but checking this before truncating the stack
- * prevents unprivileged code (e.g. scripts), which do not have it, from gaining elevated 
+ * prevents unprivileged code (e.g. scripts), which do not have it, from gaining elevated
  * privileges.
  * <p>
  * In other words, don't do this:
@@ -57,9 +57,6 @@ import java.security.BasicPermission;
  * </code></pre>
  */
 public final class SpecialPermission extends BasicPermission {
-
-    private static final long serialVersionUID = -4129500096157408168L;
-
     /**
      * Creates a new SpecialPermision object.
      */
@@ -68,11 +65,11 @@ public final class SpecialPermission extends BasicPermission {
         // but let's just keep it simple if we can.
         super("*");
     }
-    
+
     /**
      * Creates a new SpecialPermission object.
      * This constructor exists for use by the {@code Policy} object to instantiate new Permission objects.
-     * 
+     *
      * @param name ignored
      * @param actions ignored
      */

--- a/core/src/main/java/org/elasticsearch/common/inject/ConfigurationException.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/ConfigurationException.java
@@ -81,6 +81,4 @@ public final class ConfigurationException extends RuntimeException {
     public String getMessage() {
         return Errors.format("Guice configuration errors", messages);
     }
-
-    private static final long serialVersionUID = 0;
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/CreationException.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/CreationException.java
@@ -52,6 +52,4 @@ public class CreationException extends RuntimeException {
     public String getMessage() {
         return Errors.format("Guice creation errors", messages);
     }
-
-    private static final long serialVersionUID = 0;
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/ProvisionException.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/ProvisionException.java
@@ -68,6 +68,4 @@ public final class ProvisionException extends RuntimeException {
     public String getMessage() {
         return Errors.format("Guice provision errors", messages);
     }
-
-    private static final long serialVersionUID = 0;
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.inject.spi.Message;
 import org.elasticsearch.common.inject.spi.TypeListenerBinding;
 
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -66,7 +65,7 @@ import static java.util.Collections.unmodifiableList;
  *
  * @author jessewilson@google.com (Jesse Wilson)
  */
-public final class Errors implements Serializable {
+public final class Errors {
 
     /**
      * The root errors object. Used to access the list of error messages.

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/Join.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/Join.java
@@ -313,7 +313,5 @@ public final class Join {
         private JoinException(IOException cause) {
             super(cause);
         }
-
-        private static final long serialVersionUID = 1L;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.inject.ConfigurationException;
 import org.elasticsearch.common.inject.TypeLiteral;
 import org.elasticsearch.common.inject.spi.Message;
 
-import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
@@ -108,8 +107,7 @@ public class MoreTypes {
 
     /**
      * Returns a type that is functionally equal but not necessarily equal
-     * according to {@link Object#equals(Object) Object.equals()}. The returned
-     * type is {@link Serializable}.
+     * according to {@link Object#equals(Object) Object.equals()}.
      */
     public static Type canonicalize(Type type) {
         if (type instanceof ParameterizedTypeImpl
@@ -138,17 +136,6 @@ public class MoreTypes {
             // type is either serializable as-is or unsupported
             return type;
         }
-    }
-
-    /**
-     * Returns a type that's functionally equal but not necessarily equal
-     * according to {@link Object#equals(Object) Object.equals}. The returned
-     * member is {@link Serializable}.
-     */
-    public static Member serializableCopy(Member member) {
-        return member instanceof MemberImpl
-                ? member
-                : new MemberImpl(member);
     }
 
     public static Class<?> getRawType(Type type) {
@@ -450,7 +437,7 @@ public class MoreTypes {
     }
 
     public static class ParameterizedTypeImpl
-            implements ParameterizedType, Serializable, CompositeType {
+            implements ParameterizedType, CompositeType {
         private final Type ownerType;
         private final Type rawType;
         private final Type[] typeArguments;
@@ -527,12 +514,10 @@ public class MoreTypes {
         public String toString() {
             return MoreTypes.toString(this);
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     public static class GenericArrayTypeImpl
-            implements GenericArrayType, Serializable, CompositeType {
+            implements GenericArrayType, CompositeType {
         private final Type componentType;
 
         public GenericArrayTypeImpl(Type componentType) {
@@ -564,8 +549,6 @@ public class MoreTypes {
         public String toString() {
             return MoreTypes.toString(this);
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -573,7 +556,7 @@ public class MoreTypes {
      * lower bounds. We only support what the Java 6 language needs - at most one
      * bound. If a lower bound is set, the upper bound must be Object.class.
      */
-    public static class WildcardTypeImpl implements WildcardType, Serializable, CompositeType {
+    public static class WildcardTypeImpl implements WildcardType, CompositeType {
         private final Type upperBound;
         private final Type lowerBound;
 
@@ -632,8 +615,6 @@ public class MoreTypes {
         public String toString() {
             return MoreTypes.toString(this);
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     private static void checkNotPrimitive(Type type, String use) {
@@ -647,7 +628,7 @@ public class MoreTypes {
      * our exception types. We workaround this with this serializable implementation. It includes all
      * of the API methods, plus everything we use for line numbers and messaging.
      */
-    public static class MemberImpl implements Member, Serializable {
+    public static class MemberImpl implements Member {
         private final Class<?> declaringClass;
         private final String name;
         private final int modifiers;

--- a/core/src/main/java/org/elasticsearch/common/inject/matcher/AbstractMatcher.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/matcher/AbstractMatcher.java
@@ -16,8 +16,6 @@
 
 package org.elasticsearch.common.inject.matcher;
 
-import java.io.Serializable;
-
 /**
  * Implements {@code and()} and {@code or()}.
  *
@@ -35,7 +33,7 @@ public abstract class AbstractMatcher<T> implements Matcher<T> {
         return new OrMatcher<>(this, other);
     }
 
-    private static class AndMatcher<T> extends AbstractMatcher<T> implements Serializable {
+    private static class AndMatcher<T> extends AbstractMatcher<T> {
         private final Matcher<? super T> a, b;
 
         public AndMatcher(Matcher<? super T> a, Matcher<? super T> b) {
@@ -64,11 +62,9 @@ public abstract class AbstractMatcher<T> implements Matcher<T> {
         public String toString() {
             return "and(" + a + ", " + b + ")";
         }
-
-        private static final long serialVersionUID = 0;
     }
 
-    private static class OrMatcher<T> extends AbstractMatcher<T> implements Serializable {
+    private static class OrMatcher<T> extends AbstractMatcher<T> {
         private final Matcher<? super T> a, b;
 
         public OrMatcher(Matcher<? super T> a, Matcher<? super T> b) {
@@ -97,7 +93,5 @@ public abstract class AbstractMatcher<T> implements Matcher<T> {
         public String toString() {
             return "or(" + a + ", " + b + ")";
         }
-
-        private static final long serialVersionUID = 0;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/matcher/Matchers.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/matcher/Matchers.java
@@ -16,7 +16,6 @@
 
 package org.elasticsearch.common.inject.matcher;
 
-import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -42,7 +41,7 @@ public class Matchers {
 
     private static final Matcher<Object> ANY = new Any();
 
-    private static class Any extends AbstractMatcher<Object> implements Serializable {
+    private static class Any extends AbstractMatcher<Object> {
         @Override
         public boolean matches(Object o) {
             return true;
@@ -56,8 +55,6 @@ public class Matchers {
         public Object readResolve() {
             return any();
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -67,7 +64,7 @@ public class Matchers {
         return new Not<>(p);
     }
 
-    private static class Not<T> extends AbstractMatcher<T> implements Serializable {
+    private static class Not<T> extends AbstractMatcher<T> {
         final Matcher<? super T> delegate;
 
         private Not(Matcher<? super T> delegate) {
@@ -94,8 +91,6 @@ public class Matchers {
         public String toString() {
             return "not(" + delegate + ")";
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     private static void checkForRuntimeRetention(
@@ -115,8 +110,7 @@ public class Matchers {
         return new AnnotatedWithType(annotationType);
     }
 
-    private static class AnnotatedWithType extends AbstractMatcher<AnnotatedElement>
-            implements Serializable {
+    private static class AnnotatedWithType extends AbstractMatcher<AnnotatedElement> {
         private final Class<? extends Annotation> annotationType;
 
         public AnnotatedWithType(Class<? extends Annotation> annotationType) {
@@ -144,8 +138,6 @@ public class Matchers {
         public String toString() {
             return "annotatedWith(" + annotationType.getSimpleName() + ".class)";
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -157,8 +149,7 @@ public class Matchers {
         return new AnnotatedWith(annotation);
     }
 
-    private static class AnnotatedWith extends AbstractMatcher<AnnotatedElement>
-            implements Serializable {
+    private static class AnnotatedWith extends AbstractMatcher<AnnotatedElement> {
         private final Annotation annotation;
 
         public AnnotatedWith(Annotation annotation) {
@@ -187,8 +178,6 @@ public class Matchers {
         public String toString() {
             return "annotatedWith(" + annotation + ")";
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -199,8 +188,7 @@ public class Matchers {
         return new SubclassesOf(superclass);
     }
 
-    private static class SubclassesOf extends AbstractMatcher<Class>
-            implements Serializable {
+    private static class SubclassesOf extends AbstractMatcher<Class> {
         private final Class<?> superclass;
 
         public SubclassesOf(Class<?> superclass) {
@@ -227,8 +215,6 @@ public class Matchers {
         public String toString() {
             return "subclassesOf(" + superclass.getSimpleName() + ".class)";
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -238,8 +224,7 @@ public class Matchers {
         return new Only(value);
     }
 
-    private static class Only extends AbstractMatcher<Object>
-            implements Serializable {
+    private static class Only extends AbstractMatcher<Object> {
         private final Object value;
 
         public Only(Object value) {
@@ -266,8 +251,6 @@ public class Matchers {
         public String toString() {
             return "only(" + value + ")";
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -277,8 +260,7 @@ public class Matchers {
         return new IdenticalTo(value);
     }
 
-    private static class IdenticalTo extends AbstractMatcher<Object>
-            implements Serializable {
+    private static class IdenticalTo extends AbstractMatcher<Object> {
         private final Object value;
 
         public IdenticalTo(Object value) {
@@ -305,8 +287,6 @@ public class Matchers {
         public String toString() {
             return "identicalTo(" + value + ")";
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -317,7 +297,7 @@ public class Matchers {
         return new InPackage(targetPackage);
     }
 
-    private static class InPackage extends AbstractMatcher<Class> implements Serializable {
+    private static class InPackage extends AbstractMatcher<Class> {
         private final transient Package targetPackage;
         private final String packageName;
 
@@ -350,8 +330,6 @@ public class Matchers {
         public Object readResolve() {
             return inPackage(Package.getPackage(packageName));
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -364,7 +342,7 @@ public class Matchers {
         return new InSubpackage(targetPackageName);
     }
 
-    private static class InSubpackage extends AbstractMatcher<Class> implements Serializable {
+    private static class InSubpackage extends AbstractMatcher<Class>  {
         private final String targetPackageName;
 
         public InSubpackage(String targetPackageName) {
@@ -393,8 +371,6 @@ public class Matchers {
         public String toString() {
             return "inSubpackage(" + targetPackageName + ")";
         }
-
-        private static final long serialVersionUID = 0;
     }
 
     /**
@@ -405,7 +381,7 @@ public class Matchers {
         return new Returns(returnType);
     }
 
-    private static class Returns extends AbstractMatcher<Method> implements Serializable {
+    private static class Returns extends AbstractMatcher<Method> {
         private final Matcher<? super Class<?>> returnType;
 
         public Returns(Matcher<? super Class<?>> returnType) {
@@ -432,7 +408,5 @@ public class Matchers {
         public String toString() {
             return "returns(" + returnType + ")";
         }
-
-        private static final long serialVersionUID = 0;
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/name/NamedImpl.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/name/NamedImpl.java
@@ -16,11 +16,10 @@
 
 package org.elasticsearch.common.inject.name;
 
-import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.Objects;
 
-class NamedImpl implements Named, Serializable {
+class NamedImpl implements Named {
 
     private final String value;
 
@@ -58,6 +57,4 @@ class NamedImpl implements Named, Serializable {
     public Class<? extends Annotation> annotationType() {
         return Named.class;
     }
-
-    private static final long serialVersionUID = 0;
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/spi/Message.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/spi/Message.java
@@ -20,9 +20,6 @@ import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.internal.Errors;
 import org.elasticsearch.common.inject.internal.SourceProvider;
 
-import java.io.ObjectStreamException;
-import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -40,7 +37,7 @@ import java.util.Objects;
  *
  * @author crazybob@google.com (Bob Lee)
  */
-public final class Message implements Serializable, Element {
+public final class Message implements Element {
     private final String message;
     private final Throwable cause;
     private final List<Object> sources;
@@ -131,18 +128,4 @@ public final class Message implements Serializable, Element {
     public void applyTo(Binder binder) {
         binder.withSource(getSource()).addError(this);
     }
-
-    /**
-     * When serialized, we eagerly convert sources to strings. This hurts our formatting, but it
-     * guarantees that the receiving end will be able to read the message.
-     */
-    private Object writeReplace() throws ObjectStreamException {
-        Object[] sourcesAsStrings = sources.toArray();
-        for (int i = 0; i < sourcesAsStrings.length; i++) {
-            sourcesAsStrings[i] = Errors.convert(sourcesAsStrings[i]).toString();
-        }
-        return new Message(Arrays.asList(sourcesAsStrings), message, cause);
-    }
-
-    private static final long serialVersionUID = 0;
 }

--- a/core/src/main/java/org/elasticsearch/common/inject/util/Types.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/util/Types.java
@@ -45,7 +45,7 @@ public final class Types {
      * Returns a new parameterized type, applying {@code typeArguments} to
      * {@code rawType}. The returned type does not have an owner type.
      *
-     * @return a {@link java.io.Serializable serializable} parameterized type.
+     * @return a parameterized type.
      */
     public static ParameterizedType newParameterizedType(Type rawType, Type... typeArguments) {
         return newParameterizedTypeWithOwner(null, rawType, typeArguments);
@@ -55,7 +55,7 @@ public final class Types {
      * Returns a new parameterized type, applying {@code typeArguments} to
      * {@code rawType} and enclosed by {@code ownerType}.
      *
-     * @return a {@link java.io.Serializable serializable} parameterized type.
+     * @return a parameterized type.
      */
     public static ParameterizedType newParameterizedTypeWithOwner(
             Type ownerType, Type rawType, Type... typeArguments) {
@@ -66,7 +66,7 @@ public final class Types {
      * Returns an array type whose elements are all instances of
      * {@code componentType}.
      *
-     * @return a {@link java.io.Serializable serializable} generic array type.
+     * @return a generic array type.
      */
     public static GenericArrayType arrayOf(Type componentType) {
         return new GenericArrayTypeImpl(componentType);
@@ -95,7 +95,7 @@ public final class Types {
      * Returns a type modelling a {@link List} whose elements are of type
      * {@code elementType}.
      *
-     * @return a {@link java.io.Serializable serializable} parameterized type.
+     * @return a parameterized type.
      */
     public static ParameterizedType listOf(Type elementType) {
         return newParameterizedType(List.class, elementType);
@@ -105,7 +105,7 @@ public final class Types {
      * Returns a type modelling a {@link Set} whose elements are of type
      * {@code elementType}.
      *
-     * @return a {@link java.io.Serializable serializable} parameterized type.
+     * @return a parameterized type.
      */
     public static ParameterizedType setOf(Type elementType) {
         return newParameterizedType(Set.class, elementType);
@@ -115,7 +115,7 @@ public final class Types {
      * Returns a type modelling a {@link Map} whose keys are of type
      * {@code keyType} and whose values are of type {@code valueType}.
      *
-     * @return a {@link java.io.Serializable serializable} parameterized type.
+     * @return a parameterized type.
      */
     public static ParameterizedType mapOf(Type keyType, Type valueType) {
         return newParameterizedType(Map.class, keyType, valueType);
@@ -127,7 +127,7 @@ public final class Types {
      * Returns a type modelling a {@link Provider} that provides elements of type
      * {@code elementType}.
      *
-     * @return a {@link java.io.Serializable serializable} parameterized type.
+     * @return a parameterized type.
      */
     public static ParameterizedType providerOf(Type providedType) {
         return newParameterizedType(Provider.class, providedType);

--- a/core/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -296,8 +296,6 @@ public class Joda {
 
 
     public static final DurationFieldType Quarters = new DurationFieldType("quarters") {
-        private static final long serialVersionUID = -8167713675442491871L;
-
         @Override
         public DurationField getField(Chronology chronology) {
             return new ScaledDurationField(chronology.months(), Quarters, 3);
@@ -305,8 +303,6 @@ public class Joda {
     };
 
     public static final DateTimeFieldType QuarterOfYear = new DateTimeFieldType("quarterOfYear") {
-        private static final long serialVersionUID = -5677872459807379123L;
-
         @Override
         public DurationFieldType getDurationType() {
             return Quarters;

--- a/core/src/main/java/org/elasticsearch/common/logging/jdk/ESLogRecord.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/jdk/ESLogRecord.java
@@ -30,8 +30,6 @@ import java.util.logging.LogRecord;
  * information of the code calling the logger
  */
 public class ESLogRecord extends LogRecord {
-
-    private static final long serialVersionUID = 1107741560233585726L;
     private static final String FQCN = AbstractESLogger.class.getName();
     private String sourceClassName;
     private String sourceMethodName;

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/BaseFuture.java
@@ -180,9 +180,6 @@ public abstract class BaseFuture<V> implements Future<V> {
      * pass around a -1 everywhere.
      */
     static final class Sync<V> extends AbstractQueuedSynchronizer {
-
-        private static final long serialVersionUID = 0L;
-
         /* Valid states. */
         static final int RUNNING = 0;
         static final int COMPLETING = 1;

--- a/core/src/main/java/org/elasticsearch/script/ClassPermission.java
+++ b/core/src/main/java/org/elasticsearch/script/ClassPermission.java
@@ -72,8 +72,6 @@ import java.util.Set;
  * </ul>
  */
 public final class ClassPermission extends BasicPermission {
-    private static final long serialVersionUID = 3530711429252193884L;
-
     public static final String STANDARD = "<<STANDARD>>";
     /** Typical set of classes for scripting: basic data types, math, dates, and simple collections */
     // this is the list from the old grovy sandbox impl (+ some things like String, Iterator, etc that were missing)
@@ -109,17 +107,17 @@ public final class ClassPermission extends BasicPermission {
 
     /**
      * Creates a new ClassPermission object.
-     * 
+     *
      * @param name class to grant permission to
      */
     public ClassPermission(String name) {
         super(name);
     }
-    
+
     /**
      * Creates a new ClassPermission object.
      * This constructor exists for use by the {@code Policy} object to instantiate new Permission objects.
-     * 
+     *
      * @param name class to grant permission to
      * @param actions ignored
      */
@@ -144,8 +142,6 @@ public final class ClassPermission extends BasicPermission {
         // BasicPermissionCollection only handles wildcards, we expand <<STANDARD>> here
         PermissionCollection impl = super.newPermissionCollection();
         return new PermissionCollection() {
-            private static final long serialVersionUID = 6792220143549780002L;
-            
             @Override
             public void add(Permission permission) {
                 if (permission instanceof ClassPermission && STANDARD.equals(permission.getName())) {
@@ -156,12 +152,12 @@ public final class ClassPermission extends BasicPermission {
                     impl.add(permission);
                 }
             }
-            
+
             @Override
             public boolean implies(Permission permission) {
                 return impl.implies(permission);
             }
-            
+
             @Override
             public Enumeration<Permission> elements() {
                 return impl.elements();

--- a/core/src/main/java/org/joda/time/base/BaseDateTime.java
+++ b/core/src/main/java/org/joda/time/base/BaseDateTime.java
@@ -24,8 +24,6 @@ import org.joda.time.chrono.ISOChronology;
 import org.joda.time.convert.ConverterManager;
 import org.joda.time.convert.InstantConverter;
 
-import java.io.Serializable;
-
 /**
  * BaseDateTime is an abstract implementation of ReadableDateTime that stores
  * data in <code>long</code> and <code>Chronology</code> fields.
@@ -43,13 +41,7 @@ import java.io.Serializable;
  */
 public abstract class BaseDateTime
         extends AbstractDateTime
-        implements ReadableDateTime, Serializable {
-
-    /**
-     * Serialization lock
-     */
-    private static final long serialVersionUID = -6728882245981L;
-
+        implements ReadableDateTime {
     /**
      * The millis from 1970-01-01T00:00:00Z
      */

--- a/plugins/discovery-azure/build.gradle
+++ b/plugins/discovery-azure/build.gradle
@@ -56,7 +56,7 @@ dependencyLicenses {
   mapping from: /jaxb-.*/, to: 'jaxb'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-path,-serial,-unchecked'
+compileJava.options.compilerArgs << '-Xlint:-path,-unchecked'
 
 thirdPartyAudit.excludes = [
   // classes are missing

--- a/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/support/NativeList.java
+++ b/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/support/NativeList.java
@@ -31,7 +31,6 @@ import java.util.List;
  *
  */
 public class NativeList extends NativeJavaObject implements Scriptable, Wrapper {
-    private static final long serialVersionUID = 3664761893203964569L;
     private static final String LENGTH_PROPERTY = "length";
 
     private final List<Object> list;

--- a/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/support/NativeMap.java
+++ b/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/support/NativeMap.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.script.javascript.support;
 
-import java.util.Iterator;
-import java.util.Map;
-
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.Wrapper;
+
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Wrapper for exposing maps in Rhino scripts.
@@ -31,8 +31,6 @@ import org.mozilla.javascript.Wrapper;
  *
  */
 public class NativeMap implements Scriptable, Wrapper {
-    private static final long serialVersionUID = 3664761893203964569L;
-
     private Map<Object, Object> map;
     private Scriptable parentScope;
     private Scriptable prototype;

--- a/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/support/ScriptableLinkedHashMap.java
+++ b/plugins/lang-javascript/src/main/java/org/elasticsearch/script/javascript/support/ScriptableLinkedHashMap.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.script.javascript.support;
 
+import org.mozilla.javascript.Scriptable;
+
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import org.mozilla.javascript.Scriptable;
 
 /**
  * Implementation of a Scriptable Map. This is the best choice for maps that want to represent
@@ -33,8 +33,6 @@ import org.mozilla.javascript.Scriptable;
  *
  */
 public class ScriptableLinkedHashMap<K, V> extends LinkedHashMap<K, V> implements ScriptableMap<K, V> {
-    private static final long serialVersionUID = 3774167893214964123L;
-
     private Scriptable parentScope;
     private Scriptable prototype;
 

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -35,5 +35,3 @@ dependencyLicenses {
   mapping from: /stax-.*/, to: 'stax'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-serial'
-

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   compile 'org.elasticsearch:securemock:1.2'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-cast,-rawtypes,-serial,-try,-unchecked'
+compileJava.options.compilerArgs << '-Xlint:-cast,-rawtypes,-try,-unchecked'
 compileTestJava.options.compilerArgs << '-Xlint:-rawtypes'
 
 // the main files are actually test files, so use the appopriate forbidden api sigs


### PR DESCRIPTION
1. Uses forbidden patterns to prevent things from referencing
   java.io.Serializable or from mentioning serialVersionUID.
2. Uses -Xlint:-serial so we don't have to hear from javac that we aren't
   declaring serialVersionUID on any classes that we make that happen to extend
   Serializable.
3. Remove Serializable and serialVersionUID declarations.

I didn't use forbidden apis because it doesn't look like it has a way to ban
explicitly implementing Serializable. If you try to ban Serializable with
forbidden apis you end up banning all Exceptions and all Strings.

Closes #15847
