### PR TITLE
Fix for MatchQueryBuilderTests.testToQuery random fuzziness generation caused test failure

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
@@ -67,6 +67,8 @@ public final class Fuzziness implements ToXContent, Writeable<Fuzziness> {
 
     /**
      * Creates a {@link Fuzziness} instance from an edit distance. The value must be one of <tt>[0, 1, 2]</tt>
+     *
+     * Note: Using this method only makes sense if the field you are applying Fuzziness to is some sort of string.
      */
     public static Fuzziness fromEdits(int edits) {
         return new Fuzziness(edits);

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -816,12 +816,6 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
     }
 
     protected static Fuzziness randomFuzziness(String fieldName) {
-        if (randomBoolean()) {
-            return Fuzziness.fromEdits(randomIntBetween(0, 2));
-        }
-        if (randomBoolean()) {
-            return Fuzziness.AUTO;
-        }
         switch (fieldName) {
             case INT_FIELD_NAME:
                 return Fuzziness.build(randomIntBetween(3, 100));
@@ -830,6 +824,9 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             case DATE_FIELD_NAME:
                 return Fuzziness.build(randomTimeValue());
             default:
+                if (randomBoolean()) {
+                    return Fuzziness.fromEdits(randomIntBetween(0, 2));
+                }
                 return Fuzziness.AUTO;
         }
     }


### PR DESCRIPTION
For all query testing we offer the option to initialise them with random
fuzziness objects. So far there is a chance to generate an edit distance based
fuzziness for non-string fields. This is fixed by this change.

Fixes the following test failures:
- http://build-us-00.elastic.co/job/es_core_master_small/6606/
- http://build-us-00.elastic.co/job/es_core_master_centos/9555/
