### PR TITLE
Add convenience method for capturing and clearing requests

### DIFF
--- a/core/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -268,7 +268,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
 
         action.new AsyncAction(request, listener).start();
-        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.capturedRequestsByTargetNode();
+        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
 
         ShardsIterator shardIt = clusterService.state().routingTable().allShards(new String[]{TEST_INDEX});
         Set<String> set = new HashSet<>();
@@ -303,7 +303,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
 
         action.new AsyncAction(request, listener).start();
 
-        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.capturedRequestsByTargetNode();
+        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
 
         // the master should not be in the list of nodes that requests were sent to
         ShardsIterator shardIt = clusterService.state().routingTable().allShards(new String[]{TEST_INDEX});
@@ -389,8 +389,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         }
 
         action.new AsyncAction(request, listener).start();
-        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.capturedRequestsByTargetNode();
-        transport.clear();
+        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
 
         ShardsIterator shardIt = clusterService.state().getRoutingTable().allShards(new String[]{TEST_INDEX});
         Map<String, List<ShardRouting>> map = new HashMap<>();

--- a/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
@@ -135,8 +135,7 @@ public class ShardStateActionTests extends ESTestCase {
             }
         });
 
-        final CapturingTransport.CapturedRequest[] capturedRequests = transport.capturedRequests();
-        transport.clear();
+        final CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
         assertThat(capturedRequests.length, equalTo(1));
         assert !failure.get();
         transport.handleResponse(capturedRequests[0].requestId, new TransportException("simulated"));
@@ -171,8 +170,7 @@ public class ShardStateActionTests extends ESTestCase {
         progress.set(true);
         assertTrue(timedOut.get());
 
-        final CapturingTransport.CapturedRequest[] capturedRequests = transport.capturedRequests();
-        transport.clear();
+        final CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
         assertThat(capturedRequests.length, equalTo(1));
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/CapturingTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/CapturingTransport.java
@@ -67,6 +67,19 @@ public class CapturingTransport implements Transport {
     }
 
     /**
+     * Returns all requests captured so far. This method does clear the
+     * captured requests list. If you do not want the captured requests
+     * list cleared, use {@link #capturedRequests()}.
+     *
+     * @return the captured requests
+     */
+    public CapturedRequest[] getCapturedRequestsAndClear() {
+        CapturedRequest[] capturedRequests = capturedRequests();
+        clear();
+        return capturedRequests;
+    }
+
+    /**
      * returns all requests captured so far, grouped by target node.
      * Doesn't clear the captured request list. See {@link #clear()}
      */
@@ -80,6 +93,20 @@ public class CapturingTransport implements Transport {
             }
             nodeList.add(request);
         }
+        return map;
+    }
+
+    /**
+     * Returns all requests captured so far, grouped by target node.
+     * This method does clear the captured request list. If you do not
+     * want the captured requests list cleared, use
+     * {@link #capturedRequestsByTargetNode()}.
+     *
+     * @return the captured requests grouped by target node
+     */
+    public Map<String, List<CapturedRequest>> getCapturedRequestsByTargetNodeAndClear() {
+        Map<String, List<CapturedRequest>> map = capturedRequestsByTargetNode();
+        clear();
         return map;
     }
 


### PR DESCRIPTION
This commit adds convenience methods to o.e.t.t.CapturingTransport
that enables capturing requests and clearing the captured requests
with a single method. This is to simplify a common pattern in tests of
capturing requests, and then clearing the captured requests.

Closes #15897
