### PR TITLE
[Ingest] rename processor_tag to tag

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulateProcessorResult.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.ingest.core.IngestDocument;
 
 import java.io.IOException;
@@ -92,7 +93,7 @@ public class SimulateProcessorResult implements Writeable<SimulateProcessorResul
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         if (processorTag != null) {
-            builder.field("processor_tag", processorTag);
+            builder.field(AbstractProcessorFactory.TAG_KEY, processorTag);
         }
         if (failure == null) {
             ingestDocument.toXContent(builder, params);

--- a/core/src/main/java/org/elasticsearch/ingest/core/AbstractProcessorFactory.java
+++ b/core/src/main/java/org/elasticsearch/ingest/core/AbstractProcessorFactory.java
@@ -27,11 +27,11 @@ import java.util.Map;
  * Whether changes are made and what exactly is modified is up to the implementation.
  */
 public abstract class AbstractProcessorFactory<P extends Processor> implements Processor.Factory<P> {
-    static final String PROCESSOR_TAG_KEY = "processor_tag";
+    public static final String TAG_KEY = "tag";
 
     @Override
     public P create(Map<String, Object> config) throws Exception {
-        String tag = ConfigurationUtils.readOptionalStringProperty(config, PROCESSOR_TAG_KEY);
+        String tag = ConfigurationUtils.readOptionalStringProperty(config, TAG_KEY);
         return doCreate(tag, config);
     }
 

--- a/core/src/test/java/org/elasticsearch/ingest/core/PipelineFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/core/PipelineFactoryTests.java
@@ -20,8 +20,6 @@
 package org.elasticsearch.ingest.core;
 
 import org.elasticsearch.ingest.TestProcessor;
-import org.elasticsearch.ingest.core.Pipeline;
-import org.elasticsearch.ingest.core.Processor;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -37,7 +35,7 @@ public class PipelineFactoryTests extends ESTestCase {
     public void testCreate() throws Exception {
         Map<String, Object> processorConfig0 = new HashMap<>();
         Map<String, Object> processorConfig1 = new HashMap<>();
-        processorConfig0.put(AbstractProcessorFactory.PROCESSOR_TAG_KEY, "first-processor");
+        processorConfig0.put(AbstractProcessorFactory.TAG_KEY, "first-processor");
         Map<String, Object> pipelineConfig = new HashMap<>();
         pipelineConfig.put(Pipeline.DESCRIPTION_KEY, "_description");
         pipelineConfig.put(Pipeline.PROCESSORS_KEY, Arrays.asList(Collections.singletonMap("test", processorConfig0), Collections.singletonMap("test", processorConfig1)));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/AppendProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/AppendProcessorFactoryTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.processor;
 
 import org.elasticsearch.ingest.TestTemplateService;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -50,7 +51,7 @@ public class AppendProcessorFactoryTests extends ESTestCase {
         }
         config.put("value", value);
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         AppendProcessor appendProcessor = factory.create(config);
         assertThat(appendProcessor.getTag(), equalTo(processorTag));
         assertThat(appendProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/ConvertProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/ConvertProcessorFactoryTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
-import org.elasticsearch.ingest.processor.ConvertProcessor;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
@@ -37,7 +37,7 @@ public class ConvertProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("type", type.toString());
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         ConvertProcessor convertProcessor = factory.create(config);
         assertThat(convertProcessor.getTag(), equalTo(processorTag));
         assertThat(convertProcessor.getField(), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/DateProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/DateProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.DateTimeZone;
 
@@ -42,7 +43,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
         config.put("match_field", sourceField);
         config.put("match_formats", Collections.singletonList("dd/MM/yyyyy"));
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         DateProcessor processor = factory.create(config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getMatchField(), equalTo(sourceField));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/DeDotProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/DeDotProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -40,7 +41,7 @@ public class DeDotProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("separator", "_");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         DeDotProcessor deDotProcessor = factory.create(config);
         assertThat(deDotProcessor.getSeparator(), equalTo("_"));
         assertThat(deDotProcessor.getTag(), equalTo(processorTag));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/FailProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/FailProcessorFactoryTests.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.ingest.processor;
 
 import org.elasticsearch.ingest.TestTemplateService;
-import org.elasticsearch.ingest.processor.FailProcessor;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -43,7 +43,7 @@ public class FailProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("message", "error");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         FailProcessor failProcessor = factory.create(config);
         assertThat(failProcessor.getTag(), equalTo(processorTag));
         assertThat(failProcessor.getMessage().execute(Collections.emptyMap()), equalTo("error"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/GsubProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/GsubProcessorFactoryTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
-import org.elasticsearch.ingest.processor.GsubProcessor;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -36,7 +36,7 @@ public class GsubProcessorFactoryTests extends ESTestCase {
         config.put("pattern", "\\.");
         config.put("replacement", "-");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         GsubProcessor gsubProcessor = factory.create(config);
         assertThat(gsubProcessor.getTag(), equalTo(processorTag));
         assertThat(gsubProcessor.getField(), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/JoinProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/JoinProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class JoinProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("separator", "-");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         JoinProcessor joinProcessor = factory.create(config);
         assertThat(joinProcessor.getTag(), equalTo(processorTag));
         assertThat(joinProcessor.getField(), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/LowercaseProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/LowercaseProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -33,7 +34,7 @@ public class LowercaseProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         LowercaseProcessor uppercaseProcessor = factory.create(config);
         assertThat(uppercaseProcessor.getTag(), equalTo(processorTag));
         assertThat(uppercaseProcessor.getField(), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/RemoveProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/RemoveProcessorFactoryTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.processor;
 
 import org.elasticsearch.ingest.TestTemplateService;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -42,7 +43,7 @@ public class RemoveProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         RemoveProcessor removeProcessor = factory.create(config);
         assertThat(removeProcessor.getTag(), equalTo(processorTag));
         assertThat(removeProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/RenameProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/RenameProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class RenameProcessorFactoryTests extends ESTestCase {
         config.put("field", "old_field");
         config.put("to", "new_field");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         RenameProcessor renameProcessor = factory.create(config);
         assertThat(renameProcessor.getTag(), equalTo(processorTag));
         assertThat(renameProcessor.getOldFieldName(), equalTo("old_field"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/SetProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/SetProcessorFactoryTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.processor;
 
 import org.elasticsearch.ingest.TestTemplateService;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -43,7 +44,7 @@ public class SetProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("value", "value1");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         SetProcessor setProcessor = factory.create(config);
         assertThat(setProcessor.getTag(), equalTo(processorTag));
         assertThat(setProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/SplitProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/SplitProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class SplitProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("separator", "\\.");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         SplitProcessor splitProcessor = factory.create(config);
         assertThat(splitProcessor.getTag(), equalTo(processorTag));
         assertThat(splitProcessor.getField(), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/TrimProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/TrimProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -33,7 +34,7 @@ public class TrimProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         TrimProcessor uppercaseProcessor = factory.create(config);
         assertThat(uppercaseProcessor.getTag(), equalTo(processorTag));
         assertThat(uppercaseProcessor.getField(), equalTo("field1"));

--- a/core/src/test/java/org/elasticsearch/ingest/processor/UppercaseProcessorFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/processor/UppercaseProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.processor;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -33,7 +34,7 @@ public class UppercaseProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         UppercaseProcessor uppercaseProcessor = factory.create(config);
         assertThat(uppercaseProcessor.getTag(), equalTo(processorTag));
         assertThat(uppercaseProcessor.getField(), equalTo("field1"));

--- a/modules/ingest-grok/src/test/java/org/elasticsearch/ingest/grok/GrokProcessorFactoryTests.java
+++ b/modules/ingest-grok/src/test/java/org/elasticsearch/ingest/grok/GrokProcessorFactoryTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.ingest.grok;
 
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
@@ -37,7 +38,7 @@ public class GrokProcessorFactoryTests extends ESTestCase {
         config.put("field", "_field");
         config.put("pattern", "(?<foo>\\w+)");
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
         GrokProcessor processor = factory.create(config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getMatchField(), equalTo("_field"));

--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.geoip;
 
 import com.maxmind.geoip2.DatabaseReader;
+import org.elasticsearch.ingest.core.AbstractProcessorFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;
 import org.junit.BeforeClass;
@@ -61,7 +62,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         config.put("source_field", "_field");
 
         String processorTag = randomAsciiOfLength(10);
-        config.put("processor_tag", processorTag);
+        config.put(AbstractProcessorFactory.TAG_KEY, processorTag);
 
         GeoIpProcessor processor = factory.create(config);
         assertThat(processor.getTag(), equalTo(processorTag));

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/40_simulate.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/40_simulate.yaml
@@ -206,7 +206,7 @@
               "processors": [
                 {
                   "set" : {
-                    "processor_tag" : "processor[set]-0",
+                    "tag" : "processor[set]-0",
                     "field" : "field2",
                     "value" : "_value"
                   }
@@ -232,7 +232,7 @@
           }
   - length: { docs: 1 }
   - length: { docs.0.processor_results: 2 }
-  - match: { docs.0.processor_results.0.processor_tag: "processor[set]-0" }
+  - match: { docs.0.processor_results.0.tag: "processor[set]-0" }
   - length: { docs.0.processor_results.0.doc._source: 2 }
   - match: { docs.0.processor_results.0.doc._source.foo: "bar" }
   - match: { docs.0.processor_results.0.doc._source.field2: "_value" }
@@ -356,20 +356,20 @@
               "processors": [
                 {
                   "set" : {
-                    "processor_tag" : "setstatus-1",
+                    "tag" : "setstatus-1",
                     "field" : "status",
                     "value" : 200
                   }
                 },
                 {
                   "rename" : {
-                    "processor_tag" : "rename-1",
+                    "tag" : "rename-1",
                     "field" : "foofield",
                     "to" : "field1",
                     "on_failure" : [
                       {
                         "set" : {
-                          "processor_tag" : "set on_failure rename",
+                          "tag" : "set on_failure rename",
                           "field" : "foofield",
                           "value" : "exists"
                         }
@@ -406,15 +406,15 @@
           }
   - length: { docs: 1 }
   - length: { docs.0.processor_results: 5 }
-  - match: { docs.0.processor_results.0.processor_tag: "setstatus-1" }
+  - match: { docs.0.processor_results.0.tag: "setstatus-1" }
   - match: { docs.0.processor_results.0.doc._source.field1: "123.42 400 <foo>" }
   - match: { docs.0.processor_results.0.doc._source.status: 200 }
-  - match: { docs.0.processor_results.1.processor_tag: "rename-1" }
+  - match: { docs.0.processor_results.1.tag: "rename-1" }
   - match: { docs.0.processor_results.1.error.type: "illegal_argument_exception" }
   - match: { docs.0.processor_results.1.error.reason: "field [foofield] doesn't exist" }
-  - match: { docs.0.processor_results.2.processor_tag: "set on_failure rename" }
-  - is_false: docs.0.processor_results.3.processor_tag
-  - is_false: docs.0.processor_results.4.processor_tag
+  - match: { docs.0.processor_results.2.tag: "set on_failure rename" }
+  - is_false: docs.0.processor_results.3.tag
+  - is_false: docs.0.processor_results.4.tag
   - match: { docs.0.processor_results.4.doc._source.foofield: "exists" }
   - match: { docs.0.processor_results.4.doc._source.foofield2: "ran" }
   - match: { docs.0.processor_results.4.doc._source.field1: "123.42 400 <foo>" }


### PR DESCRIPTION
`processor_tag` is a bit verbose given that the key name is already within the scope of a processor's config. so `tag` is sufficient.
