### PR TITLE
Test: Make rest test framework accept http directly for the test cluster

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -46,9 +46,9 @@ class ClusterFormationTasks {
     /**
      * Adds dependent tasks to the given task to start and stop a cluster with the given configuration.
      *
-     * Returns an object that will resolve at execution time of the given task to a uri for the cluster.
+     * Returns a NodeInfo object for the first node in the cluster.
      */
-    static Object setup(Project project, Task task, ClusterConfiguration config) {
+    static NodeInfo setup(Project project, Task task, ClusterConfiguration config) {
         if (task.getEnabled() == false) {
             // no need to add cluster formation tasks if the task won't run!
             return
@@ -66,7 +66,7 @@ class ClusterFormationTasks {
         task.dependsOn(wait)
 
         // delay the resolution of the uri by wrapping in a closure, so it is not used until read for tests
-        return "${-> nodes[0].transportUri()}"
+        return nodes[0]
     }
 
     /** Adds a dependency on the given distribution */

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -62,6 +62,9 @@ public class RestIntegTestTask extends RandomizedTestingTask {
         project.gradle.projectsEvaluated {
             NodeInfo node = ClusterFormationTasks.setup(project, this, clusterConfig)
             systemProperty('tests.rest.cluster', "localhost:${-> new URL('http://' + node.httpUri()).getPort()}")
+            // TODO: our "client" qa tests currently use the rest-test plugin. instead they should have their own plugin
+            // that sets up the test cluster and passes this transport uri instead of http uri. Until then, we pass
+            // both as separate sysprops
             systemProperty('tests.cluster', "${-> node.transportUri()}")
         }
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -20,7 +20,6 @@ package org.elasticsearch.gradle.test
 
 import com.carrotsearch.gradle.junit4.RandomizedTestingTask
 import org.elasticsearch.gradle.BuildPlugin
-import org.gradle.api.GradleException
 import org.gradle.api.Task
 import org.gradle.api.internal.tasks.options.Option
 import org.gradle.api.plugins.JavaBasePlugin
@@ -61,8 +60,9 @@ public class RestIntegTestTask extends RandomizedTestingTask {
         // this must run after all projects have been configured, so we know any project
         // references can be accessed as a fully configured
         project.gradle.projectsEvaluated {
-            Object clusterUri = ClusterFormationTasks.setup(project, this, clusterConfig)
-            systemProperty('tests.cluster', clusterUri)
+            NodeInfo node = ClusterFormationTasks.setup(project, this, clusterConfig)
+            systemProperty('tests.rest.cluster', "localhost:${-> new URL('http://' + node.httpUri()).getPort()}")
+            systemProperty('tests.cluster', "${-> node.transportUri()}")
         }
     }
 

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionRestIT.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionRestIT.java
@@ -21,20 +21,13 @@ package org.elasticsearch.script.expression;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class ExpressionRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(ExpressionPlugin.class);
-    }
 
     public ExpressionRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovyRestIT.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovyRestIT.java
@@ -21,20 +21,13 @@ package org.elasticsearch.script.groovy;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class GroovyRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(GroovyPlugin.class);
-    }
 
     public GroovyRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheRestIT.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheRestIT.java
@@ -21,20 +21,13 @@ package org.elasticsearch.script.mustache;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class MustacheRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(MustachePlugin.class);
-    }
 
     public MustacheRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/analysis/AnalysisICURestIT.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/analysis/AnalysisICURestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.index.analysis;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.analysis.icu.AnalysisICUPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class AnalysisICURestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(AnalysisICUPlugin.class);
-    }
 
     public AnalysisICURestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/analysis-kuromoji/src/test/java/org/elasticsearch/index/analysis/AnalysisKuromojiRestIT.java
+++ b/plugins/analysis-kuromoji/src/test/java/org/elasticsearch/index/analysis/AnalysisKuromojiRestIT.java
@@ -21,22 +21,13 @@ package org.elasticsearch.index.analysis;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.analysis.kuromoji.AnalysisKuromojiPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class AnalysisKuromojiRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(AnalysisKuromojiPlugin.class);
-    }
-
 
     public AnalysisKuromojiRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/analysis-phonetic/src/test/java/org/elasticsearch/index/analysis/AnalysisPhoneticRestIT.java
+++ b/plugins/analysis-phonetic/src/test/java/org/elasticsearch/index/analysis/AnalysisPhoneticRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.index.analysis;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.analysis.AnalysisPhoneticPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class AnalysisPhoneticRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(AnalysisPhoneticPlugin.class);
-    }
 
     public AnalysisPhoneticRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/analysis-smartcn/src/test/java/org/elasticsearch/index/analysis/AnalysisSmartChineseRestIT.java
