### PR TITLE
Make the Task object available to the action caller

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/TransportAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/TransportAction.java
@@ -66,7 +66,7 @@ public abstract class TransportAction<Request extends ActionRequest<Request>, Re
         return future;
     }
 
-    public final void execute(Request request, ActionListener<Response> listener) {
+    public final Task execute(Request request, ActionListener<Response> listener) {
         Task task = taskManager.register("transport", actionName, request);
         if (task == null) {
             execute(null, request, listener);
@@ -85,6 +85,7 @@ public abstract class TransportAction<Request extends ActionRequest<Request>, Re
                 }
             });
         }
+        return task;
     }
 
     private final void execute(Task task, Request request, ActionListener<Response> listener) {


### PR DESCRIPTION
Sometimes action callers might be interested in having access to the task that they have just initiated. This changes allows a caller to get access to the Task object of an action that it just started if the action runs on the same node and supports the task management.

@nik9000 do you want to review it?
