### PR TITLE
Documentation: Missing quotes in quoted code

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -451,7 +451,7 @@ This example shows how to update our previous document (ID of 1) by changing the
 --------------------------------------------------
 curl -XPOST 'localhost:9200/customer/external/1/_update?pretty' -d '
 {
-  "doc": { "name": "Jane Doe", "age": 20 }
+  "doc": { "name": "Jane Doe", "age": "20" }
 }'
 --------------------------------------------------
 


### PR DESCRIPTION
The documented syntax is incorrect, it appears to be missing " " around the age which causes an error.

I propose to change:

  "doc": { "name": "Jane Doe", "age": 20 }
to
  "doc": { "name": "Jane Doe", "age": "20" }

I hope this helps

McParty
