### PR TITLE
Remove updatability of `index.flush_on_close`

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -149,7 +149,6 @@ public class ClusterModule extends AbstractModule {
         registerIndexDynamicSetting(IndexSettings.INDEX_REFRESH_INTERVAL, Validator.TIME);
         registerIndexDynamicSetting(PrimaryShardAllocator.INDEX_RECOVERY_INITIAL_SHARDS, Validator.EMPTY);
         registerIndexDynamicSetting(IndexSettings.INDEX_GC_DELETES_SETTING, Validator.TIME);
-        registerIndexDynamicSetting(IndexSettings.INDEX_FLUSH_ON_CLOSE, Validator.BOOLEAN);
         registerIndexDynamicSetting(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_WARN, Validator.TIME);
         registerIndexDynamicSetting(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_INFO, Validator.TIME);
         registerIndexDynamicSetting(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_THRESHOLD_INDEX_DEBUG, Validator.TIME);

--- a/core/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -64,10 +64,10 @@ public final class IndexSettings {
     public static final TimeValue DEFAULT_GC_DELETES = TimeValue.timeValueSeconds(60);
 
     /**
-     * Index setting to control if a flush is executed before engine is closed
-     * This setting is realtime updateable.
+     * Index setting to control if a flush is executed before engine is closed. The default is <code>true</code>
      */
     public static final String INDEX_FLUSH_ON_CLOSE = "index.flush_on_close";
+
     /**
      * Index setting to enable / disable deletes garbage collection.
      * This setting is realtime updateable
@@ -97,7 +97,7 @@ public final class IndexSettings {
     private final TimeValue syncInterval;
     private volatile TimeValue refreshInterval;
     private volatile ByteSizeValue flushThresholdSize;
-    private volatile boolean flushOnClose = true;
+    private final boolean flushOnClose;
     private final MergeSchedulerConfig mergeSchedulerConfig;
     private final MergePolicyConfig mergePolicyConfig;
 
@@ -389,12 +389,6 @@ public final class IndexSettings {
         if (!flushThresholdSize.equals(this.flushThresholdSize)) {
             logger.info("updating flush_threshold_size from [{}] to [{}]", this.flushThresholdSize, flushThresholdSize);
             this.flushThresholdSize = flushThresholdSize;
-        }
-
-        final boolean flushOnClose = settings.getAsBoolean(INDEX_FLUSH_ON_CLOSE, this.flushOnClose);
-        if (flushOnClose != this.flushOnClose) {
-            logger.info("updating {} from [{}] to [{}]", INDEX_FLUSH_ON_CLOSE, this.flushOnClose, flushOnClose);
-            this.flushOnClose = flushOnClose;
         }
 
         final int maxThreadCount = settings.getAsInt(MergeSchedulerConfig.MAX_THREAD_COUNT, mergeSchedulerConfig.getMaxThreadCount());

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -129,25 +129,13 @@ import static org.hamcrest.Matchers.equalTo;
 public class IndexShardTests extends ESSingleNodeTestCase {
 
     public void testFlushOnDeleteSetting() throws Exception {
-        boolean initValue = randomBoolean();
-        createIndex("test", settingsBuilder().put(IndexSettings.INDEX_FLUSH_ON_CLOSE, initValue).build());
+        final boolean booleanValue = randomBoolean();
+        createIndex("test", settingsBuilder().put(IndexSettings.INDEX_FLUSH_ON_CLOSE, booleanValue).build());
         ensureGreen();
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexService test = indicesService.indexService("test");
         IndexShard shard = test.getShardOrNull(0);
-        assertEquals(initValue, shard.getIndexSettings().isFlushOnClose());
-        final boolean newValue = !initValue;
-        assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put(IndexSettings.INDEX_FLUSH_ON_CLOSE, newValue).build()));
-        assertEquals(newValue, shard.getIndexSettings().isFlushOnClose());
-
-        try {
-            assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(settingsBuilder().put(IndexSettings.INDEX_FLUSH_ON_CLOSE, "FOOBAR").build()));
-            fail("exception expected");
-        } catch (IllegalArgumentException ex) {
-
-        }
-        assertEquals(newValue, shard.getIndexSettings().isFlushOnClose());
-
+        assertEquals(booleanValue, shard.getIndexSettings().isFlushOnClose());
     }
 
     public void testWriteShardState() throws Exception {


### PR DESCRIPTION
`index.flush_on_close` is a test setting and doesn't need to be updatable.

Relates to #15955

ping @jimferenczi @nik9000 
