### PR TITLE
[Ingest] Execution service enhancement

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/IngestActionFilter.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/IngestActionFilter.java
@@ -109,9 +109,7 @@ public final class IngestActionFilter extends AbstractComponent implements Actio
 
     void processBulkIndexRequest(Task task, BulkRequest original, String action, ActionFilterChain chain, ActionListener<BulkResponse> listener) {
         BulkRequestModifier bulkRequestModifier = new BulkRequestModifier(original);
-        executionService.execute(() -> bulkRequestModifier, tuple -> {
-            IndexRequest indexRequest = tuple.v1();
-            Throwable throwable = tuple.v2();
+        executionService.execute(() -> bulkRequestModifier, (indexRequest, throwable) -> {
             logger.debug("failed to execute pipeline [{}] for document [{}/{}/{}]", indexRequest.pipeline(), indexRequest.index(), indexRequest.type(), indexRequest.id(), throwable);
             bulkRequestModifier.markCurrentItemAsFailed(throwable);
         }, (success) -> {

--- a/core/src/main/java/org/elasticsearch/ingest/PipelineExecutionService.java
+++ b/core/src/main/java/org/elasticsearch/ingest/PipelineExecutionService.java
@@ -22,12 +22,12 @@ package org.elasticsearch.ingest;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.ingest.core.IngestDocument;
 import org.elasticsearch.ingest.core.Pipeline;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class PipelineExecutionService {
@@ -53,7 +53,7 @@ public class PipelineExecutionService {
     }
 
     public void execute(Iterable<ActionRequest> actionRequests,
-                        Consumer<Tuple<IndexRequest, Throwable>> itemFailureHandler, Consumer<Boolean> completionHandler) {
+                        BiConsumer<IndexRequest, Throwable> itemFailureHandler, Consumer<Boolean> completionHandler) {
         threadPool.executor(ThreadPool.Names.INGEST).execute(() -> {
             for (ActionRequest actionRequest : actionRequests) {
                 if ((actionRequest instanceof IndexRequest)) {
@@ -64,7 +64,7 @@ public class PipelineExecutionService {
                             //this shouldn't be needed here but we do it for consistency with index api which requires it to prevent double execution
                             indexRequest.pipeline(null);
                         } catch (Throwable e) {
-                            itemFailureHandler.accept(new Tuple<>(indexRequest, e));
+                            itemFailureHandler.accept(indexRequest, e);
                         }
                     }
                 }


### PR DESCRIPTION
Use `BiConsumer` instead of `Consumer` to pass down the failed index request with throwable.
