### PR TITLE
Make index uuid available in Index, ShardRouting & ShardId

### DIFF
--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -417,7 +417,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     public String toString() {
         StringBuilder builder = new StringBuilder();
         if (headers.containsKey(INDEX_HEADER_KEY)) {
-            builder.append('[').append(getIndex()).append(']');
+            builder.append(getIndex());
             if (headers.containsKey(SHARD_HEADER_KEY)) {
                 builder.append('[').append(getShardId()).append(']');
             }

--- a/core/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/core/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -39,6 +39,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_UUID_NA_VALUE;
+
 /**
  * A base class for all elasticsearch exceptions.
  */
@@ -49,6 +51,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     public static final boolean REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT = true;
     public static final boolean REST_EXCEPTION_SKIP_CAUSE_DEFAULT = false;
     private static final String INDEX_HEADER_KEY = "es.index";
+    private static final String INDEX_HEADER_KEY_UUID = "es.index_uuid";
     private static final String SHARD_HEADER_KEY = "es.shard";
     private static final String RESOURCE_HEADER_TYPE_KEY = "es.resource.type";
     private static final String RESOURCE_HEADER_ID_KEY = "es.resource.id";
@@ -70,7 +73,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
      * The message can be parameterized using <code>{}</code> as placeholders for the given
      * arguments
      *
-     * @param msg the detail message
+     * @param msg  the detail message
      * @param args the arguments for the message
      */
     public ElasticsearchException(String msg, Object... args) {
@@ -332,7 +335,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
 
     private void xContentHeader(XContentBuilder builder, String key, List<String> values) throws IOException {
         if (values != null && values.isEmpty() == false) {
-            if(values.size() == 1) {
+            if (values.size() == 1) {
                 builder.field(key, values.get(0));
             } else {
                 builder.startArray(key);
@@ -374,7 +377,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         if (cause != null && cause instanceof ElasticsearchException) {
             return ((ElasticsearchException) cause).guessRootCauses();
         }
-        return new ElasticsearchException[] {this};
+        return new ElasticsearchException[]{this};
     }
 
     /**
@@ -387,7 +390,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         if (ex instanceof ElasticsearchException) {
             return ((ElasticsearchException) ex).guessRootCauses();
         }
-        return new ElasticsearchException[] {new ElasticsearchException(t.getMessage(), t) {
+        return new ElasticsearchException[]{new ElasticsearchException(t.getMessage(), t) {
             @Override
             protected String getExceptionName() {
                 return getExceptionName(getCause());
@@ -435,7 +438,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             final String fileName = in.readOptionalString();
             final String methodName = in.readString();
             final int lineNumber = in.readVInt();
-            stackTrace[i] = new StackTraceElement(declaringClasss,methodName, fileName, lineNumber);
+            stackTrace[i] = new StackTraceElement(declaringClasss, methodName, fileName, lineNumber);
         }
         throwable.setStackTrace(stackTrace);
 
@@ -631,10 +634,11 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         CLASS_TO_ELASTICSEARCH_EXCEPTION_HANDLE = Collections.unmodifiableMap(exceptions);
     }
 
-    public String getIndex() {
+    public Index getIndex() {
         List<String> index = getHeader(INDEX_HEADER_KEY);
         if (index != null && index.isEmpty() == false) {
-            return index.get(0);
+            List<String> index_uuid = getHeader(INDEX_HEADER_KEY_UUID);
+            return new Index(index.get(0), index_uuid.get(0));
         }
 
         return null;
@@ -651,20 +655,26 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     public void setIndex(Index index) {
         if (index != null) {
             addHeader(INDEX_HEADER_KEY, index.getName());
+            addHeader(INDEX_HEADER_KEY_UUID, index.getUUID());
         }
     }
 
     public void setIndex(String index) {
         if (index != null) {
-            addHeader(INDEX_HEADER_KEY, index);
+            setIndex(new Index(index, INDEX_UUID_NA_VALUE));
         }
     }
 
     public void setShard(ShardId shardId) {
         if (shardId != null) {
-            addHeader(INDEX_HEADER_KEY, shardId.getIndex());
+            setIndex(shardId.getIndex());
             addHeader(SHARD_HEADER_KEY, Integer.toString(shardId.id()));
         }
+    }
+
+    public void setShard(String index, int shardId) {
+            setIndex(index);
+            addHeader(SHARD_HEADER_KEY, Integer.toString(shardId));
     }
 
     public void setResources(String type, String... id) {
@@ -691,7 +701,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         final ElasticsearchException[] rootCauses = ElasticsearchException.guessRootCauses(t);
         builder.field("root_cause");
         builder.startArray();
-        for (ElasticsearchException rootCause : rootCauses){
+        for (ElasticsearchException rootCause : rootCauses) {
             builder.startObject();
             rootCause.toXContent(builder, new ToXContent.DelegatingMapParams(Collections.singletonMap(ElasticsearchException.REST_EXCEPTION_SKIP_CAUSE, "true"), params));
             builder.endObject();

--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -243,7 +244,12 @@ public final class ExceptionsHelper {
 
         public GroupBy(Throwable t) {
             if (t instanceof ElasticsearchException) {
-                index = ((ElasticsearchException) t).getIndex().getName();
+                final Index index = ((ElasticsearchException) t).getIndex();
+                if (index != null) {
+                    this.index = index.getName();
+                } else {
+                    this.index = null;
+                }
             } else {
                 index = null;
             }

--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -243,7 +243,7 @@ public final class ExceptionsHelper {
 
         public GroupBy(Throwable t) {
             if (t instanceof ElasticsearchException) {
-                index = ((ElasticsearchException) t).getIndex();
+                index = ((ElasticsearchException) t).getIndex().getName();
             } else {
                 index = null;
             }

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -53,7 +53,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements St
      * The index the document was changed in.
      */
     public String getIndex() {
-        return this.shardId.getIndex();
+        return this.shardId.getIndexName();
     }
 
 
@@ -119,7 +119,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements St
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         ReplicationResponse.ShardInfo shardInfo = getShardInfo();
-        builder.field(Fields._INDEX, shardId.getIndex())
+        builder.field(Fields._INDEX, shardId.getIndexName())
             .field(Fields._TYPE, type)
             .field(Fields._ID, id)
             .field(Fields._VERSION, version);

--- a/core/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
+++ b/core/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
@@ -40,7 +40,7 @@ public class UnavailableShardsException extends ElasticsearchException {
         if (shardId == null) {
             return message;
         }
-        return "[" + shardId.index().name() + "][" + shardId.id() + "] " + message;
+        return "[" + shardId.index().getName() + "][" + shardId.id() + "] " + message;
     }
 
     public UnavailableShardsException(StreamInput in) throws IOException {

--- a/core/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
+++ b/core/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
@@ -36,12 +36,18 @@ public class UnavailableShardsException extends ElasticsearchException {
         super(buildMessage(shardId, message), args);
     }
 
+    public UnavailableShardsException(String index, int shardId, String message, Object... args) {
+        super(buildMessage(index, shardId, message), args);
+    }
+
     private static String buildMessage(ShardId shardId, String message) {
         if (shardId == null) {
             return message;
         }
-        return "[" + shardId.index().getName() + "][" + shardId.id() + "] " + message;
+        return buildMessage(shardId.getIndexName(), shardId.id(), message);
     }
+
+    private static String buildMessage(String index, int shardId, String message) {return "[" + index + "][" + shardId + "] " + message;}
 
     public UnavailableShardsException(StreamInput in) throws IOException {
         super(in);

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.Index;
 
 import java.io.IOException;
 
@@ -32,7 +33,7 @@ import java.io.IOException;
  */
 public class ClusterSearchShardsGroup implements Streamable, ToXContent {
 
-    private String index;
+    private Index index;
     private int shardId;
     ShardRouting[] shards;
 
@@ -40,7 +41,7 @@ public class ClusterSearchShardsGroup implements Streamable, ToXContent {
 
     }
 
-    public ClusterSearchShardsGroup(String index, int shardId, ShardRouting[] shards) {
+    public ClusterSearchShardsGroup(Index index, int shardId, ShardRouting[] shards) {
         this.index = index;
         this.shardId = shardId;
         this.shards = shards;
@@ -53,7 +54,7 @@ public class ClusterSearchShardsGroup implements Streamable, ToXContent {
     }
 
     public String getIndex() {
-        return index;
+        return index.getName();
     }
 
     public int getShardId() {
@@ -66,7 +67,7 @@ public class ClusterSearchShardsGroup implements Streamable, ToXContent {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        index = in.readString();
+        Index.readIndex(in);
         shardId = in.readVInt();
         shards = new ShardRouting[in.readVInt()];
         for (int i = 0; i < shards.length; i++) {
@@ -76,7 +77,7 @@ public class ClusterSearchShardsGroup implements Streamable, ToXContent {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(index);
+        index.writeTo(out);
         out.writeVInt(shardId);
         out.writeVInt(shards.length);
         for (ShardRouting shardRouting : shards) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
@@ -67,7 +67,7 @@ public class ClusterSearchShardsGroup implements Streamable, ToXContent {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        Index.readIndex(in);
+        index = Index.readIndex(in);
         shardId = in.readVInt();
         shards = new ShardRouting[in.readVInt()];
         for (int i = 0; i < shards.length; i++) {

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -77,7 +78,7 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeReadA
         ClusterSearchShardsGroup[] groupResponses = new ClusterSearchShardsGroup[groupShardsIterator.size()];
         int currentGroup = 0;
         for (ShardIterator shardIt : groupShardsIterator) {
-            String index = shardIt.shardId().getIndex();
+            Index index = shardIt.shardId().getIndex();
             int shardId = shardIt.shardId().getId();
             ShardRouting[] shardRoutings = new ShardRouting[shardIt.size()];
             int currentShard = 0;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIndices.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIndices.java
@@ -66,10 +66,10 @@ public class ClusterStatsIndices implements ToXContent, Streamable {
 
         for (ClusterStatsNodeResponse r : nodeResponses) {
             for (org.elasticsearch.action.admin.indices.stats.ShardStats shardStats : r.shardsStats()) {
-                ShardStats indexShardStats = countsPerIndex.get(shardStats.getShardRouting().getIndex());
+                ShardStats indexShardStats = countsPerIndex.get(shardStats.getShardRouting().getIndexName());
                 if (indexShardStats == null) {
                     indexShardStats = new ShardStats();
-                    countsPerIndex.put(shardStats.getShardRouting().getIndex(), indexShardStats);
+                    countsPerIndex.put(shardStats.getShardRouting().getIndexName(), indexShardStats);
                 }
 
                 indexShardStats.total++;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -81,7 +81,7 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastByNodeAc
 
     @Override
     protected EmptyResult shardOperation(ClearIndicesCacheRequest request, ShardRouting shardRouting) {
-        IndexService service = indicesService.indexService(shardRouting.getIndex());
+        IndexService service = indicesService.indexService(shardRouting.getIndexName());
         if (service != null) {
             IndexShard shard = service.getShardOrNull(shardRouting.id());
             boolean clearedAtLeastOne = false;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -102,7 +102,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
                     .filter(type -> Regex.simpleMatch(request.types(), type))
                     .collect(Collectors.toCollection(ArrayList::new));
             if (typeIntersection.isEmpty()) {
-                throw new TypeMissingException(shardId.index(), request.types());
+                throw new TypeMissingException(shardId.getIndex(), request.types());
             }
         }
 
@@ -115,7 +115,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
             }
         }
 
-        return new GetFieldMappingsResponse(singletonMap(shardId.getIndex(), typeMappings.immutableMap()));
+        return new GetFieldMappingsResponse(singletonMap(shardId.getIndexName(), typeMappings.immutableMap()));
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/recovery/TransportRecoveryAction.java
@@ -75,7 +75,7 @@ public class TransportRecoveryAction extends TransportBroadcastByNodeAction<Reco
             if (recoveryState == null) {
                 continue;
             }
-            String indexName = recoveryState.getShardId().getIndex();
+            String indexName = recoveryState.getShardId().getIndexName();
             if (!shardResponses.containsKey(indexName)) {
                 shardResponses.put(indexName, new ArrayList<>());
             }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -65,14 +65,14 @@ public class IndicesSegmentResponse extends BroadcastResponse implements ToXCont
             indices.add(shard.getShardRouting().getIndexName());
         }
 
-        for (String index : indices) {
+        for (String indexName : indices) {
             List<ShardSegments> shards = new ArrayList<>();
             for (ShardSegments shard : this.shards) {
-                if (shard.getShardRouting().index().equals(index)) {
+                if (shard.getShardRouting().getIndexName().equals(indexName)) {
                     shards.add(shard);
                 }
             }
-            indicesSegments.put(index, new IndexSegments(index, shards.toArray(new ShardSegments[shards.size()])));
+            indicesSegments.put(indexName, new IndexSegments(indexName, shards.toArray(new ShardSegments[shards.size()])));
         }
         this.indicesSegments = indicesSegments;
         return indicesSegments;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -62,7 +62,7 @@ public class IndicesSegmentResponse extends BroadcastResponse implements ToXCont
 
         Set<String> indices = new HashSet<>();
         for (ShardSegments shard : shards) {
-            indices.add(shard.getShardRouting().getIndex());
+            indices.add(shard.getShardRouting().getIndexName());
         }
 
         for (String index : indices) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -93,7 +93,7 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastByNodeActi
 
     @Override
     protected ShardSegments shardOperation(IndicesSegmentsRequest request, ShardRouting shardRouting) {
-        IndexService indexService = indicesService.indexServiceSafe(shardRouting.getIndex());
+        IndexService indexService = indicesService.indexServiceSafe(shardRouting.getIndexName());
         IndexShard indexShard = indexService.getShard(shardRouting.id());
         return new ShardSegments(indexShard.routingEntry(), indexShard.segments(request.verbose()));
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -196,7 +196,7 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
             private IndicesShardStoresResponse.StoreStatus.AllocationStatus getAllocationStatus(String index, int shardID, DiscoveryNode node) {
                 for (ShardRouting shardRouting : routingNodes.node(node.id())) {
                     ShardId shardId = shardRouting.shardId();
-                    if (shardId.id() == shardID && shardId.getIndex().equals(index)) {
+                    if (shardId.id() == shardID && shardId.getIndexName().equals(index)) {
                         if (shardRouting.primary()) {
                             return IndicesShardStoresResponse.StoreStatus.AllocationStatus.PRIMARY;
                         } else if (shardRouting.assignedToNode()) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -166,7 +166,7 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
                 ImmutableOpenMap.Builder<String, ImmutableOpenIntMap<java.util.List<IndicesShardStoresResponse.StoreStatus>>> indicesStoreStatusesBuilder = ImmutableOpenMap.builder();
                 java.util.List<IndicesShardStoresResponse.Failure> failureBuilder = new ArrayList<>();
                 for (Response fetchResponse : fetchResponses) {
-                    ImmutableOpenIntMap<java.util.List<IndicesShardStoresResponse.StoreStatus>> indexStoreStatuses = indicesStoreStatusesBuilder.get(fetchResponse.shardId.getIndex());
+                    ImmutableOpenIntMap<java.util.List<IndicesShardStoresResponse.StoreStatus>> indexStoreStatuses = indicesStoreStatusesBuilder.get(fetchResponse.shardId.getIndexName());
                     final ImmutableOpenIntMap.Builder<java.util.List<IndicesShardStoresResponse.StoreStatus>> indexShardsBuilder;
                     if (indexStoreStatuses == null) {
                         indexShardsBuilder = ImmutableOpenIntMap.builder();
@@ -179,15 +179,15 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
                     }
                     for (NodeGatewayStartedShards response : fetchResponse.responses) {
                         if (shardExistsInNode(response)) {
-                            IndicesShardStoresResponse.StoreStatus.AllocationStatus allocationStatus = getAllocationStatus(fetchResponse.shardId.getIndex(), fetchResponse.shardId.id(), response.getNode());
+                            IndicesShardStoresResponse.StoreStatus.AllocationStatus allocationStatus = getAllocationStatus(fetchResponse.shardId.getIndexName(), fetchResponse.shardId.id(), response.getNode());
                             storeStatuses.add(new IndicesShardStoresResponse.StoreStatus(response.getNode(), response.version(), response.allocationId(), allocationStatus, response.storeException()));
                         }
                     }
                     CollectionUtil.timSort(storeStatuses);
                     indexShardsBuilder.put(fetchResponse.shardId.id(), storeStatuses);
-                    indicesStoreStatusesBuilder.put(fetchResponse.shardId.getIndex(), indexShardsBuilder.build());
+                    indicesStoreStatusesBuilder.put(fetchResponse.shardId.getIndexName(), indexShardsBuilder.build());
                     for (FailedNodeException failure : fetchResponse.failures) {
-                        failureBuilder.add(new IndicesShardStoresResponse.Failure(failure.nodeId(), fetchResponse.shardId.getIndex(), fetchResponse.shardId.id(), failure.getCause()));
+                        failureBuilder.add(new IndicesShardStoresResponse.Failure(failure.nodeId(), fetchResponse.shardId.getIndexName(), fetchResponse.shardId.id(), failure.getCause()));
                     }
                 }
                 listener.onResponse(new IndicesShardStoresResponse(indicesStoreStatusesBuilder.build(), Collections.unmodifiableList(failureBuilder)));

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -92,14 +92,14 @@ public class IndicesStatsResponse extends BroadcastResponse implements ToXConten
             indices.add(shard.getShardRouting().getIndexName());
         }
 
-        for (String index : indices) {
+        for (String indexName : indices) {
             List<ShardStats> shards = new ArrayList<>();
             for (ShardStats shard : this.shards) {
-                if (shard.getShardRouting().index().equals(index)) {
+                if (shard.getShardRouting().getIndexName().equals(indexName)) {
                     shards.add(shard);
                 }
             }
-            indicesStats.put(index, new IndexStats(index, shards.toArray(new ShardStats[shards.size()])));
+            indicesStats.put(indexName, new IndexStats(indexName, shards.toArray(new ShardStats[shards.size()])));
         }
         this.indicesStats = indicesStats;
         return indicesStats;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -89,7 +89,7 @@ public class IndicesStatsResponse extends BroadcastResponse implements ToXConten
 
         Set<String> indices = new HashSet<>();
         for (ShardStats shard : shards) {
-            indices.add(shard.getShardRouting().getIndex());
+            indices.add(shard.getShardRouting().getIndexName());
         }
 
         for (String index : indices) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
@@ -59,14 +59,14 @@ public class UpgradeStatusResponse extends BroadcastResponse implements ToXConte
             indices.add(shard.getIndex());
         }
 
-        for (String index : indices) {
+        for (String indexName : indices) {
             List<ShardUpgradeStatus> shards = new ArrayList<>();
             for (ShardUpgradeStatus shard : this.shards) {
-                if (shard.getShardRouting().index().equals(index)) {
+                if (shard.getShardRouting().getIndexName().equals(indexName)) {
                     shards.add(shard);
                 }
             }
-            indicesUpgradeStats.put(index, new IndexUpgradeStatus(index, shards.toArray(new ShardUpgradeStatus[shards.size()])));
+            indicesUpgradeStats.put(indexName, new IndexUpgradeStatus(indexName, shards.toArray(new ShardUpgradeStatus[shards.size()])));
         }
         this.indicesUpgradeStatus = indicesUpgradeStats;
         return indicesUpgradeStats;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/TransportUpgradeAction.java
@@ -75,7 +75,7 @@ public class TransportUpgradeAction extends TransportBroadcastByNodeAction<Upgra
         Map<String, Tuple<Version, org.apache.lucene.util.Version>> versions = new HashMap<>();
         for (ShardUpgradeResult result : shardUpgradeResults) {
             successfulShards++;
-            String index = result.getShardId().getIndex();
+            String index = result.getShardId().getIndex().getName();
             if (result.primary()) {
                 Integer count = successfulPrimaryShards.get(index);
                 successfulPrimaryShards.put(index, count == null ? 1 : count + 1);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -96,7 +96,7 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<Valid
 
     @Override
     protected ShardValidateQueryRequest newShardRequest(int numShards, ShardRouting shard, ValidateQueryRequest request) {
-        String[] filteringAliases = indexNameExpressionResolver.filteringAliases(clusterService.state(), shard.index(), request.indices());
+        String[] filteringAliases = indexNameExpressionResolver.filteringAliases(clusterService.state(), shard.getIndexName(), request.indices());
         return new ShardValidateQueryRequest(shard.shardId(), filteringAliases, request);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -377,7 +377,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         if (unavailableException == null) {
             IndexMetaData indexMetaData = metaData.index(concreteIndex);
             if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
-                unavailableException = new IndexClosedException(new Index(metaData.index(request.index()).getIndex()));
+                unavailableException = new IndexClosedException(metaData.index(request.index()).getIndex());
             }
         }
         if (unavailableException != null) {

--- a/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -108,7 +108,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
         Term uidTerm = new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(request.type(), request.id()));
         Engine.GetResult result = indexShard.get(new Engine.Get(false, uidTerm));
         if (!result.exists()) {
-            return new ExplainResponse(shardId.getIndex(), request.type(), request.id(), false);
+            return new ExplainResponse(shardId.getIndexName(), request.type(), request.id(), false);
         }
 
         SearchContext context = new DefaultSearchContext(
@@ -134,9 +134,9 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
                 // because we are working in the same searcher in engineGetResult we can be sure that a
                 // doc isn't deleted between the initial get and this call.
                 GetResult getResult = indexShard.getService().get(result, request.id(), request.type(), request.fields(), request.fetchSourceContext(), false);
-                return new ExplainResponse(shardId.getIndex(), request.type(), request.id(), true, explanation, getResult);
+                return new ExplainResponse(shardId.getIndexName(), request.type(), request.id(), true, explanation, getResult);
             } else {
-                return new ExplainResponse(shardId.getIndex(), request.type(), request.id(), true, explanation);
+                return new ExplainResponse(shardId.getIndexName(), request.type(), request.id(), true, explanation);
             }
         } catch (IOException e) {
             throw new ElasticsearchException("Could not explain", e);

--- a/core/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -79,7 +79,7 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
                     .getShards(clusterState, concreteSingleIndex, item.type(), item.id(), item.routing(), null).shardId();
             MultiGetShardRequest shardRequest = shardRequests.get(shardId);
             if (shardRequest == null) {
-                shardRequest = new MultiGetShardRequest(request, shardId.index().getName(), shardId.id());
+                shardRequest = new MultiGetShardRequest(request, shardId.getIndexName(), shardId.id());
                 shardRequests.put(shardId, shardRequest);
             }
             shardRequest.add(i, item);

--- a/core/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/core/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -79,7 +79,7 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
                     .getShards(clusterState, concreteSingleIndex, item.type(), item.id(), item.routing(), null).shardId();
             MultiGetShardRequest shardRequest = shardRequests.get(shardId);
             if (shardRequest == null) {
-                shardRequest = new MultiGetShardRequest(request, shardId.index().name(), shardId.id());
+                shardRequest = new MultiGetShardRequest(request, shardId.index().getName(), shardId.id());
                 shardRequests.put(shardId, shardRequest);
             }
             shardRequest.add(i, item);

--- a/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/index/TransportIndexAction.java
@@ -146,7 +146,7 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
         MappingMetaData mappingMd = indexMetaData.mappingOrDefault(request.type());
         if (mappingMd != null && mappingMd.routing().required()) {
             if (request.routing() == null) {
-                throw new RoutingMissingException(request.shardId().getIndex(), request.type(), request.id());
+                throw new RoutingMissingException(request.shardId().getIndex().getName(), request.type(), request.id());
             }
         }
 
@@ -176,7 +176,7 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
      */
     public static Engine.Index executeIndexRequestOnReplica(IndexRequest request, IndexShard indexShard) {
         final ShardId shardId = indexShard.shardId();
-        SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.REPLICA, request.source()).index(shardId.getIndex()).type(request.type()).id(request.id())
+        SourceToParse sourceToParse = SourceToParse.source(SourceToParse.Origin.REPLICA, request.source()).index(shardId.getIndexName()).type(request.type()).id(request.id())
                 .routing(request.routing()).parent(request.parent()).timestamp(request.timestamp()).ttl(request.ttl());
 
         final Engine.Index operation = indexShard.prepareIndexOnReplica(sourceToParse, request.version(), request.versionType());
@@ -204,7 +204,7 @@ public class TransportIndexAction extends TransportReplicationAction<IndexReques
         Mapping update = operation.parsedDoc().dynamicMappingsUpdate();
         final ShardId shardId = indexShard.shardId();
         if (update != null) {
-            final String indexName = shardId.getIndex();
+            final String indexName = shardId.getIndexName();
             mappingUpdatedAction.updateMappingOnMasterSynchronously(indexName, request.type(), update);
             operation = prepareIndexOperationOnPrimary(request, indexShard);
             update = operation.parsedDoc().dynamicMappingsUpdate();

--- a/core/src/main/java/org/elasticsearch/action/percolate/PercolateShardResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/PercolateShardResponse.java
@@ -57,7 +57,7 @@ public class PercolateShardResponse extends BroadcastShardResponse {
     }
 
     public PercolateShardResponse(TopDocs topDocs, Map<Integer, String> ids, Map<Integer, Map<String, HighlightField>> hls, PercolateContext context) {
-        super(new ShardId(context.shardTarget().getIndex(), context.shardTarget().getShardId()));
+        super(context.indexShard().shardId());
         this.topDocs = topDocs;
         this.ids = ids;
         this.hls = hls;

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportMultiPercolateAction.java
@@ -200,7 +200,7 @@ public class TransportMultiPercolateAction extends HandledTransportAction<MultiP
                         ShardId shardId = shard.shardId();
                         TransportShardMultiPercolateAction.Request requests = requestsByShard.get(shardId);
                         if (requests == null) {
-                            requestsByShard.put(shardId, requests = new TransportShardMultiPercolateAction.Request(multiPercolateRequest, shardId.getIndex(), shardId.getId(), percolateRequest.preference()));
+                            requestsByShard.put(shardId, requests = new TransportShardMultiPercolateAction.Request(multiPercolateRequest, shardId.getIndexName(), shardId.getId(), percolateRequest.preference()));
                         }
                         logger.trace("Adding shard[{}] percolate request for item[{}]", shardId, slot);
                         requests.add(new TransportShardMultiPercolateAction.Request.Item(slot, new PercolateShardRequest(shardId, percolateRequest)));

--- a/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/type/TransportSearchTypeAction.java
@@ -163,7 +163,7 @@ public abstract class TransportSearchTypeAction extends TransportAction<SearchRe
                 if (node == null) {
                     onFirstPhaseResult(shardIndex, shard, null, shardIt, new NoShardAvailableActionException(shardIt.shardId()));
                 } else {
-                    String[] filteringAliases = indexNameExpressionResolver.filteringAliases(clusterState, shard.index(), request.indices());
+                    String[] filteringAliases = indexNameExpressionResolver.filteringAliases(clusterState, shard.index().getName(), request.indices());
                     sendExecuteFirstPhase(node, internalSearchRequest(shard, shardsIts.size(), request, filteringAliases, startTime()), new ActionListener<FirstResult>() {
                         @Override
                         public void onResponse(FirstResult result) {

--- a/core/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
+++ b/core/src/main/java/org/elasticsearch/action/suggest/TransportSuggestAction.java
@@ -143,7 +143,7 @@ public class TransportSuggestAction extends TransportBroadcastAction<SuggestRequ
                     throw new IllegalArgumentException("suggest content missing");
                 }
                 final SuggestionSearchContext context = suggestPhase.parseElement().parseInternal(parser, indexService.mapperService(),
-                        indexService.fieldData(), request.shardId().getIndex(), request.shardId().id(), request);
+                        indexService.fieldData(), request.shardId().getIndexName(), request.shardId().id(), request);
                 final Suggest result = suggestPhase.execute(context, searcher.searcher());
                 return new ShardSuggestResponse(request.shardId(), result);
             }

--- a/core/src/main/java/org/elasticsearch/action/support/DefaultShardOperationFailedException.java
+++ b/core/src/main/java/org/elasticsearch/action/support/DefaultShardOperationFailedException.java
@@ -48,7 +48,7 @@ public class DefaultShardOperationFailedException implements ShardOperationFaile
     }
 
     public DefaultShardOperationFailedException(ElasticsearchException e) {
-        this.index = e.getIndex();
+        this.index = e.getIndex() == null ? null : e.getIndex().getName();
         this.shardId = e.getShardId().id();
         this.reason = e;
         this.status = e.status();

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardResponse.java
@@ -42,7 +42,7 @@ public abstract class BroadcastShardResponse extends TransportResponse {
     }
 
     public String getIndex() {
-        return this.shardId.getIndex();
+        return this.shardId.getIndexName();
     }
 
     public int getShardId() {

--- a/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -118,7 +118,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
                 FailedNodeException exception = (FailedNodeException) responses.get(i);
                 totalShards += nodes.get(exception.nodeId()).size();
                 for (ShardRouting shard : nodes.get(exception.nodeId())) {
-                    exceptions.add(new DefaultShardOperationFailedException(shard.getIndex(), shard.getId(), exception));
+                    exceptions.add(new DefaultShardOperationFailedException(shard.getIndexName(), shard.getId(), exception));
                 }
             } else {
                 NodeResponse response = (NodeResponse) responses.get(i);
@@ -127,7 +127,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
                 successfulShards += response.getSuccessfulShards();
                 for (BroadcastShardOperationFailedException throwable : response.getExceptions()) {
                     if (!TransportActions.isShardNotAvailableException(throwable)) {
-                        exceptions.add(new DefaultShardOperationFailedException(throwable.getIndex(), throwable.getShardId().getId(), throwable));
+                        exceptions.add(new DefaultShardOperationFailedException(throwable.getShardId().getIndexName(), throwable.getShardId().getId(), throwable));
                     }
                 }
             }
@@ -406,7 +406,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
                 }
             } catch (Throwable t) {
                 BroadcastShardOperationFailedException e = new BroadcastShardOperationFailedException(shardRouting.shardId(), "operation " + actionName + " failed", t);
-                e.setIndex(shardRouting.getIndex());
+                e.setIndex(shardRouting.getIndexName());
                 e.setShard(shardRouting.shardId());
                 shardResults[shardIndex] = e;
                 if (TransportActions.isShardNotAvailableException(t)) {

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -70,7 +70,7 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
      */
     public ReplicationRequest(ActionRequest<?> request, ShardId shardId) {
         super(request);
-        this.index = shardId.getIndex();
+        this.index = shardId.getIndexName();
         this.shardId = shardId;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
@@ -96,7 +96,7 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
                     if (TransportActions.isShardNotAvailableException(e)) {
                         failures = new ReplicationResponse.ShardInfo.Failure[0];
                     } else {
-                        ReplicationResponse.ShardInfo.Failure failure = new ReplicationResponse.ShardInfo.Failure(shardId.index().name(), shardId.id(), null, e, ExceptionsHelper.status(e), true);
+                        ReplicationResponse.ShardInfo.Failure failure = new ReplicationResponse.ShardInfo.Failure(shardId.index().getName(), shardId.id(), null, e, ExceptionsHelper.status(e), true);
                         failures = new ReplicationResponse.ShardInfo.Failure[totalNumCopies];
                         Arrays.fill(failures, failure);
                     }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
@@ -90,13 +90,13 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
                 @Override
                 public void onFailure(Throwable e) {
                     logger.trace("{}: got failure from {}", actionName, shardId);
-                    int totalNumCopies = clusterState.getMetaData().index(shardId.index().getName()).getNumberOfReplicas() + 1;
+                    int totalNumCopies = clusterState.getMetaData().index(shardId.getIndexName()).getNumberOfReplicas() + 1;
                     ShardResponse shardResponse = newShardResponse();
                     ReplicationResponse.ShardInfo.Failure[] failures;
                     if (TransportActions.isShardNotAvailableException(e)) {
                         failures = new ReplicationResponse.ShardInfo.Failure[0];
                     } else {
-                        ReplicationResponse.ShardInfo.Failure failure = new ReplicationResponse.ShardInfo.Failure(shardId.index().getName(), shardId.id(), null, e, ExceptionsHelper.status(e), true);
+                        ReplicationResponse.ShardInfo.Failure failure = new ReplicationResponse.ShardInfo.Failure(shardId, null, e, ExceptionsHelper.status(e), true);
                         failures = new ReplicationResponse.ShardInfo.Failure[totalNumCopies];
                         Arrays.fill(failures, failure);
                     }
@@ -154,7 +154,7 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
                     shardFailures = new ArrayList<>();
                 }
                 for (ReplicationResponse.ShardInfo.Failure failure : shardResponse.getShardInfo().getFailures()) {
-                    shardFailures.add(new DefaultShardOperationFailedException(new BroadcastShardOperationFailedException(new ShardId(failure.index(), failure.shardId()), failure.getCause())));
+                    shardFailures.add(new DefaultShardOperationFailedException(new BroadcastShardOperationFailedException(failure.fullShardId(), failure.getCause())));
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -339,7 +339,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
             }
         }
         private void failReplicaIfNeeded(Throwable t) {
-            String index = request.shardId().getIndex();
+            String index = request.shardId().getIndex().getName();
             int shardId = request.shardId().id();
             logger.trace("failure on replica [{}][{}], action [{}], request [{}]", t, index, shardId, actionName, request);
             if (ignoreReplicaException(t) == false) {
@@ -432,7 +432,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
             resolveRequest(state.metaData(), concreteIndex, request);
             assert request.shardId() != null : "request shardId must be set in resolveRequest";
 
-            IndexShardRoutingTable indexShard = state.getRoutingTable().shardRoutingTable(request.shardId().getIndex(), request.shardId().id());
+            IndexShardRoutingTable indexShard = state.getRoutingTable().shardRoutingTable(request.shardId());
             final ShardRouting primary = indexShard.primaryShard();
             if (primary == null || primary.active() == false) {
                 logger.trace("primary shard [{}] is not yet active, scheduling a retry: action [{}], request [{}], cluster state version [{}]", request.shardId(), actionName, request, state.version());
@@ -637,7 +637,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
             }
             final int sizeActive;
             final int requiredNumber;
-            IndexRoutingTable indexRoutingTable = state.getRoutingTable().index(shardId.getIndex());
+            IndexRoutingTable indexRoutingTable = state.getRoutingTable().index(shardId.getIndexName());
             if (indexRoutingTable != null) {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId.getId());
                 if (shardRoutingTable != null) {
@@ -702,7 +702,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
     }
 
     protected Releasable getIndexShardOperationsCounter(ShardId shardId) {
-        IndexService indexService = indicesService.indexServiceSafe(shardId.index().getName());
+        IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
         IndexShard indexShard = indexService.getShard(shardId.id());
         return new IndexShardReference(indexShard);
     }
@@ -941,9 +941,7 @@ public abstract class TransportReplicationAction<Request extends ReplicationRequ
                     failuresArray = new ReplicationResponse.ShardInfo.Failure[shardReplicaFailures.size()];
                     for (Map.Entry<String, Throwable> entry : shardReplicaFailures.entrySet()) {
                         RestStatus restStatus = ExceptionsHelper.status(entry.getValue());
-                        failuresArray[slot++] = new ReplicationResponse.ShardInfo.Failure(
-                                shardId.getIndex(), shardId.getId(), entry.getKey(), entry.getValue(), restStatus, false
-                        );
+                        failuresArray[slot++] = new ReplicationResponse.ShardInfo.Failure(shardId, entry.getKey(), entry.getValue(), restStatus, false);
                     }
                 } else {
                     failuresArray = ReplicationResponse.EMPTY;

--- a/core/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -143,7 +143,7 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
                 request.concreteIndex(indexNameExpressionResolver.concreteSingleIndex(observer.observedState(), request));
                 // check if we need to execute, and if not, return
                 if (!resolveRequest(observer.observedState(), request, listener)) {
-                    listener.onFailure(new IllegalStateException(LoggerMessageFormat.format("{} request {} could not be resolved", new ShardId(request.index, request.shardId), actionName)));
+                    listener.onFailure(new IllegalStateException(LoggerMessageFormat.format("[{}][{}] request {} could not be resolved",request.index, request.shardId, actionName)));
                     return;
                 }
                 blockException = checkRequestBlock(observer.observedState(), request);
@@ -217,7 +217,7 @@ public abstract class TransportInstanceSingleOperationAction<Request extends Ins
                 Throwable listenFailure = failure;
                 if (listenFailure == null) {
                     if (shardIt == null) {
-                        listenFailure = new UnavailableShardsException(new ShardId(request.concreteIndex(), -1), "Timeout waiting for [{}], request: {}", request.timeout(), actionName);
+                        listenFailure = new UnavailableShardsException(request.concreteIndex(), -1, "Timeout waiting for [{}], request: {}", request.timeout(), actionName);
                     } else {
                         listenFailure = new UnavailableShardsException(shardIt.shardId(), "[{}] shardIt, [{}] active : Timeout waiting for [{}], request: {}", shardIt.size(), shardIt.sizeActive(), request.timeout(), actionName);
                     }

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
@@ -82,7 +82,7 @@ public class TransportMultiTermVectorsAction extends HandledTransportAction<Mult
                     termVectorsRequest.id(), termVectorsRequest.routing());
             MultiTermVectorsShardRequest shardRequest = shardRequests.get(shardId);
             if (shardRequest == null) {
-                shardRequest = new MultiTermVectorsShardRequest(request, shardId.index().getName(), shardId.id());
+                shardRequest = new MultiTermVectorsShardRequest(request, shardId.getIndexName(), shardId.id());
                 shardRequest.preference(request.preference);
                 shardRequests.put(shardId, shardRequest);
             }

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
@@ -82,7 +82,7 @@ public class TransportMultiTermVectorsAction extends HandledTransportAction<Mult
                     termVectorsRequest.id(), termVectorsRequest.routing());
             MultiTermVectorsShardRequest shardRequest = shardRequests.get(shardId);
             if (shardRequest == null) {
-                shardRequest = new MultiTermVectorsShardRequest(request, shardId.index().name(), shardId.id());
+                shardRequest = new MultiTermVectorsShardRequest(request, shardId.index().getName(), shardId.id());
                 shardRequest.preference(request.preference);
                 shardRequests.put(shardId, shardRequest);
             }

--- a/core/src/main/java/org/elasticsearch/action/termvectors/dfs/TransportDfsOnlyAction.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/dfs/TransportDfsOnlyAction.java
@@ -76,7 +76,7 @@ public class TransportDfsOnlyAction extends TransportBroadcastAction<DfsOnlyRequ
 
     @Override
     protected ShardDfsOnlyRequest newShardRequest(int numShards, ShardRouting shard, DfsOnlyRequest request) {
-        String[] filteringAliases = indexNameExpressionResolver.filteringAliases(clusterService.state(), shard.index(), request.indices());
+        String[] filteringAliases = indexNameExpressionResolver.filteringAliases(clusterService.state(), shard.index().getName(), request.indices());
         return new ShardDfsOnlyRequest(shard, numShards, filteringAliases, request.nowInMillis, request);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -75,16 +75,15 @@ public class UpdateHelper extends AbstractComponent {
         final GetResult getResult = indexShard.getService().get(request.type(), request.id(),
                 new String[]{RoutingFieldMapper.NAME, ParentFieldMapper.NAME, TTLFieldMapper.NAME, TimestampFieldMapper.NAME},
                 true, request.version(), request.versionType(), FetchSourceContext.FETCH_SOURCE, false);
-        return prepare(request, getResult);
+        return prepare(indexShard.shardId(), request, getResult);
     }
 
     /**
      * Prepares an update request by converting it into an index or delete request or an update response (no action).
      */
     @SuppressWarnings("unchecked")
-    protected Result prepare(UpdateRequest request, final GetResult getResult) {
+    protected Result prepare(ShardId shardId, UpdateRequest request, final GetResult getResult) {
         long getDateNS = System.nanoTime();
-        final ShardId shardId = new ShardId(getResult.getIndex(), request.shardId());
         if (!getResult.isExists()) {
             if (request.upsertRequest() == null && !request.docAsUpsert()) {
                 throw new DocumentMissingException(shardId, request.type(), request.id());

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -449,7 +449,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
 
             builder.startObject("indices");
             for (IndexMetaData indexMetaData : metaData()) {
-                builder.startObject(indexMetaData.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(indexMetaData.getIndex().getName(), XContentBuilder.FieldCaseConversion.NONE);
 
                 builder.field("state", indexMetaData.getState().toString().toLowerCase(Locale.ENGLISH));
 
@@ -506,7 +506,7 @@ public class ClusterState implements ToXContent, Diffable<ClusterState> {
             builder.startObject("routing_table");
             builder.startObject("indices");
             for (IndexRoutingTable indexRoutingTable : routingTable()) {
-                builder.startObject(indexRoutingTable.index(), XContentBuilder.FieldCaseConversion.NONE);
+                builder.startObject(indexRoutingTable.getIndex().getName(), XContentBuilder.FieldCaseConversion.NONE);
                 builder.startObject("shards");
                 for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                     builder.startArray(Integer.toString(indexShardRoutingTable.shardId().id()));

--- a/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -162,7 +162,7 @@ public class SnapshotsInProgress extends AbstractDiffable<Custom> implements Cus
                     List<ShardId> waitingShards = waitingIndicesMap.get(entry.key.getIndex());
                     if (waitingShards == null) {
                         waitingShards = new ArrayList<>();
-                        waitingIndicesMap.put(entry.key.getIndex(), waitingShards);
+                        waitingIndicesMap.put(entry.key.getIndexName(), waitingShards);
                     }
                     waitingShards.add(entry.key);
                 }

--- a/core/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/index/NodeIndexDeletedAction.java
@@ -103,7 +103,7 @@ public class NodeIndexDeletedAction extends AbstractComponent {
             // master. If we can't acquire the locks here immediately there might be a shard of this index still holding on to the lock
             // due to a "currently canceled recovery" or so. The shard will delete itself BEFORE the lock is released so it's guaranteed to be
             // deleted by the time we get the lock
-            indicesService.processPendingDeletes(new Index(index), indexSettings, new TimeValue(30, TimeUnit.MINUTES));
+            indicesService.processPendingDeletes(indexSettings.getIndex(), indexSettings, new TimeValue(30, TimeUnit.MINUTES));
             transportService.sendRequest(clusterState.nodes().masterNode(),
                     INDEX_STORE_DELETED_ACTION_NAME, new NodeIndexStoreDeletedMessage(index, nodeId), EmptyTransportResponseHandler.INSTANCE_SAME);
         } catch (LockObtainFailedException exc) {

--- a/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/core/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -304,29 +304,29 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
 
         public Builder addBlocks(IndexMetaData indexMetaData) {
             if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
-                addIndexBlock(indexMetaData.getIndex(), MetaDataIndexStateService.INDEX_CLOSED_BLOCK);
+                addIndexBlock(indexMetaData.getIndex().getName(), MetaDataIndexStateService.INDEX_CLOSED_BLOCK);
             }
             if (IndexMetaData.INDEX_READ_ONLY_SETTING.get(indexMetaData.getSettings())) {
-                addIndexBlock(indexMetaData.getIndex(), IndexMetaData.INDEX_READ_ONLY_BLOCK);
+                addIndexBlock(indexMetaData.getIndex().getName(), IndexMetaData.INDEX_READ_ONLY_BLOCK);
             }
             if (IndexMetaData.INDEX_BLOCKS_READ_SETTING.get(indexMetaData.getSettings())) {
-                addIndexBlock(indexMetaData.getIndex(), IndexMetaData.INDEX_READ_BLOCK);
+                addIndexBlock(indexMetaData.getIndex().getName(), IndexMetaData.INDEX_READ_BLOCK);
             }
             if (IndexMetaData.INDEX_BLOCKS_WRITE_SETTING.get(indexMetaData.getSettings())) {
-                addIndexBlock(indexMetaData.getIndex(), IndexMetaData.INDEX_WRITE_BLOCK);
+                addIndexBlock(indexMetaData.getIndex().getName(), IndexMetaData.INDEX_WRITE_BLOCK);
             }
             if (IndexMetaData.INDEX_BLOCKS_METADATA_SETTING.get(indexMetaData.getSettings())) {
-                addIndexBlock(indexMetaData.getIndex(), IndexMetaData.INDEX_METADATA_BLOCK);
+                addIndexBlock(indexMetaData.getIndex().getName(), IndexMetaData.INDEX_METADATA_BLOCK);
             }
             return this;
         }
 
         public Builder updateBlocks(IndexMetaData indexMetaData) {
-            removeIndexBlock(indexMetaData.getIndex(), MetaDataIndexStateService.INDEX_CLOSED_BLOCK);
-            removeIndexBlock(indexMetaData.getIndex(), IndexMetaData.INDEX_READ_ONLY_BLOCK);
-            removeIndexBlock(indexMetaData.getIndex(), IndexMetaData.INDEX_READ_BLOCK);
-            removeIndexBlock(indexMetaData.getIndex(), IndexMetaData.INDEX_WRITE_BLOCK);
-            removeIndexBlock(indexMetaData.getIndex(), IndexMetaData.INDEX_METADATA_BLOCK);
+            removeIndexBlock(indexMetaData.getIndex().getName(), MetaDataIndexStateService.INDEX_CLOSED_BLOCK);
+            removeIndexBlock(indexMetaData.getIndex().getName(), IndexMetaData.INDEX_READ_ONLY_BLOCK);
+            removeIndexBlock(indexMetaData.getIndex().getName(), IndexMetaData.INDEX_READ_BLOCK);
+            removeIndexBlock(indexMetaData.getIndex().getName(), IndexMetaData.INDEX_WRITE_BLOCK);
+            removeIndexBlock(indexMetaData.getIndex().getName(), IndexMetaData.INDEX_METADATA_BLOCK);
             return addBlocks(indexMetaData);
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
+++ b/core/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
@@ -67,7 +67,7 @@ public final class ClusterIndexHealth implements Iterable<ClusterShardHealth>, S
     }
 
     public ClusterIndexHealth(IndexMetaData indexMetaData, IndexRoutingTable indexRoutingTable) {
-        this.index = indexMetaData.getIndex();
+        this.index = indexMetaData.getIndex().getName();
         this.numberOfShards = indexMetaData.getNumberOfShards();
         this.numberOfReplicas = indexMetaData.getNumberOfReplicas();
         this.validationFailures = indexRoutingTable.validate(indexMetaData);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
@@ -117,7 +117,7 @@ public interface AliasOrIndex {
                         @Override
                         public Tuple<String, AliasMetaData> next() {
                             IndexMetaData indexMetaData = referenceIndexMetaDatas.get(index++);
-                            return new Tuple<>(indexMetaData.getIndex(), indexMetaData.getAliases().get(aliasName));
+                            return new Tuple<>(indexMetaData.getIndex().getName(), indexMetaData.getAliases().get(aliasName));
                         }
 
                         @Override

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -97,7 +97,7 @@ public class AliasValidator extends AbstractComponent {
 
         assert metaData != null;
         if (metaData.hasIndex(alias)) {
-            throw new InvalidAliasNameException(new Index(index), alias, "an index exists with the same name as the alias");
+            throw new InvalidAliasNameException(metaData.index(alias).getIndex(), alias, "an index exists with the same name as the alias");
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -29,13 +29,11 @@ import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.node.DiscoveryNodeFilters;
-import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -47,6 +45,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.RestStatus;
 import org.joda.time.DateTime;
@@ -72,7 +71,7 @@ import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
 /**
  *
  */
-public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuilder<IndexMetaData>, ToXContent  {
+public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuilder<IndexMetaData>, ToXContent {
 
     public interface Custom extends Diffable<Custom>, ToXContent {
 
@@ -150,6 +149,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             throw new IllegalStateException("No state match for [" + state + "]");
         }
     }
+
     public static final String INDEX_SETTING_PREFIX = "index.";
     public static final String SETTING_NUMBER_OF_SHARDS = "index.number_of_shards";
     public static final Setting<Integer> INDEX_NUMBER_OF_SHARDS_SETTING = Setting.intSetting(SETTING_NUMBER_OF_SHARDS, 5, 1, false, Setting.Scope.INDEX);
@@ -196,15 +196,15 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     public static final Setting<Settings> INDEX_ROUTING_EXCLUDE_GROUP_SETTING = Setting.groupSetting("index.routing.allocation.exclude.", true, Setting.Scope.INDEX);
 
     public static final IndexMetaData PROTO = IndexMetaData.builder("")
-        .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
-        .numberOfShards(1).numberOfReplicas(0).build();
+            .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+            .numberOfShards(1).numberOfReplicas(0).build();
 
     public static final String KEY_ACTIVE_ALLOCATIONS = "active_allocations";
 
     private final int numberOfShards;
     private final int numberOfReplicas;
 
-    private final String index;
+    private final Index index;
     private final long version;
 
     private final State state;
@@ -229,7 +229,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     private final Version indexUpgradedVersion;
     private final org.apache.lucene.util.Version minimumCompatibleLuceneVersion;
 
-    private IndexMetaData(String index, long version, State state, int numberOfShards, int numberOfReplicas, Settings settings,
+    private IndexMetaData(Index index, long version, State state, int numberOfShards, int numberOfReplicas, Settings settings,
                           ImmutableOpenMap<String, MappingMetaData> mappings, ImmutableOpenMap<String, AliasMetaData> aliases,
                           ImmutableOpenMap<String, Custom> customs, ImmutableOpenIntMap<Set<String>> activeAllocationIds,
                           DiscoveryNodeFilters requireFilters, DiscoveryNodeFilters includeFilters, DiscoveryNodeFilters excludeFilters,
@@ -254,12 +254,12 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         this.minimumCompatibleLuceneVersion = minimumCompatibleLuceneVersion;
     }
 
-    public String getIndex() {
+    public Index getIndex() {
         return index;
     }
 
     public String getIndexUUID() {
-        return settings.get(SETTING_INDEX_UUID, INDEX_UUID_NA_VALUE);
+        return index.getUUID();
     }
 
     /**
@@ -466,7 +466,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         private final Diff<ImmutableOpenIntMap<Set<String>>> activeAllocationIds;
 
         public IndexMetaDataDiff(IndexMetaData before, IndexMetaData after) {
-            index = after.index;
+            index = after.index.getName();
             version = after.version;
             state = after.state;
             settings = after.settings;
@@ -486,16 +486,16 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
             aliases = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), AliasMetaData.PROTO);
             customs = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(),
                     new DiffableUtils.DiffableValueSerializer<String, Custom>() {
-                @Override
-                public Custom read(StreamInput in, String key) throws IOException {
-                    return lookupPrototypeSafe(key).readFrom(in);
-                }
+                        @Override
+                        public Custom read(StreamInput in, String key) throws IOException {
+                            return lookupPrototypeSafe(key).readFrom(in);
+                        }
 
-                @Override
-                public Diff<Custom> readDiff(StreamInput in, String key) throws IOException {
-                    return lookupPrototypeSafe(key).readDiffFrom(in);
-                }
-            });
+                        @Override
+                        public Diff<Custom> readDiff(StreamInput in, String key) throws IOException {
+                            return lookupPrototypeSafe(key).readDiffFrom(in);
+                        }
+                    });
             activeAllocationIds = DiffableUtils.readImmutableOpenIntMapDiff(in, DiffableUtils.getVIntKeySerializer(),
                     DiffableUtils.StringSetValueSerializer.getInstance());
         }
@@ -559,7 +559,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(index);
+        out.writeString(index.getName()); // uuid will come as part of settings
         out.writeLong(version);
         out.writeByte(state.id());
         writeSettingsToStream(settings, out);
@@ -611,7 +611,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         }
 
         public Builder(IndexMetaData indexMetaData) {
-            this.index = indexMetaData.getIndex();
+            this.index = indexMetaData.getIndex().getName();
             this.state = indexMetaData.state;
             this.version = indexMetaData.version;
             this.settings = indexMetaData.getSettings();
@@ -791,19 +791,20 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
                 try {
                     minimumCompatibleLuceneVersion = org.apache.lucene.util.Version.parse(stringLuceneVersion);
                 } catch (ParseException ex) {
-                    throw new IllegalStateException("Cannot parse lucene version [" + stringLuceneVersion + "] in the [" + SETTING_VERSION_MINIMUM_COMPATIBLE +"] setting", ex);
+                    throw new IllegalStateException("Cannot parse lucene version [" + stringLuceneVersion + "] in the [" + SETTING_VERSION_MINIMUM_COMPATIBLE + "] setting", ex);
                 }
             } else {
                 minimumCompatibleLuceneVersion = null;
             }
 
-            return new IndexMetaData(index, version, state, numberOfShards, numberOfReplicas, tmpSettings, mappings.build(),
+            final String uuid = settings.get(SETTING_INDEX_UUID, INDEX_UUID_NA_VALUE);
+            return new IndexMetaData(new Index(index, uuid), version, state, numberOfShards, numberOfReplicas, tmpSettings, mappings.build(),
                     tmpAliases.build(), customs.build(), filledActiveAllocationIds.build(), requireFilters, includeFilters, excludeFilters,
                     indexCreatedVersion, indexUpgradedVersion, minimumCompatibleLuceneVersion);
         }
 
         public static void toXContent(IndexMetaData indexMetaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
-            builder.startObject(indexMetaData.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+            builder.startObject(indexMetaData.getIndex().getName(), XContentBuilder.FieldCaseConversion.NONE);
 
             builder.field("version", indexMetaData.getVersion());
             builder.field("state", indexMetaData.getState().toString().toLowerCase(Locale.ENGLISH));

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -159,7 +159,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
                 String[] indexNames = new String[resolvedIndices.size()];
                 int i = 0;
                 for (IndexMetaData indexMetaData : resolvedIndices) {
-                    indexNames[i++] = indexMetaData.getIndex();
+                    indexNames[i++] = indexMetaData.getIndex().getName();
                 }
                 throw new IllegalArgumentException("Alias [" + expression + "] has more than one indices associated with it [" + Arrays.toString(indexNames) + "], can't execute a single index op");
             }
@@ -167,14 +167,14 @@ public class IndexNameExpressionResolver extends AbstractComponent {
             for (IndexMetaData index : resolvedIndices) {
                 if (index.getState() == IndexMetaData.State.CLOSE) {
                     if (failClosed) {
-                        throw new IndexClosedException(new Index(index.getIndex()));
+                        throw new IndexClosedException(index.getIndex());
                     } else {
                         if (options.forbidClosedIndices() == false) {
-                            concreteIndices.add(index.getIndex());
+                            concreteIndices.add(index.getIndex().getName());
                         }
                     }
                 } else if (index.getState() == IndexMetaData.State.OPEN) {
-                    concreteIndices.add(index.getIndex());
+                    concreteIndices.add(index.getIndex().getName());
                 } else {
                     throw new IllegalStateException("index state [" + index.getState() + "] not supported");
                 }
@@ -640,7 +640,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
                     } else {
                         for (IndexMetaData meta : aliasOrIndex.getIndices()) {
                             if (excludeState == null || meta.getState() != excludeState) {
-                                expand.add(meta.getIndex());
+                                expand.add(meta.getIndex().getName());
                             }
                         }
                     }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -1003,7 +1003,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
                         alias.addIndex(indexMetaData);
                     } else if (aliasOrIndex instanceof AliasOrIndex.Index) {
                         AliasOrIndex.Index index = (AliasOrIndex.Index) aliasOrIndex;
-                        throw new IllegalStateException("index and alias names need to be unique, but alias [" + aliasMetaData.getAlias() + "] and index [" + index.getIndex().getIndex() + "] have the same name");
+                        throw new IllegalStateException("index and alias names need to be unique, but alias [" + aliasMetaData.getAlias() + "] and index " + index.getIndex().getIndex() + " have the same name");
                     } else {
                         throw new IllegalStateException("unexpected alias [" + aliasMetaData.getAlias() + "][" + aliasOrIndex + "]");
                     }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -50,6 +50,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.store.IndexStoreConfig;
 import org.elasticsearch.indices.recovery.RecoverySettings;
@@ -229,7 +230,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
     public boolean equalsAliases(MetaData other) {
         for (ObjectCursor<IndexMetaData> cursor : other.indices().values()) {
             IndexMetaData otherIndex = cursor.value;
-            IndexMetaData thisIndex= indices().get(otherIndex.getIndex());
+            IndexMetaData thisIndex= index(otherIndex.getIndex());
             if (thisIndex == null) {
                 return false;
             }
@@ -416,7 +417,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
             String[] indexNames = new String[result.getIndices().size()];
             int i = 0;
             for (IndexMetaData indexMetaData : result.getIndices()) {
-                indexNames[i++] = indexMetaData.getIndex();
+                indexNames[i++] = indexMetaData.getIndex().getName();
             }
             throw new IllegalArgumentException("Alias [" + aliasOrIndex + "] has more than one index associated with it [" + Arrays.toString(indexNames) + "], can't execute a single index op");
         }
@@ -449,6 +450,10 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
 
     public IndexMetaData index(String index) {
         return indices.get(index);
+    }
+
+    public IndexMetaData index(Index index) {
+        return index(index.getName());
     }
 
     public ImmutableOpenMap<String, IndexMetaData> indices() {
@@ -815,19 +820,19 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
             // we know its a new one, increment the version and store
             indexMetaDataBuilder.version(indexMetaDataBuilder.version() + 1);
             IndexMetaData indexMetaData = indexMetaDataBuilder.build();
-            indices.put(indexMetaData.getIndex(), indexMetaData);
+            indices.put(indexMetaData.getIndex().getName(), indexMetaData);
             return this;
         }
 
         public Builder put(IndexMetaData indexMetaData, boolean incrementVersion) {
-            if (indices.get(indexMetaData.getIndex()) == indexMetaData) {
+            if (indices.get(indexMetaData.getIndex().getName()) == indexMetaData) {
                 return this;
             }
             // if we put a new index metadata, increment its version
             if (incrementVersion) {
                 indexMetaData = IndexMetaData.builder(indexMetaData).version(indexMetaData.getVersion() + 1).build();
             }
-            indices.put(indexMetaData.getIndex(), indexMetaData);
+            indices.put(indexMetaData.getIndex().getName(), indexMetaData);
             return this;
         }
 
@@ -964,7 +969,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
             // do the required operations, the bottleneck isn't resolving expressions into concrete indices.
             List<String> allIndicesLst = new ArrayList<>();
             for (ObjectCursor<IndexMetaData> cursor : indices.values()) {
-                allIndicesLst.add(cursor.value.getIndex());
+                allIndicesLst.add(cursor.value.getIndex().getName());
             }
             String[] allIndices = allIndicesLst.toArray(new String[allIndicesLst.size()]);
 
@@ -973,9 +978,9 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
             for (ObjectCursor<IndexMetaData> cursor : indices.values()) {
                 IndexMetaData indexMetaData = cursor.value;
                 if (indexMetaData.getState() == IndexMetaData.State.OPEN) {
-                    allOpenIndicesLst.add(indexMetaData.getIndex());
+                    allOpenIndicesLst.add(indexMetaData.getIndex().getName());
                 } else if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
-                    allClosedIndicesLst.add(indexMetaData.getIndex());
+                    allClosedIndicesLst.add(indexMetaData.getIndex().getName());
                 }
             }
             String[] allOpenIndices = allOpenIndicesLst.toArray(new String[allOpenIndicesLst.size()]);
@@ -985,7 +990,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
             SortedMap<String, AliasOrIndex> aliasAndIndexLookup = new TreeMap<>();
             for (ObjectCursor<IndexMetaData> cursor : indices.values()) {
                 IndexMetaData indexMetaData = cursor.value;
-                aliasAndIndexLookup.put(indexMetaData.getIndex(), new AliasOrIndex.Index(indexMetaData));
+                aliasAndIndexLookup.put(indexMetaData.getIndex().getName(), new AliasOrIndex.Index(indexMetaData));
 
                 for (ObjectObjectCursor<String, AliasMetaData> aliasCursor : indexMetaData.getAliases()) {
                     AliasMetaData aliasMetaData = aliasCursor.value;

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -137,22 +137,22 @@ public class MetaDataCreateIndexService extends AbstractComponent {
 
     public void validateIndexName(String index, ClusterState state) {
         if (state.routingTable().hasIndex(index)) {
-            throw new IndexAlreadyExistsException(new Index(index));
+            throw new IndexAlreadyExistsException(state.routingTable().index(index).getIndex());
         }
         if (state.metaData().hasIndex(index)) {
-            throw new IndexAlreadyExistsException(new Index(index));
+            throw new IndexAlreadyExistsException(state.metaData().index(index).getIndex());
         }
         if (!Strings.validFileName(index)) {
-            throw new InvalidIndexNameException(new Index(index), index, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
+            throw new InvalidIndexNameException(index, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
         }
         if (index.contains("#")) {
-            throw new InvalidIndexNameException(new Index(index), index, "must not contain '#'");
+            throw new InvalidIndexNameException(index, "must not contain '#'");
         }
         if (index.charAt(0) == '_') {
-            throw new InvalidIndexNameException(new Index(index), index, "must not start with '_'");
+            throw new InvalidIndexNameException(index, "must not start with '_'");
         }
         if (!index.toLowerCase(Locale.ROOT).equals(index)) {
-            throw new InvalidIndexNameException(new Index(index), index, "must be lowercase");
+            throw new InvalidIndexNameException(index, "must be lowercase");
         }
         int byteCount = 0;
         try {
@@ -162,15 +162,15 @@ public class MetaDataCreateIndexService extends AbstractComponent {
             throw new ElasticsearchException("Unable to determine length of index name", e);
         }
         if (byteCount > MAX_INDEX_NAME_BYTES) {
-            throw new InvalidIndexNameException(new Index(index), index,
+            throw new InvalidIndexNameException(index,
                     "index name is too long, (" + byteCount +
-                    " > " + MAX_INDEX_NAME_BYTES + ")");
+                            " > " + MAX_INDEX_NAME_BYTES + ")");
         }
         if (state.metaData().hasAlias(index)) {
-            throw new InvalidIndexNameException(new Index(index), index, "already exists as alias");
+            throw new InvalidIndexNameException(index, "already exists as alias");
         }
         if (index.equals(".") || index.equals("..")) {
-            throw new InvalidIndexNameException(new Index(index), index, "must not be '.' or '..'");
+            throw new InvalidIndexNameException(index, "must not be '.' or '..'");
         }
     }
 
@@ -187,242 +187,242 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                         return new ClusterStateUpdateResponse(acknowledged);
                     }
 
-            @Override
-            public ClusterState execute(ClusterState currentState) throws Exception {
-                boolean indexCreated = false;
-                String removalReason = null;
-                try {
-                    validate(request, currentState);
-
-                    for (Alias alias : request.aliases()) {
-                        aliasValidator.validateAlias(alias, request.index(), currentState.metaData());
-                    }
-
-                    // we only find a template when its an API call (a new index)
-                    // find templates, highest order are better matching
-                    List<IndexTemplateMetaData> templates = findTemplates(request, currentState, indexTemplateFilter);
-
-                    Map<String, Custom> customs = new HashMap<>();
-
-                    // add the request mapping
-                    Map<String, Map<String, Object>> mappings = new HashMap<>();
-
-                    Map<String, AliasMetaData> templatesAliases = new HashMap<>();
-
-                    List<String> templateNames = new ArrayList<>();
-
-                    for (Map.Entry<String, String> entry : request.mappings().entrySet()) {
-                        mappings.put(entry.getKey(), parseMapping(entry.getValue()));
-                    }
-
-                    for (Map.Entry<String, Custom> entry : request.customs().entrySet()) {
-                        customs.put(entry.getKey(), entry.getValue());
-                    }
-
-                    // apply templates, merging the mappings into the request mapping if exists
-                    for (IndexTemplateMetaData template : templates) {
-                        templateNames.add(template.getName());
-                        for (ObjectObjectCursor<String, CompressedXContent> cursor : template.mappings()) {
-                            if (mappings.containsKey(cursor.key)) {
-                                XContentHelper.mergeDefaults(mappings.get(cursor.key), parseMapping(cursor.value.string()));
-                            } else {
-                                mappings.put(cursor.key, parseMapping(cursor.value.string()));
-                            }
-                        }
-                        // handle custom
-                        for (ObjectObjectCursor<String, Custom> cursor : template.customs()) {
-                            String type = cursor.key;
-                            IndexMetaData.Custom custom = cursor.value;
-                            IndexMetaData.Custom existing = customs.get(type);
-                            if (existing == null) {
-                                customs.put(type, custom);
-                            } else {
-                                IndexMetaData.Custom merged = existing.mergeWith(custom);
-                                customs.put(type, merged);
-                            }
-                        }
-                        //handle aliases
-                        for (ObjectObjectCursor<String, AliasMetaData> cursor : template.aliases()) {
-                            AliasMetaData aliasMetaData = cursor.value;
-                            //if an alias with same name came with the create index request itself,
-                            // ignore this one taken from the index template
-                            if (request.aliases().contains(new Alias(aliasMetaData.alias()))) {
-                                continue;
-                            }
-                            //if an alias with same name was already processed, ignore this one
-                            if (templatesAliases.containsKey(cursor.key)) {
-                                continue;
-                            }
-
-                            //Allow templatesAliases to be templated by replacing a token with the name of the index that we are applying it to
-                            if (aliasMetaData.alias().contains("{index}")) {
-                                String templatedAlias = aliasMetaData.alias().replace("{index}", request.index());
-                                aliasMetaData = AliasMetaData.newAliasMetaData(aliasMetaData, templatedAlias);
-                            }
-
-                            aliasValidator.validateAliasMetaData(aliasMetaData, request.index(), currentState.metaData());
-                            templatesAliases.put(aliasMetaData.alias(), aliasMetaData);
-                        }
-                    }
-
-                    Settings.Builder indexSettingsBuilder = settingsBuilder();
-                    // apply templates, here, in reverse order, since first ones are better matching
-                    for (int i = templates.size() - 1; i >= 0; i--) {
-                        indexSettingsBuilder.put(templates.get(i).settings());
-                    }
-                    // now, put the request settings, so they override templates
-                    indexSettingsBuilder.put(request.settings());
-                    if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
-                        indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 1));
-                    } else {
-                        if (indexSettingsBuilder.get(SETTING_NUMBER_OF_SHARDS) == null) {
-                            indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 5));
-                        }
-                    }
-                    if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
-                        indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 0));
-                        indexSettingsBuilder.put(SETTING_AUTO_EXPAND_REPLICAS, "0-all");
-                    } else {
-                        if (indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
-                            indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
-                        }
-                    }
-
-                    if (settings.get(SETTING_AUTO_EXPAND_REPLICAS) != null && indexSettingsBuilder.get(SETTING_AUTO_EXPAND_REPLICAS) == null) {
-                        indexSettingsBuilder.put(SETTING_AUTO_EXPAND_REPLICAS, settings.get(SETTING_AUTO_EXPAND_REPLICAS));
-                    }
-
-                    if (indexSettingsBuilder.get(SETTING_VERSION_CREATED) == null) {
-                        DiscoveryNodes nodes = currentState.nodes();
-                        final Version createdVersion = Version.smallest(version, nodes.smallestNonClientNodeVersion());
-                        indexSettingsBuilder.put(SETTING_VERSION_CREATED, createdVersion);
-                    }
-
-                    if (indexSettingsBuilder.get(SETTING_CREATION_DATE) == null) {
-                        indexSettingsBuilder.put(SETTING_CREATION_DATE, new DateTime(DateTimeZone.UTC).getMillis());
-                    }
-
-                    indexSettingsBuilder.put(SETTING_INDEX_UUID, Strings.randomBase64UUID());
-
-                    Settings actualIndexSettings = indexSettingsBuilder.build();
-
-                    // Set up everything, now locally create the index to see that things are ok, and apply
-                    final IndexMetaData tmpImd = IndexMetaData.builder(request.index()).settings(actualIndexSettings).build();
-                    // create the index here (on the master) to validate it can be created, as well as adding the mapping
-                    indicesService.createIndex(nodeServicesProvider, tmpImd, Collections.emptyList());
-                    indexCreated = true;
-                    // now add the mappings
-                    IndexService indexService = indicesService.indexServiceSafe(request.index());
-                    MapperService mapperService = indexService.mapperService();
-                    // first, add the default mapping
-                    if (mappings.containsKey(MapperService.DEFAULT_MAPPING)) {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) throws Exception {
+                        boolean indexCreated = false;
+                        String removalReason = null;
                         try {
-                            mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent(XContentFactory.jsonBuilder().map(mappings.get(MapperService.DEFAULT_MAPPING)).string()), MapperService.MergeReason.MAPPING_UPDATE, request.updateAllTypes());
-                        } catch (Exception e) {
-                            removalReason = "failed on parsing default mapping on index creation";
-                            throw new MapperParsingException("Failed to parse mapping [{}]: {}", e, MapperService.DEFAULT_MAPPING, e.getMessage());
+                            validate(request, currentState);
+
+                            for (Alias alias : request.aliases()) {
+                                aliasValidator.validateAlias(alias, request.index(), currentState.metaData());
+                            }
+
+                            // we only find a template when its an API call (a new index)
+                            // find templates, highest order are better matching
+                            List<IndexTemplateMetaData> templates = findTemplates(request, currentState, indexTemplateFilter);
+
+                            Map<String, Custom> customs = new HashMap<>();
+
+                            // add the request mapping
+                            Map<String, Map<String, Object>> mappings = new HashMap<>();
+
+                            Map<String, AliasMetaData> templatesAliases = new HashMap<>();
+
+                            List<String> templateNames = new ArrayList<>();
+
+                            for (Map.Entry<String, String> entry : request.mappings().entrySet()) {
+                                mappings.put(entry.getKey(), parseMapping(entry.getValue()));
+                            }
+
+                            for (Map.Entry<String, Custom> entry : request.customs().entrySet()) {
+                                customs.put(entry.getKey(), entry.getValue());
+                            }
+
+                            // apply templates, merging the mappings into the request mapping if exists
+                            for (IndexTemplateMetaData template : templates) {
+                                templateNames.add(template.getName());
+                                for (ObjectObjectCursor<String, CompressedXContent> cursor : template.mappings()) {
+                                    if (mappings.containsKey(cursor.key)) {
+                                        XContentHelper.mergeDefaults(mappings.get(cursor.key), parseMapping(cursor.value.string()));
+                                    } else {
+                                        mappings.put(cursor.key, parseMapping(cursor.value.string()));
+                                    }
+                                }
+                                // handle custom
+                                for (ObjectObjectCursor<String, Custom> cursor : template.customs()) {
+                                    String type = cursor.key;
+                                    IndexMetaData.Custom custom = cursor.value;
+                                    IndexMetaData.Custom existing = customs.get(type);
+                                    if (existing == null) {
+                                        customs.put(type, custom);
+                                    } else {
+                                        IndexMetaData.Custom merged = existing.mergeWith(custom);
+                                        customs.put(type, merged);
+                                    }
+                                }
+                                //handle aliases
+                                for (ObjectObjectCursor<String, AliasMetaData> cursor : template.aliases()) {
+                                    AliasMetaData aliasMetaData = cursor.value;
+                                    //if an alias with same name came with the create index request itself,
+                                    // ignore this one taken from the index template
+                                    if (request.aliases().contains(new Alias(aliasMetaData.alias()))) {
+                                        continue;
+                                    }
+                                    //if an alias with same name was already processed, ignore this one
+                                    if (templatesAliases.containsKey(cursor.key)) {
+                                        continue;
+                                    }
+
+                                    //Allow templatesAliases to be templated by replacing a token with the name of the index that we are applying it to
+                                    if (aliasMetaData.alias().contains("{index}")) {
+                                        String templatedAlias = aliasMetaData.alias().replace("{index}", request.index());
+                                        aliasMetaData = AliasMetaData.newAliasMetaData(aliasMetaData, templatedAlias);
+                                    }
+
+                                    aliasValidator.validateAliasMetaData(aliasMetaData, request.index(), currentState.metaData());
+                                    templatesAliases.put(aliasMetaData.alias(), aliasMetaData);
+                                }
+                            }
+
+                            Settings.Builder indexSettingsBuilder = settingsBuilder();
+                            // apply templates, here, in reverse order, since first ones are better matching
+                            for (int i = templates.size() - 1; i >= 0; i--) {
+                                indexSettingsBuilder.put(templates.get(i).settings());
+                            }
+                            // now, put the request settings, so they override templates
+                            indexSettingsBuilder.put(request.settings());
+                            if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
+                                indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 1));
+                            } else {
+                                if (indexSettingsBuilder.get(SETTING_NUMBER_OF_SHARDS) == null) {
+                                    indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 5));
+                                }
+                            }
+                            if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
+                                indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 0));
+                                indexSettingsBuilder.put(SETTING_AUTO_EXPAND_REPLICAS, "0-all");
+                            } else {
+                                if (indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
+                                    indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
+                                }
+                            }
+
+                            if (settings.get(SETTING_AUTO_EXPAND_REPLICAS) != null && indexSettingsBuilder.get(SETTING_AUTO_EXPAND_REPLICAS) == null) {
+                                indexSettingsBuilder.put(SETTING_AUTO_EXPAND_REPLICAS, settings.get(SETTING_AUTO_EXPAND_REPLICAS));
+                            }
+
+                            if (indexSettingsBuilder.get(SETTING_VERSION_CREATED) == null) {
+                                DiscoveryNodes nodes = currentState.nodes();
+                                final Version createdVersion = Version.smallest(version, nodes.smallestNonClientNodeVersion());
+                                indexSettingsBuilder.put(SETTING_VERSION_CREATED, createdVersion);
+                            }
+
+                            if (indexSettingsBuilder.get(SETTING_CREATION_DATE) == null) {
+                                indexSettingsBuilder.put(SETTING_CREATION_DATE, new DateTime(DateTimeZone.UTC).getMillis());
+                            }
+
+                            indexSettingsBuilder.put(SETTING_INDEX_UUID, Strings.randomBase64UUID());
+
+                            Settings actualIndexSettings = indexSettingsBuilder.build();
+
+                            // Set up everything, now locally create the index to see that things are ok, and apply
+                            final IndexMetaData tmpImd = IndexMetaData.builder(request.index()).settings(actualIndexSettings).build();
+                            // create the index here (on the master) to validate it can be created, as well as adding the mapping
+                            indicesService.createIndex(nodeServicesProvider, tmpImd, Collections.emptyList());
+                            indexCreated = true;
+                            // now add the mappings
+                            IndexService indexService = indicesService.indexServiceSafe(request.index());
+                            MapperService mapperService = indexService.mapperService();
+                            // first, add the default mapping
+                            if (mappings.containsKey(MapperService.DEFAULT_MAPPING)) {
+                                try {
+                                    mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent(XContentFactory.jsonBuilder().map(mappings.get(MapperService.DEFAULT_MAPPING)).string()), MapperService.MergeReason.MAPPING_UPDATE, request.updateAllTypes());
+                                } catch (Exception e) {
+                                    removalReason = "failed on parsing default mapping on index creation";
+                                    throw new MapperParsingException("Failed to parse mapping [{}]: {}", e, MapperService.DEFAULT_MAPPING, e.getMessage());
+                                }
+                            }
+                            for (Map.Entry<String, Map<String, Object>> entry : mappings.entrySet()) {
+                                if (entry.getKey().equals(MapperService.DEFAULT_MAPPING)) {
+                                    continue;
+                                }
+                                try {
+                                    // apply the default here, its the first time we parse it
+                                    mapperService.merge(entry.getKey(), new CompressedXContent(XContentFactory.jsonBuilder().map(entry.getValue()).string()), MapperService.MergeReason.MAPPING_UPDATE, request.updateAllTypes());
+                                } catch (Exception e) {
+                                    removalReason = "failed on parsing mappings on index creation";
+                                    throw new MapperParsingException("Failed to parse mapping [{}]: {}", e, entry.getKey(), e.getMessage());
+                                }
+                            }
+
+                            QueryShardContext queryShardContext = indexService.getQueryShardContext();
+                            for (Alias alias : request.aliases()) {
+                                if (Strings.hasLength(alias.filter())) {
+                                    aliasValidator.validateAliasFilter(alias.name(), alias.filter(), queryShardContext);
+                                }
+                            }
+                            for (AliasMetaData aliasMetaData : templatesAliases.values()) {
+                                if (aliasMetaData.filter() != null) {
+                                    aliasValidator.validateAliasFilter(aliasMetaData.alias(), aliasMetaData.filter().uncompressed(), queryShardContext);
+                                }
+                            }
+
+                            // now, update the mappings with the actual source
+                            Map<String, MappingMetaData> mappingsMetaData = new HashMap<>();
+                            for (DocumentMapper mapper : mapperService.docMappers(true)) {
+                                MappingMetaData mappingMd = new MappingMetaData(mapper);
+                                mappingsMetaData.put(mapper.type(), mappingMd);
+                            }
+
+                            final IndexMetaData.Builder indexMetaDataBuilder = IndexMetaData.builder(request.index()).settings(actualIndexSettings);
+                            for (MappingMetaData mappingMd : mappingsMetaData.values()) {
+                                indexMetaDataBuilder.putMapping(mappingMd);
+                            }
+
+                            for (AliasMetaData aliasMetaData : templatesAliases.values()) {
+                                indexMetaDataBuilder.putAlias(aliasMetaData);
+                            }
+                            for (Alias alias : request.aliases()) {
+                                AliasMetaData aliasMetaData = AliasMetaData.builder(alias.name()).filter(alias.filter())
+                                        .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).build();
+                                indexMetaDataBuilder.putAlias(aliasMetaData);
+                            }
+
+                            for (Map.Entry<String, Custom> customEntry : customs.entrySet()) {
+                                indexMetaDataBuilder.putCustom(customEntry.getKey(), customEntry.getValue());
+                            }
+
+                            indexMetaDataBuilder.state(request.state());
+
+                            final IndexMetaData indexMetaData;
+                            try {
+                                indexMetaData = indexMetaDataBuilder.build();
+                            } catch (Exception e) {
+                                removalReason = "failed to build index metadata";
+                                throw e;
+                            }
+
+                            indexService.getIndexEventListener().beforeIndexAddedToCluster(indexMetaData.getIndex(),
+                                    indexMetaData.getSettings());
+
+                            MetaData newMetaData = MetaData.builder(currentState.metaData())
+                                    .put(indexMetaData, false)
+                                    .build();
+
+                            String maybeShadowIndicator = IndexMetaData.isIndexUsingShadowReplicas(indexMetaData.getSettings()) ? "s" : "";
+                            logger.info("[{}] creating index, cause [{}], templates {}, shards [{}]/[{}{}], mappings {}",
+                                    request.index(), request.cause(), templateNames, indexMetaData.getNumberOfShards(),
+                                    indexMetaData.getNumberOfReplicas(), maybeShadowIndicator, mappings.keySet());
+
+                            ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+                            if (!request.blocks().isEmpty()) {
+                                for (ClusterBlock block : request.blocks()) {
+                                    blocks.addIndexBlock(request.index(), block);
+                                }
+                            }
+                            blocks.updateBlocks(indexMetaData);
+
+                            ClusterState updatedState = ClusterState.builder(currentState).blocks(blocks).metaData(newMetaData).build();
+
+                            if (request.state() == State.OPEN) {
+                                RoutingTable.Builder routingTableBuilder = RoutingTable.builder(updatedState.routingTable())
+                                        .addAsNew(updatedState.metaData().index(request.index()));
+                                RoutingAllocation.Result routingResult = allocationService.reroute(
+                                        ClusterState.builder(updatedState).routingTable(routingTableBuilder.build()).build(),
+                                        "index [" + request.index() + "] created");
+                                updatedState = ClusterState.builder(updatedState).routingResult(routingResult).build();
+                            }
+                            removalReason = "cleaning up after validating index on master";
+                            return updatedState;
+                        } finally {
+                            if (indexCreated) {
+                                // Index was already partially created - need to clean up
+                                indicesService.removeIndex(request.index(), removalReason != null ? removalReason : "failed to create index");
+                            }
                         }
                     }
-                    for (Map.Entry<String, Map<String, Object>> entry : mappings.entrySet()) {
-                        if (entry.getKey().equals(MapperService.DEFAULT_MAPPING)) {
-                            continue;
-                        }
-                        try {
-                            // apply the default here, its the first time we parse it
-                            mapperService.merge(entry.getKey(), new CompressedXContent(XContentFactory.jsonBuilder().map(entry.getValue()).string()), MapperService.MergeReason.MAPPING_UPDATE, request.updateAllTypes());
-                        } catch (Exception e) {
-                            removalReason = "failed on parsing mappings on index creation";
-                            throw new MapperParsingException("Failed to parse mapping [{}]: {}", e, entry.getKey(), e.getMessage());
-                        }
-                    }
-
-                    QueryShardContext queryShardContext = indexService.getQueryShardContext();
-                    for (Alias alias : request.aliases()) {
-                        if (Strings.hasLength(alias.filter())) {
-                            aliasValidator.validateAliasFilter(alias.name(), alias.filter(), queryShardContext);
-                        }
-                    }
-                    for (AliasMetaData aliasMetaData : templatesAliases.values()) {
-                        if (aliasMetaData.filter() != null) {
-                            aliasValidator.validateAliasFilter(aliasMetaData.alias(), aliasMetaData.filter().uncompressed(), queryShardContext);
-                        }
-                    }
-
-                    // now, update the mappings with the actual source
-                    Map<String, MappingMetaData> mappingsMetaData = new HashMap<>();
-                    for (DocumentMapper mapper : mapperService.docMappers(true)) {
-                        MappingMetaData mappingMd = new MappingMetaData(mapper);
-                        mappingsMetaData.put(mapper.type(), mappingMd);
-                    }
-
-                    final IndexMetaData.Builder indexMetaDataBuilder = IndexMetaData.builder(request.index()).settings(actualIndexSettings);
-                    for (MappingMetaData mappingMd : mappingsMetaData.values()) {
-                        indexMetaDataBuilder.putMapping(mappingMd);
-                    }
-
-                    for (AliasMetaData aliasMetaData : templatesAliases.values()) {
-                        indexMetaDataBuilder.putAlias(aliasMetaData);
-                    }
-                    for (Alias alias : request.aliases()) {
-                        AliasMetaData aliasMetaData = AliasMetaData.builder(alias.name()).filter(alias.filter())
-                                .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).build();
-                        indexMetaDataBuilder.putAlias(aliasMetaData);
-                    }
-
-                    for (Map.Entry<String, Custom> customEntry : customs.entrySet()) {
-                        indexMetaDataBuilder.putCustom(customEntry.getKey(), customEntry.getValue());
-                    }
-
-                    indexMetaDataBuilder.state(request.state());
-
-                    final IndexMetaData indexMetaData;
-                    try {
-                        indexMetaData = indexMetaDataBuilder.build();
-                    } catch (Exception e) {
-                        removalReason = "failed to build index metadata";
-                        throw e;
-                    }
-
-                    indexService.getIndexEventListener().beforeIndexAddedToCluster(new Index(request.index()),
-                            indexMetaData.getSettings());
-
-                    MetaData newMetaData = MetaData.builder(currentState.metaData())
-                            .put(indexMetaData, false)
-                            .build();
-
-                    String maybeShadowIndicator = IndexMetaData.isIndexUsingShadowReplicas(indexMetaData.getSettings()) ? "s" : "";
-                    logger.info("[{}] creating index, cause [{}], templates {}, shards [{}]/[{}{}], mappings {}",
-                            request.index(), request.cause(), templateNames, indexMetaData.getNumberOfShards(),
-                            indexMetaData.getNumberOfReplicas(), maybeShadowIndicator, mappings.keySet());
-
-                    ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
-                    if (!request.blocks().isEmpty()) {
-                        for (ClusterBlock block : request.blocks()) {
-                            blocks.addIndexBlock(request.index(), block);
-                        }
-                    }
-                    blocks.updateBlocks(indexMetaData);
-
-                    ClusterState updatedState = ClusterState.builder(currentState).blocks(blocks).metaData(newMetaData).build();
-
-                    if (request.state() == State.OPEN) {
-                        RoutingTable.Builder routingTableBuilder = RoutingTable.builder(updatedState.routingTable())
-                                .addAsNew(updatedState.metaData().index(request.index()));
-                        RoutingAllocation.Result routingResult = allocationService.reroute(
-                                ClusterState.builder(updatedState).routingTable(routingTableBuilder.build()).build(),
-                                "index [" + request.index() + "] created");
-                        updatedState = ClusterState.builder(updatedState).routingResult(routingResult).build();
-                    }
-                    removalReason = "cleaning up after validating index on master";
-                    return updatedState;
-                } finally {
-                    if (indexCreated) {
-                        // Index was already partially created - need to clean up
-                        indicesService.removeIndex(request.index(), removalReason != null ? removalReason : "failed to create index");
-                    }
-                }
-            }
-        });
+                });
     }
 
     private Map<String, Object> parseMapping(String mappingSource) throws Exception {
@@ -459,7 +459,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         if (validationErrors.isEmpty() == false) {
             ValidationException validationException = new ValidationException();
             validationException.addValidationErrors(validationErrors);
-            throw new IndexCreationException(new Index(indexName), validationException);
+            throw new IndexCreationException(indexName, validationException);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -112,9 +112,9 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                                             logger.warn("[{}] failed to temporary create in order to apply alias action", e, indexMetaData.getIndex());
                                             continue;
                                         }
-                                        indicesToClose.add(indexMetaData.getIndex());
+                                        indicesToClose.add(indexMetaData.getIndex().getName());
                                     }
-                                    indices.put(indexMetaData.getIndex(), indexService);
+                                    indices.put(indexMetaData.getIndex().getName(), indexService);
                                 }
 
                                 aliasValidator.validateAliasFilter(aliasAction.alias(), filter, indexService.getQueryShardContext());

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -169,7 +169,7 @@ public class MetaDataMappingService extends AbstractComponent {
 
     private boolean refreshIndexMapping(IndexService indexService, IndexMetaData.Builder builder) {
         boolean dirty = false;
-        String index = indexService.index().name();
+        String index = indexService.index().getName();
         try {
             List<String> updatedTypes = new ArrayList<>();
             for (DocumentMapper mapper : indexService.mapperService().docMappers(true)) {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -117,7 +117,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
                         nrReplicasChanged.put(numberOfReplicas, new ArrayList<>());
                     }
 
-                    nrReplicasChanged.get(numberOfReplicas).add(indexMetaData.getIndex());
+                    nrReplicasChanged.get(numberOfReplicas).add(indexMetaData.getIndex().getName());
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -30,12 +30,12 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -58,9 +58,9 @@ import java.util.Set;
  */
 public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> implements Iterable<IndexShardRoutingTable> {
 
-    public static final IndexRoutingTable PROTO = builder("").build();
+    public static final IndexRoutingTable PROTO = builder(new Index("", "_na_")).build();
 
-    private final String index;
+    private final Index index;
     private final ShardShuffler shuffler;
 
     // note, we assume that when the index routing is created, ShardRoutings are created for all possible number of
@@ -69,7 +69,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
 
     private final List<ShardRouting> allActiveShards;
 
-    IndexRoutingTable(String index, ImmutableOpenIntMap<IndexShardRoutingTable> shards) {
+    IndexRoutingTable(Index index, ImmutableOpenIntMap<IndexShardRoutingTable> shards) {
         this.index = index;
         this.shuffler = new RotationShardShuffler(Randomness.get().nextInt());
         this.shards = shards;
@@ -90,18 +90,8 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
      *
      * @return id of the index
      */
-    public String index() {
-        return this.index;
-    }
-
-
-    /**
-     * Return the index id
-     *
-     * @return id of the index
-     */
-    public String getIndex() {
-        return index();
+    public Index getIndex() {
+        return index;
     }
 
     /**
@@ -118,13 +108,17 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
     }
 
     public void validate(RoutingTableValidation validation, MetaData metaData) {
-        if (!metaData.hasIndex(index())) {
-            validation.addIndexFailure(index(), "Exists in routing does not exists in metadata");
+        if (!metaData.hasIndex(index.getName())) {
+            validation.addIndexFailure(index.getName(), "Exists in routing does not exists in metadata");
             return;
         }
-        IndexMetaData indexMetaData = metaData.index(index());
+        IndexMetaData indexMetaData = metaData.index(index.getName());
+        if (indexMetaData.getIndexUUID().equals(index.getUUID()) == false) {
+            validation.addIndexFailure(index.getName(), "Exists in routing does not exists in metadata with the same uuid");
+            return;
+        }
         for (String failure : validate(indexMetaData)) {
-            validation.addIndexFailure(index, failure);
+            validation.addIndexFailure(index.getName(), failure);
         }
 
     }
@@ -154,7 +148,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
                         + "] routing table has wrong number of replicas, expected [" + indexMetaData.getNumberOfReplicas() + "], got [" + routingNumberOfReplicas + "]");
             }
             for (ShardRouting shardRouting : indexShardRoutingTable) {
-                if (!shardRouting.index().equals(index())) {
+                if (!shardRouting.index().equals(index)) {
                     failures.add("shard routing has an index [" + shardRouting.index() + "] that is different than the routing table");
                 }
             }
@@ -332,7 +326,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
 
     @Override
     public IndexRoutingTable readFrom(StreamInput in) throws IOException {
-        String index = in.readString();
+        Index index = Index.readIndex(in);
         Builder builder = new Builder(index);
 
         int size = in.readVInt();
@@ -345,23 +339,23 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(index);
+        index.writeTo(out);
         out.writeVInt(shards.size());
         for (IndexShardRoutingTable indexShard : this) {
             IndexShardRoutingTable.Builder.writeToThin(indexShard, out);
         }
     }
 
-    public static Builder builder(String index) {
+    public static Builder builder(Index index) {
         return new Builder(index);
     }
 
     public static class Builder {
 
-        private final String index;
+        private final Index index;
         private final ImmutableOpenIntMap.Builder<IndexShardRoutingTable> shards = ImmutableOpenIntMap.builder();
 
-        public Builder(String index) {
+        public Builder(Index index) {
             this.index = index;
         }
 
@@ -422,11 +416,13 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
          * Initializes an index, to be restored from snapshot
          */
         private Builder initializeAsRestore(IndexMetaData indexMetaData, RestoreSource restoreSource, IntSet ignoreShards, boolean asNew, UnassignedInfo unassignedInfo) {
+            assert indexMetaData.getIndex().equals(index.getName());
+            assert indexMetaData.getIndexUUID().equals(index.getUUID());
             if (!shards.isEmpty()) {
                 throw new IllegalStateException("trying to initialize an index with fresh shards, but already has shards created");
             }
             for (int shardId = 0; shardId < indexMetaData.getNumberOfShards(); shardId++) {
-                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(new ShardId(indexMetaData.getIndex(), shardId));
+                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(new ShardId(index, shardId));
                 for (int i = 0; i <= indexMetaData.getNumberOfReplicas(); i++) {
                     if (asNew && ignoreShards.contains(shardId)) {
                         // This shards wasn't completely snapshotted - restore it as new shard
@@ -444,11 +440,12 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
          * Initializes a new empty index, with an option to control if its from an API or not.
          */
         private Builder initializeEmpty(IndexMetaData indexMetaData, UnassignedInfo unassignedInfo) {
+            assert indexMetaData.getIndex().equals(index);
             if (!shards.isEmpty()) {
                 throw new IllegalStateException("trying to initialize an index with fresh shards, but already has shards created");
             }
             for (int shardId = 0; shardId < indexMetaData.getNumberOfShards(); shardId++) {
-                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(new ShardId(indexMetaData.getIndex(), shardId));
+                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(new ShardId(index, shardId));
                 for (int i = 0; i <= indexMetaData.getNumberOfReplicas(); i++) {
                     indexShardRoutingBuilder.addShard(ShardRouting.newUnassigned(index, shardId, null, i == 0, unassignedInfo));
                 }
@@ -539,21 +536,18 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
             ordered.add(indexShard);
         }
 
-        CollectionUtil.timSort(ordered, new Comparator<IndexShardRoutingTable>() {
-            @Override
-            public int compare(IndexShardRoutingTable o1, IndexShardRoutingTable o2) {
-                int v = o1.shardId().index().getName().compareTo(
-                        o2.shardId().index().getName());
-                if (v == 0) {
-                    v = Integer.compare(o1.shardId().id(),
-                                        o2.shardId().id());
-                }
-                return v;
+        CollectionUtil.timSort(ordered, (o1, o2) -> {
+            int v = o1.shardId().getIndex().getName().compareTo(
+                    o2.shardId().getIndex().getName());
+            if (v == 0) {
+                v = Integer.compare(o1.shardId().id(),
+                                    o2.shardId().id());
             }
+            return v;
         });
 
         for (IndexShardRoutingTable indexShard : ordered) {
-            sb.append("----shard_id [").append(indexShard.shardId().index().getName()).append("][").append(indexShard.shardId().id()).append("]\n");
+            sb.append("----shard_id [").append(indexShard.shardId().getIndex().getName()).append("][").append(indexShard.shardId().id()).append("]\n");
             for (ShardRouting shard : indexShard) {
                 sb.append("--------").append(shard.shortSummary()).append("\n");
             }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -542,8 +542,8 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         CollectionUtil.timSort(ordered, new Comparator<IndexShardRoutingTable>() {
             @Override
             public int compare(IndexShardRoutingTable o1, IndexShardRoutingTable o2) {
-                int v = o1.shardId().index().name().compareTo(
-                        o2.shardId().index().name());
+                int v = o1.shardId().index().getName().compareTo(
+                        o2.shardId().index().getName());
                 if (v == 0) {
                     v = Integer.compare(o1.shardId().id(),
                                         o2.shardId().id());
@@ -553,7 +553,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         });
 
         for (IndexShardRoutingTable indexShard : ordered) {
-            sb.append("----shard_id [").append(indexShard.shardId().index().name()).append("][").append(indexShard.shardId().id()).append("]\n");
+            sb.append("----shard_id [").append(indexShard.shardId().index().getName()).append("][").append(indexShard.shardId().id()).append("]\n");
             for (ShardRouting shard : indexShard) {
                 sb.append("--------").append(shard.shortSummary()).append("\n");
             }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -416,8 +416,7 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
          * Initializes an index, to be restored from snapshot
          */
         private Builder initializeAsRestore(IndexMetaData indexMetaData, RestoreSource restoreSource, IntSet ignoreShards, boolean asNew, UnassignedInfo unassignedInfo) {
-            assert indexMetaData.getIndex().equals(index.getName());
-            assert indexMetaData.getIndexUUID().equals(index.getUUID());
+            assert indexMetaData.getIndex().equals(index);
             if (!shards.isEmpty()) {
                 throw new IllegalStateException("trying to initialize an index with fresh shards, but already has shards created");
             }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -635,7 +635,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         }
 
         public static void writeTo(IndexShardRoutingTable indexShard, StreamOutput out) throws IOException {
-            out.writeString(indexShard.shardId().index().name());
+            out.writeString(indexShard.shardId().index().getName());
             writeToThin(indexShard, out);
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
@@ -617,11 +618,11 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         }
 
         public static IndexShardRoutingTable readFrom(StreamInput in) throws IOException {
-            String index = in.readString();
+            Index index = Index.readIndex(in);
             return readFromThin(in, index);
         }
 
-        public static IndexShardRoutingTable readFromThin(StreamInput in, String index) throws IOException {
+        public static IndexShardRoutingTable readFromThin(StreamInput in, Index index) throws IOException {
             int iShardId = in.readVInt();
             Builder builder = new Builder(new ShardId(index, iShardId));
 
@@ -635,7 +636,7 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         }
 
         public static void writeTo(IndexShardRoutingTable indexShard, StreamOutput out) throws IOException {
-            out.writeString(indexShard.shardId().index().getName());
+            out.writeString(indexShard.shardId().getIndex().getName());
             writeToThin(indexShard, out);
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -137,7 +137,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
         List<ShardRouting> shards = new ArrayList<>();
 
         for (ShardRouting shardEntry : this) {
-            if (!shardEntry.index().equals(index)) {
+            if (!shardEntry.getIndexName().equals(index)) {
                 continue;
             }
             for (ShardRoutingState state : states) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -87,7 +87,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
         // TODO use Set with ShardIds for faster lookup.
         for (ShardRouting shardRouting : shards) {
             if (shardRouting.isSameShard(shard)) {
-                throw new IllegalStateException("Trying to add a shard [" + shard.shardId().index().name() + "][" + shard.shardId().id() + "] to a node [" + nodeId + "] where it already exists");
+                throw new IllegalStateException("Trying to add a shard [" + shard.shardId().index().getName() + "][" + shard.shardId().id() + "] to a node [" + nodeId + "] where it already exists");
             }
         }
         shards.add(shard);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -87,7 +87,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
         // TODO use Set with ShardIds for faster lookup.
         for (ShardRouting shardRouting : shards) {
             if (shardRouting.isSameShard(shard)) {
-                throw new IllegalStateException("Trying to add a shard [" + shard.shardId().index().getName() + "][" + shard.shardId().id() + "] to a node [" + nodeId + "] where it already exists");
+                throw new IllegalStateException("Trying to add a shard [" + shard.shardId().getIndex().getName() + "][" + shard.shardId().id() + "] to a node [" + nodeId + "] where it already exists");
             }
         }
         shards.add(shard);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.ArrayList;
@@ -169,7 +170,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         } else if (routing.primary() == false) { // primary without relocationID is initial recovery
             ShardRouting primary = findPrimary(routing);
             if (primary == null && initializing) {
-                primary = routingTable.index(routing.index()).shard(routing.shardId().id()).primary;
+                primary = routingTable.index(routing.index().getName()).shard(routing.shardId().id()).primary;
             } else if (primary == null) {
                 throw new IllegalStateException("replica is initializing but primary is unassigned");
             }
@@ -348,7 +349,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
      */
     public boolean allReplicasActive(ShardRouting shardRouting) {
         final List<ShardRouting> shards = assignedShards(shardRouting.shardId());
-        if (shards.isEmpty() || shards.size() < this.routingTable.index(shardRouting.index()).shard(shardRouting.id()).size()) {
+        if (shards.isEmpty() || shards.size() < this.routingTable.index(shardRouting.index().getName()).shard(shardRouting.id()).size()) {
             return false; // if we are empty nothing is active if we have less than total at least one is unassigned
         }
         for (ShardRouting shard : shards) {
@@ -778,7 +779,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         int inactivePrimaryCount = 0;
         int inactiveShardCount = 0;
         int relocating = 0;
-        Map<String, Integer> indicesAndShards = new HashMap<>();
+        Map<Index, Integer> indicesAndShards = new HashMap<>();
         for (RoutingNode node : routingNodes) {
             for (ShardRouting shard : node) {
                 if (!shard.active() && shard.relocatingNodeId() == null) {
@@ -800,10 +801,10 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             }
         }
         // Assert that the active shard routing are identical.
-        Set<Map.Entry<String, Integer>> entries = indicesAndShards.entrySet();
+        Set<Map.Entry<Index, Integer>> entries = indicesAndShards.entrySet();
         final List<ShardRouting> shards = new ArrayList<>();
-        for (Map.Entry<String, Integer> e : entries) {
-            String index = e.getKey();
+        for (Map.Entry<Index, Integer> e : entries) {
+            Index index = e.getKey();
             for (int i = 0; i < e.getValue(); i++) {
                 for (RoutingNode routingNode : routingNodes) {
                     for (ShardRouting shardRouting : routingNode) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.iterable.Iterables;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
@@ -88,6 +89,10 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         return indicesRouting.get(index);
     }
 
+    public IndexRoutingTable index(Index index) {
+        return indicesRouting.get(index.getName());
+    }
+
     public ImmutableOpenMap<String, IndexRoutingTable> indicesRouting() {
         return indicesRouting;
     }
@@ -109,7 +114,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         }
         IndexShardRoutingTable shard = indexRouting.shard(shardId);
         if (shard == null) {
-            throw new ShardNotFoundException(new ShardId(index, shardId));
+            throw new ShardNotFoundException(new ShardId(indexRouting.getIndex(), shardId));
         }
         return shard;
     }
@@ -121,7 +126,15 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
      * @throws ShardNotFoundException if provided shard id is unknown
      */
     public IndexShardRoutingTable shardRoutingTable(ShardId shardId) {
-        return shardRoutingTable(shardId.getIndex(), shardId.getId());
+        IndexRoutingTable indexRouting = index(shardId.getIndexName());
+        if (indexRouting == null || indexRouting.getIndex().equals(shardId.getIndex()) == false) {
+            throw new IndexNotFoundException(shardId.getIndex());
+        }
+        IndexShardRoutingTable shard = indexRouting.shard(shardId.id());
+        if (shard == null) {
+            throw new ShardNotFoundException(shardId);
+        }
+        return shard;
     }
 
     public RoutingTable validateRaiseException(MetaData metaData) throws RoutingValidationException {
@@ -386,7 +399,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         public Builder(RoutingTable routingTable) {
             version = routingTable.version;
             for (IndexRoutingTable indexRoutingTable : routingTable) {
-                indicesRouting.put(indexRoutingTable.index(), indexRoutingTable);
+                indicesRouting.put(indexRoutingTable.getIndex().getName(), indexRoutingTable);
             }
         }
 
@@ -401,14 +414,14 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                     if (shardRoutingEntry.initializing() && shardRoutingEntry.relocatingNodeId() != null)
                         continue;
 
-                    String index = shardRoutingEntry.index();
-                    IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index);
+                    Index index = shardRoutingEntry.index();
+                    IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index.getName());
                     if (indexBuilder == null) {
                         indexBuilder = new IndexRoutingTable.Builder(index);
-                        indexRoutingTableBuilders.put(index, indexBuilder);
+                        indexRoutingTableBuilders.put(index.getName(), indexBuilder);
                     }
 
-                    IndexShardRoutingTable refData = routingNodes.routingTable().index(shardRoutingEntry.index()).shard(shardRoutingEntry.id());
+                    IndexShardRoutingTable refData = routingNodes.routingTable().index(shardRoutingEntry.index().getName()).shard(shardRoutingEntry.id());
                     indexBuilder.addShard(refData, shardRoutingEntry);
                 }
             }
@@ -416,13 +429,13 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             Iterable<ShardRouting> shardRoutingEntries = Iterables.concat(routingNodes.unassigned(), routingNodes.unassigned().ignored());
 
             for (ShardRouting shardRoutingEntry : shardRoutingEntries) {
-                String index = shardRoutingEntry.index();
-                IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index);
+                Index index = shardRoutingEntry.index();
+                IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index.getName());
                 if (indexBuilder == null) {
                     indexBuilder = new IndexRoutingTable.Builder(index);
-                    indexRoutingTableBuilders.put(index, indexBuilder);
+                    indexRoutingTableBuilders.put(index.getName(), indexBuilder);
                 }
-                IndexShardRoutingTable refData = routingNodes.routingTable().index(shardRoutingEntry.index()).shard(shardRoutingEntry.id());
+                IndexShardRoutingTable refData = routingNodes.routingTable().index(shardRoutingEntry.index().getName()).shard(shardRoutingEntry.id());
                 indexBuilder.addShard(refData, shardRoutingEntry);
             }
 
@@ -446,7 +459,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                     continue;
                 }
                 int currentNumberOfReplicas = indexRoutingTable.shards().get(0).size() - 1; // remove the required primary
-                IndexRoutingTable.Builder builder = new IndexRoutingTable.Builder(index);
+                IndexRoutingTable.Builder builder = new IndexRoutingTable.Builder(indexRoutingTable.getIndex());
                 // re-add all the shards
                 for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                     builder.addIndexShard(indexShardRoutingTable);
@@ -526,7 +539,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 throw new IllegalStateException("once build is called the builder cannot be reused");
             }
             indexRoutingTable.validate();
-            indicesRouting.put(indexRoutingTable.index(), indexRoutingTable);
+            indicesRouting.put(indexRoutingTable.getIndex().getName(), indexRoutingTable);
             return this;
         }
 
@@ -567,7 +580,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             }
             // normalize the versions right before we build it...
             for (ObjectCursor<IndexRoutingTable> indexRoutingTable : indicesRouting.values()) {
-                indicesRouting.put(indexRoutingTable.value.index(), indexRoutingTable.value.normalizeVersions());
+                indicesRouting.put(indexRoutingTable.value.getIndex().getName(), indexRoutingTable.value.normalizeVersions());
             }
             RoutingTable table = new RoutingTable(version, indicesRouting.build());
             indicesRouting = null;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -720,7 +720,7 @@ public final class ShardRouting implements Streamable, ToXContent {
             .field("node", currentNodeId())
             .field("relocating_node", relocatingNodeId())
             .field("shard", shardId().id())
-            .field("index", shardId().index().name())
+            .field("index", shardId().index().getName())
             .field("version", version);
         if (expectedShardSize != UNAVAILABLE_EXPECTED_SHARD_SIZE) {
             builder.field("expected_shard_size_in_bytes", expectedShardSize);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
@@ -44,7 +45,7 @@ public final class ShardRouting implements Streamable, ToXContent {
      */
     public static final long UNAVAILABLE_EXPECTED_SHARD_SIZE = -1;
 
-    private String index;
+    private Index index;
     private int shardId;
     private String currentNodeId;
     private String relocatingNodeId;
@@ -75,7 +76,7 @@ public final class ShardRouting implements Streamable, ToXContent {
      * A constructor to internally create shard routing instances, note, the internal flag should only be set to true
      * by either this class or tests. Visible for testing.
      */
-    ShardRouting(String index, int shardId, String currentNodeId,
+    ShardRouting(Index index, int shardId, String currentNodeId,
                  String relocatingNodeId, RestoreSource restoreSource, boolean primary, ShardRoutingState state, long version,
                  UnassignedInfo unassignedInfo, AllocationId allocationId, boolean internal, long expectedShardSize) {
         this.index = index;
@@ -105,22 +106,19 @@ public final class ShardRouting implements Streamable, ToXContent {
     /**
      * Creates a new unassigned shard.
      */
-    public static ShardRouting newUnassigned(String index, int shardId, RestoreSource restoreSource, boolean primary, UnassignedInfo unassignedInfo) {
+    public static ShardRouting newUnassigned(Index index, int shardId, RestoreSource restoreSource, boolean primary, UnassignedInfo unassignedInfo) {
         return new ShardRouting(index, shardId, null, null, restoreSource, primary, ShardRoutingState.UNASSIGNED, 0, unassignedInfo, null, true, UNAVAILABLE_EXPECTED_SHARD_SIZE);
     }
 
-    /**
-     * The index name.
-     */
-    public String index() {
+    public Index index() {
         return this.index;
     }
 
     /**
      * The index name.
      */
-    public String getIndex() {
-        return index();
+    public String getIndexName() {
+        return index().getName();
     }
 
     /**
@@ -302,13 +300,13 @@ public final class ShardRouting implements Streamable, ToXContent {
         return entry;
     }
 
-    public static ShardRouting readShardRoutingEntry(StreamInput in, String index, int shardId) throws IOException {
+    public static ShardRouting readShardRoutingEntry(StreamInput in, Index index, int shardId) throws IOException {
         ShardRouting entry = new ShardRouting();
         entry.readFrom(in, index, shardId);
         return entry;
     }
 
-    public void readFrom(StreamInput in, String index, int shardId) throws IOException {
+    public void readFrom(StreamInput in, Index index, int shardId) throws IOException {
         this.index = index;
         this.shardId = shardId;
         readFromThin(in);
@@ -344,7 +342,7 @@ public final class ShardRouting implements Streamable, ToXContent {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        readFrom(in, in.readString(), in.readVInt());
+        readFrom(in, Index.readIndex(in), in.readVInt());
     }
 
     /**
@@ -398,7 +396,7 @@ public final class ShardRouting implements Streamable, ToXContent {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(index);
+        index.writeTo(out);
         out.writeVInt(shardId);
         writeToThin(out);
     }
@@ -720,7 +718,7 @@ public final class ShardRouting implements Streamable, ToXContent {
             .field("node", currentNodeId())
             .field("relocating_node", relocatingNodeId())
             .field("shard", shardId().id())
-            .field("index", shardId().index().getName())
+            .field("index", shardId().getIndex().getName())
             .field("version", version);
         if (expectedShardSize != UNAVAILABLE_EXPECTED_SHARD_SIZE) {
             builder.field("expected_shard_size_in_bytes", expectedShardSize);

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -269,7 +269,7 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
         long minDelaySetting = Long.MAX_VALUE;
         for (ShardRouting shard : state.routingTable().shardsWithState(ShardRoutingState.UNASSIGNED)) {
             if (shard.primary() == false) {
-                IndexMetaData indexMetaData = state.metaData().index(shard.getIndex());
+                IndexMetaData indexMetaData = state.metaData().index(shard.getIndexName());
                 boolean delayed = shard.unassignedInfo().getLastComputedLeftDelayNanos() > 0;
                 long delayTimeoutSetting = shard.unassignedInfo().getAllocationDelayTimeoutSettingNanos(settings, indexMetaData.getSettings());
                 if (delayed && delayTimeoutSetting > 0 && delayTimeoutSetting < minDelaySetting) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -131,7 +131,7 @@ public class AllocationService extends AbstractComponent {
         for (IndexRoutingTable indexRoutingTable : newRoutingTable) {
             final IndexMetaData indexMetaData = currentMetaData.index(indexRoutingTable.getIndex());
             if (indexMetaData == null) {
-                throw new IllegalStateException("no metadata found for index [" + indexRoutingTable.index() + "]");
+                throw new IllegalStateException("no metadata found for index " + indexRoutingTable.getIndex().getName());
             }
             IndexMetaData.Builder indexMetaDataBuilder = null;
             for (IndexShardRoutingTable shardRoutings : indexRoutingTable) {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.PriorityComparator;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -513,7 +512,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                 final ModelNode sourceNode = nodes.get(node.nodeId());
                 assert sourceNode != null;
                 final NodeSorter sorter = newNodeSorter();
-                sorter.reset(shard.getIndex());
+                sorter.reset(shard.getIndexName());
                 final ModelNode[] nodes = sorter.modelNodes;
                 assert sourceNode.containsShard(shard);
                 /*
@@ -591,24 +590,20 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
              */
             final AllocationDeciders deciders = allocation.deciders();
             final PriorityComparator secondaryComparator = PriorityComparator.getAllocationComparator(allocation);
-            final Comparator<ShardRouting> comparator = new Comparator<ShardRouting>() {
-                @Override
-                public int compare(ShardRouting o1,
-                                   ShardRouting o2) {
-                    if (o1.primary() ^ o2.primary()) {
-                        return o1.primary() ? -1 : o2.primary() ? 1 : 0;
-                    }
-                    final int indexCmp;
-                    if ((indexCmp = o1.index().compareTo(o2.index())) == 0) {
-                        return o1.getId() - o2.getId();
-                    }
-                    // this comparator is more expensive than all the others up there
-                    // that's why it's added last even though it could be easier to read
-                    // if we'd apply it earlier. this comparator will only differentiate across
-                    // indices all shards of the same index is treated equally.
-                    final int secondary = secondaryComparator.compare(o1, o2);
-                    return secondary == 0 ? indexCmp : secondary;
+            final Comparator<ShardRouting> comparator = (o1, o2) -> {
+                if (o1.primary() ^ o2.primary()) {
+                    return o1.primary() ? -1 : o2.primary() ? 1 : 0;
                 }
+                final int indexCmp;
+                if ((indexCmp = o1.getIndexName().compareTo(o2.getIndexName())) == 0) {
+                    return o1.getId() - o2.getId();
+                }
+                // this comparator is more expensive than all the others up there
+                // that's why it's added last even though it could be easier to read
+                // if we'd apply it earlier. this comparator will only differentiate across
+                // indices all shards of the same index is treated equally.
+                final int secondary = secondaryComparator.compare(o1, o2);
+                return secondary == 0 ? indexCmp : secondary;
             };
             /*
              * we use 2 arrays and move replicas to the second array once we allocated an identical
@@ -655,7 +650,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                             }
                             if (!node.containsShard(shard)) {
                                 // simulate weight if we would add shard to node
-                                float currentWeight = weight.weightShardAdded(this, node, shard.index());
+                                float currentWeight = weight.weightShardAdded(this, node, shard.getIndexName());
                                 /*
                                  * Unless the operation is not providing any gains we
                                  * don't check deciders
@@ -678,8 +673,8 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
                                              */
                                             if (currentDecision.type() == decision.type()) {
                                                 final int repId = shard.id();
-                                                final int nodeHigh = node.highestPrimary(shard.index());
-                                                final int minNodeHigh = minNode.highestPrimary(shard.index());
+                                                final int nodeHigh = node.highestPrimary(shard.index().getName());
+                                                final int minNodeHigh = minNode.highestPrimary(shard.getIndexName());
                                                 if ((((nodeHigh > repId && minNodeHigh > repId) || (nodeHigh < repId && minNodeHigh < repId)) && (nodeHigh < minNodeHigh))
                                                         || (nodeHigh > minNodeHigh && nodeHigh > repId && minNodeHigh < repId)) {
                                                     minNode = node;
@@ -855,9 +850,9 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         }
 
         public void addShard(ShardRouting shard, Decision decision) {
-            ModelIndex index = indices.get(shard.index());
+            ModelIndex index = indices.get(shard.getIndexName());
             if (index == null) {
-                index = new ModelIndex(shard.index());
+                index = new ModelIndex(shard.getIndexName());
                 indices.put(index.getIndexId(), index);
             }
             index.addShard(shard, decision);
@@ -865,12 +860,12 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         }
 
         public Decision removeShard(ShardRouting shard) {
-            ModelIndex index = indices.get(shard.index());
+            ModelIndex index = indices.get(shard.getIndexName());
             Decision removed = null;
             if (index != null) {
                 removed = index.removeShard(shard);
                 if (removed != null && index.numShards() == 0) {
-                    indices.remove(shard.index());
+                    indices.remove(shard.getIndexName());
                 }
             }
             numShards--;
@@ -890,7 +885,7 @@ public class BalancedShardsAllocator extends AbstractComponent implements Shards
         }
 
         public boolean containsShard(ShardRouting shard) {
-            ModelIndex index = getIndex(shard.getIndex());
+            ModelIndex index = getIndex(shard.getIndexName());
             return index == null ? false : index.containsShard(shard);
         }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
@@ -101,7 +101,7 @@ public abstract class AbstractAllocateAllocationCommand implements AllocationCom
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
-        builder.field(INDEX_KEY, shardId().index().name());
+        builder.field(INDEX_KEY, shardId().index().getName());
         builder.field(SHARD_KEY, shardId().id());
         builder.field(NODE_KEY, node());
         return builder;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -101,15 +100,15 @@ public abstract class AbstractAllocateAllocationCommand implements AllocationCom
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
-        builder.field(INDEX_KEY, shardId().index().getName());
-        builder.field(SHARD_KEY, shardId().id());
+        builder.field(INDEX_KEY, index());
+        builder.field(SHARD_KEY, shardId());
         builder.field(NODE_KEY, node());
         return builder;
     }
 
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(shardId.getIndex());
-        out.writeVInt(shardId.getId());
+        out.writeString(index);
+        out.writeVInt(shardId);
         out.writeString(node);
     }
 
@@ -143,12 +142,24 @@ public abstract class AbstractAllocateAllocationCommand implements AllocationCom
         }
     }
 
-    protected final ShardId shardId;
+    protected final String index;
+    protected final int shardId;
     protected final String node;
 
-    protected AbstractAllocateAllocationCommand(ShardId shardId, String node) {
+    protected AbstractAllocateAllocationCommand(String index, int shardId, String node) {
+        this.index = index;
         this.shardId = shardId;
         this.node = node;
+    }
+
+
+    /**
+     * Get the index name
+     *
+     * @return name of the index
+     */
+    public String index() {
+        return this.index;
     }
 
     /**
@@ -156,7 +167,7 @@ public abstract class AbstractAllocateAllocationCommand implements AllocationCom
      *
      * @return id of the shard
      */
-    public ShardId shardId() {
+    public int shardId() {
         return this.shardId;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
@@ -51,8 +51,8 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
      * @param node           node id of the node to assign the shard to
      * @param acceptDataLoss whether the user agrees to data loss
      */
-    public AllocateEmptyPrimaryAllocationCommand(ShardId shardId, String node, boolean acceptDataLoss) {
-        super(shardId, node, acceptDataLoss);
+    public AllocateEmptyPrimaryAllocationCommand(String index, int shardId, String node, boolean acceptDataLoss) {
+        super(index, shardId, node, acceptDataLoss);
     }
 
     @Override
@@ -70,7 +70,7 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
         @Override
         public AllocateEmptyPrimaryAllocationCommand build() {
             validate();
-            return new AllocateEmptyPrimaryAllocationCommand(new ShardId(index, shard), node, acceptDataLoss);
+            return new AllocateEmptyPrimaryAllocationCommand(index, shard, node, acceptDataLoss);
         }
     }
 
@@ -98,17 +98,17 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
 
         final ShardRouting shardRouting;
         try {
-            shardRouting = allocation.routingTable().shardRoutingTable(shardId).primaryShard();
+            shardRouting = allocation.routingTable().shardRoutingTable(index, shardId).primaryShard();
         } catch (IndexNotFoundException | ShardNotFoundException e) {
             return explainOrThrowRejectedCommand(explain, allocation, e);
         }
         if (shardRouting.unassigned() == false) {
-            return explainOrThrowRejectedCommand(explain, allocation, "primary " + shardId + " is already assigned");
+            return explainOrThrowRejectedCommand(explain, allocation, "primary [" + index + "][" + shardId + "] is already assigned");
         }
 
         if (shardRouting.unassignedInfo().getReason() != UnassignedInfo.Reason.INDEX_CREATED && acceptDataLoss == false) {
             return explainOrThrowRejectedCommand(explain, allocation,
-                "allocating an empty primary for " + shardId + " can result in data loss. Please confirm by setting the accept_data_loss parameter to true");
+                "allocating an empty primary for [" + index + "][" + shardId + "] can result in data loss. Please confirm by setting the accept_data_loss parameter to true");
         }
 
         initializeUnassignedShard(allocation, routingNodes, routingNode, shardRouting,

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/BasePrimaryAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/BasePrimaryAllocationCommand.java
@@ -44,8 +44,8 @@ public abstract class BasePrimaryAllocationCommand extends AbstractAllocateAlloc
 
     protected final boolean acceptDataLoss;
 
-    protected BasePrimaryAllocationCommand(ShardId shardId, String node, boolean acceptDataLoss) {
-        super(shardId, node);
+    protected BasePrimaryAllocationCommand(String index, int shardId, String node, boolean acceptDataLoss) {
+        super(index, shardId, node);
         this.acceptDataLoss = acceptDataLoss;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
@@ -53,12 +53,13 @@ public class CancelAllocationCommand implements AllocationCommand {
 
         @Override
         public CancelAllocationCommand readFrom(StreamInput in) throws IOException {
-            return new CancelAllocationCommand(ShardId.readShardId(in), in.readString(), in.readBoolean());
+            return new CancelAllocationCommand(in.readString(), in.readVInt(), in.readString(), in.readBoolean());
         }
 
         @Override
         public void writeTo(CancelAllocationCommand command, StreamOutput out) throws IOException {
-            command.shardId().writeTo(out);
+            out.writeString(command.index());
+            out.writeVInt(command.shardId());
             out.writeString(command.node());
             out.writeBoolean(command.allowPrimary());
         }
@@ -100,7 +101,7 @@ public class CancelAllocationCommand implements AllocationCommand {
             if (nodeId == null) {
                 throw new ElasticsearchParseException("[{}] command missing the node parameter", NAME);
             }
-            return new CancelAllocationCommand(new ShardId(index, shardId), nodeId, allowPrimary);
+            return new CancelAllocationCommand(index, shardId, nodeId, allowPrimary);
         }
 
         @Override
@@ -110,8 +111,8 @@ public class CancelAllocationCommand implements AllocationCommand {
             } else {
                 builder.startObject(objectName);
             }
-            builder.field("index", command.shardId().index().getName());
-            builder.field("shard", command.shardId().id());
+            builder.field("index", command.index());
+            builder.field("shard", command.shardId());
             builder.field("node", command.node());
             builder.field("allow_primary", command.allowPrimary());
             builder.endObject();
@@ -119,17 +120,20 @@ public class CancelAllocationCommand implements AllocationCommand {
     }
 
 
-    private final ShardId shardId;
+    private final String index;
+    private final int shardId;
     private final String node;
     private final boolean allowPrimary;
 
     /**
      * Creates a new {@link CancelAllocationCommand}
      *
+     * @param index index of the shard which allocation should be canceled
      * @param shardId id of the shard which allocation should be canceled
      * @param node id of the node that manages the shard which allocation should be canceled
      */
-    public CancelAllocationCommand(ShardId shardId, String node, boolean allowPrimary) {
+    public CancelAllocationCommand(String index, int shardId, String node, boolean allowPrimary) {
+        this.index = index;
         this.shardId = shardId;
         this.node = node;
         this.allowPrimary = allowPrimary;
@@ -141,10 +145,18 @@ public class CancelAllocationCommand implements AllocationCommand {
     }
 
     /**
+     * Get the index of the shard which allocation should be canceled
+     * @return index of the shard which allocation should be canceled
+     */
+    public String index() {
+        return this.index;
+    }
+    /**
+
      * Get the id of the shard which allocation should be canceled
      * @return id of the shard which allocation should be canceled
      */
-    public ShardId shardId() {
+    public int shardId() {
         return this.shardId;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -178,7 +177,10 @@ public class CancelAllocationCommand implements AllocationCommand {
         boolean found = false;
         for (RoutingNodes.RoutingNodeIterator it = allocation.routingNodes().routingNodeIter(discoNode.id()); it.hasNext(); ) {
             ShardRouting shardRouting = it.next();
-            if (!shardRouting.shardId().equals(shardId)) {
+            if (!shardRouting.shardId().getIndex().getName().equals(index)) {
+                continue;
+            }
+            if (shardRouting.shardId().id() != shardId) {
                 continue;
             }
             found = true;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/CancelAllocationCommand.java
@@ -110,7 +110,7 @@ public class CancelAllocationCommand implements AllocationCommand {
             } else {
                 builder.startObject(objectName);
             }
-            builder.field("index", command.shardId().index().name());
+            builder.field("index", command.shardId().index().getName());
             builder.field("shard", command.shardId().id());
             builder.field("node", command.node());
             builder.field("allow_primary", command.allowPrimary());

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
@@ -49,12 +48,13 @@ public class MoveAllocationCommand implements AllocationCommand {
 
         @Override
         public MoveAllocationCommand readFrom(StreamInput in) throws IOException {
-            return new MoveAllocationCommand(ShardId.readShardId(in), in.readString(), in.readString());
+            return new MoveAllocationCommand(in.readString(), in.readVInt(), in.readString(), in.readString());
         }
 
         @Override
         public void writeTo(MoveAllocationCommand command, StreamOutput out) throws IOException {
-            command.shardId().writeTo(out);
+            out.writeString(command.index());
+            out.writeVInt(command.shardId());
             out.writeString(command.fromNode());
             out.writeString(command.toNode());
         }
@@ -99,7 +99,7 @@ public class MoveAllocationCommand implements AllocationCommand {
             if (toNode == null) {
                 throw new ElasticsearchParseException("[{}] command missing the to_node parameter", NAME);
             }
-            return new MoveAllocationCommand(new ShardId(index, shardId), fromNode, toNode);
+            return new MoveAllocationCommand(index, shardId, fromNode, toNode);
         }
 
         @Override
@@ -109,19 +109,21 @@ public class MoveAllocationCommand implements AllocationCommand {
             } else {
                 builder.startObject(objectName);
             }
-            builder.field("index", command.shardId().index().getName());
-            builder.field("shard", command.shardId().id());
+            builder.field("index", command.index());
+            builder.field("shard", command.shardId());
             builder.field("from_node", command.fromNode());
             builder.field("to_node", command.toNode());
             builder.endObject();
         }
     }
 
-    private final ShardId shardId;
+    private final String index;
+    private final int shardId;
     private final String fromNode;
     private final String toNode;
 
-    public MoveAllocationCommand(ShardId shardId, String fromNode, String toNode) {
+    public MoveAllocationCommand(String index, int shardId, String fromNode, String toNode) {
+        this.index = index;
         this.shardId = shardId;
         this.fromNode = fromNode;
         this.toNode = toNode;
@@ -132,7 +134,9 @@ public class MoveAllocationCommand implements AllocationCommand {
         return NAME;
     }
 
-    public ShardId shardId() {
+    public String index() {return index; }
+
+    public int shardId() {
         return this.shardId;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
@@ -156,7 +156,10 @@ public class MoveAllocationCommand implements AllocationCommand {
 
         boolean found = false;
         for (ShardRouting shardRouting : allocation.routingNodes().node(fromDiscoNode.id())) {
-            if (!shardRouting.shardId().equals(shardId)) {
+            if (!shardRouting.shardId().getIndexName().equals(index)) {
+                continue;
+            }
+            if (shardRouting.shardId().id() != shardId) {
                 continue;
             }
             found = true;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/command/MoveAllocationCommand.java
@@ -109,7 +109,7 @@ public class MoveAllocationCommand implements AllocationCommand {
             } else {
                 builder.startObject(objectName);
             }
-            builder.field("index", command.shardId().index().name());
+            builder.field("index", command.shardId().index().getName());
             builder.field("shard", command.shardId().id());
             builder.field("from_node", command.fromNode());
             builder.field("to_node", command.toNode());

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -330,7 +330,7 @@ public class DiskThresholdDecider extends AllocationDecider {
         }
 
         // a flag for whether the primary shard has been previously allocated
-        IndexMetaData indexMetaData = allocation.metaData().index(shardRouting.getIndex());
+        IndexMetaData indexMetaData = allocation.metaData().index(shardRouting.getIndexName());
         boolean primaryHasBeenAllocated = shardRouting.primary() && shardRouting.allocatedPostIndexCreate(indexMetaData);
 
         // checks for exact byte comparisons

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -92,7 +92,7 @@ public class EnableAllocationDecider extends AllocationDecider {
             return allocation.decision(Decision.YES, NAME, "allocation disabling is ignored");
         }
 
-        final IndexMetaData indexMetaData = allocation.metaData().index(shardRouting.getIndex());
+        final IndexMetaData indexMetaData = allocation.metaData().index(shardRouting.getIndexName());
         final Allocation enable;
         if (INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.exists(indexMetaData.getSettings())) {
             enable = INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.get(indexMetaData.getSettings());

--- a/core/src/main/java/org/elasticsearch/common/logging/Loggers.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/Loggers.java
@@ -64,11 +64,11 @@ public class Loggers {
 
     /** Just like {@link #getLogger(Class, org.elasticsearch.common.settings.Settings,ShardId,String...)} but String loggerName instead of Class. */
     public static ESLogger getLogger(String loggerName, Settings settings, ShardId shardId, String... prefixes) {
-        return getLogger(loggerName, settings, asArrayList(shardId.index().name(), Integer.toString(shardId.id()), prefixes).toArray(new String[0]));
+        return getLogger(loggerName, settings, asArrayList(shardId.index().getName(), Integer.toString(shardId.id()), prefixes).toArray(new String[0]));
     }
 
     public static ESLogger getLogger(Class clazz, Settings settings, Index index, String... prefixes) {
-        return getLogger(clazz, settings, asArrayList(SPACE, index.name(), prefixes).toArray(new String[0]));
+        return getLogger(clazz, settings, asArrayList(SPACE, index.getName(), prefixes).toArray(new String[0]));
     }
 
     public static ESLogger getLogger(Class clazz, Settings settings, String... prefixes) {

--- a/core/src/main/java/org/elasticsearch/common/logging/Loggers.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/Loggers.java
@@ -59,12 +59,12 @@ public class Loggers {
     }
 
     public static ESLogger getLogger(Class clazz, Settings settings, ShardId shardId, String... prefixes) {
-        return getLogger(clazz, settings, shardId.index(), asArrayList(Integer.toString(shardId.id()), prefixes).toArray(new String[0]));
+        return getLogger(clazz, settings, shardId.getIndex(), asArrayList(Integer.toString(shardId.id()), prefixes).toArray(new String[0]));
     }
 
     /** Just like {@link #getLogger(Class, org.elasticsearch.common.settings.Settings,ShardId,String...)} but String loggerName instead of Class. */
     public static ESLogger getLogger(String loggerName, Settings settings, ShardId shardId, String... prefixes) {
-        return getLogger(loggerName, settings, asArrayList(shardId.index().getName(), Integer.toString(shardId.id()), prefixes).toArray(new String[0]));
+        return getLogger(loggerName, settings, asArrayList(shardId.getIndexName(), Integer.toString(shardId.id()), prefixes).toArray(new String[0]));
     }
 
     public static ESLogger getLogger(Class clazz, Settings settings, Index index, String... prefixes) {

--- a/core/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
@@ -64,7 +64,7 @@ public final class ShardCoreKeyMap {
             throw new IllegalArgumentException("Could not extract shard id from " + reader);
         }
         final Object coreKey = reader.getCoreCacheKey();
-        final String index = shardId.getIndex();
+        final String index = shardId.getIndexName();
         synchronized (this) {
             if (coreKeyToShard.put(coreKey, shardId) == null) {
                 Set<Object> objects = indexToCoreKey.get(index);

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -107,7 +107,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
          * Resolves the given indexes directory against this NodePath
          */
         public Path resolve(Index index) {
-            return indicesPath.resolve(index.name());
+            return indicesPath.resolve(index.getName());
         }
 
         @Override
@@ -426,7 +426,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         logger.trace("deleting index {} directory, paths({}): [{}]", index, indexPaths.length, indexPaths);
         IOUtils.rm(indexPaths);
         if (indexSettings.hasCustomDataPath()) {
-            Path customLocation = resolveCustomLocation(indexSettings, index.name());
+            Path customLocation = resolveCustomLocation(indexSettings, index.getName());
             logger.trace("deleting custom index {} directory [{}]", index, customLocation);
             IOUtils.rm(customLocation);
         }
@@ -632,7 +632,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         assert assertEnvIsLocked();
         Path[] indexPaths = new Path[nodePaths.length];
         for (int i = 0; i < nodePaths.length; i++) {
-            indexPaths[i] = nodePaths[i].indicesPath.resolve(index.name());
+            indexPaths[i] = nodePaths[i].indicesPath.resolve(index.getName());
         }
         return indexPaths;
     }
@@ -691,7 +691,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         }
         assert assertEnvIsLocked();
         final Set<ShardId> shardIds = new HashSet<>();
-        String indexName = index.name();
+        String indexName = index.getName();
         for (final NodePath nodePath : nodePaths) {
             Path location = nodePath.indicesPath;
             if (Files.isDirectory(location)) {
@@ -827,7 +827,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
      * @param shardId shard to resolve the path to
      */
     public Path resolveCustomLocation(IndexSettings indexSettings, final ShardId shardId) {
-        return resolveCustomLocation(indexSettings, shardId.index().name()).resolve(Integer.toString(shardId.id()));
+        return resolveCustomLocation(indexSettings, shardId.index().getName()).resolve(Integer.toString(shardId.id()));
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -66,6 +66,7 @@ import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableSet;
 
@@ -127,7 +128,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
 
     private final int localNodeId;
     private final AtomicBoolean closed = new AtomicBoolean(false);
-    private final Map<ShardId, InternalShardLock> shardLocks = new HashMap<>();
+    private final Map<ShardLockKey, InternalShardLock> shardLocks = new HashMap<>();
 
     // Setting to automatically append node id to custom data paths
     public static final String ADD_NODE_ID_TO_CUSTOM_PATH = "node.add_id_to_custom_path";
@@ -487,23 +488,24 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
      * write operation on a shards data directory like deleting files, creating a new index writer
      * or recover from a different shard instance into it. If the shard lock can not be acquired
      * an {@link org.apache.lucene.store.LockObtainFailedException} is thrown
-     * @param id the shard ID to lock
+     * @param shardId the shard ID to lock
      * @param lockTimeoutMS the lock timeout in milliseconds
      * @return the shard lock. Call {@link ShardLock#close()} to release the lock
      * @throws IOException if an IOException occurs.
      */
-    public ShardLock shardLock(final ShardId id, long lockTimeoutMS) throws IOException {
-        logger.trace("acquiring node shardlock on [{}], timeout [{}]", id, lockTimeoutMS);
+    public ShardLock shardLock(final ShardId shardId, long lockTimeoutMS) throws IOException {
+        logger.trace("acquiring node shardlock on [{}], timeout [{}]", shardId, lockTimeoutMS);
+        final ShardLockKey shardLockKey = new ShardLockKey(shardId);
         final InternalShardLock shardLock;
         final boolean acquired;
         synchronized (shardLocks) {
-            if (shardLocks.containsKey(id)) {
-                shardLock = shardLocks.get(id);
+            if (shardLocks.containsKey(shardLockKey)) {
+                shardLock = shardLocks.get(shardLockKey);
                 shardLock.incWaitCount();
                 acquired = false;
             } else {
-                shardLock = new InternalShardLock(id);
-                shardLocks.put(id, shardLock);
+                shardLock = new InternalShardLock(shardLockKey);
+                shardLocks.put(shardLockKey, shardLock);
                 acquired = true;
             }
         }
@@ -518,22 +520,68 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
                 }
             }
         }
-        logger.trace("successfully acquired shardlock for [{}]", id);
-        return new ShardLock(id) { // new instance prevents double closing
+        logger.trace("successfully acquired shardlock for [{}]", shardId);
+        return new ShardLock(shardId) { // new instance prevents double closing
             @Override
             protected void closeInternal() {
                 shardLock.release();
-                logger.trace("released shard lock for [{}]", id);
+                logger.trace("released shard lock for [{}]", shardLockKey);
             }
         };
     }
 
     /**
      * Returns all currently lock shards.
+     *
+     * Note: the shard ids return do not contain a valid Index UUID
      */
     public Set<ShardId> lockedShards() {
         synchronized (shardLocks) {
-            return unmodifiableSet(new HashSet<>(shardLocks.keySet()));
+            Set<ShardId> lockedShards = shardLocks.keySet().stream()
+                    .map(shardLockKey -> new ShardId(new Index(shardLockKey.indexName, "_na_"), shardLockKey.shardId)).collect(Collectors.toSet());
+            return unmodifiableSet(lockedShards);
+        }
+    }
+
+    // a key for the shard lock. we can't use shardIds, because the contain
+    // the index uuid, but we want the lock semantics to the same as we map indices to disk folders, i.e., without the uuid (for now).
+    private final class ShardLockKey {
+        final String indexName;
+        final int shardId;
+
+        public ShardLockKey(final ShardId shardId) {
+            this.indexName = shardId.getIndexName();
+            this.shardId = shardId.id();
+        }
+
+        @Override
+        public String toString() {
+            return "[" + indexName + "][" + shardId + "]";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ShardLockKey that = (ShardLockKey) o;
+
+            if (shardId != that.shardId) {
+                return false;
+            }
+            return indexName.equals(that.indexName);
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = indexName.hashCode();
+            result = 31 * result + shardId;
+            return result;
         }
     }
 
@@ -546,10 +594,10 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
          */
         private final Semaphore mutex = new Semaphore(1);
         private int waitCount = 1; // guarded by shardLocks
-        private ShardId shardId;
+        private final ShardLockKey lockKey;
 
-        InternalShardLock(ShardId id) {
-            shardId = id;
+        InternalShardLock(ShardLockKey id) {
+            lockKey = id;
             mutex.acquireUninterruptibly();
         }
 
@@ -569,10 +617,10 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
             synchronized (shardLocks) {
                 assert waitCount > 0 : "waitCount is " + waitCount + " but should be > 0";
                 --waitCount;
-                logger.trace("shard lock wait count for [{}] is now [{}]", shardId, waitCount);
+                logger.trace("shard lock wait count for [{}] is now [{}]", lockKey, waitCount);
                 if (waitCount == 0) {
-                    logger.trace("last shard lock wait decremented, removing lock for [{}]", shardId);
-                    InternalShardLock remove = shardLocks.remove(shardId);
+                    logger.trace("last shard lock wait decremented, removing lock for [{}]", lockKey);
+                    InternalShardLock remove = shardLocks.remove(lockKey);
                     assert remove != null : "Removed lock was null";
                 }
             }
@@ -581,11 +629,11 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         void acquire(long timeoutInMillis) throws LockObtainFailedException{
             try {
                 if (mutex.tryAcquire(timeoutInMillis, TimeUnit.MILLISECONDS) == false) {
-                    throw new LockObtainFailedException("Can't lock shard " + shardId + ", timed out after " + timeoutInMillis + "ms");
+                    throw new LockObtainFailedException("Can't lock shard " + lockKey + ", timed out after " + timeoutInMillis + "ms");
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new LockObtainFailedException("Can't lock shard " + shardId + ", interrupted", e);
+                throw new LockObtainFailedException("Can't lock shard " + lockKey + ", interrupted", e);
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -120,7 +120,7 @@ public class DanglingIndicesState extends AbstractComponent {
                     IndexMetaData indexMetaData = metaStateService.loadIndexState(indexName);
                     if (indexMetaData != null) {
                         logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, auto import to cluster state", indexName);
-                        if (!indexMetaData.getIndex().equals(indexName)) {
+                        if (!indexMetaData.getIndex().getName().equals(indexName)) {
                             logger.info("dangled index directory name is [{}], state name is [{}], renaming to directory name", indexName, indexMetaData.getIndex());
                             indexMetaData = IndexMetaData.builder(indexMetaData).index(indexName).build();
                         }

--- a/core/src/main/java/org/elasticsearch/gateway/Gateway.java
+++ b/core/src/main/java/org/elasticsearch/gateway/Gateway.java
@@ -99,7 +99,7 @@ public class Gateway extends AbstractComponent implements ClusterStateListener {
                 electedGlobalState = nodeState.metaData();
             }
             for (ObjectCursor<IndexMetaData> cursor : nodeState.metaData().indices().values()) {
-                indices.addTo(cursor.value.getIndex(), 1);
+                indices.addTo(cursor.value.getIndex().getName(), 1);
             }
         }
         if (found < requiredAllocation) {

--- a/core/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -130,10 +130,10 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
                         for (IndexMetaData indexMetaData : newMetaData) {
                             IndexMetaData indexMetaDataOnDisk = null;
                             if (indexMetaData.getState().equals(IndexMetaData.State.CLOSE)) {
-                                indexMetaDataOnDisk = metaStateService.loadIndexState(indexMetaData.getIndex());
+                                indexMetaDataOnDisk = metaStateService.loadIndexState(indexMetaData.getIndex().getName());
                             }
                             if (indexMetaDataOnDisk != null) {
-                                newPreviouslyWrittenIndices.add(indexMetaDataOnDisk.getIndex());
+                                newPreviouslyWrittenIndices.add(indexMetaDataOnDisk.getIndex().getName());
                             }
                         }
                         newPreviouslyWrittenIndices.addAll(previouslyWrittenIndices);
@@ -289,19 +289,19 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
         }
         Set<String> indices = new HashSet<>();
         for (ShardRouting routing : newRoutingNode) {
-            indices.add(routing.index());
+            indices.add(routing.index().getName());
         }
         // we have to check the meta data also: closed indices will not appear in the routing table, but we must still write the state if we have it written on disk previously
         for (IndexMetaData indexMetaData : state.metaData()) {
             boolean isOrWasClosed = indexMetaData.getState().equals(IndexMetaData.State.CLOSE);
             // if the index is open we might still have to write the state if it just transitioned from closed to open
             // so we have to check for that as well.
-            IndexMetaData previousMetaData = previousState.metaData().getIndices().get(indexMetaData.getIndex());
+            IndexMetaData previousMetaData = previousState.metaData().index(indexMetaData.getIndex());
             if (previousMetaData != null) {
                 isOrWasClosed = isOrWasClosed || previousMetaData.getState().equals(IndexMetaData.State.CLOSE);
             }
             if (previouslyWrittenIndices.contains(indexMetaData.getIndex()) && isOrWasClosed) {
-                indices.add(indexMetaData.getIndex());
+                indices.add(indexMetaData.getIndex().getName());
             }
         }
         return indices;
@@ -312,7 +312,7 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
         relevantIndices = new HashSet<>();
         // we have to iterate over the metadata to make sure we also capture closed indices
         for (IndexMetaData indexMetaData : state.metaData()) {
-            relevantIndices.add(indexMetaData.getIndex());
+            relevantIndices.add(indexMetaData.getIndex().getName());
         }
         return relevantIndices;
     }

--- a/core/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -300,7 +300,7 @@ public class GatewayMetaState extends AbstractComponent implements ClusterStateL
             if (previousMetaData != null) {
                 isOrWasClosed = isOrWasClosed || previousMetaData.getState().equals(IndexMetaData.State.CLOSE);
             }
-            if (previouslyWrittenIndices.contains(indexMetaData.getIndex()) && isOrWasClosed) {
+            if (previouslyWrittenIndices.contains(indexMetaData.getIndex().getName()) && isOrWasClosed) {
                 indices.add(indexMetaData.getIndex().getName());
             }
         }

--- a/core/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/core/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -116,7 +116,7 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
         public void messageReceived(final AllocateDangledRequest request, final TransportChannel channel) throws Exception {
             String[] indexNames = new String[request.indices.length];
             for (int i = 0; i < request.indices.length; i++) {
-                indexNames[i] = request.indices[i].getIndex();
+                indexNames[i] = request.indices[i].getIndex().getName();
             }
             clusterService.submitStateUpdateTask("allocation dangled indices " + Arrays.toString(indexNames), new ClusterStateUpdateTask() {
                 @Override
@@ -131,10 +131,10 @@ public class LocalAllocateDangledIndices extends AbstractComponent {
                     boolean importNeeded = false;
                     StringBuilder sb = new StringBuilder();
                     for (IndexMetaData indexMetaData : request.indices) {
-                        if (currentState.metaData().hasIndex(indexMetaData.getIndex())) {
+                        if (currentState.metaData().hasIndex(indexMetaData.getIndex().getName())) {
                             continue;
                         }
-                        if (currentState.metaData().hasAlias(indexMetaData.getIndex())) {
+                        if (currentState.metaData().hasAlias(indexMetaData.getIndex().getName())) {
                             logger.warn("ignoring dangled index [{}] on node [{}] due to an existing alias with the same name",
                                     indexMetaData.getIndex(), request.fromNode);
                             continue;

--- a/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -109,7 +109,7 @@ public class MetaStateService extends AbstractComponent {
      */
     @Nullable
     IndexMetaData loadIndexState(String index) throws IOException {
-        return indexStateFormat.loadLatestState(logger, nodeEnv.indexPaths(new Index(index)));
+        return indexStateFormat.loadLatestState(logger, nodeEnv.indexPaths(index));
     }
 
     /**
@@ -132,8 +132,7 @@ public class MetaStateService extends AbstractComponent {
     void writeIndex(String reason, IndexMetaData indexMetaData, @Nullable IndexMetaData previousIndexMetaData) throws Exception {
         logger.trace("[{}] writing state, reason [{}]", indexMetaData.getIndex(), reason);
         try {
-            indexStateFormat.write(indexMetaData, indexMetaData.getVersion(),
-                    nodeEnv.indexPaths(new Index(indexMetaData.getIndex())));
+            indexStateFormat.write(indexMetaData, indexMetaData.getVersion(), nodeEnv.indexPaths(indexMetaData.getIndex().getName()));
         } catch (Throwable ex) {
             logger.warn("[{}]: failed to write index state", ex, indexMetaData.getIndex());
             throw new IOException("failed to write state for [" + indexMetaData.getIndex() + "]", ex);

--- a/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -32,7 +32,6 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexSettings;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -90,7 +89,7 @@ public abstract class PrimaryShardAllocator extends AbstractComponent {
                 continue;
             }
 
-            final IndexMetaData indexMetaData = metaData.index(shard.getIndex());
+            final IndexMetaData indexMetaData = metaData.index(shard.getIndexName());
             // don't go wild here and create a new IndexSetting object for every shard this could cause a lot of garbage
             // on cluster restart if we allocate a boat load of shards
             if (shard.allocatedPostIndexCreate(indexMetaData) == false) {

--- a/core/src/main/java/org/elasticsearch/gateway/PriorityComparator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PriorityComparator.java
@@ -38,8 +38,8 @@ public abstract class PriorityComparator implements Comparator<ShardRouting> {
 
     @Override
     public final int compare(ShardRouting o1, ShardRouting o2) {
-        final String o1Index = o1.index();
-        final String o2Index = o2.index();
+        final String o1Index = o1.getIndexName();
+        final String o2Index = o2.getIndexName();
         int cmp = 0;
         if (o1Index.equals(o2Index) == false) {
             final Settings settingsO1 = getIndexSettings(o1Index);

--- a/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -74,7 +74,7 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
                 }
 
                 // if we are allocating a replica because of index creation, no need to go and find a copy, there isn't one...
-                IndexMetaData indexMetaData = metaData.index(shard.getIndex());
+                IndexMetaData indexMetaData = metaData.index(shard.getIndexName());
                 if (shard.allocatedPostIndexCreate(indexMetaData) == false) {
                     continue;
                 }
@@ -127,7 +127,7 @@ public abstract class ReplicaShardAllocator extends AbstractComponent {
             }
 
             // if we are allocating a replica because of index creation, no need to go and find a copy, there isn't one...
-            IndexMetaData indexMetaData = metaData.index(shard.getIndex());
+            IndexMetaData indexMetaData = metaData.index(shard.getIndexName());
             if (shard.allocatedPostIndexCreate(indexMetaData) == false) {
                 continue;
             }

--- a/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -125,7 +125,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
             logger.trace("{} loading local shard state info", shardId);
             ShardStateMetaData shardStateMetaData = ShardStateMetaData.FORMAT.loadLatestState(logger, nodeEnv.availableShardPaths(request.shardId));
             if (shardStateMetaData != null) {
-                final IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().getName()); // it's a mystery why this is sometimes null
+                final IndexMetaData metaData = clusterService.state().metaData().index(shardId.getIndexName()); // it's a mystery why this is sometimes null
                 if (metaData != null) {
                     ShardPath shardPath = null;
                     try {
@@ -134,7 +134,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
                         if (shardPath == null) {
                             throw new IllegalStateException(shardId + " no shard path found");
                         }
-                        Store.tryOpenIndex(shardPath.resolveIndex());
+                        Store.tryOpenIndex(shardPath.resolveIndex(), shardId);
                     } catch (Exception exception) {
                         logger.trace("{} can't open index for shard [{}] in path [{}]", exception, shardId, shardStateMetaData, (shardPath != null) ? shardPath.resolveIndex() : "");
                         String allocationId = shardStateMetaData.allocationId != null ? shardStateMetaData.allocationId.getId() : null;

--- a/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/core/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -49,7 +49,6 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -126,7 +125,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
             logger.trace("{} loading local shard state info", shardId);
             ShardStateMetaData shardStateMetaData = ShardStateMetaData.FORMAT.loadLatestState(logger, nodeEnv.availableShardPaths(request.shardId));
             if (shardStateMetaData != null) {
-                final IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().name()); // it's a mystery why this is sometimes null
+                final IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().getName()); // it's a mystery why this is sometimes null
                 if (metaData != null) {
                     ShardPath shardPath = null;
                     try {

--- a/core/src/main/java/org/elasticsearch/index/Index.java
+++ b/core/src/main/java/org/elasticsearch/index/Index.java
@@ -19,24 +19,21 @@
 
 package org.elasticsearch.index;
 
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
 
 /**
  *
  */
-public class Index implements Streamable {
+public class Index implements Writeable<Index> {
 
-    private String name;
-    private String uuid;
+    private final static Index PROTO = new Index("", "");
 
-    private Index() {
-
-    }
+    private final String name;
+    private final String uuid;
 
     public Index(String name, String uuid) {
         this.name = name.intern();
@@ -76,15 +73,12 @@ public class Index implements Streamable {
     }
 
     public static Index readIndex(StreamInput in) throws IOException {
-        Index index = new Index();
-        index.readFrom(in);
-        return index;
+        return PROTO.readFrom(in);
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        name = in.readString().intern();
-        uuid = in.readString().intern();
+    public Index readFrom(StreamInput in) throws IOException {
+        return new Index(in.readString(), in.readString());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/Index.java
+++ b/core/src/main/java/org/elasticsearch/index/Index.java
@@ -31,21 +31,23 @@ import java.io.IOException;
 public class Index implements Streamable {
 
     private String name;
+    private String uuid;
 
     private Index() {
 
     }
 
-    public Index(String name) {
+    public Index(String name, String uuid) {
         this.name = name.intern();
-    }
-
-    public String name() {
-        return this.name;
+        this.uuid = uuid.intern();
     }
 
     public String getName() {
-        return name();
+        return this.name;
+    }
+
+    public String getUUID() {
+        return uuid;
     }
 
     @Override
@@ -55,15 +57,21 @@ public class Index implements Streamable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
         Index index1 = (Index) o;
-        return name.equals(index1.name);
+        return uuid.equals(index1.uuid) && name.equals(index1.name); // allow for _na_ uuid
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        int result = name.hashCode();
+        result = 31 * result + uuid.hashCode();
+        return result;
     }
 
     public static Index readIndexName(StreamInput in) throws IOException {
@@ -75,10 +83,12 @@ public class Index implements Streamable {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         name = in.readString().intern();
+        uuid = in.readString().intern();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
+        out.writeString(uuid);
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/Index.java
+++ b/core/src/main/java/org/elasticsearch/index/Index.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index;
 
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -74,7 +75,7 @@ public class Index implements Streamable {
         return result;
     }
 
-    public static Index readIndexName(StreamInput in) throws IOException {
+    public static Index readIndex(StreamInput in) throws IOException {
         Index index = new Index();
         index.readFrom(in);
         return index;

--- a/core/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexNotFoundException.java
@@ -34,6 +34,15 @@ public final class IndexNotFoundException extends ResourceNotFoundException {
         setIndex(index);
     }
 
+    public IndexNotFoundException(Index index) {
+        this(index, null);
+    }
+
+    public IndexNotFoundException(Index index, Throwable cause) {
+        super("no such index", cause);
+        setIndex(index);
+    }
+
     public IndexNotFoundException(StreamInput in) throws IOException {
         super(in);
     }

--- a/core/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/core/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
@@ -120,10 +119,10 @@ public final class BitsetFilterCache extends AbstractIndexComponent implements L
         final Object coreCacheReader = context.reader().getCoreCacheKey();
         final ShardId shardId = ShardUtils.extractShardId(context.reader());
         if (shardId != null // can't require it because of the percolator
-                && indexSettings.getIndex().getName().equals(shardId.getIndex()) == false) {
+                && indexSettings.getIndex().equals(shardId.getIndex()) == false) {
             // insanity
-            throw new IllegalStateException("Trying to load bit set for index [" + shardId.getIndex()
-                    + "] with cache of index [" + indexSettings.getIndex().getName() + "]");
+            throw new IllegalStateException("Trying to load bit set for index " + shardId.getIndex()
+                    + " with cache of index " + indexSettings.getIndex());
         }
         Cache<Query, Value> filterToFbs = loadedFilters.computeIfAbsent(coreCacheReader, key -> {
             context.reader().addCoreClosedListener(BitsetFilterCache.this);

--- a/core/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
@@ -162,7 +162,7 @@ class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
     @Override
     protected MergeThread getMergeThread(IndexWriter writer, MergePolicy.OneMerge merge) throws IOException {
         MergeThread thread = super.getMergeThread(writer, merge);
-        thread.setName(EsExecutors.threadName(indexSettings, "[" + shardId.index().name() + "][" + shardId.id() + "]: " + thread.getName()));
+        thread.setName(EsExecutors.threadName(indexSettings, "[" + shardId.index().getName() + "][" + shardId.id() + "]: " + thread.getName()));
         return thread;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
@@ -162,7 +162,7 @@ class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
     @Override
     protected MergeThread getMergeThread(IndexWriter writer, MergePolicy.OneMerge merge) throws IOException {
         MergeThread thread = super.getMergeThread(writer, merge);
-        thread.setName(EsExecutors.threadName(indexSettings, "[" + shardId.index().getName() + "][" + shardId.id() + "]: " + thread.getName()));
+        thread.setName(EsExecutors.threadName(indexSettings, "[" + shardId.getIndexName() + "][" + shardId.id() + "]: " + thread.getName()));
         return thread;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/IndexIndexFieldData.java
@@ -102,7 +102,7 @@ public class IndexIndexFieldData extends AbstractIndexOrdinalsFieldData {
 
     private IndexIndexFieldData(IndexSettings indexSettings, String name) {
         super(indexSettings, name, new FieldDataType("string"), null, null);
-        atomicFieldData = new IndexAtomicFieldData(index().name());
+        atomicFieldData = new IndexAtomicFieldData(index().getName());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -112,7 +112,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
      */
     public GetResult get(Engine.GetResult engineGetResult, String id, String type, String[] fields, FetchSourceContext fetchSourceContext, boolean ignoreErrorsOnGeneratedFields) {
         if (!engineGetResult.exists()) {
-            return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
+            return new GetResult(shardId.getIndexName(), type, id, -1, false, null, null);
         }
 
         currentMetric.inc();
@@ -121,7 +121,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             DocumentMapper docMapper = mapperService.documentMapper(type);
             if (docMapper == null) {
                 missingMetric.inc(System.nanoTime() - now);
-                return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
+                return new GetResult(shardId.getIndexName(), type, id, -1, false, null, null);
             }
             fetchSourceContext = normalizeFetchSourceContent(fetchSourceContext, fields);
             GetResult getResult = innerGetLoadFromStoredFields(type, id, fields, fetchSourceContext, engineGetResult, docMapper, ignoreErrorsOnGeneratedFields);
@@ -170,25 +170,25 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                 }
             }
             if (get == null) {
-                return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
+                return new GetResult(shardId.getIndexName(), type, id, -1, false, null, null);
             }
             if (!get.exists()) {
                 // no need to release here as well..., we release in the for loop for non exists
-                return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
+                return new GetResult(shardId.getIndexName(), type, id, -1, false, null, null);
             }
         } else {
             get = indexShard.get(new Engine.Get(realtime, new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(type, id)))
                     .version(version).versionType(versionType));
             if (!get.exists()) {
                 get.release();
-                return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
+                return new GetResult(shardId.getIndexName(), type, id, -1, false, null, null);
             }
         }
 
         DocumentMapper docMapper = mapperService.documentMapper(type);
         if (docMapper == null) {
             get.release();
-            return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
+            return new GetResult(shardId.getIndexName(), type, id, -1, false, null, null);
         }
 
         try {
@@ -302,7 +302,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                     }
                 }
 
-                return new GetResult(shardId.index().getName(), type, id, get.version(), get.exists(), sourceToBeReturned, fields);
+                return new GetResult(shardId.getIndexName(), type, id, get.version(), get.exists(), sourceToBeReturned, fields);
             }
         } finally {
             get.release();
@@ -418,7 +418,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             }
         }
 
-        return new GetResult(shardId.index().getName(), type, id, get.version(), get.exists(), source, fields);
+        return new GetResult(shardId.getIndexName(), type, id, get.version(), get.exists(), source, fields);
     }
 
     private static FieldsVisitor buildFieldsVisitors(String[] fields, FetchSourceContext fetchSourceContext) {

--- a/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/core/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -19,9 +19,7 @@
 
 package org.elasticsearch.index.get;
 
-import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -52,10 +50,8 @@ import org.elasticsearch.index.mapper.internal.UidFieldMapper;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.translog.Translog;
-import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.fetch.parent.ParentFieldSubFetchPhase;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
-import org.elasticsearch.search.internal.InternalSearchHitField;
 import org.elasticsearch.search.lookup.LeafSearchLookup;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -116,7 +112,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
      */
     public GetResult get(Engine.GetResult engineGetResult, String id, String type, String[] fields, FetchSourceContext fetchSourceContext, boolean ignoreErrorsOnGeneratedFields) {
         if (!engineGetResult.exists()) {
-            return new GetResult(shardId.index().name(), type, id, -1, false, null, null);
+            return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
         }
 
         currentMetric.inc();
@@ -125,7 +121,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             DocumentMapper docMapper = mapperService.documentMapper(type);
             if (docMapper == null) {
                 missingMetric.inc(System.nanoTime() - now);
-                return new GetResult(shardId.index().name(), type, id, -1, false, null, null);
+                return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
             }
             fetchSourceContext = normalizeFetchSourceContent(fetchSourceContext, fields);
             GetResult getResult = innerGetLoadFromStoredFields(type, id, fields, fetchSourceContext, engineGetResult, docMapper, ignoreErrorsOnGeneratedFields);
@@ -174,25 +170,25 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                 }
             }
             if (get == null) {
-                return new GetResult(shardId.index().name(), type, id, -1, false, null, null);
+                return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
             }
             if (!get.exists()) {
                 // no need to release here as well..., we release in the for loop for non exists
-                return new GetResult(shardId.index().name(), type, id, -1, false, null, null);
+                return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
             }
         } else {
             get = indexShard.get(new Engine.Get(realtime, new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(type, id)))
                     .version(version).versionType(versionType));
             if (!get.exists()) {
                 get.release();
-                return new GetResult(shardId.index().name(), type, id, -1, false, null, null);
+                return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
             }
         }
 
         DocumentMapper docMapper = mapperService.documentMapper(type);
         if (docMapper == null) {
             get.release();
-            return new GetResult(shardId.index().name(), type, id, -1, false, null, null);
+            return new GetResult(shardId.index().getName(), type, id, -1, false, null, null);
         }
 
         try {
@@ -306,7 +302,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                     }
                 }
 
-                return new GetResult(shardId.index().name(), type, id, get.version(), get.exists(), sourceToBeReturned, fields);
+                return new GetResult(shardId.index().getName(), type, id, get.version(), get.exists(), sourceToBeReturned, fields);
             }
         } finally {
             get.release();
@@ -422,7 +418,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             }
         }
 
-        return new GetResult(shardId.index().name(), type, id, get.version(), get.exists(), source, fields);
+        return new GetResult(shardId.index().getName(), type, id, get.version(), get.exists(), source, fields);
     }
 
     private static FieldsVisitor buildFieldsVisitors(String[] fields, FetchSourceContext fetchSourceContext) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -23,27 +23,14 @@ import com.carrotsearch.hppc.ObjectHashSet;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
-import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.queries.TermsQuery;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchGenerationException;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisService;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
-import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -63,7 +50,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -410,7 +396,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             }
         }
         if (allowedNestedFields >= 0 && actualNestedFields > allowedNestedFields) {
-            throw new IllegalArgumentException("Limit of nested fields [" + allowedNestedFields + "] in index [" + index().name() + "] has been exceeded");
+            throw new IllegalArgumentException("Limit of nested fields [" + allowedNestedFields + "] in index [" + index().getName() + "] has been exceeded");
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
+++ b/core/src/main/java/org/elasticsearch/index/percolator/PercolatorQueriesRegistry.java
@@ -127,7 +127,7 @@ public final class PercolatorQueriesRegistry extends AbstractIndexShardComponent
                 }
             }
         } catch (Exception e) {
-            throw new PercolatorException(shardId().index(), "failed to parse query [" + id + "]", e);
+            throw new PercolatorException(shardId().getIndex(), "failed to parse query [" + id + "]", e);
         }
         return null;
     }
@@ -174,7 +174,7 @@ public final class PercolatorQueriesRegistry extends AbstractIndexShardComponent
             }
             loadedQueries = queries.size();
         } catch (Exception e) {
-            throw new PercolatorException(shardId.index(), "failed to load queries from percolator index", e);
+            throw new PercolatorException(shardId.getIndex(), "failed to load queries from percolator index", e);
         }
         logger.debug("done loading [{}] percolator queries", loadedQueries);
     }

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -888,7 +888,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
     private static void setDefaultIndexTypeFields(QueryShardContext context, Item item, List<String> moreLikeFields,
                                                   boolean useDefaultField) {
         if (item.index() == null) {
-            item.index(context.index().name());
+            item.index(context.index().getName());
         }
         if (item.type() == null) {
             if (context.queryTypes().size() > 1) {

--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -232,7 +232,7 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
         if (this.termsLookup != null) {
             termsLookup = new TermsLookup(this.termsLookup);
             if (termsLookup.index() == null) {
-                termsLookup.index(context.index().name());
+                termsLookup.index(context.index().getName());
             }
             Client client = context.getClient();
             terms = fetch(termsLookup, client);

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/random/RandomScoreFunctionBuilder.java
@@ -125,7 +125,7 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
         //TODO find a way to not get the shard_id from the current search context? make it available in QueryShardContext?
         //this currently causes NPE in FunctionScoreQueryBuilderTests#testToQuery
         final ShardId shardId = SearchContext.current().indexShard().shardId();
-        final int salt = (context.index().name().hashCode() << 10) | shardId.id();
+        final int salt = (context.index().getName().hashCode() << 10) | shardId.id();
         final IndexFieldData<?> uidFieldData = context.getForField(fieldType);
         return new RandomScoreFunction(this.seed == null ? hash(context.nowInMillis()) : seed, salt, uidFieldData);
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/ShardId.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardId.java
@@ -55,7 +55,7 @@ public class ShardId implements Streamable, Comparable<ShardId> {
     }
 
     public String getIndex() {
-        return index().name();
+        return index().getName();
     }
 
     public int id() {
@@ -68,7 +68,7 @@ public class ShardId implements Streamable, Comparable<ShardId> {
 
     @Override
     public String toString() {
-        return "[" + index.name() + "][" + shardId + "]";
+        return "[" + index.getName() + "][" + shardId + "]";
     }
 
     @Override
@@ -76,7 +76,7 @@ public class ShardId implements Streamable, Comparable<ShardId> {
         if (this == o) return true;
         if (o == null) return false;
         ShardId shardId1 = (ShardId) o;
-        return shardId == shardId1.shardId && index.name().equals(shardId1.index.name());
+        return shardId == shardId1.shardId && index.getName().equals(shardId1.index.getName());
     }
 
     @Override
@@ -112,7 +112,7 @@ public class ShardId implements Streamable, Comparable<ShardId> {
     @Override
     public int compareTo(ShardId o) {
         if (o.getId() == shardId) {
-            return index.name().compareTo(o.getIndex());
+            return index.getName().compareTo(o.getIndex());
         }
         return Integer.compare(shardId, o.getId());
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/ShardId.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardId.java
@@ -40,22 +40,22 @@ public class ShardId implements Streamable, Comparable<ShardId> {
     private ShardId() {
     }
 
-    public ShardId(String index, int shardId) {
-        this(new Index(index), shardId);
-    }
-
     public ShardId(Index index, int shardId) {
         this.index = index;
         this.shardId = shardId;
         this.hashCode = computeHashCode();
     }
 
-    public Index index() {
-        return this.index;
+    public ShardId(String index, String indexUUID, int shardId) {
+        this(new Index(index, indexUUID), shardId);
     }
 
-    public String getIndex() {
-        return index().getName();
+    public Index getIndex() {
+        return index;
+    }
+
+    public String getIndexName() {
+        return index.getName();
     }
 
     public int id() {
@@ -98,7 +98,7 @@ public class ShardId implements Streamable, Comparable<ShardId> {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        index = Index.readIndexName(in);
+        index = Index.readIndex(in);
         shardId = in.readVInt();
         hashCode = computeHashCode();
     }
@@ -112,7 +112,7 @@ public class ShardId implements Streamable, Comparable<ShardId> {
     @Override
     public int compareTo(ShardId o) {
         if (o.getId() == shardId) {
-            return index.getName().compareTo(o.getIndex());
+            return index.getName().compareTo(o.getIndex().getName());
         }
         return Integer.compare(shardId, o.getId());
     }

--- a/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -45,8 +45,8 @@ public final class ShardPath {
     public ShardPath(boolean isCustomDataPath, Path dataPath, Path shardStatePath, String indexUUID, ShardId shardId) {
         assert dataPath.getFileName().toString().equals(Integer.toString(shardId.id())) : "dataPath must end with the shard ID but didn't: " + dataPath.toString();
         assert shardStatePath.getFileName().toString().equals(Integer.toString(shardId.id())) : "shardStatePath must end with the shard ID but didn't: " + dataPath.toString();
-        assert dataPath.getParent().getFileName().toString().equals(shardId.getIndex()) : "dataPath must end with index/shardID but didn't: " + dataPath.toString();
-        assert shardStatePath.getParent().getFileName().toString().equals(shardId.getIndex()) : "shardStatePath must end with index/shardID but didn't: " + dataPath.toString();
+        assert dataPath.getParent().getFileName().toString().equals(shardId.getIndexName()) : "dataPath must end with index/shardID but didn't: " + dataPath.toString();
+        assert shardStatePath.getParent().getFileName().toString().equals(shardId.getIndexName()) : "shardStatePath must end with index/shardID but didn't: " + dataPath.toString();
         if (isCustomDataPath && dataPath.equals(shardStatePath)) {
             throw new IllegalArgumentException("shard state path must be different to the data path when using custom data paths");
         }

--- a/core/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RestoreSource;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -254,8 +255,8 @@ final class StoreRecovery {
             translogState.totalOperationsOnStart(0);
             indexShard.prepareForIndexRecovery();
             ShardId snapshotShardId = shardId;
-            if (!shardId.getIndex().equals(restoreSource.index())) {
-                snapshotShardId = new ShardId(restoreSource.index(), shardId.id());
+            if (!shardId.getIndexName().equals(restoreSource.index())) {
+                snapshotShardId = new ShardId(restoreSource.index(), IndexMetaData.INDEX_UUID_NA_VALUE, shardId.id());
             }
             indexShardRepository.restore(restoreSource.snapshotId(), restoreSource.version(), shardId, snapshotShardId, indexShard.recoveryState());
             indexShard.skipTranslogRecovery();

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardRepository.java
@@ -299,7 +299,7 @@ public class BlobStoreIndexShardRepository extends AbstractComponent implements 
             this.snapshotId = snapshotId;
             this.version = version;
             this.shardId = shardId;
-            blobContainer = blobStore.blobContainer(basePath.add("indices").add(snapshotShardId.getIndex()).add(Integer.toString(snapshotShardId.getId())));
+            blobContainer = blobStore.blobContainer(basePath.add("indices").add(snapshotShardId.getIndexName()).add(Integer.toString(snapshotShardId.getId())));
         }
 
         /**

--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -70,6 +70,7 @@ import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.RefCounted;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.env.ShardLock;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
@@ -408,9 +409,9 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      *
      * @throws IOException if the index we try to read is corrupted
      */
-    public static MetadataSnapshot readMetadataSnapshot(Path indexLocation, ESLogger logger) throws IOException {
+    public static MetadataSnapshot readMetadataSnapshot(Path indexLocation, ShardId shardId, ESLogger logger) throws IOException {
         try (Directory dir = new SimpleFSDirectory(indexLocation)) {
-            failIfCorrupted(dir, new ShardId("", 1));
+            failIfCorrupted(dir, shardId);
             return new MetadataSnapshot(null, dir, logger);
         } catch (IndexNotFoundException ex) {
             // that's fine - happens all the time no need to log
@@ -425,9 +426,9 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * can be successfully opened. This includes reading the segment infos and possible
      * corruption markers.
      */
-    public static boolean canOpenIndex(ESLogger logger, Path indexLocation) throws IOException {
+    public static boolean canOpenIndex(ESLogger logger, Path indexLocation, ShardId shardId) throws IOException {
         try {
-            tryOpenIndex(indexLocation);
+            tryOpenIndex(indexLocation, shardId);
         } catch (Exception ex) {
             logger.trace("Can't open index for path [{}]", ex, indexLocation);
             return false;
@@ -440,9 +441,9 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * segment infos and possible corruption markers. If the index can not
      * be opened, an exception is thrown
      */
-    public static void tryOpenIndex(Path indexLocation) throws IOException {
+    public static void tryOpenIndex(Path indexLocation, ShardId shardId) throws IOException {
         try (Directory dir = new SimpleFSDirectory(indexLocation)) {
-            failIfCorrupted(dir, new ShardId("", 1));
+            failIfCorrupted(dir, shardId);
             Lucene.readSegmentInfos(dir);
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/core/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -82,7 +82,7 @@ public class TermVectorsService  {
 
 
     public TermVectorsResponse getTermVectors(IndexShard indexShard, TermVectorsRequest request) {
-        final TermVectorsResponse termVectorsResponse = new TermVectorsResponse(indexShard.shardId().index().name(), request.type(), request.id());
+        final TermVectorsResponse termVectorsResponse = new TermVectorsResponse(indexShard.shardId().index().getName(), request.type(), request.id());
         final Term uidTerm = new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(request.type(), request.id()));
 
         Engine.GetResult get = indexShard.get(new Engine.Get(request.realtime(), uidTerm).version(request.version()).versionType(request.versionType()));

--- a/core/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/core/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -82,7 +82,7 @@ public class TermVectorsService  {
 
 
     public TermVectorsResponse getTermVectors(IndexShard indexShard, TermVectorsRequest request) {
-        final TermVectorsResponse termVectorsResponse = new TermVectorsResponse(indexShard.shardId().index().getName(), request.type(), request.id());
+        final TermVectorsResponse termVectorsResponse = new TermVectorsResponse(indexShard.shardId().getIndex().getName(), request.type(), request.id());
         final Term uidTerm = new Term(UidFieldMapper.NAME, Uid.createUidAsBytes(request.type(), request.id()));
 
         Engine.GetResult get = indexShard.get(new Engine.Get(request.realtime(), uidTerm).version(request.version()).versionType(request.versionType()));
@@ -262,7 +262,7 @@ public class TermVectorsService  {
 
     private Fields generateTermVectorsFromDoc(IndexShard indexShard, TermVectorsRequest request, boolean doAllFields) throws Throwable {
         // parse the document, at the moment we do update the mapping, just like percolate
-        ParsedDocument parsedDocument = parseDocument(indexShard, indexShard.shardId().getIndex(), request.type(), request.doc());
+        ParsedDocument parsedDocument = parseDocument(indexShard, indexShard.shardId().getIndexName(), request.type(), request.doc());
 
         // select the right fields and generate term vectors
         ParseContext.Document doc = parsedDocument.rootDoc();

--- a/core/src/main/java/org/elasticsearch/indices/IndexCreationException.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndexCreationException.java
@@ -30,8 +30,8 @@ import java.io.IOException;
  */
 public class IndexCreationException extends ElasticsearchException implements ElasticsearchWrapperException {
 
-    public IndexCreationException(Index index, Throwable cause) {
-        super("failed to create index", cause);
+    public IndexCreationException(String index, Throwable cause) {
+        super("failed to create index [{}]", cause, index);
         setIndex(index);
     }
 

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -258,11 +258,31 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
     }
 
     /**
+     * Returns an IndexService for the specified index if exists otherwise returns <code>null</code>.
+     *
+     */
+    @Nullable
+    public IndexService indexService(Index index) {
+        return indexService(index.getName());
+    }
+
+    /**
      * Returns an IndexService for the specified index if exists otherwise a {@link IndexNotFoundException} is thrown.
      */
     public IndexService indexServiceSafe(String index) {
         IndexService indexService = indexService(index);
         if (indexService == null) {
+            throw new IndexNotFoundException(index);
+        }
+        return indexService;
+    }
+
+    /**
+     * Returns an IndexService for the specified index if exists otherwise a {@link IndexNotFoundException} is thrown.
+     */
+    public IndexService indexServiceSafe(Index index) {
+        IndexService indexService = indexServiceSafe(index.getName());
+        if (indexService.indexUUID().equals(index.getUUID()) == false) {
             throw new IndexNotFoundException(index);
         }
         return indexService;
@@ -280,10 +300,9 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
         if (!lifecycle.started()) {
             throw new IllegalStateException("Can't create an index [" + indexMetaData.getIndex() + "], node is closed");
         }
-        final String indexName = indexMetaData.getIndex();
-        final Predicate<String> indexNameMatcher = (indexExpression) -> indexNameExpressionResolver.matchesIndex(indexName, indexExpression, clusterService.state());
+        final Index index = indexMetaData.getIndex();
+        final Predicate<String> indexNameMatcher = (indexExpression) -> indexNameExpressionResolver.matchesIndex(index.getName(), indexExpression, clusterService.state());
         final IndexSettings idxSettings = new IndexSettings(indexMetaData, this.settings, indexNameMatcher, indexScopeSetting);
-        Index index = new Index(indexMetaData.getIndex());
         if (indices.containsKey(index.getName())) {
             throw new IndexAlreadyExistsException(index);
         }
@@ -401,7 +420,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
 
     public void deleteClosedIndex(String reason, IndexMetaData metaData, ClusterState clusterState) {
         if (nodeEnv.hasNodeFile()) {
-            String indexName = metaData.getIndex();
+            String indexName = metaData.getIndex().getName();
             try {
                 if (clusterState.metaData().hasIndex(indexName)) {
                     final IndexMetaData index = clusterState.metaData().index(indexName);
@@ -421,7 +440,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
     public void deleteIndexStore(String reason, IndexMetaData metaData, ClusterState clusterState, boolean closed) throws IOException {
         if (nodeEnv.hasNodeFile()) {
             synchronized (this) {
-                String indexName = metaData.getIndex();
+                String indexName = metaData.getIndex().getName();
                 if (indices.containsKey(indexName)) {
                     String localUUid = indices.get(indexName).indexUUID();
                     throw new IllegalStateException("Can't delete index store for [" + indexName + "] - it's still part of the indices service [" + localUUid + "] [" + metaData.getIndexUUID() + "]");
@@ -433,9 +452,8 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                     throw new IllegalStateException("Can't delete closed index store for [" + indexName + "] - it's still part of the cluster state [" + index.getIndexUUID() + "] [" + metaData.getIndexUUID() + "]");
                 }
             }
-            Index index = new Index(metaData.getIndex());
             final IndexSettings indexSettings = buildIndexSettings(metaData);
-            deleteIndexStore(reason, index, indexSettings, closed);
+            deleteIndexStore(reason, indexSettings.getIndex(), indexSettings, closed);
         }
     }
 
@@ -460,7 +478,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
             }
             // this is a pure protection to make sure this index doesn't get re-imported as a dangeling index.
             // we should in the future rather write a tombstone rather than wiping the metadata.
-            MetaDataStateFormat.deleteMetaState(nodeEnv.indexPaths(index));
+            MetaDataStateFormat.deleteMetaState(nodeEnv.indexPaths(index.getName()));
         }
     }
 
@@ -490,7 +508,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
      * @throws IOException if an IOException occurs
      */
     public void deleteShardStore(String reason, ShardId shardId, ClusterState clusterState) throws IOException {
-        final IndexMetaData metaData = clusterState.getMetaData().indices().get(shardId.getIndex());
+        final IndexMetaData metaData = clusterState.getMetaData().indices().get(shardId.getIndexName());
 
         final IndexSettings indexSettings = buildIndexSettings(metaData);
         if (canDeleteShardContent(shardId, indexSettings) == false) {
@@ -500,8 +518,8 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
         logger.debug("{} deleted shard reason [{}]", shardId, reason);
 
         if (clusterState.nodes().localNode().isMasterNode() == false && // master nodes keep the index meta data, even if having no shards..
-                canDeleteIndexContents(shardId.index(), indexSettings, false)) {
-            if (nodeEnv.findAllShardIds(shardId.index()).isEmpty()) {
+                canDeleteIndexContents(shardId.getIndex(), indexSettings, false)) {
+            if (nodeEnv.findAllShardIds(shardId.getIndex()).isEmpty()) {
                 try {
                     // note that deleteIndexStore have more safety checks and may throw an exception if index was concurrently created.
                     deleteIndexStore("no longer used", metaData, clusterState, false);
@@ -510,7 +528,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
                     throw new ElasticsearchException("failed to delete unused index after deleting its last shard (" + shardId + ")", e);
                 }
             } else {
-                logger.trace("[{}] still has shard stores, leaving as is", shardId.index());
+                logger.trace("[{}] still has shard stores, leaving as is", shardId.getIndex());
             }
         }
     }
@@ -586,7 +604,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
             throw new IllegalArgumentException("settings must not be null");
         }
         PendingDelete pendingDelete = new PendingDelete(shardId, settings);
-        addPendingDelete(shardId.index(), pendingDelete);
+        addPendingDelete(shardId.getIndex(), pendingDelete);
     }
 
     /**
@@ -609,7 +627,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
     }
 
     private static final class PendingDelete implements Comparable<PendingDelete> {
-        final String index;
+        final Index index;
         final int shardId;
         final IndexSettings settings;
         final boolean deleteIndex;
@@ -628,7 +646,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
          * Creates a new pending delete of a shard
          */
         public PendingDelete(Index index, IndexSettings settings) {
-            this.index = index.getName();
+            this.index = index;
             this.shardId = -1;
             this.settings = settings;
             this.deleteIndex = true;

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -284,7 +284,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
         final Predicate<String> indexNameMatcher = (indexExpression) -> indexNameExpressionResolver.matchesIndex(indexName, indexExpression, clusterService.state());
         final IndexSettings idxSettings = new IndexSettings(indexMetaData, this.settings, indexNameMatcher, indexScopeSetting);
         Index index = new Index(indexMetaData.getIndex());
-        if (indices.containsKey(index.name())) {
+        if (indices.containsKey(index.getName())) {
             throw new IndexAlreadyExistsException(index);
         }
         logger.debug("creating Index [{}], shards [{}]/[{}{}]",
@@ -306,7 +306,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
         try {
             assert indexService.getIndexEventListener() == listener;
             listener.afterIndexCreated(indexService);
-            indices = newMapBuilder(indices).put(index.name(), indexService).immutableMap();
+            indices = newMapBuilder(indices).put(index.getName(), indexService).immutableMap();
             success = true;
             return indexService;
         } finally {
@@ -524,7 +524,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
      * @return true if the index can be deleted on this node
      */
     public boolean canDeleteIndexContents(Index index, IndexSettings indexSettings, boolean closed) {
-        final IndexService indexService = this.indices.get(index.name());
+        final IndexService indexService = this.indices.get(index.getName());
         // Closed indices may be deleted, even if they are on a shared
         // filesystem. Since it is closed we aren't deleting it for relocation
         if (indexSettings.isOnSharedFilesystem() == false || closed) {
@@ -550,7 +550,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
      * @param indexSettings the shards's relevant {@link IndexSettings}. This is required to access the indexes settings etc.
      */
     public boolean canDeleteShardContent(ShardId shardId, IndexSettings indexSettings) {
-        assert shardId.getIndex().equals(indexSettings.getIndex().name());
+        assert shardId.getIndex().equals(indexSettings.getIndex().getName());
         final IndexService indexService = this.indices.get(shardId.getIndex());
         if (indexSettings.isOnSharedFilesystem() == false) {
             if (indexService != null && nodeEnv.hasNodeFile()) {

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -53,7 +53,6 @@ import org.elasticsearch.index.NodeServicesProvider;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.flush.FlushStats;
 import org.elasticsearch.index.get.GetStats;
-import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.merge.MergeStats;
 import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
@@ -61,6 +60,7 @@ import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.IndexStoreConfig;
 import org.elasticsearch.indices.mapper.MapperRegistry;
@@ -568,8 +568,8 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
      * @param indexSettings the shards's relevant {@link IndexSettings}. This is required to access the indexes settings etc.
      */
     public boolean canDeleteShardContent(ShardId shardId, IndexSettings indexSettings) {
-        assert shardId.getIndex().equals(indexSettings.getIndex().getName());
-        final IndexService indexService = this.indices.get(shardId.getIndex());
+        assert shardId.getIndex().equals(indexSettings.getIndex());
+        final IndexService indexService = this.indices.get(shardId.getIndexName());
         if (indexSettings.isOnSharedFilesystem() == false) {
             if (indexService != null && nodeEnv.hasNodeFile()) {
                 return indexService.hasShard(shardId.id()) == false;

--- a/core/src/main/java/org/elasticsearch/indices/InvalidIndexNameException.java
+++ b/core/src/main/java/org/elasticsearch/indices/InvalidIndexNameException.java
@@ -31,6 +31,10 @@ import java.io.IOException;
  */
 public class InvalidIndexNameException extends ElasticsearchException {
 
+    public InvalidIndexNameException(String name, String desc) {
+        super("Invalid index name [" + name + "], " + desc);
+        setIndex(name);
+    }
     public InvalidIndexNameException(Index index, String name, String desc) {
         super("Invalid index name [" + name + "], " + desc);
         setIndex(index);

--- a/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -172,7 +172,7 @@ public class NodeIndicesStats implements Streamable, ToXContent {
             int entries = in.readVInt();
             statsByShard = new HashMap<>();
             for (int i = 0; i < entries; i++) {
-                Index index = Index.readIndexName(in);
+                Index index = Index.readIndex(in);
                 int indexShardListSize = in.readVInt();
                 List<IndexShardStats> indexShardStats = new ArrayList<>(indexShardListSize);
                 for (int j = 0; j < indexShardListSize; j++) {

--- a/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -215,7 +215,7 @@ public class NodeIndicesStats implements Streamable, ToXContent {
             Map<Index, CommonStats> indexStats = createStatsByIndex();
             builder.startObject(Fields.INDICES);
             for (Map.Entry<Index, CommonStats> entry : indexStats.entrySet()) {
-                builder.startObject(entry.getKey().name());
+                builder.startObject(entry.getKey().getName());
                 entry.getValue().toXContent(builder, params);
                 builder.endObject();
             }
@@ -223,7 +223,7 @@ public class NodeIndicesStats implements Streamable, ToXContent {
         } else if ("shards".equals(level)) {
             builder.startObject("shards");
             for (Map.Entry<Index, List<IndexShardStats>> entry : statsByShard.entrySet()) {
-                builder.startArray(entry.getKey().name());
+                builder.startArray(entry.getKey().getName());
                 for (IndexShardStats indexShardStats : entry.getValue()) {
                     builder.startObject().startObject(String.valueOf(indexShardStats.getShardId().getId()));
                     for (ShardStats shardStats : indexShardStats.getShards()) {

--- a/core/src/main/java/org/elasticsearch/indices/TypeMissingException.java
+++ b/core/src/main/java/org/elasticsearch/indices/TypeMissingException.java
@@ -37,6 +37,11 @@ public class TypeMissingException extends ElasticsearchException {
         setIndex(index);
     }
 
+    public TypeMissingException(String index, String... types) {
+        super("type[" + Arrays.toString(types) + "] missing");
+        setIndex(index);
+    }
+
     public TypeMissingException(StreamInput in) throws IOException{
         super(in);
     }

--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -276,15 +276,15 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         }
         IntHashSet newShardIds = new IntHashSet();
         for (IndexService indexService : indicesService) {
-            String index = indexService.index().getName();
-            IndexMetaData indexMetaData = event.state().metaData().index(index);
+            String indexName = indexService.index().getName();
+            IndexMetaData indexMetaData = event.state().metaData().index(indexName);
             if (indexMetaData == null) {
                 continue;
             }
             // now, go over and delete shards that needs to get deleted
             newShardIds.clear();
             for (ShardRouting shard : routingNode) {
-                if (shard.index().equals(index)) {
+                if (shard.index().getName().equals(indexName)) {
                     newShardIds.add(shard.id());
                 }
             }
@@ -292,14 +292,14 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
                 if (!newShardIds.contains(existingShardId)) {
                     if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
                         if (logger.isDebugEnabled()) {
-                            logger.debug("[{}][{}] removing shard (index is closed)", index, existingShardId);
+                            logger.debug("[{}][{}] removing shard (index is closed)", indexName, existingShardId);
                         }
                         indexService.removeShard(existingShardId, "removing shard (index is closed)");
                     } else {
                         // we can just remove the shard, without cleaning it locally, since we will clean it
                         // when all shards are allocated in the IndicesStore
                         if (logger.isDebugEnabled()) {
-                            logger.debug("[{}][{}] removing shard (not allocated)", index, existingShardId);
+                            logger.debug("[{}][{}] removing shard (not allocated)", indexName, existingShardId);
                         }
                         indexService.removeShard(existingShardId, "removing shard (not allocated)");
                     }

--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -235,7 +235,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         assert localNodeId != null;
 
         for (IndexService indexService : indicesService) {
-            IndexMetaData indexMetaData = event.state().metaData().index(indexService.index().name());
+            IndexMetaData indexMetaData = event.state().metaData().index(indexService.index().getName());
             if (indexMetaData != null) {
                 if (!indexMetaData.isSameUUID(indexService.indexUUID())) {
                     logger.debug("[{}] mismatch on index UUIDs between cluster state and local state, cleaning the index so it will be recreated", indexMetaData.getIndex());
@@ -276,7 +276,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
         }
         IntHashSet newShardIds = new IntHashSet();
         for (IndexService indexService : indicesService) {
-            String index = indexService.index().name();
+            String index = indexService.index().getName();
             IndexMetaData indexMetaData = event.state().metaData().index(index);
             if (indexMetaData == null) {
                 continue;
@@ -796,7 +796,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent<Indic
     private class FailedShardHandler implements Callback<IndexShard.ShardFailure> {
         @Override
         public void handle(final IndexShard.ShardFailure shardFailure) {
-            final IndexService indexService = indicesService.indexService(shardFailure.routing.shardId().index().name());
+            final IndexService indexService = indicesService.indexService(shardFailure.routing.shardId().index().getName());
             final ShardRouting shardRouting = shardFailure.routing;
             threadPool.generic().execute(() -> {
                 synchronized (mutex) {

--- a/core/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/core/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -237,7 +237,7 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
     }
 
     final IndexShardRoutingTable getShardRoutingTable(ShardId shardId, ClusterState state) {
-        final IndexRoutingTable indexRoutingTable = state.routingTable().index(shardId.index().name());
+        final IndexRoutingTable indexRoutingTable = state.routingTable().index(shardId.index().getName());
         if (indexRoutingTable == null) {
             IndexMetaData index = state.getMetaData().index(shardId.index().getName());
             if (index != null && index.getState() == IndexMetaData.State.CLOSE) {

--- a/core/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/core/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -119,7 +119,7 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
             final IndexMetaData indexMetaData = state.metaData().index(index);
             totalNumberOfShards += indexMetaData.getTotalNumberOfShards();
             numberOfShards += indexMetaData.getNumberOfShards();
-            results.put(index, Collections.synchronizedList(new ArrayList<ShardsSyncedFlushResult>()));
+            results.put(index, Collections.synchronizedList(new ArrayList<>()));
 
         }
         if (numberOfShards == 0) {
@@ -130,9 +130,10 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
         final CountDown countDown = new CountDown(numberOfShards);
 
         for (final String index : concreteIndices) {
-            final int indexNumberOfShards = state.metaData().index(index).getNumberOfShards();
+            final IndexMetaData indexMetaData = state.metaData().index(index);
+            final int indexNumberOfShards = indexMetaData.getNumberOfShards();
             for (int shard = 0; shard < indexNumberOfShards; shard++) {
-                final ShardId shardId = new ShardId(index, shard);
+                final ShardId shardId = new ShardId(indexMetaData.getIndex(), shard);
                 attemptSyncedFlush(shardId, new ActionListener<ShardsSyncedFlushResult>() {
                     @Override
                     public void onResponse(ShardsSyncedFlushResult syncedFlushResult) {
@@ -237,13 +238,13 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
     }
 
     final IndexShardRoutingTable getShardRoutingTable(ShardId shardId, ClusterState state) {
-        final IndexRoutingTable indexRoutingTable = state.routingTable().index(shardId.index().getName());
+        final IndexRoutingTable indexRoutingTable = state.routingTable().index(shardId.getIndexName());
         if (indexRoutingTable == null) {
-            IndexMetaData index = state.getMetaData().index(shardId.index().getName());
+            IndexMetaData index = state.getMetaData().index(shardId.getIndexName());
             if (index != null && index.getState() == IndexMetaData.State.CLOSE) {
-                throw new IndexClosedException(shardId.index());
+                throw new IndexClosedException(shardId.getIndex());
             }
-            throw new IndexNotFoundException(shardId.index().getName());
+            throw new IndexNotFoundException(shardId.getIndexName());
         }
         final IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId.id());
         if (shardRoutingTable == null) {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -84,7 +84,7 @@ public class RecoverySource extends AbstractComponent implements IndexEventListe
     }
 
     private RecoveryResponse recover(final StartRecoveryRequest request) throws IOException {
-        final IndexService indexService = indicesService.indexServiceSafe(request.shardId().index().name());
+        final IndexService indexService = indicesService.indexServiceSafe(request.shardId().index().getName());
         final IndexShard shard = indexService.getShard(request.shardId().id());
 
         // starting recovery from that our (the source) shard state is marking the shard to be in recovery mode as well, otherwise
@@ -111,7 +111,7 @@ public class RecoverySource extends AbstractComponent implements IndexEventListe
             throw new DelayRecoveryException("source node has the state of the target shard to be [" + targetShardRouting.state() + "], expecting to be [initializing]");
         }
 
-        logger.trace("[{}][{}] starting recovery to {}, mark_as_relocated {}", request.shardId().index().name(), request.shardId().id(), request.targetNode(), request.markAsRelocated());
+        logger.trace("[{}][{}] starting recovery to {}, mark_as_relocated {}", request.shardId().index().getName(), request.shardId().id(), request.targetNode(), request.markAsRelocated());
         final RecoverySourceHandler handler;
         if (shard.indexSettings().isOnSharedFilesystem()) {
             handler = new SharedFSRecoverySourceHandler(shard, request, recoverySettings, transportService, logger);

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -84,7 +84,7 @@ public class RecoverySource extends AbstractComponent implements IndexEventListe
     }
 
     private RecoveryResponse recover(final StartRecoveryRequest request) throws IOException {
-        final IndexService indexService = indicesService.indexServiceSafe(request.shardId().index().getName());
+        final IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex().getName());
         final IndexShard shard = indexService.getShard(request.shardId().id());
 
         // starting recovery from that our (the source) shard state is marking the shard to be in recovery mode as well, otherwise
@@ -111,7 +111,7 @@ public class RecoverySource extends AbstractComponent implements IndexEventListe
             throw new DelayRecoveryException("source node has the state of the target shard to be [" + targetShardRouting.state() + "], expecting to be [initializing]");
         }
 
-        logger.trace("[{}][{}] starting recovery to {}, mark_as_relocated {}", request.shardId().index().getName(), request.shardId().id(), request.targetNode(), request.markAsRelocated());
+        logger.trace("[{}][{}] starting recovery to {}, mark_as_relocated {}", request.shardId().getIndex().getName(), request.shardId().id(), request.targetNode(), request.markAsRelocated());
         final RecoverySourceHandler handler;
         if (shard.indexSettings().isOnSharedFilesystem()) {
             handler = new SharedFSRecoverySourceHandler(shard, request, recoverySettings, transportService, logger);

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -111,7 +111,7 @@ public class RecoverySourceHandler {
         this.recoverySettings = recoverySettings;
         this.logger = logger;
         this.transportService = transportService;
-        this.indexName = this.request.shardId().index().getName();
+        this.indexName = this.request.shardId().getIndex().getName();
         this.shardId = this.request.shardId().id();
         this.chunkSizeInBytes = recoverySettings.getChunkSize().bytesAsInt();
         this.response = new RecoveryResponse();

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -111,7 +111,7 @@ public class RecoverySourceHandler {
         this.recoverySettings = recoverySettings;
         this.logger = logger;
         this.transportService = transportService;
-        this.indexName = this.request.shardId().index().name();
+        this.indexName = this.request.shardId().index().getName();
         this.shardId = this.request.shardId().id();
         this.chunkSizeInBytes = recoverySettings.getChunkSize().bytesAsInt();
         this.response = new RecoveryResponse();

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -182,7 +182,7 @@ public class RecoveryTarget extends AbstractComponent implements IndexEventListe
 
         final AtomicReference<RecoveryResponse> responseHolder = new AtomicReference<>();
         try {
-            logger.trace("[{}][{}] starting recovery from {}", request.shardId().index().getName(), request.shardId().id(), request.sourceNode());
+            logger.trace("[{}][{}] starting recovery from {}", request.shardId().getIndex().getName(), request.shardId().id(), request.sourceNode());
             recoveryStatus.indexShard().prepareForIndexRecovery();
             recoveryStatus.CancellableThreads().execute(new CancellableThreads.Interruptable() {
                 @Override
@@ -202,7 +202,7 @@ public class RecoveryTarget extends AbstractComponent implements IndexEventListe
             onGoingRecoveries.markRecoveryAsDone(recoveryStatus.recoveryId());
             if (logger.isTraceEnabled()) {
                 StringBuilder sb = new StringBuilder();
-                sb.append('[').append(request.shardId().index().getName()).append(']').append('[').append(request.shardId().id()).append("] ");
+                sb.append('[').append(request.shardId().getIndex().getName()).append(']').append('[').append(request.shardId().id()).append("] ");
                 sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(recoveryTime).append("]\n");
                 sb.append("   phase1: recovered_files [").append(recoveryResponse.phase1FileNames.size()).append("]").append(" with total_size of [").append(new ByteSizeValue(recoveryResponse.phase1TotalSize)).append("]")
                         .append(", took [").append(timeValueMillis(recoveryResponse.phase1Time)).append("], throttling_wait [").append(timeValueMillis(recoveryResponse.phase1ThrottlingWaitTime)).append(']')
@@ -220,7 +220,7 @@ public class RecoveryTarget extends AbstractComponent implements IndexEventListe
             logger.trace("recovery cancelled", e);
         } catch (Throwable e) {
             if (logger.isTraceEnabled()) {
-                logger.trace("[{}][{}] Got exception on recovery", e, request.shardId().index().getName(), request.shardId().id());
+                logger.trace("[{}][{}] Got exception on recovery", e, request.shardId().getIndex().getName(), request.shardId().id());
             }
             Throwable cause = ExceptionsHelper.unwrapCause(e);
             if (cause instanceof CancellableThreads.ExecutionCancelledException) {

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -182,7 +182,7 @@ public class RecoveryTarget extends AbstractComponent implements IndexEventListe
 
         final AtomicReference<RecoveryResponse> responseHolder = new AtomicReference<>();
         try {
-            logger.trace("[{}][{}] starting recovery from {}", request.shardId().index().name(), request.shardId().id(), request.sourceNode());
+            logger.trace("[{}][{}] starting recovery from {}", request.shardId().index().getName(), request.shardId().id(), request.sourceNode());
             recoveryStatus.indexShard().prepareForIndexRecovery();
             recoveryStatus.CancellableThreads().execute(new CancellableThreads.Interruptable() {
                 @Override
@@ -202,7 +202,7 @@ public class RecoveryTarget extends AbstractComponent implements IndexEventListe
             onGoingRecoveries.markRecoveryAsDone(recoveryStatus.recoveryId());
             if (logger.isTraceEnabled()) {
                 StringBuilder sb = new StringBuilder();
-                sb.append('[').append(request.shardId().index().name()).append(']').append('[').append(request.shardId().id()).append("] ");
+                sb.append('[').append(request.shardId().index().getName()).append(']').append('[').append(request.shardId().id()).append("] ");
                 sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(recoveryTime).append("]\n");
                 sb.append("   phase1: recovered_files [").append(recoveryResponse.phase1FileNames.size()).append("]").append(" with total_size of [").append(new ByteSizeValue(recoveryResponse.phase1TotalSize)).append("]")
                         .append(", took [").append(timeValueMillis(recoveryResponse.phase1Time)).append("], throttling_wait [").append(timeValueMillis(recoveryResponse.phase1ThrottlingWaitTime)).append(']')
@@ -220,7 +220,7 @@ public class RecoveryTarget extends AbstractComponent implements IndexEventListe
             logger.trace("recovery cancelled", e);
         } catch (Throwable e) {
             if (logger.isTraceEnabled()) {
-                logger.trace("[{}][{}] Got exception on recovery", e, request.shardId().index().name(), request.shardId().id());
+                logger.trace("[{}][{}] Got exception on recovery", e, request.shardId().index().getName(), request.shardId().id());
             }
             Throwable cause = ExceptionsHelper.unwrapCause(e);
             if (cause instanceof CancellableThreads.ExecutionCancelledException) {

--- a/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -117,7 +117,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
                 if (shardCanBeDeleted(event.state(), indexShardRoutingTable)) {
                     ShardId shardId = indexShardRoutingTable.shardId();
                     IndexService indexService = indicesService.indexService(indexRoutingTable.getIndex());
-                    IndexSettings indexSettings = indexService != null ? indexService.getIndexSettings() : new IndexSettings(event.state().getMetaData().index(indexRoutingTable.index()), settings);
+                    IndexSettings indexSettings = indexService != null ? indexService.getIndexSettings() : new IndexSettings(event.state().getMetaData().index(indexRoutingTable.getIndex()), settings);
                     if (indicesService.canDeleteShardContent(shardId, indexSettings)) {
                         deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable);
                     }
@@ -352,7 +352,7 @@ public class IndicesStore extends AbstractComponent implements ClusterStateListe
             }
 
             ShardId shardId = request.shardId;
-            IndexService indexService = indicesService.indexService(shardId.index().getName());
+            IndexService indexService = indicesService.indexService(shardId.getIndexName());
             if (indexService != null && indexService.indexUUID().equals(request.indexUUID)) {
                 return indexService.getShardOrNull(shardId.id());
             }

--- a/core/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -34,7 +34,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -43,7 +42,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.AsyncShardFetch;
-import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.IndexShard;
@@ -57,7 +55,6 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -129,7 +126,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
     @Override
     protected NodeStoreFilesMetaData nodeOperation(NodeRequest request) {
         if (request.unallocated) {
-            IndexService indexService = indicesService.indexService(request.shardId.index().name());
+            IndexService indexService = indicesService.indexService(request.shardId.index().getName());
             if (indexService == null) {
                 return new NodeStoreFilesMetaData(clusterService.localNode(), null);
             }
@@ -137,7 +134,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
                 return new NodeStoreFilesMetaData(clusterService.localNode(), null);
             }
         }
-        IndexMetaData metaData = clusterService.state().metaData().index(request.shardId.index().name());
+        IndexMetaData metaData = clusterService.state().metaData().index(request.shardId.index().getName());
         if (metaData == null) {
             return new NodeStoreFilesMetaData(clusterService.localNode(), null);
         }
@@ -153,7 +150,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         long startTimeNS = System.nanoTime();
         boolean exists = false;
         try {
-            IndexService indexService = indicesService.indexService(shardId.index().name());
+            IndexService indexService = indicesService.indexService(shardId.index().getName());
             if (indexService != null) {
                 IndexShard indexShard = indexService.getShardOrNull(shardId.id());
                 if (indexShard != null) {
@@ -168,7 +165,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
                 }
             }
             // try and see if we an list unallocated
-            IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().name());
+            IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().getName());
             if (metaData == null) {
                 return new StoreFilesMetaData(false, shardId, Store.MetadataSnapshot.EMPTY);
             }

--- a/core/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/core/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -126,7 +126,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
     @Override
     protected NodeStoreFilesMetaData nodeOperation(NodeRequest request) {
         if (request.unallocated) {
-            IndexService indexService = indicesService.indexService(request.shardId.index().getName());
+            IndexService indexService = indicesService.indexService(request.shardId.getIndexName());
             if (indexService == null) {
                 return new NodeStoreFilesMetaData(clusterService.localNode(), null);
             }
@@ -134,7 +134,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
                 return new NodeStoreFilesMetaData(clusterService.localNode(), null);
             }
         }
-        IndexMetaData metaData = clusterService.state().metaData().index(request.shardId.index().getName());
+        IndexMetaData metaData = clusterService.state().metaData().index(request.shardId.getIndexName());
         if (metaData == null) {
             return new NodeStoreFilesMetaData(clusterService.localNode(), null);
         }
@@ -150,7 +150,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         long startTimeNS = System.nanoTime();
         boolean exists = false;
         try {
-            IndexService indexService = indicesService.indexService(shardId.index().getName());
+            IndexService indexService = indicesService.indexService(shardId.getIndexName());
             if (indexService != null) {
                 IndexShard indexShard = indexService.getShardOrNull(shardId.id());
                 if (indexShard != null) {
@@ -165,7 +165,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
                 }
             }
             // try and see if we an list unallocated
-            IndexMetaData metaData = clusterService.state().metaData().index(shardId.index().getName());
+            IndexMetaData metaData = clusterService.state().metaData().index(shardId.getIndexName());
             if (metaData == null) {
                 return new StoreFilesMetaData(false, shardId, Store.MetadataSnapshot.EMPTY);
             }
@@ -174,7 +174,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
             if (shardPath == null) {
                 return new StoreFilesMetaData(false, shardId, Store.MetadataSnapshot.EMPTY);
             }
-            return new StoreFilesMetaData(false, shardId, Store.readMetadataSnapshot(shardPath.resolveIndex(), logger));
+            return new StoreFilesMetaData(false, shardId, Store.readMetadataSnapshot(shardPath.resolveIndex(), shardId, logger));
         } finally {
             TimeValue took = new TimeValue(System.nanoTime() - startTimeNS, TimeUnit.NANOSECONDS);
             if (exists) {

--- a/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -205,7 +205,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
                 BulkRequest bulkRequest = new BulkRequest();
                 for (DocToPurge docToPurge : docsToPurge) {
 
-                    bulkRequest.add(new DeleteRequest().index(shardToPurge.routingEntry().index()).type(docToPurge.type).id(docToPurge.id).version(docToPurge.version).routing(docToPurge.routing));
+                    bulkRequest.add(new DeleteRequest().index(shardToPurge.routingEntry().getIndexName()).type(docToPurge.type).id(docToPurge.id).version(docToPurge.version).routing(docToPurge.routing));
                     bulkRequest = processBulkIfNeeded(bulkRequest, false);
                 }
                 processBulkIfNeeded(bulkRequest, true);

--- a/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
+++ b/core/src/main/java/org/elasticsearch/indices/ttl/IndicesTTLService.java
@@ -159,7 +159,7 @@ public class IndicesTTLService extends AbstractLifecycleComponent<IndicesTTLServ
             MetaData metaData = clusterService.state().metaData();
             for (IndexService indexService : indicesService) {
                 // check the value of disable_purge for this index
-                IndexMetaData indexMetaData = metaData.index(indexService.index().name());
+                IndexMetaData indexMetaData = metaData.index(indexService.index().getName());
                 if (indexMetaData == null) {
                     continue;
                 }

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateDocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateDocumentParser.java
@@ -62,7 +62,7 @@ public class PercolateDocumentParser {
         BytesReference source = request.source();
         if (source == null || source.length() == 0) {
             if (request.docSource() != null && request.docSource().length() != 0) {
-                return parseFetchedDoc(context, request.docSource(), mapperService, request.shardId().getIndex(), request.documentType());
+                return parseFetchedDoc(context, request.docSource(), mapperService, request.shardId().getIndexName(), request.documentType());
             } else {
                 return null;
             }
@@ -182,7 +182,7 @@ public class PercolateDocumentParser {
                 throw new IllegalArgumentException("Can't specify the document to percolate in the source of the request and as document id");
             }
 
-            doc = parseFetchedDoc(context, request.docSource(), mapperService, request.shardId().getIndex(), request.documentType());
+            doc = parseFetchedDoc(context, request.docSource(), mapperService, request.shardId().getIndexName(), request.documentType());
         }
 
         if (doc == null) {

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -180,7 +180,7 @@ public class PercolatorService extends AbstractComponent {
         // just like is done in other apis.
         String[] filteringAliases = indexNameExpressionResolver.filteringAliases(
                 clusterService.state(),
-                indexShard.shardId().index().name(),
+                indexShard.shardId().index().getName(),
                 request.indices()
         );
         Query aliasFilter = percolateIndexService.aliasFilter(indexShard.getQueryShardContext(), filteringAliases);

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -180,7 +180,7 @@ public class PercolatorService extends AbstractComponent {
         // just like is done in other apis.
         String[] filteringAliases = indexNameExpressionResolver.filteringAliases(
                 clusterService.state(),
-                indexShard.shardId().index().getName(),
+                indexShard.shardId().getIndex().getName(),
                 request.indices()
         );
         Query aliasFilter = percolateIndexService.aliasFilter(indexShard.getQueryShardContext(), filteringAliases);

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -348,12 +348,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent<Rep
                 if (metaData != null) {
                     IndexMetaData indexMetaData = metaData.index(index);
                     if (indexMetaData != null) {
-                        for (int i = 0; i < indexMetaData.getNumberOfShards(); i++) {
-                            ShardId shardId = new ShardId(index, i);
+                        for (int shardId = 0; shardId < indexMetaData.getNumberOfShards(); shardId++) {
                             try {
-                                indexShardRepository.delete(snapshotId, snapshot.version(), shardId);
+                                indexShardRepository.delete(snapshotId, snapshot.version(), new ShardId(indexMetaData.getIndex(), shardId));
                             } catch (SnapshotException ex) {
-                                logger.warn("[{}] failed to delete shard data for shard [{}]", ex, snapshotId, shardId);
+                                logger.warn("[{}] failed to delete shard data for shard [{}][{}]", ex, snapshotId, index, shardId);
                             }
                         }
                     }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/get/RestGetIndicesAliasesAction.java
@@ -75,7 +75,7 @@ public class RestGetIndicesAliasesAction extends BaseRestHandler {
 
                 final boolean isAllAliasesRequested = isAllOrWildcard(aliases);
                 for (IndexMetaData indexMetaData : metaData) {
-                    builder.startObject(indexMetaData.getIndex(), XContentBuilder.FieldCaseConversion.NONE);
+                    builder.startObject(indexMetaData.getIndex().getName(), XContentBuilder.FieldCaseConversion.NONE);
                     builder.startObject("aliases");
 
                     for (ObjectCursor<AliasMetaData> cursor : indexMetaData.getAliases().values()) {

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/mapping/get/RestGetMappingAction.java
@@ -78,7 +78,7 @@ public class RestGetMappingAction extends BaseRestHandler {
                     } else if (indices.length != 0) {
                         return new BytesRestResponse(channel, new IndexNotFoundException(indices[0]));
                     } else if (types.length != 0) {
-                        return new BytesRestResponse(channel, new TypeMissingException(new Index("_all"), types[0]));
+                        return new BytesRestResponse(channel, new TypeMissingException("_all", types[0]));
                     } else {
                         return new BytesRestResponse(OK, builder.endObject());
                     }

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
@@ -127,7 +127,7 @@ public class RestSegmentsAction extends AbstractCatAction {
                     for (Segment segment : segments) {
                         table.startRow();
 
-                        table.addCell(shardSegment.getShardRouting().getIndex());
+                        table.addCell(shardSegment.getShardRouting().getIndexName());
                         table.addCell(shardSegment.getShardRouting().getId());
                         table.addCell(shardSegment.getShardRouting().primary() ? "p" : "r");
                         table.addCell(nodes.get(shardSegment.getShardRouting().currentNodeId()).getHostAddress());

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -188,7 +188,7 @@ public class RestShardsAction extends AbstractCatAction {
 
             table.startRow();
 
-            table.addCell(shard.index());
+            table.addCell(shard.getIndexName());
             table.addCell(shard.id());
 
             IndexMetaData indexMeta = state.getState().getMetaData().index(shard.index());

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -554,7 +554,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> imp
         IndexService indexService = indicesService.indexServiceSafe(request.index());
         IndexShard indexShard = indexService.getShard(request.shardId());
 
-        SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), request.index(), request.shardId());
+        SearchShardTarget shardTarget = new SearchShardTarget(clusterService.localNode().id(), indexShard.shardId().getIndex(), request.shardId());
 
         Engine.Searcher engineSearcher = searcher == null ? indexShard.acquireSearcher("search") : searcher;
 
@@ -608,7 +608,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> imp
     private void freeAllContextForIndex(Index index) {
         assert index != null;
         for (SearchContext ctx : activeContexts.values()) {
-            if (index.equals(ctx.indexShard().shardId().index())) {
+            if (index.equals(ctx.indexShard().shardId().getIndex())) {
                 freeContext(ctx.id());
             }
         }

--- a/core/src/main/java/org/elasticsearch/search/SearchShardTarget.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchShardTarget.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.index.Index;
 
 import java.io.IOException;
 
@@ -40,9 +41,9 @@ public class SearchShardTarget implements Streamable, Comparable<SearchShardTarg
 
     }
 
-    public SearchShardTarget(String nodeId, String index, int shardId) {
+    public SearchShardTarget(String nodeId, Index index, int shardId) {
         this.nodeId = nodeId == null ? null : new Text(nodeId);
-        this.index = new Text(index);
+        this.index = new Text(index.getName());
         this.shardId = shardId;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -99,7 +99,7 @@ public class ShardSearchLocalRequest extends ContextAndHeaderHolder implements S
 
     public ShardSearchLocalRequest(ShardId shardId, int numberOfShards, SearchType searchType, SearchSourceBuilder source, String[] types,
             Boolean requestCache) {
-        this.index = shardId.getIndex();
+        this.index = shardId.getIndexName();
         this.shardId = shardId.id();
         this.numberOfShards = numberOfShards;
         this.searchType = searchType;

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -508,7 +508,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
 
     private SnapshotShardFailure findShardFailure(List<SnapshotShardFailure> shardFailures, ShardId shardId) {
         for (SnapshotShardFailure shardFailure : shardFailures) {
-            if (shardId.getIndex().equals(shardFailure.index()) && shardId.getId() == shardFailure.shardId()) {
+            if (shardId.getIndexName().equals(shardFailure.index()) && shardId.getId() == shardFailure.shardId()) {
                 return shardFailure;
             }
         }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -488,7 +488,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
             if (indexMetaData != null) {
                 int numberOfShards = indexMetaData.getNumberOfShards();
                 for (int i = 0; i < numberOfShards; i++) {
-                    ShardId shardId = new ShardId(index, i);
+                    ShardId shardId = new ShardId(indexMetaData.getIndex(), i);
                     SnapshotShardFailure shardFailure = findShardFailure(snapshot.shardFailures(), shardId);
                     if (shardFailure != null) {
                         IndexShardSnapshotStatus shardSnapshotStatus = new IndexShardSnapshotStatus();
@@ -751,10 +751,10 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
         Set<String> closed = new HashSet<>();
         for (ObjectObjectCursor<ShardId, SnapshotsInProgress.ShardSnapshotStatus> entry : shards) {
             if (entry.value.state() == State.MISSING) {
-                if (metaData.hasIndex(entry.key.getIndex()) && metaData.index(entry.key.getIndex()).getState() == IndexMetaData.State.CLOSE) {
-                    closed.add(entry.key.getIndex());
+                if (metaData.hasIndex(entry.key.getIndex().getName()) && metaData.index(entry.key.getIndex()).getState() == IndexMetaData.State.CLOSE) {
+                    closed.add(entry.key.getIndex().getName());
                 } else {
-                    missing.add(entry.key.getIndex());
+                    missing.add(entry.key.getIndex().getName());
                 }
             }
         }
@@ -796,7 +796,7 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
                         ShardSnapshotStatus status = shardStatus.value;
                         if (status.state().failed()) {
                             failures.add(new ShardSearchFailure(status.reason(), new SearchShardTarget(status.nodeId(), shardId.getIndex(), shardId.id())));
-                            shardFailures.add(new SnapshotShardFailure(status.nodeId(), shardId.getIndex(), shardId.id(), status.reason()));
+                            shardFailures.add(new SnapshotShardFailure(status.nodeId(), shardId, status.reason()));
                         }
                     }
                     Snapshot snapshot = repository.finalizeSnapshot(snapshotId, entry.indices(), entry.startTime(), failure, entry.shards().size(), Collections.unmodifiableList(shardFailures));
@@ -1029,16 +1029,16 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
             IndexMetaData indexMetaData = metaData.index(index);
             if (indexMetaData == null) {
                 // The index was deleted before we managed to start the snapshot - mark it as missing.
-                builder.put(new ShardId(index, 0), new SnapshotsInProgress.ShardSnapshotStatus(null, State.MISSING, "missing index"));
+                builder.put(new ShardId(index, IndexMetaData.INDEX_UUID_NA_VALUE, 0), new SnapshotsInProgress.ShardSnapshotStatus(null, State.MISSING, "missing index"));
             } else if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
                 for (int i = 0; i < indexMetaData.getNumberOfShards(); i++) {
-                    ShardId shardId = new ShardId(index, i);
+                    ShardId shardId = new ShardId(indexMetaData.getIndex(), i);
                     builder.put(shardId, new SnapshotsInProgress.ShardSnapshotStatus(null, State.MISSING, "index is closed"));
                 }
             } else {
                 IndexRoutingTable indexRoutingTable = clusterState.getRoutingTable().index(index);
                 for (int i = 0; i < indexMetaData.getNumberOfShards(); i++) {
-                    ShardId shardId = new ShardId(index, i);
+                    ShardId shardId = new ShardId(indexMetaData.getIndex(), i);
                     if (indexRoutingTable != null) {
                         ShardRouting primary = indexRoutingTable.shard(i).primaryShard();
                         if (primary == null || !primary.assignedToNode()) {

--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -341,7 +341,7 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
                             clusterStateChanged = true;
                             logger.info("[{}] dropping index [{}] due to conflict with [{}]", tribeName, tribeIndex.getIndex(), existingFromTribe);
                             removeIndex(blocks, metaData, routingTable, tribeIndex);
-                            droppedIndices.add(tribeIndex.getIndex());
+                            droppedIndices.add(tribeIndex.getIndex().getName());
                         } else if (onConflict.startsWith(ON_CONFLICT_PREFER)) {
                             // on conflict, prefer a tribe...
                             String preferredTribeName = onConflict.substring(ON_CONFLICT_PREFER.length());
@@ -365,23 +365,23 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
         }
 
         private void removeIndex(ClusterBlocks.Builder blocks, MetaData.Builder metaData, RoutingTable.Builder routingTable, IndexMetaData index) {
-            metaData.remove(index.getIndex());
-            routingTable.remove(index.getIndex());
-            blocks.removeIndexBlocks(index.getIndex());
+            metaData.remove(index.getIndex().getName());
+            routingTable.remove(index.getIndex().getName());
+            blocks.removeIndexBlocks(index.getIndex().getName());
         }
 
         private void addNewIndex(ClusterState tribeState, ClusterBlocks.Builder blocks, MetaData.Builder metaData, RoutingTable.Builder routingTable, IndexMetaData tribeIndex) {
             Settings tribeSettings = Settings.builder().put(tribeIndex.getSettings()).put(TRIBE_NAME, tribeName).build();
             metaData.put(IndexMetaData.builder(tribeIndex).settings(tribeSettings));
             routingTable.add(tribeState.routingTable().index(tribeIndex.getIndex()));
-            if (Regex.simpleMatch(blockIndicesMetadata, tribeIndex.getIndex())) {
-                blocks.addIndexBlock(tribeIndex.getIndex(), IndexMetaData.INDEX_METADATA_BLOCK);
+            if (Regex.simpleMatch(blockIndicesMetadata, tribeIndex.getIndex().getName())) {
+                blocks.addIndexBlock(tribeIndex.getIndex().getName(), IndexMetaData.INDEX_METADATA_BLOCK);
             }
-            if (Regex.simpleMatch(blockIndicesRead, tribeIndex.getIndex())) {
-                blocks.addIndexBlock(tribeIndex.getIndex(), IndexMetaData.INDEX_READ_BLOCK);
+            if (Regex.simpleMatch(blockIndicesRead, tribeIndex.getIndex().getName())) {
+                blocks.addIndexBlock(tribeIndex.getIndex().getName(), IndexMetaData.INDEX_READ_BLOCK);
             }
-            if (Regex.simpleMatch(blockIndicesWrite, tribeIndex.getIndex())) {
-                blocks.addIndexBlock(tribeIndex.getIndex(), IndexMetaData.INDEX_WRITE_BLOCK);
+            if (Regex.simpleMatch(blockIndicesWrite, tribeIndex.getIndex().getName())) {
+                blocks.addIndexBlock(tribeIndex.getIndex().getName(), IndexMetaData.INDEX_WRITE_BLOCK);
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/ESExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ESExceptionTests.java
@@ -85,9 +85,9 @@ public class ESExceptionTests extends ESTestCase {
             assertEquals(ElasticsearchException.getExceptionName(rootCauses[0]), "index_not_found_exception");
             assertEquals(rootCauses[0].getMessage(), "no such index");
             ShardSearchFailure failure = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                    new SearchShardTarget("node_1", "foo", 1));
+                    new SearchShardTarget("node_1", new Index("foo", "_na_"), 1));
             ShardSearchFailure failure1 = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                    new SearchShardTarget("node_1", "foo", 2));
+                    new SearchShardTarget("node_1", new Index("foo", "_na_"), 2));
             SearchPhaseExecutionException ex = new SearchPhaseExecutionException("search", "all shards failed", new ShardSearchFailure[]{failure, failure1});
             if (randomBoolean()) {
                 rootCauses = (randomBoolean() ? new RemoteTransportException("remoteboom", ex) : ex).guessRootCauses();
@@ -105,11 +105,11 @@ public class ESExceptionTests extends ESTestCase {
         {
             ShardSearchFailure failure = new ShardSearchFailure(
                     new ParsingException(1, 2, "foobar", null),
-                    new SearchShardTarget("node_1", "foo", 1));
-            ShardSearchFailure failure1 = new ShardSearchFailure(new QueryShardException(new Index("foo1"), "foobar", null),
-                    new SearchShardTarget("node_1", "foo1", 1));
-            ShardSearchFailure failure2 = new ShardSearchFailure(new QueryShardException(new Index("foo1"), "foobar", null),
-                    new SearchShardTarget("node_1", "foo1", 2));
+                    new SearchShardTarget("node_1", new Index("foo", "_na_"), 1));
+            ShardSearchFailure failure1 = new ShardSearchFailure(new QueryShardException(new Index("foo1", "_na_"), "foobar", null),
+                    new SearchShardTarget("node_1", new Index("foo1", "_na_"), 1));
+            ShardSearchFailure failure2 = new ShardSearchFailure(new QueryShardException(new Index("foo1", "_na_"), "foobar", null),
+                    new SearchShardTarget("node_1", new Index("foo1", "_na_"), 2));
             SearchPhaseExecutionException ex = new SearchPhaseExecutionException("search", "all shards failed", new ShardSearchFailure[]{failure, failure1, failure2});
             final ElasticsearchException[] rootCauses = ex.guessRootCauses();
             assertEquals(rootCauses.length, 2);
@@ -136,9 +136,9 @@ public class ESExceptionTests extends ESTestCase {
     public void testDeduplicate() throws IOException {
         {
             ShardSearchFailure failure = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                    new SearchShardTarget("node_1", "foo", 1));
+                    new SearchShardTarget("node_1", new Index("foo", "_na_"), 1));
             ShardSearchFailure failure1 = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                    new SearchShardTarget("node_1", "foo", 2));
+                    new SearchShardTarget("node_1", new Index("foo", "_na_"), 2));
             SearchPhaseExecutionException ex = new SearchPhaseExecutionException("search", "all shards failed", randomBoolean() ? failure1.getCause() : failure.getCause(), new ShardSearchFailure[]{failure, failure1});
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
@@ -149,11 +149,11 @@ public class ESExceptionTests extends ESTestCase {
         }
         {
             ShardSearchFailure failure = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                    new SearchShardTarget("node_1", "foo", 1));
-            ShardSearchFailure failure1 = new ShardSearchFailure(new QueryShardException(new Index("foo1"), "foobar", null),
-                    new SearchShardTarget("node_1", "foo1", 1));
-            ShardSearchFailure failure2 = new ShardSearchFailure(new QueryShardException(new Index("foo1"), "foobar", null),
-                    new SearchShardTarget("node_1", "foo1", 2));
+                    new SearchShardTarget("node_1", new Index("foo", "_na_"), 1));
+            ShardSearchFailure failure1 = new ShardSearchFailure(new QueryShardException(new Index("foo1", "_na_"), "foobar", null),
+                    new SearchShardTarget("node_1", new Index("foo1", "_na_"), 1));
+            ShardSearchFailure failure2 = new ShardSearchFailure(new QueryShardException(new Index("foo1", "_na_"), "foobar", null),
+                    new SearchShardTarget("node_1", new Index("foo1", "_na_"), 2));
             SearchPhaseExecutionException ex = new SearchPhaseExecutionException("search", "all shards failed", new ShardSearchFailure[]{failure, failure1, failure2});
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
@@ -164,9 +164,9 @@ public class ESExceptionTests extends ESTestCase {
         }
         {
             ShardSearchFailure failure = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                    new SearchShardTarget("node_1", "foo", 1));
+                    new SearchShardTarget("node_1", new Index("foo", "_na_"), 1));
             ShardSearchFailure failure1 = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                    new SearchShardTarget("node_1", "foo", 2));
+                    new SearchShardTarget("node_1", new Index("foo", "_na_"), 2));
             NullPointerException nullPointerException = new NullPointerException();
             SearchPhaseExecutionException ex = new SearchPhaseExecutionException("search", "all shards failed", nullPointerException, new ShardSearchFailure[]{failure, failure1});
             assertEquals(nullPointerException, ex.getCause());
@@ -320,7 +320,7 @@ public class ESExceptionTests extends ESTestCase {
                 new OutOfMemoryError("no memory left"),
                 new AlreadyClosedException("closed!!", new NullPointerException()),
                 new LockObtainFailedException("can't lock directory", new NullPointerException()),
-                new Throwable("this exception is unknown", new QueryShardException(new Index("foo"), "foobar", null) ), // somethin unknown
+                new Throwable("this exception is unknown", new QueryShardException(new Index("foo", "_na_"), "foobar", null) ), // somethin unknown
         };
         for (Throwable t : causes) {
             BytesStreamOutput out = new BytesStreamOutput();

--- a/core/src/test/java/org/elasticsearch/ESExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ESExceptionTests.java
@@ -118,7 +118,7 @@ public class ESExceptionTests extends ESTestCase {
             assertEquals(((ParsingException) rootCauses[0]).getLineNumber(), 1);
             assertEquals(((ParsingException) rootCauses[0]).getColumnNumber(), 2);
             assertEquals(ElasticsearchException.getExceptionName(rootCauses[1]), "query_shard_exception");
-            assertEquals((rootCauses[1]).getIndex(), "foo1");
+            assertEquals((rootCauses[1]).getIndex().getName(), "foo1");
             assertEquals(rootCauses[1].getMessage(), "foobar");
         }
 
@@ -159,7 +159,7 @@ public class ESExceptionTests extends ESTestCase {
             builder.startObject();
             ex.toXContent(builder, PARAMS);
             builder.endObject();
-            String expected = "{\"type\":\"search_phase_execution_exception\",\"reason\":\"all shards failed\",\"phase\":\"search\",\"grouped\":true,\"failed_shards\":[{\"shard\":1,\"index\":\"foo\",\"node\":\"node_1\",\"reason\":{\"type\":\"parsing_exception\",\"reason\":\"foobar\",\"line\":1,\"col\":2}},{\"shard\":1,\"index\":\"foo1\",\"node\":\"node_1\",\"reason\":{\"type\":\"query_shard_exception\",\"reason\":\"foobar\",\"index\":\"foo1\"}}]}";
+            String expected = "{\"type\":\"search_phase_execution_exception\",\"reason\":\"all shards failed\",\"phase\":\"search\",\"grouped\":true,\"failed_shards\":[{\"shard\":1,\"index\":\"foo\",\"node\":\"node_1\",\"reason\":{\"type\":\"parsing_exception\",\"reason\":\"foobar\",\"line\":1,\"col\":2}},{\"shard\":1,\"index\":\"foo1\",\"node\":\"node_1\",\"reason\":{\"type\":\"query_shard_exception\",\"reason\":\"foobar\",\"index_uuid\":\"_na_\",\"index\":\"foo1\"}}]}";
             assertEquals(expected, builder.string());
         }
         {

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -246,7 +246,7 @@ public class ExceptionSerializationTests extends ESTestCase {
 
     public void testQueryShardException() throws IOException {
         QueryShardException ex = serialize(new QueryShardException(new Index("foo", "_na_"), "fobar", null));
-        assertEquals(ex.getIndex(), "foo");
+        assertEquals(ex.getIndex().getName(), "foo");
         assertEquals(ex.getMessage(), "fobar");
 
         ex = serialize(new QueryShardException((Index) null, null, null));
@@ -268,7 +268,7 @@ public class ExceptionSerializationTests extends ESTestCase {
 
     public void testAlreadyExpiredException() throws IOException {
         AlreadyExpiredException alreadyExpiredException = serialize(new AlreadyExpiredException("index", "type", "id", 1, 2, 3));
-        assertEquals("index", alreadyExpiredException.getIndex());
+        assertEquals("index", alreadyExpiredException.getIndex().getName());
         assertEquals("type", alreadyExpiredException.type());
         assertEquals("id", alreadyExpiredException.id());
         assertEquals(2, alreadyExpiredException.ttl());
@@ -477,7 +477,7 @@ public class ExceptionSerializationTests extends ESTestCase {
 
     public void testRoutingMissingException() throws IOException {
         RoutingMissingException ex = serialize(new RoutingMissingException("idx", "type", "id"));
-        assertEquals("idx", ex.getIndex());
+        assertEquals("idx", ex.getIndex().getName());
         assertEquals("type", ex.getType());
         assertEquals("id", ex.getId());
         assertEquals("routing is required for [idx]/[type]/[id]", ex.getMessage());

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -245,7 +245,7 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testQueryShardException() throws IOException {
-        QueryShardException ex = serialize(new QueryShardException(new Index("foo"), "fobar", null));
+        QueryShardException ex = serialize(new QueryShardException(new Index("foo", "_na_"), "fobar", null));
         assertEquals(ex.getIndex(), "foo");
         assertEquals(ex.getMessage(), "fobar");
 
@@ -255,7 +255,7 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testSearchException() throws IOException {
-        SearchShardTarget target = new SearchShardTarget("foo", "bar", 1);
+        SearchShardTarget target = new SearchShardTarget("foo", new Index("bar", "_na_"), 1);
         SearchException ex = serialize(new SearchException(target, "hello world"));
         assertEquals(target, ex.shard());
         assertEquals(ex.getMessage(), "hello world");
@@ -303,7 +303,7 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testRecoverFilesRecoveryException() throws IOException {
-        ShardId id = new ShardId("foo", 1);
+        ShardId id = new ShardId("foo", "_na_", 1);
         ByteSizeValue bytes = new ByteSizeValue(randomIntBetween(0, 10000));
         RecoverFilesRecoveryException ex = serialize(new RecoverFilesRecoveryException(id, 10, bytes, null));
         assertEquals(ex.getShardId(), id);
@@ -331,7 +331,7 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testBatchOperationException() throws IOException {
-        ShardId id = new ShardId("foo", 1);
+        ShardId id = new ShardId("foo", "_na_", 1);
         TranslogRecoveryPerformer.BatchOperationException ex = serialize(new TranslogRecoveryPerformer.BatchOperationException(id, "batched the fucker", 666, null));
         assertEquals(ex.getShardId(), id);
         assertEquals(666, ex.completedOperations());
@@ -368,7 +368,7 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testPercolateException() throws IOException {
-        ShardId id = new ShardId("foo", 1);
+        ShardId id = new ShardId("foo", "_na_", 1);
         PercolateException ex = serialize(new PercolateException(id, "percolate my ass", null));
         assertEquals(id, ex.getShardId());
         assertEquals("percolate my ass", ex.getMessage());
@@ -402,9 +402,9 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testIndexFailedEngineException() throws IOException {
-        ShardId id = new ShardId("foo", 1);
+        ShardId id = new ShardId("foo", "_na_", 1);
         IndexFailedEngineException ex = serialize(new IndexFailedEngineException(id, "type", "id", null));
-        assertEquals(ex.getShardId(), new ShardId("foo", 1));
+        assertEquals(ex.getShardId(), new ShardId("foo", "_na_", 1));
         assertEquals("type", ex.type());
         assertEquals("id", ex.id());
         assertNull(ex.getCause());
@@ -433,7 +433,7 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testIllegalIndexShardStateException() throws IOException {
-        ShardId id = new ShardId("foo", 1);
+        ShardId id = new ShardId("foo", "_na_", 1);
         IndexShardState state = randomFrom(IndexShardState.values());
         IllegalIndexShardStateException ex = serialize(new IllegalIndexShardStateException(id, state, "come back later buddy"));
         assertEquals(id, ex.getShardId());
@@ -505,7 +505,7 @@ public class ExceptionSerializationTests extends ESTestCase {
 
 
     public void testRecoveryEngineException() throws IOException {
-        ShardId id = new ShardId("foo", 1);
+        ShardId id = new ShardId("foo", "_na_", 1);
         RecoveryEngineException ex = serialize(new RecoveryEngineException(id, 10, "total failure", new NullPointerException()));
         assertEquals(id, ex.getShardId());
         assertEquals("Phase[10] total failure", ex.getMessage());

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -57,7 +57,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 .putArray("index.analysis.analyzer.custom_analyzer.filter", "lowercase", "wordDelimiter")
                 .put("index.analysis.analyzer.custom_analyzer.tokenizer", "whitespace")
                 .putArray("index.analysis.analyzer.custom_analyzer.filter", "lowercase", "wordDelimiter").build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index("index"), indexSettings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
         environment = new Environment(settings);
         registry = new AnalysisRegistry(null, environment);
         analysisService = registry.build(idxSettings);

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/flush/SyncedFlushUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/flush/SyncedFlushUnitTests.java
@@ -148,7 +148,7 @@ public class SyncedFlushUnitTests extends ESTestCase {
             int failures = 0;
             List<ShardsSyncedFlushResult> shardsResults = new ArrayList<>();
             for (int shard = 0; shard < shards; shard++) {
-                final ShardId shardId = new ShardId(index, shard);
+                final ShardId shardId = new ShardId(index, "_na_", shard);
                 if (randomInt(5) < 2) {
                     // total shard failure
                     failed += replicas + 1;

--- a/core/src/test/java/org/elasticsearch/action/ingest/BulkRequestModifierTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/BulkRequestModifierTests.java
@@ -71,7 +71,7 @@ public class BulkRequestModifierTests extends ESTestCase {
         BulkResponse bulkResponse = actionListener.getResponse();
         for (int j = 0; j < bulkResponse.getItems().length; j++) {
             if (failedSlots.contains(j)) {
-                BulkItemResponse item =  bulkResponse.getItems()[j];
+                BulkItemResponse item = bulkResponse.getItems()[j];
                 assertThat(item.isFailed(), is(true));
                 assertThat(item.getFailure().getIndex(), equalTo("_index"));
                 assertThat(item.getFailure().getType(), equalTo("_type"));
@@ -116,7 +116,7 @@ public class BulkRequestModifierTests extends ESTestCase {
         List<BulkItemResponse> originalResponses = new ArrayList<>();
         for (ActionRequest actionRequest : bulkRequest.requests()) {
             IndexRequest indexRequest = (IndexRequest) actionRequest;
-            IndexResponse indexResponse = new IndexResponse(new ShardId("index", 0), indexRequest.type(), indexRequest.id(), 1, true);
+            IndexResponse indexResponse = new IndexResponse(new ShardId("index", "_na_", 0), indexRequest.type(), indexRequest.id(), 1, true);
             originalResponses.add(new BulkItemResponse(Integer.parseInt(indexRequest.id()), indexRequest.opType().lowercase(), indexResponse));
         }
         bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[originalResponses.size()]), 0));
@@ -151,7 +151,7 @@ public class BulkRequestModifierTests extends ESTestCase {
 
         @Override
         public void onResponse(BulkResponse bulkItemResponses) {
-            this.response = bulkItemResponses ;
+            this.response = bulkItemResponses;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -47,6 +47,7 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -198,7 +199,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
     void setClusterState(TestClusterService clusterService, String index) {
         int numberOfNodes = randomIntBetween(3, 5);
         DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
-        IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index);
+        IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(new Index(index,"_na_"));
 
         int shardIndex = -1;
         for (int i = 0; i < numberOfNodes; i++) {
@@ -206,7 +207,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
             discoBuilder = discoBuilder.put(node);
             int numberOfShards = randomIntBetween(1, 10);
             for (int j = 0; j < numberOfShards; j++) {
-                final ShardId shardId = new ShardId(index, ++shardIndex);
+                final ShardId shardId = new ShardId(index, "_na_", ++shardIndex);
                 ShardRouting shard = TestShardRouting.newShardRouting(index, shardId.getId(), node.id(), true, ShardRoutingState.STARTED, 1);
                 IndexShardRoutingTable.Builder indexShard = new IndexShardRoutingTable.Builder(shardId);
                 indexShard.addShard(shard);

--- a/core/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -175,7 +175,7 @@ public class BroadcastReplicationTests extends ESTestCase {
         ClusterState clusterState = state(index, randomBoolean(),
                 randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.UNASSIGNED, ShardRoutingState.UNASSIGNED);
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
-        List<ShardId> shards = broadcastReplicationAction.shards(new DummyBroadcastRequest().indices(shardId.index().name()), clusterState);
+        List<ShardId> shards = broadcastReplicationAction.shards(new DummyBroadcastRequest().indices(shardId.index().getName()), clusterState);
         assertThat(shards.size(), equalTo(1));
         assertThat(shards.get(0), equalTo(shardId));
     }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -147,7 +147,7 @@ public class BroadcastReplicationTests extends ESTestCase {
                 if (shardsSucceeded == 1 && randomBoolean()) {
                     //sometimes add failure (no failure means shard unavailable)
                     failures = new ReplicationResponse.ShardInfo.Failure[1];
-                    failures[0] = new ReplicationResponse.ShardInfo.Failure(index, shardRequests.v1().id(), null, new Exception("pretend shard failed"), RestStatus.GATEWAY_TIMEOUT, false);
+                    failures[0] = new ReplicationResponse.ShardInfo.Failure(shardRequests.v1(), null, new Exception("pretend shard failed"), RestStatus.GATEWAY_TIMEOUT, false);
                     failed++;
                 }
                 replicationResponse.setShardInfo(new ReplicationResponse.ShardInfo(2, shardsSucceeded, failures));
@@ -171,11 +171,11 @@ public class BroadcastReplicationTests extends ESTestCase {
 
     public void testShardsList() throws InterruptedException, ExecutionException {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         ClusterState clusterState = state(index, randomBoolean(),
                 randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.UNASSIGNED, ShardRoutingState.UNASSIGNED);
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
-        List<ShardId> shards = broadcastReplicationAction.shards(new DummyBroadcastRequest().indices(shardId.index().getName()), clusterState);
+        List<ShardId> shards = broadcastReplicationAction.shards(new DummyBroadcastRequest().indices(shardId.getIndexName()), clusterState);
         assertThat(shards.size(), equalTo(1));
         assertThat(shards.get(0), equalTo(shardId));
     }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -74,7 +74,7 @@ public class ClusterStateCreationUtils {
             }
         }
         numberOfNodes = Math.max(2, numberOfNodes); // we need a non-local master to test shard failures
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
         Set<String> unassignedNodes = new HashSet<>();
         for (int i = 0; i < numberOfNodes + 1; i++) {
@@ -131,7 +131,7 @@ public class ClusterStateCreationUtils {
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
         state.nodes(discoBuilder);
         state.metaData(MetaData.builder().put(indexMetaData, false).generateClusterUuidIfNeeded());
-        state.routingTable(RoutingTable.builder().add(IndexRoutingTable.builder(index).addIndexShard(indexShardRoutingBuilder.build())).build());
+        state.routingTable(RoutingTable.builder().add(IndexRoutingTable.builder(indexMetaData.getIndex()).addIndexShard(indexShardRoutingBuilder.build())).build());
         return state.build();
     }
 
@@ -155,11 +155,11 @@ public class ClusterStateCreationUtils {
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
         state.nodes(discoBuilder);
         state.metaData(MetaData.builder().put(indexMetaData, false).generateClusterUuidIfNeeded());
-        IndexRoutingTable.Builder indexRoutingTableBuilder = IndexRoutingTable.builder(index);
+        IndexRoutingTable.Builder indexRoutingTableBuilder = IndexRoutingTable.builder(indexMetaData.getIndex());
         for (int i = 0; i < numberOfShards; i++) {
             RoutingTable.Builder routing = new RoutingTable.Builder();
             routing.addAsNew(indexMetaData);
-            final ShardId shardId = new ShardId(index, i);
+            final ShardId shardId = new ShardId(index, "_na_", i);
             IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
             indexShardRoutingBuilder.addShard(TestShardRouting.newShardRouting(index, i, newNode(0).id(), null, null, true, ShardRoutingState.STARTED, 0, null));
             indexShardRoutingBuilder.addShard(TestShardRouting.newShardRouting(index, i, newNode(1).id(), null, null, false, ShardRoutingState.STARTED, 0, null));

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -171,7 +171,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testNotStartedPrimary() throws InterruptedException, ExecutionException {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         // no replicas in oder to skip the replication part
         clusterService.setState(state(index, true,
                 randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.UNASSIGNED));
@@ -209,12 +209,12 @@ public class TransportReplicationActionTests extends ESTestCase {
         clusterService.setState(state(index, true,
                 randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.UNASSIGNED));
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
-        Request request = new Request(new ShardId("unknown_index", 0)).timeout("1ms");
+        Request request = new Request(new ShardId("unknown_index", "_na_", 0)).timeout("1ms");
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
         TransportReplicationAction.ReroutePhase reroutePhase = action.new ReroutePhase(request, listener);
         reroutePhase.run();
         assertListenerThrows("must throw index not found exception", listener, IndexNotFoundException.class);
-        request = new Request(new ShardId(index, 10)).timeout("1ms");
+        request = new Request(new ShardId(index, "_na_", 10)).timeout("1ms");
         listener = new PlainActionFuture<>();
         reroutePhase = action.new ReroutePhase(request, listener);
         reroutePhase.run();
@@ -223,7 +223,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testRoutePhaseExecutesRequest() {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
 
         clusterService.setState(stateWithStartedPrimary(index, randomBoolean(), 3));
 
@@ -251,7 +251,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testPrimaryPhaseExecutesRequest() throws InterruptedException, ExecutionException {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         clusterService.setState(state(index, true, ShardRoutingState.STARTED, ShardRoutingState.STARTED));
         Request request = new Request(shardId).timeout("1ms");
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
@@ -267,7 +267,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testAddedReplicaAfterPrimaryOperation() {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         // start with no replicas
         clusterService.setState(stateWithStartedPrimary(index, true, 0));
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
@@ -300,7 +300,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testRelocatingReplicaAfterPrimaryOperation() {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         // start with a replica
         clusterService.setState(state(index, true, ShardRoutingState.STARTED,  randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.STARTED));
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
@@ -334,7 +334,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testIndexDeletedAfterPrimaryOperation() {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         clusterService.setState(state(index, true, ShardRoutingState.STARTED, ShardRoutingState.STARTED));
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
         final ClusterState stateWithDeletedIndex = state(index + "_new", true, ShardRoutingState.STARTED, ShardRoutingState.RELOCATING);
@@ -361,7 +361,7 @@ public class TransportReplicationActionTests extends ESTestCase {
     public void testWriteConsistency() throws ExecutionException, InterruptedException {
         action = new ActionWithConsistency(Settings.EMPTY, "testActionWithConsistency", transportService, clusterService, threadPool);
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         final int assignedReplicas = randomInt(2);
         final int unassignedReplicas = randomInt(2);
         final int totalShards = 1 + assignedReplicas + unassignedReplicas;
@@ -430,7 +430,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testReplication() throws ExecutionException, InterruptedException {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
 
         clusterService.setState(stateWithStartedPrimary(index, true, randomInt(5)));
 
@@ -453,7 +453,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testReplicationWithShadowIndex() throws ExecutionException, InterruptedException {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
 
         ClusterState state = stateWithStartedPrimary(index, true, randomInt(5));
         MetaData.Builder metaData = MetaData.builder(state.metaData());
@@ -511,7 +511,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         assertThat(nodesSentTo.keySet(), not(hasItem(clusterService.state().getNodes().localNodeId())));
 
         // requests were sent to the correct shard copies
-        for (ShardRouting shard : clusterService.state().getRoutingTable().shardRoutingTable(shardId.getIndex(), shardId.id())) {
+        for (ShardRouting shard : clusterService.state().getRoutingTable().shardRoutingTable(shardId)) {
             if (shard.primary() == false && executeOnReplica == false) {
                 continue;
             }
@@ -602,7 +602,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testCounterOnPrimary() throws Exception {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         // no replica, we only want to test on primary
         clusterService.setState(state(index, true,
                 ShardRoutingState.STARTED));
@@ -640,7 +640,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
     public void testCounterIncrementedWhileReplicationOngoing() throws InterruptedException, ExecutionException, IOException {
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         // one replica to make sure replication is attempted
         clusterService.setState(state(index, true,
                 ShardRoutingState.STARTED, ShardRoutingState.STARTED));
@@ -670,8 +670,8 @@ public class TransportReplicationActionTests extends ESTestCase {
     }
 
     public void testReplicasCounter() throws Exception {
-        final ShardId shardId = new ShardId("test", 0);
-        clusterService.setState(state(shardId.index().getName(), true,
+        final ShardId shardId = new ShardId("test", "_na_", 0);
+        clusterService.setState(state(shardId.getIndexName(), true,
                 ShardRoutingState.STARTED, ShardRoutingState.STARTED));
         action = new ActionWithDelay(Settings.EMPTY, "testActionWithExceptions", transportService, clusterService, threadPool);
         final Action.ReplicaOperationTransportHandler replicaOperationTransportHandler = action.new ReplicaOperationTransportHandler();
@@ -706,7 +706,7 @@ public class TransportReplicationActionTests extends ESTestCase {
     public void testCounterDecrementedIfShardOperationThrowsException() throws InterruptedException, ExecutionException, IOException {
         action = new ActionWithExceptions(Settings.EMPTY, "testActionWithExceptions", transportService, clusterService, threadPool);
         final String index = "test";
-        final ShardId shardId = new ShardId(index, 0);
+        final ShardId shardId = new ShardId(index, "_na_", 0);
         clusterService.setState(state(index, true,
                 ShardRoutingState.STARTED, ShardRoutingState.STARTED));
         logger.debug("--> using initial state:\n{}", clusterService.state().prettyPrint());
@@ -749,7 +749,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         Request(ShardId shardId) {
             this();
             this.shardId = shardId;
-            this.index = shardId.getIndex();
+            this.index = shardId.getIndexName();
             // keep things simple
         }
 

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService.ScriptType;
 import org.elasticsearch.test.ESTestCase;
@@ -144,7 +145,7 @@ public class UpdateRequestTests extends ESTestCase {
 
         // We simulate that the document is not existing yet
         GetResult getResult = new GetResult("test", "type1", "1", 0, false, null, null);
-        UpdateHelper.Result result = updateHelper.prepare(updateRequest, getResult);
+        UpdateHelper.Result result = updateHelper.prepare(new ShardId("test", "_na_", 0),updateRequest, getResult);
         Streamable action = result.action();
         assertThat(action, instanceOf(IndexRequest.class));
         IndexRequest indexAction = (IndexRequest) action;
@@ -161,7 +162,7 @@ public class UpdateRequestTests extends ESTestCase {
 
         // We simulate that the document is not existing yet
         getResult = new GetResult("test", "type1", "2", 0, false, null, null);
-        result = updateHelper.prepare(updateRequest, getResult);
+        result = updateHelper.prepare(new ShardId("test", "_na_", 0), updateRequest, getResult);
         action = result.action();
         assertThat(action, instanceOf(IndexRequest.class));
         indexAction = (IndexRequest) action;

--- a/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
@@ -262,7 +262,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                 for (ShardRouting shardRouting : indexShardRoutingTable) {
-                    if (shardRouting.currentNodeId() != null && index.equals(shardRouting.getIndex())) {
+                    if (shardRouting.currentNodeId() != null && index.equals(shardRouting.getIndexName())) {
                         String name = clusterState.nodes().get(shardRouting.currentNodeId()).name();
                         assertThat("Allocated on new node: " + name, Regex.simpleMatch(pattern, name), is(true));
                     }

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -46,6 +46,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -223,11 +224,11 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
      * Randomly updates index routing table in the cluster state
      */
     private IndexRoutingTable randomIndexRoutingTable(String index, String[] nodeIds) {
-        IndexRoutingTable.Builder builder = IndexRoutingTable.builder(index);
+        IndexRoutingTable.Builder builder = IndexRoutingTable.builder(new Index(index, "_na_"));
         int shardCount = randomInt(10);
 
         for (int i = 0; i < shardCount; i++) {
-            IndexShardRoutingTable.Builder indexShard = new IndexShardRoutingTable.Builder(new ShardId(index, i));
+            IndexShardRoutingTable.Builder indexShard = new IndexShardRoutingTable.Builder(new ShardId(index, "_na_", i));
             int replicaCount = randomIntBetween(1, 10);
             for (int j = 0; j < replicaCount; j++) {
                 UnassignedInfo unassignedInfo = null;

--- a/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingHelper;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.monitor.fs.FsInfo;
@@ -91,13 +92,14 @@ public class DiskUsageTests extends ESTestCase {
     }
 
     public void testFillShardLevelInfo() {
-        ShardRouting test_0 = ShardRouting.newUnassigned("test", 0, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        final Index index = new Index("test", "_na_");
+        ShardRouting test_0 = ShardRouting.newUnassigned(index, 0, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_0, "node1");
         ShardRoutingHelper.moveToStarted(test_0);
         Path test0Path = createTempDir().resolve("indices").resolve("test").resolve("0");
         CommonStats commonStats0 = new CommonStats();
         commonStats0.store = new StoreStats(100, 1);
-        ShardRouting test_1 = ShardRouting.newUnassigned("test", 1, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        ShardRouting test_1 = ShardRouting.newUnassigned(index, 1, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_1, "node2");
         ShardRoutingHelper.moveToStarted(test_1);
         Path test1Path = createTempDir().resolve("indices").resolve("test").resolve("1");

--- a/core/src/test/java/org/elasticsearch/cluster/ack/AckIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ack/AckIT.java
@@ -38,6 +38,8 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoverySettings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 
@@ -60,7 +62,7 @@ public class AckIT extends ESIntegTestCase {
         //otherwise the operation is most likely acknowledged even if it doesn't support ack
         return Settings.builder().put(super.nodeSettings(nodeOrdinal))
                 .put(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey(), 0).build();
-}
+    }
 
     public void testUpdateSettingsAcknowledgement() {
         createIndex("test");
@@ -83,13 +85,15 @@ public class AckIT extends ESIntegTestCase {
 
     public void testClusterRerouteAcknowledgement() throws InterruptedException {
         assertAcked(prepareCreate("test").setSettings(Settings.builder()
-                        .put(indexSettings())
-                        .put(SETTING_NUMBER_OF_SHARDS, between(cluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
-                        .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(indexSettings())
+                .put(SETTING_NUMBER_OF_SHARDS, between(cluster().numDataNodes(), DEFAULT_MAX_NUM_SHARDS))
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
         ));
         ensureGreen();
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();
+        final Index index = client().admin().cluster().prepareState().get().getState().metaData().index("test").getIndex();
+        final ShardId commandShard = new ShardId(index, moveAllocationCommand.shardId());
 
         assertAcked(client().admin().cluster().prepareReroute().add(moveAllocationCommand));
 
@@ -97,7 +101,7 @@ public class AckIT extends ESIntegTestCase {
             ClusterState clusterState = getLocalClusterState(client);
             for (ShardRouting shardRouting : clusterState.getRoutingNodes().routingNodeIter(moveAllocationCommand.fromNode())) {
                 //if the shard that we wanted to move is still on the same node, it must be relocating
-                if (shardRouting.shardId().equals(moveAllocationCommand.shardId())) {
+                if (shardRouting.shardId().equals(commandShard)) {
                     assertThat(shardRouting.relocating(), equalTo(true));
                 }
 
@@ -105,7 +109,7 @@ public class AckIT extends ESIntegTestCase {
 
             boolean found = false;
             for (ShardRouting shardRouting : clusterState.getRoutingNodes().routingNodeIter(moveAllocationCommand.toNode())) {
-                if (shardRouting.shardId().equals(moveAllocationCommand.shardId())) {
+                if (shardRouting.shardId().equals(commandShard)) {
                     assertThat(shardRouting.state(), anyOf(equalTo(ShardRoutingState.INITIALIZING), equalTo(ShardRoutingState.STARTED)));
                     found = true;
                     break;
@@ -137,6 +141,9 @@ public class AckIT extends ESIntegTestCase {
 
         MoveAllocationCommand moveAllocationCommand = getAllocationCommand();
 
+        final Index index = client().admin().cluster().prepareState().get().getState().metaData().index("test").getIndex();
+        final ShardId commandShard = new ShardId(index, moveAllocationCommand.shardId());
+
         assertAcked(client().admin().cluster().prepareReroute().setDryRun(true).add(moveAllocationCommand));
 
         //testing only on master with the latest cluster state as we didn't make any change thus we cannot guarantee that
@@ -145,7 +152,7 @@ public class AckIT extends ESIntegTestCase {
         boolean found = false;
         for (ShardRouting shardRouting : clusterStateResponse.getState().getRoutingNodes().routingNodeIter(moveAllocationCommand.fromNode())) {
             //the shard that we wanted to move is still on the same node, as we had dryRun flag
-            if (shardRouting.shardId().equals(moveAllocationCommand.shardId())) {
+            if (shardRouting.shardId().equals(commandShard)) {
                 assertThat(shardRouting.started(), equalTo(true));
                 found = true;
                 break;
@@ -154,7 +161,7 @@ public class AckIT extends ESIntegTestCase {
         assertThat(found, equalTo(true));
 
         for (ShardRouting shardRouting : clusterStateResponse.getState().getRoutingNodes().routingNodeIter(moveAllocationCommand.toNode())) {
-            if (shardRouting.shardId().equals(moveAllocationCommand.shardId())) {
+            if (shardRouting.shardId().equals(commandShard)) {
                 fail("shard [" + shardRouting + "] shouldn't be on node [" + moveAllocationCommand.toString() + "]");
             }
         }

--- a/core/src/test/java/org/elasticsearch/cluster/ack/AckIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ack/AckIT.java
@@ -199,7 +199,7 @@ public class AckIT extends ESIntegTestCase {
         assertNotNull(shardToBeMoved);
 
         logger.info("==> going to move shard [{}] from [{}] to [{}]", shardToBeMoved, fromNodeId, toNodeId);
-        return new MoveAllocationCommand(shardToBeMoved.shardId(), fromNodeId, toNodeId);
+        return new MoveAllocationCommand(shardToBeMoved.getIndexName(), shardToBeMoved.id(), fromNodeId, toNodeId);
     }
 
     public void testIndicesAliasesAcknowledgement() {

--- a/core/src/test/java/org/elasticsearch/cluster/health/RoutingTableGenerator.java
+++ b/core/src/test/java/org/elasticsearch/cluster/health/RoutingTableGenerator.java
@@ -58,7 +58,7 @@ class RoutingTableGenerator {
     }
 
     public IndexShardRoutingTable genShardRoutingTable(String index, int shardId, int replicas, ShardCounter counter) {
-        IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(new ShardId(index, shardId));
+        IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(new ShardId(index, "_na_", shardId));
         ShardRouting shardRouting = genShardRouting(index, shardId, true);
         counter.update(shardRouting);
         builder.addShard(shardRouting);
@@ -74,7 +74,7 @@ class RoutingTableGenerator {
     public IndexRoutingTable genIndexRoutingTable(IndexMetaData indexMetaData, ShardCounter counter) {
         IndexRoutingTable.Builder builder = IndexRoutingTable.builder(indexMetaData.getIndex());
         for (int shard = 0; shard < indexMetaData.getNumberOfShards(); shard++) {
-            builder.addIndexShard(genShardRoutingTable(indexMetaData.getIndex(), shard, indexMetaData.getNumberOfReplicas(), counter));
+            builder.addIndexShard(genShardRoutingTable(indexMetaData.getIndex().getName(), shard, indexMetaData.getNumberOfReplicas(), counter));
         }
         return builder.build();
     }

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -69,7 +69,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 indexNameExpressionResolver.concreteIndices(context, "bar");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("bar"));
+                assertThat(e.getIndex().getName(), equalTo("bar"));
             }
 
             results = indexNameExpressionResolver.concreteIndices(context, "foofoo", "foobar");
@@ -84,14 +84,14 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 indexNameExpressionResolver.concreteIndices(context, "bar");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("bar"));
+                assertThat(e.getIndex().getName(), equalTo("bar"));
             }
 
             try {
                 indexNameExpressionResolver.concreteIndices(context, "foo", "bar");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("bar"));
+                assertThat(e.getIndex().getName(), equalTo("bar"));
             }
 
             results = indexNameExpressionResolver.concreteIndices(context, "barbaz", "foobar");
@@ -102,7 +102,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 indexNameExpressionResolver.concreteIndices(context, "barbaz", "bar");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("bar"));
+                assertThat(e.getIndex().getName(), equalTo("bar"));
             }
 
             results = indexNameExpressionResolver.concreteIndices(context, "baz*");
@@ -227,21 +227,21 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 indexNameExpressionResolver.concreteIndices(context, "bar");
                 fail();
             } catch(IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("bar"));
+                assertThat(e.getIndex().getName(), equalTo("bar"));
             }
 
             try {
                 indexNameExpressionResolver.concreteIndices(context, "baz*");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("baz*"));
+                assertThat(e.getIndex().getName(), equalTo("baz*"));
             }
 
             try {
                 indexNameExpressionResolver.concreteIndices(context, "foo", "baz*");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("baz*"));
+                assertThat(e.getIndex().getName(), equalTo("baz*"));
             }
         }
 
@@ -362,7 +362,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 indexNameExpressionResolver.concreteIndices(context, "baz*");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("baz*"));
+                assertThat(e.getIndex().getName(), equalTo("baz*"));
             }
 
             String[] results = indexNameExpressionResolver.concreteIndices(context, "foo", "baz*");
@@ -385,7 +385,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 indexNameExpressionResolver.concreteIndices(context, "foo", "baz*");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("baz*"));
+                assertThat(e.getIndex().getName(), equalTo("baz*"));
             }
 
             results = indexNameExpressionResolver.concreteIndices(context, "foofoobar");
@@ -401,14 +401,14 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 indexNameExpressionResolver.concreteIndices(context, "baz*");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("baz*"));
+                assertThat(e.getIndex().getName(), equalTo("baz*"));
             }
 
             try {
                 indexNameExpressionResolver.concreteIndices(context, "foo", "baz*");
                 fail();
             } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex(), equalTo("baz*"));
+                assertThat(e.getIndex().getName(), equalTo("baz*"));
             }
 
             String[] results = indexNameExpressionResolver.concreteIndices(context, "foofoobar");
@@ -432,7 +432,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             indexNameExpressionResolver.concreteIndices(context, "baz*");
             fail();
         } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex(), equalTo("baz*"));
+            assertThat(e.getIndex().getName(), equalTo("baz*"));
         }
 
         try {
@@ -440,7 +440,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             indexNameExpressionResolver.concreteIndices(context, "foo", "baz*");
             fail();
         } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex(), equalTo("baz*"));
+            assertThat(e.getIndex().getName(), equalTo("baz*"));
         }
 
         try {
@@ -465,7 +465,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             fail();
         } catch(IndexClosedException e) {
             assertThat(e.getMessage(), equalTo("closed"));
-            assertEquals(e.getIndex(), "foofoo-closed");
+            assertEquals(e.getIndex().getName(), "foofoo-closed");
         }
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
@@ -485,7 +485,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             indexNameExpressionResolver.concreteIndices(context, "foo");
             fail();
         } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex(), equalTo("foo"));
+            assertThat(e.getIndex().getName(), equalTo("foo"));
         }
         results = indexNameExpressionResolver.concreteIndices(context, "foo*");
         assertThat(results, emptyArray());
@@ -493,7 +493,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             indexNameExpressionResolver.concreteIndices(context, "foo*", "bar");
             fail();
         } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex(), equalTo("bar"));
+            assertThat(e.getIndex().getName(), equalTo("bar"));
         }
 
 

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 
@@ -42,7 +41,7 @@ public class MetaDataTests extends ESTestCase {
                 .putAlias(AliasMetaData.builder("index").build());
         try {
             MetaData.builder().put(builder).build();
-            fail("expection should have been thrown");
+            fail("exception should have been thrown");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), equalTo("index and alias names need to be unique, but alias [index] and index [index] have the same name"));
         }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/AllocationIdTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/AllocationIdTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -37,7 +38,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class AllocationIdTests extends ESTestCase {
     public void testShardToStarted() {
         logger.info("-- create unassigned shard");
-        ShardRouting shard = ShardRouting.newUnassigned("test", 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
+        ShardRouting shard = ShardRouting.newUnassigned(new Index("test","_na_"), 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
         assertThat(shard.allocationId(), nullValue());
 
         logger.info("-- initialize the shard");
@@ -57,7 +58,7 @@ public class AllocationIdTests extends ESTestCase {
 
     public void testSuccessfulRelocation() {
         logger.info("-- build started shard");
-        ShardRouting shard = ShardRouting.newUnassigned("test", 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
+        ShardRouting shard = ShardRouting.newUnassigned(new Index("test","_na_"), 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
         shard.initialize("node1", -1);
         shard.moveToStarted();
 
@@ -80,7 +81,7 @@ public class AllocationIdTests extends ESTestCase {
 
     public void testCancelRelocation() {
         logger.info("-- build started shard");
-        ShardRouting shard = ShardRouting.newUnassigned("test", 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
+        ShardRouting shard = ShardRouting.newUnassigned(new Index("test","_na_"), 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
         shard.initialize("node1", -1);
         shard.moveToStarted();
 
@@ -100,7 +101,7 @@ public class AllocationIdTests extends ESTestCase {
 
     public void testMoveToUnassigned() {
         logger.info("-- build started shard");
-        ShardRouting shard = ShardRouting.newUnassigned("test", 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
+        ShardRouting shard = ShardRouting.newUnassigned(new Index("test","_na_"), 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
         shard.initialize("node1", -1);
         shard.moveToStarted();
 
@@ -111,7 +112,7 @@ public class AllocationIdTests extends ESTestCase {
 
     public void testReinitializing() {
         logger.info("-- build started shard");
-        ShardRouting shard = ShardRouting.newUnassigned("test", 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
+        ShardRouting shard = ShardRouting.newUnassigned(new Index("test","_na_"), 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
         shard.initialize("node1", -1);
         shard.moveToStarted();
         AllocationId allocationId = shard.allocationId();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -141,7 +141,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         assertThat(client().admin().cluster().prepareState().get().getState().getRoutingTable().index("test").getShards().get(0).primaryShard().unassignedInfo().getReason(), equalTo(UnassignedInfo.Reason.NODE_LEFT));
 
         logger.info("--> force allocation of stale copy to node that does not have shard copy");
-        client().admin().cluster().prepareReroute().add(new AllocateStalePrimaryAllocationCommand(new ShardId("test", 0), dataNodeWithNoShardCopy, true)).get();
+        client().admin().cluster().prepareReroute().add(new AllocateStalePrimaryAllocationCommand("test", 0, dataNodeWithNoShardCopy, true)).get();
 
         logger.info("--> wait until shard is failed and becomes unassigned again");
         assertBusy(() -> assertTrue(client().admin().cluster().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned()));
@@ -161,9 +161,9 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             logger.info("--> adding allocation command for shard " + shardId);
             // force allocation based on node id
             if (useStaleReplica) {
-                rerouteBuilder.add(new AllocateStalePrimaryAllocationCommand(new ShardId("test", shardId), storeStatus.getNode().getId(), true));
+                rerouteBuilder.add(new AllocateStalePrimaryAllocationCommand("test", shardId, storeStatus.getNode().getId(), true));
             } else {
-                rerouteBuilder.add(new AllocateEmptyPrimaryAllocationCommand(new ShardId("test", shardId), storeStatus.getNode().getId(), true));
+                rerouteBuilder.add(new AllocateEmptyPrimaryAllocationCommand("test", shardId, storeStatus.getNode().getId(), true));
             }
         }
         rerouteBuilder.get();
@@ -182,7 +182,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
 
         assertThat(client().admin().cluster().prepareState().get().getState().getRoutingTable().shardRoutingTable("test", 0).assignedShards(), empty());
 
-        client().admin().cluster().prepareReroute().add(new AllocateEmptyPrimaryAllocationCommand(new ShardId("test", 0), node, true)).get();
+        client().admin().cluster().prepareReroute().add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node, true)).get();
         ensureGreen("test");
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingServiceTests.java
@@ -198,7 +198,7 @@ public class RoutingServiceTests extends ESAllocationTestCase {
             ShardRouting shortDelayUnassignedReplica = null;
             ShardRouting longDelayUnassignedReplica = null;
             for (ShardRouting shr : unassigned) {
-                if (shr.getIndex().equals("short_delay")) {
+                if (shr.getIndexName().equals("short_delay")) {
                     shortDelayUnassignedReplica = shr;
                 } else {
                     longDelayUnassignedReplica = shr;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
@@ -127,7 +127,7 @@ public class RoutingTableTests extends ESAllocationTestCase {
     }
 
     public void testIndex() {
-        assertThat(this.testRoutingTable.index(TEST_INDEX_1).getIndex(), is(TEST_INDEX_1));
+        assertThat(this.testRoutingTable.index(TEST_INDEX_1).getIndex().getName(), is(TEST_INDEX_1));
         assertThat(this.testRoutingTable.index("foobar"), is(nullValue()));
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
@@ -71,8 +71,8 @@ public class RoutingTableTests extends ESAllocationTestCase {
                 .build();
 
         this.testRoutingTable = new RoutingTable.Builder()
-                .add(new IndexRoutingTable.Builder(TEST_INDEX_1).initializeAsNew(metaData.index(TEST_INDEX_1)).build())
-                .add(new IndexRoutingTable.Builder(TEST_INDEX_2).initializeAsNew(metaData.index(TEST_INDEX_2)).build())
+                .add(new IndexRoutingTable.Builder(metaData.index(TEST_INDEX_1).getIndex()).initializeAsNew(metaData.index(TEST_INDEX_1)).build())
+                .add(new IndexRoutingTable.Builder(metaData.index(TEST_INDEX_2).getIndex()).initializeAsNew(metaData.index(TEST_INDEX_2)).build())
                 .build();
         this.clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.DEFAULT).metaData(metaData).routingTable(testRoutingTable).build();
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -161,35 +161,35 @@ public class ShardRoutingTests extends ESTestCase {
             switch (changeId) {
                 case 0:
                     // change index
-                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index() + "a", otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.getIndexName() + "a", otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
                     break;
                 case 1:
                     // change shard id
-                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id() + 1, otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.getIndexName(), otherRouting.id() + 1, otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
                     break;
                 case 2:
                     // change current node
-                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId() == null ? "1" : otherRouting.currentNodeId() + "_1", otherRouting.relocatingNodeId(),
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.getIndexName(), otherRouting.id(), otherRouting.currentNodeId() == null ? "1" : otherRouting.currentNodeId() + "_1", otherRouting.relocatingNodeId(),
                             otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
                     break;
                 case 3:
                     // change relocating node
-                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(),
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.getIndexName(), otherRouting.id(), otherRouting.currentNodeId(),
                             otherRouting.relocatingNodeId() == null ? "1" : otherRouting.relocatingNodeId() + "_1",
                             otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
                     break;
                 case 4:
                     // change restore source
-                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.getIndexName(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.restoreSource() == null ? new RestoreSource(new SnapshotId("test", "s1"), Version.CURRENT, "test") :
                                     new RestoreSource(otherRouting.restoreSource().snapshotId(), Version.CURRENT, otherRouting.index() + "_1"),
                             otherRouting.primary(), otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
                     break;
                 case 5:
                     // change primary flag
-                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.getIndexName(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.restoreSource(), otherRouting.primary() == false, otherRouting.state(), otherRouting.version(), otherRouting.unassignedInfo());
                     break;
                 case 6:
@@ -204,7 +204,7 @@ public class ShardRoutingTests extends ESTestCase {
                         unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test");
                     }
 
-                    otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                    otherRouting = TestShardRouting.newShardRouting(otherRouting.getIndexName(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.restoreSource(), otherRouting.primary(), newState, otherRouting.version(), unassignedInfo);
                     break;
             }
@@ -216,7 +216,7 @@ public class ShardRoutingTests extends ESTestCase {
 
             if (randomBoolean()) {
                 // change unassigned info
-                otherRouting = TestShardRouting.newShardRouting(otherRouting.index(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
+                otherRouting = TestShardRouting.newShardRouting(otherRouting.getIndexName(), otherRouting.id(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                         otherRouting.restoreSource(), otherRouting.primary(), otherRouting.state(), otherRouting.version(),
                         otherRouting.unassignedInfo() == null ? new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test") :
                                 new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, otherRouting.unassignedInfo().getMessage() + "_1"));

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -88,7 +88,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         } else {
             toNodeId = "node1";
         }
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand(new ShardId("test", 0), existingNodeId, toNodeId)));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand("test", 0, existingNodeId, toNodeId)));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node(existingNodeId).get(0).state(), equalTo(ShardRoutingState.RELOCATING));
@@ -102,11 +102,11 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().node(toNodeId).get(0).state(), equalTo(ShardRoutingState.STARTED));
     }
 
-    private AbstractAllocateAllocationCommand randomAllocateCommand(ShardId shardId, String node) {
+    private AbstractAllocateAllocationCommand randomAllocateCommand(String index, int shardId, String node) {
         return randomFrom(
-            new AllocateReplicaAllocationCommand(shardId, node),
-            new AllocateEmptyPrimaryAllocationCommand(shardId, node, true),
-            new AllocateStalePrimaryAllocationCommand(shardId, node, true)
+            new AllocateReplicaAllocationCommand(index, shardId, node),
+            new AllocateEmptyPrimaryAllocationCommand(index, shardId, node, true),
+            new AllocateStalePrimaryAllocationCommand(index, shardId, node, true)
         );
     }
 
@@ -115,18 +115,19 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
                 .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none")
                 .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), "none")
                 .build());
+        final String index = "test";
 
         logger.info("--> building initial routing table");
         MetaData metaData = MetaData.builder()
-                .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+                .put(IndexMetaData.builder(index).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
                 .build();
         // shard routing is added as "from recovery" instead of "new index creation" so that we can test below that allocating an empty
         // primary with accept_data_loss flag set to false fails
         RoutingTable routingTable = RoutingTable.builder()
-                .addAsRecovery(metaData.index("test"))
+                .addAsRecovery(metaData.index(index))
                 .build();
         ClusterState clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
-        ShardId shardId = new ShardId("test", 0);
+        final int shardId = 0;
 
         logger.info("--> adding 3 nodes on same rack and do rerouting");
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder()
@@ -141,7 +142,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> allocating to non-existent node, should fail");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(shardId, "node42")));
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(index, shardId, "node42")));
             fail("expected IllegalArgumentException when allocating to non-existing node");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("failed to resolve [node42], no matching nodes"));
@@ -149,7 +150,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> allocating to non-data node, should fail");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(shardId, "node4")));
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(index, shardId, "node4")));
             fail("expected IllegalArgumentException when allocating to non-data node");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("allocation can only be done on data nodes"));
@@ -157,7 +158,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> allocating non-existing shard, should fail");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(new ShardId("test", 1), "node2")));
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand("test", 1, "node2")));
             fail("expected ShardNotFoundException when allocating non-existing shard");
         } catch (ShardNotFoundException e) {
             assertThat(e.getMessage(), containsString("no such shard"));
@@ -165,7 +166,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> allocating non-existing index, should fail");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(new ShardId("test2", 0), "node2")));
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand("test2", 0, "node2")));
             fail("expected ShardNotFoundException when allocating non-existing index");
         } catch (IndexNotFoundException e) {
             assertThat(e.getMessage(), containsString("no such index"));
@@ -173,7 +174,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> allocating empty primary with acceptDataLoss flag set to false");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand(new ShardId("test", 0), "node1", false)));
+            allocation.reroute(clusterState, new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand("test", 0, "node1", false)));
             fail("expected IllegalArgumentException when allocating empty primary with acceptDataLoss flag set to false");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("allocating an empty primary for " + shardId + " can result in data loss. Please confirm by setting the accept_data_loss parameter to true"));
@@ -181,14 +182,14 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> allocating stale primary with acceptDataLoss flag set to false");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(new AllocateStalePrimaryAllocationCommand(shardId, "node1", false)));
+            allocation.reroute(clusterState, new AllocationCommands(new AllocateStalePrimaryAllocationCommand(index, shardId, "node1", false)));
             fail("expected IllegalArgumentException when allocating stale primary with acceptDataLoss flag set to false");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("allocating an empty primary for " + shardId + " can result in data loss. Please confirm by setting the accept_data_loss parameter to true"));
         }
 
         logger.info("--> allocating empty primary with acceptDataLoss flag set to true");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand(new ShardId("test", 0), "node1", true)));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand("test", 0, "node1", true)));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
@@ -204,13 +205,13 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> allocate the replica shard on the primary shard node, should fail");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand(new ShardId("test", 0), "node1")));
+            allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node1")));
             fail("expected IllegalArgumentException when allocating replica shard on the primary shard node");
         } catch (IllegalArgumentException e) {
         }
 
         logger.info("--> allocate the replica shard on on the second node");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand(new ShardId("test", 0), "node2")));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
@@ -229,7 +230,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> verify that we fail when there are no unassigned shards");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand(new ShardId("test", 0), "node3")));
+            allocation.reroute(clusterState, new AllocationCommands(randomAllocateCommand("test", 0, "node3")));
             fail("expected IllegalArgumentException when allocating shard while no unassigned shard available");
         } catch (IllegalArgumentException e) {
         }
@@ -261,7 +262,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(0));
 
         logger.info("--> allocating empty primary shard with accept_data_loss flag set to true");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand(new ShardId("test", 0), "node1", true)));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateEmptyPrimaryAllocationCommand("test", 0, "node1", true)));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
@@ -270,7 +271,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> cancel primary allocation, make sure it fails...");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand(new ShardId("test", 0), "node1", false)));
+            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", false)));
             fail();
         } catch (IllegalArgumentException e) {
         }
@@ -284,13 +285,13 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> cancel primary allocation, make sure it fails...");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand(new ShardId("test", 0), "node1", false)));
+            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", false)));
             fail();
         } catch (IllegalArgumentException e) {
         }
 
         logger.info("--> allocate the replica shard on on the second node");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand(new ShardId("test", 0), "node2")));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
@@ -299,7 +300,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(INITIALIZING).size(), equalTo(1));
 
         logger.info("--> cancel the relocation allocation");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand(new ShardId("test", 0), "node2", false)));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node2", false)));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
@@ -308,7 +309,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().node("node3").size(), equalTo(0));
 
         logger.info("--> allocate the replica shard on on the second node");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand(new ShardId("test", 0), "node2")));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
@@ -318,7 +319,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("--> cancel the primary being replicated, make sure it fails");
         try {
-            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand(new ShardId("test", 0), "node1", false)));
+            allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", false)));
             fail();
         } catch (IllegalArgumentException e) {
         }
@@ -332,7 +333,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(STARTED).size(), equalTo(1));
 
         logger.info("--> cancel allocation of the replica shard");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand(new ShardId("test", 0), "node2", false)));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node2", false)));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
@@ -341,7 +342,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().node("node3").size(), equalTo(0));
 
         logger.info("--> allocate the replica shard on on the second node");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand(new ShardId("test", 0), "node2")));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new AllocateReplicaAllocationCommand("test", 0, "node2")));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(rerouteResult.changed(), equalTo(true));
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
@@ -357,7 +358,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(STARTED).size(), equalTo(1));
 
         logger.info("--> move the replica shard");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand(new ShardId("test", 0), "node2", "node3")));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand("test", 0, "node2", "node3")));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
         assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
@@ -367,7 +368,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().node("node3").shardsWithState(INITIALIZING).size(), equalTo(1));
 
         logger.info("--> cancel the move of the replica shard");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand(new ShardId("test", 0), "node3", false)));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node3", false)));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(clusterState.getRoutingNodes().node("node1").size(), equalTo(1));
         assertThat(clusterState.getRoutingNodes().node("node1").shardsWithState(STARTED).size(), equalTo(1));
@@ -376,7 +377,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
 
         logger.info("--> cancel the primary allocation (with allow_primary set to true)");
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand(new ShardId("test", 0), "node1", true)));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new CancelAllocationCommand("test", 0, "node1", true)));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertThat(rerouteResult.changed(), equalTo(true));
         assertThat(clusterState.getRoutingNodes().node("node2").shardsWithState(STARTED).get(0).primary(), equalTo(true));
@@ -386,33 +387,33 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
     public void testSerialization() throws Exception {
         AllocationCommands commands = new AllocationCommands(
-                new AllocateEmptyPrimaryAllocationCommand(new ShardId("test", 1), "node1", true),
-                new AllocateStalePrimaryAllocationCommand(new ShardId("test", 2), "node1", true),
-                new AllocateReplicaAllocationCommand(new ShardId("test", 2), "node1"),
-                new MoveAllocationCommand(new ShardId("test", 3), "node2", "node3"),
-                new CancelAllocationCommand(new ShardId("test", 4), "node5", true)
+                new AllocateEmptyPrimaryAllocationCommand("test", 1, "node1", true),
+                new AllocateStalePrimaryAllocationCommand("test", 2, "node1", true),
+                new AllocateReplicaAllocationCommand("test", 2, "node1"),
+                new MoveAllocationCommand("test", 3, "node2", "node3"),
+                new CancelAllocationCommand("test", 4, "node5", true)
         );
         BytesStreamOutput bytes = new BytesStreamOutput();
         AllocationCommands.writeTo(commands, bytes);
         AllocationCommands sCommands = AllocationCommands.readFrom(StreamInput.wrap(bytes.bytes()));
 
         assertThat(sCommands.commands().size(), equalTo(5));
-        assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).shardId(), equalTo(new ShardId("test", 1)));
+        assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).shardId(), equalTo(new ShardId("test", "_na_", 1)));
         assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).node(), equalTo("node1"));
         assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).acceptDataLoss(), equalTo(true));
 
-        assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).shardId(), equalTo(new ShardId("test", 2)));
+        assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).shardId(), equalTo(new ShardId("test", "_na_", 2)));
         assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).node(), equalTo("node1"));
         assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).acceptDataLoss(), equalTo(true));
 
-        assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).shardId(), equalTo(new ShardId("test", 2)));
+        assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).shardId(), equalTo(new ShardId("test", "_na_", 2)));
         assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).node(), equalTo("node1"));
 
-        assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).shardId(), equalTo(new ShardId("test", 3)));
+        assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).shardId(), equalTo(new ShardId("test", "_na_", 3)));
         assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).fromNode(), equalTo("node2"));
         assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).toNode(), equalTo("node3"));
 
-        assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).shardId(), equalTo(new ShardId("test", 4)));
+        assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).shardId(), equalTo(new ShardId("test", "_na_", 4)));
         assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).node(), equalTo("node5"));
         assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).allowPrimary(), equalTo(true));
     }
@@ -434,22 +435,22 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         AllocationCommands sCommands = AllocationCommands.fromXContent(parser);
 
         assertThat(sCommands.commands().size(), equalTo(5));
-        assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).shardId(), equalTo(new ShardId("test", 1)));
+        assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).shardId(), equalTo(new ShardId("test", "_na_", 1)));
         assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).node(), equalTo("node1"));
         assertThat(((AllocateEmptyPrimaryAllocationCommand) (sCommands.commands().get(0))).acceptDataLoss(), equalTo(true));
 
-        assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).shardId(), equalTo(new ShardId("test", 2)));
+        assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).shardId(), equalTo(new ShardId("test", "_na_", 2)));
         assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).node(), equalTo("node1"));
         assertThat(((AllocateStalePrimaryAllocationCommand) (sCommands.commands().get(1))).acceptDataLoss(), equalTo(true));
 
-        assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).shardId(), equalTo(new ShardId("test", 2)));
+        assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).shardId(), equalTo(new ShardId("test", "_na_", 2)));
         assertThat(((AllocateReplicaAllocationCommand) (sCommands.commands().get(2))).node(), equalTo("node1"));
 
-        assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).shardId(), equalTo(new ShardId("test", 3)));
+        assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).shardId(), equalTo(new ShardId("test", "_na_", 3)));
         assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).fromNode(), equalTo("node2"));
         assertThat(((MoveAllocationCommand) (sCommands.commands().get(3))).toNode(), equalTo("node3"));
 
-        assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).shardId(), equalTo(new ShardId("test", 4)));
+        assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).shardId(), equalTo(new ShardId("test", "_na_", 4)));
         assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).node(), equalTo("node5"));
         assertThat(((CancelAllocationCommand) (sCommands.commands().get(4))).allowPrimary(), equalTo(true));
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationPriorityTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationPriorityTests.java
@@ -74,26 +74,26 @@ public class AllocationPriorityTests extends ESAllocationTestCase {
         routingTable = allocation.reroute(clusterState, "reroute").routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
         assertEquals(2, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).index());
-        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).index());
+        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
+        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
 
         routingTable = allocation.applyStartedShards(clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING)).routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
         assertEquals(2, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).index());
-        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).index());
+        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
+        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
 
         routingTable = allocation.applyStartedShards(clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING)).routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
         assertEquals(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).toString(),2, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).index());
-        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).index());
+        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
+        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
 
         routingTable = allocation.applyStartedShards(clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING)).routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
         assertEquals(2, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).index());
-        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).index());
+        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
+        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
 
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
@@ -872,10 +872,10 @@ public class AwarenessAllocationTests extends ESAllocationTestCase {
             if (routing.primary()) {
                 primaryNode = routing.currentNodeId();
             } else if (routing.initializing()) {
-                commands.add(new CancelAllocationCommand(routing.shardId(), routing.currentNodeId(), false));
+                commands.add(new CancelAllocationCommand(routing.shardId().getIndexName(), routing.id(), routing.currentNodeId(), false));
             }
         }
-        commands.add(new MoveAllocationCommand(new ShardId("test", 0), primaryNode, "A-4"));
+        commands.add(new MoveAllocationCommand("test", 0, primaryNode, "A-4"));
 
         routingTable = strategy.reroute(clusterState, commands).routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/CatAllocationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/CatAllocationTestCase.java
@@ -98,10 +98,10 @@ public abstract class CatAllocationTestCase extends ESAllocationTestCase {
         for(Idx idx : indices.values()) {
             IndexMetaData idxMeta = IndexMetaData.builder(idx.name).settings(settings(Version.CURRENT)).numberOfShards(idx.numShards()).numberOfReplicas(idx.numReplicas()).build();
             builder.put(idxMeta, false);
-            IndexRoutingTable.Builder tableBuilder = new IndexRoutingTable.Builder(idx.name).initializeAsRecovery(idxMeta);
+            IndexRoutingTable.Builder tableBuilder = new IndexRoutingTable.Builder(idxMeta.getIndex()).initializeAsRecovery(idxMeta);
             Map<Integer, IndexShardRoutingTable> shardIdToRouting = new HashMap<>();
             for (ShardRouting r : idx.routing) {
-                IndexShardRoutingTable refData = new IndexShardRoutingTable.Builder(new ShardId(idx.name, r.id())).addShard(r).build();
+                IndexShardRoutingTable refData = new IndexShardRoutingTable.Builder(r.shardId()).addShard(r).build();
                 if (shardIdToRouting.containsKey(r.getId())) {
                     refData = new IndexShardRoutingTable.Builder(shardIdToRouting.get(r.getId())).addShard(r).build();
                 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -642,7 +642,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
                     RoutingNodes.UnassignedShards.UnassignedIterator iterator = unassigned.iterator();
                     while (iterator.hasNext()) {
                         ShardRouting next = iterator.next();
-                        if ("test1".equals(next.index())) {
+                        if ("test1".equals(next.index().getName())) {
                             iterator.removeAndIgnore();
                         }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
-import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -130,7 +129,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
         routingNodes = clusterState.getRoutingNodes();
 
         assertThat(routingNodes.node("node3").size(), equalTo(1));
-        assertThat(routingNodes.node("node3").get(0).shardId().index().name(), equalTo("test1"));
+        assertThat(routingNodes.node("node3").get(0).shardId().index().getName(), equalTo("test1"));
     }
 
 
@@ -235,7 +234,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
         routingNodes = clusterState.getRoutingNodes();
 
         assertThat(routingNodes.node("node3").size(), equalTo(1));
-        assertThat(routingNodes.node("node3").get(0).shardId().index().name(), equalTo("test1"));
+        assertThat(routingNodes.node("node3").get(0).shardId().index().getName(), equalTo("test1"));
     }
 
     public void testClusterPrimariesActive2() {
@@ -442,7 +441,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
         routingNodes = clusterState.getRoutingNodes();
 
         assertThat(routingNodes.node("node3").size(), equalTo(1));
-        assertThat(routingNodes.node("node3").get(0).shardId().index().name(), anyOf(equalTo("test1"), equalTo("test2")));
+        assertThat(routingNodes.node("node3").get(0).shardId().index().getName(), anyOf(equalTo("test1"), equalTo("test2")));
     }
 
     public void testClusterAllActive2() {

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -129,7 +129,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
         routingNodes = clusterState.getRoutingNodes();
 
         assertThat(routingNodes.node("node3").size(), equalTo(1));
-        assertThat(routingNodes.node("node3").get(0).shardId().index().getName(), equalTo("test1"));
+        assertThat(routingNodes.node("node3").get(0).shardId().getIndex().getName(), equalTo("test1"));
     }
 
 
@@ -234,7 +234,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
         routingNodes = clusterState.getRoutingNodes();
 
         assertThat(routingNodes.node("node3").size(), equalTo(1));
-        assertThat(routingNodes.node("node3").get(0).shardId().index().getName(), equalTo("test1"));
+        assertThat(routingNodes.node("node3").get(0).shardId().getIndex().getName(), equalTo("test1"));
     }
 
     public void testClusterPrimariesActive2() {
@@ -441,7 +441,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
         routingNodes = clusterState.getRoutingNodes();
 
         assertThat(routingNodes.node("node3").size(), equalTo(1));
-        assertThat(routingNodes.node("node3").get(0).shardId().index().getName(), anyOf(equalTo("test1"), equalTo("test2")));
+        assertThat(routingNodes.node("node3").get(0).shardId().getIndex().getName(), anyOf(equalTo("test1"), equalTo("test2")));
     }
 
     public void testClusterAllActive2() {

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
@@ -149,7 +149,7 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
 
         logger.info("--> moving primary shard to node3");
         rerouteResult = allocation.reroute(clusterState, new AllocationCommands(
-                new MoveAllocationCommand(clusterState.routingTable().index("test").shard(0).primaryShard().shardId(), clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId(), "node3"))
+                new MoveAllocationCommand("test", 0, clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId(), "node3"))
         );
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
@@ -223,7 +223,7 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
 
         logger.info("--> moving primary shard to node3");
         rerouteResult = allocation.reroute(clusterState, new AllocationCommands(
-                new MoveAllocationCommand(clusterState.routingTable().index("test").shard(0).primaryShard().shardId(), clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId(), "node3"))
+                new MoveAllocationCommand("test",0 , clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId(), "node3"))
         );
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ExpectedShardSizeAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ExpectedShardSizeAllocationTests.java
@@ -150,7 +150,7 @@ public class ExpectedShardSizeAllocationTests extends ESAllocationTestCase {
         } else {
             toNodeId = "node1";
         }
-        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand(new ShardId("test", 0), existingNodeId, toNodeId)));
+        rerouteResult = allocation.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand("test", 0, existingNodeId, toNodeId)));
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
         assertEquals(clusterState.getRoutingNodes().node(existingNodeId).get(0).state(), ShardRoutingState.RELOCATING);

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ExpectedShardSizeAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ExpectedShardSizeAllocationTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESAllocationTestCase;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -54,7 +53,7 @@ public class ExpectedShardSizeAllocationTests extends ESAllocationTestCase {
                 return new ClusterInfo() {
                     @Override
                     public Long getShardSize(ShardRouting shardRouting) {
-                        if (shardRouting.index().equals("test") && shardRouting.shardId().getId() == 0) {
+                        if (shardRouting.getIndexName().equals("test") && shardRouting.shardId().getId() == 0) {
                             return byteSize;
                         }
                         return null;
@@ -112,7 +111,7 @@ public class ExpectedShardSizeAllocationTests extends ESAllocationTestCase {
                 return new ClusterInfo() {
                     @Override
                     public Long getShardSize(ShardRouting shardRouting) {
-                        if (shardRouting.index().equals("test") && shardRouting.shardId().getId() == 0) {
+                        if (shardRouting.getIndexName().equals("test") && shardRouting.shardId().getId() == 0) {
                             return byteSize;
                         }
                         return null;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedShardsRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedShardsRoutingTests.java
@@ -109,7 +109,7 @@ public class FailedShardsRoutingTests extends ESAllocationTestCase {
 
         logger.info("--> moving primary shard to node3");
         rerouteResult = allocation.reroute(clusterState, new AllocationCommands(
-                        new MoveAllocationCommand(clusterState.routingTable().index("test").shard(0).primaryShard().shardId(), clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId(), "node3"))
+                        new MoveAllocationCommand("test", 0, clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId(), "node3"))
         );
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();
@@ -125,7 +125,7 @@ public class FailedShardsRoutingTests extends ESAllocationTestCase {
 
         logger.info("--> moving primary shard to node3");
         rerouteResult = allocation.reroute(clusterState, new AllocationCommands(
-                        new MoveAllocationCommand(clusterState.routingTable().index("test").shard(0).primaryShard().shardId(), clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId(), "node3"))
+                        new MoveAllocationCommand("test", 0, clusterState.routingTable().index("test").shard(0).primaryShard().currentNodeId(), "node3"))
         );
         assertThat(rerouteResult.changed(), equalTo(true));
         clusterState = ClusterState.builder(clusterState).routingTable(rerouteResult.routingTable()).build();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -299,26 +299,26 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     public void testRebalanceDoesNotAllocatePrimaryAndReplicasOnDifferentVersionNodes() {
-        ShardId shard1 = new ShardId("test1", 0);
-        ShardId shard2 = new ShardId("test2", 0);
+        ShardId shard1 = new ShardId("test1", "_na_", 0);
+        ShardId shard2 = new ShardId("test2", "_na_", 0);
         final DiscoveryNode newNode = new DiscoveryNode("newNode", DummyTransportAddress.INSTANCE, Version.CURRENT);
         final DiscoveryNode oldNode1 = new DiscoveryNode("oldNode1", DummyTransportAddress.INSTANCE, VersionUtils.getPreviousVersion());
         final DiscoveryNode oldNode2 = new DiscoveryNode("oldNode2", DummyTransportAddress.INSTANCE, VersionUtils.getPreviousVersion());
         MetaData metaData = MetaData.builder()
-            .put(IndexMetaData.builder(shard1.getIndex()).settings(settings(Version.CURRENT).put(Settings.EMPTY)).numberOfShards(1).numberOfReplicas(1))
-            .put(IndexMetaData.builder(shard2.getIndex()).settings(settings(Version.CURRENT).put(Settings.EMPTY)).numberOfShards(1).numberOfReplicas(1))
+            .put(IndexMetaData.builder(shard1.getIndexName()).settings(settings(Version.CURRENT).put(Settings.EMPTY)).numberOfShards(1).numberOfReplicas(1))
+            .put(IndexMetaData.builder(shard2.getIndexName()).settings(settings(Version.CURRENT).put(Settings.EMPTY)).numberOfShards(1).numberOfReplicas(1))
             .build();
         RoutingTable routingTable = RoutingTable.builder()
             .add(IndexRoutingTable.builder(shard1.getIndex())
                 .addIndexShard(new IndexShardRoutingTable.Builder(shard1)
-                    .addShard(TestShardRouting.newShardRouting(shard1.getIndex(), shard1.getId(), newNode.id(), true, ShardRoutingState.STARTED, 10))
-                    .addShard(TestShardRouting.newShardRouting(shard1.getIndex(), shard1.getId(), oldNode1.id(), false, ShardRoutingState.STARTED, 10))
+                    .addShard(TestShardRouting.newShardRouting(shard1.getIndexName(), shard1.getId(), newNode.id(), true, ShardRoutingState.STARTED, 10))
+                    .addShard(TestShardRouting.newShardRouting(shard1.getIndexName(), shard1.getId(), oldNode1.id(), false, ShardRoutingState.STARTED, 10))
                     .build())
             )
             .add(IndexRoutingTable.builder(shard2.getIndex())
                 .addIndexShard(new IndexShardRoutingTable.Builder(shard2)
-                    .addShard(TestShardRouting.newShardRouting(shard2.getIndex(), shard2.getId(), newNode.id(), true, ShardRoutingState.STARTED, 10))
-                    .addShard(TestShardRouting.newShardRouting(shard2.getIndex(), shard2.getId(), oldNode1.id(), false, ShardRoutingState.STARTED, 10))
+                    .addShard(TestShardRouting.newShardRouting(shard2.getIndexName(), shard2.getId(), newNode.id(), true, ShardRoutingState.STARTED, 10))
+                    .addShard(TestShardRouting.newShardRouting(shard2.getIndexName(), shard2.getId(), oldNode1.id(), false, ShardRoutingState.STARTED, 10))
                     .build())
             )
             .build();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/RebalanceAfterActiveTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/RebalanceAfterActiveTests.java
@@ -66,7 +66,7 @@ public class RebalanceAfterActiveTests extends ESAllocationTestCase {
                         return new ClusterInfo() {
                             @Override
                             public Long getShardSize(ShardRouting shardRouting) {
-                                if (shardRouting.index().equals("test")) {
+                                if (shardRouting.getIndexName().equals("test")) {
                                     return sizes[shardRouting.getId()];
                                 }
                                 return null;                    }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsLimitAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsLimitAllocationTests.java
@@ -206,10 +206,10 @@ public class ShardsLimitAllocationTests extends ESAllocationTestCase {
         assertThat(numberOfShardsOfType(clusterState.getRoutingNodes(), STARTED), equalTo(10));
 
         for (ShardRouting shardRouting : clusterState.getRoutingNodes().node("node1")) {
-            assertThat(shardRouting.index(), equalTo("test"));
+            assertThat(shardRouting.getIndexName(), equalTo("test"));
         }
         for (ShardRouting shardRouting : clusterState.getRoutingNodes().node("node2")) {
-            assertThat(shardRouting.index(), equalTo("test1"));
+            assertThat(shardRouting.getIndexName(), equalTo("test1"));
         }
 
         logger.info("update " + ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey() + " for test, see that things move");

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardNoReplicasRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/SingleShardNoReplicasRoutingTests.java
@@ -274,8 +274,8 @@ public class SingleShardNoReplicasRoutingTests extends ESAllocationTestCase {
             assertThat(nodeIndex, lessThan(25));
             // check that we don't have a shard associated with a node with the same index name (we have a single shard)
             for (ShardRouting shardRoutingEntry : routingNode) {
-                assertThat(encounteredIndices, not(hasItem(shardRoutingEntry.index())));
-                encounteredIndices.add(shardRoutingEntry.index());
+                assertThat(encounteredIndices, not(hasItem(shardRoutingEntry.getIndexName())));
+                encounteredIndices.add(shardRoutingEntry.getIndexName());
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/StartedShardsRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/StartedShardsRoutingTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESAllocationTestCase;
 
 import java.util.Arrays;
@@ -47,14 +48,15 @@ public class StartedShardsRoutingTests extends ESAllocationTestCase {
                 .settings(settings(Version.CURRENT))
                 .numberOfShards(3).numberOfReplicas(0)
                 .build();
+        final Index index = indexMetaData.getIndex();
         ClusterState.Builder stateBuilder = ClusterState.builder(ClusterName.DEFAULT)
                 .nodes(DiscoveryNodes.builder().put(newNode("node1")).put(newNode("node2")))
                 .metaData(MetaData.builder().put(indexMetaData, false));
 
-        final ShardRouting initShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.INITIALIZING, 1);
-        final ShardRouting startedShard = TestShardRouting.newShardRouting("test", 1, "node2", true, ShardRoutingState.STARTED, 1);
-        final ShardRouting relocatingShard = TestShardRouting.newShardRouting("test", 2, "node1", "node2", true, ShardRoutingState.RELOCATING, 1);
-        stateBuilder.routingTable(RoutingTable.builder().add(IndexRoutingTable.builder("test")
+        final ShardRouting initShard = TestShardRouting.newShardRouting(index, 0, "node1", true, ShardRoutingState.INITIALIZING, 1);
+        final ShardRouting startedShard = TestShardRouting.newShardRouting(index, 1, "node2", true, ShardRoutingState.STARTED, 1);
+        final ShardRouting relocatingShard = TestShardRouting.newShardRouting(index, 2, "node1", "node2", true, ShardRoutingState.RELOCATING, 1);
+        stateBuilder.routingTable(RoutingTable.builder().add(IndexRoutingTable.builder(index)
                 .addIndexShard(new IndexShardRoutingTable.Builder(initShard.shardId()).addShard(initShard).build())
                 .addIndexShard(new IndexShardRoutingTable.Builder(startedShard.shardId()).addShard(startedShard).build())
                 .addIndexShard(new IndexShardRoutingTable.Builder(relocatingShard.shardId()).addShard(relocatingShard).build())).build());

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -284,7 +284,7 @@ public class ThrottlingAllocationTests extends ESAllocationTestCase {
         assertEquals(clusterState.getRoutingNodes().getOutgoingRecoveries("node2"), 0);
         assertEquals(clusterState.getRoutingNodes().getOutgoingRecoveries("node3"), 0);
 
-        RoutingAllocation.Result reroute = strategy.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand(clusterState.getRoutingNodes().node("node1").get(0).shardId(), "node1", "node2")));
+        RoutingAllocation.Result reroute = strategy.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand("test", clusterState.getRoutingNodes().node("node1").get(0).shardId().id(), "node1", "node2")));
         assertEquals(reroute.explanations().explanations().size(), 1);
         assertEquals(reroute.explanations().explanations().get(0).decisions().type(), Decision.Type.YES);
         routingTable = reroute.routingTable();
@@ -297,7 +297,7 @@ public class ThrottlingAllocationTests extends ESAllocationTestCase {
         assertEquals(clusterState.getRoutingNodes().getOutgoingRecoveries("node3"), 0);
 
         // outgoing throttles
-        reroute = strategy.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand(clusterState.getRoutingNodes().node("node3").get(0).shardId(), "node3", "node1")), true);
+        reroute = strategy.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand("test", clusterState.getRoutingNodes().node("node3").get(0).shardId().id(), "node3", "node1")), true);
         assertEquals(reroute.explanations().explanations().size(), 1);
         assertEquals(reroute.explanations().explanations().get(0).decisions().type(), Decision.Type.THROTTLE);
         assertEquals(clusterState.getRoutingNodes().getIncomingRecoveries("node1"), 0);
@@ -312,7 +312,7 @@ public class ThrottlingAllocationTests extends ESAllocationTestCase {
         assertThat(routingTable.shardsWithState(UNASSIGNED).size(), equalTo(0));
 
         // incoming throttles
-        reroute = strategy.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand(clusterState.getRoutingNodes().node("node3").get(0).shardId(), "node3", "node2")), true);
+        reroute = strategy.reroute(clusterState, new AllocationCommands(new MoveAllocationCommand("test", clusterState.getRoutingNodes().node("node3").get(0).shardId().id(), "node3", "node2")), true);
         assertEquals(reroute.explanations().explanations().size(), 1);
         assertEquals(reroute.explanations().explanations().get(0).decisions().type(), Decision.Type.THROTTLE);
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.elasticsearch.common.transport.LocalTransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -95,13 +96,15 @@ public class DiskThresholdDeciderUnitTests extends ESTestCase {
         ClusterInfoService cis = EmptyClusterInfoService.INSTANCE;
         DiskThresholdDecider decider = new DiskThresholdDecider(Settings.EMPTY, nss, cis, null);
 
-        ShardRouting test_0 = ShardRouting.newUnassigned("test", 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
-        DiscoveryNode node_0 = new DiscoveryNode("node_0", DummyTransportAddress.INSTANCE, Version.CURRENT);
-        DiscoveryNode node_1 = new DiscoveryNode("node_1", DummyTransportAddress.INSTANCE, Version.CURRENT);
-
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
                 .build();
+
+        final Index index = metaData.index("test").getIndex();
+
+        ShardRouting test_0 = ShardRouting.newUnassigned(index, 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        DiscoveryNode node_0 = new DiscoveryNode("node_0", DummyTransportAddress.INSTANCE, Version.CURRENT);
+        DiscoveryNode node_1 = new DiscoveryNode("node_1", DummyTransportAddress.INSTANCE, Version.CURRENT);
 
         RoutingTable routingTable = RoutingTable.builder()
                 .addAsNew(metaData.index("test"))
@@ -140,32 +143,33 @@ public class DiskThresholdDeciderUnitTests extends ESTestCase {
         DiscoveryNode node_0 = new DiscoveryNode("node_0", DummyTransportAddress.INSTANCE, Version.CURRENT);
         DiscoveryNode node_1 = new DiscoveryNode("node_1", DummyTransportAddress.INSTANCE, Version.CURRENT);
 
-        ShardRouting test_0 = ShardRouting.newUnassigned("test", 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        MetaData metaData = MetaData.builder()
+                .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+                .build();
+        final IndexMetaData indexMetaData = metaData.index("test");
+
+        ShardRouting test_0 = ShardRouting.newUnassigned(indexMetaData.getIndex(), 0, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_0, node_0.getId());
         ShardRoutingHelper.moveToStarted(test_0);
         shardRoutingMap.put(test_0, "/node0/least");
 
-        ShardRouting test_1 = ShardRouting.newUnassigned("test", 1, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        ShardRouting test_1 = ShardRouting.newUnassigned(indexMetaData.getIndex(), 1, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_1, node_1.getId());
         ShardRoutingHelper.moveToStarted(test_1);
         shardRoutingMap.put(test_1, "/node1/least");
 
-        ShardRouting test_2 = ShardRouting.newUnassigned("test", 2, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        ShardRouting test_2 = ShardRouting.newUnassigned(indexMetaData.getIndex(), 2, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_2, node_1.getId());
         ShardRoutingHelper.moveToStarted(test_2);
         shardRoutingMap.put(test_2, "/node1/most");
 
-        ShardRouting test_3 = ShardRouting.newUnassigned("test", 3, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        ShardRouting test_3 = ShardRouting.newUnassigned(indexMetaData.getIndex(), 3, null, true, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_3, node_1.getId());
         ShardRoutingHelper.moveToStarted(test_3);
         // Intentionally not in the shardRoutingMap. We want to test what happens when we don't know where it is.
 
-        MetaData metaData = MetaData.builder()
-                .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
-                .build();
-
         RoutingTable routingTable = RoutingTable.builder()
-                .addAsNew(metaData.index("test"))
+                .addAsNew(indexMetaData)
                 .build();
 
         ClusterState clusterState = ClusterState.builder(org.elasticsearch.cluster.ClusterName.DEFAULT).metaData(metaData).routingTable(routingTable).build();
@@ -220,17 +224,18 @@ public class DiskThresholdDeciderUnitTests extends ESTestCase {
         shardSizes.put("[test][2][r]", 1000L);
         shardSizes.put("[other][0][p]", 10000L);
         ClusterInfo info = new DevNullClusterInfo(ImmutableOpenMap.of(), ImmutableOpenMap.of(), shardSizes.build());
-        ShardRouting test_0 = ShardRouting.newUnassigned("test", 0, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        final Index index = new Index("test", "_na_");
+        ShardRouting test_0 = ShardRouting.newUnassigned(index, 0, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_0, "node1");
         ShardRoutingHelper.moveToStarted(test_0);
         ShardRoutingHelper.relocate(test_0, "node2");
 
-        ShardRouting test_1 = ShardRouting.newUnassigned("test", 1, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        ShardRouting test_1 = ShardRouting.newUnassigned(index, 1, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_1, "node2");
         ShardRoutingHelper.moveToStarted(test_1);
         ShardRoutingHelper.relocate(test_1, "node1");
 
-        ShardRouting test_2 = ShardRouting.newUnassigned("test", 2, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        ShardRouting test_2 = ShardRouting.newUnassigned(index, 2, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_2, "node1");
         ShardRoutingHelper.moveToStarted(test_2);
 
@@ -244,13 +249,13 @@ public class DiskThresholdDeciderUnitTests extends ESTestCase {
         assertEquals(0l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/some/other/dev"));
         assertEquals(0l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/some/other/dev"));
 
-        ShardRouting test_3 = ShardRouting.newUnassigned("test", 3, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        ShardRouting test_3 = ShardRouting.newUnassigned(index, 3, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_3, "node1");
         ShardRoutingHelper.moveToStarted(test_3);
         assertEquals(0l, DiskThresholdDecider.getShardSize(test_3, info));
 
 
-        ShardRouting other_0 = ShardRouting.newUnassigned("other", 0, null, randomBoolean(), new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
+        ShardRouting other_0 = ShardRouting.newUnassigned(new Index("other", "_NA_"), 0, null, randomBoolean(), new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(other_0, "node2");
         ShardRoutingHelper.moveToStarted(other_0);
         ShardRoutingHelper.relocate(other_0, "node1");

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationTests.java
@@ -233,18 +233,18 @@ public class EnableAllocationTests extends ESAllocationTestCase {
             case PRIMARIES:
                 for (ShardRouting routing : mutableShardRoutings) {
                     assertTrue("only primaries are allowed to relocate", routing.primary());
-                    assertThat("only test index can rebalance", routing.getIndex(), equalTo("test"));
+                    assertThat("only test index can rebalance", routing.getIndexName(), equalTo("test"));
                 }
                 break;
             case REPLICAS:
                 for (ShardRouting routing : mutableShardRoutings) {
                     assertFalse("only replicas are allowed to relocate", routing.primary());
-                    assertThat("only test index can rebalance", routing.getIndex(), equalTo("test"));
+                    assertThat("only test index can rebalance", routing.getIndexName(), equalTo("test"));
                 }
                 break;
             case ALL:
                 for (ShardRouting routing : mutableShardRoutings) {
-                    assertThat("only test index can rebalance", routing.getIndex(), equalTo("test"));
+                    assertThat("only test index can rebalance", routing.getIndexName(), equalTo("test"));
                 }
                 break;
             default:

--- a/core/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/structure/RoutingIteratorTests.java
@@ -59,28 +59,28 @@ import static org.hamcrest.Matchers.sameInstance;
 public class RoutingIteratorTests extends ESAllocationTestCase {
     public void testEmptyIterator() {
         ShardShuffler shuffler = new RotationShardShuffler(0);
-        ShardIterator shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(Collections.<ShardRouting>emptyList()));
+        ShardIterator shardIterator = new PlainShardIterator(new ShardId("test1", "_na_", 0), shuffler.shuffle(Collections.<ShardRouting>emptyList()));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(Collections.<ShardRouting>emptyList()));
+        shardIterator = new PlainShardIterator(new ShardId("test1", "_na_", 0), shuffler.shuffle(Collections.<ShardRouting>emptyList()));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(Collections.<ShardRouting>emptyList()));
+        shardIterator = new PlainShardIterator(new ShardId("test1", "_na_", 0), shuffler.shuffle(Collections.<ShardRouting>emptyList()));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));
 
-        shardIterator = new PlainShardIterator(new ShardId("test1", 0), shuffler.shuffle(Collections.<ShardRouting>emptyList()));
+        shardIterator = new PlainShardIterator(new ShardId("test1", "_na_", 0), shuffler.shuffle(Collections.<ShardRouting>emptyList()));
         assertThat(shardIterator.remaining(), equalTo(0));
         assertThat(shardIterator.nextOrNull(), nullValue());
         assertThat(shardIterator.remaining(), equalTo(0));

--- a/core/src/test/java/org/elasticsearch/common/lucene/ShardCoreKeyMapTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/ShardCoreKeyMapTests.java
@@ -62,7 +62,7 @@ public class ShardCoreKeyMapTests extends ESTestCase {
         try (Directory dir = newDirectory();
                 RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
             writer.addDocument(new Document());
-            try (DirectoryReader dirReader = ElasticsearchDirectoryReader.wrap(writer.getReader(), new ShardId("index1", 1))) {
+            try (DirectoryReader dirReader = ElasticsearchDirectoryReader.wrap(writer.getReader(), new ShardId("index1", "_na_", 1))) {
                 reader = dirReader.leaves().get(0).reader();
             }
         }
@@ -89,9 +89,9 @@ public class ShardCoreKeyMapTests extends ESTestCase {
         RandomIndexWriter w3 = new RandomIndexWriter(random(), dir3);
         w3.addDocument(new Document());
 
-        ShardId shardId1 = new ShardId("index1", 1);
-        ShardId shardId2 = new ShardId("index1", 3);
-        ShardId shardId3 = new ShardId("index2", 2);
+        ShardId shardId1 = new ShardId("index1", "_na_", 1);
+        ShardId shardId2 = new ShardId("index1", "_na_", 3);
+        ShardId shardId3 = new ShardId("index2", "_na_", 2);
 
         ElasticsearchDirectoryReader reader1 = ElasticsearchDirectoryReader.wrap(w1.getReader(), shardId1);
         ElasticsearchDirectoryReader reader2 = ElasticsearchDirectoryReader.wrap(w2.getReader(), shardId2);

--- a/core/src/test/java/org/elasticsearch/common/lucene/index/ESDirectoryReaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/index/ESDirectoryReaderTests.java
@@ -54,7 +54,7 @@ public class ESDirectoryReaderTests extends ESTestCase {
         iw.addDocument(doc);
         
         // open reader
-        ShardId shardId = new ShardId(new Index("fake"), 1);
+        ShardId shardId = new ShardId("fake", "_na_", 1);
         DirectoryReader ir = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(iw, true), shardId);
         assertEquals(2, ir.numDocs());
         assertEquals(1, ir.leaves().size());

--- a/core/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
@@ -78,7 +78,7 @@ public class VersionsTests extends ESTestCase {
     public void testVersions() throws Exception {
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
-        DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", 1));
+        DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
         MatcherAssert.assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(Versions.NOT_FOUND));
 
         Document doc = new Document();
@@ -145,7 +145,7 @@ public class VersionsTests extends ESTestCase {
         docs.add(doc);
 
         writer.updateDocuments(new Term(UidFieldMapper.NAME, "1"), docs);
-        DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", 1));
+        DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
         assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(5l));
         assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(5l));
 
@@ -170,7 +170,7 @@ public class VersionsTests extends ESTestCase {
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
 
-        DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", 1));
+        DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
         MatcherAssert.assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(Versions.NOT_FOUND));
 
         Document doc = new Document();
@@ -281,7 +281,7 @@ public class VersionsTests extends ESTestCase {
 
         // Force merge and check versions
         iw.forceMerge(1, true);
-        final LeafReader ir = SlowCompositeReaderWrapper.wrap(ElasticsearchDirectoryReader.wrap(DirectoryReader.open(iw.getDirectory()), new ShardId("foo", 1)));
+        final LeafReader ir = SlowCompositeReaderWrapper.wrap(ElasticsearchDirectoryReader.wrap(DirectoryReader.open(iw.getDirectory()), new ShardId("foo", "_na_", 1)));
         final NumericDocValues versions = ir.getNumericDocValues(VersionFieldMapper.NAME);
         assertThat(versions, notNullValue());
         for (int i = 0; i < ir.maxDoc(); ++i) {
@@ -334,7 +334,7 @@ public class VersionsTests extends ESTestCase {
         assertEquals(87, Versions.loadVersion(reader, new Term(UidFieldMapper.NAME, "6")));
         assertEquals(size+1, Versions.lookupStates.size());
         // now wrap the reader
-        DirectoryReader wrapped = ElasticsearchDirectoryReader.wrap(reader, new ShardId("bogus", 5));
+        DirectoryReader wrapped = ElasticsearchDirectoryReader.wrap(reader, new ShardId("bogus", "_na_", 5));
         assertEquals(87, Versions.loadVersion(wrapped, new Term(UidFieldMapper.NAME, "6")));
         // same size map: core cache key is shared
         assertEquals(size+1, Versions.lookupStates.size());

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -1043,7 +1043,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         CountDownLatch beginRelocationLatch = new CountDownLatch(1);
         CountDownLatch endRelocationLatch = new CountDownLatch(1);
         transportServiceNode2.addTracer(new IndicesStoreIntegrationIT.ReclocationStartEndTracer(logger, beginRelocationLatch, endRelocationLatch));
-        internalCluster().client().admin().cluster().prepareReroute().add(new MoveAllocationCommand(new ShardId("test", 0), node_1, node_2)).get();
+        internalCluster().client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("test", 0, node_1, node_2)).get();
         // wait for relocation to start
         beginRelocationLatch.await();
         disruption.startDisrupting();

--- a/core/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -243,7 +243,7 @@ public class AsyncShardFetchTests extends ESTestCase {
         private AtomicInteger reroute = new AtomicInteger();
 
         public TestFetch(ThreadPool threadPool) {
-            super(Loggers.getLogger(TestFetch.class), "test", new ShardId("test", 1), null);
+            super(Loggers.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), null);
             this.threadPool = threadPool;
         }
 

--- a/core/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
@@ -107,7 +107,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
             IndexMetaData dangledIndex = IndexMetaData.builder("test1").settings(indexSettings).build();
             metaStateService.writeIndex("test_write", dangledIndex, null);
 
-            for (Path path : env.indexPaths(new Index("test1"))) {
+            for (Path path : env.indexPaths("test1")) {
                 Files.move(path, path.getParent().resolve("test1_renamed"));
             }
 

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -183,7 +183,7 @@ public class GatewayMetaStateTests extends ESAllocationTestCase {
 
         if (expectMetaData) {
             assertThat(indices.hasNext(), equalTo(true));
-            assertThat(indices.next().getNewMetaData().getIndex(), equalTo("test"));
+            assertThat(indices.next().getNewMetaData().getIndex().getName(), equalTo("test"));
             assertThat(indices.hasNext(), equalTo(false));
         } else {
             assertThat(indices.hasNext(), equalTo(false));

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -357,7 +357,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
         ImmutableOpenMap<String,IndexMetaData> indices = loadedMetaData.indices();
         assertThat(indices.size(), equalTo(latestMetaData.indices().size()));
         for (IndexMetaData original : latestMetaData) {
-            IndexMetaData deserialized = indices.get(original.getIndex());
+            IndexMetaData deserialized = indices.get(original.getIndex().getName());
             assertThat(deserialized, notNullValue());
             assertThat(deserialized.getVersion(), equalTo(original.getVersion()));
             assertThat(deserialized.getNumberOfReplicas(), equalTo(original.getNumberOfReplicas()));

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
@@ -170,7 +170,7 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
 
     private boolean indexDirectoryExists(String nodeName, String indexName) {
         NodeEnvironment nodeEnv = ((InternalTestCluster) cluster()).getInstance(NodeEnvironment.class, nodeName);
-        for (Path path : nodeEnv.indexPaths(new Index(indexName))) {
+        for (Path path : nodeEnv.indexPaths(indexName)) {
             if (Files.exists(path)) {
                 return true;
             }

--- a/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -53,7 +53,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
-    private final ShardId shardId = new ShardId("test", 0);
+    private final ShardId shardId = new ShardId("test", "_na_", 0);
     private final DiscoveryNode node1 = newNode("node1");
     private final DiscoveryNode node2 = newNode("node2");
     private final DiscoveryNode node3 = newNode("node3");
@@ -298,12 +298,12 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
     private RoutingAllocation getRestoreRoutingAllocation(AllocationDeciders allocationDeciders) {
         Version version = randomFrom(Version.CURRENT, Version.V_2_0_0);
         MetaData metaData = MetaData.builder()
-            .put(IndexMetaData.builder(shardId.getIndex()).settings(settings(version)).numberOfShards(1).numberOfReplicas(0)
+            .put(IndexMetaData.builder(shardId.getIndexName()).settings(settings(version)).numberOfShards(1).numberOfReplicas(0)
                 .putActiveAllocationIds(0, version == Version.CURRENT ? Sets.newHashSet("allocId") : Collections.emptySet()))
             .build();
 
         RoutingTable routingTable = RoutingTable.builder()
-            .addAsRestore(metaData.index(shardId.getIndex()), new RestoreSource(new SnapshotId("test", "test"), version, shardId.getIndex()))
+            .addAsRestore(metaData.index(shardId.getIndex()), new RestoreSource(new SnapshotId("test", "test"), version, shardId.getIndexName()))
             .build();
         ClusterState state = ClusterState.builder(org.elasticsearch.cluster.ClusterName.DEFAULT)
             .metaData(metaData)
@@ -366,14 +366,14 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
     private RoutingAllocation getRecoverOnAnyNodeRoutingAllocation(AllocationDeciders allocationDeciders) {
         Version version = randomFrom(Version.CURRENT, Version.V_2_0_0);
         MetaData metaData = MetaData.builder()
-            .put(IndexMetaData.builder(shardId.getIndex()).settings(settings(version)
+            .put(IndexMetaData.builder(shardId.getIndexName()).settings(settings(version)
                 .put(IndexMetaData.SETTING_SHARED_FILESYSTEM, true)
                 .put(IndexMetaData.SETTING_SHARED_FS_ALLOW_RECOVERY_ON_ANY_NODE, true))
                 .numberOfShards(1).numberOfReplicas(0).putActiveAllocationIds(0, version == Version.CURRENT ? Sets.newHashSet("allocId") : Collections.emptySet()))
             .build();
 
         RoutingTable routingTable = RoutingTable.builder()
-            .addAsRestore(metaData.index(shardId.getIndex()), new RestoreSource(new SnapshotId("test", "test"), Version.CURRENT, shardId.getIndex()))
+            .addAsRestore(metaData.index(shardId.getIndex()), new RestoreSource(new SnapshotId("test", "test"), Version.CURRENT, shardId.getIndexName()))
             .build();
         ClusterState state = ClusterState.builder(org.elasticsearch.cluster.ClusterName.DEFAULT)
             .metaData(metaData)
@@ -388,7 +388,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
      */
     public void testEnoughCopiesFoundForAllocationOnLegacyIndex() {
         MetaData metaData = MetaData.builder()
-                .put(IndexMetaData.builder(shardId.getIndex()).settings(settings(Version.V_2_0_0)).numberOfShards(1).numberOfReplicas(2))
+                .put(IndexMetaData.builder(shardId.getIndexName()).settings(settings(Version.V_2_0_0)).numberOfShards(1).numberOfReplicas(2))
                 .build();
         RoutingTable routingTable = RoutingTable.builder()
                 .addAsRecovery(metaData.index(shardId.getIndex()))
@@ -429,7 +429,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
      */
     public void testEnoughCopiesFoundForAllocationOnLegacyIndexWithDifferentVersion() {
         MetaData metaData = MetaData.builder()
-                .put(IndexMetaData.builder(shardId.getIndex()).settings(settings(Version.V_2_0_0)).numberOfShards(1).numberOfReplicas(2))
+                .put(IndexMetaData.builder(shardId.getIndexName()).settings(settings(Version.V_2_0_0)).numberOfShards(1).numberOfReplicas(2))
                 .build();
         RoutingTable routingTable = RoutingTable.builder()
                 .addAsRecovery(metaData.index(shardId.getIndex()))
@@ -466,7 +466,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
     private RoutingAllocation routingAllocationWithOnePrimaryNoReplicas(AllocationDeciders deciders, boolean asNew, Version version, String... activeAllocationIds) {
         MetaData metaData = MetaData.builder()
-                .put(IndexMetaData.builder(shardId.getIndex()).settings(settings(version))
+                .put(IndexMetaData.builder(shardId.getIndexName()).settings(settings(version))
                     .numberOfShards(1).numberOfReplicas(0).putActiveAllocationIds(0, Sets.newHashSet(activeAllocationIds)))
             .build();
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();

--- a/core/src/test/java/org/elasticsearch/gateway/PriorityComparatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PriorityComparatorTests.java
@@ -126,8 +126,8 @@ public class PriorityComparatorTests extends ESTestCase {
         ShardRouting previous = null;
         for (ShardRouting routing : shards) {
             if (previous != null) {
-                IndexMeta prevMeta = map.get(previous.getIndex());
-                IndexMeta currentMeta = map.get(routing.getIndex());
+                IndexMeta prevMeta = map.get(previous.getIndexName());
+                IndexMeta currentMeta = map.get(routing.getIndexName());
                 if (prevMeta.priority == currentMeta.priority) {
                     if (prevMeta.creationDate == currentMeta.creationDate) {
                         if (prevMeta.name.equals(currentMeta.name) == false) {

--- a/core/src/test/java/org/elasticsearch/gateway/PriorityComparatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PriorityComparatorTests.java
@@ -60,9 +60,9 @@ public class PriorityComparatorTests extends ESTestCase {
         });
         RoutingNodes.UnassignedShards.UnassignedIterator iterator = shards.iterator();
         ShardRouting next = iterator.next();
-        assertEquals("newest", next.index());
+        assertEquals("newest", next.getIndexName());
         next = iterator.next();
-        assertEquals("oldest", next.index());
+        assertEquals("oldest", next.getIndexName());
         assertFalse(iterator.hasNext());
     }
 
@@ -90,9 +90,9 @@ public class PriorityComparatorTests extends ESTestCase {
         });
         RoutingNodes.UnassignedShards.UnassignedIterator iterator = shards.iterator();
         ShardRouting next = iterator.next();
-        assertEquals("oldest", next.index());
+        assertEquals("oldest", next.getIndexName());
         next = iterator.next();
-        assertEquals("newest", next.index());
+        assertEquals("newest", next.getIndexName());
         assertFalse(iterator.hasNext());
     }
 

--- a/core/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -64,7 +64,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  */
 public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
-    private final ShardId shardId = new ShardId("test", 0);
+    private final ShardId shardId = new ShardId("test", "_na_", 0);
     private final DiscoveryNode node1 = newNode("node1");
     private final DiscoveryNode node2 = newNode("node2");
     private final DiscoveryNode node3 = newNode("node3");
@@ -286,7 +286,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
     private RoutingAllocation onePrimaryOnNode1And1Replica(AllocationDeciders deciders, Settings settings, UnassignedInfo.Reason reason) {
         ShardRouting primaryShard = TestShardRouting.newShardRouting(shardId.getIndex(), shardId.getId(), node1.id(), true, ShardRoutingState.STARTED, 10);
         MetaData metaData = MetaData.builder()
-                .put(IndexMetaData.builder(shardId.getIndex()).settings(settings(Version.CURRENT).put(settings))
+                .put(IndexMetaData.builder(shardId.getIndexName()).settings(settings(Version.CURRENT).put(settings))
                     .numberOfShards(1).numberOfReplicas(1)
                     .putActiveAllocationIds(0, Sets.newHashSet(primaryShard.allocationId().getId())))
             .build();
@@ -308,7 +308,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
     private RoutingAllocation onePrimaryOnNode1And1ReplicaRecovering(AllocationDeciders deciders) {
         ShardRouting primaryShard = TestShardRouting.newShardRouting(shardId.getIndex(), shardId.getId(), node1.id(), true, ShardRoutingState.STARTED, 10);
         MetaData metaData = MetaData.builder()
-                .put(IndexMetaData.builder(shardId.getIndex()).settings(settings(Version.CURRENT))
+                .put(IndexMetaData.builder(shardId.getIndexName()).settings(settings(Version.CURRENT))
                     .numberOfShards(1).numberOfReplicas(1)
                     .putActiveAllocationIds(0, Sets.newHashSet(primaryShard.allocationId().getId())))
                 .build();

--- a/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -116,9 +116,9 @@ public class IndexModuleTests extends ESTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        index = new Index("foo");
         settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
-        indexSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        indexSettings = IndexSettingsModule.newIndexSettings("foo", settings);
+        index = indexSettings.getIndex();
         environment = new Environment(settings);
         nodeServicesProvider = newNodeServiceProvider(settings, environment, null);
         nodeEnvironment = new NodeEnvironment(settings, environment);
@@ -147,7 +147,6 @@ public class IndexModuleTests extends ESTestCase {
 
 
     public void testRegisterIndexStore() throws IOException {
-        final Index index = new Index("foo");
         final Settings settings = Settings
             .builder()
             .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -155,6 +154,7 @@ public class IndexModuleTests extends ESTestCase {
             .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), "foo_store")
             .build();
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        final Index index = indexSettings.getIndex();
         IndexModule module = new IndexModule(indexSettings, null, new AnalysisRegistry(null, environment));
         module.addIndexStore("foo_store", FooStore::new);
         IndexService indexService = module.newIndexService(nodeEnvironment, deleter, nodeServicesProvider, mapperRegistry);
@@ -217,7 +217,7 @@ public class IndexModuleTests extends ESTestCase {
                 .put("index.similarity.my_similarity.key", "there is a key")
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
-        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings(new Index("foo"), indexSettings), null, new AnalysisRegistry(null, environment));
+        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings("foo", indexSettings), null, new AnalysisRegistry(null, environment));
         module.addSimilarity("test_similarity", (string, settings) -> new SimilarityProvider() {
             @Override
             public String name() {
@@ -245,7 +245,7 @@ public class IndexModuleTests extends ESTestCase {
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
-        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings(new Index("foo"), indexSettings), null, new AnalysisRegistry(null, environment));
+        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings("foo", indexSettings), null, new AnalysisRegistry(null, environment));
         try {
             module.newIndexService(nodeEnvironment, deleter, nodeServicesProvider, mapperRegistry);
         } catch (IllegalArgumentException ex) {
@@ -259,7 +259,7 @@ public class IndexModuleTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .build();
-        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings(new Index("foo"), indexSettings), null, new AnalysisRegistry(null, environment));
+        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings("foo", indexSettings), null, new AnalysisRegistry(null, environment));
         try {
             module.newIndexService(nodeEnvironment, deleter, nodeServicesProvider, mapperRegistry);
         } catch (IllegalArgumentException ex) {
@@ -271,7 +271,7 @@ public class IndexModuleTests extends ESTestCase {
         Settings indexSettings = Settings.settingsBuilder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings(new Index("foo"), indexSettings), null, new AnalysisRegistry(null, environment));
+        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings("foo", indexSettings), null, new AnalysisRegistry(null, environment));
         try {
             module.registerQueryCache("index", IndexQueryCache::new);
             fail("only once");
@@ -299,7 +299,7 @@ public class IndexModuleTests extends ESTestCase {
                 .put(IndexModule.INDEX_QUERY_CACHE_TYPE_SETTING.getKey(), "custom")
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings(new Index("foo"), indexSettings), null, new AnalysisRegistry(null, environment));
+        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings("foo", indexSettings), null, new AnalysisRegistry(null, environment));
         module.registerQueryCache("custom", (a, b) -> new CustomQueryCache());
         try {
             module.registerQueryCache("custom", (a, b) -> new CustomQueryCache());
@@ -317,7 +317,7 @@ public class IndexModuleTests extends ESTestCase {
         Settings indexSettings = Settings.settingsBuilder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings(new Index("foo"), indexSettings), null, new AnalysisRegistry(null, environment));
+        IndexModule module = new IndexModule(IndexSettingsModule.newIndexSettings("foo", indexSettings), null, new AnalysisRegistry(null, environment));
         IndexService indexService = module.newIndexService(nodeEnvironment, deleter, nodeServicesProvider, mapperRegistry);
         assertTrue(indexService.cache().query() instanceof IndexQueryCache);
         indexService.close("simon says", false);
@@ -335,7 +335,7 @@ public class IndexModuleTests extends ESTestCase {
 
         @Override
         public Index index() {
-            return new Index("test");
+            return new Index("test", "_na_");
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -114,7 +114,7 @@ public class IndexSettingsTests extends ESTestCase {
         if (settings.length > 0) {
             settingSet.addAll(Arrays.asList(settings));
         }
-        return new IndexSettings(metaData, nodeSettings, (idx) -> Regex.simpleMatch(idx, metaData.getIndex()), new IndexScopedSettings(Settings.EMPTY, settingSet));
+        return new IndexSettings(metaData, nodeSettings, (idx) -> Regex.simpleMatch(idx, metaData.getIndex().getName()), new IndexScopedSettings(Settings.EMPTY, settingSet));
     }
 
 

--- a/core/src/test/java/org/elasticsearch/index/MergePolicySettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/MergePolicySettingsTests.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.index.IndexSettingsTests.newIndexMeta;
 import static org.hamcrest.Matchers.equalTo;
 
 public class MergePolicySettingsTests extends ESTestCase {
-    protected final ShardId shardId = new ShardId(new Index("index"), 1);
+    protected final ShardId shardId = new ShardId("index", "_na_", 1);
 
     public void testCompoundFileSettings() throws IOException {
         assertThat(new MergePolicyConfig(logger, indexSettings(Settings.EMPTY)).getMergePolicy().getNoCFSRatio(), equalTo(0.1));

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisModuleTests.java
@@ -68,8 +68,7 @@ public class AnalysisModuleTests extends ModuleTestCase {
     }
 
     public AnalysisService getAnalysisService(AnalysisRegistry registry, Settings settings) throws IOException {
-        Index index = new Index("test");
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("test", settings);
         return registry.build(idxSettings);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisServiceTests.java
@@ -58,7 +58,7 @@ public class AnalysisServiceTests extends ESTestCase {
             .put(IndexMetaData.SETTING_VERSION_CREATED, version)
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
             .build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index("index"), settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
         assertThat(analysisService.defaultIndexAnalyzer().analyzer(), instanceOf(StandardAnalyzer.class));
         assertThat(analysisService.defaultSearchAnalyzer().analyzer(), instanceOf(StandardAnalyzer.class));
@@ -68,7 +68,7 @@ public class AnalysisServiceTests extends ESTestCase {
     public void testOverrideDefaultAnalyzer() throws IOException {
         Version version = VersionUtils.randomVersion(getRandom());
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
-        AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings(new Index("index"), settings),
+        AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings("index", settings),
                 Collections.singletonMap("default", analyzerProvider("default")),
                 Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
         assertThat(analysisService.defaultIndexAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
@@ -80,7 +80,7 @@ public class AnalysisServiceTests extends ESTestCase {
         Version version = VersionUtils.randomVersionBetween(getRandom(), Version.V_3_0_0, Version.CURRENT);
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
         try {
-            AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings(new Index("index"), settings),
+            AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings("index", settings),
                     Collections.singletonMap("default_index", new PreBuiltAnalyzerProvider("default_index", AnalyzerScope.INDEX, new EnglishAnalyzer())),
                     Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
             fail("Expected ISE");
@@ -93,7 +93,7 @@ public class AnalysisServiceTests extends ESTestCase {
     public void testBackCompatOverrideDefaultIndexAnalyzer() {
         Version version = VersionUtils.randomVersionBetween(getRandom(), VersionUtils.getFirstVersion(), VersionUtils.getPreviousVersion(Version.V_3_0_0));
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
-        AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings(new Index("index"), settings),
+        AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings("index", settings),
                 Collections.singletonMap("default_index", analyzerProvider("default_index")),
                 Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
         assertThat(analysisService.defaultIndexAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
@@ -104,7 +104,7 @@ public class AnalysisServiceTests extends ESTestCase {
     public void testOverrideDefaultSearchAnalyzer() {
         Version version = VersionUtils.randomVersion(getRandom());
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
-        AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings(new Index("index"), settings),
+        AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings("index", settings),
                 Collections.singletonMap("default_search", analyzerProvider("default_search")),
                 Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
         assertThat(analysisService.defaultIndexAnalyzer().analyzer(), instanceOf(StandardAnalyzer.class));
@@ -118,7 +118,7 @@ public class AnalysisServiceTests extends ESTestCase {
         Map<String, AnalyzerProvider> analyzers = new HashMap<>();
         analyzers.put("default_index", analyzerProvider("default_index"));
         analyzers.put("default_search", analyzerProvider("default_search"));
-        AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings(new Index("index"), settings),
+        AnalysisService analysisService = new AnalysisService(IndexSettingsModule.newIndexSettings("index", settings),
                 analyzers, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
         assertThat(analysisService.defaultIndexAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
         assertThat(analysisService.defaultSearchAnalyzer().analyzer(), instanceOf(EnglishAnalyzer.class));
@@ -137,7 +137,7 @@ public class AnalysisServiceTests extends ESTestCase {
                 .put("index.analysis.analyzer.custom_analyzer_1.tokenizer", "whitespace")
                 .putArray("index.analysis.analyzer.custom_analyzer_1.filter", "lowercase", "word_delimiter").build();
 
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index("index"), indexSettings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
         try (NamedAnalyzer custom_analyser = analysisService.analyzer("custom_analyzer")) {
             assertNotNull(custom_analyser);
@@ -182,7 +182,7 @@ public class AnalysisServiceTests extends ESTestCase {
                 .putArray("index.analysis.analyzer.custom_analyzer.filter", "lowercase", "wordDelimiter")
                 .put("index.analysis.analyzer.custom_analyzer_1.tokenizer", "whitespace")
                 .putArray("index.analysis.analyzer.custom_analyzer_1.filter", "lowercase", "word_delimiter").build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index("index"), indexSettings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
 
         TokenFilterFactory word_delimiter = analysisService.tokenFilter("word_delimiter");
@@ -192,7 +192,7 @@ public class AnalysisServiceTests extends ESTestCase {
         assertSame(analysisService.tokenFilter("porterStem"), analysisService.tokenFilter("porter_stem"));
 
         //unconfigured
-        IndexSettings idxSettings1 = IndexSettingsModule.newIndexSettings(new Index("index"),  settingsBuilder()
+        IndexSettings idxSettings1 = IndexSettingsModule.newIndexSettings("index",  settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
         AnalysisService analysisService1 = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings1);
         assertSame(analysisService1.tokenFilter("wordDelimiter"), analysisService1.tokenFilter("word_delimiter"));
@@ -203,7 +203,7 @@ public class AnalysisServiceTests extends ESTestCase {
         Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
         Settings indexSettings = settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index("index"), indexSettings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
         AnalysisService otherAnalysisSergice = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
         final int numIters = randomIntBetween(5, 20);

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisTestsHelper.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisTestsHelper.java
@@ -45,11 +45,10 @@ public class AnalysisTestsHelper {
 
     public static AnalysisService createAnalysisServiceFromSettings(
             Settings settings) throws IOException {
-        Index index = new Index("test");
         if (settings.get(IndexMetaData.SETTING_VERSION_CREATED) == null) {
             settings = Settings.builder().put(settings).put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
         }
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("test", settings);
         Environment environment = new Environment(settings);
         return new AnalysisRegistry(new HunspellService(settings, environment, Collections.emptyMap()), environment).build(idxSettings);
     }

--- a/core/src/test/java/org/elasticsearch/index/analysis/CharFilterTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/CharFilterTests.java
@@ -33,7 +33,6 @@ import static org.elasticsearch.common.settings.Settings.settingsBuilder;
  */
 public class CharFilterTests extends ESTokenStreamTestCase {
     public void testMappingCharFilter() throws Exception {
-        Index index = new Index("test");
         Settings settings = settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put("index.analysis.char_filter.my_mapping.type", "mapping")
@@ -42,7 +41,7 @@ public class CharFilterTests extends ESTokenStreamTestCase {
                 .putArray("index.analysis.analyzer.custom_with_char_filter.char_filter", "my_mapping")
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("test", settings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
         NamedAnalyzer analyzer1 = analysisService.analyzer("custom_with_char_filter");
 
@@ -53,14 +52,13 @@ public class CharFilterTests extends ESTokenStreamTestCase {
     }
 
     public void testHtmlStripCharFilter() throws Exception {
-        Index index = new Index("test");
         Settings settings = settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put("index.analysis.analyzer.custom_with_char_filter.tokenizer", "standard")
                 .putArray("index.analysis.analyzer.custom_with_char_filter.char_filter", "html_strip")
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("test", settings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
 
         NamedAnalyzer analyzer1 = analysisService.analyzer("custom_with_char_filter");

--- a/core/src/test/java/org/elasticsearch/index/analysis/CompoundAnalysisTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/CompoundAnalysisTests.java
@@ -50,9 +50,8 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class CompoundAnalysisTests extends ESTestCase {
     public void testDefaultsCompoundAnalysis() throws Exception {
-        Index index = new Index("test");
         Settings settings = getJsonSettings();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("test", settings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings),
                 Collections.emptyMap(),Collections.singletonMap("myfilter", MyFilterTokenFilterFactory::new),Collections.emptyMap(),Collections.emptyMap()).build(idxSettings);
 
@@ -70,8 +69,7 @@ public class CompoundAnalysisTests extends ESTestCase {
     }
 
     private List<String> analyze(Settings settings, String analyzerName, String text) throws IOException {
-        Index index = new Index("test");
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("test", settings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings),
                 Collections.emptyMap(), Collections.singletonMap("myfilter", MyFilterTokenFilterFactory::new),Collections.emptyMap(),Collections.emptyMap()).build(idxSettings);
 

--- a/core/src/test/java/org/elasticsearch/index/analysis/NGramTokenizerFactoryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/NGramTokenizerFactoryTests.java
@@ -48,7 +48,7 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class NGramTokenizerFactoryTests extends ESTokenStreamTestCase {
     public void testParseTokenChars() {
-        final Index index = new Index("test");
+        final Index index = new Index("test", "_na_");
         final String name = "ngr";
         final Settings indexSettings = newAnalysisSettingsBuilder().build();
         IndexSettings indexProperties = IndexSettingsModule.newIndexSettings(index, indexSettings);
@@ -71,7 +71,7 @@ public class NGramTokenizerFactoryTests extends ESTokenStreamTestCase {
     }
 
     public void testNoTokenChars() throws IOException {
-        final Index index = new Index("test");
+        final Index index = new Index("test", "_na_");
         final String name = "ngr";
         final Settings indexSettings = newAnalysisSettingsBuilder().build();
         final Settings settings = newAnalysisSettingsBuilder().put("min_gram", 2).put("max_gram", 4).putArray("token_chars", new String[0]).build();
@@ -82,7 +82,7 @@ public class NGramTokenizerFactoryTests extends ESTokenStreamTestCase {
 
     public void testPreTokenization() throws IOException {
         // Make sure that pretokenization works well and that it can be used even with token chars which are supplementary characters
-        final Index index = new Index("test");
+        final Index index = new Index("test", "_na_");
         final String name = "ngr";
         final Settings indexSettings = newAnalysisSettingsBuilder().build();
         Settings settings = newAnalysisSettingsBuilder().put("min_gram", 2).put("max_gram", 3).put("token_chars", "letter,digit").build();
@@ -99,7 +99,7 @@ public class NGramTokenizerFactoryTests extends ESTokenStreamTestCase {
 
     public void testPreTokenizationEdge() throws IOException {
         // Make sure that pretokenization works well and that it can be used even with token chars which are supplementary characters
-        final Index index = new Index("test");
+        final Index index = new Index("test", "_na_");
         final String name = "ngr";
         final Settings indexSettings = newAnalysisSettingsBuilder().build();
         Settings settings = newAnalysisSettingsBuilder().put("min_gram", 2).put("max_gram", 3).put("token_chars", "letter,digit").build();
@@ -117,7 +117,7 @@ public class NGramTokenizerFactoryTests extends ESTokenStreamTestCase {
     public void testBackwardsCompatibilityEdgeNgramTokenFilter() throws Exception {
         int iters = scaledRandomIntBetween(20, 100);
         for (int i = 0; i < iters; i++) {
-            final Index index = new Index("test");
+            final Index index = new Index("test", "_na_");
             final String name = "ngr";
             Version v = randomVersion(random());
             if (v.onOrAfter(Version.V_0_90_2)) {

--- a/core/src/test/java/org/elasticsearch/index/analysis/PatternCaptureTokenFilterTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/PatternCaptureTokenFilterTests.java
@@ -40,7 +40,7 @@ public class PatternCaptureTokenFilterTests extends ESTokenStreamTestCase {
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .build();
 
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index("index"), settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
 
         NamedAnalyzer analyzer1 = analysisService.analyzer("single");
@@ -58,7 +58,7 @@ public class PatternCaptureTokenFilterTests extends ESTokenStreamTestCase {
 
     public void testNoPatterns() {
         try {
-            new PatternCaptureGroupTokenFilterFactory(IndexSettingsModule.newIndexSettings(new Index("test"), Settings.EMPTY), null, "pattern_capture", settingsBuilder().put("pattern", "foobar").build());
+            new PatternCaptureGroupTokenFilterFactory(IndexSettingsModule.newIndexSettings("test", Settings.EMPTY), null, "pattern_capture", settingsBuilder().put("pattern", "foobar").build());
             fail ("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("required setting 'patterns' is missing"));

--- a/core/src/test/java/org/elasticsearch/index/analysis/StopAnalyzerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/StopAnalyzerTests.java
@@ -38,7 +38,7 @@ public class StopAnalyzerTests extends ESTokenStreamTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index("index"), settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
 
         NamedAnalyzer analyzer1 = analysisService.analyzer("analyzer1");

--- a/core/src/test/java/org/elasticsearch/index/analysis/synonyms/SynonymsAnalysisTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/synonyms/SynonymsAnalysisTests.java
@@ -67,7 +67,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), home)
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
 
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index("index"), settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
         analysisService = new AnalysisRegistry(null, new Environment(settings)).build(idxSettings);
 
 

--- a/core/src/test/java/org/elasticsearch/index/cache/bitset/BitSetFilterCacheTests.java
+++ b/core/src/test/java/org/elasticsearch/index/cache/bitset/BitSetFilterCacheTests.java
@@ -34,7 +34,6 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.join.BitSetProducer;
-import org.apache.lucene.store.BaseDirectoryWrapper;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.util.Accountable;
@@ -157,7 +156,7 @@ public class BitSetFilterCacheTests extends ESTestCase {
                 stats.addAndGet(accountable.ramBytesUsed());
                 if (writerReader != reader) {
                     assertNotNull(shardId);
-                    assertEquals("test", shardId.index().name());
+                    assertEquals("test", shardId.index().getName());
                     assertEquals(0, shardId.id());
                 } else {
                     assertNull(shardId);
@@ -170,7 +169,7 @@ public class BitSetFilterCacheTests extends ESTestCase {
                 stats.addAndGet(-accountable.ramBytesUsed());
                 if (writerReader != reader) {
                     assertNotNull(shardId);
-                    assertEquals("test", shardId.index().name());
+                    assertEquals("test", shardId.index().getName());
                     assertEquals(0, shardId.id());
                 } else {
                     assertNull(shardId);

--- a/core/src/test/java/org/elasticsearch/index/cache/bitset/BitSetFilterCacheTests.java
+++ b/core/src/test/java/org/elasticsearch/index/cache/bitset/BitSetFilterCacheTests.java
@@ -56,7 +56,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class BitSetFilterCacheTests extends ESTestCase {
 
-    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings(new Index("test"), Settings.EMPTY);
+    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
     private final IndicesWarmer warmer = new IndicesWarmer(Settings.EMPTY, null);
 
 
@@ -92,7 +92,7 @@ public class BitSetFilterCacheTests extends ESTestCase {
         writer.commit();
 
         DirectoryReader reader = DirectoryReader.open(writer, false);
-        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId(new Index("test"), 0));
+        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId("test", "_na_", 0));
         IndexSearcher searcher = new IndexSearcher(reader);
 
         BitsetFilterCache cache = new BitsetFilterCache(INDEX_SETTINGS, warmer, new BitsetFilterCache.Listener() {
@@ -117,7 +117,7 @@ public class BitSetFilterCacheTests extends ESTestCase {
         writer.forceMerge(1);
         reader.close();
         reader = DirectoryReader.open(writer, false);
-        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId(new Index("test"), 0));
+        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId("test", "_na_", 0));
         searcher = new IndexSearcher(reader);
 
         assertThat(matchCount(filter, reader), equalTo(3));
@@ -143,7 +143,7 @@ public class BitSetFilterCacheTests extends ESTestCase {
         writer.addDocument(document);
         writer.commit();
         final DirectoryReader writerReader = DirectoryReader.open(writer, false);
-        final IndexReader reader = ElasticsearchDirectoryReader.wrap(writerReader, new ShardId("test", 0));
+        final IndexReader reader = ElasticsearchDirectoryReader.wrap(writerReader, new ShardId("test", "_na_", 0));
 
         final AtomicLong stats = new AtomicLong();
         final AtomicInteger onCacheCalls = new AtomicInteger();
@@ -156,7 +156,7 @@ public class BitSetFilterCacheTests extends ESTestCase {
                 stats.addAndGet(accountable.ramBytesUsed());
                 if (writerReader != reader) {
                     assertNotNull(shardId);
-                    assertEquals("test", shardId.index().getName());
+                    assertEquals("test", shardId.getIndexName());
                     assertEquals(0, shardId.id());
                 } else {
                     assertNull(shardId);
@@ -169,7 +169,7 @@ public class BitSetFilterCacheTests extends ESTestCase {
                 stats.addAndGet(-accountable.ramBytesUsed());
                 if (writerReader != reader) {
                     assertNotNull(shardId);
-                    assertEquals("test", shardId.index().getName());
+                    assertEquals("test", shardId.getIndexName());
                     assertEquals(0, shardId.id());
                 } else {
                     assertNull(shardId);
@@ -217,7 +217,7 @@ public class BitSetFilterCacheTests extends ESTestCase {
         writer.addDocument(new Document());
         DirectoryReader reader = DirectoryReader.open(writer, true);
         writer.close();
-        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId(new Index("test2"), 0));
+        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId("test2", "_na_", 0));
         
         BitSetProducer producer = cache.getBitSetProducer(new MatchAllDocsQuery());
         

--- a/core/src/test/java/org/elasticsearch/index/codec/CodecTests.java
+++ b/core/src/test/java/org/elasticsearch/index/codec/CodecTests.java
@@ -108,7 +108,7 @@ public class CodecTests extends ESTestCase {
         Settings nodeSettings = settingsBuilder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .build();
-        IndexSettings settings = IndexSettingsModule.newIndexSettings(new Index("_na"), nodeSettings);
+        IndexSettings settings = IndexSettingsModule.newIndexSettings("_na", nodeSettings);
         SimilarityService similarityService = new SimilarityService(settings, Collections.emptyMap());
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(nodeSettings)).build(settings);
         MapperRegistry mapperRegistry = new MapperRegistry(Collections.emptyMap(), Collections.emptyMap());

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -134,8 +134,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class InternalEngineTests extends ESTestCase {
 
-    protected final ShardId shardId = new ShardId(new Index("index"), 1);
-    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings(new Index("index"), Settings.EMPTY);
+    protected final ShardId shardId = new ShardId(new Index("index", "_na_"), 1);
+    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
 
     protected ThreadPool threadPool;
 
@@ -275,7 +275,7 @@ public class InternalEngineTests extends ESTestCase {
             public void onFailedEngine(String reason, @Nullable Throwable t) {
                 // we don't need to notify anybody in this test
             }
-        }, new TranslogHandler(shardId.index().getName(), logger), IndexSearcher.getDefaultQueryCache(), IndexSearcher.getDefaultQueryCachingPolicy(), translogConfig, TimeValue.timeValueMinutes(5));
+        }, new TranslogHandler(shardId.getIndexName(), logger), IndexSearcher.getDefaultQueryCache(), IndexSearcher.getDefaultQueryCachingPolicy(), translogConfig, TimeValue.timeValueMinutes(5));
         try {
             config.setCreate(Lucene.indexExists(store.directory()) == false);
         } catch (IOException e) {
@@ -1879,10 +1879,10 @@ public class InternalEngineTests extends ESTestCase {
         public final AtomicInteger recoveredOps = new AtomicInteger(0);
 
         public TranslogHandler(String indexName, ESLogger logger) {
-            super(new ShardId("test", 0), null, logger);
+            super(new ShardId("test", "_na_", 0), null, logger);
             Settings settings = Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
             RootObjectMapper.Builder rootBuilder = new RootObjectMapper.Builder("test");
-            Index index = new Index(indexName);
+            Index index = new Index(indexName, "_na_");
             IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(index, settings);
             AnalysisService analysisService = new AnalysisService(indexSettings, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
             SimilarityService similarityService = new SimilarityService(indexSettings, Collections.emptyMap());

--- a/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
@@ -88,7 +88,7 @@ import static org.hamcrest.Matchers.nullValue;
  */
 public class ShadowEngineTests extends ESTestCase {
 
-    protected final ShardId shardId = new ShardId(new Index("index"), 1);
+    protected final ShardId shardId = new ShardId("index", "_na_", 1);
 
     protected ThreadPool threadPool;
 
@@ -181,7 +181,7 @@ public class ShadowEngineTests extends ESTestCase {
 
 
     protected Store createStore(final Directory directory) throws IOException {
-        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(shardId.index(), Settings.EMPTY);
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(shardId.getIndex(), Settings.EMPTY);
         final DirectoryService directoryService = new DirectoryService(shardId, indexSettings) {
             @Override
             public Directory newDirectory() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -142,7 +142,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
         if (readerContext != null) {
             readerContext.reader().close();
         }
-        topLevelReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", 1));
+        topLevelReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
         LeafReader reader = SlowCompositeReaderWrapper.wrap(topLevelReader);
         readerContext = reader.getContext();
         return readerContext;

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -389,7 +389,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
             }
         }
         DirectoryReader directoryReader = DirectoryReader.open(writer, true);
-        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(new Index("test"), 0));
+        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId("test", "_na_", 0));
         IndexSearcher searcher = new IndexSearcher(directoryReader);
         IndexFieldData<?> fieldData = getForField("text");
         final Object missingValue;

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -49,7 +49,6 @@ import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
@@ -389,7 +388,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
             }
         }
         DirectoryReader directoryReader = DirectoryReader.open(writer, true);
-        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId("test", "_na_", 0));
+        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(indexService.index(), 0));
         IndexSearcher searcher = new IndexSearcher(directoryReader);
         IndexFieldData<?> fieldData = getForField("text");
         final Object missingValue;

--- a/core/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
@@ -67,7 +67,7 @@ public class FieldDataCacheTests extends ESTestCase {
             }
         }
         iw.close();
-        DirectoryReader ir = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("_index", 0));
+        DirectoryReader ir = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("_index", "_na_", 0));
 
         DummyAccountingFieldDataCache fieldDataCache = new DummyAccountingFieldDataCache();
         // Testing SortedSetDVOrdinalsIndexFieldData:

--- a/core/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -145,14 +145,14 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         writer.addDocument(doc);
         DirectoryReader open = DirectoryReader.open(writer, true);
         final boolean wrap = randomBoolean();
-        final IndexReader reader = wrap ? ElasticsearchDirectoryReader.wrap(open, new ShardId("test", 1)) : open;
+        final IndexReader reader = wrap ? ElasticsearchDirectoryReader.wrap(open, new ShardId("test", "_na_", 1)) : open;
         final AtomicInteger onCacheCalled = new AtomicInteger();
         final AtomicInteger onRemovalCalled = new AtomicInteger();
         ifdService.setListener(new IndexFieldDataCache.Listener() {
             @Override
             public void onCache(ShardId shardId, String fieldName, FieldDataType fieldDataType, Accountable ramUsage) {
                 if (wrap) {
-                    assertEquals(new ShardId("test", 1), shardId);
+                    assertEquals(new ShardId("test", "_na_", 1), shardId);
                 } else {
                     assertNull(shardId);
                 }
@@ -162,7 +162,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
             @Override
             public void onRemoval(ShardId shardId, String fieldName, FieldDataType fieldDataType, boolean wasEvicted, long sizeInBytes) {
                 if (wrap) {
-                    assertEquals(new ShardId("test", 1), shardId);
+                    assertEquals(new ShardId("test", "_na_", 1), shardId);
                 } else {
                     assertNull(shardId);
                 }
@@ -207,7 +207,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         ThreadPool threadPool = new ThreadPool("random_threadpool_name");
         try {
             IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null, threadPool);
-            IndexFieldDataService ifds = new IndexFieldDataService(IndexSettingsModule.newIndexSettings(new Index("test"), Settings.EMPTY), cache, null, null);
+            IndexFieldDataService ifds = new IndexFieldDataService(IndexSettingsModule.newIndexSettings("test", Settings.EMPTY), cache, null, null);
             ft.setName("some_long");
             ft.setHasDocValues(true);
             ifds.getForField(ft); // no exception

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -191,7 +191,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                 .build();
         Settings indexSettings = Settings.settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, version).build();
-        index = new Index(randomAsciiOfLengthBetween(1, 10));
+        index = new Index(randomAsciiOfLengthBetween(1, 10), "_na_");
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings);
         final TestClusterService clusterService = new TestClusterService();
         clusterService.setState(new ClusterState.Builder(clusterService.state()).metaData(new MetaData.Builder().put(

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -195,7 +195,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings);
         final TestClusterService clusterService = new TestClusterService();
         clusterService.setState(new ClusterState.Builder(clusterService.state()).metaData(new MetaData.Builder().put(
-                new IndexMetaData.Builder(index.name()).settings(indexSettings).numberOfShards(1).numberOfReplicas(0))));
+                new IndexMetaData.Builder(index.getName()).settings(indexSettings).numberOfShards(1).numberOfReplicas(0))));
         SettingsModule settingsModule = new SettingsModule(settings, new SettingsFilter(settings));
         settingsModule.registerSetting(InternalSettingsPlugin.VERSION_CREATED);
         final Client proxy = (Client) Proxy.newProxyInstance(

--- a/core/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
@@ -220,7 +220,7 @@ public abstract class AbstractNumberNestedSortingTestCase extends AbstractFieldD
 
         MultiValueMode sortMode = MultiValueMode.SUM;
         DirectoryReader directoryReader = DirectoryReader.open(writer, false);
-        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(new Index("test"), 0));
+        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId("test", "_na_", 0));
         IndexSearcher searcher = new IndexSearcher(directoryReader);
         Query parentFilter = new TermQuery(new Term("__type", "parent"));
         Query childFilter = Queries.not(parentFilter);

--- a/core/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/search/nested/AbstractNumberNestedSortingTestCase.java
@@ -38,7 +38,6 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.AbstractFieldDataTestCase;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
@@ -220,7 +219,7 @@ public abstract class AbstractNumberNestedSortingTestCase extends AbstractFieldD
 
         MultiValueMode sortMode = MultiValueMode.SUM;
         DirectoryReader directoryReader = DirectoryReader.open(writer, false);
-        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId("test", "_na_", 0));
+        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(indexService.index(), 0));
         IndexSearcher searcher = new IndexSearcher(directoryReader);
         Query parentFilter = new TermQuery(new Term("__type", "parent"));
         Query childFilter = Queries.not(parentFilter);

--- a/core/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
@@ -95,7 +95,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
 
         MultiValueMode sortMode = randomFrom(Arrays.asList(MultiValueMode.MIN, MultiValueMode.MAX));
         DirectoryReader reader = DirectoryReader.open(writer, false);
-        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId(new Index("test"), 0));
+        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId("test", "_na_", 0));
         IndexSearcher searcher = new IndexSearcher(reader);
         PagedBytesIndexFieldData indexFieldData1 = getForField("f");
         IndexFieldData<?> indexFieldData2 = NoOrdinalsStringFieldDataTests.hideOrdinals(indexFieldData1);
@@ -280,7 +280,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
 
         MultiValueMode sortMode = MultiValueMode.MIN;
         DirectoryReader reader = DirectoryReader.open(writer, false);
-        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId(new Index("test"), 0));
+        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId("test", "_na_", 0));
         IndexSearcher searcher = new IndexSearcher(reader);
         PagedBytesIndexFieldData indexFieldData = getForField("field2");
         Query parentFilter = new TermQuery(new Term("__type", "parent"));

--- a/core/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/nested/NestedSortingTests.java
@@ -43,7 +43,6 @@ import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.fielddata.AbstractFieldDataTestCase;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -95,7 +94,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
 
         MultiValueMode sortMode = randomFrom(Arrays.asList(MultiValueMode.MIN, MultiValueMode.MAX));
         DirectoryReader reader = DirectoryReader.open(writer, false);
-        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId("test", "_na_", 0));
+        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId(indexService.index(), 0));
         IndexSearcher searcher = new IndexSearcher(reader);
         PagedBytesIndexFieldData indexFieldData1 = getForField("f");
         IndexFieldData<?> indexFieldData2 = NoOrdinalsStringFieldDataTests.hideOrdinals(indexFieldData1);
@@ -280,7 +279,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
 
         MultiValueMode sortMode = MultiValueMode.MIN;
         DirectoryReader reader = DirectoryReader.open(writer, false);
-        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId("test", "_na_", 0));
+        reader = ElasticsearchDirectoryReader.wrap(reader, new ShardId(indexService.index(), 0));
         IndexSearcher searcher = new IndexSearcher(reader);
         PagedBytesIndexFieldData indexFieldData = getForField("field2");
         Query parentFilter = new TermQuery(new Term("__type", "parent"));

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexSearcherWrapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexSearcherWrapperTests.java
@@ -56,7 +56,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         doc.add(new StringField("id", "1", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         doc.add(new TextField("field", "doc", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         writer.addDocument(doc);
-        DirectoryReader open = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", 1));
+        DirectoryReader open = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
         IndexSearcher searcher = new IndexSearcher(open);
         assertEquals(1, searcher.search(new TermQuery(new Term("field", "doc")), 1).totalHits);
         final AtomicInteger closeCalls = new AtomicInteger(0);
@@ -106,7 +106,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         doc.add(new StringField("id", "1", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         doc.add(new TextField("field", "doc", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         writer.addDocument(doc);
-        DirectoryReader open = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", 1));
+        DirectoryReader open = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
         IndexSearcher searcher = new IndexSearcher(open);
         assertEquals(1, searcher.search(new TermQuery(new Term("field", "doc")), 1).totalHits);
         searcher.setSimilarity(iwc.getSimilarity());
@@ -148,7 +148,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         doc.add(new StringField("id", "1", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         doc.add(new TextField("field", "doc", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         writer.addDocument(doc);
-        DirectoryReader open = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", 1));
+        DirectoryReader open = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
         IndexSearcher searcher = new IndexSearcher(open);
         assertEquals(1, searcher.search(new TermQuery(new Term("field", "doc")), 1).totalHits);
         searcher.setSimilarity(iwc.getSimilarity());
@@ -168,7 +168,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         doc.add(new StringField("id", "1", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         doc.add(new TextField("field", "doc", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         writer.addDocument(doc);
-        DirectoryReader open = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", 1));
+        DirectoryReader open = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
         IndexSearcher searcher = new IndexSearcher(open);
         assertEquals(1, searcher.search(new TermQuery(new Term("field", "doc")), 1).totalHits);
         searcher.setSimilarity(iwc.getSimilarity());
@@ -258,7 +258,7 @@ public class IndexSearcherWrapperTests extends ESTestCase {
         public DirectoryReader getDelegate() {
             if (hideDelegate) {
                 try {
-                    return ElasticsearchDirectoryReader.wrap(super.getDelegate(), new ShardId("foo", 1));
+                    return ElasticsearchDirectoryReader.wrap(super.getDelegate(), new ShardId("foo", "_na_", 1));
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -137,7 +137,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
 
     public void testWriteShardState() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            ShardId id = new ShardId("foo", 1);
+            ShardId id = new ShardId("foo", "_na_", 1);
             long version = between(1, Integer.MAX_VALUE / 2);
             boolean primary = randomBoolean();
             AllocationId allocationId = randomBoolean() ? null : randomAllocationId();
@@ -163,7 +163,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         createIndex("test");
         ensureGreen();
         NodeEnvironment env = getInstanceFromNode(NodeEnvironment.class);
-        Path[] shardPaths = env.availableShardPaths(new ShardId("test", 0));
+        Path[] shardPaths = env.availableShardPaths(new ShardId("test", "_na_", 0));
         logger.info("--> paths: [{}]", (Object)shardPaths);
         // Should not be able to acquire the lock because it's already open
         try {
@@ -175,7 +175,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         // Test without the regular shard lock to assume we can acquire it
         // (worst case, meaning that the shard lock could be acquired and
         // we're green to delete the shard's directory)
-        ShardLock sLock = new DummyShardLock(new ShardId("test", 0));
+        ShardLock sLock = new DummyShardLock(new ShardId("test", "_na_", 0));
         try {
             env.deleteShardDirectoryUnderLock(sLock, IndexSettingsModule.newIndexSettings("test", Settings.EMPTY));
             fail("should not have been able to delete the directory");
@@ -250,7 +250,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         ShardStateMetaData shardStateMetaData = load(logger, env.availableShardPaths(shard.shardId));
         assertEquals(shardStateMetaData, getShardStateMetadata(shard));
 
-        routing = TestShardRouting.newShardRouting(shard.shardId.index().getName(), shard.shardId.id(), routing.currentNodeId(), null, routing.primary(), ShardRoutingState.INITIALIZING, shard.shardRouting.allocationId(), shard.shardRouting.version() + 1);
+        routing = TestShardRouting.newShardRouting(shard.shardId.getIndexName(), shard.shardId.id(), routing.currentNodeId(), null, routing.primary(), ShardRoutingState.INITIALIZING, shard.shardRouting.allocationId(), shard.shardRouting.version() + 1);
         shard.updateRoutingEntry(routing, true);
         shard.deleteShardState();
 
@@ -274,7 +274,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         ShardPath shardPath = ShardPath.loadShardPath(logger, env, shard.shardId(), test.getIndexSettings());
         assertNotNull(shardPath);
         // but index can't be opened for a failed shard
-        assertThat("store index should be corrupted", Store.canOpenIndex(logger, shardPath.resolveIndex()), equalTo(false));
+        assertThat("store index should be corrupted", Store.canOpenIndex(logger, shardPath.resolveIndex(), shard.shardId()), equalTo(false));
     }
 
     ShardStateMetaData getShardStateMetadata(IndexShard shard) {
@@ -407,7 +407,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
     }
 
     private void setDurability(IndexShard shard, Translog.Durability durability) {
-        client().admin().indices().prepareUpdateSettings(shard.shardId.getIndex()).setSettings(settingsBuilder().put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), durability.name()).build()).get();
+        client().admin().indices().prepareUpdateSettings(shard.shardId.getIndexName()).setSettings(settingsBuilder().put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), durability.name()).build()).get();
         assertEquals(durability, shard.getTranslogDurability());
     }
 

--- a/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTests.java
@@ -49,7 +49,7 @@ import java.util.Map;
 /** Separate test class from ShardPathTests because we need static (BeforeClass) setup to install mock filesystems... */
 public class NewPathForShardTests extends ESTestCase {
 
-    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings(new Index("index"), Settings.EMPTY);
+    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
 
     // Sneakiness to install mock file stores so we can pretend how much free space we have on each path.data:
     private static MockFileStore aFileStore = new MockFileStore("mocka");
@@ -182,7 +182,7 @@ public class NewPathForShardTests extends ESTestCase {
         aFileStore.usableSpace = 100000;
         bFileStore.usableSpace = 1000;
 
-        ShardId shardId = new ShardId("index", 0);
+        ShardId shardId = new ShardId("index", "_na_", 0);
         ShardPath result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, Collections.<Path,Integer>emptyMap());
         assertTrue(result.getDataPath().toString().contains(aPathPart));
 
@@ -190,7 +190,7 @@ public class NewPathForShardTests extends ESTestCase {
         aFileStore.usableSpace = 1000;
         bFileStore.usableSpace = 100000;
 
-        shardId = new ShardId("index", 0);
+        shardId = new ShardId("index", "_na_", 0);
         result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, Collections.<Path,Integer>emptyMap());
         assertTrue(result.getDataPath().toString().contains(bPathPart));
 

--- a/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
@@ -42,11 +42,11 @@ public class ShardPathTests extends ESTestCase {
             Settings.Builder builder = settingsBuilder().put(IndexMetaData.SETTING_INDEX_UUID, "0xDEADBEEF")
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
             Settings settings = builder.build();
-            ShardId shardId = new ShardId("foo", 0);
+            ShardId shardId = new ShardId("foo", "_na_", 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);
             ShardStateMetaData.FORMAT.write(new ShardStateMetaData(2, true, "0xDEADBEEF", AllocationId.newInitializing()), 2, path);
-            ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.index(), settings));
+            ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
             assertEquals(path, shardPath.getDataPath());
             assertEquals("0xDEADBEEF", shardPath.getIndexUUID());
             assertEquals("foo", shardPath.getShardId().getIndex());
@@ -60,12 +60,12 @@ public class ShardPathTests extends ESTestCase {
             Settings.Builder builder = settingsBuilder().put(IndexMetaData.SETTING_INDEX_UUID, "0xDEADBEEF")
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
             Settings settings = builder.build();
-            ShardId shardId = new ShardId("foo", 0);
+            ShardId shardId = new ShardId("foo", "_na_", 0);
             Path[] paths = env.availableShardPaths(shardId);
             assumeTrue("This test tests multi data.path but we only got one", paths.length > 1);
             int id = randomIntBetween(1, 10);
             ShardStateMetaData.FORMAT.write(new ShardStateMetaData(id, true, "0xDEADBEEF", AllocationId.newInitializing()), id, paths);
-            ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.index(), settings));
+            ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
             fail("Expected IllegalStateException");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), containsString("more than one shard state found"));
@@ -77,12 +77,12 @@ public class ShardPathTests extends ESTestCase {
             Settings.Builder builder = settingsBuilder().put(IndexMetaData.SETTING_INDEX_UUID, "foobar")
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
             Settings settings = builder.build();
-            ShardId shardId = new ShardId("foo", 0);
+            ShardId shardId = new ShardId("foo", "_na_", 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);
             int id = randomIntBetween(1, 10);
             ShardStateMetaData.FORMAT.write(new ShardStateMetaData(id, true, "0xDEADBEEF", AllocationId.newInitializing()), id, path);
-            ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.index(), settings));
+            ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
             fail("Expected IllegalStateException");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), containsString("expected: foobar on shard path"));
@@ -92,7 +92,7 @@ public class ShardPathTests extends ESTestCase {
     public void testIllegalCustomDataPath() {
         final Path path = createTempDir().resolve("foo").resolve("0");
         try {
-            new ShardPath(true, path, path, "foo", new ShardId("foo", 0));
+            new ShardPath(true, path, path, "foo", new ShardId("foo", "_na_", 0));
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), is("shard state path must be different to the data path when using custom data paths"));
@@ -101,7 +101,7 @@ public class ShardPathTests extends ESTestCase {
 
     public void testValidCtor() {
         final Path path = createTempDir().resolve("foo").resolve("0");
-        ShardPath shardPath = new ShardPath(false, path, path, "foo", new ShardId("foo", 0));
+        ShardPath shardPath = new ShardPath(false, path, path, "foo", new ShardId("foo", "_na_", 0));
         assertFalse(shardPath.isCustomDataPath());
         assertEquals(shardPath.getDataPath(), path);
         assertEquals(shardPath.getShardStatePath(), path);
@@ -132,11 +132,11 @@ public class ShardPathTests extends ESTestCase {
             nodeSettings = Settings.EMPTY;
         }
         try (final NodeEnvironment env = newNodeEnvironment(nodeSettings)) {
-            ShardId shardId = new ShardId("foo", 0);
+            ShardId shardId = new ShardId("foo", "_na_", 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);
             ShardStateMetaData.FORMAT.write(new ShardStateMetaData(2, true, "0xDEADBEEF", AllocationId.newInitializing()), 2, path);
-            ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.index(), indexSetttings));
+            ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), indexSetttings));
             boolean found = false;
             for (Path p : env.nodeDataPaths()) {
                 if (p.equals(shardPath.getRootStatePath())) {

--- a/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
@@ -49,7 +49,7 @@ public class ShardPathTests extends ESTestCase {
             ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
             assertEquals(path, shardPath.getDataPath());
             assertEquals("0xDEADBEEF", shardPath.getIndexUUID());
-            assertEquals("foo", shardPath.getShardId().getIndex());
+            assertEquals("foo", shardPath.getShardId().getIndexName());
             assertEquals(path.resolve("translog"), shardPath.resolveTranslog());
             assertEquals(path.resolve("index"), shardPath.resolveIndex());
         }

--- a/core/src/test/java/org/elasticsearch/index/shard/ShardUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/ShardUtilsTests.java
@@ -38,7 +38,7 @@ public class ShardUtilsTests extends ESTestCase {
         BaseDirectoryWrapper dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
         writer.commit();
-        ShardId id = new ShardId("foo", random().nextInt());
+        ShardId id = new ShardId("foo", "_na_", random().nextInt());
         try (DirectoryReader reader = DirectoryReader.open(writer, random().nextBoolean())) {
             ElasticsearchDirectoryReader wrap = ElasticsearchDirectoryReader.wrap(reader, id);
             assertEquals(id, ShardUtils.extractShardId(wrap));

--- a/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
@@ -52,8 +52,8 @@ public class IndexStoreTests extends ESTestCase {
         final IndexModule.Type type = RandomPicks.randomFrom(random(), values);
         Settings settings = Settings.settingsBuilder().put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), type.name().toLowerCase(Locale.ROOT))
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(new Index("foo"), settings);
-        FsDirectoryService service = new FsDirectoryService(indexSettings, null, new ShardPath(false, tempDir, tempDir, "foo", new ShardId("foo", 0)));
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("foo", settings);
+        FsDirectoryService service = new FsDirectoryService(indexSettings, null, new ShardPath(false, tempDir, tempDir, "foo", new ShardId("foo", "_na_", 0)));
         try (final Directory directory = service.newFSDirectory(tempDir, NoLockFactory.INSTANCE)) {
             switch (type) {
                 case NIOFS:
@@ -85,7 +85,7 @@ public class IndexStoreTests extends ESTestCase {
 
     public void testStoreDirectoryDefault() throws IOException {
         final Path tempDir = createTempDir().resolve("foo").resolve("0");
-        FsDirectoryService service = new FsDirectoryService(IndexSettingsModule.newIndexSettings(new Index("foo"), Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build()), null, new ShardPath(false, tempDir, tempDir, "foo", new ShardId("foo", 0)));
+        FsDirectoryService service = new FsDirectoryService(IndexSettingsModule.newIndexSettings("foo", Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build()), null, new ShardPath(false, tempDir, tempDir, "foo", new ShardId("foo", "_na_", 0)));
         try (final Directory directory = service.newFSDirectory(tempDir, NoLockFactory.INSTANCE)) {
             if (Constants.WINDOWS) {
                 assertTrue(directory.toString(), directory instanceof MMapDirectory || directory instanceof SimpleFSDirectory);
@@ -100,7 +100,7 @@ public class IndexStoreTests extends ESTestCase {
     public void testUpdateThrottleType() throws IOException {
         Settings settings = Settings.settingsBuilder().put(IndexStoreConfig.INDICES_STORE_THROTTLE_TYPE_SETTING.getKey(), "all")
             .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(new Index("foo"), settings);
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("foo", settings);
         IndexStoreConfig indexStoreConfig = new IndexStoreConfig(settings);
         IndexStore store = new IndexStore(indexSettings, indexStoreConfig);
         assertEquals(StoreRateLimiting.Type.NONE, store.rateLimiting().getType());

--- a/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -109,10 +109,10 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class StoreTests extends ESTestCase {
 
-    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings(new Index("index"), Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build());
+    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build());
 
     public void testRefCount() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         IndexSettings indexSettings = INDEX_SETTINGS;
 
@@ -361,7 +361,7 @@ public class StoreTests extends ESTestCase {
     // agree on the oldest version of a segment. We should fix this test by
     // switching to a static bw index
     public void testWriteLegacyChecksums() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         // set default codec - all segments need checksums
@@ -445,7 +445,7 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testNewChecksums() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         // set default codec - all segments need checksums
@@ -504,7 +504,7 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testMixedChecksums() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         // this time random codec....
@@ -595,7 +595,7 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testRenameFile() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random(), false);
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         {
@@ -867,7 +867,7 @@ public class StoreTests extends ESTestCase {
             IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random)).setCodec(TestUtil.getDefaultCodec());
             iwc.setMergePolicy(NoMergePolicy.INSTANCE);
             iwc.setUseCompoundFile(random.nextBoolean());
-            final ShardId shardId = new ShardId(new Index("index"), 1);
+            final ShardId shardId = new ShardId("index", "_na_", 1);
             DirectoryService directoryService = new LuceneManagedDirectoryService(random);
             Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
             IndexWriter writer = new IndexWriter(store.directory(), iwc);
@@ -897,7 +897,7 @@ public class StoreTests extends ESTestCase {
             IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random)).setCodec(TestUtil.getDefaultCodec());
             iwc.setMergePolicy(NoMergePolicy.INSTANCE);
             iwc.setUseCompoundFile(random.nextBoolean());
-            final ShardId shardId = new ShardId(new Index("index"), 1);
+            final ShardId shardId = new ShardId("index", "_na_", 1);
             DirectoryService directoryService = new LuceneManagedDirectoryService(random);
             store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
             IndexWriter writer = new IndexWriter(store.directory(), iwc);
@@ -995,7 +995,7 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testCleanupFromSnapshot() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         // this time random codec....
@@ -1109,7 +1109,7 @@ public class StoreTests extends ESTestCase {
         metaDataMap.put("_0_1.del", new StoreFileMetaData("_0_1.del", 42, "foobarbaz", null, new BytesRef()));
         Store.MetadataSnapshot snapshot = new Store.MetadataSnapshot(unmodifiableMap(metaDataMap), emptyMap(), 0);
 
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         for (String file : metaDataMap.keySet()) {
@@ -1126,7 +1126,7 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testOnCloseCallback() throws IOException {
-        final ShardId shardId = new ShardId(new Index(randomRealisticUnicodeOfCodepointLengthBetween(1, 10)), randomIntBetween(0, 100));
+        final ShardId shardId = new ShardId(new Index(randomRealisticUnicodeOfCodepointLengthBetween(1, 10), "_na_"), randomIntBetween(0, 100));
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         final AtomicInteger count = new AtomicInteger(0);
         final ShardLock lock = new DummyShardLock(shardId);
@@ -1150,12 +1150,12 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testStoreStats() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Settings settings = Settings.builder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT)
                 .put(Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.timeValueMinutes(0)).build();
-        Store store = new Store(shardId, IndexSettingsModule.newIndexSettings(new Index("index"), settings), directoryService, new DummyShardLock(shardId));
+        Store store = new Store(shardId, IndexSettingsModule.newIndexSettings("index", settings), directoryService, new DummyShardLock(shardId));
         long initialStoreSize = 0;
         for (String extraFiles : store.directory().listAll()) {
             assertTrue("expected extraFS file but got: " + extraFiles, extraFiles.startsWith("extra"));
@@ -1244,7 +1244,7 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testUserDataRead() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         IndexWriterConfig config = newIndexWriterConfig(random(), new MockAnalyzer(random())).setCodec(TestUtil.getDefaultCodec());
@@ -1279,7 +1279,7 @@ public class StoreTests extends ESTestCase {
 
     public void testStreamStoreFilesMetaData() throws Exception {
         Store.MetadataSnapshot metadataSnapshot = createMetaDataSnapshot();
-        TransportNodesListShardStoreMetaData.StoreFilesMetaData outStoreFileMetaData = new TransportNodesListShardStoreMetaData.StoreFilesMetaData(randomBoolean(), new ShardId("test", 0),metadataSnapshot);
+        TransportNodesListShardStoreMetaData.StoreFilesMetaData outStoreFileMetaData = new TransportNodesListShardStoreMetaData.StoreFilesMetaData(randomBoolean(), new ShardId("test", "_na_", 0),metadataSnapshot);
         ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
         OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
         org.elasticsearch.Version targetNodeVersion = randomVersion(random());
@@ -1298,7 +1298,7 @@ public class StoreTests extends ESTestCase {
 
     public void testMarkCorruptedOnTruncatedSegmentsFile() throws IOException {
         IndexWriterConfig iwc = newIndexWriterConfig();
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         DirectoryService directoryService = new LuceneManagedDirectoryService(random());
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         IndexWriter writer = new IndexWriter(store.directory(), iwc);
@@ -1342,19 +1342,19 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testCanOpenIndex() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         IndexWriterConfig iwc = newIndexWriterConfig();
         Path tempDir = createTempDir();
         final BaseDirectoryWrapper dir = newFSDirectory(tempDir);
-        assertFalse(Store.canOpenIndex(logger, tempDir));
+        assertFalse(Store.canOpenIndex(logger, tempDir,shardId));
         IndexWriter writer = new IndexWriter(dir, iwc);
         Document doc = new Document();
         doc.add(new StringField("id", "1", random().nextBoolean() ? Field.Store.YES : Field.Store.NO));
         writer.addDocument(doc);
         writer.commit();
         writer.close();
-        assertTrue(Store.canOpenIndex(logger, tempDir));
+        assertTrue(Store.canOpenIndex(logger, tempDir, shardId));
 
-        final ShardId shardId = new ShardId(new Index("index"), 1);
         DirectoryService directoryService = new DirectoryService(shardId, INDEX_SETTINGS) {
             @Override
             public long throttleTimeInNanos() {
@@ -1368,12 +1368,12 @@ public class StoreTests extends ESTestCase {
         };
         Store store = new Store(shardId, INDEX_SETTINGS, directoryService, new DummyShardLock(shardId));
         store.markStoreCorrupted(new CorruptIndexException("foo", "bar"));
-        assertFalse(Store.canOpenIndex(logger, tempDir));
+        assertFalse(Store.canOpenIndex(logger, tempDir, shardId));
         store.close();
     }
 
     public void testDeserializeCorruptionException() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         final Directory dir = new RAMDirectory(); // I use ram dir to prevent that virusscanner being a PITA
         DirectoryService directoryService = new DirectoryService(shardId, INDEX_SETTINGS) {
             @Override
@@ -1413,7 +1413,7 @@ public class StoreTests extends ESTestCase {
     }
 
     public void testCanReadOldCorruptionMarker() throws IOException {
-        final ShardId shardId = new ShardId(new Index("index"), 1);
+        final ShardId shardId = new ShardId("index", "_na_", 1);
         final Directory dir = new RAMDirectory(); // I use ram dir to prevent that virusscanner being a PITA
         DirectoryService directoryService = new DirectoryService(shardId, INDEX_SETTINGS) {
             @Override

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -91,7 +91,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 @LuceneTestCase.SuppressFileSystems("ExtrasFS")
 public class TranslogTests extends ESTestCase {
 
-    protected final ShardId shardId = new ShardId(new Index("index"), 1);
+    protected final ShardId shardId = new ShardId("index", "_na_", 1);
 
     protected Translog translog;
     protected Path translogDir;
@@ -141,7 +141,7 @@ public class TranslogTests extends ESTestCase {
                 .put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT)
                 .build();
         ByteSizeValue bufferSize = randomBoolean() ? TranslogConfig.DEFAULT_BUFFER_SIZE : new ByteSizeValue(10 + randomInt(128 * 1024), ByteSizeUnit.BYTES);
-        return new TranslogConfig(shardId, path, IndexSettingsModule.newIndexSettings(shardId.index(), build), BigArrays.NON_RECYCLING_INSTANCE, bufferSize);
+        return new TranslogConfig(shardId, path, IndexSettingsModule.newIndexSettings(shardId.getIndex(), build), BigArrays.NON_RECYCLING_INSTANCE, bufferSize);
     }
 
     protected void addToTranslogAndList(Translog translog, ArrayList<Translog.Operation> list, Translog.Operation op) throws IOException {

--- a/core/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
@@ -130,7 +130,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
                 throw new RuntimeException("FAIL");
             }
         });
-        client().admin().cluster().prepareReroute().add(new MoveAllocationCommand(new ShardId("index1", 0), node1, node2)).get();
+        client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("index1", 0, node1, node2)).get();
         ensureGreen("index1");
         ClusterState state = client().admin().cluster().prepareState().get().getState();
         List<ShardRouting> shard = state.getRoutingNodes().shardsWithState(ShardRoutingState.STARTED);

--- a/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -64,8 +64,8 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 4))
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 3))
                 .build());
-        assertFalse("shard on shared filesystem", indicesService.canDeleteIndexContents(new Index("test"), idxSettings, false));
-        assertTrue("shard on shared filesystem and closed", indicesService.canDeleteIndexContents(new Index("test"), idxSettings, true));
+        assertFalse("shard on shared filesystem", indicesService.canDeleteIndexContents(idxSettings.getIndex(), idxSettings, false));
+        assertTrue("shard on shared filesystem and closed", indicesService.canDeleteIndexContents(idxSettings.getIndex(), idxSettings, true));
     }
 
     public void testCanDeleteShardContent() {
@@ -73,12 +73,12 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         IndexMetaData meta = IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(
                 1).build();
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", meta.getSettings());
-        assertFalse("no shard location", indicesService.canDeleteShardContent(new ShardId("test", 0), indexSettings));
+        assertFalse("no shard location", indicesService.canDeleteShardContent(new ShardId("test", "_na_", 0), indexSettings));
         IndexService test = createIndex("test");
         assertTrue(test.hasShard(0));
-        assertFalse("shard is allocated", indicesService.canDeleteShardContent(new ShardId("test", 0), indexSettings));
+        assertFalse("shard is allocated", indicesService.canDeleteShardContent(new ShardId("test", "_na_", 0), indexSettings));
         test.removeShard(0, "boom");
-        assertTrue("shard is removed", indicesService.canDeleteShardContent(new ShardId("test", 0), indexSettings));
+        assertTrue("shard is removed", indicesService.canDeleteShardContent(new ShardId("test", "_na_", 0), indexSettings));
     }
 
     public void testDeleteIndexStore() throws Exception {
@@ -175,7 +175,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         if (randomBoolean()) {
             indicesService.addPendingDelete(new ShardId(test.index(), 0), test.getIndexSettings());
             indicesService.addPendingDelete(new ShardId(test.index(), 1), test.getIndexSettings());
-            indicesService.addPendingDelete(new ShardId("bogus", 1), test.getIndexSettings());
+            indicesService.addPendingDelete(new ShardId("bogus", "_na_", 1), test.getIndexSettings());
             assertEquals(indicesService.numPendingDeletes(test.index()), 2);
             // shard lock released... we can now delete
             indicesService.processPendingDeletes(test.index(), test.getIndexSettings(), new TimeValue(0, TimeUnit.MILLISECONDS));

--- a/core/src/test/java/org/elasticsearch/indices/cache/query/IndicesQueryCacheTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/cache/query/IndicesQueryCacheTests.java
@@ -86,7 +86,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         w.addDocument(new Document());
         DirectoryReader r = DirectoryReader.open(w, false);
         w.close();
-        ShardId shard = new ShardId(new Index("index"), 0);
+        ShardId shard = new ShardId("index", "_na_", 0);
         r = ElasticsearchDirectoryReader.wrap(r, shard);
         IndexSearcher s = new IndexSearcher(r);
         s.setQueryCachingPolicy(QueryCachingPolicy.ALWAYS_CACHE);
@@ -156,7 +156,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         w1.addDocument(new Document());
         DirectoryReader r1 = DirectoryReader.open(w1, false);
         w1.close();
-        ShardId shard1 = new ShardId(new Index("index"), 0);
+        ShardId shard1 = new ShardId("index", "_na_", 0);
         r1 = ElasticsearchDirectoryReader.wrap(r1, shard1);
         IndexSearcher s1 = new IndexSearcher(r1);
         s1.setQueryCachingPolicy(QueryCachingPolicy.ALWAYS_CACHE);
@@ -166,7 +166,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         w2.addDocument(new Document());
         DirectoryReader r2 = DirectoryReader.open(w2, false);
         w2.close();
-        ShardId shard2 = new ShardId(new Index("index"), 1);
+        ShardId shard2 = new ShardId("index", "_na_", 1);
         r2 = ElasticsearchDirectoryReader.wrap(r2, shard2);
         IndexSearcher s2 = new IndexSearcher(r2);
         s2.setQueryCachingPolicy(QueryCachingPolicy.ALWAYS_CACHE);
@@ -281,7 +281,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         w1.addDocument(new Document());
         DirectoryReader r1 = DirectoryReader.open(w1, false);
         w1.close();
-        ShardId shard1 = new ShardId(new Index("index"), 0);
+        ShardId shard1 = new ShardId("index", "_na_", 0);
         r1 = ElasticsearchDirectoryReader.wrap(r1, shard1);
         IndexSearcher s1 = new IndexSearcher(r1);
         s1.setQueryCachingPolicy(QueryCachingPolicy.ALWAYS_CACHE);
@@ -291,7 +291,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         w2.addDocument(new Document());
         DirectoryReader r2 = DirectoryReader.open(w2, false);
         w2.close();
-        ShardId shard2 = new ShardId(new Index("index"), 1);
+        ShardId shard2 = new ShardId("index", "_na_", 1);
         r2 = ElasticsearchDirectoryReader.wrap(r2, shard2);
         IndexSearcher s2 = new IndexSearcher(r2);
         s2.setQueryCachingPolicy(QueryCachingPolicy.ALWAYS_CACHE);

--- a/core/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.ShardId;
@@ -90,6 +91,8 @@ public class FlushIT extends ESIntegTestCase {
         prepareCreate("test").setSettings(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).get();
         ensureGreen();
 
+        final Index index = client().admin().cluster().prepareState().get().getState().metaData().index("test").getIndex();
+
         IndexStats indexStats = client().admin().indices().prepareStats("test").get().getIndex("test");
         for (ShardStats shardStats : indexStats.getShards()) {
             assertNull(shardStats.getCommitStats().getUserData().get(Engine.SYNC_COMMIT_ID));
@@ -98,7 +101,7 @@ public class FlushIT extends ESIntegTestCase {
         ShardsSyncedFlushResult result;
         if (randomBoolean()) {
             logger.info("--> sync flushing shard 0");
-            result = SyncedFlushUtil.attemptSyncedFlush(internalCluster(), new ShardId("test", "_na_", 0));
+            result = SyncedFlushUtil.attemptSyncedFlush(internalCluster(), new ShardId(index, 0));
         } else {
             logger.info("--> sync flushing index [test]");
             SyncedFlushResponse indicesResult = client().admin().indices().prepareSyncedFlush("test").get();

--- a/core/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -98,7 +98,7 @@ public class FlushIT extends ESIntegTestCase {
         ShardsSyncedFlushResult result;
         if (randomBoolean()) {
             logger.info("--> sync flushing shard 0");
-            result = SyncedFlushUtil.attemptSyncedFlush(internalCluster(), new ShardId("test", 0));
+            result = SyncedFlushUtil.attemptSyncedFlush(internalCluster(), new ShardId("test", "_na_", 0));
         } else {
             logger.info("--> sync flushing index [test]");
             SyncedFlushResponse indicesResult = client().admin().indices().prepareSyncedFlush("test").get();
@@ -121,7 +121,7 @@ public class FlushIT extends ESIntegTestCase {
         ShardRouting shardRouting = clusterState.getRoutingTable().index("test").shard(0).iterator().next();
         String currentNodeName = clusterState.nodes().resolveNode(shardRouting.currentNodeId()).name();
         assertFalse(currentNodeName.equals(newNodeName));
-        internalCluster().client().admin().cluster().prepareReroute().add(new MoveAllocationCommand(new ShardId("test", 0), currentNodeName, newNodeName)).get();
+        internalCluster().client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("test", 0, currentNodeName, newNodeName)).get();
 
         client().admin().cluster().prepareHealth()
                 .setWaitForRelocatingShards(0)

--- a/core/src/test/java/org/elasticsearch/indices/flush/SyncedFlushSingleNodeTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/flush/SyncedFlushSingleNodeTests.java
@@ -133,7 +133,7 @@ public class SyncedFlushSingleNodeTests extends ESSingleNodeTestCase {
 
         SyncedFlushService flushService = getInstanceFromNode(SyncedFlushService.class);
         SyncedFlushUtil.LatchedListener listener = new SyncedFlushUtil.LatchedListener();
-        flushService.attemptSyncedFlush(new ShardId("test", 1), listener);
+        flushService.attemptSyncedFlush(new ShardId("test", "_na_", 1), listener);
         listener.latch.await();
         assertNotNull(listener.error);
         assertNull(listener.result);
@@ -151,7 +151,7 @@ public class SyncedFlushSingleNodeTests extends ESSingleNodeTestCase {
         assertEquals("closed", listener.error.getMessage());
 
         listener = new SyncedFlushUtil.LatchedListener();
-        flushService.attemptSyncedFlush(new ShardId("index not found", 0), listener);
+        flushService.attemptSyncedFlush(new ShardId("index not found", "_na_", 0), listener);
         listener.latch.await();
         assertNotNull(listener.error);
         assertNull(listener.result);

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -258,7 +258,7 @@ public class IndexRecoveryIT extends ESIntegTestCase {
 
         logger.info("--> move shard from: {} to: {}", nodeA, nodeB);
         client().admin().cluster().prepareReroute()
-                .add(new MoveAllocationCommand(new ShardId(INDEX_NAME, 0), nodeA, nodeB))
+                .add(new MoveAllocationCommand(INDEX_NAME, 0, nodeA, nodeB))
                 .execute().actionGet().getState();
 
         logger.info("--> waiting for recovery to start both on source and target");
@@ -384,7 +384,7 @@ public class IndexRecoveryIT extends ESIntegTestCase {
 
         logger.info("--> move replica shard from: {} to: {}", nodeA, nodeC);
         client().admin().cluster().prepareReroute()
-                .add(new MoveAllocationCommand(new ShardId(INDEX_NAME, 0), nodeA, nodeC))
+                .add(new MoveAllocationCommand(INDEX_NAME, 0, nodeA, nodeC))
                 .execute().actionGet().getState();
 
         response = client().admin().indices().prepareRecoveries(INDEX_NAME).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -58,7 +58,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RecoverySourceHandlerTests extends ESTestCase {
-    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings(new Index("index"), Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build());
+    private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build());
     private final ShardId shardId = new ShardId(INDEX_SETTINGS.getIndex(), 1);
     private final ClusterSettings service = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTests.java
@@ -346,7 +346,7 @@ public class RecoveryStateTests extends ESTestCase {
         stages[i] = stages[j];
         stages[j] = t;
         try {
-            RecoveryState state = new RecoveryState(new ShardId("bla", 0), randomBoolean(), randomFrom(Type.values()), discoveryNode, discoveryNode);
+            RecoveryState state = new RecoveryState(new ShardId("bla", "_na_", 0), randomBoolean(), randomFrom(Type.values()), discoveryNode, discoveryNode);
             for (Stage stage : stages) {
                 state.setStage(stage);
             }
@@ -360,7 +360,7 @@ public class RecoveryStateTests extends ESTestCase {
         i = randomIntBetween(1, stages.length - 1);
         ArrayList<Stage> list = new ArrayList<>(Arrays.asList(Arrays.copyOfRange(stages, 0, i)));
         list.addAll(Arrays.asList(stages));
-        RecoveryState state = new RecoveryState(new ShardId("bla", 0), randomBoolean(), randomFrom(Type.values()), discoveryNode, discoveryNode);
+        RecoveryState state = new RecoveryState(new ShardId("bla", "_na_", 0), randomBoolean(), randomFrom(Type.values()), discoveryNode, discoveryNode);
         for (Stage stage : list) {
             state.setStage(stage);
         }

--- a/core/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
@@ -40,7 +40,7 @@ public class StartRecoveryRequestTests extends ESTestCase {
     public void testSerialization() throws Exception {
         Version targetNodeVersion = randomVersion(random());
         StartRecoveryRequest outRequest = new StartRecoveryRequest(
-                new ShardId("test", 0),
+                new ShardId("test", "_na_", 0),
                 new DiscoveryNode("a", new LocalTransportAddress("1"), targetNodeVersion),
                 new DiscoveryNode("b", new LocalTransportAddress("1"), targetNodeVersion),
                 true,

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -69,7 +69,7 @@ public class IndicesStoreTests extends ESTestCase {
 
         ClusterState.Builder clusterState = ClusterState.builder(new ClusterName("test"));
         clusterState.metaData(MetaData.builder().put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(numShards).numberOfReplicas(numReplicas)));
-        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", 1));
+        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
 
         assertFalse(indicesStore.shardCanBeDeleted(clusterState.build(), routingTable.build()));
     }
@@ -80,7 +80,7 @@ public class IndicesStoreTests extends ESTestCase {
 
         ClusterState.Builder clusterState = ClusterState.builder(new ClusterName("test"));
         clusterState.metaData(MetaData.builder().put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(numShards).numberOfReplicas(numReplicas)));
-        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", 1));
+        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
 
         for (int i = 0; i < numShards; i++) {
             int unStartedShard = randomInt(numReplicas);
@@ -108,7 +108,7 @@ public class IndicesStoreTests extends ESTestCase {
         ClusterState.Builder clusterState = ClusterState.builder(new ClusterName("test"));
         clusterState.metaData(MetaData.builder().put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(numShards).numberOfReplicas(numReplicas)));
         clusterState.nodes(DiscoveryNodes.builder().localNodeId(localNode.id()).put(localNode).put(new DiscoveryNode("xyz", new LocalTransportAddress("xyz"), Version.CURRENT)));
-        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", 1));
+        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
         int localShardId = randomInt(numShards - 1);
         for (int i = 0; i < numShards; i++) {
             String nodeId = i == localShardId ? localNode.getId() : randomBoolean() ? "abc" : "xyz";
@@ -130,7 +130,7 @@ public class IndicesStoreTests extends ESTestCase {
         ClusterState.Builder clusterState = ClusterState.builder(new ClusterName("test"));
         clusterState.metaData(MetaData.builder().put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(numShards).numberOfReplicas(numReplicas)));
         clusterState.nodes(DiscoveryNodes.builder().localNodeId(localNode.id()).put(localNode));
-        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", 1));
+        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
         for (int i = 0; i < numShards; i++) {
             String relocatingNodeId = randomBoolean() ? null : "def";
             routingTable.addShard(TestShardRouting.newShardRouting("test", i, "xyz", relocatingNodeId, true, ShardRoutingState.STARTED, 0));
@@ -152,7 +152,7 @@ public class IndicesStoreTests extends ESTestCase {
         ClusterState.Builder clusterState = ClusterState.builder(new ClusterName("test"));
         clusterState.metaData(MetaData.builder().put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(numShards).numberOfReplicas(numReplicas)));
         clusterState.nodes(DiscoveryNodes.builder().localNodeId(localNode.id()).put(localNode).put(new DiscoveryNode("xyz", new LocalTransportAddress("xyz"), nodeVersion)));
-        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", 1));
+        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
         for (int i = 0; i < numShards; i++) {
             routingTable.addShard(TestShardRouting.newShardRouting("test", i, "xyz", null, true, ShardRoutingState.STARTED, 0));
             for (int j = 0; j < numReplicas; j++) {
@@ -177,7 +177,7 @@ public class IndicesStoreTests extends ESTestCase {
                 .put(new DiscoveryNode("xyz", new LocalTransportAddress("xyz"), Version.CURRENT))
                 .put(new DiscoveryNode("def", new LocalTransportAddress("def"), nodeVersion) // <-- only set relocating, since we're testing that in this test
                 ));
-        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", 1));
+        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
         for (int i = 0; i < numShards; i++) {
             routingTable.addShard(TestShardRouting.newShardRouting("test", i, "xyz", "def", true, ShardRoutingState.STARTED, 0));
             for (int j = 0; j < numReplicas; j++) {

--- a/core/src/test/java/org/elasticsearch/mget/SimpleMgetIT.java
+++ b/core/src/test/java/org/elasticsearch/mget/SimpleMgetIT.java
@@ -59,7 +59,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         assertThat(mgetResponse.getResponses()[1].getIndex(), is("nonExistingIndex"));
         assertThat(mgetResponse.getResponses()[1].isFailed(), is(true));
         assertThat(mgetResponse.getResponses()[1].getFailure().getMessage(), is("no such index"));
-        assertThat(((ElasticsearchException)mgetResponse.getResponses()[1].getFailure().getFailure()).getIndex(), is("nonExistingIndex"));
+        assertThat(((ElasticsearchException) mgetResponse.getResponses()[1].getFailure().getFailure()).getIndex().getName(), is("nonExistingIndex"));
 
 
         mgetResponse = client().prepareMultiGet()
@@ -69,7 +69,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
         assertThat(mgetResponse.getResponses()[0].getIndex(), is("nonExistingIndex"));
         assertThat(mgetResponse.getResponses()[0].isFailed(), is(true));
         assertThat(mgetResponse.getResponses()[0].getFailure().getMessage(), is("no such index"));
-        assertThat(((ElasticsearchException)mgetResponse.getResponses()[0].getFailure().getFailure()).getIndex(), is("nonExistingIndex"));
+        assertThat(((ElasticsearchException) mgetResponse.getResponses()[0].getFailure().getFailure()).getIndex().getName(), is("nonExistingIndex"));
 
 
     }

--- a/core/src/test/java/org/elasticsearch/percolator/PercolateDocumentParserTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolateDocumentParserTests.java
@@ -92,7 +92,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         parser = new PercolateDocumentParser(highlightPhase, new SortParseElement(), aggregationPhase);
 
         request = Mockito.mock(PercolateShardRequest.class);
-        Mockito.when(request.shardId()).thenReturn(new ShardId(new Index("_index"), 0));
+        Mockito.when(request.shardId()).thenReturn(new ShardId("_index", "_na_", 0));
         Mockito.when(request.documentType()).thenReturn("type");
     }
 
@@ -104,7 +104,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
                 .endObject();
         Mockito.when(request.source()).thenReturn(source.bytes());
 
-        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", "_index", 0), mapperService);
+        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService);
         ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
     }
@@ -123,7 +123,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
                 .endObject();
         Mockito.when(request.source()).thenReturn(source.bytes());
 
-        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", "_index", 0), mapperService);
+        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService);
         ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
         assertThat(context.percolateQuery(), equalTo(new TermQuery(new Term("field1", "value1"))));
@@ -147,7 +147,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         Mockito.when(request.source()).thenReturn(source.bytes());
         Mockito.when(request.docSource()).thenReturn(docSource.bytes());
 
-        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", "_index", 0), mapperService);
+        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService);
         ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
         assertThat(context.percolateQuery(), equalTo(new TermQuery(new Term("field1", "value1"))));
@@ -174,7 +174,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         Mockito.when(request.source()).thenReturn(source.bytes());
         Mockito.when(request.docSource()).thenReturn(docSource.bytes());
 
-        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", "_index", 0), mapperService);
+        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService);
         try {
             parser.parse(request, context, mapperService, queryShardContext);
         } catch (IllegalArgumentException e) {

--- a/core/src/test/java/org/elasticsearch/percolator/PercolatorServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolatorServiceTests.java
@@ -42,22 +42,15 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.analysis.AnalysisService;
-import org.elasticsearch.index.analysis.AnalyzerProvider;
-import org.elasticsearch.index.analysis.CharFilterFactory;
-import org.elasticsearch.index.analysis.TokenFilterFactory;
-import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.mapper.internal.UidFieldMapper;
+import org.elasticsearch.index.percolator.ExtractQueryTermsService;
 import org.elasticsearch.index.percolator.PercolatorFieldMapper;
 import org.elasticsearch.index.percolator.PercolatorQueriesRegistry;
-import org.elasticsearch.index.percolator.ExtractQueryTermsService;
+import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.similarity.SimilarityService;
-import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.test.ESTestCase;
@@ -65,7 +58,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -96,6 +88,9 @@ public class PercolatorServiceTests extends ESTestCase {
         when(context.shardTarget()).thenReturn(new SearchShardTarget("_id", new Index("_index", "_na_"), 0));
         when(context.percolatorTypeFilter()).thenReturn(new MatchAllDocsQuery());
         when(context.isOnlyCount()).thenReturn(true);
+        IndexShard shard = mock(IndexShard.class);
+        when(shard.shardId()).thenReturn(new ShardId("_index", "_na_", 0));
+        when(context.indexShard()).thenReturn(shard);
 
         PercolatorQueriesRegistry registry = createRegistry();
         addPercolatorQuery("1", new TermQuery(new Term("field", "brown")), indexWriter, registry);
@@ -121,6 +116,9 @@ public class PercolatorServiceTests extends ESTestCase {
         when(context.shardTarget()).thenReturn(new SearchShardTarget("_id", new Index("_index", "_na_"), 0));
         when(context.percolatorTypeFilter()).thenReturn(new MatchAllDocsQuery());
         when(context.size()).thenReturn(10);
+        IndexShard shard = mock(IndexShard.class);
+        when(shard.shardId()).thenReturn(new ShardId("_index", "_na_", 0));
+        when(context.indexShard()).thenReturn(shard);
 
         PercolatorQueriesRegistry registry = createRegistry();
         addPercolatorQuery("1", new TermQuery(new Term("field", "brown")), indexWriter, registry);

--- a/core/src/test/java/org/elasticsearch/percolator/PercolatorServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolatorServiceTests.java
@@ -93,7 +93,7 @@ public class PercolatorServiceTests extends ESTestCase {
 
     public void testCount() throws Exception {
         PercolateContext context = mock(PercolateContext.class);
-        when(context.shardTarget()).thenReturn(new SearchShardTarget("_id", "_index", 0));
+        when(context.shardTarget()).thenReturn(new SearchShardTarget("_id", new Index("_index", "_na_"), 0));
         when(context.percolatorTypeFilter()).thenReturn(new MatchAllDocsQuery());
         when(context.isOnlyCount()).thenReturn(true);
 
@@ -118,7 +118,7 @@ public class PercolatorServiceTests extends ESTestCase {
 
     public void testTopMatching() throws Exception {
         PercolateContext context = mock(PercolateContext.class);
-        when(context.shardTarget()).thenReturn(new SearchShardTarget("_id", "_index", 0));
+        when(context.shardTarget()).thenReturn(new SearchShardTarget("_id", new Index("_index", "_na_"), 0));
         when(context.percolatorTypeFilter()).thenReturn(new MatchAllDocsQuery());
         when(context.size()).thenReturn(10);
 
@@ -158,7 +158,7 @@ public class PercolatorServiceTests extends ESTestCase {
     }
 
     PercolatorQueriesRegistry createRegistry() {
-        Index index = new Index("_index");
+        Index index = new Index("_index", "_na_");
         IndexSettings indexSettings = new IndexSettings(new IndexMetaData.Builder("_index").settings(
                 Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                         .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -130,7 +130,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> relocate the shard from node1 to node2");
         client().admin().cluster().prepareReroute()
-                .add(new MoveAllocationCommand(new ShardId("test", 0), node_1, node_2))
+                .add(new MoveAllocationCommand("test", 0, node_1, node_2))
                 .execute().actionGet();
 
         clusterHealthResponse = client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForRelocatingShards(0).setTimeout(ACCEPTABLE_RELOCATION_TIME).execute().actionGet();
@@ -190,7 +190,7 @@ public class RelocationIT extends ESIntegTestCase {
                 indexer.continueIndexing(numDocs);
                 logger.info("--> START relocate the shard from {} to {}", nodes[fromNode], nodes[toNode]);
                 client().admin().cluster().prepareReroute()
-                        .add(new MoveAllocationCommand(new ShardId("test", 0), nodes[fromNode], nodes[toNode]))
+                        .add(new MoveAllocationCommand("test", 0, nodes[fromNode], nodes[toNode]))
                         .get();
                 if (rarely()) {
                     logger.debug("--> flushing");
@@ -319,7 +319,7 @@ public class RelocationIT extends ESIntegTestCase {
 
 
             client().admin().cluster().prepareReroute()
-                    .add(new MoveAllocationCommand(new ShardId("test", 0), nodes[fromNode], nodes[toNode]))
+                    .add(new MoveAllocationCommand("test", 0, nodes[fromNode], nodes[toNode]))
                     .get();
 
 
@@ -406,7 +406,7 @@ public class RelocationIT extends ESIntegTestCase {
         logger.info("--> verifying no temporary recoveries are left");
         for (String node : internalCluster().getNodeNames()) {
             NodeEnvironment nodeEnvironment = internalCluster().getInstance(NodeEnvironment.class, node);
-            for (final Path shardLoc : nodeEnvironment.availableShardPaths(new ShardId(indexName, 0))) {
+            for (final Path shardLoc : nodeEnvironment.availableShardPaths(new ShardId(indexName, "_na_", 0))) {
                 if (Files.exists(shardLoc)) {
                     assertBusy(new Runnable() {
                         @Override

--- a/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -134,9 +135,9 @@ public class BytesRestResponseTests extends ESTestCase {
         RestRequest request = new FakeRestRequest();
         RestChannel channel = new DetailedExceptionRestChannel(request);
         ShardSearchFailure failure = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                new SearchShardTarget("node_1", "foo", 1));
+                new SearchShardTarget("node_1", new Index("foo", "_na_"), 1));
         ShardSearchFailure failure1 = new ShardSearchFailure(new ParsingException(1, 2, "foobar", null),
-                new SearchShardTarget("node_1", "foo", 2));
+                new SearchShardTarget("node_1", new Index("foo", "_na_"), 2));
         SearchPhaseExecutionException ex = new SearchPhaseExecutionException("search", "all shards failed",  new ShardSearchFailure[] {failure, failure1});
         BytesRestResponse response = new BytesRestResponse(channel, new RemoteTransportException("foo", ex));
         String text = response.content().toUtf8();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
@@ -114,11 +113,11 @@ public class NestedAggregatorTests extends ESSingleNodeTestCase {
         indexWriter.commit();
         indexWriter.close();
 
+        IndexService indexService = createIndex("test");
         DirectoryReader directoryReader = DirectoryReader.open(directory);
-        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId("test", "_na_", 0));
+        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(indexService.index(), 0));
         IndexSearcher searcher = new IndexSearcher(directoryReader);
 
-        IndexService indexService = createIndex("test");
         indexService.mapperService().merge("test", new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef("test", "nested_field", "type=nested").string()), MapperService.MergeReason.MAPPING_UPDATE, false);
         SearchContext searchContext = createSearchContext(indexService);
         AggregationContext context = new AggregationContext(searchContext);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -115,7 +115,7 @@ public class NestedAggregatorTests extends ESSingleNodeTestCase {
         indexWriter.close();
 
         DirectoryReader directoryReader = DirectoryReader.open(directory);
-        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(new Index("test"), 0));
+        directoryReader = ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId("test", "_na_", 0));
         IndexSearcher searcher = new IndexSearcher(directoryReader);
 
         IndexService indexService = createIndex("test");

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -75,7 +76,7 @@ public class SignificanceHeuristicTests extends ESTestCase {
 
         @Override
         public SearchShardTarget shardTarget() {
-            return new SearchShardTarget("no node, this is a unit test", "no index, this is a unit test", 0);
+            return new SearchShardTarget("no node, this is a unit test", new Index("no index, this is a unit test", "_na_"), 0);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
@@ -165,7 +165,7 @@ public class FetchSubPhasePluginIT extends ESIntegTestCase {
                 hitField = new InternalSearchHitField(NAMES[0], new ArrayList<>(1));
                 hitContext.hit().fields().put(NAMES[0], hitField);
             }
-            TermVectorsResponse termVector = context.indexShard().getTermVectors(new TermVectorsRequest(context.indexShard().shardId().index().getName(), hitContext.hit().type(), hitContext.hit().id()));
+            TermVectorsResponse termVector = context.indexShard().getTermVectors(new TermVectorsRequest(context.indexShard().shardId().getIndex().getName(), hitContext.hit().type(), hitContext.hit().id()));
             try {
                 Map<String, Integer> tv = new HashMap<>();
                 TermsEnum terms = termVector.getFields().terms(field).iterator();

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlightBuilderTests.java
@@ -275,7 +275,7 @@ public class HighlightBuilderTests extends ESTestCase {
     public void testBuildSearchContextHighlight() throws IOException {
         Settings indexSettings = Settings.settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        Index index = new Index(randomAsciiOfLengthBetween(1, 10));
+        Index index = new Index(randomAsciiOfLengthBetween(1, 10), "_na_");
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings);
         // shard context will only need indicesQueriesRegistry for building Query objects nested in highlighter
         QueryShardContext mockShardContext = new QueryShardContext(idxSettings, null, null, null, null, null, null, indicesQueriesRegistry) {

--- a/core/src/test/java/org/elasticsearch/search/internal/InternalSearchHitTests.java
+++ b/core/src/test/java/org/elasticsearch/search/internal/InternalSearchHitTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.internal;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ESTestCase;
 
@@ -36,7 +37,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class InternalSearchHitTests extends ESTestCase {
 
     public void testSerializeShardTarget() throws Exception {
-        SearchShardTarget target = new SearchShardTarget("_node_id", "_index", 0);
+        SearchShardTarget target = new SearchShardTarget("_node_id", new Index("_index", "_na_"), 0);
 
         Map<String, InternalSearchHits> innerHits = new HashMap<>();
         InternalSearchHit innerHit1 = new InternalSearchHit(0, "_id", new Text("_type"), null);

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -159,8 +158,7 @@ public class QueryRescoreBuilderTests extends ESTestCase {
     public void testBuildRescoreSearchContext() throws ElasticsearchParseException, IOException {
         Settings indexSettings = Settings.settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        Index index = new Index(randomAsciiOfLengthBetween(1, 10));
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAsciiOfLengthBetween(1, 10), indexSettings);
         // shard context will only need indicesQueriesRegistry for building Query objects nested in query rescorer
         QueryShardContext mockShardContext = new QueryShardContext(idxSettings, null, null, null, null, null, null, indicesQueriesRegistry) {
             @Override

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -1896,9 +1896,9 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             public ClusterState execute(ClusterState currentState) {
                 // Simulate orphan snapshot
                 ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> shards = ImmutableOpenMap.builder();
-                shards.put(new ShardId("test-idx", 0), new ShardSnapshotStatus("unknown-node", State.ABORTED));
-                shards.put(new ShardId("test-idx", 1), new ShardSnapshotStatus("unknown-node", State.ABORTED));
-                shards.put(new ShardId("test-idx", 2), new ShardSnapshotStatus("unknown-node", State.ABORTED));
+                shards.put(new ShardId("test-idx", "_na_", 0), new ShardSnapshotStatus("unknown-node", State.ABORTED));
+                shards.put(new ShardId("test-idx", "_na_", 1), new ShardSnapshotStatus("unknown-node", State.ABORTED));
+                shards.put(new ShardId("test-idx", "_na_", 2), new ShardSnapshotStatus("unknown-node", State.ABORTED));
                 List<Entry> entries = new ArrayList<>();
                 entries.add(new Entry(new SnapshotId("test-repo", "test-snap"), true, State.ABORTED, Collections.singletonList("test-idx"), System.currentTimeMillis(), shards.build()));
                 return ClusterState.builder(currentState).putCustom(SnapshotsInProgress.TYPE, new SnapshotsInProgress(Collections.unmodifiableList(entries))).build();

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/messy/tests/TemplateQueryParserTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/messy/tests/TemplateQueryParserTests.java
@@ -98,8 +98,8 @@ public class TemplateQueryParserTests extends ESTestCase {
                 new Class<?>[]{Client.class}, (proxy1, method, args) -> {
                     throw new UnsupportedOperationException("client is just a dummy");
                 });
-        Index index = new Index("test");
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("test", settings);
+        Index index = idxSettings.getIndex();
         ScriptModule scriptModule = new ScriptModule(settings);
         // TODO: make this use a mock engine instead of mustache and it will no longer be messy!
         scriptModule.addScriptEngine(MustacheScriptEngineService.class);

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/analysis/AnalysisTestUtils.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/analysis/AnalysisTestUtils.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 public class AnalysisTestUtils {
 
     public static AnalysisService createAnalysisService(Settings settings) throws IOException {
-        Index index = new Index("test");
+        Index index = new Index("test", "_na_");
         Settings indexSettings = settingsBuilder().put(settings)
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .build();

--- a/plugins/analysis-kuromoji/src/test/java/org/elasticsearch/index/analysis/KuromojiAnalysisTests.java
+++ b/plugins/analysis-kuromoji/src/test/java/org/elasticsearch/index/analysis/KuromojiAnalysisTests.java
@@ -205,7 +205,7 @@ public class KuromojiAnalysisTests extends ESTestCase {
                 .build();
         final SettingsModule settingsModule = new SettingsModule(settings, new SettingsFilter(settings));
         settingsModule.registerSetting(InternalSettingsPlugin.VERSION_CREATED);
-        Index index = new Index("test");
+        Index index = new Index("test", "_na_");
 
         AnalysisModule analysisModule = new AnalysisModule(new Environment(settings));
         new AnalysisKuromojiPlugin().onModule(analysisModule);

--- a/plugins/analysis-phonetic/src/test/java/org/elasticsearch/index/analysis/SimplePhoneticAnalysisTests.java
+++ b/plugins/analysis-phonetic/src/test/java/org/elasticsearch/index/analysis/SimplePhoneticAnalysisTests.java
@@ -56,7 +56,7 @@ public class SimplePhoneticAnalysisTests extends ESTestCase {
     }
 
     private AnalysisService testSimpleConfiguration(Settings settings) throws IOException {
-        Index index = new Index("test");
+        Index index = new Index("test", "_na_");
         AnalysisModule analysisModule = new AnalysisModule(new Environment(settings));
         new AnalysisPhoneticPlugin().onModule(analysisModule);
         SettingsModule settingsModule = new SettingsModule(settings, new SettingsFilter(settings));

--- a/plugins/analysis-smartcn/src/test/java/org/elasticsearch/index/analysis/SimpleSmartChineseAnalysisTests.java
+++ b/plugins/analysis-smartcn/src/test/java/org/elasticsearch/index/analysis/SimpleSmartChineseAnalysisTests.java
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class SimpleSmartChineseAnalysisTests extends ESTestCase {
     public void testDefaultsIcuAnalysis() throws IOException {
-        Index index = new Index("test");
+        Index index = new Index("test", "_na_");
         Settings settings = settingsBuilder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)

--- a/plugins/analysis-stempel/src/test/java/org/elasticsearch/index/analysis/PolishAnalysisTests.java
+++ b/plugins/analysis-stempel/src/test/java/org/elasticsearch/index/analysis/PolishAnalysisTests.java
@@ -48,7 +48,6 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class PolishAnalysisTests extends ESTestCase {
     public void testDefaultsPolishAnalysis() throws IOException {
-        Index index = new Index("test");
         Settings settings = settingsBuilder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -63,7 +62,7 @@ public class PolishAnalysisTests extends ESTestCase {
                 new EnvironmentModule(new Environment(settings)), analysisModule)
                 .createInjector();
 
-        final AnalysisService analysisService = parentInjector.getInstance(AnalysisRegistry.class).build(IndexSettingsModule.newIndexSettings(index, settings));
+        final AnalysisService analysisService = parentInjector.getInstance(AnalysisRegistry.class).build(IndexSettingsModule.newIndexSettings("test", settings));
         TokenFilterFactory tokenizerFactory = analysisService.tokenFilter("polish_stem");
         MatcherAssert.assertThat(tokenizerFactory, instanceOf(PolishStemTokenFilterFactory.class));
 

--- a/plugins/analysis-stempel/src/test/java/org/elasticsearch/index/analysis/SimplePolishTokenFilterTests.java
+++ b/plugins/analysis-stempel/src/test/java/org/elasticsearch/index/analysis/SimplePolishTokenFilterTests.java
@@ -56,7 +56,7 @@ public class SimplePolishTokenFilterTests extends ESTestCase {
     }
 
     private void testToken(String source, String expected) throws IOException {
-        Index index = new Index("test");
+        Index index = new Index("test", "_na_");
         Settings settings = Settings.settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
@@ -78,7 +78,7 @@ public class SimplePolishTokenFilterTests extends ESTestCase {
     }
 
     private void testAnalyzer(String source, String... expected_terms) throws IOException {
-        Index index = new Index("test");
+        Index index = new Index("test", "_na_");
         Settings settings = Settings.settingsBuilder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())

--- a/plugins/delete-by-query/src/test/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryActionTests.java
+++ b/plugins/delete-by-query/src/test/java/org/elasticsearch/action/deletebyquery/TransportDeleteByQueryActionTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchShardTarget;
@@ -226,7 +227,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
                 } else {
                     deleted++;
                 }
-                items[i] = new BulkItemResponse(i, "delete", new DeleteResponse(new ShardId("test", 0), "type", String.valueOf(i), 1, delete));
+                items[i] = new BulkItemResponse(i, "delete", new DeleteResponse(new ShardId("test", "_na_", 0), "type", String.valueOf(i), 1, delete));
             } else {
                 items[i] = new BulkItemResponse(i, "delete", new BulkItemResponse.Failure("test", "type", String.valueOf(i), new Throwable("item failed")));
                 failed++;
@@ -282,7 +283,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
                     deleted[0] = deleted[0] + 1;
                     deleted[index] = deleted[index] + 1;
                 }
-                items[i] = new BulkItemResponse(i, "delete", new DeleteResponse(new ShardId("test-" + index, 0), "type", String.valueOf(i), 1, delete));
+                items[i] = new BulkItemResponse(i, "delete", new DeleteResponse(new ShardId("test-" + index, "_na_", 0), "type", String.valueOf(i), 1, delete));
             } else {
                 items[i] = new BulkItemResponse(i, "delete", new BulkItemResponse.Failure("test-" + index, "type", String.valueOf(i), new Throwable("item failed")));
                 failed[0] = failed[0] + 1;
@@ -340,7 +341,7 @@ public class TransportDeleteByQueryActionTests extends ESSingleNodeTestCase {
         SearchHit[] docs = new SearchHit[nbDocs];
         for (int i = 0; i < nbDocs; i++) {
             InternalSearchHit doc = new InternalSearchHit(randomInt(), String.valueOf(i), new Text("type"), null);
-            doc.shard(new SearchShardTarget("node", "test", randomInt()));
+            doc.shard(new SearchShardTarget("node", new Index("test", "_na_"), randomInt()));
             docs[i] = doc;
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.cluster.routing;
 
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
 /**
@@ -28,22 +30,44 @@ import org.elasticsearch.test.ESTestCase;
 public class TestShardRouting {
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, boolean primary, ShardRoutingState state, long version) {
+        return newShardRouting(new Index(index, IndexMetaData.INDEX_UUID_NA_VALUE), shardId, currentNodeId,primary, state, version);
+    }
+
+    public static ShardRouting newShardRouting(Index index, int shardId, String currentNodeId, boolean primary, ShardRoutingState state, long version) {
         return new ShardRouting(index, shardId, currentNodeId, null, null, primary, state, version, buildUnassignedInfo(state), buildAllocationId(state), true, -1);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, long version) {
+        return newShardRouting(new Index(index, IndexMetaData.INDEX_UUID_NA_VALUE), shardId, currentNodeId, relocatingNodeId, primary, state,version);
+    }
+
+    public static ShardRouting newShardRouting(Index index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, long version) {
         return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, null, primary, state, version, buildUnassignedInfo(state), buildAllocationId(state), true, -1);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, AllocationId allocationId, long version) {
+        return newShardRouting(new Index(index, IndexMetaData.INDEX_UUID_NA_VALUE), shardId, currentNodeId, relocatingNodeId, primary, state, allocationId, version);
+    }
+
+    public static ShardRouting newShardRouting(Index index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, AllocationId allocationId, long version) {
         return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, null, primary, state, version, buildUnassignedInfo(state), allocationId, true, -1);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, RestoreSource restoreSource, boolean primary, ShardRoutingState state, long version) {
+        return newShardRouting(new Index(index, IndexMetaData.INDEX_UUID_NA_VALUE), shardId, currentNodeId, relocatingNodeId, restoreSource, primary, state, version);
+    }
+
+    public static ShardRouting newShardRouting(Index index, int shardId, String currentNodeId, String relocatingNodeId, RestoreSource restoreSource, boolean primary, ShardRoutingState state, long version) {
         return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, restoreSource, primary, state, version, buildUnassignedInfo(state), buildAllocationId(state), true, -1);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId,
+                                               String relocatingNodeId, RestoreSource restoreSource, boolean primary, ShardRoutingState state, long version,
+                                               UnassignedInfo unassignedInfo) {
+        return newShardRouting(new Index(index, IndexMetaData.INDEX_UUID_NA_VALUE), shardId, currentNodeId, relocatingNodeId, restoreSource, primary, state,version, unassignedInfo);
+    }
+
+    public static ShardRouting newShardRouting(Index index, int shardId, String currentNodeId,
                                                String relocatingNodeId, RestoreSource restoreSource, boolean primary, ShardRoutingState state, long version,
                                                UnassignedInfo unassignedInfo) {
         return new ShardRouting(index, shardId, currentNodeId, relocatingNodeId, restoreSource, primary, state, version, unassignedInfo, buildAllocationId(state), true, -1);

--- a/test/framework/src/main/java/org/elasticsearch/index/MapperTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/MapperTestUtils.java
@@ -52,7 +52,7 @@ public class MapperTestUtils {
         }
         Settings finalSettings = settingsBuilder.build();
         MapperRegistry mapperRegistry = indicesModule.getMapperRegistry();
-        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(new Index("test"), finalSettings);
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", finalSettings);
         AnalysisService analysisService = new AnalysisRegistry(null, new Environment(finalSettings)).build(indexSettings);
         SimilarityService similarityService = new SimilarityService(indexSettings, Collections.emptyMap());
         return new MapperService(indexSettings,

--- a/test/framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESAllocationTestCase.java
@@ -235,7 +235,7 @@ public abstract class ESAllocationTestCase extends ESTestCase {
             boolean changed = false;
             while (unassignedIterator.hasNext()) {
                 ShardRouting shard = unassignedIterator.next();
-                IndexMetaData indexMetaData = allocation.metaData().index(shard.getIndex());
+                IndexMetaData indexMetaData = allocation.metaData().index(shard.getIndexName());
                 if (shard.primary() || shard.allocatedPostIndexCreate(indexMetaData) == false) {
                     continue;
                 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESBackcompatTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESBackcompatTestCase.java
@@ -230,7 +230,7 @@ public abstract class ESBackcompatTestCase extends ESIntegTestCase {
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                 for (ShardRouting shardRouting : indexShardRoutingTable) {
-                    if (shardRouting.currentNodeId() != null && index.equals(shardRouting.getIndex())) {
+                    if (shardRouting.currentNodeId() != null && index.equals(shardRouting.getIndexName())) {
                         String name = clusterState.nodes().get(shardRouting.currentNodeId()).name();
                         assertThat("Allocated on new node: " + name, Regex.simpleMatch(pattern, name), is(true));
                     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -110,7 +110,6 @@ import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.cache.request.IndicesRequestCache;
 import org.elasticsearch.indices.store.IndicesStore;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeMocksPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
@@ -1946,7 +1945,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
                 for (ShardRouting shardRouting : indexShardRoutingTable) {
-                    if (shardRouting.currentNodeId() != null && index.equals(shardRouting.getIndex())) {
+                    if (shardRouting.currentNodeId() != null && index.equals(shardRouting.getIndexName())) {
                         String name = clusterState.nodes().get(shardRouting.currentNodeId()).name();
                         nodes.add(name);
                         assertThat("Allocated on new node: " + name, Regex.simpleMatch(pattern, name), is(true));

--- a/test/framework/src/main/java/org/elasticsearch/test/IndexSettingsModule.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/IndexSettingsModule.java
@@ -49,7 +49,7 @@ public class IndexSettingsModule extends AbstractModule {
     }
 
     public static IndexSettings newIndexSettings(String index, Settings settings, Setting<?>... setting) {
-        return newIndexSettings(new Index(index), settings, setting);
+        return newIndexSettings(new Index(index, settings.get(IndexMetaData.SETTING_INDEX_UUID, IndexMetaData.INDEX_UUID_NA_VALUE)), settings, setting);
     }
 
     public static IndexSettings newIndexSettings(Index index, Settings settings, Setting<?>... setting) {
@@ -63,6 +63,6 @@ public class IndexSettingsModule extends AbstractModule {
         if (setting.length > 0) {
             settingSet.addAll(Arrays.asList(setting));
         }
-        return new IndexSettings(metaData, Settings.EMPTY, (idx) -> Regex.simpleMatch(idx, metaData.getIndex()), new IndexScopedSettings(Settings.EMPTY, settingSet));
+        return new IndexSettings(metaData, Settings.EMPTY, (idx) -> Regex.simpleMatch(idx, metaData.getIndex().getName()), new IndexScopedSettings(Settings.EMPTY, settingSet));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -147,7 +147,7 @@ public abstract class TestCluster implements Iterable<Client>, Closeable {
                     ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().execute().actionGet();
                     ObjectArrayList<String> concreteIndices = new ObjectArrayList<>();
                     for (IndexMetaData indexMetaData : clusterStateResponse.getState().metaData()) {
-                        concreteIndices.add(indexMetaData.getIndex());
+                        concreteIndices.add(indexMetaData.getIndex().getName());
                     }
                     if (!concreteIndices.isEmpty()) {
                         assertAcked(client().admin().indices().prepareDelete(concreteIndices.toArray(String.class)));


### PR DESCRIPTION
In the early days Elasticsearch used to use the index name as the index identity. Around 1.0.0 we introduced a unique index uuid which is stored in the index setting. Since then we used that uuid in a few places but it is by far not the main identifier when working with indices, partially because it's not always readily available in all places.

This PR start to make a move in the direction of using uuids instead of name by making sure that the uuid is available on the Index class (currently just a wrapper around the name) and as such also available via ShardRouting and ShardId. 

Note that this is by no means an attempt to do the right thing with the uuid in all places. In almost all places it falls back to the name based comparison that was done before. It is meant as a first step towards slowly improving the situation. 

PS. This came from starting to think about implementing storing indices on disk using folders `NAME_UUID` pattern (instead of just name as we do today) and thus being able to avoid collision between indices that are named the same (but deleted and recreated). The hope is that this will als remove the need for the in memory shard locks we have now. The problem was that I didn't have easy access to the uuid in all places.

While the tests are not all passing ( 99% of them are). I think this is ready to get initial feedback.
