### PR TITLE
Name eclipse projects to gradle path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,11 @@ tasks.idea.dependsOn(buildSrcIdea)
 // eclipse configuration
 allprojects {
   apply plugin: 'eclipse'
+  // Name all the non-root projects after their path so that paths get grouped together when imported into eclipse.
+  if (path != ':') {
+    System.err.println(eclipse.project.name + ' ' + path)
+    eclipse.project.name = path
+  }
 
   plugins.withType(JavaBasePlugin) {
     eclipse.classpath.defaultOutputDir = new File(project.buildDir, 'eclipse')


### PR DESCRIPTION
This groups like projects together which is nice. It creates two weirdly
named projects:
1. buildSrc - its still just called buildSrc and it doesn't match. I don't
   see why we import it into Eclipse anyway. Its groovy and easier to just edit
   in vim or whatever.
2. elasticsearch - this is the name of the root project. It's also not
   particularly useful to import into eclipse but we've always named it this way
   and the name ':' was even more confusing so we just kept the name.
