### PR TITLE
[TEST] Move Jarhell check inside the test.security.manager guard

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -82,15 +82,14 @@ public class BootstrapForTesting {
         // initialize sysprops
         BootstrapInfo.getSystemProperties();
 
-        // check for jar hell
-        try {
-            JarHell.checkJarHell();
-        } catch (Exception e) {
-            throw new RuntimeException("found jar hell in test classpath", e);
-        }
-
         // install security manager if requested
         if (systemPropertyAsBoolean("tests.security.manager", true)) {
+            // check for jar hell
+            try {
+                JarHell.checkJarHell();
+            } catch (Exception e) {
+                throw new RuntimeException("found jar hell in test classpath", e);
+            }
             try {
                 // initialize paths the same exact way as bootstrap
                 Permissions perms = new Permissions();


### PR DESCRIPTION
This change moves the JarHell check under the test.security.manager guard
such that users that have to opt out of JarHell for testing can do so by disabling
security. It will all users to use our test framework but when doing so the parameter
`-Dtests.security.manager=false` will signal how serious it is to opt out of this check

Relates to #11932
