### PR TITLE
Avoid circular reference in exception

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -576,8 +576,12 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         if (current.getTragicException() != null) {
             try {
                 close();
+            } catch (AlreadyClosedException inner) {
+                // don't do anything in this case. The AlreadyClosedException comes from TranslogWriter and we should not add it as suppressed because
+                // will contain the Exception ex as cause. See also https://github.com/elastic/elasticsearch/issues/15941
             } catch (Exception inner) {
                 ex.addSuppressed(inner);
+                assert (ex != inner.getCause());
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -580,8 +580,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 // don't do anything in this case. The AlreadyClosedException comes from TranslogWriter and we should not add it as suppressed because
                 // will contain the Exception ex as cause. See also https://github.com/elastic/elasticsearch/issues/15941
             } catch (Exception inner) {
-                ex.addSuppressed(inner);
                 assert (ex != inner.getCause());
+                ex.addSuppressed(inner);
             }
         }
     }


### PR DESCRIPTION
Don't set the suppressed Exception in Translog.closeOnTragicEvent(Exception ex) if it is an
AlreadyClosedException. ACE is thrown by the TranslogWriter and as cause might
contain the Exception that we add the suppressed ACE to. We then end up with a
circular reference where Exception A has a suppressed Exception B that has as cause A.
This would cause a stackoverflow when we try to serialize it.
For a more detailed description see #15941

closes #15941
