### PR TITLE
Add load averages to OS stats on FreeBSD

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -111,8 +111,9 @@ public class OsProbe {
      * Returns the system load averages
      */
     public double[] getSystemLoadAverage() {
-        if (Constants.LINUX) {
-            double[] loadAverage = readProcLoadavg("/proc/loadavg");
+        if (Constants.LINUX || Constants.FREE_BSD) {
+            final String procLoadAvg = Constants.LINUX ? "/proc/loadavg" : "/compat/linux/proc/loadavg";
+            double[] loadAverage = readProcLoadavg(procLoadAvg);
             if (loadAverage != null) {
                 return loadAverage;
             }

--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -118,4 +118,7 @@ grant {
 
   // load averages on Linux
   permission java.io.FilePermission "/proc/loadavg", "read";
+
+  // load averages on FreeBSD
+  permission java.io.FilePermission "/compat/linux/proc/loadavg", "read";
 };


### PR DESCRIPTION
This commit adds load averages to the OS stats on FreeBSD. For these
stats to be available, linprocfs must be available and mounted at
/compat/linux/proc.

Closes #15917
