### PR TITLE
Skipping hidden files compilation for script service

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.cache.RemovalNotification;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -532,6 +533,10 @@ public class ScriptService extends AbstractComponent implements Closeable {
         public void onFileInit(Path file) {
             if (logger.isTraceEnabled()) {
                 logger.trace("Loading script file : [{}]", file);
+            }
+            if (FileSystemUtils.isHidden(file)) {
+                logger.warn("--- Hidden file skipped : [{}]", file);
+                return;
             }
             Tuple<String, String> scriptNameExt = scriptNameExt(file);
             if (scriptNameExt != null) {

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -56,7 +56,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.query.TemplateQueryParser;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.watcher.FileChangesListener;
 import org.elasticsearch.watcher.FileWatcher;
@@ -531,13 +530,14 @@ public class ScriptService extends AbstractComponent implements Closeable {
 
         @Override
         public void onFileInit(Path file) {
+            if (FileSystemUtils.isHidden(file)) {
+                logger.debug("Hidden script file skipped : [{}]", file);
+                return;
+            }
             if (logger.isTraceEnabled()) {
                 logger.trace("Loading script file : [{}]", file);
             }
-            if (FileSystemUtils.isHidden(file)) {
-                logger.warn("--- Hidden file skipped : [{}]", file);
-                return;
-            }
+
             Tuple<String, String> scriptNameExt = scriptNameExt(file);
             if (scriptNameExt != null) {
                 ScriptEngineService engineService = getScriptEngineServiceForFileExt(scriptNameExt.v2());

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -151,36 +151,29 @@ public class ScriptServiceTests extends ESTestCase {
         }
     }
 
-    public void testHiddenFileSkipped() throws IOException {
-        ContextAndHeaderHolder contextAndHeaders = new ContextAndHeaderHolder();
+    public void testHiddenScriptFileSkipped() throws IOException {
         buildScriptService(Settings.EMPTY);
 
-        logger.info("--> setup one hidden test file");
-        Path testFileHidden = scriptsFilePath.resolve(".hidden_file");
-        Path testRegularFile = scriptsFilePath.resolve("test_file.tst");
-        Streams.copy("test_hidden_file".getBytes("UTF-8"), Files.newOutputStream(testFileHidden));
-        Streams.copy("test_file".getBytes("UTF-8"), Files.newOutputStream(testRegularFile));
+        Path testHiddenFile = scriptsFilePath.resolve(".hidden_file");
+        Path testFile = scriptsFilePath.resolve("test_file.tst");
+        Streams.copy("test_hidden_file".getBytes("UTF-8"), Files.newOutputStream(testHiddenFile));
+        Streams.copy("test_file".getBytes("UTF-8"), Files.newOutputStream(testFile));
         resourceWatcherService.notifyNow();
 
         try {
-            logger.info("--> verify if hidden_file was skipped");
             scriptService.compile(new Script("hidden_file", ScriptType.FILE, "test", null),
-                    ScriptContext.Standard.SEARCH, contextAndHeaders, Collections.emptyMap());
+                    ScriptContext.Standard.SEARCH, Collections.emptyMap());
             fail("the script hidden_file should not be processed");
         } catch (IllegalArgumentException ex) {
             assertThat(ex.getMessage(), containsString("Unable to find on disk file script [hidden_file] using lang [test]"));
         }
 
-        logger.info("--> verify if test_file was correctly processed");
         CompiledScript compiledScript = scriptService.compile(new Script("test_file", ScriptType.FILE, "test", null),
-                ScriptContext.Standard.SEARCH, contextAndHeaders, Collections.emptyMap());
+                ScriptContext.Standard.SEARCH, Collections.emptyMap());
         assertThat(compiledScript.compiled(), equalTo((Object) "compiled_test_file"));
 
-        logger.info("--> delete hidden file");
-        Files.delete(testFileHidden);
-
-        logger.info("--> delete test file");
-        Files.delete(testRegularFile);
+        Files.delete(testHiddenFile);
+        Files.delete(testFile);
         resourceWatcherService.notifyNow();
     }
 


### PR DESCRIPTION
If hidden files are detected during the ScriptService initialization, they will be ignored and a warning message will be logged.

Closes #15269 
