### PR TITLE
Remove Xlint from lang-groovy and discovery-azure

### DIFF
--- a/modules/lang-groovy/build.gradle
+++ b/modules/lang-groovy/build.gradle
@@ -26,9 +26,6 @@ dependencies {
   compile 'org.codehaus.groovy:groovy:2.4.4:indy'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-rawtypes,-unchecked,-cast'
-compileTestJava.options.compilerArgs << '-Xlint:-rawtypes,-unchecked,-cast'
-
 integTest {
   cluster {
     systemProperty 'es.script.inline', 'on'

--- a/modules/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/modules/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -23,6 +23,7 @@ import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyCodeSource;
 import groovy.lang.Script;
+
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Scorer;
 import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
@@ -182,6 +183,7 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
             String fake = MessageDigests.toHexString(MessageDigests.sha1().digest(script.getBytes(StandardCharsets.UTF_8)));
             // same logic as GroovyClassLoader.parseClass() but with a different codesource string:
             return AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
                 public Class<?> run() {
                     GroovyCodeSource gcs = new GroovyCodeSource(script, fake, BootstrapInfo.UNTRUSTED_CODEBASE);
                     gcs.setCachable(false);
@@ -203,7 +205,7 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
      */
     @SuppressWarnings("unchecked")
     private Script createScript(Object compiledScript, Map<String, Object> vars) throws InstantiationException, IllegalAccessException {
-        Class scriptClass = (Class) compiledScript;
+        Class<?> scriptClass = (Class<?>) compiledScript;
         Script scriptObject = (Script) scriptClass.newInstance();
         Binding binding = new Binding();
         binding.getVariables().putAll(vars);
@@ -211,7 +213,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
         return scriptObject;
     }
 
-    @SuppressWarnings({"unchecked"})
     @Override
     public ExecutableScript executable(CompiledScript compiledScript, Map<String, Object> vars) {
         try {
@@ -225,7 +226,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
         }
     }
 
-    @SuppressWarnings({"unchecked"})
     @Override
     public SearchScript search(final CompiledScript compiledScript, final SearchLookup lookup, @Nullable final Map<String, Object> vars) {
         return new SearchScript() {
@@ -288,7 +288,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
             }
         }
 
-        @SuppressWarnings({"unchecked"})
         @Override
         public void setNextVar(String name, Object value) {
             variables.put(name, value);

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/MinDocCountTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/MinDocCountTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.messy.tests;
 import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -65,7 +66,7 @@ public class MinDocCountTests extends AbstractTermsTestCase {
         return Collections.singleton(GroovyPlugin.class);
     }
 
-    private static final QueryBuilder QUERY = QueryBuilders.termQuery("match", true);
+    private static final QueryBuilder<?> QUERY = QueryBuilders.termQuery("match", true);
 
     private static int cardinality;
 
@@ -77,7 +78,6 @@ public class MinDocCountTests extends AbstractTermsTestCase {
         final List<IndexRequestBuilder> indexRequests = new ArrayList<>();
         final Set<String> stringTerms = new HashSet<>();
         final LongSet longTerms = new LongHashSet();
-        final Set<String> dateTerms = new HashSet<>();
         for (int i = 0; i < cardinality; ++i) {
             String stringTerm;
             do {
@@ -319,7 +319,6 @@ public class MinDocCountTests extends AbstractTermsTestCase {
                 throw ae;
             }
         }
-
     }
 
     public void testHistogramCountAsc() throws Exception {
@@ -372,11 +371,9 @@ public class MinDocCountTests extends AbstractTermsTestCase {
                     .execute().actionGet();
             assertSubset(allHisto, (Histogram) response.getAggregations().get("histo"), minDocCount);
         }
-
     }
 
     private void testMinDocCountOnDateHistogram(Histogram.Order order) throws Exception {
-        final int interval = randomIntBetween(1, 3);
         final SearchResponse allResponse = client().prepareSearch("idx").setTypes("type")
                 .setSize(0)
                 .setQuery(QUERY)
@@ -393,7 +390,5 @@ public class MinDocCountTests extends AbstractTermsTestCase {
                     .execute().actionGet();
             assertSubset(allHisto, (Histogram) response.getAggregations().get("histo"), minDocCount);
         }
-
     }
-
 }

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptedMetricTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptedMetricTests.java
@@ -147,15 +147,15 @@ public class ScriptedMetricTests extends ESIntegTestCase {
         for (Object object : aggregationList) {
             assertThat(object, notNullValue());
             assertThat(object, instanceOf(Map.class));
-            Map<String, Object> map = (Map<String, Object>) object;
+            Map<?, ?> map = (Map<?, ?>) object;
             assertThat(map.size(), lessThanOrEqualTo(1));
             if (map.size() == 1) {
-            assertThat(map.get("count"), notNullValue());
-            assertThat(map.get("count"), instanceOf(Number.class));
-            assertThat((Number) map.get("count"), equalTo((Number) 1));
+                assertThat(map.get("count"), notNullValue());
+                assertThat(map.get("count"), instanceOf(Number.class));
+                assertThat((Number) map.get("count"), equalTo((Number) 1));
                 numShardsRun++;
+            }
         }
-    }
         // We don't know how many shards will have documents but we need to make
         // sure that at least one shard ran the map script
         assertThat(numShardsRun, greaterThan(0));
@@ -740,6 +740,7 @@ public class ScriptedMetricTests extends ESIntegTestCase {
         assertThat(scriptedMetric.getName(), equalTo("scripted"));
         assertThat(scriptedMetric.aggregation(), notNullValue());
         assertThat(scriptedMetric.aggregation(), instanceOf(List.class));
+        @SuppressWarnings("unchecked") // We'll just get a ClassCastException a couple lines down if we're wrong, its ok.
         List<Integer> aggregationResult = (List<Integer>) scriptedMetric.aggregation();
         assertThat(aggregationResult.size(), equalTo(1));
         assertThat(aggregationResult.get(0), equalTo(0));

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SearchFieldsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SearchFieldsTests.java
@@ -339,9 +339,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
                 .execute().actionGet();
         client().admin().indices().refresh(refreshRequest()).actionGet();
 
-        SearchResponse response = client().prepareSearch()
-                .setQuery(matchAllQuery())
-.addScriptField("s_obj1", new Script("_source.obj1"))
+        SearchResponse response = client().prepareSearch().setQuery(matchAllQuery()).addScriptField("s_obj1", new Script("_source.obj1"))
                 .addScriptField("s_obj1_test", new Script("_source.obj1.test")).addScriptField("s_obj2", new Script("_source.obj2"))
                 .addScriptField("s_obj2_arr2", new Script("_source.obj2.arr2")).addScriptField("s_arr3", new Script("_source.arr3"))
                 .execute().actionGet();
@@ -355,7 +353,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
         assertThat(response.getHits().getAt(0).field("s_obj1_test").value().toString(), equalTo("something"));
 
         Map<String, Object> sObj2 = response.getHits().getAt(0).field("s_obj2").value();
-        List sObj2Arr2 = (List) sObj2.get("arr2");
+        List<?> sObj2Arr2 = (List<?>) sObj2.get("arr2");
         assertThat(sObj2Arr2.size(), equalTo(2));
         assertThat(sObj2Arr2.get(0).toString(), equalTo("arr_value1"));
         assertThat(sObj2Arr2.get(1).toString(), equalTo("arr_value2"));
@@ -365,8 +363,8 @@ public class SearchFieldsTests extends ESIntegTestCase {
         assertThat(sObj2Arr2.get(0).toString(), equalTo("arr_value1"));
         assertThat(sObj2Arr2.get(1).toString(), equalTo("arr_value2"));
 
-        List sObj2Arr3 = response.getHits().getAt(0).field("s_arr3").values();
-        assertThat(((Map) sObj2Arr3.get(0)).get("arr3_field1").toString(), equalTo("arr3_value1"));
+        List<?> sObj2Arr3 = response.getHits().getAt(0).field("s_arr3").values();
+        assertThat(((Map<?, ?>) sObj2Arr3.get(0)).get("arr3_field1").toString(), equalTo("arr3_value1"));
     }
 
     public void testPartialFields() throws Exception {

--- a/plugins/discovery-azure/build.gradle
+++ b/plugins/discovery-azure/build.gradle
@@ -56,8 +56,6 @@ dependencyLicenses {
   mapping from: /jaxb-.*/, to: 'jaxb'
 }
 
-compileJava.options.compilerArgs << '-Xlint:-path,-unchecked'
-
 thirdPartyAudit.excludes = [
   // classes are missing
   'javax.servlet.ServletContextEvent', 


### PR DESCRIPTION
discovery-azure didn't actually need it.

This removes all non-default Xlints from modules.
