### PR TITLE
Fix MatchedQueriesFetchSubPhase's consumption of DocIdSetIterator.

### DIFF
--- a/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
+++ b/src/main/java/org/elasticsearch/search/fetch/matchedqueries/MatchedQueriesFetchSubPhase.java
@@ -104,7 +104,7 @@ public class MatchedQueriesFetchSubPhase implements FetchSubPhase {
                     if (filterIterator != null && docAndNestedDocsIterator != null) {
                         int matchedDocId = -1;
                         for (int docId = docAndNestedDocsIterator.nextDoc(); docId < DocIdSetIterator.NO_MORE_DOCS; docId = docAndNestedDocsIterator.nextDoc()) {
-                            if (docId != matchedDocId) {
+                            if (docId > matchedDocId) {
                                 matchedDocId = filterIterator.advance(docId);
                             }
                             if (matchedDocId == docId) {

--- a/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/bucket/TopHitsTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -791,7 +792,7 @@ public class TopHitsTests extends ElasticsearchIntegrationTest {
         assertThat(version, equalTo(1l));
 
         // Can't use named queries for the same reason explain doesn't work:
-        assertThat(searchHit.matchedQueries(), emptyArray());
+        assertThat(Arrays.asList(searchHit.matchedQueries()), equalTo(Arrays.asList("test")));
 
         SearchHitField field = searchHit.field("comments.user");
         assertThat(field.getValue().toString(), equalTo("a"));


### PR DESCRIPTION
Closes #15949
