### PR TITLE
Ingest: move get/put/delete pipeline methods to ClusterAdminClient

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/Client.java
+++ b/core/src/main/java/org/elasticsearch/client/Client.java
@@ -51,17 +51,9 @@ import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptResponse;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptRequest;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptRequestBuilder;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
-import org.elasticsearch.action.ingest.DeletePipelineRequest;
-import org.elasticsearch.action.ingest.DeletePipelineRequestBuilder;
-import org.elasticsearch.action.ingest.GetPipelineRequest;
-import org.elasticsearch.action.ingest.GetPipelineRequestBuilder;
-import org.elasticsearch.action.ingest.GetPipelineResponse;
-import org.elasticsearch.action.ingest.PutPipelineRequest;
-import org.elasticsearch.action.ingest.PutPipelineRequestBuilder;
 import org.elasticsearch.action.ingest.SimulatePipelineRequest;
 import org.elasticsearch.action.ingest.SimulatePipelineRequestBuilder;
 import org.elasticsearch.action.ingest.SimulatePipelineResponse;
-import org.elasticsearch.action.ingest.WritePipelineResponse;
 import org.elasticsearch.action.percolate.MultiPercolateRequest;
 import org.elasticsearch.action.percolate.MultiPercolateRequestBuilder;
 import org.elasticsearch.action.percolate.MultiPercolateResponse;
@@ -603,51 +595,6 @@ public interface Client extends ElasticsearchClient, Releasable {
     ActionFuture<FieldStatsResponse> fieldStats(FieldStatsRequest request);
 
     void fieldStats(FieldStatsRequest request, ActionListener<FieldStatsResponse> listener);
-
-    /**
-     * Stores an ingest pipeline
-     */
-    void putPipeline(PutPipelineRequest request, ActionListener<WritePipelineResponse> listener);
-
-    /**
-     * Stores an ingest pipeline
-     */
-    ActionFuture<WritePipelineResponse> putPipeline(PutPipelineRequest request);
-
-    /**
-     * Stores an ingest pipeline
-     */
-    PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source);
-
-    /**
-     * Deletes a stored ingest pipeline
-     */
-    void deletePipeline(DeletePipelineRequest request, ActionListener<WritePipelineResponse> listener);
-
-    /**
-     * Deletes a stored ingest pipeline
-     */
-    ActionFuture<WritePipelineResponse> deletePipeline(DeletePipelineRequest request);
-
-    /**
-     * Deletes a stored ingest pipeline
-     */
-    DeletePipelineRequestBuilder prepareDeletePipeline();
-
-    /**
-     * Returns a stored ingest pipeline
-     */
-    void getPipeline(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener);
-
-    /**
-     * Returns a stored ingest pipeline
-     */
-    ActionFuture<GetPipelineResponse> getPipeline(GetPipelineRequest request);
-
-    /**
-     * Returns a stored ingest pipeline
-     */
-    GetPipelineRequestBuilder prepareGetPipeline(String... ids);
 
     /**
      * Simulates an ingest pipeline

--- a/core/src/main/java/org/elasticsearch/client/Client.java
+++ b/core/src/main/java/org/elasticsearch/client/Client.java
@@ -51,9 +51,6 @@ import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptResponse;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptRequest;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptRequestBuilder;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
-import org.elasticsearch.action.ingest.SimulatePipelineRequest;
-import org.elasticsearch.action.ingest.SimulatePipelineRequestBuilder;
-import org.elasticsearch.action.ingest.SimulatePipelineResponse;
 import org.elasticsearch.action.percolate.MultiPercolateRequest;
 import org.elasticsearch.action.percolate.MultiPercolateRequestBuilder;
 import org.elasticsearch.action.percolate.MultiPercolateResponse;
@@ -85,7 +82,6 @@ import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.support.Headers;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.Settings;
 
@@ -595,21 +591,6 @@ public interface Client extends ElasticsearchClient, Releasable {
     ActionFuture<FieldStatsResponse> fieldStats(FieldStatsRequest request);
 
     void fieldStats(FieldStatsRequest request, ActionListener<FieldStatsResponse> listener);
-
-    /**
-     * Simulates an ingest pipeline
-     */
-    void simulatePipeline(SimulatePipelineRequest request, ActionListener<SimulatePipelineResponse> listener);
-
-    /**
-     * Simulates an ingest pipeline
-     */
-    ActionFuture<SimulatePipelineResponse> simulatePipeline(SimulatePipelineRequest request);
-
-    /**
-     * Simulates an ingest pipeline
-     */
-    SimulatePipelineRequestBuilder prepareSimulatePipeline(BytesReference source);
 
     /**
      * Returns this clients settings

--- a/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -84,6 +84,15 @@ import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
 import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateRequest;
 import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateRequestBuilder;
 import org.elasticsearch.action.admin.cluster.validate.template.RenderSearchTemplateResponse;
+import org.elasticsearch.action.ingest.DeletePipelineRequest;
+import org.elasticsearch.action.ingest.DeletePipelineRequestBuilder;
+import org.elasticsearch.action.ingest.GetPipelineRequest;
+import org.elasticsearch.action.ingest.GetPipelineRequestBuilder;
+import org.elasticsearch.action.ingest.GetPipelineResponse;
+import org.elasticsearch.action.ingest.PutPipelineRequest;
+import org.elasticsearch.action.ingest.PutPipelineRequestBuilder;
+import org.elasticsearch.action.ingest.WritePipelineResponse;
+import org.elasticsearch.common.bytes.BytesReference;
 
 /**
  * Administrative actions/operations against indices.
@@ -474,4 +483,49 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      * Return the rendered search request for a given search template.
      */
     RenderSearchTemplateRequestBuilder prepareRenderSearchTemplate();
