### PR TITLE
More robust handling of CORS HTTP Access Control

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/Strings.java
+++ b/core/src/main/java/org/elasticsearch/common/Strings.java
@@ -1140,4 +1140,5 @@ public class Strings {
             return sb.toString();
         }
     }
+
 }

--- a/core/src/main/java/org/elasticsearch/http/netty/HttpRequestHandler.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/HttpRequestHandler.java
@@ -20,18 +20,13 @@
 package org.elasticsearch.http.netty;
 
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.http.netty.pipelining.OrderedUpstreamMessageEvent;
-import org.elasticsearch.rest.support.RestUtils;
 import org.jboss.netty.channel.ChannelHandler;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ExceptionEvent;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.jboss.netty.handler.codec.http.HttpRequest;
-
-import java.util.regex.Pattern;
-
 
 /**
  *
@@ -40,15 +35,12 @@ import java.util.regex.Pattern;
 public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
 
     private final NettyHttpServerTransport serverTransport;
-    private final Pattern corsPattern;
     private final boolean httpPipeliningEnabled;
     private final boolean detailedErrorsEnabled;
     private final ThreadContext threadContext;
 
     public HttpRequestHandler(NettyHttpServerTransport serverTransport, boolean detailedErrorsEnabled, ThreadContext threadContext) {
         this.serverTransport = serverTransport;
-        this.corsPattern = RestUtils
-                .checkCorsSettingForRegex(HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN.get(serverTransport.settings()));
         this.httpPipeliningEnabled = serverTransport.pipelining;
         this.detailedErrorsEnabled = detailedErrorsEnabled;
         this.threadContext = threadContext;
@@ -70,9 +62,9 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
         // when reading, or using a cumalation buffer
         NettyHttpRequest httpRequest = new NettyHttpRequest(request, e.getChannel());
         if (oue != null) {
-            serverTransport.dispatchRequest(httpRequest, new NettyHttpChannel(serverTransport, httpRequest, corsPattern, oue, detailedErrorsEnabled));
+            serverTransport.dispatchRequest(httpRequest, new NettyHttpChannel(serverTransport, httpRequest, oue, detailedErrorsEnabled));
         } else {
-            serverTransport.dispatchRequest(httpRequest, new NettyHttpChannel(serverTransport, httpRequest, corsPattern, detailedErrorsEnabled));
+            serverTransport.dispatchRequest(httpRequest, new NettyHttpChannel(serverTransport, httpRequest, detailedErrorsEnabled));
         }
         super.messageReceived(ctx, e);
     }

--- a/core/src/main/java/org/elasticsearch/http/netty/cors/CorsConfig.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/cors/CorsConfig.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty.cors;
+
+import org.jboss.netty.handler.codec.http.DefaultHttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
+
+/**
+ * Configuration for Cross-Origin Resource Sharing (CORS).
+ *
+ * This class was lifted from the Netty project:
+ *  https://github.com/netty/netty
+ */
+public final class CorsConfig {
+
+    private final Optional<Set<String>> origins;
+    private final Optional<Pattern> pattern;
+    private final boolean anyOrigin;
+    private final boolean enabled;
+    private final boolean allowCredentials;
+    private final long maxAge;
+    private final Set<HttpMethod> allowedRequestMethods;
+    private final Set<String> allowedRequestHeaders;
+    private final boolean allowNullOrigin;
+    private final Map<CharSequence, Callable<?>> preflightHeaders;
+    private final boolean shortCircuit;
+
+    CorsConfig(final CorsConfigBuilder builder) {
+        origins = builder.origins.map(s -> new LinkedHashSet<>(s));
+        pattern = builder.pattern;
+        anyOrigin = builder.anyOrigin;
+        enabled = builder.enabled;
+        allowCredentials = builder.allowCredentials;
+        maxAge = builder.maxAge;
+        allowedRequestMethods = builder.requestMethods;
+        allowedRequestHeaders = builder.requestHeaders;
+        allowNullOrigin = builder.allowNullOrigin;
+        preflightHeaders = builder.preflightHeaders;
+        shortCircuit = builder.shortCircuit;
+    }
+
+    /**
+     * Determines if support for CORS is enabled.
+     *
+     * @return {@code true} if support for CORS is enabled, false otherwise.
+     */
+    public boolean isCorsSupportEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Determines whether a wildcard origin, '*', is supported.
+     *
+     * @return {@code boolean} true if any origin is allowed.
+     */
+    public boolean isAnyOriginSupported() {
+        return anyOrigin;
+    }
+
+    /**
+     * Returns the set of allowed origins.
+     *
+     * @return {@code Set} the allowed origins.
+     */
+    public Optional<Set<String>> origins() {
+        return origins;
+    }
+
+    /**
+     * Returns whether the input origin is allowed by this configuration.
+     *
+     * @return {@code true} if the origin is allowed, otherwise {@code false}
+     */
+    public boolean isOriginAllowed(final String origin) {
+        if (origins.isPresent()) {
+            return origins.get().contains(origin);
+        } else if (pattern.isPresent()) {
+            return pattern.get().matcher(origin).matches();
+        }
+        return false;
+    }
+
+    /**
+     * Web browsers may set the 'Origin' request header to 'null' if a resource is loaded
+     * from the local file system.
+     *
+     * If isNullOriginAllowed is true then the server will response with the wildcard for the
+     * the CORS response header 'Access-Control-Allow-Origin'.
+     *
+     * @return {@code true} if a 'null' origin should be supported.
+     */
+    public boolean isNullOriginAllowed() {
+        return allowNullOrigin;
+    }
+
+    /**
+     * Determines if cookies are supported for CORS requests.
+     *
+     * By default cookies are not included in CORS requests but if isCredentialsAllowed returns
+     * true cookies will be added to CORS requests. Setting this value to true will set the
+     * CORS 'Access-Control-Allow-Credentials' response header to true.
+     *
+     * Please note that cookie support needs to be enabled on the client side as well.
+     * The client needs to opt-in to send cookies by calling:
+     * <pre>
+     * xhr.withCredentials = true;
+     * </pre>
+     * The default value for 'withCredentials' is false in which case no cookies are sent.
+     * Settning this to true will included cookies in cross origin requests.
+     *
+     * @return {@code true} if cookies are supported.
+     */
+    public boolean isCredentialsAllowed() {
+        return allowCredentials;
+    }
+
+    /**
+     * Gets the maxAge setting.
+     *
+     * When making a preflight request the client has to perform two request with can be inefficient.
+     * This setting will set the CORS 'Access-Control-Max-Age' response header and enables the
+     * caching of the preflight response for the specified time. During this time no preflight
+     * request will be made.
+     *
+     * @return {@code long} the time in seconds that a preflight request may be cached.
+     */
+    public long maxAge() {
+        return maxAge;
+    }
+
+    /**
+     * Returns the allowed set of Request Methods. The Http methods that should be returned in the
+     * CORS 'Access-Control-Request-Method' response header.
+     *
+     * @return {@code Set} of {@link HttpMethod}s that represent the allowed Request Methods.
+     */
+    public Set<HttpMethod> allowedRequestMethods() {
+        return Collections.unmodifiableSet(allowedRequestMethods);
+    }
+
+    /**
+     * Returns the allowed set of Request Headers.
+     *
+     * The header names returned from this method will be used to set the CORS
+     * 'Access-Control-Allow-Headers' response header.
+     *
+     * @return {@code Set<String>} of strings that represent the allowed Request Headers.
+     */
+    public Set<String> allowedRequestHeaders() {
+        return Collections.unmodifiableSet(allowedRequestHeaders);
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * @return {@link HttpHeaders} the HTTP response headers to be added.
+     */
+    public HttpHeaders preflightResponseHeaders() {
+        if (preflightHeaders.isEmpty()) {
+            return HttpHeaders.EMPTY_HEADERS;
+        }
+        final HttpHeaders preflightHeaders = new DefaultHttpHeaders();
+        for (Map.Entry<CharSequence, Callable<?>> entry : this.preflightHeaders.entrySet()) {
+            final Object value = getValue(entry.getValue());
+            if (value instanceof Iterable) {
+                preflightHeaders.add(entry.getKey().toString(), (Iterable<?>) value);
+            } else {
+                preflightHeaders.add(entry.getKey().toString(), value);
+            }
+        }
+        return preflightHeaders;
+    }
+
+    /**
+     * Determines whether a CORS request should be rejected if it's invalid before being
+     * further processing.
+     *
+     * CORS headers are set after a request is processed. This may not always be desired
+     * and this setting will check that the Origin is valid and if it is not valid no
+     * further processing will take place, and a error will be returned to the calling client.
+     *
+     * @return {@code true} if a CORS request should short-curcuit upon receiving an invalid Origin header.
+     */
+    public boolean isShortCircuit() {
+        return shortCircuit;
+    }
+
+    private static <T> T getValue(final Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (final Exception e) {
+            throw new IllegalStateException("Could not generate value for callable [" + callable + ']', e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return  "CorsConfig[enabled=" + enabled +
+                    ", origins=" + origins +
+                    ", anyOrigin=" + anyOrigin +
+                    ", isCredentialsAllowed=" + allowCredentials +
+                    ", maxAge=" + maxAge +
+                    ", allowedRequestMethods=" + allowedRequestMethods +
+                    ", allowedRequestHeaders=" + allowedRequestHeaders +
+                    ", preflightHeaders=" + preflightHeaders + ']';
+    }
+}

--- a/core/src/main/java/org/elasticsearch/http/netty/cors/CorsConfigBuilder.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/cors/CorsConfigBuilder.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty.cors;
+
+import org.jboss.netty.handler.codec.http.HttpMethod;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
+
+/**
+ * Builder used to configure and build a {@link CorsConfig} instance.
+ *
+ * This class was lifted from the Netty project:
+ *  https://github.com/netty/netty
+ */
+public final class CorsConfigBuilder {
+
+    /**
+     * Creates a Builder instance with it's origin set to '*'.
+     *
+     * @return Builder to support method chaining.
+     */
+    public static CorsConfigBuilder forAnyOrigin() {
+        return new CorsConfigBuilder();
+    }
+
+    /**
+     * Creates a {@link CorsConfigBuilder} instance with the specified origin.
+     *
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public static CorsConfigBuilder forOrigin(final String origin) {
+        if ("*".equals(origin)) {
+            return new CorsConfigBuilder();
+        }
+        return new CorsConfigBuilder(origin);
+    }
+
+
+    /**
+     * Create a {@link CorsConfigBuilder} instance with the specified pattern origin.
+     *
+     * @param pattern the regular expression pattern to match incoming origins on.
+     * @return {@link CorsConfigBuilder} with the configured origin pattern.
+     */
+    public static CorsConfigBuilder forPattern(final Pattern pattern) {
+        if (pattern == null) {
+            throw new IllegalArgumentException("CORS pattern cannot be null");
+        }
+        return new CorsConfigBuilder(pattern);
+    }
+
+    /**
+     * Creates a {@link CorsConfigBuilder} instance with the specified origins.
+     *
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public static CorsConfigBuilder forOrigins(final String... origins) {
+        return new CorsConfigBuilder(origins);
+    }
+
+    Optional<Set<String>> origins;
+    Optional<Pattern> pattern;
+    final boolean anyOrigin;
+    boolean allowNullOrigin;
+    boolean enabled = true;
+    boolean allowCredentials;
+    long maxAge;
+    final Set<HttpMethod> requestMethods = new HashSet<>();
+    final Set<String> requestHeaders = new HashSet<>();
+    final Map<CharSequence, Callable<?>> preflightHeaders = new HashMap<>();
+    private boolean noPreflightHeaders;
+    boolean shortCircuit;
+
+    /**
+     * Creates a new Builder instance with the origin passed in.
+     *
+     * @param origins the origin to be used for this builder.
+     */
+    CorsConfigBuilder(final String... origins) {
+        this.origins = Optional.of(new LinkedHashSet<>(Arrays.asList(origins)));
+        pattern = Optional.empty();
+        anyOrigin = false;
+    }
+
+    /**
+     * Creates a new Builder instance allowing any origin, "*" which is the
+     * wildcard origin.
+     *
+     */
+    CorsConfigBuilder() {
+        anyOrigin = true;
+        origins = Optional.empty();
+        pattern = Optional.empty();
+    }
+
+    /**
+     * Creates a new Builder instance allowing any origin that matches the pattern.
+     *
+     * @param pattern the pattern to match against for incoming origins.
+     */
+    CorsConfigBuilder(final Pattern pattern) {
+        this.pattern = Optional.of(pattern);
+        origins = Optional.empty();
+        anyOrigin = false;
+    }
+
+    /**
+     * Web browsers may set the 'Origin' request header to 'null' if a resource is loaded
+     * from the local file system. Calling this method will enable a successful CORS response
+     * with a wildcard for the the CORS response header 'Access-Control-Allow-Origin'.
+     *
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    CorsConfigBuilder allowNullOrigin() {
+        allowNullOrigin = true;
+        return this;
+    }
+
+    /**
+     * Disables CORS support.
+     *
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder disable() {
+        enabled = false;
+        return this;
+    }
+
+    /**
+     * By default cookies are not included in CORS requests, but this method will enable cookies to
+     * be added to CORS requests. Calling this method will set the CORS 'Access-Control-Allow-Credentials'
+     * response header to true.
+     *
+     * Please note, that cookie support needs to be enabled on the client side as well.
+     * The client needs to opt-in to send cookies by calling:
+     * <pre>
+     * xhr.withCredentials = true;
+     * </pre>
+     * The default value for 'withCredentials' is false in which case no cookies are sent.
+     * Setting this to true will included cookies in cross origin requests.
+     *
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder allowCredentials() {
+        allowCredentials = true;
+        return this;
+    }
+
+    /**
+     * When making a preflight request the client has to perform two request with can be inefficient.
+     * This setting will set the CORS 'Access-Control-Max-Age' response header and enables the
+     * caching of the preflight response for the specified time. During this time no preflight
+     * request will be made.
+     *
+     * @param max the maximum time, in seconds, that the preflight response may be cached.
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder maxAge(final long max) {
+        maxAge = max;
+        return this;
+    }
+
+    /**
+     * Specifies the allowed set of HTTP Request Methods that should be returned in the
+     * CORS 'Access-Control-Request-Method' response header.
+     *
+     * @param methods the {@link HttpMethod}s that should be allowed.
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder allowedRequestMethods(final HttpMethod... methods) {
+        requestMethods.addAll(Arrays.asList(methods));
+        return this;
+    }
+
+    /**
+     * Specifies the if headers that should be returned in the CORS 'Access-Control-Allow-Headers'
+     * response header.
+     *
+     * If a client specifies headers on the request, for example by calling:
+     * <pre>
+     * xhr.setRequestHeader('My-Custom-Header', "SomeValue");
+     * </pre>
+     * the server will receive the above header name in the 'Access-Control-Request-Headers' of the
+     * preflight request. The server will then decide if it allows this header to be sent for the
+     * real request (remember that a preflight is not the real request but a request asking the server
+     * if it allow a request).
+     *
+     * @param headers the headers to be added to the preflight 'Access-Control-Allow-Headers' response header.
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder allowedRequestHeaders(final String... headers) {
+        requestHeaders.addAll(Arrays.asList(headers));
+        return this;
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * An intermediary like a load balancer might require that a CORS preflight request
+     * have certain headers set. This enables such headers to be added.
+     *
+     * @param name the name of the HTTP header.
+     * @param values the values for the HTTP header.
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder preflightResponseHeader(final CharSequence name, final Object... values) {
+        if (values.length == 1) {
+            preflightHeaders.put(name, new ConstantValueGenerator(values[0]));
+        } else {
+            preflightResponseHeader(name, Arrays.asList(values));
+        }
+        return this;
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * An intermediary like a load balancer might require that a CORS preflight request
+     * have certain headers set. This enables such headers to be added.
+     *
+     * @param name the name of the HTTP header.
+     * @param value the values for the HTTP header.
+     * @param <T> the type of values that the Iterable contains.
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public <T> CorsConfigBuilder preflightResponseHeader(final CharSequence name, final Iterable<T> value) {
+        preflightHeaders.put(name, new ConstantValueGenerator(value));
+        return this;
+    }
+
+    /**
+     * Returns HTTP response headers that should be added to a CORS preflight response.
+     *
+     * An intermediary like a load balancer might require that a CORS preflight request
+     * have certain headers set. This enables such headers to be added.
+     *
+     * Some values must be dynamically created when the HTTP response is created, for
+     * example the 'Date' response header. This can be accomplished by using a Callable
+     * which will have its 'call' method invoked when the HTTP response is created.
+     *
+     * @param name the name of the HTTP header.
+     * @param valueGenerator a Callable which will be invoked at HTTP response creation.
+     * @param <T> the type of the value that the Callable can return.
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public <T> CorsConfigBuilder preflightResponseHeader(final CharSequence name, final Callable<T> valueGenerator) {
+        preflightHeaders.put(name, valueGenerator);
+        return this;
+    }
+
+    /**
+     * Specifies that no preflight response headers should be added to a preflight response.
+     *
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder noPreflightResponseHeaders() {
+        noPreflightHeaders = true;
+        return this;
+    }
+
+    /**
+     * Specifies that a CORS request should be rejected if it's invalid before being
+     * further processing.
+     *
+     * CORS headers are set after a request is processed. This may not always be desired
+     * and this setting will check that the Origin is valid and if it is not valid no
+     * further processing will take place, and a error will be returned to the calling client.
+     *
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder shortCircuit() {
+        shortCircuit = true;
+        return this;
+    }
+
+    /**
+     * Builds a {@link CorsConfig} with settings specified by previous method calls.
+     *
+     * @return {@link CorsConfig} the configured CorsConfig instance.
+     */
+    public CorsConfig build() {
+        if (preflightHeaders.isEmpty() && !noPreflightHeaders) {
+            preflightHeaders.put("date", DateValueGenerator.INSTANCE);
+            preflightHeaders.put("content-length", new ConstantValueGenerator("0"));
+        }
+        return new CorsConfig(this);
+    }
+
+    /**
+     * This class is used for preflight HTTP response values that do not need to be
+     * generated, but instead the value is "static" in that the same value will be returned
+     * for each call.
+     */
+    private static final class ConstantValueGenerator implements Callable<Object> {
+
+        private final Object value;
+
+        /**
+         * Sole constructor.
+         *
+         * @param value the value that will be returned when the call method is invoked.
+         */
+        private ConstantValueGenerator(final Object value) {
+            if (value == null) {
+                throw new IllegalArgumentException("value must not be null");
+            }
+            this.value = value;
+        }
+
+        @Override
+        public Object call() {
+            return value;
+        }
+    }
+
+    /**
+     * This callable is used for the DATE preflight HTTP response HTTP header.
+     * It's value must be generated when the response is generated, hence will be
+     * different for every call.
+     */
+    private static final class DateValueGenerator implements Callable<Date> {
+
+        static final DateValueGenerator INSTANCE = new DateValueGenerator();
+
+        @Override
+        public Date call() throws Exception {
+            return new Date();
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/http/netty/cors/CorsHandler.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/cors/CorsHandler.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty.cors;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.rest.support.RestUtils;
+import org.jboss.netty.channel.ChannelFutureListener;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_METHODS;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_MAX_AGE;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.ORIGIN;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.USER_AGENT;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.VARY;
+import static org.jboss.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static org.jboss.netty.handler.codec.http.HttpResponseStatus.OK;
+
+/**
+ * Handles <a href="http://www.w3.org/TR/cors/">Cross Origin Resource Sharing</a> (CORS) requests.
+ * <p>
+ * This handler can be configured using a {@link CorsConfig}, please
+ * refer to this class for details about the configuration options available.
+ *
+ * This code was borrowed from Netty 4 and refactored to work for Elasticsearch's Netty 3 setup.
+ */
+public class CorsHandler extends SimpleChannelUpstreamHandler {
+
+    public static final String ANY_ORIGIN = "*";
+    private final CorsConfig config;
+
+    private HttpRequest request;
+
+    /**
+     * Creates a new instance with the specified {@link CorsConfig}.
+     */
+    public CorsHandler(final CorsConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("Config cannot be null");
+        }
+        this.config = config;
+    }
+
+    @Override
+    public void messageReceived(final ChannelHandlerContext ctx, final MessageEvent e) throws Exception {
+        if (config.isCorsSupportEnabled() && e.getMessage() instanceof HttpRequest) {
+            request = (HttpRequest) e.getMessage();
+            if (RestUtils.isBrowser(request.headers().get(USER_AGENT))) {
+                if (isPreflightRequest(request)) {
+                    handlePreflight(ctx, request);
+                    return;
+                }
+                if (config.isShortCircuit() && !validateOrigin()) {
+                    forbidden(ctx, request);
+                    return;
+                }
+            }
+        }
+        super.messageReceived(ctx, e);
+    }
+
+    public static void setCorsResponseHeaders(HttpRequest request, HttpResponse resp, CorsConfig config) {
+        if (!config.isCorsSupportEnabled()) {
+            return;
+        }
+        String originHeader = request.headers().get(ORIGIN);
+        if (!Strings.isNullOrEmpty(originHeader)) {
+            final String originHeaderVal;
+            if (config.isAnyOriginSupported()) {
+                originHeaderVal = ANY_ORIGIN;
+            } else if (config.isOriginAllowed(originHeader)) {
+                originHeaderVal = originHeader;
+            } else {
+                originHeaderVal = null;
+            }
+            if (originHeaderVal != null) {
+                resp.headers().add(ACCESS_CONTROL_ALLOW_ORIGIN, originHeaderVal);
+            }
+        }
+        if (config.isCredentialsAllowed()) {
+            resp.headers().add(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        }
+    }
+
+    private void handlePreflight(final ChannelHandlerContext ctx, final HttpRequest request) {
+        final HttpResponse response = new DefaultHttpResponse(request.getProtocolVersion(), OK);
+        if (setOrigin(response)) {
+            setAllowMethods(response);
+            setAllowHeaders(response);
+            setAllowCredentials(response);
+            setMaxAge(response);
+            setPreflightHeaders(response);
+            ctx.getChannel().write(response).addListener(ChannelFutureListener.CLOSE);
+        } else {
+            forbidden(ctx, request);
+        }
+    }
+
+    private static void forbidden(final ChannelHandlerContext ctx, final HttpRequest request) {
+        ctx.getChannel().write(new DefaultHttpResponse(request.getProtocolVersion(), FORBIDDEN))
+            .addListener(ChannelFutureListener.CLOSE);
+    }
+
+    /**
+     * This is a non CORS specification feature which enables the setting of preflight
+     * response headers that might be required by intermediaries.
+     *
+     * @param response the HttpResponse to which the preflight response headers should be added.
+     */
+    private void setPreflightHeaders(final HttpResponse response) {
+        response.headers().add(config.preflightResponseHeaders());
+    }
+
+    private boolean setOrigin(final HttpResponse response) {
+        final String origin = request.headers().get(ORIGIN);
+        if (!Strings.isNullOrEmpty(origin)) {
+            if ("null".equals(origin) && config.isNullOriginAllowed()) {
+                setAnyOrigin(response);
+                return true;
+            }
+            if (config.isAnyOriginSupported()) {
+                if (config.isCredentialsAllowed()) {
+                    echoRequestOrigin(response);
+                    setVaryHeader(response);
+                } else {
+                    setAnyOrigin(response);
+                }
+                return true;
+            }
+            if (config.isOriginAllowed(origin)) {
+                setOrigin(response, origin);
+                setVaryHeader(response);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean validateOrigin() {
+        if (config.isAnyOriginSupported()) {
+            return true;
+        }
+
+        final String origin = request.headers().get(ORIGIN);
+        if (Strings.isNullOrEmpty(origin)) {
+            // Not a CORS request so we cannot validate it. It may be a non CORS request.
+            return true;
+        }
+
+        if ("null".equals(origin) && config.isNullOriginAllowed()) {
+            return true;
+        }
+
+        return config.isOriginAllowed(origin);
+    }
+
+    private void echoRequestOrigin(final HttpResponse response) {
+        setOrigin(response, request.headers().get(ORIGIN));
+    }
+
+    private static void setVaryHeader(final HttpResponse response) {
+        response.headers().set(VARY, ORIGIN);
+    }
+
+    private static void setAnyOrigin(final HttpResponse response) {
+        setOrigin(response, ANY_ORIGIN);
+    }
+
+    private static void setOrigin(final HttpResponse response, final String origin) {
+        response.headers().set(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+    }
+
+    private void setAllowCredentials(final HttpResponse response) {
+        if (config.isCredentialsAllowed()
+                && !response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).equals(ANY_ORIGIN)) {
+            response.headers().set(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        }
+    }
+
+    private static boolean isPreflightRequest(final HttpRequest request) {
+        final HttpHeaders headers = request.headers();
+        return request.getMethod().equals(HttpMethod.OPTIONS) &&
+                   headers.contains(HttpHeaders.Names.ORIGIN) &&
+                   headers.contains(HttpHeaders.Names.ACCESS_CONTROL_REQUEST_METHOD);
+    }
+
+    private void setAllowMethods(final HttpResponse response) {
+        response.headers().set(ACCESS_CONTROL_ALLOW_METHODS,
+            String.join(", ", config.allowedRequestMethods().stream()
+                                          .map(HttpMethod::getName)
+                                          .collect(Collectors.toList())).trim());
+    }
+
+    private void setAllowHeaders(final HttpResponse response) {
+        response.headers().set(ACCESS_CONTROL_ALLOW_HEADERS, config.allowedRequestHeaders());
+    }
+
+    private void setMaxAge(final HttpResponse response) {
+        response.headers().set(ACCESS_CONTROL_MAX_AGE, config.maxAge());
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/rest/support/RestUtils.java
+++ b/core/src/main/java/org/elasticsearch/rest/support/RestUtils.java
@@ -20,10 +20,12 @@
 package org.elasticsearch.rest.support;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.path.PathTrie;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -237,5 +239,22 @@ public class RestUtils {
         }
 
         return null;
+    }
+
+    /**
+     * Return the CORS setting as an array of origins.
+     *
+     * @param corsSetting the CORS allow origin setting as configured by the user;
+     *                    should never pass null, but we check for it anyway.
+     * @return an array of origins if set, otherwise {@code null}.
+     */
+    public static String[] corsSettingAsArray(String corsSetting) {
+        if (Strings.isNullOrEmpty(corsSetting)) {
+            return new String[0];
+        }
+        return Arrays.asList(corsSetting.split(","))
+                     .stream()
+                     .map(String::trim)
+                     .toArray(size -> new String[size]);
     }
 }

--- a/core/src/test/java/org/elasticsearch/http/netty/NettyHttpChannelTests.java
+++ b/core/src/test/java/org/elasticsearch/http/netty/NettyHttpChannelTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.http.HttpTransportSettings;
+import org.elasticsearch.http.netty.cors.CorsHandler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
@@ -51,11 +52,19 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_CREDENTIALS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_METHODS;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_CORS_ENABLED;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class NettyHttpChannelTests extends ESTestCase {
+
+    private static final String ORIGIN = "remote-host";
+
     private NetworkService networkService;
     private ThreadPool threadPool;
     private MockBigArrays bigArrays;
@@ -84,6 +93,57 @@ public class NettyHttpChannelTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put(HttpTransportSettings.SETTING_CORS_ENABLED.getKey(), true)
                 .build();
+        HttpResponse response = execRequestWithCors(settings, ORIGIN);
+        // inspect response and validate
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), nullValue());
+    }
+
+    public void testCorsEnabledWithAllowOrigins() {
+        final String originValue = ORIGIN;
+        // create a http transport with CORS enabled and allow origin configured
+        Settings settings = Settings.builder()
+                .put(SETTING_CORS_ENABLED.getKey(), true)
+                .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), originValue)
+                .build();
+        HttpResponse response = execRequestWithCors(settings, originValue);
+        // inspect response and validate
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
+        String allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat(allowedOrigins, is(originValue));
+    }
+
+    public void testThatStringLiteralWorksOnMatch() {
+        final String originValue = ORIGIN;
+        Settings settings = Settings.builder()
+                                .put(SETTING_CORS_ENABLED.getKey(), true)
+                                .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), originValue)
+                                .put(SETTING_CORS_ALLOW_METHODS.getKey(), "get, options, post")
+                                .put(SETTING_CORS_ALLOW_CREDENTIALS.getKey(), true)
+                                .build();
+        HttpResponse response = execRequestWithCors(settings, originValue);
+        // inspect response and validate
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
+        String allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat(allowedOrigins, is(originValue));
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo("true"));
+    }
+
+    public void testThatAnyOriginWorks() {
+        final String originValue = CorsHandler.ANY_ORIGIN;
+        Settings settings = Settings.builder()
+                                .put(SETTING_CORS_ENABLED.getKey(), true)
+                                .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), originValue)
+                                .build();
+        HttpResponse response = execRequestWithCors(settings, originValue);
+        // inspect response and validate
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
+        String allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
+        assertThat(allowedOrigins, is(originValue));
+        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS), nullValue());
+    }
+
+    public void testHeadersSet() {
+        Settings settings = Settings.builder().build();
         httpServerTransport = new NettyHttpServerTransport(settings, networkService, bigArrays, threadPool);
         HttpRequest httpRequest = new TestHttpRequest();
         httpRequest.headers().add(HttpHeaders.Names.ORIGIN, "remote");
@@ -93,24 +153,27 @@ public class NettyHttpChannelTests extends ESTestCase {
 
         // send a response
         NettyHttpChannel channel = new NettyHttpChannel(httpServerTransport, request, null, randomBoolean());
-        channel.sendResponse(new TestReponse());
+        TestReponse resp = new TestReponse();
+        final String customHeader = "custom-header";
+        final String customHeaderValue = "xyz";
+        resp.addHeader(customHeader, customHeaderValue);
+        channel.sendResponse(resp);
 
         // inspect what was written
         List<Object> writtenObjects = writeCapturingChannel.getWrittenObjects();
         assertThat(writtenObjects.size(), is(1));
         HttpResponse response = (HttpResponse) writtenObjects.get(0);
-        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), nullValue());
+        assertThat(response.headers().get("non-existent-header"), nullValue());
+        assertThat(response.headers().get(customHeader), equalTo(customHeaderValue));
+        assertThat(response.headers().get(HttpHeaders.Names.CONTENT_LENGTH), equalTo(Integer.toString(resp.content().length())));
+        assertThat(response.headers().get(HttpHeaders.Names.CONTENT_TYPE), equalTo(resp.contentType()));
     }
 
