### PR TITLE
Add SmoothingModel and candidate generator serialization to PhraseSuggestionBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.SmoothingModel;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -704,6 +705,13 @@ public abstract class StreamInput extends InputStream {
      */
     public ScoreFunctionBuilder<?> readScoreFunction() throws IOException {
         return readNamedWriteable(ScoreFunctionBuilder.class);
+    }
+
+    /**
+     * Reads a {@link SmoothingModel} from the current stream
+     */
+    public SmoothingModel readSmoothingModel() throws IOException {
+        return readNamedWriteable(SmoothingModel.class);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -710,7 +710,7 @@ public abstract class StreamInput extends InputStream {
     /**
      * Reads a {@link SmoothingModel} from the current stream
      */
-    public SmoothingModel readSmoothingModel() throws IOException {
+    public SmoothingModel readPhraseSuggestionSmoothingModel() throws IOException {
         return readNamedWriteable(SmoothingModel.class);
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.SmoothingModel;
 import org.joda.time.ReadableInstant;
 
 import java.io.EOFException;
@@ -668,6 +669,13 @@ public abstract class StreamOutput extends OutputStream {
      */
     public void writeScoreFunction(ScoreFunctionBuilder<?> scoreFunctionBuilder) throws IOException {
         writeNamedWriteable(scoreFunctionBuilder);
+    }
+
+    /**
+     * Writes the given {@link SmoothingModel} to the stream
+     */
+    public void writeSmoothingModel(SmoothingModel smoothinModel) throws IOException {
+        writeNamedWriteable(smoothinModel);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -674,7 +674,7 @@ public abstract class StreamOutput extends OutputStream {
     /**
      * Writes the given {@link SmoothingModel} to the stream
      */
-    public void writeSmoothingModel(SmoothingModel smoothinModel) throws IOException {
+    public void writePhraseSuggestionSmoothingModel(SmoothingModel smoothinModel) throws IOException {
         writeNamedWriteable(smoothinModel);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -42,7 +41,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 public final class DirectCandidateGeneratorBuilder
-        implements Writeable<DirectCandidateGeneratorBuilder>, CandidateGenerator {
+        implements CandidateGenerator {
 
     private static final String TYPE = "direct_generator";
     static final DirectCandidateGeneratorBuilder PROTOTYPE = new DirectCandidateGeneratorBuilder("_na_");

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -754,7 +754,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
         boolean hasModel = model != null;
         out.writeBoolean(hasModel);
         if (hasModel) {
-            out.writeSmoothingModel(model);
+            out.writePhraseSuggestionSmoothingModel(model);
         }
         out.writeOptionalBoolean(forceUnigrams);
         out.writeOptionalVInt(tokenLimit);
@@ -788,7 +788,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
         builder.confidence = in.readOptionalFloat();
         builder.gramSize = in.readOptionalVInt();
         if (in.readBoolean()) {
-            builder.model = in.readSmoothingModel();
+            builder.model = in.readPhraseSuggestionSmoothingModel();
         }
         builder.forceUnigrams = in.readOptionalBoolean();
         builder.tokenLimit = in.readOptionalVInt();

--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.not;
 public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBuilder<SB>> extends ESTestCase {
 
     private static final int NUMBER_OF_TESTBUILDERS = 20;
-    private static NamedWriteableRegistry namedWriteableRegistry;
+    protected static NamedWriteableRegistry namedWriteableRegistry;
 
     /**
      * setup for the whole base test class

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/LaplaceModelTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/LaplaceModelTests.java
@@ -28,6 +28,11 @@ public class LaplaceModelTests extends SmoothingModelTestCase {
 
     @Override
     protected SmoothingModel createTestModel() {
+        return createRandomModel();
+    }
+
+
+    static SmoothingModel createRandomModel() {
         return new Laplace(randomDoubleBetween(0.0, 10.0, false));
     }
 

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/LinearInterpolationModelTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/LinearInterpolationModelTests.java
@@ -28,6 +28,10 @@ public class LinearInterpolationModelTests extends SmoothingModelTestCase {
 
     @Override
     protected SmoothingModel createTestModel() {
+        return createRandomModel();
+    }
+
+    static LinearInterpolation createRandomModel() {
         double trigramLambda = randomDoubleBetween(0.0, 10.0, false);
         double bigramLambda = randomDoubleBetween(0.0, 10.0, false);
         double unigramLambda = randomDoubleBetween(0.0, 10.0, false);

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -62,11 +62,13 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             testBuilder.collateParams(collateParams );
         }
         if (randomBoolean()) {
-            randomSmoothingModel();
+            testBuilder.smoothingModel(randomSmoothingModel());
         }
-
         if (randomBoolean()) {
-            // NORELEASE add random generator
+            int numGenerators = randomIntBetween(1, 5);
+            for (int i = 0; i < numGenerators; i++) {
+                testBuilder.addCandidateGenerator(DirectCandidateGeneratorTests.randomCandidateGenerator());
+            }
         }
         return testBuilder;
     }
@@ -89,7 +91,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
 
     @Override
     protected void mutateSpecificParameters(PhraseSuggestionBuilder builder) throws IOException {
-        switch (randomIntBetween(0, 7)) {
+        switch (randomIntBetween(0, 12)) {
         case 0:
             builder.maxErrors(randomValueOtherThan(builder.maxErrors(), () -> randomFloat()));
             break;
@@ -133,12 +135,16 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             builder.forceUnigrams(builder.forceUnigrams() == null ? randomBoolean() : ! builder.forceUnigrams());
             break;
         case 10:
-            builder.collateParams().put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            Map<String, Object> collateParams = builder.collateParams() == null ? new HashMap<>(1) : builder.collateParams();
+            collateParams.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            builder.collateParams(collateParams);
             break;
         case 11:
             builder.smoothingModel(randomValueOtherThan(builder.smoothingModel(), PhraseSuggestionBuilderTests::randomSmoothingModel));
             break;
-        // TODO mutate random Model && generator
+        case 12:
+            builder.addCandidateGenerator(DirectCandidateGeneratorTests.randomCandidateGenerator());
+            break;
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -21,12 +21,24 @@ package org.elasticsearch.search.suggest.phrase;
 
 import org.elasticsearch.script.Template;
 import org.elasticsearch.search.suggest.AbstractSuggestionBuilderTestCase;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.Laplace;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.LinearInterpolation;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.SmoothingModel;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder.StupidBackoff;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestCase<PhraseSuggestionBuilder> {
+
+    @BeforeClass
+    public static void initSmoothingModels() {
+        namedWriteableRegistry.registerPrototype(SmoothingModel.class, Laplace.PROTOTYPE);
+        namedWriteableRegistry.registerPrototype(SmoothingModel.class, LinearInterpolation.PROTOTYPE);
+        namedWriteableRegistry.registerPrototype(SmoothingModel.class, StupidBackoff.PROTOTYPE);
+    }
 
     @Override
     protected PhraseSuggestionBuilder randomSuggestionBuilder() {
@@ -50,13 +62,29 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             testBuilder.collateParams(collateParams );
         }
         if (randomBoolean()) {
-            // NORELEASE add random model
+            randomSmoothingModel();
         }
 
         if (randomBoolean()) {
             // NORELEASE add random generator
         }
         return testBuilder;
+    }
+
+    private static SmoothingModel randomSmoothingModel() {
+        SmoothingModel model = null;
+        switch (randomIntBetween(0,2)) {
+        case 0:
+            model = LaplaceModelTests.createRandomModel();
+            break;
+        case 1:
+            model = StupidBackoffModelTests.createRandomModel();
+            break;
+        case 2:
+            model = LinearInterpolationModelTests.createRandomModel();
+            break;
+        }
+        return model;
     }
 
     @Override
@@ -106,6 +134,9 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             break;
         case 10:
             builder.collateParams().put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            break;
+        case 11:
+            builder.smoothingModel(randomValueOtherThan(builder.smoothingModel(), PhraseSuggestionBuilderTests::randomSmoothingModel));
             break;
         // TODO mutate random Model && generator
         }

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/StupidBackoffModelTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/StupidBackoffModelTests.java
@@ -28,6 +28,10 @@ public class StupidBackoffModelTests extends SmoothingModelTestCase {
 
     @Override
     protected SmoothingModel createTestModel() {
+        return createRandomModel();
+    }
+
+    static SmoothingModel createRandomModel() {
         return new StupidBackoff(randomDoubleBetween(0.0, 10.0, false));
     }
 


### PR DESCRIPTION
With SmoothingModels and CandidateGenerator now beeing able to be serialized via NamedWritable infrastructure, PhraseSuggestionBuilder can now properly delegate read/write and equals/hashCode to their implementations. Also adding randomization of smoothing model and candidate generators to tests.
