### PR TITLE
Checkstyle!

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.groovy
@@ -61,10 +61,6 @@ public class ForbiddenPatternsTask extends DefaultTask {
         // add mandatory rules
         patterns.put('nocommit', /nocommit/)
         patterns.put('tab', /\t/)
-        patterns.put('wildcard imports', /^\s*import.*\.\*/)
-        // We don't use Java serialization so we fail if it looks like we're trying to.
-        patterns.put('declares serialVersionUID', /serialVersionUID/)
-        patterns.put('references Serializable', /java\.io\.Serializable/)
 
         inputs.property("excludes", filesFilter.excludes)
         inputs.property("rules", patterns)

--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <property name="charset" value="UTF-8" />
+
+  <module name="TreeWalker">
+    <!-- ~3500 violations
+    <module name="LineLength">
+      <property name="max" value="140"/>
+    </module>
+    -->
+
+    <module name="AvoidStarImport" />
+    <!-- Doesn't pass but we could make it pass pretty quick.
+    <module name="UnusedImports">
+      The next property is optional. If we remove it then imports that are
+      only referenced by Javadoc cause the check to fail.
+      <property name="processJavadoc" value="true" />
+    </module>
+    -->
+
+    <!-- Non-inner classes must be in files that match their names. -->
+    <module name="OuterTypeFilename" />
+    <!-- No line wraps inside of import and package statements. -->
+    <module name="NoLineWrap" />
+    <!-- Each java file has only one outer class -->
+    <module name="OneTopLevelClass" />
+
+    <!-- We don't use Java's builtin serialization and we suppress all warning
+      about it. The flip side of that coin is that we shouldn't _try_ to use
+      it. We can't outright ban it with ForbiddenApis because it complain about
+      every we reference a class that implements Serializable like String or
+      Exception.
+      -->
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="serialVersionUID" />
+      <property name="message" value="Do not declare serialVersionUID." />
+      <property name="ignoreComments" value="true" />
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="java\.io\.Serializable" />
+      <property name="message" value="References java.io.Serializable." />
+      <property name="ignoreComments" value="true" />
+    </module>
+    <!-- end Orwellian suppression of Serializable -->
+  </module>
+</module>


### PR DESCRIPTION
This duplicates all of the checks that we have in ForbiddenPatterns with
checkstyle to demonstrate that it is possible. We should either remove
them from checkstyle or remove java from forbidden patterns with a note
to go look in checkstyle. Or just live with a little duplication.

It removes a few tests that were in forbidden patterns and moves them to
checkstyle because they are only appropriate to java. In some cases they are
better - the java.io.Serializable test now doesn't fail if you put
`java.io.Serializable` in comments.

Adds a few basic checks that already pass as well as some commented out checks
that don't pass. Things like "lines wrap at 140 characters", which is part
of CONTRIBUTING.md. Its true for all but about 3500 lines.
