### PR TITLE
[DOCS] Clarify Shadow replica setting

### DIFF
--- a/docs/reference/indices/shadow-replicas.asciidoc
+++ b/docs/reference/indices/shadow-replicas.asciidoc
@@ -58,9 +58,9 @@ curl -XPUT 'localhost:9200/my_index' -d '
 [WARNING]
 ========================
 In the above example, the "/opt/data/my_index" path is a shared filesystem that
-must be available on every node in the Elasticsearch cluster. You must also
-ensure that the Elasticsearch process has the correct permissions to read from
-and write to the directory used in the `index.data_path` setting.
+must be available on every data node in the Elasticsearch cluster. You must
+also ensure that the Elasticsearch process has the correct permissions to read
+from and write to the directory used in the `index.data_path` setting.
 ========================
 
 An index that has been created with the `index.shadow_replicas` setting set to


### PR DESCRIPTION
Clarifying that the path setting is required on every _data_ node, rather than _every_ node.

@dakrone Want to take a quick look?

Fixes #16004
