### PR TITLE
Update bulk.asciidoc

### DIFF
--- a/docs/java-api/docs/bulk.asciidoc
+++ b/docs/java-api/docs/bulk.asciidoc
@@ -119,5 +119,5 @@ bulkProcessor.close();
 Both methods flush any remaining documents and disable all other scheduled flushes if they were scheduled by setting
 `flushInterval`. If concurrent requests were enabled the `awaitClose` method waits for up to the specified timeout for
 all bulk requests to complete then returns `true`, if the specified waiting time elapses before all bulk requests complete,
-`false` is returned. The `close` method doesn't wait for any remaining bulk requests to complete and exists immediately.
+`false` is returned. The `close` method doesn't wait for any remaining bulk requests to complete and exits immediately.
 


### PR DESCRIPTION
The `close` method doesn't wait for any remaining bulk requests to complete and exists immediately.

It looks like `close` exits immediately not exists immediately.
