### PR TITLE
Replace server side timeout by client side timeout

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -123,7 +123,7 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
         // Set timeout option. Defaults to 5mn. See cloud.azure.storage.timeout or cloud.azure.storage.xxx.timeout
         try {
             int timeout = (int) azureStorageSettings.getTimeout().getMillis();
-            client.getDefaultRequestOptions().setTimeoutIntervalInMs(timeout);
+            client.getDefaultRequestOptions().setMaximumExecutionTimeInMs(timeout);
         } catch (ClassCastException e) {
             throw new IllegalArgumentException("Can not cast [" + azureStorageSettings.getTimeout() + "] to int.");
         }


### PR DESCRIPTION
This commit replaces server side timeout (which is BTW not correctly implemented in azure client 2.0.0 but fixed later #16084) with a client side timeout.

As a consequence, for each request sent to azure, azure client will raise an exception after a given amount of time (timeout).

Closes #12567.
