### PR TITLE
Add more tests for Azure Repository client selection

### DIFF
--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTest.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTest.java
@@ -61,6 +61,16 @@ public class AzureStorageServiceTest extends ESTestCase {
         assertThat(client.getEndpoint(), is(URI.create("https://azure1")));
     }
 
+    public void testGetDefaultClientWithNoSecondary() {
+        AzureStorageServiceImpl azureStorageService = new AzureStorageServiceMock(Settings.builder()
+            .put("cloud.azure.storage.azure1.account", "myaccount1")
+            .put("cloud.azure.storage.azure1.key", "mykey1")
+            .build());
+        azureStorageService.doStart();
+        CloudBlobClient client = azureStorageService.getSelectedClient(null, LocationMode.PRIMARY_ONLY);
+        assertThat(client.getEndpoint(), is(URI.create("https://azure1")));
+    }
+
     public void testGetSelectedClientPrimary() {
         AzureStorageServiceImpl azureStorageService = new AzureStorageServiceMock(settings);
         azureStorageService.doStart();
@@ -80,6 +90,13 @@ public class AzureStorageServiceTest extends ESTestCase {
         azureStorageService.doStart();
         CloudBlobClient client = azureStorageService.getSelectedClient("azure3", LocationMode.PRIMARY_ONLY);
         assertThat(client.getEndpoint(), is(URI.create("https://azure3")));
+    }
+
+    public void testGetDefaultClientWithPrimaryAndSecondaries() {
+        AzureStorageServiceImpl azureStorageService = new AzureStorageServiceMock(settings);
+        azureStorageService.doStart();
+        CloudBlobClient client = azureStorageService.getSelectedClient(null, LocationMode.PRIMARY_ONLY);
+        assertThat(client.getEndpoint(), is(URI.create("https://azure1")));
     }
 
     public void testGetSelectedClientNonExisting() {


### PR DESCRIPTION
One test we forgot in #14843 and #13779 is the default client selection.

Most of the time, users won't define explicitly which client they want to use because they are providing only one connection to Azure storage:

``` yml
cloud:
    azure:
        storage:
            my_account:
                account: your_azure_storage_account
                key: your_azure_storage_key
```

Then using the default client like this:

``` sh
# This one will use the default account (my_account1)
curl -XPUT localhost:9200/_snapshot/my_backup1?pretty -d '{
  "type": "azure"
}'
```

This commit adds tests to check that the right client is still selected when no client is explicitly set when creating the snapshot.