+
+    /**
+     * Stores an ingest pipeline
+     */
+    void putPipeline(PutPipelineRequest request, ActionListener<WritePipelineResponse> listener);
+
+    /**
+     * Stores an ingest pipeline
+     */
+    ActionFuture<WritePipelineResponse> putPipeline(PutPipelineRequest request);
+
+    /**
+     * Stores an ingest pipeline
+     */
+    PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source);
+
+    /**
+     * Deletes a stored ingest pipeline
+     */
+    void deletePipeline(DeletePipelineRequest request, ActionListener<WritePipelineResponse> listener);
+
+    /**
+     * Deletes a stored ingest pipeline
+     */
+    ActionFuture<WritePipelineResponse> deletePipeline(DeletePipelineRequest request);
+
+    /**
+     * Deletes a stored ingest pipeline
+     */
+    DeletePipelineRequestBuilder prepareDeletePipeline();
+
+    /**
+     * Returns a stored ingest pipeline
+     */
+    void getPipeline(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener);
+
+    /**
+     * Returns a stored ingest pipeline
+     */
+    ActionFuture<GetPipelineResponse> getPipeline(GetPipelineRequest request);
+
+    /**
+     * Returns a stored ingest pipeline
+     */
+    GetPipelineRequestBuilder prepareGetPipeline(String... ids);
 }

--- a/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -91,6 +91,9 @@ import org.elasticsearch.action.ingest.GetPipelineRequestBuilder;
 import org.elasticsearch.action.ingest.GetPipelineResponse;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineRequestBuilder;
+import org.elasticsearch.action.ingest.SimulatePipelineRequest;
+import org.elasticsearch.action.ingest.SimulatePipelineRequestBuilder;
+import org.elasticsearch.action.ingest.SimulatePipelineResponse;
 import org.elasticsearch.action.ingest.WritePipelineResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 
@@ -528,4 +531,19 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      * Returns a stored ingest pipeline
      */
     GetPipelineRequestBuilder prepareGetPipeline(String... ids);
