### PR TITLE
Tests: Add expectThrows utility to base test case

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -629,13 +629,12 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /** Checks a specific exception class is thrown by the given runnable, and returns it. */
-    @SuppressWarnings("unchecked")
     public static <T extends Throwable> T expectThrows(Class<T> expectedType, ThrowingRunnable runnable) {
         try {
             runnable.run();
         } catch (Throwable e) {
             if (expectedType.isInstance(e)) {
-                return (T) e;
+                return expectedType.cast(e);
             }
             AssertionFailedError assertion = new AssertionFailedError("Unexpected exception type, expected " + expectedType.getSimpleName());
             assertion.initCause(e);

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.test;
+
+import junit.framework.AssertionFailedError;
+import org.elasticsearch.test.ESTestCase;
+
+public class ESTestCaseTests extends ESTestCase {
+    public void testExpectThrows() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+            throw new IllegalArgumentException("bad arg");
+        });
+        assertEquals("bad arg", e.getMessage());
+
+        try {
+            expectThrows(IllegalArgumentException.class, () -> {
+               throw new IllegalStateException("bad state");
+            });
+            fail("expected assertion error");
+        } catch (AssertionFailedError assertFailed) {
+            assertEquals("Unexpected exception type, expected IllegalArgumentException", assertFailed.getMessage());
+            assertNotNull(assertFailed.getCause());
+            assertEquals("bad state", assertFailed.getCause().getMessage());
+        }
+
+        try {
+            expectThrows(IllegalArgumentException.class, () -> {});
+            fail("expected assertion error");
+        } catch (AssertionFailedError assertFailed) {
+            assertNull(assertFailed.getCause());
+            assertEquals("Expected exception IllegalArgumentException", assertFailed.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
In junit5, a neat assertion method is added which makes testing expected
failures a little more straightforward. The block of code that is
expected to throw is passed in with a lambda expression, and the caught
exception returned for inspection.

This change adds an implementation of expectThrows to ESTestCase. When
junit5 is eventually releassed and we switch to it, we can remove.
