### PR TITLE
Modify load average format

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -65,6 +65,9 @@ public class OsStats implements Streamable, ToXContent {
         static final XContentBuilderString CPU = new XContentBuilderString("cpu");
         static final XContentBuilderString PERCENT = new XContentBuilderString("percent");
         static final XContentBuilderString LOAD_AVERAGE = new XContentBuilderString("load_average");
+        static final XContentBuilderString LOAD_AVERAGE_1M = new XContentBuilderString("1m");
+        static final XContentBuilderString LOAD_AVERAGE_5M = new XContentBuilderString("5m");
+        static final XContentBuilderString LOAD_AVERAGE_15M = new XContentBuilderString("15m");
 
         static final XContentBuilderString MEM = new XContentBuilderString("mem");
         static final XContentBuilderString SWAP = new XContentBuilderString("swap");
@@ -77,7 +80,6 @@ public class OsStats implements Streamable, ToXContent {
 
         static final XContentBuilderString FREE_PERCENT = new XContentBuilderString("free_percent");
         static final XContentBuilderString USED_PERCENT = new XContentBuilderString("used_percent");
-
     }
 
     @Override
@@ -88,11 +90,17 @@ public class OsStats implements Streamable, ToXContent {
             builder.startObject(Fields.CPU);
             builder.field(Fields.PERCENT, cpu.getPercent());
             if (cpu.getLoadAverage() != null) {
-                builder.startArray(Fields.LOAD_AVERAGE);
-                builder.value(cpu.getLoadAverage()[0]);
-                builder.value(cpu.getLoadAverage()[1]);
-                builder.value(cpu.getLoadAverage()[2]);
-                builder.endArray();
+                builder.startObject(Fields.LOAD_AVERAGE);
+                if (cpu.getLoadAverage()[0] != -1) {
+                    builder.field(Fields.LOAD_AVERAGE_1M, cpu.getLoadAverage()[0]);
+                }
+                if (cpu.getLoadAverage()[1] != -1) {
+                    builder.field(Fields.LOAD_AVERAGE_5M, cpu.getLoadAverage()[1]);
+                }
+                if (cpu.getLoadAverage()[2] != -1) {
+                    builder.field(Fields.LOAD_AVERAGE_15M, cpu.getLoadAverage()[2]);
+                }
+                builder.endObject();
             }
             builder.endObject();
         }

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -266,9 +266,9 @@ public class RestNodesAction extends AbstractCatAction {
 
             table.addCell(osStats == null ? null : Short.toString(osStats.getCpu().getPercent()));
             boolean hasLoadAverage = osStats != null && osStats.getCpu().getLoadAverage() != null;
-            table.addCell(!hasLoadAverage ? null : String.format(Locale.ROOT, "%.2f", osStats.getCpu().getLoadAverage()[0]));
-            table.addCell(!hasLoadAverage ? null : String.format(Locale.ROOT, "%.2f", osStats.getCpu().getLoadAverage()[1]));
-            table.addCell(!hasLoadAverage ? null : String.format(Locale.ROOT, "%.2f", osStats.getCpu().getLoadAverage()[2]));
+            table.addCell(!hasLoadAverage || osStats.getCpu().getLoadAverage()[0] == -1 ? null : String.format(Locale.ROOT, "%.2f", osStats.getCpu().getLoadAverage()[0]));
+            table.addCell(!hasLoadAverage || osStats.getCpu().getLoadAverage()[1] == -1 ? null : String.format(Locale.ROOT, "%.2f", osStats.getCpu().getLoadAverage()[1]));
+            table.addCell(!hasLoadAverage || osStats.getCpu().getLoadAverage()[2] == -1 ? null : String.format(Locale.ROOT, "%.2f", osStats.getCpu().getLoadAverage()[2]));
             table.addCell(jvmStats == null ? null : jvmStats.getUptime());
             table.addCell(node.clientNode() ? "c" : node.dataNode() ? "d" : "-");
             table.addCell(masterId == null ? "x" : masterId.equals(node.id()) ? "*" : node.masterNode() ? "m" : "-");

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -131,9 +131,15 @@ the operating system:
 `os.cpu.percent`::
     Recent CPU usage for the whole system, or -1 if not supported
 
-`os.cpu.load_average`::
-	Array of system load averages for the last one minute, five
-	minute and fifteen minutes (value of -1 indicates not supported)
+`os.cpu.load_average.1m`::
+    One-minute load average on the system (field is not present if
+    one-minute load average is not available)
+`os.cpu.load_average.5m`::
+    Five-minute load average on the system (field is not present if
+    five-minute load average is not available)
+`os.cpu.load_average.15m`::
+    Fifteen-minute load average on the system (field is not present if
+    fifteen-minute load average is not available)
 
 `os.mem.total_in_bytes`::
 	Total amount of physical memory in bytes

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -560,30 +560,30 @@ and high risk of being misused. The ability to change the thread pool type for a
 that it is still possible to adjust relevant thread pool parameters for each of the thread pools (e.g., depending on
 the thread pool type, `keep_alive`, `queue_size`, etc.).
 
+[[breaking_30_cpu_stats]]
 === System CPU stats
 
 The recent CPU usage (as a percent) has been added to the OS stats
 reported under the node stats API and the cat nodes API. The breaking
-change here is that there is a new object in the "os" object in the node
-stats response. This object is called "cpu" and includes "percent" and
-"load_average" as fields. This moves the "load_average" field that was
-previously a top-level field in the "os" object to the "cpu" object. The
-format of the "load_average" field has changed to an array of length
-three representing the one-minute, five-minute and fifteen-minute load
-averages (a value of -1 for any of array components indicates that the
-corresponding metric is not available).
+change here is that there is a new object in the `os` object in the node
+stats response. This object is called `cpu` and includes "percent" and
+`load_average` as fields. This moves the `load_average` field that was
+previously a top-level field in the `os` object to the `cpu` object. The
+format of the `load_average` field has changed to an object with fields
+`1m`, `5m`, and `15m` representing the one-minute, five-minute and
+fifteen-minute loads respectively. If any of these fields are not present,
+it indicates that the corresponding value is not available.
 
-In the cat nodes API response, the "cpu" field is output by default. The
-previous "load" field has been removed and is replaced by "load_1m",
-"load_5m", and "load_15m" which represent the one-minute, five-minute
-and fifteen-minute loads respectively. These values are output by
-default, and a value of -1 indicates that the corresponding metric is
-not available.
+In the cat nodes API response, the `cpu` field is output by default. The
+previous `load` field has been removed and is replaced by `load_1m`,
+`load_5m`, and `load_15m` which represent the one-minute, five-minute
+and fifteen-minute loads respectively. The field will be null if the
+corresponding value is not available.
 
-Finally, the API for org.elasticsearch.monitor.os.OsStats has
+Finally, the API for `org.elasticsearch.monitor.os.OsStats` has
 changed. The `getLoadAverage` method has been removed. The value for
 this can now be obtained from `OsStats.Cpu#getLoadAverage` but it is no
-longer a double and is instead an object encapuslating the one-minute,
+longer a double and is instead an object encapsulating the one-minute,
 five-minute and fifteen-minute load averages. Additionally, the recent
 CPU usage can be obtained from `OsStats.Cpu#getPercent`.
 


### PR DESCRIPTION
This commit modifies the load_average in the node stats API response
to be an object containing the one-minute, five-minute and
fifteen-minute load averages as fields (if those values are
available). Additionally, this commit modifies the cat nodes API
response to format the one-minute, five-minute and fifteen-minute load
averages as null if any of the respective values are not available.

Relates #15907
