### PR TITLE
Check for invalid index settings on metadata upgrade

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -20,11 +20,15 @@ package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.misc.IndexMergeTool;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.MapperService;
@@ -32,6 +36,7 @@ import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableSet;
@@ -48,11 +53,13 @@ import static org.elasticsearch.common.util.set.Sets.newHashSet;
 public class MetaDataIndexUpgradeService extends AbstractComponent {
 
     private final MapperRegistry mapperRegistry;
+    private final IndexScopedSettings indexScopedSettigns;
 
     @Inject
-    public MetaDataIndexUpgradeService(Settings settings, MapperRegistry mapperRegistry) {
+    public MetaDataIndexUpgradeService(Settings settings, MapperRegistry mapperRegistry, IndexScopedSettings indexScopedSettings) {
         super(settings);
         this.mapperRegistry = mapperRegistry;
+        this.indexScopedSettigns = indexScopedSettings;
     }
 
     /**
@@ -65,13 +72,13 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
     public IndexMetaData upgradeIndexMetaData(IndexMetaData indexMetaData) {
         // Throws an exception if there are too-old segments:
         if (isUpgraded(indexMetaData)) {
-            return indexMetaData;
+            return archiveBrokenIndexSettings(indexMetaData);
         }
         checkSupportedVersion(indexMetaData);
         IndexMetaData newMetaData = indexMetaData;
         checkMappingsCompatibility(newMetaData);
         newMetaData = markAsUpgraded(newMetaData);
-        return newMetaData;
+        return archiveBrokenIndexSettings(newMetaData);
     }
 
 
@@ -79,7 +86,7 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
      * Checks if the index was already opened by this version of Elasticsearch and doesn't require any additional checks.
      */
     private boolean isUpgraded(IndexMetaData indexMetaData) {
-        return indexMetaData.getUpgradedVersion().onOrAfter(Version.V_3_0_0);
+        return indexMetaData.getUpgradedVersion().onOrAfter(Version.V_3_0_0); // TODO should this be Version.CURRENT?
     }
 
     /**
@@ -169,6 +176,41 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
             fakeAnalyzer.close();
             super.close();
         }
+    }
+
+    private static final String ARCHIVED_SETTINGS_PREFIX = "archived.";
+
+    IndexMetaData archiveBrokenIndexSettings(IndexMetaData indexMetaData) {
+        Settings settings = indexMetaData.getSettings();
+        Settings.Builder builder = Settings.builder();
+        boolean changed = false;
+        for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
+            try {
+                Setting<?> setting = indexScopedSettigns.get(entry.getKey());
+                if (setting != null) {
+                    setting.get(settings);
+                    builder.put(entry.getKey(), entry.getValue());
+                } else {
+                    if (indexScopedSettigns.isPrivateSetting(entry.getKey()) || entry.getKey().startsWith(ARCHIVED_SETTINGS_PREFIX)) {
+                        builder.put(entry.getKey(), entry.getValue());
+                    } else {
+                        changed = true;
+                        logger.warn("[{}] found unknown index setting: {} value: {} - archiving", indexMetaData.getIndex(), entry.getKey(), entry.getValue());
+                        // we put them back in here such that tools can check from the outside if there are any indices with broken settings. The setting can remain there
+                        // but we want users to be aware that some of their setting are broken and they can research why and what they need to do to replace them.
+                        builder.put(ARCHIVED_SETTINGS_PREFIX + entry.getKey(), entry.getValue());
+                    }
+                }
+            } catch (IllegalArgumentException ex) {
+                changed = true;
+                logger.warn("[{}] found invalid index setting: {} value: {} - archiving",ex, indexMetaData.getIndex(), entry.getKey(), entry.getValue());
+                // we put them back in here such that tools can check from the outside if there are any indices with broken settings. The setting can remain there
+                // but we want users to be aware that some of their setting sare broken and they can research why and what they need to do to replace them.
+                builder.put(ARCHIVED_SETTINGS_PREFIX + entry.getKey(), entry.getValue());
+            }
+        }
+
+        return changed ? IndexMetaData.builder(indexMetaData).settings(builder.build()).build() : indexMetaData;
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -152,4 +152,17 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
     public IndexScopedSettings copy(Settings settings, IndexMetaData metaData) {
         return new IndexScopedSettings(settings, this, metaData);
     }
+
+    public boolean isPrivateSetting(String key) {
+        switch (key) {
+            case IndexMetaData.SETTING_CREATION_DATE:
+            case IndexMetaData.SETTING_INDEX_UUID:
+            case IndexMetaData.SETTING_VERSION_CREATED:
+            case IndexMetaData.SETTING_VERSION_UPGRADED:
+            case MergePolicyConfig.INDEX_MERGE_ENABLED:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeServiceTests.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.mapper.MapperRegistry;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+
+public class MetaDataIndexUpgradeServiceTests extends ESTestCase {
+
+    public void testArchiveBrokenIndexSettings() {
+        MetaDataIndexUpgradeService service = new MetaDataIndexUpgradeService(Settings.EMPTY, new MapperRegistry(Collections.emptyMap(), Collections.emptyMap()), IndexScopedSettings.DEFAULT_SCOPED_SETTINGS);
+        IndexMetaData src = newIndexMeta("foo", Settings.EMPTY);
+        IndexMetaData indexMetaData = service.archiveBrokenIndexSettings(src);
+        assertSame(indexMetaData, src);
+
+        src = newIndexMeta("foo", Settings.builder().put("index.refresh_interval", "-200").build());
+        indexMetaData = service.archiveBrokenIndexSettings(src);
+        assertNotSame(indexMetaData, src);
+        assertEquals("-200", indexMetaData.getSettings().get("archived.index.refresh_interval"));
+
+        src = newIndexMeta("foo", Settings.builder().put("index.codec", "best_compression1").build());
+        indexMetaData = service.archiveBrokenIndexSettings(src);
+        assertNotSame(indexMetaData, src);
+        assertEquals("best_compression1", indexMetaData.getSettings().get("archived.index.codec"));
+
+        src = newIndexMeta("foo", Settings.builder().put("index.refresh.interval", "-1").build());
+        indexMetaData = service.archiveBrokenIndexSettings(src);
+        assertNotSame(indexMetaData, src);
+        assertEquals("-1", indexMetaData.getSettings().get("archived.index.refresh.interval"));
+
+        src = newIndexMeta("foo", indexMetaData.getSettings()); // double archive?
+        indexMetaData = service.archiveBrokenIndexSettings(src);
+        assertSame(indexMetaData, src);
+    }
+
+    public static IndexMetaData newIndexMeta(String name, Settings indexSettings) {
+        Settings build = Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_CREATION_DATE, 1)
+            .put(IndexMetaData.SETTING_INDEX_UUID, "BOOM")
+            .put(IndexMetaData.SETTING_VERSION_UPGRADED, Version.V_0_18_1_ID)
+            .put(indexSettings)
+            .build();
+        IndexMetaData metaData = IndexMetaData.builder(name).settings(build).build();
+        return metaData;
+    }
+
+}


### PR DESCRIPTION
this change allows us to open existing IndexMetaData that contains invalid, removed settings
or settings with invalid values and instead of filling up the users disks with exceptions we _archive_
the settings with and `archive.` prefix. This allows us to warn the user via logs (once it's archived) as
well as via external tools like the upgrade validation tool since those archived settings will be preserved
even over restarts etc. It will prevent indices from failing during the allocaiton phase but instead will
print a prominent warning on index metadata recovery from disk.
