### PR TITLE
make get alias expand to open and closed indices by default

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -35,7 +35,7 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
 
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpand();
 
     public GetAliasesRequest(String[] aliases) {
         this.aliases = aliases;

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yaml
@@ -188,3 +188,31 @@
                 index \s+ alias \n
                 test  \s+ test_1 \n
             $/
+
+---
+"Alias against closed index":
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          aliases:
+            test_alias: {}
+
+  - do:
+      indices.close:
+        index: test_index
+
+  - do:
+      cat.aliases: {}
+
+  - match:
+      $body: |
+                /^
+                    test_alias          \s+
+                    test_index          \s+
+                    -                   \s+
+                    -                   \s+
+                    -                   \s+
+                $/
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yaml
@@ -205,3 +205,25 @@ setup:
   - is_true: test_index
 
   - is_true: test_index_2
+
+---
+"Get alias against closed indices":
+
+  - do:
+      indices.close:
+        index: test_index_2
+
+  - do:
+      indices.get_alias:
+        name: test_alias
+
+  - is_true: test_index
+  - is_true: test_index_2
+
+  - do:
+      indices.get_alias:
+        name: test_alias
+        expand_wildcards: open
+
+  - is_true: test_index
+  - is_false: test_index_2


### PR DESCRIPTION
This change affects get alias, get aliases as well as cat aliases. They all return closed indices too by default. get alias and get aliases also allow to return open indices only through the `expand_wildcards` option (set it to `open`).

Closes #14982