+++ b/plugins/analysis-smartcn/src/test/java/org/elasticsearch/index/analysis/AnalysisSmartChineseRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.index.analysis;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.analysis.smartcn.AnalysisSmartChinesePlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class AnalysisSmartChineseRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(AnalysisSmartChinesePlugin.class);
-    }
 
     public AnalysisSmartChineseRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/analysis-stempel/src/test/java/org/elasticsearch/index/analysis/AnalysisPolishRestIT.java
+++ b/plugins/analysis-stempel/src/test/java/org/elasticsearch/index/analysis/AnalysisPolishRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.index.analysis;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.analysis.stempel.AnalysisStempelPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class AnalysisPolishRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(AnalysisStempelPlugin.class);
-    }
 
     public AnalysisPolishRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/delete-by-query/src/test/java/org/elasticsearch/plugin/deletebyquery/test/rest/DeleteByQueryRestIT.java
+++ b/plugins/delete-by-query/src/test/java/org/elasticsearch/plugin/deletebyquery/test/rest/DeleteByQueryRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.plugin.deletebyquery.test.rest;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.deletebyquery.DeleteByQueryPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class DeleteByQueryRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(DeleteByQueryPlugin.class);
-    }
 
     public DeleteByQueryRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/discovery-azure/src/test/java/org/elasticsearch/discovery/azure/AzureDiscoveryRestIT.java
+++ b/plugins/discovery-azure/src/test/java/org/elasticsearch/discovery/azure/AzureDiscoveryRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.discovery.azure;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.discovery.azure.AzureDiscoveryPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class AzureDiscoveryRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(AzureDiscoveryPlugin.class);
-    }
 
     public AzureDiscoveryRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/cloud/aws/DiscoveryEc2RestIT.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/cloud/aws/DiscoveryEc2RestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.cloud.aws;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.discovery.ec2.Ec2DiscoveryPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class DiscoveryEc2RestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(Ec2DiscoveryPlugin.class);
-    }
 
     public DiscoveryEc2RestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/discovery-gce/src/test/java/org/elasticsearch/discovery/gce/DiscoveryGCERestIT.java
+++ b/plugins/discovery-gce/src/test/java/org/elasticsearch/discovery/gce/DiscoveryGCERestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.discovery.gce;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.discovery.gce.GceDiscoveryPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class DiscoveryGCERestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(GceDiscoveryPlugin.class);
-    }
 
     public DiscoveryGCERestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/discovery-multicast/src/test/java/org/elasticsearch/plugin/discovery/multicast/MulticastDiscoveryRestIT.java
+++ b/plugins/discovery-multicast/src/test/java/org/elasticsearch/plugin/discovery/multicast/MulticastDiscoveryRestIT.java
@@ -21,20 +21,13 @@ package org.elasticsearch.plugin.discovery.multicast;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class MulticastDiscoveryRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(MulticastDiscoveryPlugin.class);
-    }
 
     public MulticastDiscoveryRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/JvmExampleRestIT.java
+++ b/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/JvmExampleRestIT.java
@@ -21,20 +21,13 @@ package org.elasticsearch.plugin.example;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class JvmExampleRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(JvmExamplePlugin.class);
-    }
 
     public JvmExampleRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/LangJavaScriptRestIT.java
+++ b/plugins/lang-javascript/src/test/java/org/elasticsearch/script/javascript/LangJavaScriptRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.script.javascript;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.javascript.JavaScriptPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class LangJavaScriptRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(JavaScriptPlugin.class);
-    }
 
     public LangJavaScriptRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/lang-plan-a/src/test/java/org/elasticsearch/plan/a/PlanARestIT.java
+++ b/plugins/lang-plan-a/src/test/java/org/elasticsearch/plan/a/PlanARestIT.java
@@ -21,21 +21,14 @@ package org.elasticsearch.plan.a;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 /** Runs yaml rest tests */
 public class PlanARestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(PlanAPlugin.class);
-    }
 
     public PlanARestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/lang-python/src/test/java/org/elasticsearch/script/python/LangPythonScriptRestIT.java
+++ b/plugins/lang-python/src/test/java/org/elasticsearch/script/python/LangPythonScriptRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.script.python;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.python.PythonPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class LangPythonScriptRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(PythonPlugin.class);
-    }
 
     public LangPythonScriptRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/MapperAttachmentsRestIT.java
+++ b/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/MapperAttachmentsRestIT.java
@@ -21,7 +21,6 @@ package org.elasticsearch.mapper.attachments;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
@@ -29,14 +28,6 @@ import org.elasticsearch.test.rest.parser.RestTestParseException;
 import java.io.IOException;
 
 public class MapperAttachmentsRestIT extends ESRestTestCase {
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
-                .put("plugin.types", MapperAttachmentsPlugin.class.getName())
-                .build();
-    }
 
     public MapperAttachmentsRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/mapper-murmur3/src/test/java/org/elasticsearch/index/mapper/murmur3/MapperMurmur3RestIT.java
