### PR TITLE
Translog: close channel on failures while converting a writer to a reader

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -265,7 +265,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         FileChannel channel = FileChannel.open(path, StandardOpenOption.READ);
         try {
             assert Translog.parseIdFromFileName(path) == checkpoint.generation : "expected generation: " + Translog.parseIdFromFileName(path) + " but got: " + checkpoint.generation;
-            TranslogReader reader = TranslogReader.open(channel, path, checkpoint, translogUUID);
+            TranslogReader reader = TranslogReader.open(channel, path, checkpoint, translogUUID, shardId());
             channel = null;
             return reader;
         } finally {
@@ -1258,9 +1258,9 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
     void closeFilesIfNoPendingViews() throws IOException {
         try (ReleasableLock ignored = writeLock.acquire()) {
             if (closed.get() && outstandingViews.isEmpty()) {
-                logger.trace("closing files. translog is closed and there are no pending views");
                 ArrayList<Closeable> toClose = new ArrayList<>(readers);
                 toClose.add(current);
+                logger.trace("closing [{}] files. translog is closed and there are no pending views", toClose.size());
                 IOUtils.close(toClose);
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogSnapshot.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogSnapshot.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.translog;
 
 import org.elasticsearch.common.io.Channels;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -40,8 +41,8 @@ public class TranslogSnapshot extends BaseTranslogReader implements Translog.Sna
      * Create a snapshot of translog file channel. The length parameter should be consistent with totalOperations and point
      * at the end of the last operation in this snapshot.
      */
-    public TranslogSnapshot(long generation, FileChannel channel, Path path, long firstOperationOffset, long length, int totalOperations) {
-        super(generation, channel, path, firstOperationOffset);
+    public TranslogSnapshot(long generation, FileChannel channel, Path path, long firstOperationOffset, long length, int totalOperations, ShardId shardId) {
+        super(generation, channel, path, firstOperationOffset, shardId);
         this.length = length;
         this.totalOperations = totalOperations;
         this.reusableBuffer = ByteBuffer.allocate(1024);

--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -197,11 +197,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
                 return new TranslogReader(generation, channel, path, firstOperationOffset, getWrittenOffset(), operationCounter, shardId);
             } catch (Throwable t) {
                 // close the channel, as we are closed and failed to create a new reader
-                try {
-                    channel.close();
-                } catch (Throwable tWhileClosing) {
-                    t.addSuppressed(tWhileClosing);
-                }
+                IOUtils.closeWhileHandlingException(channel);
                 throw t;
             }
         } else {

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1742,6 +1742,7 @@ public class TranslogTests extends ESTestCase {
     public void testWithRandomException() throws IOException {
         final int runs = randomIntBetween(5, 10);
         for (int run = 0; run < runs; run++) {
+            logger.info("--> run [{}]", run);
             Path tempDir = createTempDir();
             final FailSwitch fail = new FailSwitch();
             fail.failRandomly();
@@ -1793,6 +1794,8 @@ public class TranslogTests extends ESTestCase {
             } catch (TranslogException | MockDirectoryWrapper.FakeIOException ex) {
                 // failed - that's ok, we didn't even create it
             }
+
+            logger.info("--> finished writing in run [{}]", run);
             // now randomly open this failing tlog again just to make sure we can also recover from failing during recovery
             if (randomBoolean()) {
                 try {
@@ -1802,6 +1805,7 @@ public class TranslogTests extends ESTestCase {
                 }
             }
 
+            logger.info("--> validating translog. run [{}]", run);
             try (Translog translog = new Translog(config)) {
                 Translog.Snapshot snapshot = translog.newSnapshot();
                 assertEquals(syncedDocs.size(), snapshot.totalOperations());

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogVersionTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogVersionTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.translog;
 
 import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -87,7 +88,7 @@ public class TranslogVersionTests extends ESTestCase {
     public TranslogReader openReader(Path path, long id) throws IOException {
         FileChannel channel = FileChannel.open(path, StandardOpenOption.READ);
         try {
-            TranslogReader reader = TranslogReader.open(channel, path, new Checkpoint(Files.size(path), 1, id), null);
+            TranslogReader reader = TranslogReader.open(channel, path, new Checkpoint(Files.size(path), 1, id), null, new ShardId("test", 0));
             channel = null;
             return reader;
         } finally {


### PR DESCRIPTION
TranslogWriter.closeIntoReader transfers the file ownership from a writer to a reader and closes the writer. If the transfer fails, we need to make sure we closed the underlying channel as the writer is already closes.

See: http://build-us-00.elastic.co/job/es_core_master_regression/4355
