### PR TITLE
Allow direct reading and writing of NamedWritables

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/GeometryCollectionBuilder.java
@@ -151,7 +151,7 @@ public class GeometryCollectionBuilder extends ShapeBuilder {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(shapes.size());
         for (ShapeBuilder shape : shapes) {
-            out.writeShape(shape);
+            out.writeNamedWriteable(shape);
         }
     }
 
@@ -160,7 +160,7 @@ public class GeometryCollectionBuilder extends ShapeBuilder {
         GeometryCollectionBuilder geometryCollectionBuilder = new GeometryCollectionBuilder();
         int shapes = in.readVInt();
         for (int i = 0; i < shapes; i++) {
-            geometryCollectionBuilder.shape(in.readShape());
+            geometryCollectionBuilder.shape(in.readNamedWriteable(ShapeBuilder.class));
         }
         return geometryCollectionBuilder;
     }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableAwareStreamInput.java
@@ -34,7 +34,7 @@ public class NamedWriteableAwareStreamInput extends FilterStreamInput {
     }
 
     @Override
-    <C> C readNamedWriteable(Class<C> categoryClass) throws IOException {
+    public <C> C readNamedWriteable(Class<C> categoryClass) throws IOException {
         String name = readString();
         NamedWriteable<? extends C> namedWriteable = namedWriteableRegistry.getPrototype(categoryClass, name);
         return namedWriteable.readFrom(this);

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -33,11 +33,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
-import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -658,7 +655,7 @@ public abstract class StreamInput extends InputStream {
      * Default implementation throws {@link UnsupportedOperationException} as StreamInput doesn't hold a registry.
      * Use {@link FilterInputStream} instead which wraps a stream and supports a {@link NamedWriteableRegistry} too.
      */
-    <C> C readNamedWriteable(@SuppressWarnings("unused") Class<C> categoryClass) throws IOException {
+    public <C> C readNamedWriteable(@SuppressWarnings("unused") Class<C> categoryClass) throws IOException {
         throw new UnsupportedOperationException("can't read named writeable from StreamInput");
     }
 
@@ -667,27 +664,6 @@ public abstract class StreamInput extends InputStream {
      */
     public QueryBuilder readQuery() throws IOException {
         return readNamedWriteable(QueryBuilder.class);
-    }
-
-    /**
-     * Reads a {@link ShapeBuilder} from the current stream
-     */
-    public ShapeBuilder readShape() throws IOException {
-        return readNamedWriteable(ShapeBuilder.class);
-    }
-
-    /**
-     * Reads a {@link RescoreBuilder} from the current stream
-     */
-    public RescoreBuilder<?> readRescorer() throws IOException {
-        return readNamedWriteable(RescoreBuilder.class);
-    }
-
-    /**
-     * Reads a {@link org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder} from the current stream
-     */
-    public ScoreFunctionBuilder<?> readScoreFunction() throws IOException {
-        return readNamedWriteable(ScoreFunctionBuilder.class);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -32,11 +32,8 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
-import org.elasticsearch.search.rescore.RescoreBuilder;
 import org.joda.time.ReadableInstant;
 
 import java.io.EOFException;
@@ -634,7 +631,7 @@ public abstract class StreamOutput extends OutputStream {
     /**
      * Writes a {@link NamedWriteable} to the current stream, by first writing its name and then the object itself
      */
-    void writeNamedWriteable(NamedWriteable namedWriteable) throws IOException {
+    public void writeNamedWriteable(NamedWriteable<?> namedWriteable) throws IOException {
         writeString(namedWriteable.getWriteableName());
         namedWriteable.writeTo(this);
     }
@@ -644,20 +641,6 @@ public abstract class StreamOutput extends OutputStream {
      */
     public void writeQuery(QueryBuilder queryBuilder) throws IOException {
         writeNamedWriteable(queryBuilder);
-    }
-
-    /**
-     * Writes a {@link ShapeBuilder} to the current stream
-     */
-    public void writeShape(ShapeBuilder shapeBuilder) throws IOException {
-        writeNamedWriteable(shapeBuilder);
-    }
-
-    /**
-     * Writes a {@link ScoreFunctionBuilder} to the current stream
-     */
-    public void writeScoreFunction(ScoreFunctionBuilder<?> scoreFunctionBuilder) throws IOException {
-        writeNamedWriteable(scoreFunctionBuilder);
     }
 
     /**
@@ -677,11 +660,4 @@ public abstract class StreamOutput extends OutputStream {
             obj.writeTo(this);
         }
      }
-
-     /**
-     * Writes a {@link RescoreBuilder} to the current stream
-     */
-    public void writeRescorer(RescoreBuilder<?> rescorer) throws IOException {
-        writeNamedWriteable(rescorer);
-    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.geo.GeoShapeFieldMapper;
-import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -384,7 +383,7 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
         String fieldName = in.readString();
         GeoShapeQueryBuilder builder;
         if (in.readBoolean()) {
-            builder = new GeoShapeQueryBuilder(fieldName, in.readShape());
+            builder = new GeoShapeQueryBuilder(fieldName, in.readNamedWriteable(ShapeBuilder.class));
         } else {
             String indexedShapeId = in.readOptionalString();
             String indexedShapeType = in.readOptionalString();
@@ -411,7 +410,7 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
         boolean hasShape = shape != null;
         out.writeBoolean(hasShape);
         if (hasShape) {
-            out.writeShape(shape);
+            out.writeNamedWriteable(shape);
         } else {
             out.writeOptionalString(indexedShapeId);
             out.writeOptionalString(indexedShapeType);

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -386,12 +386,12 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeQuery(filter);
-            out.writeScoreFunction(scoreFunction);
+            out.writeNamedWriteable(scoreFunction);
         }
 
         @Override
         public FilterFunctionBuilder readFrom(StreamInput in) throws IOException {
-            return new FilterFunctionBuilder(in.readQuery(), in.readScoreFunction());
+            return new FilterFunctionBuilder(in.readQuery(), in.readNamedWriteable(ScoreFunctionBuilder.class));
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -41,14 +41,13 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.search.searchafter.SearchAfterBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.fetch.innerhits.InnerHitsBuilder;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.rescore.RescoreBuilder;
-import org.elasticsearch.search.rescore.RescoreBuilder;
+import org.elasticsearch.search.searchafter.SearchAfterBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
@@ -1222,7 +1221,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
             int size = in.readVInt();
             List<RescoreBuilder<?>> rescoreBuilders = new ArrayList<>();
             for (int i = 0; i < size; i++) {
-                rescoreBuilders.add(in.readRescorer());
+                rescoreBuilders.add(in.readNamedWriteable(RescoreBuilder.class));
             }
             builder.rescoreBuilders = rescoreBuilders;
         }
@@ -1340,7 +1339,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
         if (hasRescoreBuilders) {
             out.writeVInt(rescoreBuilders.size());
             for (RescoreBuilder<?> rescoreBuilder : rescoreBuilders) {
-                out.writeRescorer(rescoreBuilder);
+                out.writeNamedWriteable(rescoreBuilder);
             }
         }
         boolean hasScriptFields = scriptFields != null;

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
@@ -170,7 +170,7 @@ public class QueryRescoreBuilderTests extends ESTestCase {
 
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
             RescoreBuilder<?> rescoreBuilder = randomRescoreBuilder();
-            QueryRescoreContext rescoreContext = (QueryRescoreContext) rescoreBuilder.build(mockShardContext);
+            QueryRescoreContext rescoreContext = rescoreBuilder.build(mockShardContext);
             XContentParser parser = createParser(rescoreBuilder);
 
             QueryRescoreContext parsedRescoreContext = (QueryRescoreContext) new RescoreParseElement().parseSingleRescoreContext(parser, mockShardContext);
@@ -336,9 +336,9 @@ public class QueryRescoreBuilderTests extends ESTestCase {
 
     private static RescoreBuilder<?> serializedCopy(RescoreBuilder<?> original) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.writeRescorer(original);
+            output.writeNamedWriteable(original);
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(output.bytes()), namedWriteableRegistry)) {
-                return in.readRescorer();
+                return in.readNamedWriteable(RescoreBuilder.class);
             }
         }
     }


### PR DESCRIPTION
When the serialization infrastructure for NamedWritable objects was introduced, the generic read/writeNamedWritable methods in StreamInput and StreamOutput had limited access. Instead of using it directly we exposed public readFoo/writeFoo methods for each NamedWritable category (which was only QueryBuilders then).

Now with the ongoing search refactoring, we got a lot more categories of NamesWritable objects (shapes, rescore, function scores, soon also suggesters, aggs, sorts), which all require additional read/write methods in StreamInput/StreamOutput, thereby bloating it.

This PR allows direct access to read/writeNamedWritable in the streaming classes, thereby reducing the number of specialized methods we need (and will need in the future)
