### PR TITLE
Always require units for bytes and time settings

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -76,19 +76,6 @@ public final class Settings implements ToXContent {
     public static final Settings EMPTY = new Builder().build();
     private static final Pattern ARRAY_PATTERN = Pattern.compile("(.*)\\.\\d+$");
 
-    /** Name of the setting to use to disable required units for byte size, time settings. */
-    public static final String SETTINGS_REQUIRE_UNITS = "settings_require_units";
-
-    private static boolean settingsRequireUnits = true;
-
-    public static void setSettingsRequireUnits(boolean v) {
-        settingsRequireUnits = v;
-    }
-
-    public static boolean getSettingsRequireUnits() {
-        return settingsRequireUnits;
-    }
-
     private final Map<String, String> forcedUnderscoreSettings;
     private SortedMap<String, String> settings;
 

--- a/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -213,12 +213,7 @@ public class ByteSizeValue implements Streamable {
                 bytes = 0;
             } else {
                 // Missing units:
-                if (Settings.getSettingsRequireUnits()) {
-                    throw new ElasticsearchParseException("failed to parse setting [{}] with value [{}] as a size in bytes: unit is missing or unrecognized", settingName, sValue);
-                } else {
-                    // Leniency default to bytes:
-                    bytes = Long.parseLong(sValue);
-                }
+                throw new ElasticsearchParseException("failed to parse setting [{}] with value [{}] as a size in bytes: unit is missing or unrecognized", settingName, sValue);
             }
         } catch (NumberFormatException e) {
             throw new ElasticsearchParseException("failed to parse [{}]", e, sValue);

--- a/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -280,13 +280,8 @@ public class TimeValue implements Streamable {
                 // Allow this special value to be unit-less:
                 millis = 0;
             } else {
-                if (Settings.getSettingsRequireUnits()) {
-                    // Missing units:
-                    throw new ElasticsearchParseException("Failed to parse setting [{}] with value [{}] as a time value: unit is missing or unrecognized", settingName, sValue);
-                } else {
-                    // Leniency default to msec for bwc:
-                    millis = Long.parseLong(sValue);
-                }
+                // Missing units:
+                throw new ElasticsearchParseException("Failed to parse setting [{}] with value [{}] as a time value: unit is missing or unrecognized", settingName, sValue);
             }
             return new TimeValue(millis, TimeUnit.MILLISECONDS);
         } catch (NumberFormatException e) {

--- a/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
+++ b/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
@@ -168,11 +168,6 @@ public class InternalSettingsPreparer {
             output.put(ClusterName.SETTING, ClusterName.DEFAULT.value());
         }
 
-        String v = output.get(Settings.SETTINGS_REQUIRE_UNITS);
-        if (v != null) {
-            Settings.setSettingsRequireUnits(Booleans.parseBoolean(v, true));
-        }
-
         replacePromptPlaceholders(output, terminal);
         // all settings placeholders have been resolved. resolve the value for the name setting by checking for name,
         // then looking for node.name, and finally generate one if needed

--- a/core/src/test/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -329,19 +329,6 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         }
     }
 
-    public void testMissingUnitsLenient() {
-        try {
-            createNode(Settings.builder().put(Settings.SETTINGS_REQUIRE_UNITS, "false").build());
-            assertAcked(prepareCreate("test"));
-            ensureGreen();
-            client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.refresh_interval", "10")).execute().actionGet();
-        } finally {
-            // Restore the default so subsequent tests require units:
-            assertFalse(Settings.getSettingsRequireUnits());
-            Settings.setSettingsRequireUnits(true);
-        }
-    }
-
     private void createNode(Settings settings) {
         internalCluster().startNode(Settings.builder()
                         .put(ClusterName.SETTING, "ClusterSettingsIT")


### PR DESCRIPTION
With #11437 we made units required, but left an emergency escape hatch (the `settings_require_units` setting, defaulting to `true`) as an insurance policy in case something was wrong with the back-compat logic to upgrade cluster settings...

I think for 3.0 we should remove this escape hatch and always, unconditionally require units.