+
+    /**
+     * Simulates an ingest pipeline
+     */
+    void simulatePipeline(SimulatePipelineRequest request, ActionListener<SimulatePipelineResponse> listener);
+
+    /**
+     * Simulates an ingest pipeline
+     */
+    ActionFuture<SimulatePipelineResponse> simulatePipeline(SimulatePipelineRequest request);
+
+    /**
+     * Simulates an ingest pipeline
+     */
+    SimulatePipelineRequestBuilder prepareSimulatePipeline(BytesReference source);
 }

--- a/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -811,51 +811,6 @@ public abstract class AbstractClient extends AbstractComponent implements Client
     }
 
     @Override
-    public void putPipeline(PutPipelineRequest request, ActionListener<WritePipelineResponse> listener) {
-        execute(PutPipelineAction.INSTANCE, request, listener);
-    }
-
-    @Override
-    public ActionFuture<WritePipelineResponse> putPipeline(PutPipelineRequest request) {
-        return execute(PutPipelineAction.INSTANCE, request);
-    }
-
-    @Override
-    public PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source) {
-        return new PutPipelineRequestBuilder(this, PutPipelineAction.INSTANCE, id, source);
-    }
-
-    @Override
-    public void deletePipeline(DeletePipelineRequest request, ActionListener<WritePipelineResponse> listener) {
-        execute(DeletePipelineAction.INSTANCE, request, listener);
-    }
-
-    @Override
-    public ActionFuture<WritePipelineResponse> deletePipeline(DeletePipelineRequest request) {
-        return execute(DeletePipelineAction.INSTANCE, request);
-    }
-
-    @Override
-    public DeletePipelineRequestBuilder prepareDeletePipeline() {
-        return new DeletePipelineRequestBuilder(this, DeletePipelineAction.INSTANCE);
-    }
-
-    @Override
-    public void getPipeline(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener) {
-        execute(GetPipelineAction.INSTANCE, request, listener);
-    }
-
-    @Override
-    public ActionFuture<GetPipelineResponse> getPipeline(GetPipelineRequest request) {
-        return execute(GetPipelineAction.INSTANCE, request);
-    }
-
-    @Override
-    public GetPipelineRequestBuilder prepareGetPipeline(String... ids) {
-        return new GetPipelineRequestBuilder(this, GetPipelineAction.INSTANCE, ids);
-    }
-
-    @Override
     public void simulatePipeline(SimulatePipelineRequest request, ActionListener<SimulatePipelineResponse> listener) {
         execute(SimulatePipelineAction.INSTANCE, request, listener);
     }
@@ -1248,6 +1203,51 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         @Override
         public RenderSearchTemplateRequestBuilder prepareRenderSearchTemplate() {
             return new RenderSearchTemplateRequestBuilder(this, RenderSearchTemplateAction.INSTANCE);
+        }
+
+        @Override
+        public void putPipeline(PutPipelineRequest request, ActionListener<WritePipelineResponse> listener) {
+            execute(PutPipelineAction.INSTANCE, request, listener);
+        }
+
+        @Override
+        public ActionFuture<WritePipelineResponse> putPipeline(PutPipelineRequest request) {
+            return execute(PutPipelineAction.INSTANCE, request);
+        }
+
+        @Override
+        public PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source) {
+            return new PutPipelineRequestBuilder(this, PutPipelineAction.INSTANCE, id, source);
+        }
+
+        @Override
+        public void deletePipeline(DeletePipelineRequest request, ActionListener<WritePipelineResponse> listener) {
+            execute(DeletePipelineAction.INSTANCE, request, listener);
+        }
+
+        @Override
+        public ActionFuture<WritePipelineResponse> deletePipeline(DeletePipelineRequest request) {
+            return execute(DeletePipelineAction.INSTANCE, request);
+        }
+
+        @Override
+        public DeletePipelineRequestBuilder prepareDeletePipeline() {
+            return new DeletePipelineRequestBuilder(this, DeletePipelineAction.INSTANCE);
+        }
+
+        @Override
+        public void getPipeline(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener) {
+            execute(GetPipelineAction.INSTANCE, request, listener);
+        }
+
+        @Override
+        public ActionFuture<GetPipelineResponse> getPipeline(GetPipelineRequest request) {
+            return execute(GetPipelineAction.INSTANCE, request);
+        }
+
+        @Override
+        public GetPipelineRequestBuilder prepareGetPipeline(String... ids) {
+            return new GetPipelineRequestBuilder(this, GetPipelineAction.INSTANCE, ids);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -810,21 +810,6 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         return new FieldStatsRequestBuilder(this, FieldStatsAction.INSTANCE);
     }
 
