### PR TITLE
Create default for ExecutableScript#unwrap

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/AbstractExecutableScript.java
+++ b/core/src/main/java/org/elasticsearch/script/AbstractExecutableScript.java
@@ -24,9 +24,4 @@ public abstract class AbstractExecutableScript implements ExecutableScript {
     @Override
     public void setNextVar(String name, Object value) {
     }
-
-    @Override
-    public Object unwrap(Object value) {
-        return value;
-    }
 }

--- a/core/src/main/java/org/elasticsearch/script/ExecutableScript.java
+++ b/core/src/main/java/org/elasticsearch/script/ExecutableScript.java
@@ -32,8 +32,12 @@ public interface ExecutableScript {
     Object run();
 
     /**
-     * Unwraps a possible script value. For example, when passing vars and expecting the returned value to
-     * be part of the vars.
+     * Unwraps a possible script value. For example, when passing vars and
+     * expecting the returned value to be part of the vars. Javascript and
+     * Python need this but other scripting engines just return the values
+     * passed in.
      */
-    Object unwrap(Object value);
+    default Object unwrap(Object value) {
+        return value;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -1447,12 +1447,6 @@ public class DateHistogramIT extends ESIntegTestCase {
                     final LeafSearchLookup leafLookup = lookup.getLeafSearchLookup(context);
 
                     return new LeafSearchScript() {
-
-                        @Override
-                        public Object unwrap(Object value) {
-                            return null;
-                        }
-
                         @Override
                         public void setNextVar(String name, Object value) {
                         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
@@ -388,12 +388,6 @@ public class AvgIT extends AbstractNumericTestCase {
                     final LeafSearchLookup leafLookup = lookup.getLeafSearchLookup(context);
 
                     return new LeafSearchScript() {
-
-                        @Override
-                        public Object unwrap(Object value) {
-                            return null;
-                        }
-
                         @Override
                         public void setNextVar(String name, Object value) {
                         }
@@ -526,12 +520,6 @@ public class AvgIT extends AbstractNumericTestCase {
                     final LeafSearchLookup leafLookup = lookup.getLeafSearchLookup(context);
 
                     return new LeafSearchScript() {
-
-                        @Override
-                        public Object unwrap(Object value) {
-                            throw new UnsupportedOperationException();
-                        }
-
                         @Override
                         public void setNextVar(String name, Object value) {
                             vars.put(name, value);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -384,12 +384,6 @@ public class SumIT extends AbstractNumericTestCase {
                     final LeafSearchLookup leafLookup = lookup.getLeafSearchLookup(context);
 
                     return new LeafSearchScript() {
-
-                        @Override
-                        public Object unwrap(Object value) {
-                            return null;
-                        }
-
                         @Override
                         public void setNextVar(String name, Object value) {
                         }

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -33,10 +33,10 @@ import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
-import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
@@ -154,12 +154,6 @@ public class UpdateIT extends ESIntegTestCase {
 
                     return ctx;
                 }
-
-                @Override
-                public Object unwrap(Object value) {
-                    return value;
-                }
-
             };
         }
 
@@ -245,12 +239,6 @@ public class UpdateIT extends ESIntegTestCase {
                     source.put(field, currentValue.longValue() + inc.longValue());
                     return ctx;
                 }
-
-                @Override
-                public Object unwrap(Object value) {
-                    return value;
-                }
-
             };
         }
 
@@ -336,12 +324,6 @@ public class UpdateIT extends ESIntegTestCase {
                     source.put("balance", oldBalance.intValue() - deduction);
                     return ctx;
                 }
-
-                @Override
-                public Object unwrap(Object value) {
-                    return value;
-                }
-
             };
         }
 
@@ -428,12 +410,6 @@ public class UpdateIT extends ESIntegTestCase {
 
                     return ctx;
                 }
-
-                @Override
-                public Object unwrap(Object value) {
-                    return value;
-                }
-
             };
         }
 

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionExecutableScript.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionExecutableScript.java
@@ -19,13 +19,13 @@
 
 package org.elasticsearch.script.expression;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.lucene.expressions.Expression;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ScriptException;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A bridge to evaluate an {@link Expression} against a map of variables in the context
@@ -89,10 +89,5 @@ public class ExpressionExecutableScript implements ExecutableScript {
         } catch (Exception exception) {
             throw new ScriptException("Error evaluating " + compiledScript, exception);
         }
-    }
-
-    @Override
-    public Object unwrap(Object value) {
-        return value;
     }
 }

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionSearchScript.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionSearchScript.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.script.expression;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
 import org.apache.lucene.expressions.Bindings;
 import org.apache.lucene.expressions.Expression;
 import org.apache.lucene.expressions.SimpleBindings;
@@ -31,10 +35,6 @@ import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * A bridge to evaluate an {@link Expression} against {@link Bindings} in the context
@@ -88,9 +88,6 @@ class ExpressionSearchScript implements SearchScript {
 
             @Override
             public double runAsDouble() { return evaluate(); }
-
-            @Override
-            public Object unwrap(Object value) { return value; }
 
             @Override
             public void setDocument(int d) {

--- a/modules/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/modules/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -19,10 +19,14 @@
 
 package org.elasticsearch.script.groovy;
 
-import groovy.lang.Binding;
-import groovy.lang.GroovyClassLoader;
-import groovy.lang.GroovyCodeSource;
-import groovy.lang.Script;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Scorer;
@@ -56,14 +60,10 @@ import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.HashMap;
-import java.util.Map;
+import groovy.lang.Binding;
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyCodeSource;
+import groovy.lang.Script;
 
 /**
  * Provides the infrastructure for Groovy as a scripting language for Elasticsearch
@@ -333,12 +333,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
         public double runAsDouble() {
             return ((Number) run()).doubleValue();
         }
-
-        @Override
-        public Object unwrap(Object value) {
-            return value;
-        }
-
     }
 
     /**

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngineService.java
@@ -18,7 +18,12 @@
  */
 package org.elasticsearch.script.mustache;
 
-import com.github.mustachejava.Mustache;
+import java.lang.ref.SoftReference;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.Map;
+
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -34,11 +39,7 @@ import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.lang.ref.SoftReference;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Collections;
-import java.util.Map;
+import com.github.mustachejava.Mustache;
 
 /**
  * Main entry point handling template registration, compilation and
@@ -173,11 +174,6 @@ public class MustacheScriptEngineService extends AbstractComponent implements Sc
                 throw new ScriptException("Error running " + template, e);
             }
             return result.bytes();
-        }
-
-        @Override
-        public Object unwrap(Object value) {
-            return value;
         }
     }
 }

--- a/plugins/lang-plan-a/src/main/java/org/elasticsearch/plan/a/ScriptImpl.java
+++ b/plugins/lang-plan-a/src/main/java/org/elasticsearch/plan/a/ScriptImpl.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.plan.a;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.lucene.search.Scorer;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.ScoreAccessor;
 import org.elasticsearch.search.lookup.LeafSearchLookup;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * ScriptImpl can be used as either an {@link ExecutableScript} or a {@link LeafSearchScript}
@@ -112,16 +112,6 @@ final class ScriptImpl implements ExecutableScript, LeafSearchScript {
     @Override
     public long runAsLong() {
         return ((Number)run()).longValue();
-    }
-
-    /**
-     * This method has no effect in Plan A.
-     * @param value The value to unwrap.
-     * @return The value passed in.
-     */
-    @Override
-    public Object unwrap(final Object value) {
-        return value;
     }
 
     /**


### PR DESCRIPTION
Tons of scripts just return the variable they are passed and that is the
most intuitive behavior so that may as well be the default implementation.
