### PR TITLE
Make sure IndexShard is active during recovery so it gets its fair share of the indexing buffer

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -440,12 +440,12 @@ public class IndexShard extends AbstractIndexShardComponent {
             }
             this.recoveryState = recoveryState;
 
-            IndexShardState state = changeState(IndexShardState.RECOVERING, reason);
+            IndexShardState previousState = changeState(IndexShardState.RECOVERING, reason);
 
             // Make sure we get our fair share of the indexing buffer during recovery:
             activate();
 
-            return state;
+            return previousState;
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1002,7 +1002,7 @@ public class IndexShard extends AbstractIndexShardComponent {
             // to wake up and fix our indexing buffer.  We could do this async instead, but cost should
             // be low, and it's rare this happens.
             indexingMemoryController.forceCheck();
-            assert engineConfig.getIndexingBufferSize() != IndexingMemoryController.INACTIVE_SHARD_INDEXING_BUFFER: "active=" + active + " state=" + state + " shard=" + shardId();
+            assert engineConfig.getIndexingBufferSize() != IndexingMemoryController.INACTIVE_SHARD_INDEXING_BUFFER || state == IndexShardState.CLOSED: "active=" + active + " state=" + state + " shard=" + shardId();
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -422,6 +422,8 @@ public class IndexShard extends AbstractIndexShardComponent {
 
     private IndexShardState recovering(String reason, RecoveryState recoveryState) throws IndexShardStartedException,
             IndexShardRelocatedException, IndexShardRecoveringException, IndexShardClosedException {
+
+        IndexShardState previousState;
         synchronized (mutex) {
             if (state == IndexShardState.CLOSED) {
                 throw new IndexShardClosedException(shardId);
@@ -440,13 +442,13 @@ public class IndexShard extends AbstractIndexShardComponent {
             }
             this.recoveryState = recoveryState;
 
-            IndexShardState previousState = changeState(IndexShardState.RECOVERING, reason);
-
-            // Make sure we get our fair share of the indexing buffer during recovery:
-            activate();
-
-            return previousState;
+            previousState = changeState(IndexShardState.RECOVERING, reason);
         }
+
+        // Make sure we get our fair share of the indexing buffer during recovery:
+        activate();
+
+        return previousState;
     }
 
     public IndexShard relocated(String reason) throws IndexShardNotStartedException {

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -423,7 +423,6 @@ public class IndexShard extends AbstractIndexShardComponent {
     private IndexShardState recovering(String reason, RecoveryState recoveryState) throws IndexShardStartedException,
             IndexShardRelocatedException, IndexShardRecoveringException, IndexShardClosedException {
 
-        IndexShardState previousState;
         synchronized (mutex) {
             if (state == IndexShardState.CLOSED) {
                 throw new IndexShardClosedException(shardId);
@@ -441,7 +440,6 @@ public class IndexShard extends AbstractIndexShardComponent {
                 throw new IndexShardRecoveringException(shardId);
             }
             this.recoveryState = recoveryState;
-
             return changeState(IndexShardState.RECOVERING, reason);
         }
     }
@@ -922,6 +920,7 @@ public class IndexShard extends AbstractIndexShardComponent {
         engineConfig.setEnableGcDeletes(false);
         engineConfig.setCreate(indexExists == false);
         if (skipTranslogRecovery == false) {
+            // This will activate our shard so we get our fair share of the indexing buffer during recovery:
             activate();
             assert engineConfig.getIndexingBufferSize() != IndexingMemoryController.INACTIVE_SHARD_INDEXING_BUFFER;
         }


### PR DESCRIPTION
This PR is based on 2.2.  It's a start for #16206, but I still need to make a test case.

I fixed `IndexShard.recovering` to forcefully activate the shard (and have IMC re-budget indexing buffers), and also fixed `IndexShard.checkIdle` to always return `false` (still active) if the shard is still recovering.
