### PR TITLE
Fix minor problems in the configuration doc

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -44,7 +44,7 @@ using the <<cluster-nodes-info>> API, with:
 
 [source,js]
 --------------------------------------------------
-curl localhost:9200/_nodes/process?pretty
+curl localhost:9200/_nodes/stats/process?pretty
 --------------------------------------------------
 
 [float]


### PR DESCRIPTION
`/_nodes/process` won't show file descriptors. should be `/_nodes/stats/process`
