### PR TITLE
Move missing() from SortBuilder interface to class

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -68,7 +68,6 @@ public class FieldSortBuilder extends SortBuilder {
      * Sets the value when a field is missing in a doc. Can also be set to <tt>_last</tt> or
      * <tt>_first</tt> to sort missing last or first respectively.
      */
-    @Override
     public FieldSortBuilder missing(Object missing) {
         this.missing = missing;
         return this;

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -219,16 +219,6 @@ public class GeoDistanceSortBuilder extends SortBuilder
     }
 
     /**
-     * Not relevant.
-     *
-     * TODO should this throw an exception rather than silently ignore a parameter that is not used?
-     */
-    @Override
-    public GeoDistanceSortBuilder missing(Object missing) {
-        return this;
-    }
-
-    /**
      * Defines which distance to use for sorting in the case a document contains multiple geo points.
      * Possible values: min and max
      */

--- a/core/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
@@ -42,11 +42,6 @@ public class ScoreSortBuilder extends SortBuilder {
     }
 
     @Override
-    public SortBuilder missing(Object missing) {
-        return this;
-    }
-
-    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject("_score");
         if (order == SortOrder.ASC) {

--- a/core/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -63,14 +63,6 @@ public class ScriptSortBuilder extends SortBuilder {
     }
 
     /**
-     * Not really relevant.
-     */
-    @Override
-    public SortBuilder missing(Object missing) {
-        return this;
-    }
-
-    /**
      * Defines which distance to use for sorting in the case a document contains multiple geo points.
      * Possible values: min and max
      */

--- a/core/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
@@ -45,10 +45,4 @@ public abstract class SortBuilder implements ToXContent {
      * The order of sorting. Defaults to {@link SortOrder#ASC}.
      */
     public abstract SortBuilder order(SortOrder order);
-
-    /**
-     * Sets the value when a field is missing in a doc. Can also be set to <tt>_last</tt> or
-     * <tt>_first</tt> to sort missing last or first respectively.
-     */
-    public abstract SortBuilder missing(Object missing);
 }


### PR DESCRIPTION
As mentioned by @cbuescher on #16151 this method is really implemented only in
the FieldSortBuilder. Moving the method down.

Relates to #15178
