### PR TITLE
Skip capturing least/most FS info for an FS with no total

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -406,10 +406,26 @@ public class InternalClusterInfoService extends AbstractComponent implements Clu
                 String nodeId = nodeStats.getNode().id();
                 String nodeName = nodeStats.getNode().getName();
                 if (logger.isTraceEnabled()) {
-                    logger.trace("node: [{}], most available: total disk: {}, available disk: {} / least available: total disk: {}, available disk: {}", nodeId, mostAvailablePath.getTotal(), leastAvailablePath.getAvailable(), leastAvailablePath.getTotal(), leastAvailablePath.getAvailable());
+                    logger.trace("node: [{}], most available: total disk: {}, available disk: {} / least available: total disk: {}, available disk: {}",
+                            nodeId, mostAvailablePath.getTotal(), leastAvailablePath.getAvailable(),
+                            leastAvailablePath.getTotal(), leastAvailablePath.getAvailable());
                 }
-                newLeastAvaiableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, leastAvailablePath.getPath(), leastAvailablePath.getTotal().bytes(), leastAvailablePath.getAvailable().bytes()));
-                newMostAvaiableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, mostAvailablePath.getPath(), mostAvailablePath.getTotal().bytes(), mostAvailablePath.getAvailable().bytes()));
+                if (leastAvailablePath.getTotal().bytes() < 0) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("node: [{}] least available path has less than 0 total bytes of disk [{}], skipping",
+                                nodeId, leastAvailablePath.getTotal().bytes());
+                    }
+                } else {
+                    newLeastAvaiableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, leastAvailablePath.getPath(), leastAvailablePath.getTotal().bytes(), leastAvailablePath.getAvailable().bytes()));
+                }
+                if (mostAvailablePath.getTotal().bytes() < 0) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("node: [{}] most available path has less than 0 total bytes of disk [{}], skipping",
+                                nodeId, mostAvailablePath.getTotal().bytes());
+                    }
+                } else {
+                    newMostAvaiableUsages.put(nodeId, new DiskUsage(nodeId, nodeName, mostAvailablePath.getPath(), mostAvailablePath.getTotal().bytes(), mostAvailablePath.getAvailable().bytes()));
+                }
 
             }
         }

--- a/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -178,7 +178,7 @@ public class DiskUsageTests extends ESTestCase {
 
         FsInfo.Path[] node3FSInfo =  new FsInfo.Path[] {
                 new FsInfo.Path("/most", "/dev/sda", 100, 90, 70),
-                new FsInfo.Path("/least", "/dev/sda", -10, -1, -1),
+                new FsInfo.Path("/least", "/dev/sda", 10, -8, 0),
         };
         NodeStats[] nodeStats = new NodeStats[] {
                 new NodeStats(new DiscoveryNode("node_1", DummyTransportAddress.INSTANCE, Version.CURRENT), 0,
@@ -201,7 +201,7 @@ public class DiskUsageTests extends ESTestCase {
 
         DiskUsage leastNode_3 = newLeastAvailableUsages.get("node_3");
         DiskUsage mostNode_3 = newMostAvailableUsages.get("node_3");
-        assertNull("node3 should have been skipped", leastNode_3);
+        assertDiskUsage(leastNode_3, node3FSInfo[1]);
         assertDiskUsage(mostNode_3, node3FSInfo[0]);
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -164,7 +164,50 @@ public class DiskUsageTests extends ESTestCase {
         assertDiskUsage(mostNode_3, node3FSInfo[1]);
     }
 
+    public void testFillDiskUsageSomeInvalidValues() {
+        ImmutableOpenMap.Builder<String, DiskUsage> newLeastAvailableUsages = ImmutableOpenMap.builder();
+        ImmutableOpenMap.Builder<String, DiskUsage> newMostAvailableUsages = ImmutableOpenMap.builder();
+        FsInfo.Path[] node1FSInfo =  new FsInfo.Path[] {
+                new FsInfo.Path("/middle", "/dev/sda", 100, 90, 80),
+                new FsInfo.Path("/least", "/dev/sdb", -1, -1, -1),
+                new FsInfo.Path("/most", "/dev/sdc", 300, 290, 280),
+        };
+        FsInfo.Path[] node2FSInfo = new FsInfo.Path[] {
+                new FsInfo.Path("/least_most", "/dev/sda", -2, -1, -1),
+        };
+
+        FsInfo.Path[] node3FSInfo =  new FsInfo.Path[] {
+                new FsInfo.Path("/most", "/dev/sda", 100, 90, 70),
+                new FsInfo.Path("/least", "/dev/sda", -10, -1, -1),
+        };
+        NodeStats[] nodeStats = new NodeStats[] {
+                new NodeStats(new DiscoveryNode("node_1", DummyTransportAddress.INSTANCE, Version.CURRENT), 0,
+                        null,null,null,null,null,new FsInfo(0, node1FSInfo), null,null,null,null,null),
+                new NodeStats(new DiscoveryNode("node_2", DummyTransportAddress.INSTANCE, Version.CURRENT), 0,
+                        null,null,null,null,null, new FsInfo(0, node2FSInfo), null,null,null,null,null),
+                new NodeStats(new DiscoveryNode("node_3", DummyTransportAddress.INSTANCE, Version.CURRENT), 0,
+                        null,null,null,null,null, new FsInfo(0, node3FSInfo), null,null,null,null,null)
+        };
+        InternalClusterInfoService.fillDiskUsagePerNode(logger, nodeStats, newLeastAvailableUsages, newMostAvailableUsages);
+        DiskUsage leastNode_1 = newLeastAvailableUsages.get("node_1");
+        DiskUsage mostNode_1 = newMostAvailableUsages.get("node_1");
+        assertNull("node1 should have been skipped", leastNode_1);
+        assertDiskUsage(mostNode_1, node1FSInfo[2]);
+
+        DiskUsage leastNode_2 = newLeastAvailableUsages.get("node_2");
+        DiskUsage mostNode_2 = newMostAvailableUsages.get("node_2");
+        assertNull("node2 should have been skipped", leastNode_2);
+        assertNull("node2 should have been skipped", mostNode_2);
+
+        DiskUsage leastNode_3 = newLeastAvailableUsages.get("node_3");
+        DiskUsage mostNode_3 = newMostAvailableUsages.get("node_3");
+        assertNull("node3 should have been skipped", leastNode_3);
+        assertDiskUsage(mostNode_3, node3FSInfo[0]);
+    }
+
     private void assertDiskUsage(DiskUsage usage, FsInfo.Path path) {
+        assertNotNull(usage);
+        assertNotNull(path);
         assertEquals(usage.toString(), usage.getPath(), path.getPath());
         assertEquals(usage.toString(), usage.getTotalBytes(), path.getTotal().bytes());
         assertEquals(usage.toString(), usage.getFreeBytes(), path.getAvailable().bytes());


### PR DESCRIPTION
If an operating system reports -1 for the total bytes of a filesystem
path, we should ignore it when capturing the least and most available
statistics.

Relates to #15919
