### PR TITLE
Security permissions for Groovy closures

### DIFF
--- a/modules/lang-groovy/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/lang-groovy/src/main/plugin-metadata/plugin-security.policy
@@ -53,4 +53,5 @@ grant {
   permission org.elasticsearch.script.ClassPermission "groovy.lang.Closure";
   permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.GeneratedClosure";
   permission org.elasticsearch.script.ClassPermission "groovy.lang.MetaClass";
+  permission org.elasticsearch.script.ClassPermission "groovy.lang.Range";
 };

--- a/modules/lang-groovy/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/lang-groovy/src/main/plugin-metadata/plugin-security.policy
@@ -25,6 +25,7 @@ grant {
   // needed by groovy engine
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed by GroovyScriptEngineService to close its classloader (why?)
   permission java.lang.RuntimePermission "closeClassLoader";
   // Allow executing groovy scripts with codesource of /untrusted
@@ -48,4 +49,8 @@ grant {
   permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation";
   permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.vmplugin.v7.IndyInterface";
   permission org.elasticsearch.script.ClassPermission "sun.reflect.ConstructorAccessorImpl";
+
+  permission org.elasticsearch.script.ClassPermission "groovy.lang.Closure";
+  permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.GeneratedClosure";
+  permission org.elasticsearch.script.ClassPermission "groovy.lang.MetaClass";
 };

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovyScriptTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovyScriptTests.java
@@ -51,7 +51,6 @@ import static org.hamcrest.Matchers.equalTo;
  */
 // TODO: refactor into unit test or proper rest tests
 public class GroovyScriptTests extends ESIntegTestCase {
-
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.singleton(GroovyPlugin.class);
@@ -72,20 +71,6 @@ public class GroovyScriptTests extends ESIntegTestCase {
                 .setSource(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).sort(SortBuilders.scriptSort(script, "number")))
                 .get();
         assertNoFailures(resp);
-    }
-
-    public void testUseClosure() {
-        client().prepareIndex("test", "type", "1").setSource("message", "This is a message!").setSource("numbers", new int[] { 1, 2, 3, 4 }).setRefresh(true).get();
-        client().prepareIndex("test", "type", "1").setSource("message", "This is a message! too").setSource("numbers", new int[] { 4, 2, 3, 5 }).setRefresh(true).get();
-
-        SearchSourceBuilder searchSourceBuilder =
-            SearchSourceBuilder
-                .searchSource()
-                .scriptField("use_closure", new Script("doc['numbers'].values.findAll { it % 2 == 0 }", ScriptType.INLINE, "groovy", null));
-        SearchResponse response = client().prepareSearch()
-            .setSource(searchSourceBuilder)
-            .get();
-        assertNoFailures(response);
     }
 
     public void testGroovyExceptionSerialization() throws Exception {

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovyScriptTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovyScriptTests.java
@@ -51,6 +51,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 // TODO: refactor into unit test or proper rest tests
 public class GroovyScriptTests extends ESIntegTestCase {
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.singleton(GroovyPlugin.class);
@@ -71,6 +72,20 @@ public class GroovyScriptTests extends ESIntegTestCase {
                 .setSource(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).sort(SortBuilders.scriptSort(script, "number")))
                 .get();
         assertNoFailures(resp);
+    }
+
+    public void testUseClosure() {
+        client().prepareIndex("test", "type", "1").setSource("message", "This is a message!").setSource("numbers", new int[] { 1, 2, 3, 4 }).setRefresh(true).get();
+        client().prepareIndex("test", "type", "1").setSource("message", "This is a message! too").setSource("numbers", new int[] { 4, 2, 3, 5 }).setRefresh(true).get();
+
+        SearchSourceBuilder searchSourceBuilder =
+            SearchSourceBuilder
+                .searchSource()
+                .scriptField("use_closure", new Script("doc['numbers'].values.findAll { it % 2 == 0 }", ScriptType.INLINE, "groovy", null));
+        SearchResponse response = client().prepareSearch()
+            .setSource(searchSourceBuilder)
+            .get();
+        assertNoFailures(response);
     }
 
     public void testGroovyExceptionSerialization() throws Exception {

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
@@ -87,6 +87,8 @@ public class GroovySecurityTests extends ESTestCase {
         assertSuccess("def t = Instant.now().getMillis()");
         // GroovyCollections
         assertSuccess("def n = [1,2,3]; GroovyCollections.max(n)");
+        // Groovy closures
+        assertSuccess("[1, 2, 3, 4].findAll { it % 2 == 0 }");
 
         // Fail cases:
         assertFailure("pr = Runtime.getRuntime().exec(\"touch /tmp/gotcha\"); pr.waitFor()", MissingPropertyException.class);

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
@@ -89,6 +89,7 @@ public class GroovySecurityTests extends ESTestCase {
         assertSuccess("def n = [1,2,3]; GroovyCollections.max(n)");
         // Groovy closures
         assertSuccess("[1, 2, 3, 4].findAll { it % 2 == 0 }");
+        assertSuccess("def buckets=[ [2, 4, 6, 8], [10, 12, 16, 14], [18, 22, 20, 24] ]; buckets[-3..-1].every { it.every { i -> i % 2 == 0 } }");
 
         // Fail cases:
         assertFailure("pr = Runtime.getRuntime().exec(\"touch /tmp/gotcha\"); pr.waitFor()", MissingPropertyException.class);


### PR DESCRIPTION
The purpose behind this pull request is to add some permissions that Groovy needs to use closures in its current state. While granting `java.lang.reflect.ReflectPermission "supressAccessChecks"` is undesirable, there is an upstream pull request in apache/groovy#248 to modify the Groovy compiler so that these permissions are not necessary. Therefore, the long-term plan is to grant these permissions so as to not break existing scripts, and remove these permissions when the upstream pull request is accepted (and make a breaking change in a major release if not). These permissions are not staying around forever.

Closes #16194 
