### PR TITLE
Limit the accepted length of the _id

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -215,6 +215,11 @@ public class IndexRequest extends ReplicationRequest<IndexRequest> implements Do
                 validationException = addValidationError("ttl must not be negative", validationException);
             }
         }
+
+        if (id != null && id.getBytes(StandardCharsets.UTF_8).length > 512) {
+            validationException = addValidationError("id is too long, must be no longer than 512 bytes but was: " +
+                            id.getBytes(StandardCharsets.UTF_8).length, validationException);
+        }
         return validationException;
     }
 

--- a/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -71,6 +71,28 @@ public class IndexRequestTests extends ESTestCase {
         assertThat(request.validate().validationErrors(), not(empty()));
     }
 
+    public void testIndexingRejectsLongIds() {
+        String id = randomAsciiOfLength(511);
+        IndexRequest request = new IndexRequest("index", "type", id);
+        request.source("{}");
+        ActionRequestValidationException validate = request.validate();
+        assertNull(validate);
+
+        id = randomAsciiOfLength(512);
+        request = new IndexRequest("index", "type", id);
+        request.source("{}");
+        validate = request.validate();
+        assertNull(validate);
+
+        id = randomAsciiOfLength(513);
+        request = new IndexRequest("index", "type", id);
+        request.source("{}");
+        validate = request.validate();
+        assertThat(validate, notNullValue());
+        assertThat(validate.getMessage(),
+                containsString("id is too long, must be no longer than 512 bytes but was: 513"));
+}
+
     public void testSetTTLAsTimeValue() {
         IndexRequest indexRequest = new IndexRequest();
         TimeValue ttl = TimeValue.parseTimeValue(randomTimeValue(), null, "ttl");

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -97,6 +97,11 @@ characteristics as the former `scan` search type.
 [[breaking_30_rest_api_changes]]
 === REST API changes
 
+==== id values longer than 512 bytes are rejected
+
+When specifying an `_id` value longer than 512 bytes, the request will be
+rejected.
+
 ==== search exists api removed
 
 The search exists api has been removed in favour of using the search api with

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/10_with_id.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/10_with_id.yaml
@@ -24,3 +24,11 @@
  - match:   { _id:      "1"}
  - match:   { _version: 1}
  - match:   { _source: { foo: bar }}
+
+ - do:
+      catch: request
+      index:
+          index:  idx
+          type:   type
+          id:     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          body:   { foo: bar }


### PR DESCRIPTION
Elasticsearch should reject ids that are this long, to ensure a document
always remains retrievable for clients that impose a maximum URI length

Closes #16034
