### PR TITLE
Cleanup the raw generics in ActionFilter

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/ActionFilter.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ActionFilter.java
@@ -40,13 +40,15 @@ public interface ActionFilter {
      * Enables filtering the execution of an action on the request side, either by sending a response through the
      * {@link ActionListener} or by continuing the execution through the given {@link ActionFilterChain chain}
      */
-    void apply(Task task, String action, ActionRequest<?> request, ActionListener<?> listener, ActionFilterChain chain);
+    <Request extends ActionRequest<Request>, Response extends ActionResponse> void apply(Task task, String action, Request request,
+            ActionListener<Response> listener, ActionFilterChain<Request, Response> chain);
 
     /**
      * Enables filtering the execution of an action on the response side, either by sending a response through the
      * {@link ActionListener} or by continuing the execution through the given {@link ActionFilterChain chain}
      */
-    void apply(String action, ActionResponse response, ActionListener<?> listener, ActionFilterChain chain);
+    <Response extends ActionResponse> void apply(String action, Response response, ActionListener<Response> listener,
+            ActionFilterChain<?, Response> chain);
 
     /**
      * A simple base class for injectable action filters that spares the implementation from handling the
@@ -60,7 +62,8 @@ public interface ActionFilter {
         }
 
         @Override
-        public final void apply(Task task, String action, ActionRequest<?> request, ActionListener<?> listener, ActionFilterChain chain) {
+        public final <Request extends ActionRequest<Request>, Response extends ActionResponse> void apply(Task task, String action, Request request,
+                ActionListener<Response> listener, ActionFilterChain<Request, Response> chain) {
             if (apply(action, request, listener)) {
                 chain.proceed(task, action, request, listener);
             }
@@ -73,7 +76,8 @@ public interface ActionFilter {
         protected abstract boolean apply(String action, ActionRequest<?> request, ActionListener<?> listener);
 
         @Override
-        public final void apply(String action, ActionResponse response, ActionListener<?> listener, ActionFilterChain chain) {
+        public final <Response extends ActionResponse> void apply(String action, Response response, ActionListener<Response> listener,
+                ActionFilterChain<?, Response> chain) {
             if (apply(action, response, listener)) {
                 chain.proceed(action, response, listener);
             }

--- a/core/src/main/java/org/elasticsearch/action/support/ActionFilterChain.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ActionFilterChain.java
@@ -27,17 +27,17 @@ import org.elasticsearch.tasks.Task;
 /**
  * A filter chain allowing to continue and process the transport action request
  */
-public interface ActionFilterChain {
+public interface ActionFilterChain<Request extends ActionRequest<Request>, Response extends ActionResponse> {
 
     /**
      * Continue processing the request. Should only be called if a response has not been sent through
      * the given {@link ActionListener listener}
      */
-    void proceed(Task task, final String action, final ActionRequest request, final ActionListener listener);
+    void proceed(Task task, final String action, final Request request, final ActionListener<Response> listener);
 
     /**
      * Continue processing the response. Should only be called if a response has not been sent through
      * the given {@link ActionListener listener}
      */
-    void proceed(final String action, final ActionResponse response, final ActionListener listener);
+    void proceed(final String action, final Response response, final ActionListener<Response> listener);
 }

--- a/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -220,9 +220,10 @@ public class TransportActionFilterChainTests extends ESTestCase {
 
         RequestTestFilter testFilter = new RequestTestFilter(randomInt(), new RequestCallback() {
             @Override
-            public void execute(Task task, final String action, final ActionRequest actionRequest, final ActionListener actionListener, final ActionFilterChain actionFilterChain) {
+            public <Request extends ActionRequest<Request>, Response extends ActionResponse> void execute(Task task, String action, Request request,
+                    ActionListener<Response> listener, ActionFilterChain<Request, Response> actionFilterChain) {
                 for (int i = 0; i <= additionalContinueCount; i++) {
-                    actionFilterChain.proceed(task, action, actionRequest, actionListener);
+                    actionFilterChain.proceed(task, action, request, listener);
                 }
             }
         });
@@ -276,7 +277,8 @@ public class TransportActionFilterChainTests extends ESTestCase {
 
         ResponseTestFilter testFilter = new ResponseTestFilter(randomInt(), new ResponseCallback() {
             @Override
-            public void execute(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain) {
+            public <Response extends ActionResponse> void execute(String action, Response response, ActionListener<Response> listener,
+                    ActionFilterChain<?, Response> chain) {
                 for (int i = 0; i <= additionalContinueCount; i++) {
                     chain.proceed(action, response, listener);
                 }
@@ -344,17 +346,18 @@ public class TransportActionFilterChainTests extends ESTestCase {
             return order;
         }
 
-        @SuppressWarnings("unchecked")
         @Override
-        public void apply(Task task, String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
+        public <Request extends ActionRequest<Request>, Response extends ActionResponse> void apply(Task task, String action, Request request,
+                ActionListener<Response> listener, ActionFilterChain<Request, Response> chain) {
             this.runs.incrementAndGet();
             this.lastActionName = action;
             this.executionToken = counter.incrementAndGet();
-            this.callback.execute(task, action, actionRequest, actionListener, actionFilterChain);
+            this.callback.execute(task, action, request, listener, chain);
         }
 
         @Override
-        public void apply(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain) {
+        public <Response extends ActionResponse> void apply(String action, Response response, ActionListener<Response> listener,
+                ActionFilterChain<?, Response> chain) {
             chain.proceed(action, response, listener);
         }
     }
@@ -377,12 +380,14 @@ public class TransportActionFilterChainTests extends ESTestCase {
         }
 
         @Override
-        public void apply(Task task, String action, ActionRequest request, ActionListener listener, ActionFilterChain chain) {
+        public <Request extends ActionRequest<Request>, Response extends ActionResponse> void apply(Task task, String action, Request request,
+                ActionListener<Response> listener, ActionFilterChain<Request, Response> chain) {
             chain.proceed(task, action, request, listener);
         }
 
         @Override
-        public void apply(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain) {
+        public <Response extends ActionResponse> void apply(String action, Response response, ActionListener<Response> listener,
+                ActionFilterChain<?, Response> chain) {
             this.runs.incrementAndGet();
             this.lastActionName = action;
             this.executionToken = counter.incrementAndGet();
@@ -393,21 +398,24 @@ public class TransportActionFilterChainTests extends ESTestCase {
     private static enum RequestOperation implements RequestCallback {
         CONTINUE_PROCESSING {
             @Override
-            public void execute(Task task, String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
-                actionFilterChain.proceed(task, action, actionRequest, actionListener);
+            public <Request extends ActionRequest<Request>, Response extends ActionResponse> void execute(Task task, String action, Request request,
+                    ActionListener<Response> listener, ActionFilterChain<Request, Response> actionFilterChain) {
+                actionFilterChain.proceed(task, action, request, listener);
             }
         },
         LISTENER_RESPONSE {
             @Override
-            @SuppressWarnings("unchecked")
-            public void execute(Task task, String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
-                actionListener.onResponse(new TestResponse());
+            @SuppressWarnings("unchecked")  // Safe because its all we test with
+            public <Request extends ActionRequest<Request>, Response extends ActionResponse> void execute(Task task, String action, Request request,
+                    ActionListener<Response> listener, ActionFilterChain<Request, Response> actionFilterChain) {
+                ((ActionListener<TestResponse>) listener).onResponse(new TestResponse());
             }
         },
         LISTENER_FAILURE {
             @Override
-            public void execute(Task task, String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain) {
-                actionListener.onFailure(new ElasticsearchTimeoutException(""));
+            public <Request extends ActionRequest<Request>, Response extends ActionResponse> void execute(Task task, String action, Request request,
+                    ActionListener<Response> listener, ActionFilterChain<Request, Response> actionFilterChain) {
+                listener.onFailure(new ElasticsearchTimeoutException(""));
             }
         }
     }
@@ -415,31 +423,36 @@ public class TransportActionFilterChainTests extends ESTestCase {
     private static enum ResponseOperation implements ResponseCallback {
         CONTINUE_PROCESSING {
             @Override
-            public void execute(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain) {
+            public <Response extends ActionResponse> void execute(String action, Response response, ActionListener<Response> listener,
+                    ActionFilterChain<?, Response> chain) {
                 chain.proceed(action, response, listener);
             }
         },
         LISTENER_RESPONSE {
             @Override
-            @SuppressWarnings("unchecked")
-            public void execute(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain) {
-                listener.onResponse(new TestResponse());
+            @SuppressWarnings("unchecked") // Safe because its all we test with
+            public <Response extends ActionResponse> void execute(String action, Response response, ActionListener<Response> listener,
+                    ActionFilterChain<?, Response> chain) {
+                ((ActionListener<TestResponse>) listener).onResponse(new TestResponse());
             }
         },
         LISTENER_FAILURE {
             @Override
-            public void execute(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain) {
+            public <Response extends ActionResponse> void execute(String action, Response response, ActionListener<Response> listener,
+                    ActionFilterChain<?, Response> chain) {
                 listener.onFailure(new ElasticsearchTimeoutException(""));
             }
         }
     }
 
     private static interface RequestCallback {
-        void execute(Task task, String action, ActionRequest actionRequest, ActionListener actionListener, ActionFilterChain actionFilterChain);
+        <Request extends ActionRequest<Request>, Response extends ActionResponse> void execute(Task task, String action, Request request,
+                ActionListener<Response> listener, ActionFilterChain<Request, Response> actionFilterChain);
     }
 
     private static interface ResponseCallback {
-        void execute(String action, ActionResponse response, ActionListener listener, ActionFilterChain chain);
+        <Response extends ActionResponse> void execute(String action, Response response, ActionListener<Response> listener,
+                ActionFilterChain<?, Response> chain);
     }
 
     public static class TestRequest extends ActionRequest<TestRequest> {

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionModule;
@@ -100,7 +101,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         }
 
         @Override
-        protected boolean apply(String action, ActionRequest request, ActionListener listener) {
+        protected boolean apply(String action, ActionRequest<?> request, ActionListener<?> listener) {
             if (blockedActions.contains(action)) {
                 throw new ElasticsearchException("force exception on [" + action + "]");
             }
@@ -108,7 +109,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         }
 
         @Override
-        protected boolean apply(String action, ActionResponse response, ActionListener listener) {
+        protected boolean apply(String action, ActionResponse response, ActionListener<?> listener) {
             return true;
         }
 


### PR DESCRIPTION
Mostly these were pretty easy to clean up by insisting that the request
and response stays consistent across the filter. There are a few places
where we have to make assumptions in tests but those are valid assumptions
for the test.