+++ b/plugins/mapper-murmur3/src/test/java/org/elasticsearch/index/mapper/murmur3/MapperMurmur3RestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.index.mapper.murmur3;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.mapper.MapperMurmur3Plugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class MapperMurmur3RestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(MapperMurmur3Plugin.class);
-    }
 
     public MapperMurmur3RestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/MapperSizeRestIT.java
+++ b/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/MapperSizeRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.index.mapper.size;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.mapper.MapperSizePlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class MapperSizeRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(MapperSizePlugin.class);
-    }
 
     public MapperSizeRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryRestIT.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.repositories.azure;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.repository.azure.AzureRepositoryPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class AzureRepositoryRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(AzureRepositoryPlugin.class);
-    }
 
     public AzureRepositoryRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsRepositoryRestIT.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsRepositoryRestIT.java
@@ -19,23 +19,14 @@
 package org.elasticsearch.repositories.hdfs;
 
 import java.io.IOException;
-import java.util.Collection;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
-import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.repositories.hdfs.HdfsPlugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 public class HdfsRepositoryRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(HdfsPlugin.class);
-    }
 
     public HdfsRepositoryRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryS3RestIT.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryS3RestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.repositories.s3;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.repository.s3.S3RepositoryPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class RepositoryS3RestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(S3RepositoryPlugin.class);
-    }
 
     public RepositoryS3RestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SMBStoreRestIT.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SMBStoreRestIT.java
@@ -21,21 +21,13 @@ package org.elasticsearch.index.store;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.plugin.store.smb.SMBStorePlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestCandidate;
 import org.elasticsearch.test.rest.parser.RestTestParseException;
 
 import java.io.IOException;
-import java.util.Collection;
 
 public class SMBStoreRestIT extends ESRestTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return pluginList(SMBStorePlugin.class);
