### PR TITLE
Allow RandomQueryBuilder to work independent from AbstractQueryTestCase

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
@@ -21,12 +21,41 @@ package org.elasticsearch.index.query;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
+import org.elasticsearch.common.collect.Tuple;
+
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class AbstractTermQueryTestCase<QB extends BaseTermQueryBuilder<QB>> extends AbstractQueryTestCase<QB> {
     @Override
     protected final QB doCreateTestQueryBuilder() {
+        Tuple<String, Object> nameValue = randomFieldNameAndValue();
+        return createQueryBuilder(nameValue.v1(), nameValue.v2());
+    }
+
+    protected abstract QB createQueryBuilder(String fieldName, Object value);
+
+    public void testIllegalArguments() throws QueryShardException {
+        try {
+            if (randomBoolean()) {
+                createQueryBuilder(null, randomAsciiOfLengthBetween(1, 30));
+            } else {
+                createQueryBuilder("", randomAsciiOfLengthBetween(1, 30));
+            }
+            fail("fieldname cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            createQueryBuilder("field", null);
+            fail("value cannot be null or empty");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    protected static Tuple<String, Object> randomFieldNameAndValue() {
         String fieldName = null;
         Object value;
         switch (randomIntBetween(0, 3)) {
@@ -67,29 +96,7 @@ public abstract class AbstractTermQueryTestCase<QB extends BaseTermQueryBuilder<
         if (fieldName == null) {
             fieldName = randomAsciiOfLengthBetween(1, 10);
         }
-        return createQueryBuilder(fieldName, value);
-    }
-
-    protected abstract QB createQueryBuilder(String fieldName, Object value);
-
-    public void testIllegalArguments() throws QueryShardException {
-        try {
-            if (randomBoolean()) {
-                createQueryBuilder(null, randomAsciiOfLengthBetween(1, 30));
-            } else {
-                createQueryBuilder("", randomAsciiOfLengthBetween(1, 30));
-            }
-            fail("fieldname cannot be null or empty");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-
-        try {
-            createQueryBuilder("field", null);
-            fail("value cannot be null or empty");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        return new Tuple<String, Object>(fieldName, value);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -69,19 +69,25 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
                 types = new String[0];
             }
         }
+        return createRandomQueryBuilder(types);
+    }
+
+    /**
+     * @param optionalTypes if array contains entries, they will be used to set the types in the resulting {@link IdsQueryBuilder}
+     */
+    public static IdsQueryBuilder createRandomQueryBuilder(String[] optionalTypes) {
         int numberOfIds = randomIntBetween(0, 10);
         String[] ids = new String[numberOfIds];
         for (int i = 0; i < numberOfIds; i++) {
             ids[i] = randomAsciiOfLengthBetween(1, 10);
         }
         IdsQueryBuilder query;
-        if (types.length > 0 || randomBoolean()) {
-            query = new IdsQueryBuilder(types);
-            query.addIds(ids);
+        if (optionalTypes.length > 0 || randomBoolean()) {
+            query = new IdsQueryBuilder(optionalTypes);
         } else {
             query = new IdsQueryBuilder();
-            query.addIds(ids);
         }
+        query.addIds(ids);
         return query;
     }
 
@@ -155,12 +161,12 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
 
     public void testFromJson() throws IOException {
         String json =
-                "{\n" + 
-                "  \"ids\" : {\n" + 
-                "    \"type\" : [ \"my_type\" ],\n" + 
-                "    \"values\" : [ \"1\", \"100\", \"4\" ],\n" + 
-                "    \"boost\" : 1.0\n" + 
-                "  }\n" + 
+                "{\n" +
+                "  \"ids\" : {\n" +
+                "    \"type\" : [ \"my_type\" ],\n" +
+                "    \"values\" : [ \"1\", \"100\", \"4\" ],\n" +
+                "    \"boost\" : 1.0\n" +
+                "  }\n" +
                 "}";
         IdsQueryBuilder parsed = (IdsQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);

--- a/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchAllQueryBuilderTests.java
@@ -32,6 +32,10 @@ public class MatchAllQueryBuilderTests extends AbstractQueryTestCase<MatchAllQue
 
     @Override
     protected MatchAllQueryBuilder doCreateTestQueryBuilder() {
+        return createRandomQueryBuilder();
+    }
+
+    public static MatchAllQueryBuilder createRandomQueryBuilder() {
         return new MatchAllQueryBuilder();
     }
 
@@ -52,10 +56,10 @@ public class MatchAllQueryBuilderTests extends AbstractQueryTestCase<MatchAllQue
 
     public void testFromJson() throws IOException {
         String json =
-                "{\n" + 
-                "  \"match_all\" : {\n" + 
-                "    \"boost\" : 1.2\n" + 
-                "  }\n" + 
+                "{\n" +
+                "  \"match_all\" : {\n" +
+                "    \"boost\" : 1.2\n" +
+                "  }\n" +
                 "}";
         MatchAllQueryBuilder parsed = (MatchAllQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);

--- a/core/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -35,14 +35,7 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
 
     @Override
     protected PrefixQueryBuilder doCreateTestQueryBuilder() {
-        String fieldName = randomBoolean() ? STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10);
-        String value = randomAsciiOfLengthBetween(1, 10);
-        PrefixQueryBuilder query = new PrefixQueryBuilder(fieldName, value);
-
-        if (randomBoolean()) {
-            query.rewrite(getRandomRewriteMethod());
-        }
-        return query;
+        return createRandomQueryBuilder();
     }
 
     @Override
@@ -93,5 +86,16 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
         assertEquals(json, "ki", parsed.value());
         assertEquals(json, 2.0, parsed.boost(), 0.00001);
         assertEquals(json, "user", parsed.fieldName());
+    }
+
+    public static PrefixQueryBuilder createRandomQueryBuilder() {
+        String fieldName = randomBoolean() ? STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10);
+        String value = randomAsciiOfLengthBetween(1, 10);
+        PrefixQueryBuilder query = new PrefixQueryBuilder(fieldName, value);
+
+        if (randomBoolean()) {
+            query.rewrite(getRandomRewriteMethod());
+        }
+        return query;
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomQueryBuilder.java
@@ -32,18 +32,21 @@ import java.util.Random;
 public class RandomQueryBuilder {
 
     /**
-     * Create a new query of a random type
+     * Create a new query of a random type.
+     * Currently supported are only the leaf queries {@link MatchAllQueryBuilder}, {@link TermQueryBuilder} or
+     * {@link IdsQueryBuilder}, the multi term queryies {@link PrefixQueryBuilder} and {@link WildcardQueryBuilder}
+     * and the {@link EmptyQueryBuilder}.
      * @param r random seed
      * @return a random {@link QueryBuilder}
      */
     public static QueryBuilder createQuery(Random r) {
         switch (RandomInts.randomIntBetween(r, 0, 4)) {
             case 0:
-                return new MatchAllQueryBuilderTests().createTestQueryBuilder();
+                return MatchAllQueryBuilderTests.createRandomQueryBuilder();
             case 1:
-                return new TermQueryBuilderTests().createTestQueryBuilder();
+                return TermQueryBuilderTests.createRandomQueryBuilder();
             case 2:
-                return new IdsQueryBuilderTests().createTestQueryBuilder();
+                return IdsQueryBuilderTests.createRandomQueryBuilder(new String[0]);
             case 3:
                 return createMultiTermQuery(r);
             case 4:
@@ -82,10 +85,10 @@ public class RandomQueryBuilder {
                 multiTermQueryBuilder = new FuzzyQueryBuilder(AbstractQueryTestCase.STRING_FIELD_NAME, RandomStrings.randomAsciiOfLengthBetween(r, 1, 10));
                 break;
             case 4:
-                multiTermQueryBuilder = new PrefixQueryBuilderTests().createTestQueryBuilder();
+                multiTermQueryBuilder = PrefixQueryBuilderTests.createRandomQueryBuilder();
                 break;
             case 5:
-                multiTermQueryBuilder = new WildcardQueryBuilderTests().createTestQueryBuilder();
+                multiTermQueryBuilder = WildcardQueryBuilderTests.createRandomQueryBuilder();
                 break;
             default:
                 throw new UnsupportedOperationException();

--- a/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
@@ -71,18 +72,23 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
 
     public void testFromJson() throws IOException {
         String json =
-                "{\n" + 
-                "  \"term\" : {\n" + 
-                "    \"exact_value\" : {\n" + 
-                "      \"value\" : \"Quick Foxes!\",\n" + 
-                "      \"boost\" : 1.0\n" + 
-                "    }\n" + 
-                "  }\n" + 
+                "{\n" +
+                "  \"term\" : {\n" +
+                "    \"exact_value\" : {\n" +
+                "      \"value\" : \"Quick Foxes!\",\n" +
+                "      \"boost\" : 1.0\n" +
+                "    }\n" +
+                "  }\n" +
                 "}";
 
         TermQueryBuilder parsed = (TermQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
 
         assertEquals(json, "Quick Foxes!", parsed.value());
+    }
+
+    public static TermQueryBuilder createRandomQueryBuilder() {
+        Tuple<String, Object> randomFieldNameAndValue = randomFieldNameAndValue();
+        return new TermQueryBuilder(randomFieldNameAndValue.v1(), randomFieldNameAndValue.v2());
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -31,19 +31,7 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
 
     @Override
     protected WildcardQueryBuilder doCreateTestQueryBuilder() {
-        WildcardQueryBuilder query;
-
-        // mapped or unmapped field
-        String text = randomAsciiOfLengthBetween(1, 10);
-        if (randomBoolean()) {
-            query = new WildcardQueryBuilder(STRING_FIELD_NAME, text);
-        } else {
-            query = new WildcardQueryBuilder(randomAsciiOfLengthBetween(1, 10), text);
-        }
-        if (randomBoolean()) {
-            query.rewrite(randomFrom(getRandomRewriteMethod()));
-        }
-        return query;
+        return createRandomQueryBuilder();
     }
 
     @Override
@@ -92,5 +80,20 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
 
         assertEquals(json, "ki*y", parsed.value());
         assertEquals(json, 2.0, parsed.boost(), 0.0001);
+    }
+
+    public static WildcardQueryBuilder createRandomQueryBuilder() {
+        WildcardQueryBuilder query;
+        // mapped or unmapped field
+        String text = randomAsciiOfLengthBetween(1, 10);
+        if (randomBoolean()) {
+            query = new WildcardQueryBuilder(STRING_FIELD_NAME, text);
+        } else {
+            query = new WildcardQueryBuilder(randomAsciiOfLengthBetween(1, 10), text);
+        }
+        if (randomBoolean()) {
+            query.rewrite(randomFrom(getRandomRewriteMethod()));
+        }
+        return query;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.index.query.AbstractQueryTestCase;
 import org.elasticsearch.index.query.EmptyQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.RandomQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
 import org.elasticsearch.indices.query.IndicesQueriesRegistry;
 import org.elasticsearch.script.Script;
@@ -223,16 +224,10 @@ public class SearchSourceBuilderTests extends ESTestCase {
             }
         }
         if (randomBoolean()) {
-            // NORELEASE make RandomQueryBuilder work outside of the
-            // AbstractQueryTestCase
-            // builder.query(RandomQueryBuilder.createQuery(getRandom()));
-            builder.query(QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
+            builder.query(RandomQueryBuilder.createQuery(getRandom()));
         }
         if (randomBoolean()) {
-            // NORELEASE make RandomQueryBuilder work outside of the
-            // AbstractQueryTestCase
-            // builder.postFilter(RandomQueryBuilder.createQuery(getRandom()));
-            builder.postFilter(QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
+            builder.postFilter(RandomQueryBuilder.createQuery(getRandom()));
         }
         if (randomBoolean()) {
             int numSorts = randomIntBetween(1, 5);


### PR DESCRIPTION
Currently random test query generation via RandomQueryBuilder.createQuery() will initialize AbstractQueryTestCase, and for that reason is unusable from other tests (like SearchSourceBuilderTests). This change factors out common test query generation code into static helper methods in the respective test classes that can be used without having to instantiate AbstractQueryTestCase.
