### PR TITLE
Fix for MatchQueryBuilderTests.testToQuery test failure

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -196,21 +196,20 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
             assertTrue(numericRangeQuery.includesMax());
 
             double value;
+            double width = 0;
             try {
                 value = Double.parseDouble(queryBuilder.value().toString());
             } catch (NumberFormatException e) {
                 // Maybe its a date
                 value = ISODateTimeFormat.dateTimeParser().parseMillis(queryBuilder.value().toString());
+                width = queryBuilder.fuzziness().asTimeValue().getMillis();
             }
-            double width;
-            if (queryBuilder.fuzziness().equals(Fuzziness.AUTO)) {
-                width = 1;
-            } else {
-                try {
+
+            if (width == 0) {
+                if (queryBuilder.fuzziness().equals(Fuzziness.AUTO)) {
+                    width = 1;
+                } else {
                     width = queryBuilder.fuzziness().asDouble();
-                } catch (NumberFormatException e) {
-                    // Maybe a time value?
-                    width = queryBuilder.fuzziness().asTimeValue().getMillis();
                 }
             }
             assertEquals(value - width, numericRangeQuery.getMin().doubleValue(), width * .1);


### PR DESCRIPTION
See http://build-us-00.elastic.co/job/es_core_master_window-2012/2308/testReport/junit/org.elasticsearch.index.query/MatchQueryBuilderTests/testToQuery/ for test failure details.

The change fixes the above test failure.

@nik9000 can you take a quick look and check this makes sense wrt. #15860 
