### PR TITLE
Geoip processor: remove redundant latitude and longitude fields and make location an object with lat and lon subfields

### DIFF
--- a/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/plugins/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -163,16 +163,11 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 case TIMEZONE:
                     geoData.put("timezone", location.getTimeZone());
                     break;
-                case LATITUDE:
-                    geoData.put("latitude", location.getLatitude());
-                    break;
-                case LONGITUDE:
-                    geoData.put("longitude", location.getLongitude());
-                    break;
                 case LOCATION:
-                    if (location.getLatitude() != null && location.getLongitude() != null) {
-                        geoData.put("location", Arrays.asList(location.getLongitude(), location.getLatitude()));
-                    }
+                    Map<String, Object> locationObject = new HashMap<>();
+                    locationObject.put("lat", location.getLatitude());
+                    locationObject.put("lon", location.getLongitude());
+                    geoData.put("location", locationObject);
                     break;
             }
         }

--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -20,12 +20,11 @@
 package org.elasticsearch.ingest.geoip;
 
 import com.maxmind.geoip2.DatabaseReader;
-import org.elasticsearch.ingest.core.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
+import org.elasticsearch.ingest.core.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +46,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(ingestDocument.getSourceAndMetadata().get("source_field"), equalTo("82.170.213.79"));
         @SuppressWarnings("unchecked")
         Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
-        assertThat(geoData.size(), equalTo(10));
+        assertThat(geoData.size(), equalTo(8));
         assertThat(geoData.get("ip"), equalTo("82.170.213.79"));
         assertThat(geoData.get("country_iso_code"), equalTo("NL"));
         assertThat(geoData.get("country_name"), equalTo("Netherlands"));
@@ -55,9 +54,10 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("region_name"), equalTo("North Holland"));
         assertThat(geoData.get("city_name"), equalTo("Amsterdam"));
         assertThat(geoData.get("timezone"), equalTo("Europe/Amsterdam"));
-        assertThat(geoData.get("latitude"), equalTo(52.374));
-        assertThat(geoData.get("longitude"), equalTo(4.8897));
-        assertThat(geoData.get("location"), equalTo(Arrays.asList(4.8897d, 52.374d)));
+        Map<String, Object> location = new HashMap<>();
+        location.put("lat", 52.374d);
+        location.put("lon", 4.8897d);
+        assertThat(geoData.get("location"), equalTo(location));
     }
 
     public void testCountry() throws Exception {

--- a/plugins/ingest-geoip/src/test/resources/rest-api-spec/test/ingest_geoip/20_geoip_processor.yaml
+++ b/plugins/ingest-geoip/src/test/resources/rest-api-spec/test/ingest_geoip/20_geoip_processor.yaml
@@ -33,7 +33,8 @@
   - length: { _source.geoip: 5 }
   - match: { _source.geoip.city_name: "Minneapolis" }
   - match: { _source.geoip.country_iso_code: "US" }
-  - match: { _source.geoip.location: [-93.2166, 44.9759] }
+  - match: { _source.geoip.location.lon: -93.2166 }
+  - match: { _source.geoip.location.lat: 44.9759 }
   - match: { _source.geoip.region_name: "Minnesota" }
   - match: { _source.geoip.continent_name: "North America" }
 
@@ -74,13 +75,12 @@
         type: test
         id: 1
   - match: { _source.field1: "128.101.101.101" }
-  - length: { _source.geoip: 10 }
+  - length: { _source.geoip: 8 }
   - match: { _source.geoip.city_name: "Minneapolis" }
   - match: { _source.geoip.country_iso_code: "US" }
   - match: { _source.geoip.ip: "128.101.101.101" }
-  - match: { _source.geoip.latitude: 44.9759 }
-  - match: { _source.geoip.longitude: -93.2166 }
-  - match: { _source.geoip.location: [-93.2166, 44.9759] }
+  - match: { _source.geoip.location.lon: -93.2166 }
+  - match: { _source.geoip.location.lat: 44.9759 }
   - match: { _source.geoip.timezone: "America/Chicago" }
   - match: { _source.geoip.country_name: "United States" }
   - match: { _source.geoip.region_name: "Minnesota" }


### PR DESCRIPTION
Geoip processor: remove redundant latitude and longitude fields and make location an object with lat and lon subfields
