### PR TITLE
Scripting: Allow to get size of array in mustache

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -61,7 +61,9 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
 
         @Override
         public Object get(Object key) {
-            if (key instanceof Number) {
+            if ("size".equals(key)) {
+                return size();
+            } else if (key instanceof Number) {
                 return Array.get(array, ((Number) key).intValue());
             }
             try {
@@ -117,7 +119,9 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
 
         @Override
         public Object get(Object key) {
-            if (key instanceof Number) {
+            if ("size".equals(key)) {
+                return col.size();
+            } else if (key instanceof Number) {
                 return Iterables.get(col, ((Number) key).intValue());
             }
             try {


### PR DESCRIPTION
This adds support for returning the size of an array
or an collection, in addition to access fields via
`array.0` you can specify `array.size` to get its size.
