### PR TITLE
Fix incorrect file-based example in script_fields

### DIFF
--- a/docs/reference/modules/scripting.asciidoc
+++ b/docs/reference/modules/scripting.asciidoc
@@ -54,9 +54,11 @@ GET /_search
 {
     "script_fields": {
         "my_field": {
-            "file": "my_script",
-            "params": {
-              "my_var": 2
+            "script": {
+                "file": "my_script",
+                "params": {
+                    "my_var": 2
+                }
             }
         }
     }


### PR DESCRIPTION
When following the example I get error message _must specify a script in script fields_. The file parameter as well as the rest must be folded inside JSON object under "script".