-    }
 
     public SMBStoreRestIT(@Name("yaml") RestTestCandidate testCandidate) {
         super(testCandidate);

--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
@@ -67,11 +67,6 @@ public abstract class ESSmokeClientTestCase extends LuceneTestCase {
      */
     public static final String TESTS_CLUSTER = "tests.cluster";
 
-    /**
-     * Defaults to localhost:9300
-     */
-    public static final String TESTS_CLUSTER_DEFAULT = "localhost:9300";
-
     protected static final ESLogger logger = ESLoggerFactory.getLogger(ESSmokeClientTestCase.class.getName());
 
     private static final AtomicInteger counter = new AtomicInteger();
@@ -131,11 +126,10 @@ public abstract class ESSmokeClientTestCase extends LuceneTestCase {
     }
 
     @BeforeClass
-    public static void initializeSettings() throws UnknownHostException {
+    public static void initializeSettings() {
         clusterAddresses = System.getProperty(TESTS_CLUSTER);
         if (clusterAddresses == null || clusterAddresses.isEmpty()) {
-            clusterAddresses = TESTS_CLUSTER_DEFAULT;
-            logger.info("[{}] not set. Falling back to [{}]", TESTS_CLUSTER, TESTS_CLUSTER_DEFAULT);
+            fail("Must specify " + TESTS_CLUSTER + " for smoke client test");
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -39,7 +40,6 @@ import static org.elasticsearch.test.ESIntegTestCase.TESTS_CLUSTER;
 import static org.elasticsearch.test.rest.ESRestTestCase.REST_TESTS_BLACKLIST;
 import static org.elasticsearch.test.rest.ESRestTestCase.REST_TESTS_SPEC;
 import static org.elasticsearch.test.rest.ESRestTestCase.REST_TESTS_SUITE;
-import static org.elasticsearch.test.rest.ESRestTestCase.Rest;
 
 /**
  * A {@link RunListener} that emits to {@link System#err} a string with command
@@ -82,7 +82,7 @@ public class ReproduceInfoPrinter extends RunListener {
         gradleMessageBuilder.appendAllOpts(failure.getDescription());
 
         //Rest tests are a special case as they allow for additional parameters
-        if (failure.getDescription().getTestClass().isAnnotationPresent(Rest.class)) {
+        if (ESRestTestCase.class.isAssignableFrom(failure.getDescription().getTestClass())) {
             gradleMessageBuilder.appendRestTestsProperties();
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestExecutionContext.java
@@ -31,6 +31,7 @@ import org.elasticsearch.test.rest.spec.RestSpec;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,9 +120,9 @@ public class RestTestExecutionContext implements Closeable {
     /**
      * Creates the embedded REST client when needed. Needs to be called before each test.
      */
-    public void initClient(InetSocketAddress[] addresses, Settings settings) throws IOException, RestException {
+    public void initClient(URL[] urls, Settings settings) throws IOException, RestException {
         if (restClient == null) {
-            restClient = new RestClient(restSpec, settings, addresses);
+            restClient = new RestClient(restSpec, settings, urls);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/client/RestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/client/RestClient.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
@@ -48,6 +49,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyManagementException;
@@ -80,18 +82,18 @@ public class RestClient implements Closeable {
     private final RestSpec restSpec;
     private final CloseableHttpClient httpClient;
     private final Headers headers;
-    private final InetSocketAddress[] addresses;
+    private final URL[] urls;
     private final Version esVersion;
 
-    public RestClient(RestSpec restSpec, Settings settings, InetSocketAddress[] addresses) throws IOException, RestException {
-        assert addresses.length > 0;
+    public RestClient(RestSpec restSpec, Settings settings, URL[] urls) throws IOException, RestException {
+        assert urls.length > 0;
         this.restSpec = restSpec;
         this.headers = new Headers(settings);
         this.protocol = settings.get(PROTOCOL, "http");
         this.httpClient = createHttpClient(settings);
-        this.addresses = addresses;
+        this.urls = urls;
         this.esVersion = readAndCheckVersion();
-        logger.info("REST client initialized {}, elasticsearch version: [{}]", addresses, esVersion);
+        logger.info("REST client initialized {}, elasticsearch version: [{}]", urls, esVersion);
     }
 
     private Version readAndCheckVersion() throws IOException, RestException {
@@ -102,8 +104,8 @@ public class RestClient implements Closeable {
         assert restApi.getMethods().size() == 1;
 
         String version = null;
-        for (InetSocketAddress address : addresses) {
-            RestResponse restResponse = new RestResponse(httpRequestBuilder(address)
+        for (URL url : urls) {
+            RestResponse restResponse = new RestResponse(httpRequestBuilder(url)
                     .path(restApi.getPaths().get(0))
                     .method(restApi.getMethods().get(0)).execute());
             checkStatusCode(restResponse);
@@ -152,6 +154,8 @@ public class RestClient implements Closeable {
 
         HttpRequestBuilder httpRequestBuilder = callApiBuilder(apiName, requestParams, body);
         for (Map.Entry<String, String> header : headers.entrySet()) {
+            logger.error("Adding header " + header.getKey());
+            logger.error(" with value " + header.getValue());
             httpRequestBuilder.addHeader(header.getKey(), header.getValue());
         }
         logger.debug("calling api [{}]", apiName);
@@ -246,17 +250,18 @@ public class RestClient implements Closeable {
         return restApi;
     }
 
-    protected HttpRequestBuilder httpRequestBuilder(InetSocketAddress address) {
+    protected HttpRequestBuilder httpRequestBuilder(URL url) {
         return new HttpRequestBuilder(httpClient)
                 .addHeaders(headers)
                 .protocol(protocol)
-                .host(NetworkAddress.formatAddress(address.getAddress())).port(address.getPort());
+                .host(url.getHost())
+                .port(url.getPort());
     }
 
     protected HttpRequestBuilder httpRequestBuilder() {
         //the address used is randomized between the available ones
-        InetSocketAddress address = RandomizedTest.randomFrom(addresses);
-        return httpRequestBuilder(address);
+        URL url = RandomizedTest.randomFrom(urls);
+        return httpRequestBuilder(url);
     }
 
     protected CloseableHttpClient createHttpClient(Settings settings) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/parser/RestTestSuiteParseContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/parser/RestTestSuiteParseContext.java
@@ -136,7 +136,7 @@ public class RestTestSuiteParseContext {
             token = parser.nextToken();
         }
         if (token != XContentParser.Token.FIELD_NAME) {
-            throw new RestTestParseException("malformed test section: field name expected but found " + token);
+            throw new RestTestParseException("malformed test section: field name expected but found " + token + " at " + parser.getTokenLocation());
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/parser/RestTestSuiteParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/parser/RestTestSuiteParser.java
@@ -18,17 +18,17 @@
  */
 package org.elasticsearch.test.rest.parser;
 
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.yaml.YamlXContent;
-import org.elasticsearch.test.rest.section.RestTestSuite;
-import org.elasticsearch.test.rest.section.TestSection;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.yaml.YamlXContent;
+import org.elasticsearch.test.rest.section.RestTestSuite;
+import org.elasticsearch.test.rest.section.TestSection;
 
 /**
  * Parser for a complete test suite (yaml file)


### PR DESCRIPTION
The rest test framework, because it used to be tightly integrated with
ESIntegTestCase, currently expects the addresses for the test cluster to
be passed using the transport protocol port. However, it only uses this
to then find the http address.

This change makes ESRestTestCase extend from ESTestCase instead of
ESIntegTestCase, and changes the sysprop used to tests.rest.cluster,
which now takes the http address.

closes #15459