-    @Override
-    public void simulatePipeline(SimulatePipelineRequest request, ActionListener<SimulatePipelineResponse> listener) {
-        execute(SimulatePipelineAction.INSTANCE, request, listener);
-    }
-
-    @Override
-    public ActionFuture<SimulatePipelineResponse> simulatePipeline(SimulatePipelineRequest request) {
-        return execute(SimulatePipelineAction.INSTANCE, request);
-    }
-
-    @Override
-    public SimulatePipelineRequestBuilder prepareSimulatePipeline(BytesReference source) {
-        return new SimulatePipelineRequestBuilder(this, SimulatePipelineAction.INSTANCE, source);
-    }
-
     static class Admin implements AdminClient {
 
         private final ClusterAdmin clusterAdmin;
@@ -1248,6 +1233,21 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         @Override
         public GetPipelineRequestBuilder prepareGetPipeline(String... ids) {
             return new GetPipelineRequestBuilder(this, GetPipelineAction.INSTANCE, ids);
+        }
+
+        @Override
+        public void simulatePipeline(SimulatePipelineRequest request, ActionListener<SimulatePipelineResponse> listener) {
+            execute(SimulatePipelineAction.INSTANCE, request, listener);
+        }
+
+        @Override
+        public ActionFuture<SimulatePipelineResponse> simulatePipeline(SimulatePipelineRequest request) {
+            return execute(SimulatePipelineAction.INSTANCE, request);
+        }
+
+        @Override
+        public SimulatePipelineRequestBuilder prepareSimulatePipeline(BytesReference source) {
+            return new SimulatePipelineRequestBuilder(this, SimulatePipelineAction.INSTANCE, source);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/ingest/RestDeletePipelineAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/ingest/RestDeletePipelineAction.java
@@ -42,6 +42,6 @@ public class RestDeletePipelineAction extends BaseRestHandler {
         DeletePipelineRequest request = new DeletePipelineRequest(restRequest.param("id"));
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
-        client.deletePipeline(request, new AcknowledgedRestListener<>(channel));
+        client.admin().cluster().deletePipeline(request, new AcknowledgedRestListener<>(channel));
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/ingest/RestGetPipelineAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/ingest/RestGetPipelineAction.java
@@ -42,6 +42,6 @@ public class RestGetPipelineAction extends BaseRestHandler {
     protected void handleRequest(RestRequest restRequest, RestChannel channel, Client client) throws Exception {
         GetPipelineRequest request = new GetPipelineRequest(Strings.splitStringByCommaToArray(restRequest.param("id")));
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
-        client.getPipeline(request, new RestStatusToXContentListener<>(channel));
+        client.admin().cluster().getPipeline(request, new RestStatusToXContentListener<>(channel));
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
@@ -43,6 +43,6 @@ public class RestPutPipelineAction extends BaseRestHandler {
         PutPipelineRequest request = new PutPipelineRequest(restRequest.param("id"), RestActions.getRestContent(restRequest));
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
-        client.putPipeline(request, new AcknowledgedRestListener<>(channel));
+        client.admin().cluster().putPipeline(request, new AcknowledgedRestListener<>(channel));
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/ingest/RestSimulatePipelineAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/ingest/RestSimulatePipelineAction.java
@@ -46,6 +46,6 @@ public class RestSimulatePipelineAction extends BaseRestHandler {
         SimulatePipelineRequest request = new SimulatePipelineRequest(RestActions.getRestContent(restRequest));
         request.setId(restRequest.param("id"));
         request.setVerbose(restRequest.paramAsBoolean("verbose", false));
-        client.simulatePipeline(request, new RestToXContentListener<>(channel));
+        client.admin().cluster().simulatePipeline(request, new RestToXContentListener<>(channel));
     }
 }

--- a/core/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/core/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -77,9 +77,9 @@ public class IngestClientIT extends ESIntegTestCase {
             .endObject()
             .endArray()
             .endObject().bytes();
-        client().preparePutPipeline("_id", pipelineSource)
+        client().admin().cluster().preparePutPipeline("_id", pipelineSource)
                 .get();
-        GetPipelineResponse getResponse = client().prepareGetPipeline("_id")
+        GetPipelineResponse getResponse = client().admin().cluster().prepareGetPipeline("_id")
                 .get();
         assertThat(getResponse.isFound(), is(true));
         assertThat(getResponse.pipelines().size(), equalTo(1));
@@ -134,7 +134,7 @@ public class IngestClientIT extends ESIntegTestCase {
             .endArray()
             .endObject().bytes();
         PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source);
-        client().putPipeline(putPipelineRequest).get();
+        client().admin().cluster().putPipeline(putPipelineRequest).get();
 
         int numRequests = scaledRandomIntBetween(32, 128);
         BulkRequest bulkRequest = new BulkRequest();
@@ -170,10 +170,10 @@ public class IngestClientIT extends ESIntegTestCase {
             .endArray()
             .endObject().bytes();
         PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source);
-        client().putPipeline(putPipelineRequest).get();
+        client().admin().cluster().putPipeline(putPipelineRequest).get();
 
         GetPipelineRequest getPipelineRequest = new GetPipelineRequest("_id");
-        GetPipelineResponse getResponse = client().getPipeline(getPipelineRequest).get();
+        GetPipelineResponse getResponse = client().admin().cluster().getPipeline(getPipelineRequest).get();
         assertThat(getResponse.isFound(), is(true));
         assertThat(getResponse.pipelines().size(), equalTo(1));
         assertThat(getResponse.pipelines().get(0).getId(), equalTo("_id"));
@@ -192,10 +192,10 @@ public class IngestClientIT extends ESIntegTestCase {
         assertThat(doc.get("processed"), equalTo(true));
 
         DeletePipelineRequest deletePipelineRequest = new DeletePipelineRequest("_id");
-        WritePipelineResponse response = client().deletePipeline(deletePipelineRequest).get();
+        WritePipelineResponse response = client().admin().cluster().deletePipeline(deletePipelineRequest).get();
         assertThat(response.isAcknowledged(), is(true));
 
-        getResponse = client().prepareGetPipeline("_id").get();
+        getResponse = client().admin().cluster().prepareGetPipeline("_id").get();
         assertThat(getResponse.isFound(), is(false));
         assertThat(getResponse.pipelines().size(), equalTo(0));
     }

--- a/core/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/core/src/test/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -100,12 +100,12 @@ public class IngestClientIT extends ESIntegTestCase {
             .endObject().bytes();
         SimulatePipelineResponse response;
         if (randomBoolean()) {
-            response = client().prepareSimulatePipeline(bytes)
+            response = client().admin().cluster().prepareSimulatePipeline(bytes)
                 .setId("_id").get();
         } else {
             SimulatePipelineRequest request = new SimulatePipelineRequest(bytes);
             request.setId("_id");
-            response = client().simulatePipeline(request).get();
+            response = client().admin().cluster().simulatePipeline(request).get();
         }
         assertThat(response.isVerbose(), equalTo(false));
         assertThat(response.getPipelineId(), equalTo("_id"));


### PR DESCRIPTION
 These methods allow to modify and retrieve the content of pipelines, which are stored in the cluster state. Their actions names were already correct under the category `cluster:admin/ingest/pipeline/*` , the corresponding methods should be moved under `client.admin().cluster()` .
