### PR TITLE
Fix Azure repository with only one primary account

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -90,8 +90,8 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
         logger.trace("selecting a client for account [{}], mode [{}]", account, mode.name());
         AzureStorageSettings azureStorageSettings = null;
 
-        if (this.primaryStorageSettings == null || this.secondariesStorageSettings.isEmpty()) {
-            throw new IllegalArgumentException("No azure storage can be found. Check your elasticsearch.yml.");
+        if (this.primaryStorageSettings == null) {
+            throw new IllegalArgumentException("No primary azure storage can be found. Check your elasticsearch.yml.");
         }
 
         if (account != null) {

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTest.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTest.java
@@ -47,8 +47,18 @@ public class AzureStorageServiceTest extends ESTestCase {
             azureStorageService.getSelectedClient("whatever", LocationMode.PRIMARY_ONLY);
             fail("we should have raised an IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("No azure storage can be found. Check your elasticsearch.yml."));
+            assertThat(e.getMessage(), is("No primary azure storage can be found. Check your elasticsearch.yml."));
         }
+    }
+
+    public void testGetSelectedClientWithNoSecondary() {
+        AzureStorageServiceImpl azureStorageService = new AzureStorageServiceMock(Settings.builder()
+            .put("cloud.azure.storage.azure1.account", "myaccount1")
+            .put("cloud.azure.storage.azure1.key", "mykey1")
+            .build());
+        azureStorageService.doStart();
+        CloudBlobClient client = azureStorageService.getSelectedClient("azure1", LocationMode.PRIMARY_ONLY);
+        assertThat(client.getEndpoint(), is(URI.create("https://azure1")));
     }
 
     public void testGetSelectedClientPrimary() {


### PR DESCRIPTION
Using a single azure account is now rejected.
This commit fixes this issue and adds a test for it.

This regression was introduced with #13779. Hopefully no elasticsearch version has been released since then.

Needs to be merged in 2.2, 2.x and master branches.