-    public void testCorsEnabledWithAllowOrigins() {
-        // create a http transport with CORS enabled and allow origin configured
-        Settings settings = Settings.builder()
-                .put(HttpTransportSettings.SETTING_CORS_ENABLED.getKey(), true)
-                .put(HttpTransportSettings.SETTING_CORS_ALLOW_ORIGIN.getKey(), "remote-host")
-                .build();
+    private HttpResponse execRequestWithCors(final Settings settings, final String originValue) {
+        // construct request and send it over the transport layer
         httpServerTransport = new NettyHttpServerTransport(settings, networkService, bigArrays, threadPool);
         HttpRequest httpRequest = new TestHttpRequest();
-        httpRequest.headers().add(HttpHeaders.Names.ORIGIN, "remote");
+        httpRequest.headers().add(HttpHeaders.Names.ORIGIN, ORIGIN);
         httpRequest.headers().add(HttpHeaders.Names.USER_AGENT, "Mozilla fake");
         WriteCapturingChannel writeCapturingChannel = new WriteCapturingChannel();
         NettyHttpRequest request = new NettyHttpRequest(httpRequest, writeCapturingChannel);
@@ -118,13 +181,10 @@ public class NettyHttpChannelTests extends ESTestCase {
         NettyHttpChannel channel = new NettyHttpChannel(httpServerTransport, request, null, randomBoolean());
         channel.sendResponse(new TestReponse());
 
-        // inspect what was written
+        // get the response
         List<Object> writtenObjects = writeCapturingChannel.getWrittenObjects();
         assertThat(writtenObjects.size(), is(1));
-        HttpResponse response = (HttpResponse) writtenObjects.get(0);
-        assertThat(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), notNullValue());
-        String allowedOrigins = response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
-        assertThat(allowedOrigins, is("remote-host"));
+        return (HttpResponse) writtenObjects.get(0);
     }
 
     private static class WriteCapturingChannel implements Channel {

--- a/core/src/test/java/org/elasticsearch/rest/CorsNotSetIT.java
+++ b/core/src/test/java/org/elasticsearch/rest/CorsNotSetIT.java
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.rest;
 
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.rest.client.http.HttpResponse;
 
 import static org.hamcrest.Matchers.hasKey;
@@ -31,7 +32,8 @@ import static org.hamcrest.Matchers.not;
 /**
  *
  */
-public class CorsRegexDefaultIT extends ESIntegTestCase {
+@ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class CorsNotSetIT extends ESIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {


### PR DESCRIPTION
Uses a refactored version of Netty's CORS implementation to provide more
robust cross-origin resource request functionality.  The CORS specific
Elasticsearch parameters remain the same, just the underlying
implementation has changed.

It has also been refactored in a way that allows dropping in Netty's
CORS handler as a replacement once Elasticsearch is upgraded to Netty 4.
