### PR TITLE
Single IPv4 addresses in IP field term queries

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -40,6 +40,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
@@ -124,6 +125,16 @@ public class SimpleSearchIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse search = client().prepareSearch()
+            .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.168.0.1")))
+            .execute().actionGet();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+            .setQuery(queryStringQuery("ip: 192.168.0.1"))
+            .execute().actionGet();
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
                 .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.168.0.1/32")))
                 .execute().actionGet();
         assertHitCount(search, 1l);


### PR DESCRIPTION
This commit modifies IpFieldMapper#termQuery to permit single IPv4
addresses for use in match and query_string queries.

Closes #16058 
