### PR TITLE
Term vector APIs should no longer update mappings

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/core/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -71,12 +71,10 @@ import static org.elasticsearch.index.mapper.SourceToParse.source;
 
 public class TermVectorsService  {
 
-    private final MappingUpdatedAction mappingUpdatedAction;
     private final TransportDfsOnlyAction dfsAction;
 
     @Inject
-    public TermVectorsService(MappingUpdatedAction mappingUpdatedAction, TransportDfsOnlyAction dfsAction) {
-        this.mappingUpdatedAction = mappingUpdatedAction;
+    public TermVectorsService(TransportDfsOnlyAction dfsAction) {
         this.dfsAction = dfsAction;
     }
 
@@ -293,15 +291,10 @@ public class TermVectorsService  {
 
     private ParsedDocument parseDocument(IndexShard indexShard, String index, String type, BytesReference doc) throws Throwable {
         MapperService mapperService = indexShard.mapperService();
-
-        // TODO: make parsing not dynamically create fields not in the original mapping
         DocumentMapperForType docMapper = mapperService.documentMapperWithAutoCreate(type);
         ParsedDocument parsedDocument = docMapper.getDocumentMapper().parse(source(doc).index(index).type(type).flyweight(true));
         if (docMapper.getMapping() != null) {
             parsedDocument.addDynamicMappingsUpdate(docMapper.getMapping());
-        }
-        if (parsedDocument.dynamicMappingsUpdate() != null) {
-            mappingUpdatedAction.updateMappingOnMasterSynchronously(index, type, parsedDocument.dynamicMappingsUpdate());
         }
         return parsedDocument;
     }

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -18,6 +18,7 @@ your application to Elasticsearch 3.0.
 * <<breaking_30_percolator>>
 * <<breaking_30_packaging>>
 * <<breaking_30_scripting>>
+* <<breaking_30_term_vectors>>
 
 [[breaking_30_search_changes]]
 === Warmers
@@ -707,3 +708,8 @@ Previously script mode settings (e.g., "script.inline: true",
 values `off`, `false`, `0`, and `no` for disabling a scripting mode.
 The variants `on`, `1`, and `yes ` for enabling and `off`, `0`,
 and `no` for disabling are no longer supported.
+
+[[breaking_30_term_vectors]]
+=== Term vectors
+
+The term vectors APIs no longer persist unmapped fields in the mappings.


### PR DESCRIPTION
Before if an unmaps field was found by the term vector APIs, this missing field would be added to the mappings. This PR changes that and doesn't modify the mapping any more if an unmapped field is found.
