### PR TITLE
Normalize unavailable load average

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -124,7 +124,7 @@ public class OsProbe {
         }
         try {
             double oneMinuteLoadAverage = (double) getSystemLoadAverage.invoke(osMxBean);
-            return new double[] { oneMinuteLoadAverage, -1, -1 };
+            return new double[] { oneMinuteLoadAverage >= 0 ? oneMinuteLoadAverage : -1, -1, -1 };
         } catch (Throwable t) {
             return null;
         }

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -119,6 +119,9 @@ public class OsProbe {
             }
             // fallback
         }
+        if (Constants.WINDOWS) {
+            return null;
+        }
         if (getSystemLoadAverage == null) {
             return null;
         }

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  *
@@ -89,7 +90,7 @@ public class OsStats implements Streamable, ToXContent {
         if (cpu != null) {
             builder.startObject(Fields.CPU);
             builder.field(Fields.PERCENT, cpu.getPercent());
-            if (cpu.getLoadAverage() != null) {
+            if (cpu.getLoadAverage() != null && Arrays.stream(cpu.getLoadAverage()).anyMatch(load -> load != -1)) {
                 builder.startObject(Fields.LOAD_AVERAGE);
                 if (cpu.getLoadAverage()[0] != -1) {
                     builder.field(Fields.LOAD_AVERAGE_1M, cpu.getLoadAverage()[0]);

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -55,11 +55,7 @@ public class OsProbeTests extends ESTestCase {
         }
         if (Constants.WINDOWS) {
             // load average is unavailable on Windows
-            if (loadAverage != null) {
-                assertThat(loadAverage[0], equalTo((double) -1));
-                assertThat(loadAverage[1], equalTo((double) -1));
-                assertThat(loadAverage[2], equalTo((double) -1));
-            }
+            assertNull(loadAverage);
         } else if (Constants.LINUX) {
             // we should be able to get the load average
             assertNotNull(loadAverage);

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class OsProbeTests extends ESTestCase {
@@ -71,7 +70,7 @@ public class OsProbeTests extends ESTestCase {
             // one minute load average is available, but 10-minute and 15-minute load averages are not
             // load average can be negative if not available or not computed yet, otherwise it should be >= 0
             if (loadAverage != null) {
-                assertThat(loadAverage[0], anyOf(lessThan((double) 0), greaterThanOrEqualTo((double) 0)));
+                assertThat(loadAverage[0], anyOf(equalTo((double) -1), greaterThanOrEqualTo((double) 0)));
                 assertThat(loadAverage[1], equalTo((double) -1));
                 assertThat(loadAverage[2], equalTo((double) -1));
             }

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -66,6 +66,12 @@ public class OsProbeTests extends ESTestCase {
             assertThat(loadAverage[0], greaterThanOrEqualTo((double) 0));
             assertThat(loadAverage[1], greaterThanOrEqualTo((double) 0));
             assertThat(loadAverage[2], greaterThanOrEqualTo((double) 0));
+        } else if (Constants.FREE_BSD) {
+            // five- and fifteen-minute load averages not available if linprocfs is not mounted at /compat/linux/proc
+            assertNotNull(loadAverage);
+            assertThat(loadAverage[0], greaterThanOrEqualTo((double) 0));
+            assertThat(loadAverage[1], anyOf(equalTo((double) -1), greaterThanOrEqualTo((double) 0)));
+            assertThat(loadAverage[2], anyOf(equalTo((double) -1), greaterThanOrEqualTo((double) 0)));
         } else {
             // one minute load average is available, but 10-minute and 15-minute load averages are not
             // load average can be negative if not available or not computed yet, otherwise it should be >= 0

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -72,9 +72,14 @@ public class OsProbeTests extends ESTestCase {
             assertThat(loadAverage[0], greaterThanOrEqualTo((double) 0));
             assertThat(loadAverage[1], anyOf(equalTo((double) -1), greaterThanOrEqualTo((double) 0)));
             assertThat(loadAverage[2], anyOf(equalTo((double) -1), greaterThanOrEqualTo((double) 0)));
-        } else {
+        } else if (Constants.MAC_OS_X) {
             // one minute load average is available, but 10-minute and 15-minute load averages are not
-            // load average can be negative if not available or not computed yet, otherwise it should be >= 0
+            assertNotNull(loadAverage);
+            assertThat(loadAverage[0], greaterThanOrEqualTo((double) 0));
+            assertThat(loadAverage[1], equalTo((double) -1));
+            assertThat(loadAverage[2], equalTo((double) -1));
+        } else {
+            // unknown system, but the best case is that we have the one-minute load average
             if (loadAverage != null) {
                 assertThat(loadAverage[0], anyOf(equalTo((double) -1), greaterThanOrEqualTo((double) 0)));
                 assertThat(loadAverage[1], equalTo((double) -1));


### PR DESCRIPTION
This pull request cleans up the handling of load averages in various places.
1. The first cleanup is to normalize the value of unavailable load averages to `-1`; the `OperatingSystemMXBean#getSystemLoadAverage` method at best guarantees that the return value is negative when the load average is not available but the value of `-1` is utilized in various places as "not available".
2. The second cleanup is to prevent builds on FreeBSD from failing. On FreeBSD systems it is either the case that `linprocfs` is mounted at `/compat/linux/proc` and all load averages are available, or this is not the case and at best the one-minute load average is available.
3. The third cleanup is to tighten the test assertions by adding OS X to the list of systems where we can make definitive statements about the availability of load averages.
4. The fourth cleanup is to just set load averages to null on Windows because load average is never available there.
5. The final cleanup is to not output the `load_average` object if none of the load average values are meaningful.

Relates #12049, #14741, #15907, #15932, #15934 
