### PR TITLE
2.0 Breaking Changes - Settings docs don't mention index.gateway.local.sync

### DIFF
--- a/docs/reference/migration/migrate_2_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_2_0/settings.asciidoc
@@ -126,6 +126,10 @@ to prevent clashes with the watcher plugin
 * `watcher.interval.medium` is now `resource.reload.interval.medium`
 * `watcher.interval.high` is now `resource.reload.interval.high`
 
+==== index.gateway setting renamed
+
+* `index.gateway.local.sync` is now `index.translog.sync_interval`
+
 ==== Hunspell dictionary configuration
 
 The parameter `indices.analysis.hunspell.dictionary.location` has been


### PR DESCRIPTION
Seems like `index.gateway.local.sync` got renamed to `index.translog.sync_interval` in https://github.com/elastic/elasticsearch/commit/d596f5cc45284a60a88276b90f2bb1937415307b but it is not mentioned in the settings changes under [Setting changes](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_setting_changes.html)
