### PR TITLE
TransportClient: Add exception when using plugin.types, to help migration to addPlugin

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -97,6 +97,9 @@ public class TransportClient extends AbstractClient {
          * The settings to configure the transport client with.
          */
         public Builder settings(Settings settings) {
+            if (settings.get("plugin.types") != null) {
+                throw new IllegalArgumentException("plugin.types is no longer supported. Use the addPlugin method on TransportClient.");
+            }
             this.settings = settings;
             return this;
         }
@@ -113,9 +116,6 @@ public class TransportClient extends AbstractClient {
          * Builds a new instance of the transport client.
          */
         public TransportClient build() {
-            if (settings.get("plugin.types") != null) {
-                throw new IllegalArgumentException("plugin.types is no longer supported. Use the addPlugin method on TransportClient.");
-            }
             Settings settings = InternalSettingsPreparer.prepareSettings(this.settings);
             settings = settingsBuilder()
                     .put(NettyTransport.PING_SCHEDULE, "5s") // enable by default the transport schedule ping interval

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -113,6 +113,9 @@ public class TransportClient extends AbstractClient {
          * Builds a new instance of the transport client.
          */
         public TransportClient build() {
+            if (settings.get("plugin.types") != null) {
+                throw new IllegalArgumentException("plugin.types is no longer supported. Use the addPlugin method on TransportClient.");
+            }
             Settings settings = InternalSettingsPreparer.prepareSettings(this.settings);
             settings = settingsBuilder()
                     .put(NettyTransport.PING_SCHEDULE, "5s") // enable by default the transport schedule ping interval

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
@@ -28,7 +28,6 @@ public class TransportClientTests extends ESTestCase {
         try {
             TransportClient.Builder builder = TransportClient.builder();
             builder.settings(Settings.builder().put("plugin.types", "BogusPlugin").build());
-            builder.build();
             fail();
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("plugin.types is no longer supported"));

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientTests.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.transport;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+public class TransportClientTests extends ESTestCase {
+
+    public void testPluginTypesError() {
+        try {
+            TransportClient.Builder builder = TransportClient.builder();
+            builder.settings(Settings.builder().put("plugin.types", "BogusPlugin").build());
+            builder.build();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("plugin.types is no longer supported"));
+        }
+    }
+}


### PR DESCRIPTION
closes #15693
