### PR TITLE
Deprecate fuzzy query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -26,7 +26,11 @@ import java.io.IOException;
 
 /**
  * A Query that does fuzzy matching for a specific value.
+ *
+ * @deprecated Fuzzy queries are not useful enough. This class will be removed with 3.0. In most cases you may want to use a match query
+ * with the fuzziness parameter for strings or range queries for numeric and date fields.
  */
+@Deprecated
 public class FuzzyQueryBuilder extends MultiTermQueryBuilder implements BoostableQueryBuilder<FuzzyQueryBuilder> {
 
     private final String name;
@@ -144,7 +148,7 @@ public class FuzzyQueryBuilder extends MultiTermQueryBuilder implements Boostabl
         this.maxExpansions = maxExpansions;
         return this;
     }
-    
+
     public FuzzyQueryBuilder transpositions(boolean transpositions) {
       this.transpositions = transpositions;
       return this;

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryParser.java
@@ -34,8 +34,10 @@ import org.elasticsearch.index.query.support.QueryParsers;
 import java.io.IOException;
 
 /**
- *
+ * @deprecated Fuzzy queries are not useful enough. This class will be removed with 3.0. In most cases you may want to use a match query
+ * with the fuzziness parameter for strings or range queries for numeric and date fields.
  */
+@Deprecated
 public class FuzzyQueryParser implements QueryParser {
 
     public static final String NAME = "fuzzy";

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -189,7 +189,14 @@ public abstract class QueryBuilders {
      *
      * @param name  The name of the field
      * @param value The value of the term
+     *
+     * @deprecated Fuzzy queries are not useful enough and will be removed with 3.0. In most cases you may want to use a match query
+     * with the fuzziness parameter for strings or range queries for numeric and date fields.
+     *
+     * @see #matchQuery(String, Object)
+     * @see #rangeQuery(String)
      */
+    @Deprecated
     public static FuzzyQueryBuilder fuzzyQuery(String name, String value) {
         return new FuzzyQueryBuilder(name, value);
     }
@@ -199,7 +206,14 @@ public abstract class QueryBuilders {
      *
      * @param name  The name of the field
      * @param value The value of the term
+     *
+     * @deprecated Fuzzy queries are not useful enough and will be removed with 3.0. In most cases you may want to use a match query
+     * with the fuzziness parameter for strings or range queries for numeric and date fields.
+     *
+     * @see #matchQuery(String, Object)
+     * @see #rangeQuery(String)
      */
+    @Deprecated
     public static FuzzyQueryBuilder fuzzyQuery(String name, Object value) {
         return new FuzzyQueryBuilder(name, value);
     }

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleIndexQueryParserTests.java
@@ -449,6 +449,7 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         return (TermQuery) q;
     }
 
+    @SuppressWarnings("deprecation") // fuzzy queries will be removed in 3.0
     @Test
     public void testFuzzyQueryBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();
@@ -469,6 +470,7 @@ public class SimpleIndexQueryParserTests extends ESSingleNodeTestCase {
         assertThat(fuzzyQuery.getRewriteMethod(), instanceOf(MultiTermQuery.TopTermsBlendedFreqScoringRewrite.class));
     }
 
+    @SuppressWarnings("deprecation") // fuzzy queries will be removed in 3.0
     @Test
     public void testFuzzyQueryWithFieldsBuilder() throws IOException {
         IndexQueryParserService queryParser = queryParser();

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
@@ -2393,6 +2393,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
     }
 
+    @SuppressWarnings("deprecation") // fuzzy queries will be removed in 3.0
     @Test
     public void testPostingsHighlighterFuzzyQuery() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));

--- a/core/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesIT.java
+++ b/core/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesIT.java
@@ -249,6 +249,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation") // fuzzy queries will be removed in 3.0
     @Test
     public void testFuzzyQuerySupportsName() {
         createIndex("test1");

--- a/core/src/test/java/org/elasticsearch/search/profile/RandomQueryGenerator.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/RandomQueryGenerator.java
@@ -62,6 +62,7 @@ public class RandomQueryGenerator {
         }
     }
 
+    @SuppressWarnings("deprecation") // #randomFuzzyQuery() will be removed in 3.0
     private static QueryBuilder randomTerminalQuery(List<String> stringFields, List<String> numericFields, int numDocs) {
         switch (randomIntBetween(0,6)) {
             case 0:
@@ -184,6 +185,8 @@ public class RandomQueryGenerator {
         return q;
     }
 
+    @SuppressWarnings("deprecation") // fuzzy queries will be removed in 3.0
+    @Deprecated
     private static QueryBuilder randomFuzzyQuery(List<String> fields) {
 
         QueryBuilder q = QueryBuilders.fuzzyQuery(randomField(fields), randomQueryString(1));

--- a/core/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -214,6 +214,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
         assertThat(validateQueryResponse.getQueryExplanation().get(0).getExplanation(), containsString("field:\"foo (one* two*)\""));
     }
 
+    @SuppressWarnings("deprecation") // fuzzy queries will be removed in 3.0
     @Test
     public void explainWithRewriteValidateQuery() throws Exception {
         client().admin().indices().prepareCreate("test")

--- a/docs/java-api/query-dsl/fuzzy-query.asciidoc
+++ b/docs/java-api/query-dsl/fuzzy-query.asciidoc
@@ -1,6 +1,8 @@
 [[java-query-dsl-fuzzy-query]]
 ==== Fuzzy Query
 
+deprecated[2.3.0, Will be removed without a replacement for `string` fields. Note that the `fuzziness` parameter is still supported for match queries and in suggesters. Use range queries for `date` and `numeric` fields instead.]
+
 See {ref}/query-dsl-fuzzy-query.html[Fuzzy Query]
 
 [source,java]

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -1,6 +1,8 @@
 [[query-dsl-fuzzy-query]]
 === Fuzzy Query
 
+deprecated[2.3.0, Will be removed without a replacement for `string` fields. Note that the `fuzziness` parameter is still supported for match queries and in suggesters. Use range queries for `date` and `numeric` fields instead.]
+
 The fuzzy query uses similarity based on Levenshtein edit distance for
 `string` fields, and a `+/-` margin on numeric and date fields.
 


### PR DESCRIPTION
With this commit we deprecate the widely misunderstood
fuzzy query but will still allow the fuzziness
parameter in match queries and suggesters.

Relates to #15760
