### PR TITLE
Fix for search after

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -28,7 +28,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.Template;
 import org.elasticsearch.search.Scroll;
-import org.elasticsearch.search.searchafter.SearchAfterBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;

--- a/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
@@ -70,7 +70,7 @@ public class SearchAfterBuilderTests extends ESTestCase {
         SearchAfterBuilder searchAfterBuilder = new SearchAfterBuilder();
         Object[] values = new Object[numSearchFrom];
         for (int i = 0; i < numSearchFrom; i++) {
-            int branch = randomInt(8);
+            int branch = randomInt(9);
             switch (branch) {
                 case 0:
                     values[i] = randomInt();
@@ -99,6 +99,9 @@ public class SearchAfterBuilderTests extends ESTestCase {
                 case 8:
                     values[i] = new Text(randomAsciiOfLengthBetween(5, 20));
                     break;
+                case 9:
+                    values[i] = null;
+                    break;
             }
         }
         searchAfterBuilder.setSortValues(values);
@@ -115,7 +118,7 @@ public class SearchAfterBuilderTests extends ESTestCase {
         jsonBuilder.startObject();
         jsonBuilder.startArray("search_after");
         for (int i = 0; i < numSearchAfter; i++) {
-            int branch = randomInt(8);
+            int branch = randomInt(9);
             switch (branch) {
                 case 0:
                     jsonBuilder.value(randomInt());
@@ -143,6 +146,9 @@ public class SearchAfterBuilderTests extends ESTestCase {
                     break;
                 case 8:
                     jsonBuilder.value(new Text(randomAsciiOfLengthBetween(5, 20)));
+                    break;
+                case 9:
+                    jsonBuilder.nullValue();
                     break;
             }
         }
@@ -223,18 +229,7 @@ public class SearchAfterBuilderTests extends ESTestCase {
             assertEquals(searchAfterBuilder.hashCode(), secondSearchAfterBuilder.hashCode());
         }
     }
-
-    public void testWithNullValue() throws Exception {
-        SearchAfterBuilder builder = new SearchAfterBuilder();
-        builder.setSortValues(new Object[] {1, "1", null});
-        try {
-            serializedCopy(builder);
-            fail("Should fail on null values");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), Matchers.equalTo("Can't handle search_after field value of type [null]"));
-        }
-    }
-
+    
     public void testWithNullArray() throws Exception {
         SearchAfterBuilder builder = new SearchAfterBuilder();
         try {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -154,10 +154,6 @@
         "request_cache": {
           "type" : "boolean",
           "description" : "Specify if request cache should be used for this request or not, defaults to index level setting"
-        },
-        "search_after": {
-          "type" : "list",
-          "description" : "An array of sort values that indicates where the sort of the top hits should start"
         }
       }
     },


### PR DESCRIPTION
- Removes search_after from the query string param of the rest api spec.
- Handle null values when sorting on strings.
- Wait for green status in the integ tests.
