### PR TITLE
Fix the use of nested `inner_hits` in query dsl

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -109,6 +110,8 @@ public class QueryShardContext {
     private NestedScope nestedScope;
     private QueryParseContext parseContext;
     boolean isFilter; // pkg private for testing
+    private boolean hasParentQueryWithInnerHits;
+    private Map<String, InnerHitsContext.BaseInnerHits> childInnerHits;
 
     public QueryShardContext(IndexSettings indexSettings, Client client, BitsetFilterCache bitsetFilterCache, IndexFieldDataService indexFieldDataService, MapperService mapperService, SimilarityService similarityService, ScriptService scriptService,
                              final IndicesQueriesRegistry indicesQueriesRegistry) {
@@ -244,6 +247,29 @@ public class QueryShardContext {
             innerHitsContext = sc.innerHits();
         }
         innerHitsContext.addInnerHitDefinition(name, context);
+    }
+
+    public void setChildInnerHits(String name, InnerHitsContext.BaseInnerHits innerHits) {
+        this.childInnerHits = Collections.singletonMap(name, innerHits);
+    }
+
+    /**
+     * @return Any inner hits that an inner query has processed if {@link #hasParentQueryWithInnerHits()} was set
+     * to true before processing the inner query.
+     */
+    public Map<String, InnerHitsContext.BaseInnerHits>  getChildInnerHits() {
+        return childInnerHits;
+    }
+
+    /**
+     * @return Whether a parent query in the dsl has inner hits enabled
+     */
+    public boolean hasParentQueryWithInnerHits() {
+        return hasParentQueryWithInnerHits;
+    }
+
+    public void setHasParentQueryWithInnerHits(boolean hasParentQueryWithInnerHits) {
+        this.hasParentQueryWithInnerHits = hasParentQueryWithInnerHits;
     }
 
     public Collection<String> simpleMatchToIndexNames(String pattern) {

--- a/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsIT.java
@@ -1219,4 +1219,255 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertHitCount(response, 1);
     }
 
+    public void testParentChildHierarchy() throws Exception {
+        assertAcked(prepareCreate("index1")
+            .addMapping("level1")
+            .addMapping("level2", "_parent", "type=level1")
+            .addMapping("level3", "_parent", "type=level2")
+            .addMapping("level4", "_parent", "type=level3")
+        );
+
+        client().prepareIndex("index1", "level1", "1").setSource("{}").get();
+        client().prepareIndex("index1", "level2", "2").setParent("1").setRouting("1").setSource("{}").get();
+        client().prepareIndex("index1", "level3", "3").setParent("2").setRouting("1").setSource("{}").get();
+        client().prepareIndex("index1", "level4", "4").setParent("3").setRouting("1").setSource("{}").get();
+        refresh();
+
+        SearchResponse response = client().prepareSearch("index1")
+            .setQuery(
+                hasChildQuery("level2",
+                    hasChildQuery("level3",
+                        hasChildQuery("level4", matchAllQuery()).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+                    ).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+                ).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+            )
+            .get();
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+        assertThat(response.getHits().getAt(0).getType(), equalTo("level1"));
+        assertThat(response.getHits().getAt(0).getIndex(), equalTo("index1"));
+
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("level2");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("level2"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+
+        assertThat(innerHits.getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("level3");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("level3"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("3"));
+
+        assertThat(innerHits.getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("level4");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("level4"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("4"));
+        assertThat(innerHits.getAt(0).getInnerHits(), nullValue());
+
+        response = client().prepareSearch("index1")
+            .setQuery(
+                hasParentQuery("level3",
+                    hasParentQuery("level2",
+                        hasParentQuery("level1", matchAllQuery()).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+                    ).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+                ).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+            )
+            .get();
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).getId(), equalTo("4"));
+        assertThat(response.getHits().getAt(0).getType(), equalTo("level4"));
+        assertThat(response.getHits().getAt(0).getIndex(), equalTo("index1"));
+
+        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = response.getHits().getAt(0).getInnerHits().get("level3");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("level3"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("3"));
+
+        assertThat(innerHits.getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("level2");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("level2"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+
+        assertThat(innerHits.getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("level1");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("level1"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+    }
+
+    public void testNestedHierarchy() throws Exception {
+        XContentBuilder mapping  = jsonBuilder().startObject().startObject("type").startObject("properties")
+                .startObject("level1")
+                    .field("type", "nested")
+                    .startObject("properties")
+                        .startObject("level2")
+                            .field("type", "nested")
+                            .startObject("properties")
+                                .startObject("level3")
+                                    .field("type", "nested")
+                                    .startObject("properties")
+                                        .startObject("level4")
+                                            .field("type", "nested")
+                                        .endObject()
+                                    .endObject()
+                                .endObject()
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .endObject().endObject().endObject();
+        assertAcked(prepareCreate("index")
+            .addMapping("type", mapping)
+        );
+
+        XContentBuilder source = jsonBuilder().startObject()
+            .startArray("level1")
+                .startObject()
+                    .field("field", "value1")
+                    .startArray("level2")
+                        .startObject()
+                            .field("field", "value2")
+                            .startArray("level3")
+                                .startObject()
+                                    .field("field", "value3")
+                                    .startArray("level4")
+                                        .startObject()
+                                            .field("field", "value4")
+                                        .endObject()
+                                    .endArray()
+                                .endObject()
+                            .endArray()
+                        .endObject()
+                    .endArray()
+                .endObject()
+            .endArray()
+            .endObject();
+        client().prepareIndex("index", "type", "1").setSource(source).get();
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch("index")
+            .setQuery(
+                nestedQuery("level1",
+                    nestedQuery("level1.level2",
+                        nestedQuery("level1.level2.level3",
+                            nestedQuery("level1.level2.level3.level4", matchAllQuery()).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+                        ).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+                    ).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+                ).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+            )
+            .get();
+
+        assertHitCount(searchResponse, 1);
+        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
+        assertThat(searchResponse.getHits().getAt(0).getType(), equalTo("type"));
+        assertThat(searchResponse.getHits().getAt(0).getNestedIdentity(), nullValue());
+
+        assertThat(searchResponse.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        SearchHits innerHits = searchResponse.getHits().getAt(0).getInnerHits().get("level1");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("type"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("level1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild(), nullValue());
+
+        assertThat(innerHits.getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("level1.level2");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("type"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("level1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getField().string(), equalTo("level2"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild(), nullValue());
+
+        assertThat(innerHits.getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("level1.level2.level3");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("type"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("level1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getField().string(), equalTo("level2"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild().getField().string(), equalTo("level3"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild().getChild(), nullValue());
+
+        assertThat(innerHits.getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("level1.level2.level3.level4");
+        assertThat(innerHits, notNullValue());
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getType(), equalTo("type"));
+        assertThat(innerHits.getAt(0).getId(), equalTo("1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("level1"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getField().string(), equalTo("level2"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild().getField().string(), equalTo("level3"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild().getChild().getField().string(), equalTo("level4"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild().getChild().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild().getChild().getChild().getChild(), nullValue());
+    }
+
+    public void testParentChildAndNestedHierarchy() throws Exception {
+        assertAcked(prepareCreate("index")
+            .addMapping("level1")
+            .addMapping("level2", "_parent", "type=level1", "level3", "type=nested")
+        );
+
+        client().prepareIndex("index", "level1", "1").setSource("{}").get();
+        XContentBuilder source = jsonBuilder().startObject()
+            .startArray("level3")
+                .startObject()
+                    .field("field", "value")
+                .endObject()
+            .endArray()
+            .endObject();
+        client().prepareIndex("index", "level2", "2").setParent("1").setSource(source).get();
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch("index")
+            .setQuery(
+                hasChildQuery("level2",
+                    nestedQuery("level3", matchAllQuery()).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+                ).innerHit(new QueryInnerHits(null, new InnerHitsBuilder.InnerHit()))
+            )
+            .get();
+        assertHitCount(searchResponse, 1);
+        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
+        assertThat(searchResponse.getHits().getAt(0).getType(), equalTo("level1"));
+
+        assertThat(searchResponse.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+        SearchHits innerHits = searchResponse.getHits().getAt(0).getInnerHits().get("level2");
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(0).getType(), equalTo("level2"));
+        assertThat(innerHits.getAt(0).getNestedIdentity(), nullValue());
+
+        assertThat(innerHits.getAt(0).getInnerHits().size(), equalTo(1));
+        innerHits = innerHits.getAt(0).getInnerHits().get("level3");
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
+        assertThat(innerHits.getAt(0).getId(), equalTo("2"));
+        assertThat(innerHits.getAt(0).getType(), equalTo("level2"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("level3"));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
+        assertThat(innerHits.getAt(0).getNestedIdentity().getChild(), nullValue());
+    }
+
 }


### PR DESCRIPTION
Fix support for using inner hits hierarchically when using nested `has_child`, `has_parent` or `nested` queries in the query dsl.

PR for #11118
