### PR TITLE
remove redundant `_score *` in `script_score` examples

### DIFF
--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -112,7 +112,7 @@ simple sample:
 [source,js]
 --------------------------------------------------
 "script_score" : {
-    "script" : "_score * doc['my_numeric_field'].value"
+    "script" : "doc['my_numeric_field'].value"
 }
 --------------------------------------------------
 
@@ -133,7 +133,7 @@ script, and provide parameters to it:
             "param1": value1,
             "param2": value2
         },
-        "inline": "_score * doc['my_numeric_field'].value / pow(param1, param2)"
+        "inline": "doc['my_numeric_field'].value / pow(param1, param2)"
     }
 }
 --------------------------------------------------


### PR DESCRIPTION
```
"script_score" : {
    "script" : "_score * doc['my_numeric_field'].value"
}
```

for `script_score`, isn't the `_score *` implied for the defaults? (which would mean it gets squared by this example?)  That is my reading of

> Note that unlike the custom_score query, the score of the query is multiplied with the result of the script scoring. If you wish to inhibit this, set "boost_mode": "replace"
