### PR TITLE
Tribe node: pass path.conf to inner tribe clients

### DIFF
--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -135,6 +135,9 @@ public class TribeService extends AbstractLifecycleComponent<TribeService> {
             Settings.Builder sb = Settings.builder().put(entry.getValue());
             sb.put("name", settings.get("name") + "/" + entry.getKey());
             sb.put(Environment.PATH_HOME_SETTING.getKey(), Environment.PATH_HOME_SETTING.get(settings)); // pass through ES home dir
+            if (Environment.PATH_CONF_SETTING.exists(settings)) {
+                sb.put(Environment.PATH_CONF_SETTING.getKey(), Environment.PATH_CONF_SETTING.get(settings));
+            }
             sb.put(TRIBE_NAME, entry.getKey());
             if (sb.get("http.enabled") == null) {
                 sb.put("http.enabled", false);

--- a/qa/evil-tests/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
@@ -91,7 +91,7 @@ public class TribeUnitTests extends ESTestCase {
         System.setProperty("es.tribe.t2.discovery.id.seed", Long.toString(random().nextLong()));
 
         try {
-            assertTribeNodeSuccesfullyCreated(Settings.EMPTY);
+            assertTribeNodeSuccessfullyCreated(Settings.EMPTY);
         } finally {
             System.clearProperty("es.cluster.name");
             System.clearProperty("es.tribe.t1.cluster.name");
@@ -108,10 +108,10 @@ public class TribeUnitTests extends ESTestCase {
             .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true)
             .put(Environment.PATH_CONF_SETTING.getKey(), pathConf)
             .build();
-        assertTribeNodeSuccesfullyCreated(settings);
+        assertTribeNodeSuccessfullyCreated(settings);
     }
 
-    private static void assertTribeNodeSuccesfullyCreated(Settings extraSettings) throws Exception {
+    private static void assertTribeNodeSuccessfullyCreated(Settings extraSettings) throws Exception {
         //tribe node doesn't need the node.mode setting, as it's forced local internally anyways. The tribe clients do need it to make sure
         //they can find their corresponding tribes using the proper transport
         Settings settings = Settings.builder().put("http.enabled", false).put("node.name", "tribe_node")


### PR DESCRIPTION
If we don't do this, and some path.conf is set when starting the tribe node, that path.conf will be ignored and the inner tribe clients will try to read elsewhere, where they most likely don't have permissions to read from.

Closes #16253
