### PR TITLE
Ensure all resources are closed on Node#close()

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -21,6 +21,7 @@ package org.elasticsearch.bootstrap;
 
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.StringHelper;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.PidFile;
 import org.elasticsearch.common.SuppressForbidden;
@@ -40,6 +41,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.Locale;
@@ -114,7 +116,11 @@ final class Bootstrap {
                 public boolean handle(int code) {
                     if (CTRL_CLOSE_EVENT == code) {
                         logger.info("running graceful exit on windows");
-                        Bootstrap.stop();
+                        try {
+                            Bootstrap.stop();
+                        } catch (IOException e) {
+                            throw new ElasticsearchException("failed to stop node", e);
+                        }
                         return true;
                     }
                     return false;
@@ -154,7 +160,11 @@ final class Bootstrap {
                 @Override
                 public void run() {
                     if (node != null) {
-                        node.close();
+                        try {
+                            node.close();
+                        } catch (IOException ex) {
+                            throw new ElasticsearchException("failed to stop node", ex);
+                        }
                     }
                 }
             });
@@ -221,9 +231,9 @@ final class Bootstrap {
         keepAliveThread.start();
     }
 
-    static void stop() {
+    static void stop() throws IOException {
         try {
-            Releasables.close(INSTANCE.node);
+            INSTANCE.node.close();
         } finally {
             INSTANCE.keepAliveLatch.countDown();
         }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.bootstrap;
 
 import org.apache.lucene.util.Constants;
+import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.StringHelper;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
@@ -159,12 +160,10 @@ final class Bootstrap {
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override
                 public void run() {
-                    if (node != null) {
-                        try {
-                            node.close();
-                        } catch (IOException ex) {
-                            throw new ElasticsearchException("failed to stop node", ex);
-                        }
+                    try {
+                        IOUtils.close(node);
+                    } catch (IOException ex) {
+                        throw new ElasticsearchException("failed to stop node", ex);
                     }
                 }
             });
@@ -233,7 +232,7 @@ final class Bootstrap {
 
     static void stop() throws IOException {
         try {
-            INSTANCE.node.close();
+            IOUtils.close(INSTANCE.node);
         } finally {
             INSTANCE.keepAliveLatch.countDown();
         }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.bootstrap;
 
+import java.io.IOException;
+
 /**
  * This class starts elasticsearch.
  */
@@ -48,7 +50,7 @@ public final class Elasticsearch {
      *
      * NOTE: If this method is renamed and/or moved, make sure to update service.bat!
      */
-    static void close(String[] args) {
+    static void close(String[] args) throws IOException {
         Bootstrap.stop();
     }
 }

--- a/core/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
+++ b/core/src/main/java/org/elasticsearch/cache/recycler/PageCacheRecycler.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cache.recycler;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.recycler.AbstractRecyclerC;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.settings.Settings;
@@ -38,7 +39,7 @@ import static org.elasticsearch.common.recycler.Recyclers.dequeFactory;
 import static org.elasticsearch.common.recycler.Recyclers.none;
 
 /** A recycler of fixed-size pages. */
-public class PageCacheRecycler extends AbstractComponent {
+public class PageCacheRecycler extends AbstractComponent implements Releasable {
 
     public static final String TYPE = "recycler.page.type";
     public static final String LIMIT_HEAP = "recycler.page.limit.heap";
@@ -49,6 +50,7 @@ public class PageCacheRecycler extends AbstractComponent {
     private final Recycler<long[]> longPage;
     private final Recycler<Object[]> objectPage;
 
+    @Override
     public void close() {
         bytePage.close();
         intPage.close();

--- a/core/src/main/java/org/elasticsearch/common/lease/Releasable.java
+++ b/core/src/main/java/org/elasticsearch/common/lease/Releasable.java
@@ -21,10 +21,12 @@ package org.elasticsearch.common.lease;
 
 import org.elasticsearch.ElasticsearchException;
 
+import java.io.Closeable;
+
 /**
  * Specialization of {@link AutoCloseable} that may only throw an {@link ElasticsearchException}.
  */
-public interface Releasable extends AutoCloseable {
+public interface Releasable extends Closeable {
 
     @Override
     void close();

--- a/core/src/main/java/org/elasticsearch/common/lease/Releasables.java
+++ b/core/src/main/java/org/elasticsearch/common/lease/Releasables.java
@@ -19,37 +19,23 @@
 
 package org.elasticsearch.common.lease;
 
+import org.apache.lucene.util.IOUtils;
+
+import java.io.IOException;
 import java.util.Arrays;
 
 /** Utility methods to work with {@link Releasable}s. */
 public enum Releasables {
     ;
 
-    private static void rethrow(Throwable t) {
-        if (t instanceof RuntimeException) {
-            throw (RuntimeException) t;
-        }
-        if (t instanceof Error) {
-            throw (Error) t;
-        }
-        throw new RuntimeException(t);
-    }
-
     private static void close(Iterable<? extends Releasable> releasables, boolean ignoreException) {
-        Throwable th = null;
-        for (Releasable releasable : releasables) {
-            if (releasable != null) {
-                try {
-                    releasable.close();
-                } catch (Throwable t) {
-                    if (th == null) {
-                        th = t;
-                    }
-                }
+        try {
+            // this does the right thing with respect to add suppressed and not wrapping errors etc.
+            IOUtils.close(releasables);
+        } catch (Throwable t) {
+            if (ignoreException == false) {
+                IOUtils.reThrowUnchecked(t);
             }
-        }
-        if (th != null && !ignoreException) {
-            rethrow(th);
         }
     }
 
@@ -99,25 +85,11 @@ public enum Releasables {
      *  </pre>
      */
     public static Releasable wrap(final Iterable<Releasable> releasables) {
-        return new Releasable() {
-
-            @Override
-            public void close() {
-                Releasables.close(releasables);
-            }
-
-        };
+        return () -> close(releasables);
     }
 
     /** @see #wrap(Iterable) */
     public static Releasable wrap(final Releasable... releasables) {
-        return new Releasable() {
-
-            @Override
-            public void close() {
-                Releasables.close(releasables);
-            }
-
-        };
+        return () -> close(releasables);
     }
 }

--- a/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.cache.RemovalListener;
 import org.elasticsearch.common.cache.RemovalNotification;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Setting;
@@ -52,7 +53,7 @@ import java.util.function.ToLongBiFunction;
 
 /**
  */
-public class IndicesFieldDataCache extends AbstractComponent implements RemovalListener<IndicesFieldDataCache.Key, Accountable> {
+public class IndicesFieldDataCache extends AbstractComponent implements RemovalListener<IndicesFieldDataCache.Key, Accountable>, Releasable{
 
     public static final Setting<TimeValue> INDICES_FIELDDATA_CLEAN_INTERVAL_SETTING = Setting.positiveTimeSetting("indices.fielddata.cache.cleanup_interval", TimeValue.timeValueMinutes(1), false, Setting.Scope.CLUSTER);
     public static final Setting<ByteSizeValue> INDICES_FIELDDATA_CACHE_SIZE_KEY = Setting.byteSizeSetting("indices.fielddata.cache.size", new ByteSizeValue(-1), false, Setting.Scope.CLUSTER);
@@ -84,6 +85,7 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
                 new FieldDataCacheCleaner(this.cache, this.logger, this.threadPool, this.cleanInterval));
     }
 
+    @Override
     public void close() {
         cache.invalidateAll();
         this.closed = true;

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
@@ -85,7 +86,7 @@ import java.util.stream.StreamSupport;
 import static org.apache.lucene.search.BooleanClause.Occur.FILTER;
 import static org.apache.lucene.search.BooleanClause.Occur.MUST;
 
-public class PercolatorService extends AbstractComponent {
+public class PercolatorService extends AbstractComponent implements Releasable {
 
     public final static float NO_SCORE = Float.NEGATIVE_INFINITY;
     public final static String TYPE_NAME = ".percolator";
@@ -304,6 +305,7 @@ public class PercolatorService extends AbstractComponent {
         }
     }
 
+    @Override
     public void close() {
         cache.close();
     }

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientIT.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientIT.java
@@ -32,6 +32,8 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOException;
+
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -48,7 +50,7 @@ public class TransportClientIT extends ESIntegTestCase {
 
     }
 
-    public void testNodeVersionIsUpdated() {
+    public void testNodeVersionIsUpdated() throws IOException {
         TransportClient client = (TransportClient)  internalCluster().client();
         TransportClientNodesService nodeService = client.nodeService();
         Node node = new Node(Settings.builder()

--- a/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -279,7 +279,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         setMinimumMasterNodes(2);
 
         // make sure it has been processed on all nodes (master node spawns a secondary cluster state update task)
-        for (Client client : internalCluster()) {
+        for (Client client : internalCluster().getClients()) {
             assertThat(client.admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setLocal(true).get().isTimedOut(),
                     equalTo(false));
         }
@@ -303,7 +303,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         assertTrue(awaitBusy(
                         () -> {
                             boolean success = true;
-                            for (Client client : internalCluster()) {
+                            for (Client client : internalCluster().getClients()) {
                                 boolean clientHasNoMasterBlock = hasNoMasterBlock.test(client);
                                 if (logger.isDebugEnabled()) {
                                     logger.debug("Checking for NO_MASTER_BLOCK on client: {} NO_MASTER_BLOCK: [{}]", client, clientHasNoMasterBlock);

--- a/core/src/test/java/org/elasticsearch/index/mapper/update/UpdateMappingOnClusterIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/update/UpdateMappingOnClusterIT.java
@@ -167,7 +167,7 @@ public class UpdateMappingOnClusterIT extends ESIntegTestCase {
 
     private void compareMappingOnNodes(GetMappingsResponse previousMapping) {
         // make sure all nodes have same cluster state
-        for (Client client : cluster()) {
+        for (Client client : cluster().getClients()) {
             GetMappingsResponse currentMapping = client.admin().indices().prepareGetMappings(INDEX).addTypes(TYPE).setLocal(true).get();
             assertThat(previousMapping.getMappings().get(INDEX).get(TYPE).source(), equalTo(currentMapping.getMappings().get(INDEX).get(TYPE).source()));
         }

--- a/core/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -92,7 +92,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
 
         refresh();
 
-        for (Client client : internalCluster()) {
+        for (Client client : internalCluster().getClients()) {
             ValidateQueryResponse response = client.admin().indices().prepareValidateQuery("test")
                     .setQuery(QueryBuilders.wrapperQuery("foo".getBytes(StandardCharsets.UTF_8)))
                     .setExplain(true)
@@ -104,7 +104,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
 
         }
 
-        for (Client client : internalCluster()) {
+        for (Client client : internalCluster().getClients()) {
             ValidateQueryResponse response = client.admin().indices().prepareValidateQuery("test")
                     .setQuery(QueryBuilders.queryStringQuery("foo"))
                     .setExplain(true)

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryF.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryF.java
@@ -119,8 +119,9 @@ public class AzureRepositoryF {
                     IOUtils.close(node);
                 } catch (IOException e) {
                     throw new ElasticsearchException(e);
+                } finally {
+                    latch.countDown();
                 }
-                latch.countDown();
             }
         });
         node.start();

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryF.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryF.java
@@ -19,12 +19,15 @@
 
 package org.elasticsearch.repositories.azure;
 
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.MockNode;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugin.repository.azure.AzureRepositoryPlugin;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 
@@ -112,7 +115,11 @@ public class AzureRepositoryF {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                node.close();
+                try {
+                    IOUtils.close(node);
+                } catch (IOException e) {
+                    throw new ElasticsearchException(e);
+                }
                 latch.countDown();
             }
         });

--- a/qa/evil-tests/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.tribe;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -34,6 +35,7 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.hamcrest.CoreMatchers.either;
@@ -76,10 +78,9 @@ public class TribeUnitTests extends ESTestCase {
     }
 
     @AfterClass
-    public static void closeTribes() {
-        tribe1.close();
+    public static void closeTribes() throws IOException {
+        IOUtils.close(tribe1, tribe2);
         tribe1 = null;
-        tribe2.close();
         tribe2 = null;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/CompositeTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/CompositeTestCluster.java
@@ -241,8 +241,8 @@ public class CompositeTestCluster extends TestCluster {
     }
 
     @Override
-    public synchronized Iterator<Client> iterator() {
-        return Collections.singleton(client()).iterator();
+    public synchronized Iterable<Client> getClients() {
+        return Collections.singleton(client());
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -129,6 +129,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -675,7 +676,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     public static Iterable<Client> clients() {
-        return cluster();
+        return cluster().getClients();
     }
 
     protected int minimumNumberOfShards() {
@@ -1099,7 +1100,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             Map<String, Object> masterStateMap = convertToMap(masterClusterState);
             int masterClusterStateSize = masterClusterState.toString().length();
             String masterId = masterClusterState.nodes().masterNodeId();
-            for (Client client : cluster()) {
+            for (Client client : cluster().getClients()) {
                 ClusterState localClusterState = client.admin().cluster().prepareState().all().setLocal(true).get().getState();
                 byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterState);
                 // remove local node reference

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -51,6 +51,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,7 +69,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
 
     private static Node NODE = null;
 
-    private void reset() {
+    private void reset() throws IOException {
         assert NODE != null;
         stopNode();
         startNode();
@@ -83,13 +84,13 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
         assertFalse(clusterHealthResponse.isTimedOut());
     }
 
-    private static void stopNode() {
+    private static void stopNode() throws IOException {
         Node node = NODE;
         NODE = null;
-        Releasables.close(node);
+        node.close();
     }
 
-    private void cleanup(boolean resetNode) {
+    private void cleanup(boolean resetNode) throws IOException {
         assertAcked(client().admin().indices().prepareDelete("*").get());
         if (resetNode) {
             reset();
@@ -126,7 +127,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     }
 
     @AfterClass
-    public static void tearDownClass() {
+    public static void tearDownClass() throws IOException {
         stopNode();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test;
 
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
@@ -87,7 +88,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     private static void stopNode() throws IOException {
         Node node = NODE;
         NODE = null;
-        node.close();
+        IOUtils.close(node);
     }
 
     private void cleanup(boolean resetNode) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -167,8 +167,8 @@ public final class ExternalTestCluster extends TestCluster {
     }
 
     @Override
-    public Iterator<Client> iterator() {
-        return Collections.singleton(client).iterator();
+    public Iterable<Client> getClients() {
+        return Collections.singleton(client);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -815,7 +815,7 @@ public final class InternalTestCluster extends TestCluster {
             }
         }
 
-        void closeNode() {
+        void closeNode() throws IOException {
             registerDataPath();
             node.close();
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1720,27 +1720,29 @@ public final class InternalTestCluster extends TestCluster {
         return null;
     }
 
-    @Override
-    public synchronized Iterator<Client> iterator() {
+    public synchronized Iterable<Client> getClients() {
         ensureOpen();
-        final Iterator<NodeAndClient> iterator = nodes.values().iterator();
-        return new Iterator<Client>() {
+        return () -> {
+            ensureOpen();
+            final Iterator<NodeAndClient> iterator = nodes.values().iterator();
+            return new Iterator<Client>() {
 
-            @Override
-            public boolean hasNext() {
-                return iterator.hasNext();
-            }
+                @Override
+                public boolean hasNext() {
+                    return iterator.hasNext();
+                }
 
-            @Override
-            public Client next() {
-                return iterator.next().client(random);
-            }
+                @Override
+                public Client next() {
+                    return iterator.next().client(random);
+                }
 
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException("");
-            }
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException("");
+                }
 
+            };
         };
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -43,7 +43,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
  * Base test cluster that exposes the basis to run tests against any elasticsearch cluster, whose layout
  * (e.g. number of nodes) is predefined and cannot be changed during the tests execution
  */
-public abstract class TestCluster implements Iterable<Client>, Closeable {
+public abstract class TestCluster implements Closeable {
 
     protected final ESLogger logger = Loggers.getLogger(getClass());
     private final long seed;
@@ -227,6 +227,11 @@ public abstract class TestCluster implements Iterable<Client>, Closeable {
      * Returns the cluster name
      */
     public abstract String getClusterName();
+
+    /**
+     * Returns an {@link Iterable} over all clients in this test cluster
+     */
+    public abstract Iterable<Client> getClients();
 
 
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -130,8 +130,8 @@ public class InternalTestClusterTests extends ESTestCase {
                 cluster1.beforeTest(random, random.nextDouble());
             }
             assertArrayEquals(cluster0.getNodeNames(), cluster1.getNodeNames());
-            Iterator<Client> iterator1 = cluster1.iterator();
-            for (Client client : cluster0) {
+            Iterator<Client> iterator1 = cluster1.getClients().iterator();
+            for (Client client : cluster0.getClients()) {
                 assertTrue(iterator1.hasNext());
                 Client other = iterator1.next();
                 assertSettings(client.settings(), other.settings(), false);


### PR DESCRIPTION
We are leaking all kinds of resources if something during Node#close() barfs.
This commit cuts over to a list of closeables to release resources that
also closed remaining services if one or more services fail to close.

Closes #13685
