### PR TITLE
Do not apply minimum-should-match on a boolean query if the coords are disabled

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -117,6 +117,9 @@ public class Queries {
         if (minimumShouldMatch == null) {
             return query;
         }
+        if (query.isCoordDisabled()) {
+            return query;
+        }
         int optionalClauses = 0;
         for (BooleanClause c : query.clauses()) {
             if (c.getOccur() == BooleanClause.Occur.SHOULD) {

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -272,6 +272,17 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
         assertEquals(3, bq.getMinimumNumberShouldMatch());
     }
 
+    public void testMinShouldMatchDisableCoord() throws Exception {
+        BooleanQuery bq = (BooleanQuery) parseQuery(
+                boolQuery()
+                        .should(termQuery("foo", "bar"))
+                        .should(termQuery("foo2", "bar2"))
+                        .minimumNumberShouldMatch("3")
+                        .disableCoord(true)
+                        .buildAsBytes()).toQuery(createShardContext());
+        assertEquals(0, bq.getMinimumNumberShouldMatch());
+    }
+
     public void testFromJson() throws IOException {
         String query =
                 "{" +

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -288,7 +288,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 Map.Entry<String, Float> field = fieldsIterator.next();
                 assertTermOrBoostQuery(booleanClause.getQuery(), field.getKey(), queryBuilder.value(), field.getValue());
             }
-            if (queryBuilder.minimumShouldMatch() != null) {
+            if (queryBuilder.minimumShouldMatch() != null && !boolQuery.isCoordDisabled()) {
                 assertThat(boolQuery.getMinimumNumberShouldMatch(), greaterThan(0));
             }
         } else if (queryBuilder.fields().size() == 1) {


### PR DESCRIPTION
Fixes #15858
