### PR TITLE
Remove index.flush_on_close entirely

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -64,11 +64,6 @@ public final class IndexSettings {
     public static final TimeValue DEFAULT_GC_DELETES = TimeValue.timeValueSeconds(60);
 
     /**
-     * Index setting to control if a flush is executed before engine is closed. The default is <code>true</code>
-     */
-    public static final String INDEX_FLUSH_ON_CLOSE = "index.flush_on_close";
-
-    /**
      * Index setting to enable / disable deletes garbage collection.
      * This setting is realtime updateable
      */
@@ -97,7 +92,6 @@ public final class IndexSettings {
     private final TimeValue syncInterval;
     private volatile TimeValue refreshInterval;
     private volatile ByteSizeValue flushThresholdSize;
-    private final boolean flushOnClose;
     private final MergeSchedulerConfig mergeSchedulerConfig;
     private final MergePolicyConfig mergePolicyConfig;
 
@@ -185,7 +179,6 @@ public final class IndexSettings {
         syncInterval = settings.getAsTime(INDEX_TRANSLOG_SYNC_INTERVAL, TimeValue.timeValueSeconds(5));
         refreshInterval =  settings.getAsTime(INDEX_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL);
         flushThresholdSize = settings.getAsBytesSize(INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE, new ByteSizeValue(512, ByteSizeUnit.MB));
-        flushOnClose = settings.getAsBoolean(IndexSettings.INDEX_FLUSH_ON_CLOSE, true);
         mergeSchedulerConfig = new MergeSchedulerConfig(settings);
         gcDeletesInMillis = settings.getAsTime(IndexSettings.INDEX_GC_DELETES_SETTING, DEFAULT_GC_DELETES).getMillis();
         this.mergePolicyConfig = new MergePolicyConfig(logger, settings);
@@ -437,11 +430,6 @@ public final class IndexSettings {
      * Returns the transaction log threshold size when to forcefully flush the index and clear the transaction log.
      */
     public ByteSizeValue getFlushThresholdSize() { return flushThresholdSize; }
-
-    /**
-     * Returns <code>true</code> iff this index should be flushed on close. Default is <code>true</code>
-     */
-    public boolean isFlushOnClose() { return flushOnClose; }
 
     /**
      * Returns the {@link MergeSchedulerConfig}

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -802,7 +802,7 @@ public class IndexShard extends AbstractIndexShardComponent {
             } finally {
                 final Engine engine = this.currentEngineReference.getAndSet(null);
                 try {
-                    if (engine != null && flushEngine && indexSettings.isFlushOnClose()) {
+                    if (engine != null && flushEngine) {
                         engine.flushAndClose();
                     }
                 } finally { // playing safe here and close the engine even if the above succeeds - close can be called multiple times

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -128,16 +128,6 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class IndexShardTests extends ESSingleNodeTestCase {
 
-    public void testFlushOnDeleteSetting() throws Exception {
-        final boolean booleanValue = randomBoolean();
-        createIndex("test", settingsBuilder().put(IndexSettings.INDEX_FLUSH_ON_CLOSE, booleanValue).build());
-        ensureGreen();
-        IndicesService indicesService = getInstanceFromNode(IndicesService.class);
-        IndexService test = indicesService.indexService("test");
-        IndexShard shard = test.getShardOrNull(0);
-        assertEquals(booleanValue, shard.getIndexSettings().isFlushOnClose());
-    }
-
     public void testWriteShardState() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
             ShardId id = new ShardId("foo", 1);

--- a/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -111,7 +111,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
                 .put(indexSettings())
                 .put(EXCEPTION_TOP_LEVEL_RATIO_KEY, topLevelRate)
                 .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)
-                .put(MockEngineSupport.WRAP_READER_RATIO, 1.0d);
+                .put(MockEngineSupport.WRAP_READER_RATIO.getKey(), 1.0d);
         logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
         client().admin().indices().prepareCreate("test")
                 .setSettings(settings)

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -92,7 +92,7 @@ public class SearchWithRandomExceptionsIT extends ESIntegTestCase {
                 .put(indexSettings())
                 .put(EXCEPTION_TOP_LEVEL_RATIO_KEY, topLevelRate)
                 .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)
-            .put(MockEngineSupport.WRAP_READER_RATIO, 1.0d);
+            .put(MockEngineSupport.WRAP_READER_RATIO.getKey(), 1.0d);
         logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
         assertAcked(prepareCreate("test")
                 .setSettings(settings)

--- a/test/framework/src/main/java/org/elasticsearch/test/engine/MockInternalEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/engine/MockInternalEngine.java
@@ -49,9 +49,9 @@ final class MockInternalEngine extends InternalEngine {
 
     @Override
     public void close() throws IOException {
-        switch (support().flushOrClose(this, MockEngineSupport.CloseAction.CLOSE)) {
+        switch (support().flushOrClose(MockEngineSupport.CloseAction.CLOSE)) {
             case FLUSH_AND_CLOSE:
-                super.flushAndClose();
+                flushAndCloseInternal();
                 break;
             case CLOSE:
                 super.close();
@@ -62,16 +62,24 @@ final class MockInternalEngine extends InternalEngine {
     @Override
     public void flushAndClose() throws IOException {
         if (randomizeFlushOnClose) {
-            switch (support().flushOrClose(this, MockEngineSupport.CloseAction.FLUSH_AND_CLOSE)) {
+            switch (support().flushOrClose(MockEngineSupport.CloseAction.FLUSH_AND_CLOSE)) {
                 case FLUSH_AND_CLOSE:
-                    super.flushAndClose();
+                    flushAndCloseInternal();
                     break;
                 case CLOSE:
                     super.close();
                     break;
             }
         } else {
+            flushAndCloseInternal();
+        }
+    }
+
+    private void flushAndCloseInternal() throws IOException {
+        if (support().isFlushOnCloseDisabled() == false) {
             super.flushAndClose();
+        } else {
+            super.close();
         }
     }
 


### PR DESCRIPTION
This undocumented setting was mainly used for testing and a safety net for
a new flushOnClose feature back in 1.x. We can now safely remove this setting.
The test usage now uses a mock plugin setting to achive the same.
