### PR TITLE
Default standard output to the journal in systemd

### DIFF
--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -26,11 +26,8 @@ ExecStart=/usr/share/elasticsearch/bin/elasticsearch \
                                                 -Des.default.path.data=${DATA_DIR} \
                                                 -Des.default.path.conf=${CONF_DIR}
 
-# Connects standard output to /dev/null
-StandardOutput=null
-
-# Connects standard error to journal
-StandardError=journal
+StandardOutput=journal
+StandardError=inherit
 
 # Specifies the maximum file descriptor number that can be opened by this process
 LimitNOFILE=65535

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -644,3 +644,14 @@ When percolating an existing document then specifying a document in the source o
 any more.
 
 Percolator documents are no longer excluded from the search response.
+
+=== Default logging using systemd
+
+In previous versions of Elasticsearch, the default logging
+configuration routed standard output to /dev/null and standard error to
+the journal. However, there are often critical error messages at
+startup that are logged to standard output rather than standard error
+and these error messages would be lost to the nether. The default has
+changed to now route standard output to the journal and standard error
+to inherit this setting (these are the defaults for systemd). These
+settings can be modified by editing the elasticsearch.service file.


### PR DESCRIPTION
This commit modifies the default setting for standard output in the
systemd configuration to the journal instead of /dev/null. This is to
address a user pain point where Elasticsearch would fail to start but
the error message would be sent to standard output and therefore
/dev/null leading to difficult-to-debug situations.

Relates #15315, relates #16134 
