### PR TITLE
[Mapping] Avoid NPE when merging default parent field

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/internal/ParentFieldMapper.java
@@ -381,6 +381,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
         ParentFieldMapper fieldMergeWith = (ParentFieldMapper) mergeWith;
         if (Objects.equals(parentType, fieldMergeWith.parentType) == false) {
             mergeResult.addConflict("The _parent field's type option can't be changed: [" + parentType + "]->[" + fieldMergeWith.parentType + "]");
+            return;
         }
 
         List<String> conflicts = new ArrayList<>();


### PR DESCRIPTION
If type is unequal then report conflict and stop to avoid possible NPE down the line

Report on the forum: https://discuss.elastic.co/t/updating-child-mapping-with-new-field-fails-with-nullpointerexception/39256

This issue only occurs on 2.1.x and 2.0.x releases since from 2.2 mapping conflicts are no longer accumulated and instead if there is a conflict the an exception is thrown and the mapping merging aborts.

I do plan to add the test in this pr (slightly different) also to 2.2, 2.x and master branches.
