### PR TITLE
Change the percolate api to not dynamically add fields to mapping

### DIFF
--- a/core/src/main/java/org/elasticsearch/percolator/PercolateDocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateDocumentParser.java
@@ -49,14 +49,13 @@ public class PercolateDocumentParser {
     private final HighlightPhase highlightPhase;
     private final SortParseElement sortParseElement;
     private final AggregationPhase aggregationPhase;
-    private final MappingUpdatedAction mappingUpdatedAction;
 
     @Inject
-    public PercolateDocumentParser(HighlightPhase highlightPhase, SortParseElement sortParseElement, AggregationPhase aggregationPhase, MappingUpdatedAction mappingUpdatedAction) {
+    public PercolateDocumentParser(HighlightPhase highlightPhase, SortParseElement sortParseElement,
+                                   AggregationPhase aggregationPhase) {
         this.highlightPhase = highlightPhase;
         this.sortParseElement = sortParseElement;
         this.aggregationPhase = aggregationPhase;
-        this.mappingUpdatedAction = mappingUpdatedAction;
     }
 
     public ParsedDocument parse(PercolateShardRequest request, PercolateContext context, MapperService mapperService, QueryShardContext queryShardContext) {
@@ -97,9 +96,6 @@ public class PercolateDocumentParser {
                         doc = docMapper.getDocumentMapper().parse(source(parser).index(index).type(request.documentType()).flyweight(true));
                         if (docMapper.getMapping() != null) {
                             doc.addDynamicMappingsUpdate(docMapper.getMapping());
-                        }
-                        if (doc.dynamicMappingsUpdate() != null) {
-                            mappingUpdatedAction.updateMappingOnMasterSynchronously(request.shardId().getIndex(), request.documentType(), doc.dynamicMappingsUpdate());
                         }
                         // the document parsing exists the "doc" object, so we need to set the new current field.
                         currentFieldName = parser.currentName();

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -52,6 +52,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.fieldvisitor.SingleFieldsVisitor;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.percolator.PercolatorFieldMapper;
@@ -201,7 +202,8 @@ public class PercolatorService extends AbstractComponent {
 
             // parse the source either into one MemoryIndex, if it is a single document or index multiple docs if nested
             PercolatorIndex percolatorIndex;
-            boolean isNested = indexShard.mapperService().documentMapper(request.documentType()).hasNestedObjects();
+            DocumentMapper documentMapper = indexShard.mapperService().documentMapper(request.documentType());
+            boolean isNested = documentMapper != null && documentMapper.hasNestedObjects();
             if (parsedDocument.docs().size() > 1) {
                 assert isNested;
                 percolatorIndex = multi;

--- a/core/src/test/java/org/elasticsearch/percolator/PercolateDocumentParserTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolateDocumentParserTests.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.percolate.PercolateShardRequest;
-import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -90,10 +89,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         HighlightPhase highlightPhase = new HighlightPhase(Settings.EMPTY, new Highlighters());
         AggregatorParsers aggregatorParsers = new AggregatorParsers(Collections.emptySet(), Collections.emptySet());
         AggregationPhase aggregationPhase = new AggregationPhase(new AggregationParseElement(aggregatorParsers), new AggregationBinaryParseElement(aggregatorParsers));
-        MappingUpdatedAction mappingUpdatedAction = Mockito.mock(MappingUpdatedAction.class);
-        parser = new PercolateDocumentParser(
-                highlightPhase, new SortParseElement(), aggregationPhase, mappingUpdatedAction
-        );
+        parser = new PercolateDocumentParser(highlightPhase, new SortParseElement(), aggregationPhase);
 
         request = Mockito.mock(PercolateShardRequest.class);
         Mockito.when(request.shardId()).thenReturn(new ShardId(new Index("_index"), 0));

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -644,6 +644,10 @@ The percolate api can no longer accept documents that have fields that don't exi
 When percolating an existing document then specifying a document in the source of the percolate request is not allowed
 any more.
 
+The percolate api no longer modifies the mappings. Before the percolate api could be used to dynamically introduce new
+fields to the mappings based on the fields in the document being percolated. This no longer works, because these
+unmapped fields are not persisted in the mapping.
+
 Percolator documents are no longer excluded from the search response.
 
 [[breaking_30_packaging]]

--- a/docs/reference/search/percolate.asciidoc
+++ b/docs/reference/search/percolate.asciidoc
@@ -20,14 +20,8 @@ in a request to the percolate API.
 =====================================
 
 Fields referred to in a percolator query must *already* exist in the mapping
-associated with the index used for percolation.
-There are two ways to make sure that a field mapping exist:
-
-* Add or update a mapping via the <<indices-create-index,create index>> or
-  <<indices-put-mapping,put mapping>> APIs.
-* Percolate a document before registering a query. Percolating a document can
-  add field mappings dynamically, in the same way as happens when indexing a
-  document.
+associated with the index used for percolation. In order to make sure these fields exist,
+add or update a mapping via the <<indices-create-index,create index>> or <<indices-put-mapping,put mapping>> APIs.
 
 =====================================
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/percolate/18_highligh_with_query.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/percolate/18_highligh_with_query.yaml
@@ -27,7 +27,7 @@
   - do:
       percolate:
         index: test_index
-        type:  test_type
+        type:  type_1
         body:
           doc:
               foo: "bar foo"


### PR DESCRIPTION
The percolate api shouldn't add field mappings for fields inside the document being percolated that are unmapped. In the end this is a read api and a read api shouldn't change the mapping or anything else.

Closes #15751
