### PR TITLE
Don't guard IndexShard#refresh calls by a check to isRefreshNeeded

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -635,7 +635,9 @@ public final class IndexService extends AbstractIndexComponent implements IndexC
                     case STARTED:
                     case RELOCATED:
                         try {
-                            shard.refresh("schedule");
+                            if (shard.isRefreshNeeded()) {
+                                shard.refresh("schedule");
+                            }
                         } catch (EngineClosedException | AlreadyClosedException ex) {
                             // fine - continue;
                         }


### PR DESCRIPTION
While conceptually correct this call can be confusing since if a
realtime GET is exectued after refresh is called with realtime=true it might
fetch the wrong document out of the translog since the isRefreshNeeded guard
might return false once the new searcher is published but it will not
wait until the verision map is flushed and that can cause a slight race condition
if a subsequent call GETs a document that it expects to come from the index.

Ie. the `_size` mapper tests do this and expecte the GET call to return the document
from the index but it comes from the t-log due to this race.

This change only uses the guard in an async refresh that we schedule to prevent unnecessary
refresh calls but will allow API Refresh calls to have the somewhat less confusing semantics.

This was introduces lately only on unrelease major version branches.

here is a related test failure http://build-us-00.elastic.co/job/es_core_master_regression/4349/
