### PR TITLE
[Ingest] fix NPE when Grok matches expression, but no captures defined.

### DIFF
--- a/modules/ingest-grok/src/main/java/org/elasticsearch/ingest/grok/Grok.java
+++ b/modules/ingest-grok/src/main/java/org/elasticsearch/ingest/grok/Grok.java
@@ -134,7 +134,7 @@ final class Grok {
         Map<String, Object> fields = new HashMap<>();
         Matcher matcher = compiledExpression.matcher(textAsBytes);
         int result = matcher.search(0, textAsBytes.length, Option.DEFAULT);
-        if (result != -1) {
+        if (result != -1 && compiledExpression.numberOfNames() > 0) {
             Region region = matcher.getEagerRegion();
             for (Iterator<NameEntry> entry = compiledExpression.namedBackrefIterator(); entry.hasNext();) {
                 NameEntry e = entry.next();
@@ -148,11 +148,11 @@ final class Grok {
                 GrokMatchGroup match = new GrokMatchGroup(groupName, matchValue);
                 fields.put(match.getName(), match.getValue());
             }
-        } else {
-            return null;
+            return fields;
+        } else if (result != -1) {
+            return fields;
         }
-
-        return fields;
+        return null;
     }
 }
 

--- a/modules/ingest-grok/src/test/java/org/elasticsearch/ingest/grok/GrokProcessorTests.java
+++ b/modules/ingest-grok/src/test/java/org/elasticsearch/ingest/grok/GrokProcessorTests.java
@@ -57,6 +57,17 @@ public class GrokProcessorTests extends ESTestCase {
         }
     }
 
+    public void testMatchWithoutCaptures() throws Exception {
+        String fieldName = "value";
+        IngestDocument originalDoc = new IngestDocument(new HashMap<>(), new HashMap<>());
+        originalDoc.setFieldValue(fieldName, fieldName);
+        IngestDocument doc = new IngestDocument(originalDoc);
+        Grok grok = new Grok(Collections.emptyMap(), fieldName);
+        GrokProcessor processor = new GrokProcessor(grok, fieldName);
+        processor.execute(doc);
+        assertThat(doc, equalTo(originalDoc));
+    }
+
     public void testNotStringField() {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());

--- a/modules/ingest-grok/src/test/java/org/elasticsearch/ingest/grok/GrokTests.java
+++ b/modules/ingest-grok/src/test/java/org/elasticsearch/ingest/grok/GrokTests.java
@@ -57,6 +57,13 @@ public class GrokTests extends ESTestCase {
         );
     }
 
+    public void testMatchWithoutCaptures() {
+        String line = "value";
+        Grok grok = new Grok(basePatterns, "value");
+        Map<String, Object> matches = grok.captures(line);
+        assertEquals(0, matches.size());
+    }
+
     public void testSimpleSyslogLine() {
         String line = "Mar 16 00:01:25 evita postfix/smtpd[1713]: connect from camomile.cloud9.net[168.100.1.3]";
         Grok grok = new Grok(basePatterns, "%{SYSLOGLINE}");


### PR DESCRIPTION
As was found here: https://github.com/elastic/elasticsearch/issues/15901#issuecomment-170666936.

Grok would throw a NPE when the expression matched, but no captures are found. In this case, Grok should do nothing to the document, but it should also succeed.
