### PR TITLE
Randomize which MockPlugins are used for IT

### DIFF
--- a/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -22,11 +22,14 @@ package org.elasticsearch.cluster.routing;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.GatewayAllocator;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.disruption.NetworkDisconnectPartition;
+import org.elasticsearch.test.transport.MockTransportService;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -40,6 +43,12 @@ import static org.hamcrest.Matchers.equalTo;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 @ESIntegTestCase.SuppressLocalMode
 public class PrimaryAllocationIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // disruption tests need MockTransportService
+        return pluginList(MockTransportService.TestPlugin.class);
+    }
 
     public void testDoNotAllowStaleReplicasToBePromotedToPrimary() throws Exception {
         logger.info("--> starting 3 nodes, 1 master, 2 data");

--- a/core/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -169,11 +169,13 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         IndexService.BaseAsyncTask task = new IndexService.BaseAsyncTask(indexService, TimeValue.timeValueMillis(1)) {
             @Override
             protected void runInternal() {
+                final CountDownLatch l1 = latch.get();
+                final CountDownLatch l2 = latch2.get();
                 count.incrementAndGet();
                 assertTrue("generic threadpool is configured", Thread.currentThread().getName().contains("[generic]"));
-                latch.get().countDown();
+                l1.countDown();
                 try {
-                    latch2.get().await();
+                    l2.await();
                 } catch (InterruptedException e) {
                     fail("interrupted");
                 }

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -31,13 +31,13 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockFSDirectoryService;
 import org.elasticsearch.test.store.MockFSIndexStore;
-
 import java.io.IOException;
+import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
@@ -46,7 +46,11 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 
 public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
 
-    @TestLogging("action.search.type:TRACE,index.shard:TRACE")
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return pluginList(MockFSIndexStore.TestPlugin.class);
+    }
+
     public void testRandomDirectoryIOExceptions() throws IOException, InterruptedException, ExecutionException {
         String mapping = XContentFactory.jsonBuilder().
             startObject().

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1799,14 +1799,30 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 InternalTestCluster.DEFAULT_ENABLE_HTTP_PIPELINING, nodePrefix, mockPlugins);
     }
 
-    /** Return the mock plugins the cluster should use. These may be randomly omitted based on the cluster seed. */
+    /** Return the mock plugins the cluster should use */
     protected Collection<Class<? extends Plugin>> getMockPlugins() {
-        return pluginList(MockTransportService.TestPlugin.class,
-                          MockFSIndexStore.TestPlugin.class,
-                          NodeMocksPlugin.class,
-                          MockEngineFactoryPlugin.class,
-                          MockSearchService.TestPlugin.class,
-                          AssertingLocalTransport.TestPlugin.class);
+        final ArrayList<Class<? extends Plugin>> mocks = new ArrayList<>();
+        if (randomBoolean()) { // sometimes run without those completely
+            if (randomBoolean()) {
+                mocks.add(MockTransportService.TestPlugin.class);
+            }
+            if (randomBoolean()) {
+                mocks.add(MockFSIndexStore.TestPlugin.class);
+            }
+            if (randomBoolean()) {
+                mocks.add(NodeMocksPlugin.class);
+            }
+            if (randomBoolean()) {
+                mocks.add(MockEngineFactoryPlugin.class);
+            }
+            if (randomBoolean()) {
+                mocks.add(MockSearchService.TestPlugin.class);
+            }
+            if (randomBoolean()) {
+                mocks.add(AssertingLocalTransport.TestPlugin.class);
+            }
+        }
+        return Collections.unmodifiableList(mocks);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -367,7 +367,7 @@ public final class InternalTestCluster extends TestCluster {
         return builder.build();
     }
 
-    private Collection<Class<? extends Plugin>> getPlugins(long seed) {
+    private Collection<Class<? extends Plugin>> getPlugins() {
         Set<Class<? extends Plugin>> plugins = new HashSet<>(nodeConfigurationSource.nodePlugins());
         plugins.addAll(mockPlugins);
         if (isLocalTransportConfigured() == false) {
@@ -589,7 +589,7 @@ public final class InternalTestCluster extends TestCluster {
         assert Thread.holdsLock(this);
         ensureOpen();
         settings = getSettings(nodeId, seed, settings);
-        Collection<Class<? extends Plugin>> plugins = getPlugins(seed);
+        Collection<Class<? extends Plugin>> plugins = getPlugins();
         String name = buildNodeName(nodeId);
         assert !nodes.containsKey(name);
         Settings finalSettings = settingsBuilder()

--- a/test/framework/src/main/java/org/elasticsearch/test/NodeConfigurationSource.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/NodeConfigurationSource.java
@@ -51,18 +51,6 @@ public abstract class NodeConfigurationSource {
      */
     public abstract Settings nodeSettings(int nodeOrdinal);
 
-    /** Plugins that will be randomly added to the node */
-    public Collection<Class<? extends Plugin>> mockPlugins() {
-        List<Class<? extends Plugin>> plugins = new ArrayList<>();
-        plugins.add(MockTransportService.TestPlugin.class);
-        plugins.add(MockFSIndexStore.TestPlugin.class);
-        plugins.add(NodeMocksPlugin.class);
-        plugins.add(MockEngineFactoryPlugin.class);
-        plugins.add(MockSearchService.TestPlugin.class);
-        plugins.add(AssertingLocalTransport.TestPlugin.class);
-        return plugins;
-    }
-
     /** Returns plugins that should be loaded on the node */
     public Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.emptyList();


### PR DESCRIPTION
in 2.x we randomly swap mocks in/out. This was lost on the way towards a better build...Now it's coming back with even more randomization
