### PR TITLE
Uppercase ells ('L') in long literals

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -28,6 +28,9 @@
     <module name="NoLineWrap" />
     <!-- Each java file has only one outer class -->
     <module name="OneTopLevelClass" />
+    <!-- The suffix L is preferred, because the letter l (ell) is often
+    hard to distinguish from the digit 1 (one). -->
+    <module name="UpperEll" />
 
     <!-- We don't use Java's builtin serialization and we suppress all warning
       about it. The flip side of that coin is that we shouldn't _try_ to use

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -302,7 +302,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     }
 
     public long getCreationDate() {
-        return settings.getAsLong(SETTING_CREATION_DATE, -1l);
+        return settings.getAsLong(SETTING_CREATION_DATE, -1L);
     }
 
     public State getState() {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -106,7 +106,7 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
     private final Reason reason;
     private final long unassignedTimeMillis; // used for display and log messages, in milliseconds
     private final long unassignedTimeNanos; // in nanoseconds, used to calculate delay for delayed shard allocation
-    private volatile long lastComputedLeftDelayNanos = 0l; // how long to delay shard allocation, not serialized (always positive, 0 means no delay)
+    private volatile long lastComputedLeftDelayNanos = 0L; // how long to delay shard allocation, not serialized (always positive, 0 means no delay)
     private final String message;
     private final Throwable failure;
 
@@ -217,7 +217,7 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
             return 0;
         }
         TimeValue delayTimeout = INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexSettings, settings);
-        return Math.max(0l, delayTimeout.nanos());
+        return Math.max(0L, delayTimeout.nanos());
     }
 
     /**
@@ -236,8 +236,8 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
     public long updateDelay(long nanoTimeNow, Settings settings, Settings indexSettings) {
         long delayTimeoutNanos = getAllocationDelayTimeoutSettingNanos(settings, indexSettings);
         final long newComputedLeftDelayNanos;
-        if (delayTimeoutNanos == 0l) {
-            newComputedLeftDelayNanos = 0l;
+        if (delayTimeoutNanos == 0L) {
+            newComputedLeftDelayNanos = 0L;
         } else {
             assert nanoTimeNow >= unassignedTimeNanos;
             newComputedLeftDelayNanos = Math.max(0L, delayTimeoutNanos - (nanoTimeNow - unassignedTimeNanos));
@@ -277,7 +277,7 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
                 }
             }
         }
-        return minDelaySetting == Long.MAX_VALUE ? 0l : minDelaySetting;
+        return minDelaySetting == Long.MAX_VALUE ? 0L : minDelaySetting;
     }
 
 
@@ -294,7 +294,7 @@ public class UnassignedInfo implements ToXContent, Writeable<UnassignedInfo> {
                 }
             }
         }
-        return nextDelay == Long.MAX_VALUE ? 0l : nextDelay;
+        return nextDelay == Long.MAX_VALUE ? 0L : nextDelay;
     }
 
     public String shortSummary() {

--- a/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -179,7 +179,7 @@ public class GeoUtils {
             final double width = Math.sqrt((meters*meters)/(ratio*ratio)); // convert to cell width
             final long part = Math.round(Math.ceil(EARTH_EQUATOR / width));
             final int level = Long.SIZE - Long.numberOfLeadingZeros(part)-1; // (log_2)
-            return (part<=(1l<<level)) ?level :(level+1); // adjust level
+            return (part<=(1L<<level)) ?level :(level+1); // adjust level
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoveryService.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 public class DiscoveryService extends AbstractLifecycleComponent<DiscoveryService> {
 
     public static final Setting<TimeValue> INITIAL_STATE_TIMEOUT_SETTING = Setting.positiveTimeSetting("discovery.initial_state_timeout", TimeValue.timeValueSeconds(30), false, Setting.Scope.CLUSTER);
-    public static final Setting<Long> DISCOVERY_SEED_SETTING = Setting.longSetting("discovery.id.seed", 0l, Long.MIN_VALUE, false, Setting.Scope.CLUSTER);
+    public static final Setting<Long> DISCOVERY_SEED_SETTING = Setting.longSetting("discovery.id.seed", 0L, Long.MIN_VALUE, false, Setting.Scope.CLUSTER);
 
     private static class InitialStateListener implements InitialStateDiscoveryListener {
 

--- a/core/src/main/java/org/elasticsearch/gateway/PriorityComparator.java
+++ b/core/src/main/java/org/elasticsearch/gateway/PriorityComparator.java
@@ -60,7 +60,7 @@ public abstract class PriorityComparator implements Comparator<ShardRouting> {
     }
 
     private long timeCreated(Settings settings) {
-        return settings.getAsLong(IndexMetaData.SETTING_CREATION_DATE, -1l);
+        return settings.getAsLong(IndexMetaData.SETTING_CREATION_DATE, -1L);
     }
 
     protected abstract Settings getIndexSettings(String index);

--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -456,7 +456,7 @@ public final class IndexService extends AbstractIndexComponent implements IndexC
             if (shardId != null) {
                 final IndexShard shard = indexService.getShardOrNull(shardId.id());
                 if (shard != null) {
-                    long ramBytesUsed = accountable != null ? accountable.ramBytesUsed() : 0l;
+                    long ramBytesUsed = accountable != null ? accountable.ramBytesUsed() : 0L;
                     shard.shardBitsetFilterCache().onCached(ramBytesUsed);
                 }
             }
@@ -467,7 +467,7 @@ public final class IndexService extends AbstractIndexComponent implements IndexC
             if (shardId != null) {
                 final IndexShard shard = indexService.getShardOrNull(shardId.id());
                 if (shard != null) {
-                    long ramBytesUsed = accountable != null ? accountable.ramBytesUsed() : 0l;
+                    long ramBytesUsed = accountable != null ? accountable.ramBytesUsed() : 0L;
                     shard.shardBitsetFilterCache().onRemoval(ramBytesUsed);
                 }
             }

--- a/core/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -121,7 +121,7 @@ public interface ScriptDocValues<T> extends List<T> {
         public long getValue() {
             int numValues = values.count();
             if (numValues == 0) {
-                return 0l;
+                return 0L;
             }
             return values.valueAt(0);
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -81,7 +81,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     public static final String DEFAULT_MAPPING = "_default_";
-    public static final Setting<Long> INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING = Setting.longSetting("index.mapping.nested_fields.limit", 50l, 0, true, Setting.Scope.INDEX);
+    public static final Setting<Long> INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING = Setting.longSetting("index.mapping.nested_fields.limit", 50L, 0, true, Setting.Scope.INDEX);
     public static final boolean INDEX_MAPPER_DYNAMIC_DEFAULT = true;
     public static final Setting<Boolean> INDEX_MAPPER_DYNAMIC_SETTING = Setting.boolSetting("index.mapper.dynamic", INDEX_MAPPER_DYNAMIC_DEFAULT, false, Setting.Scope.INDEX);
     private static ObjectHashSet<String> META_FIELDS = ObjectHashSet.from(

--- a/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ip/IpFieldMapper.java
@@ -66,7 +66,7 @@ import static org.elasticsearch.index.mapper.core.TypeParsers.parseNumberField;
 public class IpFieldMapper extends NumberFieldMapper {
 
     public static final String CONTENT_TYPE = "ip";
-    public static final long MAX_IP = 4294967296l;
+    public static final long MAX_IP = 4294967296L;
 
     public static String longToIp(long longIp) {
         int octet3 = (int) ((longIp >> 24) % 256);

--- a/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -187,7 +187,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
      *         "name": "__0",
      *         "physical_name": "_0.cfs",
      *         "length": 3354,
-     *         "checksum": "491liz",
+     *         "checksum": "491Liz",
      *         "written_by": "5.1.0"
      *     }, {
      *         "name": "__4",

--- a/core/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/core/src/main/java/org/elasticsearch/index/store/Store.java
@@ -930,7 +930,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                         return new Tuple<>(indexInput.readStringStringMap(), lastFound);
                     }
                 }
-                return new Tuple<>(new HashMap<>(), -1l);
+                return new Tuple<>(new HashMap<>(), -1L);
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1132,7 +1132,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> imp
                 // Use the same value for both checks since lastAccessTime can
                 // be modified by another thread between checks!
                 final long lastAccessTime = context.lastAccessTime();
-                if (lastAccessTime == -1l) { // its being processed or timeout is disabled
+                if (lastAccessTime == -1L) { // its being processed or timeout is disabled
                     continue;
                 }
                 if ((time - lastAccessTime > context.keepAlive())) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/avg/AvgAggregator.java
@@ -110,7 +110,7 @@ public class AvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalAvg(name, 0.0, 0l, formatter, pipelineAggregators(), metaData());
+        return new InternalAvg(name, 0.0, 0L, formatter, pipelineAggregators(), metaData());
     }
 
     public static class Factory extends ValuesSourceAggregatorFactory.LeafOnly<ValuesSource.Numeric> {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/GeoCentroidAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/GeoCentroidAggregator.java
@@ -114,7 +114,7 @@ public final class GeoCentroidAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalGeoCentroid(name, null, 0l, pipelineAggregators(), metaData());
+        return new InternalGeoCentroid(name, null, 0L, pipelineAggregators(), metaData());
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -100,7 +100,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalValueCount(name, 0l, formatter, pipelineAggregators(), metaData());
+        return new InternalValueCount(name, 0L, formatter, pipelineAggregators(), metaData());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -119,7 +119,7 @@ public class HotThreadsIT extends ESIntegTestCase {
                                 .setQuery(matchAllQuery())
                                 .setPostFilter(boolQuery().must(matchAllQuery()).mustNot(boolQuery().must(termQuery("field1", "value1")).must(termQuery("field1", "value2"))))
                                 .get(),
-                        3l);
+                        3L);
             }
             latch.await();
             assertThat(hasErrors.get(), is(false));

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -93,7 +93,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         ensureYellow();
         response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.YELLOW));
-        assertThat(response.indicesStats.getDocs().getCount(), Matchers.equalTo(0l));
+        assertThat(response.indicesStats.getDocs().getCount(), Matchers.equalTo(0L));
         assertThat(response.indicesStats.getIndexCount(), Matchers.equalTo(1));
         assertShardStats(response.getIndicesStats().getShards(), 1, 2, 2, 0.0);
 
@@ -104,7 +104,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         refresh(); // make the doc visible
         response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
-        assertThat(response.indicesStats.getDocs().getCount(), Matchers.equalTo(1l));
+        assertThat(response.indicesStats.getDocs().getCount(), Matchers.equalTo(1L));
         assertShardStats(response.getIndicesStats().getShards(), 1, 4, 2, 1.0);
 
         prepareCreate("test2").setSettings("number_of_shards", 3, "number_of_replicas", 0).get();
@@ -141,10 +141,10 @@ public class ClusterStatsIT extends ESIntegTestCase {
         ensureYellow("test1");
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
         String msg = response.toString();
-        assertThat(msg, response.getTimestamp(), Matchers.greaterThan(946681200000l)); // 1 Jan 2000
-        assertThat(msg, response.indicesStats.getStore().getSizeInBytes(), Matchers.greaterThan(0l));
+        assertThat(msg, response.getTimestamp(), Matchers.greaterThan(946681200000L)); // 1 Jan 2000
+        assertThat(msg, response.indicesStats.getStore().getSizeInBytes(), Matchers.greaterThan(0L));
 
-        assertThat(msg, response.nodesStats.getFs().getTotal().bytes(), Matchers.greaterThan(0l));
+        assertThat(msg, response.nodesStats.getFs().getTotal().bytes(), Matchers.greaterThan(0L));
         assertThat(msg, response.nodesStats.getJvm().getVersions().size(), Matchers.greaterThan(0));
 
         assertThat(msg, response.nodesStats.getVersions().size(), Matchers.greaterThan(0));

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -54,7 +54,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 public class CreateIndexIT extends ESIntegTestCase {
     public void testCreationDateGivenFails() {
         try {
-            prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_CREATION_DATE, 4l)).get();
+            prepareCreate("test").setSettings(Settings.builder().put(IndexMetaData.SETTING_CREATION_DATE, 4L)).get();
             fail();
         } catch (IllegalArgumentException ex) {
             assertEquals("unknown setting [index.creation_date]", ex.getMessage());

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -93,7 +93,7 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         assertThat(shardStores.values().size(), equalTo(2));
         for (ObjectCursor<List<IndicesShardStoresResponse.StoreStatus>> shardStoreStatuses : shardStores.values()) {
             for (IndicesShardStoresResponse.StoreStatus storeStatus : shardStoreStatuses.value) {
-                assertThat(storeStatus.getVersion(), greaterThan(-1l));
+                assertThat(storeStatus.getVersion(), greaterThan(-1L));
                 assertThat(storeStatus.getAllocationId(), notNullValue());
                 assertThat(storeStatus.getNode(), notNullValue());
                 assertThat(storeStatus.getStoreException(), nullValue());
@@ -191,10 +191,10 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
             for (IndicesShardStoresResponse.StoreStatus status : shardStatus.value) {
                 if (corruptedShardIDMap.containsKey(shardStatus.key)
                         && corruptedShardIDMap.get(shardStatus.key).contains(status.getNode().name())) {
-                    assertThat(status.getVersion(), greaterThanOrEqualTo(0l));
+                    assertThat(status.getVersion(), greaterThanOrEqualTo(0L));
                     assertThat(status.getStoreException(), notNullValue());
                 } else {
-                    assertThat(status.getVersion(), greaterThanOrEqualTo(0l));
+                    assertThat(status.getVersion(), greaterThanOrEqualTo(0L));
                     assertNull(status.getStoreException());
                 }
             }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsTests.java
@@ -66,11 +66,11 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
 
         IndicesStatsResponse rsp = client().admin().indices().prepareStats("test").get();
         SegmentsStats stats = rsp.getIndex("test").getTotal().getSegments();
-        assertThat(stats.getTermsMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getStoredFieldsMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getTermVectorsMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getNormsMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getDocValuesMemoryInBytes(), greaterThan(0l));
+        assertThat(stats.getTermsMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getStoredFieldsMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getTermVectorsMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getNormsMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getDocValuesMemoryInBytes(), greaterThan(0L));
 
         // now check multiple segments stats are merged together
         client().prepareIndex("test", "doc", "2").setSource("foo", "bar").get();
@@ -93,7 +93,7 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
         for (ShardStats shardStats : rsp.getIndex("test").getShards()) {
             final CommitStats commitStats = shardStats.getCommitStats();
             assertNotNull(commitStats);
-            assertThat(commitStats.getGeneration(), greaterThan(0l));
+            assertThat(commitStats.getGeneration(), greaterThan(0L));
             assertThat(commitStats.getId(), notNullValue());
             assertThat(commitStats.getUserData(), hasKey(Translog.TRANSLOG_GENERATION_KEY));
             assertThat(commitStats.getUserData(), hasKey(Translog.TRANSLOG_UUID_KEY));

--- a/core/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsCheckDocFreqIT.java
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsCheckDocFreqIT.java
@@ -99,7 +99,7 @@ public class GetTermVectorsCheckDocFreqIT extends ESIntegTestCase {
         Fields fields = response.getFields();
         assertThat(fields.size(), equalTo(1));
         Terms terms = fields.terms("field");
-        assertThat(terms.size(), equalTo(8l));
+        assertThat(terms.size(), equalTo(8L));
         assertThat(terms.getSumTotalTermFreq(), Matchers.equalTo((long) -1));
         assertThat(terms.getDocCount(), Matchers.equalTo(-1));
         assertThat(terms.getSumDocFreq(), equalTo((long) -1));
@@ -158,7 +158,7 @@ public class GetTermVectorsCheckDocFreqIT extends ESIntegTestCase {
         Fields fields = response.getFields();
         assertThat(fields.size(), equalTo(1));
         Terms terms = fields.terms("field");
-        assertThat(terms.size(), equalTo(8l));
+        assertThat(terms.size(), equalTo(8L));
         assertThat(terms.getSumTotalTermFreq(), Matchers.equalTo((long) (9 * numDocs)));
         assertThat(terms.getDocCount(), Matchers.equalTo(numDocs));
         assertThat(terms.getSumDocFreq(), equalTo((long) numDocs * values.length));
@@ -214,7 +214,7 @@ public class GetTermVectorsCheckDocFreqIT extends ESIntegTestCase {
         Fields fields = response.getFields();
         assertThat(fields.size(), equalTo(1));
         Terms terms = fields.terms("field");
-        assertThat(terms.size(), equalTo(8l));
+        assertThat(terms.size(), equalTo(8L));
         assertThat(terms.getSumTotalTermFreq(), Matchers.equalTo((long) (9 * numDocs)));
         assertThat(terms.getDocCount(), Matchers.equalTo(numDocs));
         assertThat(terms.getSumDocFreq(), equalTo((long) numDocs * values.length));

--- a/core/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
@@ -317,7 +317,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
             assertThat(fields.size(), equalTo(ft.storeTermVectors() ? 1 : 0));
             if (ft.storeTermVectors()) {
                 Terms terms = fields.terms("field");
-                assertThat(terms.size(), equalTo(8l));
+                assertThat(terms.size(), equalTo(8L));
                 TermsEnum iterator = terms.iterator();
                 for (int j = 0; j < values.length; j++) {
                     String string = values[j];
@@ -637,7 +637,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         int[][] endOffset = {{15}, {43}, {19}, {25}, {39}, {30}, {9}, {3, 34}};
 
         Terms terms = fields.terms(fieldName);
-        assertThat(terms.size(), equalTo(8l));
+        assertThat(terms.size(), equalTo(8L));
         TermsEnum iterator = terms.iterator();
         for (int j = 0; j < values.length; j++) {
             String string = values[j];
@@ -1087,12 +1087,12 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
-        assertThat(response.getVersion(), equalTo(1l));
+        assertThat(response.getVersion(), equalTo(1L));
 
         response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(1).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
-        assertThat(response.getVersion(), equalTo(1l));
+        assertThat(response.getVersion(), equalTo(1L));
 
         try {
             client().prepareGet(indexOrAlias(), "type1", "1").setVersion(2).get();
@@ -1109,13 +1109,13 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(1l));
+        assertThat(response.getVersion(), equalTo(1L));
 
         response = client().prepareTermVectors(indexOrAlias(), "type1", "1").setVersion(1).setRealtime(false).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(1l));
+        assertThat(response.getVersion(), equalTo(1L));
 
         try {
             client().prepareGet(indexOrAlias(), "type1", "1").setVersion(2).setRealtime(false).get();
@@ -1134,7 +1134,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(2l));
+        assertThat(response.getVersion(), equalTo(2L));
 
         try {
             client().prepareGet(indexOrAlias(), "type1", "1").setVersion(1).get();
@@ -1147,7 +1147,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(2l));
+        assertThat(response.getVersion(), equalTo(2L));
 
         // From Lucene index:
         refresh();
@@ -1157,7 +1157,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(2l));
+        assertThat(response.getVersion(), equalTo(2L));
 
         try {
             client().prepareGet(indexOrAlias(), "type1", "1").setVersion(1).setRealtime(false).get();
@@ -1170,7 +1170,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(2l));
+        assertThat(response.getVersion(), equalTo(2L));
     }
 
     public void testFilterLength() throws ExecutionException, InterruptedException, IOException {

--- a/core/src/test/java/org/elasticsearch/broadcast/BroadcastActionsIT.java
+++ b/core/src/test/java/org/elasticsearch/broadcast/BroadcastActionsIT.java
@@ -58,7 +58,7 @@ public class BroadcastActionsIT extends ESIntegTestCase {
             SearchResponse countResponse = client().prepareSearch("test").setSize(0)
                     .setQuery(termQuery("_type", "type1"))
                     .get();
-            assertThat(countResponse.getHits().totalHits(), equalTo(2l));
+            assertThat(countResponse.getHits().totalHits(), equalTo(2L));
             assertThat(countResponse.getTotalShards(), equalTo(numShards.numPrimaries));
             assertThat(countResponse.getSuccessfulShards(), equalTo(numShards.numPrimaries));
             assertThat(countResponse.getFailedShards(), equalTo(0));

--- a/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/BasicBackwardsCompatibilityIT.java
@@ -122,11 +122,11 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
             assertThat(id, client().prepareIndex("test", "type1", id).setRouting(routingKey).setSource("field1", English.intToEnglish(i)).get().isCreated(), is(true));
             GetResponse get = client().prepareGet("test", "type1", id).setRouting(routingKey).setVersion(1).get();
             assertThat("Document with ID " + id + " should exist but doesn't", get.isExists(), is(true));
-            assertThat(get.getVersion(), equalTo(1l));
+            assertThat(get.getVersion(), equalTo(1L));
             client().prepareIndex("test", "type1", id).setRouting(routingKey).setSource("field1", English.intToEnglish(i)).execute().actionGet();
             get = client().prepareGet("test", "type1", id).setRouting(routingKey).setVersion(2).get();
             assertThat("Document with ID " + id + " should exist but doesn't", get.isExists(), is(true));
-            assertThat(get.getVersion(), equalTo(2l));
+            assertThat(get.getVersion(), equalTo(2L));
         }
 
         assertVersionCreated(compatibilityVersion(), "test");
@@ -416,30 +416,30 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
                     client().prepareIndex(indexName, "type1", "4").setSource(jsonBuilder().startObject().startObject("obj2").field("obj2_val", "1").endObject().field("y2", "y_2").field("field3", "value3_4").endObject()));
 
             SearchResponse countResponse = client().prepareSearch().setSize(0).setQuery(existsQuery("field1")).get();
-            assertHitCount(countResponse, 2l);
+            assertHitCount(countResponse, 2L);
 
             countResponse = client().prepareSearch().setSize(0).setQuery(constantScoreQuery(existsQuery("field1"))).get();
-            assertHitCount(countResponse, 2l);
+            assertHitCount(countResponse, 2L);
 
             countResponse = client().prepareSearch().setSize(0).setQuery(queryStringQuery("_exists_:field1")).get();
-            assertHitCount(countResponse, 2l);
+            assertHitCount(countResponse, 2L);
 
             countResponse = client().prepareSearch().setSize(0).setQuery(existsQuery("field2")).get();
-            assertHitCount(countResponse, 2l);
+            assertHitCount(countResponse, 2L);
 
             countResponse = client().prepareSearch().setSize(0).setQuery(existsQuery("field3")).get();
-            assertHitCount(countResponse, 1l);
+            assertHitCount(countResponse, 1L);
 
             // wildcard check
             countResponse = client().prepareSearch().setSize(0).setQuery(existsQuery("x*")).get();
-            assertHitCount(countResponse, 2l);
+            assertHitCount(countResponse, 2L);
 
             // object check
             countResponse = client().prepareSearch().setSize(0).setQuery(existsQuery("obj1")).get();
-            assertHitCount(countResponse, 2l);
+            assertHitCount(countResponse, 2L);
 
             countResponse = client().prepareSearch().setSize(0).setQuery(queryStringQuery("_missing_:field1")).get();
-            assertHitCount(countResponse, 2l);
+            assertHitCount(countResponse, 2L);
 
             if (!backwardsCluster().upgradeOneNode()) {
                 break;
@@ -598,7 +598,7 @@ public class BasicBackwardsCompatibilityIT extends ESBackcompatTestCase {
         assertThat(termVectorsResponse.isExists(), equalTo(true));
         Fields fields = termVectorsResponse.getFields();
         assertThat(fields.size(), equalTo(1));
-        assertThat(fields.terms("field").size(), equalTo(8l));
+        assertThat(fields.terms("field").size(), equalTo(8L));
     }
 
     public void testIndicesStats() {

--- a/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
@@ -332,7 +332,7 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
             }
         }
         SearchResponse test = client().prepareSearch(indexName).get();
-        assertThat(test.getHits().getTotalHits(), greaterThanOrEqualTo(1l));
+        assertThat(test.getHits().getTotalHits(), greaterThanOrEqualTo(1L));
     }
 
     void assertBasicSearchWorks(String indexName) {

--- a/core/src/test/java/org/elasticsearch/bwcompat/StaticIndexBackwardCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/StaticIndexBackwardCompatibilityIT.java
@@ -49,7 +49,7 @@ public class StaticIndexBackwardCompatibilityIT extends ESIntegTestCase {
         assertEquals(index, getIndexResponse.indices()[0]);
         ensureYellow(index);
         SearchResponse test = client().prepareSearch(index).get();
-        assertThat(test.getHits().getTotalHits(), greaterThanOrEqualTo(1l));
+        assertThat(test.getHits().getTotalHits(), greaterThanOrEqualTo(1L));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterServiceIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterServiceIT.java
@@ -632,7 +632,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         controlSources = new HashSet<>(Arrays.asList("1", "2", "3", "4", "5"));
         for (PendingClusterTask task : response) {
             if (controlSources.remove(task.getSource().string())) {
-                assertThat(task.getTimeInQueueInMillis(), greaterThan(0l));
+                assertThat(task.getTimeInQueueInMillis(), greaterThan(0L));
             }
         }
         assertTrue(controlSources.isEmpty());

--- a/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -115,8 +115,8 @@ public class DiskUsageTests extends ESTestCase {
         assertEquals(2, shardSizes.size());
         assertTrue(shardSizes.containsKey(ClusterInfo.shardIdentifierFromRouting(test_0)));
         assertTrue(shardSizes.containsKey(ClusterInfo.shardIdentifierFromRouting(test_1)));
-        assertEquals(100l, shardSizes.get(ClusterInfo.shardIdentifierFromRouting(test_0)).longValue());
-        assertEquals(1000l, shardSizes.get(ClusterInfo.shardIdentifierFromRouting(test_1)).longValue());
+        assertEquals(100L, shardSizes.get(ClusterInfo.shardIdentifierFromRouting(test_0)).longValue());
+        assertEquals(1000L, shardSizes.get(ClusterInfo.shardIdentifierFromRouting(test_1)).longValue());
 
         assertEquals(2, routingToPath.size());
         assertTrue(routingToPath.containsKey(test_0));

--- a/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -117,7 +117,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         logger.info("--> verify we the data back");
         for (int i = 0; i < 10; i++) {
-            assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(100l));
+            assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(100L));
         }
 
         internalCluster().stopCurrentMasterNode();

--- a/core/src/test/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -248,10 +248,10 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         assertExists(getResponse);
 
         SearchResponse countResponse = client().prepareSearch("test1").setSize(0).get();
-        assertHitCount(countResponse, 1l);
+        assertHitCount(countResponse, 1L);
 
         SearchResponse searchResponse = client().prepareSearch("test1").get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         countResponse = client().prepareSearch("test2").setSize(0).get();
         assertThat(countResponse.getTotalShards(), equalTo(2));

--- a/core/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -58,7 +58,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         client().admin().indices().prepareRefresh().execute().actionGet();
-        assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(100l));
+        assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(100L));
 
         logger.info("--> decommission the second node");
         client().admin().cluster().prepareUpdateSettings()
@@ -77,7 +77,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         }
 
         client().admin().indices().prepareRefresh().execute().actionGet();
-        assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(100l));
+        assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(100L));
     }
 
     public void testDisablingAllocationFiltering() throws Exception {
@@ -99,7 +99,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         client().admin().indices().prepareRefresh().execute().actionGet();
-        assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(100l));
+        assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(100L));
         ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
         IndexRoutingTable indexRoutingTable = clusterState.routingTable().index("test");
         int numShardsOnNode1 = 0;

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetaDataTests.java
@@ -55,7 +55,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
                         .settings(settings(Version.CURRENT))
                         .numberOfShards(1)
                         .numberOfReplicas(2)
-                        .creationDate(2l))
+                        .creationDate(2L))
                 .put(IndexMetaData.builder("test5")
                         .settings(settings(Version.CURRENT).put("setting1", "value1").put("setting2", "value2"))
                         .numberOfShards(1)
@@ -66,12 +66,12 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
                         .settings(settings(Version.CURRENT).put("setting1", "value1").put("setting2", "value2"))
                         .numberOfShards(1)
                         .numberOfReplicas(2)
-                        .creationDate(2l))
+                        .creationDate(2L))
                 .put(IndexMetaData.builder("test7")
                         .settings(settings(Version.CURRENT))
                         .numberOfShards(1)
                         .numberOfReplicas(2)
-                        .creationDate(2l)
+                        .creationDate(2L)
                         .putMapping("mapping1", MAPPING_SOURCE1)
                         .putMapping("mapping2", MAPPING_SOURCE2))
                 .put(IndexMetaData.builder("test8")
@@ -84,7 +84,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
                         .putAlias(newAliasMetaDataBuilder("alias2")))
                 .put(IndexMetaData.builder("test9")
                         .settings(settings(Version.CURRENT).put("setting1", "value1").put("setting2", "value2"))
-                        .creationDate(2l)
+                        .creationDate(2L)
                         .numberOfShards(1)
                         .numberOfReplicas(2)
                         .putMapping("mapping1", MAPPING_SOURCE1)
@@ -125,7 +125,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
                         .settings(settings(Version.CURRENT)
                                 .put("setting1", "value1")
                                 .put("setting2", "value2"))
-                        .creationDate(2l)
+                        .creationDate(2L)
                         .numberOfShards(1)
                         .numberOfReplicas(2)
                         .putMapping("mapping1", MAPPING_SOURCE1)
@@ -152,14 +152,14 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         IndexMetaData indexMetaData = parsedMetaData.index("test1");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(-1l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(-1L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(3));
         assertThat(indexMetaData.getMappings().size(), equalTo(0));
 
         indexMetaData = parsedMetaData.index("test2");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(2));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(3));
-        assertThat(indexMetaData.getCreationDate(), equalTo(-1l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(-1L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(5));
         assertThat(indexMetaData.getSettings().get("setting1"), equalTo("value1"));
         assertThat(indexMetaData.getSettings().get("setting2"), equalTo("value2"));
@@ -168,13 +168,13 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test3");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(-1l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(-1L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(3));
         assertThat(indexMetaData.getMappings().size(), equalTo(1));
         assertThat(indexMetaData.getMappings().get("mapping1").source().string(), equalTo(MAPPING_SOURCE1));
 
         indexMetaData = parsedMetaData.index("test4");
-        assertThat(indexMetaData.getCreationDate(), equalTo(2l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(2L));
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(4));
@@ -183,7 +183,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test5");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(-1l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(-1L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(5));
         assertThat(indexMetaData.getSettings().get("setting1"), equalTo("value1"));
         assertThat(indexMetaData.getSettings().get("setting2"), equalTo("value2"));
@@ -194,7 +194,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test6");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(2l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(2L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(6));
         assertThat(indexMetaData.getSettings().get("setting1"), equalTo("value1"));
         assertThat(indexMetaData.getSettings().get("setting2"), equalTo("value2"));
@@ -203,7 +203,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test7");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(2l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(2L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(4));
         assertThat(indexMetaData.getMappings().size(), equalTo(2));
         assertThat(indexMetaData.getMappings().get("mapping1").source().string(), equalTo(MAPPING_SOURCE1));
@@ -212,7 +212,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test8");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(-1l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(-1L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(5));
         assertThat(indexMetaData.getSettings().get("setting1"), equalTo("value1"));
         assertThat(indexMetaData.getSettings().get("setting2"), equalTo("value2"));
@@ -226,7 +226,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test9");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(2l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(2L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(6));
         assertThat(indexMetaData.getSettings().get("setting1"), equalTo("value1"));
         assertThat(indexMetaData.getSettings().get("setting2"), equalTo("value2"));
@@ -240,7 +240,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test10");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(-1l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(-1L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(5));
         assertThat(indexMetaData.getSettings().get("setting1"), equalTo("value1"));
         assertThat(indexMetaData.getSettings().get("setting2"), equalTo("value2"));
@@ -254,7 +254,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test11");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(-1l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(-1L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(5));
         assertThat(indexMetaData.getSettings().get("setting1"), equalTo("value1"));
         assertThat(indexMetaData.getSettings().get("setting2"), equalTo("value2"));
@@ -272,7 +272,7 @@ public class ToAndFromJsonMetaDataTests extends ESTestCase {
         indexMetaData = parsedMetaData.index("test12");
         assertThat(indexMetaData.getNumberOfShards(), equalTo(1));
         assertThat(indexMetaData.getNumberOfReplicas(), equalTo(2));
-        assertThat(indexMetaData.getCreationDate(), equalTo(2l));
+        assertThat(indexMetaData.getCreationDate(), equalTo(2L));
         assertThat(indexMetaData.getSettings().getAsMap().size(), equalTo(6));
         assertThat(indexMetaData.getSettings().get("setting1"), equalTo("value1"));
         assertThat(indexMetaData.getSettings().get("setting2"), equalTo("value2"));

--- a/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -122,7 +122,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
 
         logger.info("--> check that the up-to-date primary shard gets promoted and that documents are available");
         ensureYellow("test");
-        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2l);
+        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2L);
     }
 
     public void testFailedAllocationOfStalePrimaryToDataNodeWithNoData() throws Exception {
@@ -171,7 +171,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         logger.info("--> check that the stale primary shard gets allocated and that documents are available");
         ensureYellow("test");
 
-        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(matchAllQuery()).get(), useStaleReplica ? 1l : 0l);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(matchAllQuery()).get(), useStaleReplica ? 1L : 0L);
     }
 
     public void testForcePrimaryShardIfAllocationDecidersSayNoAfterIndexCreation() throws ExecutionException, InterruptedException {
@@ -200,6 +200,6 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         internalCluster().fullRestart();
         logger.info("--> checking that index still gets allocated with only 1 shard copy being available");
         ensureYellow("test");
-        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 1l);
+        assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 1L);
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -221,7 +221,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(1));
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo(), notNullValue());
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo().getReason(), equalTo(UnassignedInfo.Reason.NODE_LEFT));
-        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo().getUnassignedTimeInMillis(), greaterThan(0l));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo().getUnassignedTimeInMillis(), greaterThan(0L));
     }
 
     /**
@@ -252,7 +252,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo().getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo().getMessage(), equalTo("test fail"));
         assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo().getDetails(), equalTo("test fail"));
-        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo().getUnassignedTimeInMillis(), greaterThan(0l));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).get(0).unassignedInfo().getUnassignedTimeInMillis(), greaterThan(0L));
     }
 
     /**
@@ -276,9 +276,9 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
         UnassignedInfo unassignedInfo = new UnassignedInfo(RandomPicks.randomFrom(getRandom(), reasons), null);
         long delay = unassignedInfo.updateDelay(unassignedInfo.getUnassignedTimeInNanos() + 1, // add 1 tick delay
                 Settings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "10h").build(), Settings.EMPTY);
-        assertThat(delay, equalTo(0l));
+        assertThat(delay, equalTo(0L));
         delay = unassignedInfo.getLastComputedLeftDelayNanos();
-        assertThat(delay, equalTo(0l));
+        assertThat(delay, equalTo(0L));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardVersioningTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardVersioningTests.java
@@ -64,14 +64,14 @@ public class ShardVersioningTests extends ESAllocationTestCase {
         for (int i = 0; i < routingTable.index("test1").shards().size(); i++) {
             assertThat(routingTable.index("test1").shard(i).shards().size(), equalTo(2));
             assertThat(routingTable.index("test1").shard(i).primaryShard().state(), equalTo(INITIALIZING));
-            assertThat(routingTable.index("test1").shard(i).primaryShard().version(), equalTo(1l));
+            assertThat(routingTable.index("test1").shard(i).primaryShard().version(), equalTo(1L));
             assertThat(routingTable.index("test1").shard(i).replicaShards().get(0).state(), equalTo(UNASSIGNED));
         }
 
         for (int i = 0; i < routingTable.index("test2").shards().size(); i++) {
             assertThat(routingTable.index("test2").shard(i).shards().size(), equalTo(2));
             assertThat(routingTable.index("test2").shard(i).primaryShard().state(), equalTo(INITIALIZING));
-            assertThat(routingTable.index("test2").shard(i).primaryShard().version(), equalTo(1l));
+            assertThat(routingTable.index("test2").shard(i).primaryShard().version(), equalTo(1L));
             assertThat(routingTable.index("test2").shard(i).replicaShards().get(0).state(), equalTo(UNASSIGNED));
         }
 
@@ -84,17 +84,17 @@ public class ShardVersioningTests extends ESAllocationTestCase {
         for (int i = 0; i < routingTable.index("test1").shards().size(); i++) {
             assertThat(routingTable.index("test1").shard(i).shards().size(), equalTo(2));
             assertThat(routingTable.index("test1").shard(i).primaryShard().state(), equalTo(STARTED));
-            assertThat(routingTable.index("test1").shard(i).primaryShard().version(), equalTo(2l));
+            assertThat(routingTable.index("test1").shard(i).primaryShard().version(), equalTo(2L));
             assertThat(routingTable.index("test1").shard(i).replicaShards().get(0).state(), equalTo(INITIALIZING));
-            assertThat(routingTable.index("test1").shard(i).replicaShards().get(0).version(), equalTo(2l));
+            assertThat(routingTable.index("test1").shard(i).replicaShards().get(0).version(), equalTo(2L));
         }
 
         for (int i = 0; i < routingTable.index("test2").shards().size(); i++) {
             assertThat(routingTable.index("test2").shard(i).shards().size(), equalTo(2));
             assertThat(routingTable.index("test2").shard(i).primaryShard().state(), equalTo(INITIALIZING));
-            assertThat(routingTable.index("test2").shard(i).primaryShard().version(), equalTo(1l));
+            assertThat(routingTable.index("test2").shard(i).primaryShard().version(), equalTo(1L));
             assertThat(routingTable.index("test2").shard(i).replicaShards().get(0).state(), equalTo(UNASSIGNED));
-            assertThat(routingTable.index("test2").shard(i).replicaShards().get(0).version(), equalTo(1l));
+            assertThat(routingTable.index("test2").shard(i).replicaShards().get(0).version(), equalTo(1L));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -239,20 +239,20 @@ public class DiskThresholdDeciderUnitTests extends ESTestCase {
         ShardRoutingHelper.initialize(test_2, "node1");
         ShardRoutingHelper.moveToStarted(test_2);
 
-        assertEquals(1000l, DiskThresholdDecider.getShardSize(test_2, info));
-        assertEquals(100l, DiskThresholdDecider.getShardSize(test_1, info));
-        assertEquals(10l, DiskThresholdDecider.getShardSize(test_0, info));
+        assertEquals(1000L, DiskThresholdDecider.getShardSize(test_2, info));
+        assertEquals(100L, DiskThresholdDecider.getShardSize(test_1, info));
+        assertEquals(10L, DiskThresholdDecider.getShardSize(test_0, info));
 
         RoutingNode node = new RoutingNode("node1", new DiscoveryNode("node1", LocalTransportAddress.PROTO, Version.CURRENT), Arrays.asList(test_0, test_1.buildTargetRelocatingShard(), test_2));
-        assertEquals(100l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, false, "/dev/null"));
-        assertEquals(90l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/null"));
-        assertEquals(0l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/some/other/dev"));
-        assertEquals(0l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/some/other/dev"));
+        assertEquals(100L, DiskThresholdDecider.sizeOfRelocatingShards(node, info, false, "/dev/null"));
+        assertEquals(90L, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/null"));
+        assertEquals(0L, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/some/other/dev"));
+        assertEquals(0L, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/some/other/dev"));
 
         ShardRouting test_3 = ShardRouting.newUnassigned(index, 3, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_3, "node1");
         ShardRoutingHelper.moveToStarted(test_3);
-        assertEquals(0l, DiskThresholdDecider.getShardSize(test_3, info));
+        assertEquals(0L, DiskThresholdDecider.getShardSize(test_3, info));
 
 
         ShardRouting other_0 = ShardRouting.newUnassigned(new Index("other", "_NA_"), 0, null, randomBoolean(), new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
@@ -263,11 +263,11 @@ public class DiskThresholdDeciderUnitTests extends ESTestCase {
 
         node = new RoutingNode("node1", new DiscoveryNode("node1", LocalTransportAddress.PROTO, Version.CURRENT), Arrays.asList(test_0, test_1.buildTargetRelocatingShard(), test_2, other_0.buildTargetRelocatingShard()));
         if (other_0.primary()) {
-            assertEquals(10100l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, false, "/dev/null"));
-            assertEquals(10090l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/null"));
+            assertEquals(10100L, DiskThresholdDecider.sizeOfRelocatingShards(node, info, false, "/dev/null"));
+            assertEquals(10090L, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/null"));
         } else {
-            assertEquals(100l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, false, "/dev/null"));
-            assertEquals(90l, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/null"));
+            assertEquals(100L, DiskThresholdDecider.sizeOfRelocatingShards(node, info, false, "/dev/null"));
+            assertEquals(90L, DiskThresholdDecider.sizeOfRelocatingShards(node, info, true, "/dev/null"));
         }
 
     }

--- a/core/src/test/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -95,7 +95,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         assertAcked(response);
         assertThat(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
-        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1l));
+        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
         assertThat(discoverySettings.getPublishDiff(), equalTo(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY)));
 
 
@@ -118,7 +118,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         assertAcked(response);
         assertThat(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
-        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1l));
+        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
         assertFalse(discoverySettings.getPublishDiff());
         response = client().admin().cluster()
                 .prepareUpdateSettings()
@@ -138,7 +138,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         assertAcked(response);
         assertThat(response.getPersistentSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
-        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1l));
+        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
         assertThat(discoverySettings.getPublishDiff(), equalTo(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY)));
 
 
@@ -162,7 +162,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         assertAcked(response);
         assertThat(response.getPersistentSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
-        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1l));
+        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
         assertFalse(discoverySettings.getPublishDiff());
         response = client().admin().cluster()
                 .prepareUpdateSettings()
@@ -254,7 +254,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         assertAcked(response);
         assertThat(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
-        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1l));
+        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
 
         try {
             client().admin().cluster()
@@ -266,7 +266,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             assertEquals(ex.getMessage(), "Failed to parse setting [discovery.zen.publish_timeout] with value [whatever] as a time value: unit is missing or unrecognized");
         }
 
-        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1l));
+        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
 
         try {
             client().admin().cluster()
@@ -278,7 +278,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             assertEquals(ex.getMessage(), "Failed to parse value [-1] for setting [discovery.zen.publish_timeout] must be >= 0s");
         }
 
-        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1l));
+        assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
     }
 
     public void testClusterUpdateSettingsWithBlocks() {

--- a/core/src/test/java/org/elasticsearch/common/lucene/search/morelikethis/MoreLikeThisQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/search/morelikethis/MoreLikeThisQueryTests.java
@@ -62,7 +62,7 @@ public class MoreLikeThisQueryTests extends ESTestCase {
         mltQuery.setMinTermFrequency(1);
         mltQuery.setMinDocFreq(1);
         long count = searcher.count(mltQuery);
-        assertThat(count, equalTo(2l));
+        assertThat(count, equalTo(2L));
 
         reader.close();
         indexWriter.close();

--- a/core/src/test/java/org/elasticsearch/common/lucene/store/InputStreamIndexInputTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/store/InputStreamIndexInputTests.java
@@ -51,7 +51,7 @@ public class InputStreamIndexInputTests extends ESTestCase {
         for (int i = 0; i < 3; i++) {
             InputStreamIndexInput is = new InputStreamIndexInput(input, 1);
             assertThat(input.getFilePointer(), lessThan(input.length()));
-            assertThat(is.actualSizeToRead(), equalTo(1l));
+            assertThat(is.actualSizeToRead(), equalTo(1L));
             assertThat(is.read(), equalTo(1));
             assertThat(is.read(), equalTo(-1));
         }
@@ -59,14 +59,14 @@ public class InputStreamIndexInputTests extends ESTestCase {
         for (int i = 0; i < 3; i++) {
             InputStreamIndexInput is = new InputStreamIndexInput(input, 1);
             assertThat(input.getFilePointer(), lessThan(input.length()));
-            assertThat(is.actualSizeToRead(), equalTo(1l));
+            assertThat(is.actualSizeToRead(), equalTo(1L));
             assertThat(is.read(), equalTo(2));
             assertThat(is.read(), equalTo(-1));
         }
 
         assertThat(input.getFilePointer(), equalTo(input.length()));
         InputStreamIndexInput is = new InputStreamIndexInput(input, 1);
-        assertThat(is.actualSizeToRead(), equalTo(0l));
+        assertThat(is.actualSizeToRead(), equalTo(0L));
         assertThat(is.read(), equalTo(-1));
     }
 
@@ -89,7 +89,7 @@ public class InputStreamIndexInputTests extends ESTestCase {
         for (int i = 0; i < 3; i++) {
             assertThat(input.getFilePointer(), lessThan(input.length()));
             InputStreamIndexInput is = new InputStreamIndexInput(input, 1);
-            assertThat(is.actualSizeToRead(), equalTo(1l));
+            assertThat(is.actualSizeToRead(), equalTo(1L));
             assertThat(is.read(read), equalTo(1));
             assertThat(read[0], equalTo((byte) 1));
         }
@@ -97,14 +97,14 @@ public class InputStreamIndexInputTests extends ESTestCase {
         for (int i = 0; i < 3; i++) {
             assertThat(input.getFilePointer(), lessThan(input.length()));
             InputStreamIndexInput is = new InputStreamIndexInput(input, 1);
-            assertThat(is.actualSizeToRead(), equalTo(1l));
+            assertThat(is.actualSizeToRead(), equalTo(1L));
             assertThat(is.read(read), equalTo(1));
             assertThat(read[0], equalTo((byte) 2));
         }
 
         assertThat(input.getFilePointer(), equalTo(input.length()));
         InputStreamIndexInput is = new InputStreamIndexInput(input, 1);
-        assertThat(is.actualSizeToRead(), equalTo(0l));
+        assertThat(is.actualSizeToRead(), equalTo(0L));
         assertThat(is.read(read), equalTo(-1));
     }
 
@@ -124,28 +124,28 @@ public class InputStreamIndexInputTests extends ESTestCase {
 
         assertThat(input.getFilePointer(), lessThan(input.length()));
         InputStreamIndexInput is = new InputStreamIndexInput(input, 2);
-        assertThat(is.actualSizeToRead(), equalTo(2l));
+        assertThat(is.actualSizeToRead(), equalTo(2L));
         assertThat(is.read(), equalTo(1));
         assertThat(is.read(), equalTo(1));
         assertThat(is.read(), equalTo(-1));
 
         assertThat(input.getFilePointer(), lessThan(input.length()));
         is = new InputStreamIndexInput(input, 2);
-        assertThat(is.actualSizeToRead(), equalTo(2l));
+        assertThat(is.actualSizeToRead(), equalTo(2L));
         assertThat(is.read(), equalTo(1));
         assertThat(is.read(), equalTo(2));
         assertThat(is.read(), equalTo(-1));
 
         assertThat(input.getFilePointer(), lessThan(input.length()));
         is = new InputStreamIndexInput(input, 2);
-        assertThat(is.actualSizeToRead(), equalTo(2l));
+        assertThat(is.actualSizeToRead(), equalTo(2L));
         assertThat(is.read(), equalTo(2));
         assertThat(is.read(), equalTo(2));
         assertThat(is.read(), equalTo(-1));
 
         assertThat(input.getFilePointer(), equalTo(input.length()));
         is = new InputStreamIndexInput(input, 2);
-        assertThat(is.actualSizeToRead(), equalTo(0l));
+        assertThat(is.actualSizeToRead(), equalTo(0L));
         assertThat(is.read(), equalTo(-1));
     }
 
@@ -167,28 +167,28 @@ public class InputStreamIndexInputTests extends ESTestCase {
 
         assertThat(input.getFilePointer(), lessThan(input.length()));
         InputStreamIndexInput is = new InputStreamIndexInput(input, 2);
-        assertThat(is.actualSizeToRead(), equalTo(2l));
+        assertThat(is.actualSizeToRead(), equalTo(2L));
         assertThat(is.read(read), equalTo(2));
         assertThat(read[0], equalTo((byte) 1));
         assertThat(read[1], equalTo((byte) 1));
 
         assertThat(input.getFilePointer(), lessThan(input.length()));
         is = new InputStreamIndexInput(input, 2);
-        assertThat(is.actualSizeToRead(), equalTo(2l));
+        assertThat(is.actualSizeToRead(), equalTo(2L));
         assertThat(is.read(read), equalTo(2));
         assertThat(read[0], equalTo((byte) 1));
         assertThat(read[1], equalTo((byte) 2));
 
         assertThat(input.getFilePointer(), lessThan(input.length()));
         is = new InputStreamIndexInput(input, 2);
-        assertThat(is.actualSizeToRead(), equalTo(2l));
+        assertThat(is.actualSizeToRead(), equalTo(2L));
         assertThat(is.read(read), equalTo(2));
         assertThat(read[0], equalTo((byte) 2));
         assertThat(read[1], equalTo((byte) 2));
 
         assertThat(input.getFilePointer(), equalTo(input.length()));
         is = new InputStreamIndexInput(input, 2);
-        assertThat(is.actualSizeToRead(), equalTo(0l));
+        assertThat(is.actualSizeToRead(), equalTo(0L));
         assertThat(is.read(read), equalTo(-1));
     }
 
@@ -210,7 +210,7 @@ public class InputStreamIndexInputTests extends ESTestCase {
 
         assertThat(input.getFilePointer(), lessThan(input.length()));
         InputStreamIndexInput is = new InputStreamIndexInput(input, 4);
-        assertThat(is.actualSizeToRead(), equalTo(4l));
+        assertThat(is.actualSizeToRead(), equalTo(4L));
         assertThat(is.read(read), equalTo(4));
         assertThat(read[0], equalTo((byte) 1));
         assertThat(read[1], equalTo((byte) 1));
@@ -219,14 +219,14 @@ public class InputStreamIndexInputTests extends ESTestCase {
 
         assertThat(input.getFilePointer(), lessThan(input.length()));
         is = new InputStreamIndexInput(input, 4);
-        assertThat(is.actualSizeToRead(), equalTo(2l));
+        assertThat(is.actualSizeToRead(), equalTo(2L));
         assertThat(is.read(read), equalTo(2));
         assertThat(read[0], equalTo((byte) 2));
         assertThat(read[1], equalTo((byte) 2));
 
         assertThat(input.getFilePointer(), equalTo(input.length()));
         is = new InputStreamIndexInput(input, 4);
-        assertThat(is.actualSizeToRead(), equalTo(0l));
+        assertThat(is.actualSizeToRead(), equalTo(0L));
         assertThat(is.read(read), equalTo(-1));
     }
 

--- a/core/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
@@ -93,8 +93,8 @@ public class VersionsTests extends ESTestCase {
         doc.add(new NumericDocValuesField(VersionFieldMapper.NAME, 1));
         writer.updateDocument(new Term(UidFieldMapper.NAME, "1"), doc);
         directoryReader = reopen(directoryReader);
-        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(1l));
-        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(1l));
+        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(1L));
+        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(1L));
 
         doc = new Document();
         Field uid = new Field(UidFieldMapper.NAME, "1", UidFieldMapper.Defaults.FIELD_TYPE);
@@ -103,8 +103,8 @@ public class VersionsTests extends ESTestCase {
         doc.add(version);
         writer.updateDocument(new Term(UidFieldMapper.NAME, "1"), doc);
         directoryReader = reopen(directoryReader);
-        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(2l));
-        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(2l));
+        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(2L));
+        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(2L));
 
         // test reuse of uid field
         doc = new Document();
@@ -114,8 +114,8 @@ public class VersionsTests extends ESTestCase {
         writer.updateDocument(new Term(UidFieldMapper.NAME, "1"), doc);
 
         directoryReader = reopen(directoryReader);
-        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(3l));
-        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(3l));
+        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(3L));
+        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(3L));
 
         writer.deleteDocuments(new Term(UidFieldMapper.NAME, "1"));
         directoryReader = reopen(directoryReader);
@@ -146,16 +146,16 @@ public class VersionsTests extends ESTestCase {
 
         writer.updateDocuments(new Term(UidFieldMapper.NAME, "1"), docs);
         DirectoryReader directoryReader = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(writer, true), new ShardId("foo", "_na_", 1));
-        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(5l));
-        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(5l));
+        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(5L));
+        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(5L));
 
         version.setLongValue(6L);
         writer.updateDocuments(new Term(UidFieldMapper.NAME, "1"), docs);
         version.setLongValue(7L);
         writer.updateDocuments(new Term(UidFieldMapper.NAME, "1"), docs);
         directoryReader = reopen(directoryReader);
-        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(7l));
-        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(7l));
+        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(7L));
+        assertThat(Versions.loadDocIdAndVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")).version, equalTo(7L));
 
         writer.deleteDocuments(new Term(UidFieldMapper.NAME, "1"));
         directoryReader = reopen(directoryReader);
@@ -184,8 +184,8 @@ public class VersionsTests extends ESTestCase {
         writer.commit();
 
         directoryReader = reopen(directoryReader);
-        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(1l));
-        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "2")), equalTo(2l));
+        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "1")), equalTo(1L));
+        assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "2")), equalTo(2L));
         assertThat(Versions.loadVersion(directoryReader, new Term(UidFieldMapper.NAME, "3")), equalTo(Versions.NOT_FOUND));
         directoryReader.close();
         writer.close();

--- a/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -101,8 +101,8 @@ public class TimeZoneRoundingTests extends ESTestCase {
         int timezoneOffset = -2;
         Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forOffsetHours(timezoneOffset))
                 .build();
-        assertThat(tzRounding.round(0), equalTo(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()));
-        assertThat(tzRounding.nextRoundingValue(0l - TimeValue.timeValueHours(24 + timezoneOffset).millis()), equalTo(0l - TimeValue
+        assertThat(tzRounding.round(0), equalTo(0L - TimeValue.timeValueHours(24 + timezoneOffset).millis()));
+        assertThat(tzRounding.nextRoundingValue(0L - TimeValue.timeValueHours(24 + timezoneOffset).millis()), equalTo(0L - TimeValue
                 .timeValueHours(timezoneOffset).millis()));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.forID("-08:00")).build();
@@ -135,8 +135,8 @@ public class TimeZoneRoundingTests extends ESTestCase {
     public void testTimeTimeZoneRounding() {
         // hour unit
         Rounding tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forOffsetHours(-2)).build();
-        assertThat(tzRounding.round(0), equalTo(0l));
-        assertThat(tzRounding.nextRoundingValue(0l), equalTo(TimeValue.timeValueHours(1l).getMillis()));
+        assertThat(tzRounding.round(0), equalTo(0L));
+        assertThat(tzRounding.nextRoundingValue(0L), equalTo(TimeValue.timeValueHours(1L).getMillis()));
 
         tzRounding = TimeZoneRounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(DateTimeZone.forOffsetHours(-2)).build();
         assertThat(tzRounding.round(utc("2009-02-03T01:01:01")), equalTo(utc("2009-02-03T01:00:00")));

--- a/core/src/test/java/org/elasticsearch/common/unit/ByteSizeUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/ByteSizeUnitTests.java
@@ -34,47 +34,47 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class ByteSizeUnitTests extends ESTestCase {
     public void testBytes() {
-        assertThat(BYTES.toBytes(1), equalTo(1l));
-        assertThat(BYTES.toKB(1024), equalTo(1l));
-        assertThat(BYTES.toMB(1024 * 1024), equalTo(1l));
-        assertThat(BYTES.toGB(1024 * 1024 * 1024), equalTo(1l));
+        assertThat(BYTES.toBytes(1), equalTo(1L));
+        assertThat(BYTES.toKB(1024), equalTo(1L));
+        assertThat(BYTES.toMB(1024 * 1024), equalTo(1L));
+        assertThat(BYTES.toGB(1024 * 1024 * 1024), equalTo(1L));
     }
 
     public void testKB() {
-        assertThat(KB.toBytes(1), equalTo(1024l));
-        assertThat(KB.toKB(1), equalTo(1l));
-        assertThat(KB.toMB(1024), equalTo(1l));
-        assertThat(KB.toGB(1024 * 1024), equalTo(1l));
+        assertThat(KB.toBytes(1), equalTo(1024L));
+        assertThat(KB.toKB(1), equalTo(1L));
+        assertThat(KB.toMB(1024), equalTo(1L));
+        assertThat(KB.toGB(1024 * 1024), equalTo(1L));
     }
 
     public void testMB() {
-        assertThat(MB.toBytes(1), equalTo(1024l * 1024));
-        assertThat(MB.toKB(1), equalTo(1024l));
-        assertThat(MB.toMB(1), equalTo(1l));
-        assertThat(MB.toGB(1024), equalTo(1l));
+        assertThat(MB.toBytes(1), equalTo(1024L * 1024));
+        assertThat(MB.toKB(1), equalTo(1024L));
+        assertThat(MB.toMB(1), equalTo(1L));
+        assertThat(MB.toGB(1024), equalTo(1L));
     }
 
     public void testGB() {
-        assertThat(GB.toBytes(1), equalTo(1024l * 1024 * 1024));
-        assertThat(GB.toKB(1), equalTo(1024l * 1024));
-        assertThat(GB.toMB(1), equalTo(1024l));
-        assertThat(GB.toGB(1), equalTo(1l));
+        assertThat(GB.toBytes(1), equalTo(1024L * 1024 * 1024));
+        assertThat(GB.toKB(1), equalTo(1024L * 1024));
+        assertThat(GB.toMB(1), equalTo(1024L));
+        assertThat(GB.toGB(1), equalTo(1L));
     }
 
     public void testTB() {
-        assertThat(TB.toBytes(1), equalTo(1024l * 1024 * 1024 * 1024));
-        assertThat(TB.toKB(1), equalTo(1024l * 1024 * 1024));
-        assertThat(TB.toMB(1), equalTo(1024l * 1024));
-        assertThat(TB.toGB(1), equalTo(1024l));
-        assertThat(TB.toTB(1), equalTo(1l));
+        assertThat(TB.toBytes(1), equalTo(1024L * 1024 * 1024 * 1024));
+        assertThat(TB.toKB(1), equalTo(1024L * 1024 * 1024));
+        assertThat(TB.toMB(1), equalTo(1024L * 1024));
+        assertThat(TB.toGB(1), equalTo(1024L));
+        assertThat(TB.toTB(1), equalTo(1L));
     }
 
     public void testPB() {
-        assertThat(PB.toBytes(1), equalTo(1024l * 1024 * 1024 * 1024 * 1024));
-        assertThat(PB.toKB(1), equalTo(1024l * 1024 * 1024 * 1024));
-        assertThat(PB.toMB(1), equalTo(1024l * 1024 * 1024));
-        assertThat(PB.toGB(1), equalTo(1024l * 1024));
-        assertThat(PB.toTB(1), equalTo(1024l));
-        assertThat(PB.toPB(1), equalTo(1l));
+        assertThat(PB.toBytes(1), equalTo(1024L * 1024 * 1024 * 1024 * 1024));
+        assertThat(PB.toKB(1), equalTo(1024L * 1024 * 1024 * 1024));
+        assertThat(PB.toMB(1), equalTo(1024L * 1024 * 1024));
+        assertThat(PB.toGB(1), equalTo(1024L * 1024));
+        assertThat(PB.toTB(1), equalTo(1024L));
+        assertThat(PB.toPB(1), equalTo(1L));
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -32,15 +32,15 @@ import static org.hamcrest.Matchers.is;
  */
 public class ByteSizeValueTests extends ESTestCase {
     public void testActualPeta() {
-        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.PB).bytes(), equalTo(4503599627370496l));
+        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.PB).bytes(), equalTo(4503599627370496L));
     }
 
     public void testActualTera() {
-        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.TB).bytes(), equalTo(4398046511104l));
+        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.TB).bytes(), equalTo(4398046511104L));
     }
 
     public void testActual() {
-        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.GB).bytes(), equalTo(4294967296l));
+        MatcherAssert.assertThat(new ByteSizeValue(4, ByteSizeUnit.GB).bytes(), equalTo(4294967296L));
     }
 
     public void testSimple() {

--- a/core/src/test/java/org/elasticsearch/common/unit/FuzzinessTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/FuzzinessTests.java
@@ -40,7 +40,7 @@ public class FuzzinessTests extends ESTestCase {
         assertThat(Fuzziness.build(randomFrom(options)).asInt(), equalTo(1));
         assertThat(Fuzziness.build(randomFrom(options)).asFloat(), equalTo(1f));
         assertThat(Fuzziness.build(randomFrom(options)).asDouble(), equalTo(1d));
-        assertThat(Fuzziness.build(randomFrom(options)).asLong(), equalTo(1l));
+        assertThat(Fuzziness.build(randomFrom(options)).asLong(), equalTo(1L));
         assertThat(Fuzziness.build(randomFrom(options)).asShort(), equalTo((short) 1));
     }
 
@@ -143,7 +143,7 @@ public class FuzzinessTests extends ESTestCase {
         assertThat(Fuzziness.AUTO.asInt(), equalTo(1));
         assertThat(Fuzziness.AUTO.asFloat(), equalTo(1f));
         assertThat(Fuzziness.AUTO.asDouble(), equalTo(1d));
-        assertThat(Fuzziness.AUTO.asLong(), equalTo(1l));
+        assertThat(Fuzziness.AUTO.asLong(), equalTo(1L));
         assertThat(Fuzziness.AUTO.asShort(), equalTo((short) 1));
         assertThat(Fuzziness.AUTO.asTimeValue(), equalTo(TimeValue.parseTimeValue("1ms", TimeValue.timeValueMillis(1), "fuzziness")));
 

--- a/core/src/test/java/org/elasticsearch/common/unit/SizeValueTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/SizeValueTests.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.is;
 public class SizeValueTests extends ESTestCase {
     public void testThatConversionWorks() {
         SizeValue sizeValue = new SizeValue(1000);
-        assertThat(sizeValue.kilo(), is(1l));
+        assertThat(sizeValue.kilo(), is(1L));
         assertThat(sizeValue.toString(), is("1k"));
 
         sizeValue = new SizeValue(1000, SizeUnit.KILO);

--- a/core/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
@@ -60,7 +60,7 @@ public class TimeValueTests extends ESTestCase {
     }
 
     public void testMinusOne() {
-        assertThat(new TimeValue(-1).nanos(), lessThan(0l));
+        assertThat(new TimeValue(-1).nanos(), lessThan(0L));
     }
 
     public void testParseTimeValue() {

--- a/core/src/test/java/org/elasticsearch/common/xcontent/ObjectParserTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/ObjectParserTests.java
@@ -315,8 +315,8 @@ public class ObjectParserTests extends ESTestCase {
         assertArrayEquals(parse.double_array_field.toArray(), Arrays.asList(2.1d).toArray());
         assertEquals(parse.double_field, 2.1d, 0.0d);
 
-        assertArrayEquals(parse.long_array_field.toArray(), Arrays.asList(4l).toArray());
-        assertEquals(parse.long_field, 4l);
+        assertArrayEquals(parse.long_array_field.toArray(), Arrays.asList(4L).toArray());
+        assertEquals(parse.long_field, 4L);
 
         assertArrayEquals(parse.string_array_field.toArray(), Arrays.asList("5").toArray());
         assertEquals(parse.string_field, "5");

--- a/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
+++ b/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
@@ -63,7 +63,7 @@ public class SimpleJodaTests extends ESTestCase {
         DateTimeFormatter formatter = ISODateTimeFormat.dateTimeNoMillis().withZone(DateTimeZone.UTC);
         long millis = formatter.parseMillis("1970-01-01T00:00:00Z");
 
-        assertThat(millis, equalTo(0l));
+        assertThat(millis, equalTo(0L));
     }
 
     public void testUpperBound() {
@@ -79,20 +79,20 @@ public class SimpleJodaTests extends ESTestCase {
     public void testIsoDateFormatDateOptionalTimeUTC() {
         DateTimeFormatter formatter = ISODateTimeFormat.dateOptionalTimeParser().withZone(DateTimeZone.UTC);
         long millis = formatter.parseMillis("1970-01-01T00:00:00Z");
-        assertThat(millis, equalTo(0l));
+        assertThat(millis, equalTo(0L));
         millis = formatter.parseMillis("1970-01-01T00:00:00.001Z");
-        assertThat(millis, equalTo(1l));
+        assertThat(millis, equalTo(1L));
         millis = formatter.parseMillis("1970-01-01T00:00:00.1Z");
-        assertThat(millis, equalTo(100l));
+        assertThat(millis, equalTo(100L));
         millis = formatter.parseMillis("1970-01-01T00:00:00.1");
-        assertThat(millis, equalTo(100l));
+        assertThat(millis, equalTo(100L));
         millis = formatter.parseMillis("1970-01-01T00:00:00");
-        assertThat(millis, equalTo(0l));
+        assertThat(millis, equalTo(0L));
         millis = formatter.parseMillis("1970-01-01");
-        assertThat(millis, equalTo(0l));
+        assertThat(millis, equalTo(0L));
 
         millis = formatter.parseMillis("1970");
-        assertThat(millis, equalTo(0l));
+        assertThat(millis, equalTo(0L));
 
         try {
             formatter.parseMillis("1970 kuku");
@@ -109,15 +109,15 @@ public class SimpleJodaTests extends ESTestCase {
     public void testIsoVsCustom() {
         DateTimeFormatter formatter = ISODateTimeFormat.dateOptionalTimeParser().withZone(DateTimeZone.UTC);
         long millis = formatter.parseMillis("1970-01-01T00:00:00");
-        assertThat(millis, equalTo(0l));
+        assertThat(millis, equalTo(0L));
 
         formatter = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm:ss").withZone(DateTimeZone.UTC);
         millis = formatter.parseMillis("1970/01/01 00:00:00");
-        assertThat(millis, equalTo(0l));
+        assertThat(millis, equalTo(0L));
 
         FormatDateTimeFormatter formatter2 = Joda.forPattern("yyyy/MM/dd HH:mm:ss");
         millis = formatter2.parser().parseMillis("1970/01/01 00:00:00");
-        assertThat(millis, equalTo(0l));
+        assertThat(millis, equalTo(0L));
     }
 
     public void testWriteAndParse() {
@@ -345,19 +345,19 @@ public class SimpleJodaTests extends ESTestCase {
     public void testThatEpochParserIsIdempotent() {
         FormatDateTimeFormatter formatter = Joda.forPattern("epoch_millis");
         DateTime dateTime = formatter.parser().parseDateTime("1234567890123");
-        assertThat(dateTime.getMillis(), is(1234567890123l));
+        assertThat(dateTime.getMillis(), is(1234567890123L));
         dateTime = formatter.printer().parseDateTime("1234567890456");
-        assertThat(dateTime.getMillis(), is(1234567890456l));
+        assertThat(dateTime.getMillis(), is(1234567890456L));
         dateTime = formatter.parser().parseDateTime("1234567890789");
-        assertThat(dateTime.getMillis(), is(1234567890789l));
+        assertThat(dateTime.getMillis(), is(1234567890789L));
 
         FormatDateTimeFormatter secondsFormatter = Joda.forPattern("epoch_second");
         DateTime secondsDateTime = secondsFormatter.parser().parseDateTime("1234567890");
-        assertThat(secondsDateTime.getMillis(), is(1234567890000l));
+        assertThat(secondsDateTime.getMillis(), is(1234567890000L));
         secondsDateTime = secondsFormatter.printer().parseDateTime("1234567890");
-        assertThat(secondsDateTime.getMillis(), is(1234567890000l));
+        assertThat(secondsDateTime.getMillis(), is(1234567890000L));
         secondsDateTime = secondsFormatter.parser().parseDateTime("1234567890");
-        assertThat(secondsDateTime.getMillis(), is(1234567890000l));
+        assertThat(secondsDateTime.getMillis(), is(1234567890000L));
     }
 
     public void testThatDefaultFormatterChecksForCorrectYearLength() throws Exception {

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -469,7 +469,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
                                     int shard = MathUtils.mod(Murmur3HashFunction.hash(id), numPrimaries);
                                     logger.trace("[{}] indexing id [{}] through node [{}] targeting shard [{}]", name, id, node, shard);
                                     IndexResponse response = client.prepareIndex("test", "type", id).setSource("{}").setTimeout("1s").get();
-                                    assertThat(response.getVersion(), equalTo(1l));
+                                    assertThat(response.getVersion(), equalTo(1L));
                                     ackedDocs.put(id, node);
                                     logger.trace("[{}] indexed id [{}] through node [{}]", name, id, node);
                                 } catch (ElasticsearchException e) {
@@ -728,14 +728,14 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
 
 
         IndexResponse indexResponse = internalCluster().client(notIsolatedNode).prepareIndex("test", "type").setSource("field", "value").get();
-        assertThat(indexResponse.getVersion(), equalTo(1l));
+        assertThat(indexResponse.getVersion(), equalTo(1L));
 
         logger.info("Verifying if document exists via node[" + notIsolatedNode + "]");
         GetResponse getResponse = internalCluster().client(notIsolatedNode).prepareGet("test", "type", indexResponse.getId())
                 .setPreference("_local")
                 .get();
         assertThat(getResponse.isExists(), is(true));
-        assertThat(getResponse.getVersion(), equalTo(1l));
+        assertThat(getResponse.getVersion(), equalTo(1L));
         assertThat(getResponse.getId(), equalTo(indexResponse.getId()));
 
         scheme.stopDisrupting();
@@ -749,7 +749,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
                     .setPreference("_local")
                     .get();
             assertThat(getResponse.isExists(), is(true));
-            assertThat(getResponse.getVersion(), equalTo(1l));
+            assertThat(getResponse.getVersion(), equalTo(1L));
             assertThat(getResponse.getId(), equalTo(indexResponse.getId()));
         }
     }
@@ -1049,7 +1049,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
         // wait for relocation to finish
         endRelocationLatch.await();
         // now search for the documents and see if we get a reply
-        assertThat(client().prepareSearch().setSize(0).get().getHits().totalHits(), equalTo(100l));
+        assertThat(client().prepareSearch().setSize(0).get().getHits().totalHits(), equalTo(100L));
     }
 
     public void testIndexImportedFromDataOnlyNodesIfMasterLostDataFolder() throws Exception {

--- a/core/src/test/java/org/elasticsearch/document/DocumentActionsIT.java
+++ b/core/src/test/java/org/elasticsearch/document/DocumentActionsIT.java
@@ -157,14 +157,14 @@ public class DocumentActionsIT extends ESIntegTestCase {
             // test successful
             SearchResponse countResponse = client().prepareSearch("test").setSize(0).setQuery(termQuery("_type", "type1")).execute().actionGet();
             assertNoFailures(countResponse);
-            assertThat(countResponse.getHits().totalHits(), equalTo(2l));
+            assertThat(countResponse.getHits().totalHits(), equalTo(2L));
             assertThat(countResponse.getSuccessfulShards(), equalTo(numShards.numPrimaries));
             assertThat(countResponse.getFailedShards(), equalTo(0));
 
             // count with no query is a match all one
             countResponse = client().prepareSearch("test").setSize(0).execute().actionGet();
             assertThat("Failures " + countResponse.getShardFailures(), countResponse.getShardFailures() == null ? 0 : countResponse.getShardFailures().length, equalTo(0));
-            assertThat(countResponse.getHits().totalHits(), equalTo(2l));
+            assertThat(countResponse.getHits().totalHits(), equalTo(2L));
             assertThat(countResponse.getSuccessfulShards(), equalTo(numShards.numPrimaries));
             assertThat(countResponse.getFailedShards(), equalTo(0));
         }

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsIntegrationIT.java
@@ -144,32 +144,32 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         // default:
         FieldStatsResponse response = client().prepareFieldStats().setFields("value").get();
         assertAllSuccessful(response);
-        assertThat(response.getAllFieldStats().get("value").getMinValue(), equalTo(-10l));
-        assertThat(response.getAllFieldStats().get("value").getMaxValue(), equalTo(300l));
+        assertThat(response.getAllFieldStats().get("value").getMinValue(), equalTo(-10L));
+        assertThat(response.getAllFieldStats().get("value").getMaxValue(), equalTo(300L));
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("_all").get("value").getMinValue(), equalTo(-10l));
-        assertThat(response.getIndicesMergedFieldStats().get("_all").get("value").getMaxValue(), equalTo(300l));
+        assertThat(response.getIndicesMergedFieldStats().get("_all").get("value").getMinValue(), equalTo(-10L));
+        assertThat(response.getIndicesMergedFieldStats().get("_all").get("value").getMaxValue(), equalTo(300L));
 
         // Level: cluster
         response = client().prepareFieldStats().setFields("value").setLevel("cluster").get();
         assertAllSuccessful(response);
-        assertThat(response.getAllFieldStats().get("value").getMinValue(), equalTo(-10l));
-        assertThat(response.getAllFieldStats().get("value").getMaxValue(), equalTo(300l));
+        assertThat(response.getAllFieldStats().get("value").getMinValue(), equalTo(-10L));
+        assertThat(response.getAllFieldStats().get("value").getMaxValue(), equalTo(300L));
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("_all").get("value").getMinValue(), equalTo(-10l));
-        assertThat(response.getIndicesMergedFieldStats().get("_all").get("value").getMaxValue(), equalTo(300l));
+        assertThat(response.getIndicesMergedFieldStats().get("_all").get("value").getMinValue(), equalTo(-10L));
+        assertThat(response.getIndicesMergedFieldStats().get("_all").get("value").getMaxValue(), equalTo(300L));
 
         // Level: indices
         response = client().prepareFieldStats().setFields("value").setLevel("indices").get();
         assertAllSuccessful(response);
         assertThat(response.getAllFieldStats(), nullValue());
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(3));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(-10l));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMaxValue(), equalTo(100l));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(101l));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(200l));
-        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMinValue(), equalTo(201l));
-        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMaxValue(), equalTo(300l));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(-10L));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMaxValue(), equalTo(100L));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(101L));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(200L));
+        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMinValue(), equalTo(201L));
+        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMaxValue(), equalTo(300L));
 
         // Illegal level option:
         try {
@@ -189,8 +189,8 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         ));
         ensureGreen("test1", "test2");
 
-        client().prepareIndex("test1", "test").setSource("value", 1l).get();
-        client().prepareIndex("test1", "test").setSource("value", 2l).get();
+        client().prepareIndex("test1", "test").setSource("value", 1L).get();
+        client().prepareIndex("test1", "test").setSource("value", 2L).get();
         client().prepareIndex("test2", "test").setSource("value", "a").get();
         client().prepareIndex("test2", "test").setSource("value", "b").get();
         refresh();
@@ -205,8 +205,8 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         FieldStatsResponse response = client().prepareFieldStats().setFields("value").setLevel("indices").get();
         assertAllSuccessful(response);
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1l));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMaxValue(), equalTo(2l));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMaxValue(), equalTo(2L));
         assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(new BytesRef("a")));
         assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(new BytesRef("b")));
     }
@@ -235,8 +235,8 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         assertAllSuccessful(response);
         assertThat(response.getAllFieldStats(), nullValue());
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMinValue(), equalTo(201l));
-        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMaxValue(), equalTo(300l));
+        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMinValue(), equalTo(201L));
+        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMaxValue(), equalTo(300L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -246,10 +246,10 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         assertAllSuccessful(response);
         assertThat(response.getAllFieldStats(), nullValue());
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(-10l));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMaxValue(), equalTo(100l));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(101l));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(200l));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(-10L));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMaxValue(), equalTo(100L));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(101L));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(200L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -259,10 +259,10 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         assertAllSuccessful(response);
         assertThat(response.getAllFieldStats(), nullValue());
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(101l));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(200l));
-        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMinValue(), equalTo(201l));
-        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMaxValue(), equalTo(300l));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(101L));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(200L));
+        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMinValue(), equalTo(201L));
+        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMaxValue(), equalTo(300L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -290,8 +290,8 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         assertAllSuccessful(response);
         assertThat(response.getAllFieldStats(), nullValue());
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(101l));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(200l));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(101L));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMaxValue(), equalTo(200L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -301,8 +301,8 @@ public class FieldStatsIntegrationIT extends ESIntegTestCase {
         assertAllSuccessful(response);
         assertThat(response.getAllFieldStats(), nullValue());
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMinValue(), equalTo(201l));
-        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMaxValue(), equalTo(300l));
+        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMinValue(), equalTo(201L));
+        assertThat(response.getIndicesMergedFieldStats().get("test3").get("value").getMaxValue(), equalTo(300L));
     }
 
     public void testIncompatibleFilter() throws Exception {

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -66,9 +66,9 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
     }
 
     public void testLong() {
-        testNumberRange("field1", "long", 312321312312412l, 312321312312422l);
+        testNumberRange("field1", "long", 312321312312412L, 312321312312422L);
         testNumberRange("field1", "long", -5, 5);
-        testNumberRange("field1", "long", -312321312312422l, -312321312312412l);
+        testNumberRange("field1", "long", -312321312312422L, -312321312312412L);
     }
 
     public void testString() {
@@ -79,8 +79,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         client().admin().indices().prepareRefresh().get();
 
         FieldStatsResponse result = client().prepareFieldStats().setFields("field").get();
-        assertThat(result.getAllFieldStats().get("field").getMaxDoc(), equalTo(11l));
-        assertThat(result.getAllFieldStats().get("field").getDocCount(), equalTo(11l));
+        assertThat(result.getAllFieldStats().get("field").getMaxDoc(), equalTo(11L));
+        assertThat(result.getAllFieldStats().get("field").getDocCount(), equalTo(11L));
         assertThat(result.getAllFieldStats().get("field").getDensity(), equalTo(100));
         assertThat(result.getAllFieldStats().get("field").getMinValue(), equalTo(new BytesRef(String.format(Locale.ENGLISH, "%03d", 0))));
         assertThat(result.getAllFieldStats().get("field").getMaxValue(), equalTo(new BytesRef(String.format(Locale.ENGLISH, "%03d", 10))));
@@ -97,8 +97,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         client().admin().indices().prepareRefresh().get();
 
         FieldStatsResponse result = client().prepareFieldStats().setFields(fieldName).get();
-        assertThat(result.getAllFieldStats().get(fieldName).getMaxDoc(), equalTo(11l));
-        assertThat(result.getAllFieldStats().get(fieldName).getDocCount(), equalTo(11l));
+        assertThat(result.getAllFieldStats().get(fieldName).getMaxDoc(), equalTo(11L));
+        assertThat(result.getAllFieldStats().get(fieldName).getDocCount(), equalTo(11L));
         assertThat(result.getAllFieldStats().get(fieldName).getDensity(), equalTo(100));
         assertThat(result.getAllFieldStats().get(fieldName).getMinValue(), equalTo(-1d));
         assertThat(result.getAllFieldStats().get(fieldName).getMaxValue(), equalTo(9d));
@@ -114,8 +114,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
         client().admin().indices().prepareRefresh().get();
 
         FieldStatsResponse result = client().prepareFieldStats().setFields(fieldName).get();
-        assertThat(result.getAllFieldStats().get(fieldName).getMaxDoc(), equalTo(11l));
-        assertThat(result.getAllFieldStats().get(fieldName).getDocCount(), equalTo(11l));
+        assertThat(result.getAllFieldStats().get(fieldName).getMaxDoc(), equalTo(11L));
+        assertThat(result.getAllFieldStats().get(fieldName).getDocCount(), equalTo(11L));
         assertThat(result.getAllFieldStats().get(fieldName).getDensity(), equalTo(100));
         assertThat(result.getAllFieldStats().get(fieldName).getMinValue(), equalTo(-1f));
         assertThat(result.getAllFieldStats().get(fieldName).getMaxValue(), equalTo(9f));
@@ -144,44 +144,44 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
 
     public void testMerge() {
         List<FieldStats> stats = new ArrayList<>();
-        stats.add(new FieldStats.Long(1, 1l, 1l, 1l, 1l, 1l));
-        stats.add(new FieldStats.Long(1, 1l, 1l, 1l, 1l, 1l));
-        stats.add(new FieldStats.Long(1, 1l, 1l, 1l, 1l, 1l));
+        stats.add(new FieldStats.Long(1, 1L, 1L, 1L, 1L, 1L));
+        stats.add(new FieldStats.Long(1, 1L, 1L, 1L, 1L, 1L));
+        stats.add(new FieldStats.Long(1, 1L, 1L, 1L, 1L, 1L));
 
-        FieldStats stat = new FieldStats.Long(1, 1l, 1l, 1l, 1l, 1l);
+        FieldStats stat = new FieldStats.Long(1, 1L, 1L, 1L, 1L, 1L);
         for (FieldStats otherStat : stats) {
             stat.append(otherStat);
         }
-        assertThat(stat.getMaxDoc(), equalTo(4l));
-        assertThat(stat.getDocCount(), equalTo(4l));
-        assertThat(stat.getSumDocFreq(), equalTo(4l));
-        assertThat(stat.getSumTotalTermFreq(), equalTo(4l));
+        assertThat(stat.getMaxDoc(), equalTo(4L));
+        assertThat(stat.getDocCount(), equalTo(4L));
+        assertThat(stat.getSumDocFreq(), equalTo(4L));
+        assertThat(stat.getSumTotalTermFreq(), equalTo(4L));
     }
 
     public void testMerge_notAvailable() {
         List<FieldStats> stats = new ArrayList<>();
-        stats.add(new FieldStats.Long(1, 1l, 1l, 1l, 1l, 1l));
-        stats.add(new FieldStats.Long(1, 1l, 1l, 1l, 1l, 1l));
-        stats.add(new FieldStats.Long(1, 1l, 1l, 1l, 1l, 1l));
+        stats.add(new FieldStats.Long(1, 1L, 1L, 1L, 1L, 1L));
+        stats.add(new FieldStats.Long(1, 1L, 1L, 1L, 1L, 1L));
+        stats.add(new FieldStats.Long(1, 1L, 1L, 1L, 1L, 1L));
 
-        FieldStats stat = new FieldStats.Long(1, -1l, -1l, -1l, 1l, 1l);
+        FieldStats stat = new FieldStats.Long(1, -1L, -1L, -1L, 1L, 1L);
         for (FieldStats otherStat : stats) {
             stat.append(otherStat);
         }
-        assertThat(stat.getMaxDoc(), equalTo(4l));
-        assertThat(stat.getDocCount(), equalTo(-1l));
-        assertThat(stat.getSumDocFreq(), equalTo(-1l));
-        assertThat(stat.getSumTotalTermFreq(), equalTo(-1l));
+        assertThat(stat.getMaxDoc(), equalTo(4L));
+        assertThat(stat.getDocCount(), equalTo(-1L));
+        assertThat(stat.getSumDocFreq(), equalTo(-1L));
+        assertThat(stat.getSumTotalTermFreq(), equalTo(-1L));
 
-        stats.add(new FieldStats.Long(1, -1l, -1l, -1l, 1l, 1l));
+        stats.add(new FieldStats.Long(1, -1L, -1L, -1L, 1L, 1L));
         stat = stats.remove(0);
         for (FieldStats otherStat : stats) {
             stat.append(otherStat);
         }
-        assertThat(stat.getMaxDoc(), equalTo(4l));
-        assertThat(stat.getDocCount(), equalTo(-1l));
-        assertThat(stat.getSumDocFreq(), equalTo(-1l));
-        assertThat(stat.getSumTotalTermFreq(), equalTo(-1l));
+        assertThat(stat.getMaxDoc(), equalTo(4L));
+        assertThat(stat.getDocCount(), equalTo(-1L));
+        assertThat(stat.getSumDocFreq(), equalTo(-1L));
+        assertThat(stat.getSumTotalTermFreq(), equalTo(-1L));
     }
 
     public void testInvalidField() {
@@ -213,9 +213,9 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
 
     public void testNumberFiltering() {
         createIndex("test1", Settings.EMPTY, "type", "value", "type=long");
-        client().prepareIndex("test1", "test").setSource("value", 1l).get();
+        client().prepareIndex("test1", "test").setSource("value", 1L).get();
         createIndex("test2", Settings.EMPTY, "type", "value", "type=long");
-        client().prepareIndex("test2", "test").setSource("value", 3l).get();
+        client().prepareIndex("test2", "test").setSource("value", 3L).get();
         client().admin().indices().prepareRefresh().get();
 
         FieldStatsResponse response = client().prepareFieldStats()
@@ -223,8 +223,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setLevel("indices")
                 .get();
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1l));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3l));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -246,7 +246,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setLevel("indices")
                 .get();
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1l));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -254,7 +254,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setLevel("indices")
                 .get();
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1l));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -269,7 +269,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setLevel("indices")
                 .get();
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3l));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -277,7 +277,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setLevel("indices")
                 .get();
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(1));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3l));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3L));
 
         response = client().prepareFieldStats()
                 .setFields("value")
@@ -292,8 +292,8 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 .setLevel("indices")
                 .get();
         assertThat(response.getIndicesMergedFieldStats().size(), equalTo(2));
-        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1l));
-        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3l));
+        assertThat(response.getIndicesMergedFieldStats().get("test1").get("value").getMinValue(), equalTo(1L));
+        assertThat(response.getIndicesMergedFieldStats().get("test2").get("value").getMinValue(), equalTo(3L));
 
         response = client().prepareFieldStats()
                 .setFields("value")

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -232,7 +232,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> verify 1 doc in the index");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1l);
+            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
         }
 
         logger.info("--> closing test index...");
@@ -250,9 +250,9 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify 1 doc in the index");
-        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1l);
+        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1l);
+            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
         }
     }
 
@@ -268,7 +268,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> verify 1 doc in the index");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1l);
+            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
         }
         assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(true));
 
@@ -328,7 +328,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> verify 1 doc in the index");
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1l);
+            assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
         }
         assertThat(client().prepareGet("test", "type1", "1").execute().actionGet().isExists(), equalTo(true));
 

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -215,7 +215,7 @@ public class MetaDataStateFormatTests extends ESTestCase {
         long checksumAfterCorruption;
         long actualChecksumAfterCorruption;
         try (ChecksumIndexInput input = dir.openChecksumInput(fileToCorrupt.getFileName().toString(), IOContext.DEFAULT)) {
-            assertThat(input.getFilePointer(), is(0l));
+            assertThat(input.getFilePointer(), is(0L));
             input.seek(input.length() - 8); // one long is the checksum... 8 bytes
             checksumAfterCorruption = input.getChecksum();
             actualChecksumAfterCorruption = input.readLong();

--- a/core/src/test/java/org/elasticsearch/gateway/QuorumGatewayIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/QuorumGatewayIT.java
@@ -67,7 +67,7 @@ public class QuorumGatewayIT extends ESIntegTestCase {
         refresh();
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2l);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2L);
         }
         logger.info("--> restart all nodes");
         internalCluster().fullRestart(new RestartCallback() {
@@ -89,7 +89,7 @@ public class QuorumGatewayIT extends ESIntegTestCase {
                     activeClient.prepareIndex("test", "type1", "3").setSource(jsonBuilder().startObject().field("field", "value3").endObject()).get();
                     assertNoFailures(activeClient.admin().indices().prepareRefresh().get());
                     for (int i = 0; i < 10; i++) {
-                        assertHitCount(activeClient.prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 3l);
+                        assertHitCount(activeClient.prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 3L);
                     }
                 }
             }
@@ -100,7 +100,7 @@ public class QuorumGatewayIT extends ESIntegTestCase {
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 3l);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 3L);
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/gateway/RecoveryBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/RecoveryBackwardsCompatibilityIT.java
@@ -98,8 +98,8 @@ public class RecoveryBackwardsCompatibilityIT extends ESBackcompatTestCase {
             final String recoverStateAsJSON = XContentHelper.toString(recoveryState, params);
             if (!recoveryState.getPrimary()) {
                 RecoveryState.Index index = recoveryState.getIndex();
-                assertThat(recoverStateAsJSON, index.recoveredBytes(), equalTo(0l));
-                assertThat(recoverStateAsJSON, index.reusedBytes(), greaterThan(0l));
+                assertThat(recoverStateAsJSON, index.recoveredBytes(), equalTo(0L));
+                assertThat(recoverStateAsJSON, index.reusedBytes(), greaterThan(0L));
                 assertThat(recoverStateAsJSON, index.reusedBytes(), equalTo(index.totalBytes()));
                 assertThat(recoverStateAsJSON, index.recoveredFileCount(), equalTo(0));
                 assertThat(recoverStateAsJSON, index.reusedFileCount(), equalTo(index.totalFileCount()));

--- a/core/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -409,7 +409,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
                         recoveryState.getShardId().getId(), recoveryState.getSourceNode().name(), recoveryState.getTargetNode().name(),
                         recoveryState.getIndex().recoveredBytes(), recoveryState.getIndex().reusedBytes());
                 assertThat("no bytes should be recovered", recoveryState.getIndex().recoveredBytes(), equalTo(recovered));
-                assertThat("data should have been reused", recoveryState.getIndex().reusedBytes(), greaterThan(0l));
+                assertThat("data should have been reused", recoveryState.getIndex().reusedBytes(), greaterThan(0L));
                 // we have to recover the segments file since we commit the translog ID on engine startup
                 assertThat("all bytes should be reused except of the segments file", recoveryState.getIndex().reusedBytes(), equalTo(recoveryState.getIndex().totalBytes() - recovered));
                 assertThat("no files should be recovered except of the segments file", recoveryState.getIndex().recoveredFileCount(), equalTo(1));
@@ -421,7 +421,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
                             recoveryState.getShardId().getId(), recoveryState.getSourceNode().name(), recoveryState.getTargetNode().name(),
                             recoveryState.getIndex().recoveredBytes(), recoveryState.getIndex().reusedBytes());
                 }
-                assertThat(recoveryState.getIndex().recoveredBytes(), equalTo(0l));
+                assertThat(recoveryState.getIndex().recoveredBytes(), equalTo(0L));
                 assertThat(recoveryState.getIndex().reusedBytes(), equalTo(recoveryState.getIndex().totalBytes()));
                 assertThat(recoveryState.getIndex().recoveredFileCount(), equalTo(0));
                 assertThat(recoveryState.getIndex().reusedFileCount(), equalTo(recoveryState.getIndex().totalFileCount()));

--- a/core/src/test/java/org/elasticsearch/gateway/ReusePeerRecoverySharedTest.java
+++ b/core/src/test/java/org/elasticsearch/gateway/ReusePeerRecoverySharedTest.java
@@ -127,7 +127,7 @@ public class ReusePeerRecoverySharedTest {
                         recoveryState.getSourceNode().name(), recoveryState.getTargetNode().name(),
                         recoveryState.getIndex().recoveredBytes(), recoveryState.getIndex().reusedBytes());
                 assertThat("no bytes should be recovered", recoveryState.getIndex().recoveredBytes(), equalTo(recovered));
-                assertThat("data should have been reused", recoveryState.getIndex().reusedBytes(), greaterThan(0l));
+                assertThat("data should have been reused", recoveryState.getIndex().reusedBytes(), greaterThan(0L));
                 // we have to recover the segments file since we commit the translog ID on engine startup
                 assertThat("all bytes should be reused except of the segments file", recoveryState.getIndex().reusedBytes(),
                         equalTo(recoveryState.getIndex().totalBytes() - recovered));
@@ -142,7 +142,7 @@ public class ReusePeerRecoverySharedTest {
                             recoveryState.getShardId().getId(), recoveryState.getSourceNode().name(), recoveryState.getTargetNode().name(),
                             recoveryState.getIndex().recoveredBytes(), recoveryState.getIndex().reusedBytes());
                 }
-                assertThat(recoveryState.getIndex().recoveredBytes(), equalTo(0l));
+                assertThat(recoveryState.getIndex().recoveredBytes(), equalTo(0L));
                 assertThat(recoveryState.getIndex().reusedBytes(), equalTo(recoveryState.getIndex().totalBytes()));
                 assertThat(recoveryState.getIndex().recoveredFileCount(), equalTo(0));
                 assertThat(recoveryState.getIndex().reusedFileCount(), equalTo(recoveryState.getIndex().totalFileCount()));

--- a/core/src/test/java/org/elasticsearch/get/GetActionIT.java
+++ b/core/src/test/java/org/elasticsearch/get/GetActionIT.java
@@ -462,12 +462,12 @@ public class GetActionIT extends ESIntegTestCase {
         response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(Versions.MATCH_ANY).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
-        assertThat(response.getVersion(), equalTo(1l));
+        assertThat(response.getVersion(), equalTo(1L));
 
         response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(1).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
-        assertThat(response.getVersion(), equalTo(1l));
+        assertThat(response.getVersion(), equalTo(1L));
 
         try {
             client().prepareGet(indexOrAlias(), "type1", "1").setVersion(2).get();
@@ -483,13 +483,13 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(1l));
+        assertThat(response.getVersion(), equalTo(1L));
 
         response = client().prepareGet(indexOrAlias(), "type1", "1").setVersion(1).setRealtime(false).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(1l));
+        assertThat(response.getVersion(), equalTo(1L));
 
         try {
             client().prepareGet(indexOrAlias(), "type1", "1").setVersion(2).setRealtime(false).get();
@@ -507,7 +507,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(2l));
+        assertThat(response.getVersion(), equalTo(2L));
 
         try {
             client().prepareGet(indexOrAlias(), "type1", "1").setVersion(1).get();
@@ -520,7 +520,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(2l));
+        assertThat(response.getVersion(), equalTo(2L));
 
         // From Lucene index:
         refresh();
@@ -529,7 +529,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(2l));
+        assertThat(response.getVersion(), equalTo(2L));
 
         try {
             client().prepareGet(indexOrAlias(), "type1", "1").setVersion(1).setRealtime(false).get();
@@ -542,7 +542,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getId(), equalTo("1"));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getVersion(), equalTo(2l));
+        assertThat(response.getVersion(), equalTo(2L));
     }
 
     public void testMultiGetWithVersion() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/VersionTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/VersionTypeTests.java
@@ -192,24 +192,24 @@ public class VersionTypeTests extends ESTestCase {
     }
 
     public void testUpdateVersion() {
-        assertThat(VersionType.INTERNAL.updateVersion(Versions.NOT_SET, 10), equalTo(1l));
-        assertThat(VersionType.INTERNAL.updateVersion(Versions.NOT_FOUND, 10), equalTo(1l));
-        assertThat(VersionType.INTERNAL.updateVersion(1, 1), equalTo(2l));
-        assertThat(VersionType.INTERNAL.updateVersion(2, Versions.MATCH_ANY), equalTo(3l));
+        assertThat(VersionType.INTERNAL.updateVersion(Versions.NOT_SET, 10), equalTo(1L));
+        assertThat(VersionType.INTERNAL.updateVersion(Versions.NOT_FOUND, 10), equalTo(1L));
+        assertThat(VersionType.INTERNAL.updateVersion(1, 1), equalTo(2L));
+        assertThat(VersionType.INTERNAL.updateVersion(2, Versions.MATCH_ANY), equalTo(3L));
 
 
-        assertThat(VersionType.EXTERNAL.updateVersion(Versions.NOT_SET, 10), equalTo(10l));
-        assertThat(VersionType.EXTERNAL.updateVersion(Versions.NOT_FOUND, 10), equalTo(10l));
-        assertThat(VersionType.EXTERNAL.updateVersion(1, 10), equalTo(10l));
+        assertThat(VersionType.EXTERNAL.updateVersion(Versions.NOT_SET, 10), equalTo(10L));
+        assertThat(VersionType.EXTERNAL.updateVersion(Versions.NOT_FOUND, 10), equalTo(10L));
+        assertThat(VersionType.EXTERNAL.updateVersion(1, 10), equalTo(10L));
 
-        assertThat(VersionType.EXTERNAL_GTE.updateVersion(Versions.NOT_SET, 10), equalTo(10l));
-        assertThat(VersionType.EXTERNAL_GTE.updateVersion(Versions.NOT_FOUND, 10), equalTo(10l));
-        assertThat(VersionType.EXTERNAL_GTE.updateVersion(1, 10), equalTo(10l));
-        assertThat(VersionType.EXTERNAL_GTE.updateVersion(10, 10), equalTo(10l));
+        assertThat(VersionType.EXTERNAL_GTE.updateVersion(Versions.NOT_SET, 10), equalTo(10L));
+        assertThat(VersionType.EXTERNAL_GTE.updateVersion(Versions.NOT_FOUND, 10), equalTo(10L));
+        assertThat(VersionType.EXTERNAL_GTE.updateVersion(1, 10), equalTo(10L));
+        assertThat(VersionType.EXTERNAL_GTE.updateVersion(10, 10), equalTo(10L));
 
-        assertThat(VersionType.FORCE.updateVersion(Versions.NOT_SET, 10), equalTo(10l));
-        assertThat(VersionType.FORCE.updateVersion(Versions.NOT_FOUND, 10), equalTo(10l));
-        assertThat(VersionType.FORCE.updateVersion(11, 10), equalTo(10l));
+        assertThat(VersionType.FORCE.updateVersion(Versions.NOT_SET, 10), equalTo(10L));
+        assertThat(VersionType.FORCE.updateVersion(Versions.NOT_FOUND, 10), equalTo(10L));
+        assertThat(VersionType.FORCE.updateVersion(11, 10), equalTo(10L));
 
 // Old indexing code
 //        if (index.versionType() == VersionType.INTERNAL) { // internal version type

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -293,8 +293,8 @@ public class InternalEngineTests extends ESTestCase {
              Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE)) {
             List<Segment> segments = engine.segments(false);
             assertThat(segments.isEmpty(), equalTo(true));
-            assertThat(engine.segmentsStats().getCount(), equalTo(0l));
-            assertThat(engine.segmentsStats().getMemoryInBytes(), equalTo(0l));
+            assertThat(engine.segmentsStats().getCount(), equalTo(0L));
+            assertThat(engine.segmentsStats().getMemoryInBytes(), equalTo(0L));
 
             // create a doc and refresh
             ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, null);
@@ -307,12 +307,12 @@ public class InternalEngineTests extends ESTestCase {
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(1));
             SegmentsStats stats = engine.segmentsStats();
-            assertThat(stats.getCount(), equalTo(1l));
-            assertThat(stats.getTermsMemoryInBytes(), greaterThan(0l));
-            assertThat(stats.getStoredFieldsMemoryInBytes(), greaterThan(0l));
-            assertThat(stats.getTermVectorsMemoryInBytes(), equalTo(0l));
-            assertThat(stats.getNormsMemoryInBytes(), greaterThan(0l));
-            assertThat(stats.getDocValuesMemoryInBytes(), greaterThan(0l));
+            assertThat(stats.getCount(), equalTo(1L));
+            assertThat(stats.getTermsMemoryInBytes(), greaterThan(0L));
+            assertThat(stats.getStoredFieldsMemoryInBytes(), greaterThan(0L));
+            assertThat(stats.getTermVectorsMemoryInBytes(), equalTo(0L));
+            assertThat(stats.getNormsMemoryInBytes(), greaterThan(0L));
+            assertThat(stats.getDocValuesMemoryInBytes(), greaterThan(0L));
             assertThat(segments.get(0).isCommitted(), equalTo(false));
             assertThat(segments.get(0).isSearch(), equalTo(true));
             assertThat(segments.get(0).getNumDocs(), equalTo(2));
@@ -324,7 +324,7 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(1));
-            assertThat(engine.segmentsStats().getCount(), equalTo(1l));
+            assertThat(engine.segmentsStats().getCount(), equalTo(1L));
             assertThat(segments.get(0).isCommitted(), equalTo(true));
             assertThat(segments.get(0).isSearch(), equalTo(true));
             assertThat(segments.get(0).getNumDocs(), equalTo(2));
@@ -337,10 +337,10 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(2));
-            assertThat(engine.segmentsStats().getCount(), equalTo(2l));
+            assertThat(engine.segmentsStats().getCount(), equalTo(2L));
             assertThat(engine.segmentsStats().getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
             assertThat(engine.segmentsStats().getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
-            assertThat(engine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0l));
+            assertThat(engine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0L));
             assertThat(engine.segmentsStats().getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
             assertThat(engine.segmentsStats().getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
             assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
@@ -363,7 +363,7 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(2));
-            assertThat(engine.segmentsStats().getCount(), equalTo(2l));
+            assertThat(engine.segmentsStats().getCount(), equalTo(2L));
             assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
             assertThat(segments.get(0).isCommitted(), equalTo(true));
             assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -384,7 +384,7 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(3));
-            assertThat(engine.segmentsStats().getCount(), equalTo(3l));
+            assertThat(engine.segmentsStats().getCount(), equalTo(3L));
             assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
             assertThat(segments.get(0).isCommitted(), equalTo(true));
             assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -494,7 +494,7 @@ public class InternalEngineTests extends ESTestCase {
         engine.index(new Engine.Index(newUid("1"), doc));
 
         CommitStats stats1 = engine.commitStats();
-        assertThat(stats1.getGeneration(), greaterThan(0l));
+        assertThat(stats1.getGeneration(), greaterThan(0L));
         assertThat(stats1.getId(), notNullValue());
         assertThat(stats1.getUserData(), hasKey(Translog.TRANSLOG_GENERATION_KEY));
 
@@ -895,46 +895,46 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index create = new Engine.Index(newUid("1"), doc, Versions.MATCH_DELETED);
         engine.index(create);
-        assertThat(create.version(), equalTo(1l));
+        assertThat(create.version(), equalTo(1L));
 
         create = new Engine.Index(newUid("1"), doc, create.version(), create.versionType().versionTypeForReplicationAndRecovery(), REPLICA, 0);
         replicaEngine.index(create);
-        assertThat(create.version(), equalTo(1l));
+        assertThat(create.version(), equalTo(1L));
     }
 
     public void testVersioningNewIndex() {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
 
         index = new Engine.Index(newUid("1"), doc, index.version(), index.versionType().versionTypeForReplicationAndRecovery(), REPLICA, 0);
         replicaEngine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
     }
 
     public void testExternalVersioningNewIndex() {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc, 12, VersionType.EXTERNAL, PRIMARY, 0);
         engine.index(index);
-        assertThat(index.version(), equalTo(12l));
+        assertThat(index.version(), equalTo(12L));
 
         index = new Engine.Index(newUid("1"), doc, index.version(), index.versionType().versionTypeForReplicationAndRecovery(), REPLICA, 0);
         replicaEngine.index(index);
-        assertThat(index.version(), equalTo(12l));
+        assertThat(index.version(), equalTo(12L));
     }
 
     public void testVersioningIndexConflict() {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
 
         index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(2l));
+        assertThat(index.version(), equalTo(2L));
 
-        index = new Engine.Index(newUid("1"), doc, 1l, VersionType.INTERNAL, Engine.Operation.Origin.PRIMARY, 0);
+        index = new Engine.Index(newUid("1"), doc, 1L, VersionType.INTERNAL, Engine.Operation.Origin.PRIMARY, 0);
         try {
             engine.index(index);
             fail();
@@ -943,7 +943,7 @@ public class InternalEngineTests extends ESTestCase {
         }
 
         // future versions should not work as well
-        index = new Engine.Index(newUid("1"), doc, 3l, VersionType.INTERNAL, PRIMARY, 0);
+        index = new Engine.Index(newUid("1"), doc, 3L, VersionType.INTERNAL, PRIMARY, 0);
         try {
             engine.index(index);
             fail();
@@ -956,11 +956,11 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc, 12, VersionType.EXTERNAL, PRIMARY, 0);
         engine.index(index);
-        assertThat(index.version(), equalTo(12l));
+        assertThat(index.version(), equalTo(12L));
 
         index = new Engine.Index(newUid("1"), doc, 14, VersionType.EXTERNAL, PRIMARY, 0);
         engine.index(index);
-        assertThat(index.version(), equalTo(14l));
+        assertThat(index.version(), equalTo(14L));
 
         index = new Engine.Index(newUid("1"), doc, 13, VersionType.EXTERNAL, PRIMARY, 0);
         try {
@@ -975,15 +975,15 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
 
         index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(2l));
+        assertThat(index.version(), equalTo(2L));
 
         engine.flush();
 
-        index = new Engine.Index(newUid("1"), doc, 1l, VersionType.INTERNAL, PRIMARY, 0);
+        index = new Engine.Index(newUid("1"), doc, 1L, VersionType.INTERNAL, PRIMARY, 0);
         try {
             engine.index(index);
             fail();
@@ -992,7 +992,7 @@ public class InternalEngineTests extends ESTestCase {
         }
 
         // future versions should not work as well
-        index = new Engine.Index(newUid("1"), doc, 3l, VersionType.INTERNAL, PRIMARY, 0);
+        index = new Engine.Index(newUid("1"), doc, 3L, VersionType.INTERNAL, PRIMARY, 0);
         try {
             engine.index(index);
             fail();
@@ -1005,11 +1005,11 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc, 12, VersionType.EXTERNAL, PRIMARY, 0);
         engine.index(index);
-        assertThat(index.version(), equalTo(12l));
+        assertThat(index.version(), equalTo(12L));
 
         index = new Engine.Index(newUid("1"), doc, 14, VersionType.EXTERNAL, PRIMARY, 0);
         engine.index(index);
-        assertThat(index.version(), equalTo(14l));
+        assertThat(index.version(), equalTo(14L));
 
         engine.flush();
 
@@ -1121,13 +1121,13 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
 
         index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(2l));
+        assertThat(index.version(), equalTo(2L));
 
-        Engine.Delete delete = new Engine.Delete("test", "1", newUid("1"), 1l, VersionType.INTERNAL, PRIMARY, 0, false);
+        Engine.Delete delete = new Engine.Delete("test", "1", newUid("1"), 1L, VersionType.INTERNAL, PRIMARY, 0, false);
         try {
             engine.delete(delete);
             fail();
@@ -1136,7 +1136,7 @@ public class InternalEngineTests extends ESTestCase {
         }
 
         // future versions should not work as well
-        delete = new Engine.Delete("test", "1", newUid("1"), 3l, VersionType.INTERNAL, PRIMARY, 0, false);
+        delete = new Engine.Delete("test", "1", newUid("1"), 3L, VersionType.INTERNAL, PRIMARY, 0, false);
         try {
             engine.delete(delete);
             fail();
@@ -1145,12 +1145,12 @@ public class InternalEngineTests extends ESTestCase {
         }
 
         // now actually delete
-        delete = new Engine.Delete("test", "1", newUid("1"), 2l, VersionType.INTERNAL, PRIMARY, 0, false);
+        delete = new Engine.Delete("test", "1", newUid("1"), 2L, VersionType.INTERNAL, PRIMARY, 0, false);
         engine.delete(delete);
-        assertThat(delete.version(), equalTo(3l));
+        assertThat(delete.version(), equalTo(3L));
 
         // now check if we can index to a delete doc with version
-        index = new Engine.Index(newUid("1"), doc, 2l, VersionType.INTERNAL, PRIMARY, 0);
+        index = new Engine.Index(newUid("1"), doc, 2L, VersionType.INTERNAL, PRIMARY, 0);
         try {
             engine.index(index);
             fail();
@@ -1171,15 +1171,15 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
 
         index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(2l));
+        assertThat(index.version(), equalTo(2L));
 
         engine.flush();
 
-        Engine.Delete delete = new Engine.Delete("test", "1", newUid("1"), 1l, VersionType.INTERNAL, PRIMARY, 0, false);
+        Engine.Delete delete = new Engine.Delete("test", "1", newUid("1"), 1L, VersionType.INTERNAL, PRIMARY, 0, false);
         try {
             engine.delete(delete);
             fail();
@@ -1188,7 +1188,7 @@ public class InternalEngineTests extends ESTestCase {
         }
 
         // future versions should not work as well
-        delete = new Engine.Delete("test", "1", newUid("1"), 3l, VersionType.INTERNAL, PRIMARY, 0, false);
+        delete = new Engine.Delete("test", "1", newUid("1"), 3L, VersionType.INTERNAL, PRIMARY, 0, false);
         try {
             engine.delete(delete);
             fail();
@@ -1199,14 +1199,14 @@ public class InternalEngineTests extends ESTestCase {
         engine.flush();
 
         // now actually delete
-        delete = new Engine.Delete("test", "1", newUid("1"), 2l, VersionType.INTERNAL, PRIMARY, 0, false);
+        delete = new Engine.Delete("test", "1", newUid("1"), 2L, VersionType.INTERNAL, PRIMARY, 0, false);
         engine.delete(delete);
-        assertThat(delete.version(), equalTo(3l));
+        assertThat(delete.version(), equalTo(3L));
 
         engine.flush();
 
         // now check if we can index to a delete doc with version
-        index = new Engine.Index(newUid("1"), doc, 2l, VersionType.INTERNAL, PRIMARY, 0);
+        index = new Engine.Index(newUid("1"), doc, 2L, VersionType.INTERNAL, PRIMARY, 0);
         try {
             engine.index(index);
             fail();
@@ -1227,7 +1227,7 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index create = new Engine.Index(newUid("1"), doc, Versions.MATCH_DELETED, VersionType.INTERNAL, PRIMARY, 0);
         engine.index(create);
-        assertThat(create.version(), equalTo(1l));
+        assertThat(create.version(), equalTo(1L));
 
         create = new Engine.Index(newUid("1"), doc, Versions.MATCH_DELETED, VersionType.INTERNAL, PRIMARY, 0);
         try {
@@ -1242,7 +1242,7 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index create = new Engine.Index(newUid("1"), doc, Versions.MATCH_DELETED, VersionType.INTERNAL, PRIMARY, 0);
         engine.index(create);
-        assertThat(create.version(), equalTo(1l));
+        assertThat(create.version(), equalTo(1L));
 
         engine.flush();
 
@@ -1259,19 +1259,19 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
 
         index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(2l));
+        assertThat(index.version(), equalTo(2L));
 
         // apply the second index to the replica, should work fine
         index = new Engine.Index(newUid("1"), doc, index.version(), VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
         replicaEngine.index(index);
-        assertThat(index.version(), equalTo(2l));
+        assertThat(index.version(), equalTo(2L));
 
         // now, the old one should not work
-        index = new Engine.Index(newUid("1"), doc, 1l, VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
+        index = new Engine.Index(newUid("1"), doc, 1L, VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
         try {
             replicaEngine.index(index);
             fail();
@@ -1281,10 +1281,10 @@ public class InternalEngineTests extends ESTestCase {
 
         // second version on replica should fail as well
         try {
-            index = new Engine.Index(newUid("1"), doc, 2l
+            index = new Engine.Index(newUid("1"), doc, 2L
                     , VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
             replicaEngine.index(index);
-            assertThat(index.version(), equalTo(2l));
+            assertThat(index.version(), equalTo(2L));
         } catch (VersionConflictEngineException e) {
             // all is well
         }
@@ -1294,33 +1294,33 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocument(), B_1, null);
         Engine.Index index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
 
         // apply the first index to the replica, should work fine
-        index = new Engine.Index(newUid("1"), doc, 1l
+        index = new Engine.Index(newUid("1"), doc, 1L
                 , VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
         replicaEngine.index(index);
-        assertThat(index.version(), equalTo(1l));
+        assertThat(index.version(), equalTo(1L));
 
         // index it again
         index = new Engine.Index(newUid("1"), doc);
         engine.index(index);
-        assertThat(index.version(), equalTo(2l));
+        assertThat(index.version(), equalTo(2L));
 
         // now delete it
         Engine.Delete delete = new Engine.Delete("test", "1", newUid("1"));
         engine.delete(delete);
-        assertThat(delete.version(), equalTo(3l));
+        assertThat(delete.version(), equalTo(3L));
 
         // apply the delete on the replica (skipping the second index)
-        delete = new Engine.Delete("test", "1", newUid("1"), 3l
+        delete = new Engine.Delete("test", "1", newUid("1"), 3L
                 , VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0, false);
         replicaEngine.delete(delete);
-        assertThat(delete.version(), equalTo(3l));
+        assertThat(delete.version(), equalTo(3L));
 
         // second time delete with same version should fail
         try {
-            delete = new Engine.Delete("test", "1", newUid("1"), 3l
+            delete = new Engine.Delete("test", "1", newUid("1"), 3L
                     , VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0, false);
             replicaEngine.delete(delete);
             fail("excepted VersionConflictEngineException to be thrown");
@@ -1330,7 +1330,7 @@ public class InternalEngineTests extends ESTestCase {
 
         // now do the second index on the replica, it should fail
         try {
-            index = new Engine.Index(newUid("1"), doc, 2l, VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
+            index = new Engine.Index(newUid("1"), doc, 2L, VersionType.INTERNAL.versionTypeForReplicationAndRecovery(), REPLICA, 0);
             replicaEngine.index(index);
             fail("excepted VersionConflictEngineException to be thrown");
         } catch (VersionConflictEngineException e) {
@@ -1610,7 +1610,7 @@ public class InternalEngineTests extends ESTestCase {
             ParsedDocument doc = testParsedDocument(Integer.toString(i), Integer.toString(i), "test", null, -1, -1, testDocument(), new BytesArray("{}"), null);
             Engine.Index firstIndexRequest = new Engine.Index(newUid(Integer.toString(i)), doc, Versions.MATCH_DELETED, VersionType.INTERNAL, PRIMARY, System.nanoTime());
             engine.index(firstIndexRequest);
-            assertThat(firstIndexRequest.version(), equalTo(1l));
+            assertThat(firstIndexRequest.version(), equalTo(1L));
         }
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
@@ -1662,7 +1662,7 @@ public class InternalEngineTests extends ESTestCase {
             ParsedDocument doc = testParsedDocument(Integer.toString(i), Integer.toString(i), "test", null, -1, -1, testDocument(), new BytesArray("{}"), null);
             Engine.Index firstIndexRequest = new Engine.Index(newUid(Integer.toString(i)), doc, Versions.MATCH_DELETED, VersionType.INTERNAL, PRIMARY, System.nanoTime());
             engine.index(firstIndexRequest);
-            assertThat(firstIndexRequest.version(), equalTo(1l));
+            assertThat(firstIndexRequest.version(), equalTo(1L));
         }
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
@@ -1757,7 +1757,7 @@ public class InternalEngineTests extends ESTestCase {
                     ParsedDocument doc = testParsedDocument("extra" + Integer.toString(i), "extra" + Integer.toString(i), "test", null, -1, -1, testDocument(), new BytesArray("{}"), null);
                     Engine.Index firstIndexRequest = new Engine.Index(newUid(Integer.toString(i)), doc, Versions.MATCH_DELETED, VersionType.INTERNAL, PRIMARY, System.nanoTime());
                     engine.index(firstIndexRequest);
-                    assertThat(firstIndexRequest.version(), equalTo(1l));
+                    assertThat(firstIndexRequest.version(), equalTo(1L));
                 }
                 engine.refresh("test");
                 try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
@@ -1786,7 +1786,7 @@ public class InternalEngineTests extends ESTestCase {
             ParsedDocument doc = testParsedDocument(Integer.toString(i), Integer.toString(i), "test", null, -1, -1, testDocument(), new BytesArray("{}"), null);
             Engine.Index firstIndexRequest = new Engine.Index(newUid(Integer.toString(i)), doc, Versions.MATCH_DELETED, VersionType.INTERNAL, PRIMARY, System.nanoTime());
             engine.index(firstIndexRequest);
-            assertThat(firstIndexRequest.version(), equalTo(1l));
+            assertThat(firstIndexRequest.version(), equalTo(1L));
         }
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
@@ -1835,7 +1835,7 @@ public class InternalEngineTests extends ESTestCase {
         ParsedDocument doc = testParsedDocument(uuidValue, Integer.toString(randomId), "test", null, -1, -1, testDocument(), new BytesArray("{}"), null);
         Engine.Index firstIndexRequest = new Engine.Index(newUid(uuidValue), doc, 1, VersionType.EXTERNAL, PRIMARY, System.nanoTime());
         engine.index(firstIndexRequest);
-        assertThat(firstIndexRequest.version(), equalTo(1l));
+        assertThat(firstIndexRequest.version(), equalTo(1L));
         if (flush) {
             engine.flush();
         }
@@ -1844,7 +1844,7 @@ public class InternalEngineTests extends ESTestCase {
         Engine.Index idxRequest = new Engine.Index(newUid(uuidValue), doc, 2, VersionType.EXTERNAL, PRIMARY, System.nanoTime());
         engine.index(idxRequest);
         engine.refresh("test");
-        assertThat(idxRequest.version(), equalTo(2l));
+        assertThat(idxRequest.version(), equalTo(2L));
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.searcher().search(new MatchAllDocsQuery(), numDocs + 1);
             assertThat(topDocs.totalHits, equalTo(numDocs + 1));
@@ -1909,7 +1909,7 @@ public class InternalEngineTests extends ESTestCase {
             ParsedDocument doc = testParsedDocument(Integer.toString(i), Integer.toString(i), "test", null, -1, -1, testDocument(), new BytesArray("{}"), null);
             Engine.Index firstIndexRequest = new Engine.Index(newUid(Integer.toString(i)), doc, Versions.MATCH_DELETED, VersionType.INTERNAL, PRIMARY, System.nanoTime());
             engine.index(firstIndexRequest);
-            assertThat(firstIndexRequest.version(), equalTo(1l));
+            assertThat(firstIndexRequest.version(), equalTo(1L));
         }
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {

--- a/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
@@ -252,7 +252,7 @@ public class ShadowEngineTests extends ESTestCase {
         primaryEngine.index(new Engine.Index(newUid("1"), doc));
 
         CommitStats stats1 = replicaEngine.commitStats();
-        assertThat(stats1.getGeneration(), greaterThan(0l));
+        assertThat(stats1.getGeneration(), greaterThan(0L));
         assertThat(stats1.getId(), notNullValue());
         assertThat(stats1.getUserData(), hasKey(Translog.TRANSLOG_GENERATION_KEY));
 
@@ -276,8 +276,8 @@ public class ShadowEngineTests extends ESTestCase {
         primaryEngine = createInternalEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE);
         List<Segment> segments = primaryEngine.segments(false);
         assertThat(segments.isEmpty(), equalTo(true));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(0l));
-        assertThat(primaryEngine.segmentsStats().getMemoryInBytes(), equalTo(0l));
+        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(0L));
+        assertThat(primaryEngine.segmentsStats().getMemoryInBytes(), equalTo(0L));
 
         // create a doc and refresh
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, null);
@@ -290,12 +290,12 @@ public class ShadowEngineTests extends ESTestCase {
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(1));
         SegmentsStats stats = primaryEngine.segmentsStats();
-        assertThat(stats.getCount(), equalTo(1l));
-        assertThat(stats.getTermsMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getStoredFieldsMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getTermVectorsMemoryInBytes(), equalTo(0l));
-        assertThat(stats.getNormsMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getDocValuesMemoryInBytes(), greaterThan(0l));
+        assertThat(stats.getCount(), equalTo(1L));
+        assertThat(stats.getTermsMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getStoredFieldsMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getTermVectorsMemoryInBytes(), equalTo(0L));
+        assertThat(stats.getNormsMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getDocValuesMemoryInBytes(), greaterThan(0L));
         assertThat(segments.get(0).isCommitted(), equalTo(false));
         assertThat(segments.get(0).isSearch(), equalTo(true));
         assertThat(segments.get(0).getNumDocs(), equalTo(2));
@@ -307,12 +307,12 @@ public class ShadowEngineTests extends ESTestCase {
         segments = replicaEngine.segments(false);
         assertThat(segments.size(), equalTo(0));
         stats = replicaEngine.segmentsStats();
-        assertThat(stats.getCount(), equalTo(0l));
-        assertThat(stats.getTermsMemoryInBytes(), equalTo(0l));
-        assertThat(stats.getStoredFieldsMemoryInBytes(), equalTo(0l));
-        assertThat(stats.getTermVectorsMemoryInBytes(), equalTo(0l));
-        assertThat(stats.getNormsMemoryInBytes(), equalTo(0l));
-        assertThat(stats.getDocValuesMemoryInBytes(), equalTo(0l));
+        assertThat(stats.getCount(), equalTo(0L));
+        assertThat(stats.getTermsMemoryInBytes(), equalTo(0L));
+        assertThat(stats.getStoredFieldsMemoryInBytes(), equalTo(0L));
+        assertThat(stats.getTermVectorsMemoryInBytes(), equalTo(0L));
+        assertThat(stats.getNormsMemoryInBytes(), equalTo(0L));
+        assertThat(stats.getDocValuesMemoryInBytes(), equalTo(0L));
         assertThat(segments.size(), equalTo(0));
 
         // flush the primary engine
@@ -323,7 +323,7 @@ public class ShadowEngineTests extends ESTestCase {
         // Check that the primary AND replica sees segments now
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(1));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(1l));
+        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(1L));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));
         assertThat(segments.get(0).getNumDocs(), equalTo(2));
@@ -332,7 +332,7 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = replicaEngine.segments(false);
         assertThat(segments.size(), equalTo(1));
-        assertThat(replicaEngine.segmentsStats().getCount(), equalTo(1l));
+        assertThat(replicaEngine.segmentsStats().getCount(), equalTo(1L));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));
         assertThat(segments.get(0).getNumDocs(), equalTo(2));
@@ -346,10 +346,10 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(2));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(2l));
+        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(2L));
         assertThat(primaryEngine.segmentsStats().getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
         assertThat(primaryEngine.segmentsStats().getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
-        assertThat(primaryEngine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0l));
+        assertThat(primaryEngine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0L));
         assertThat(primaryEngine.segmentsStats().getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
         assertThat(primaryEngine.segmentsStats().getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
         assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
@@ -370,10 +370,10 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = replicaEngine.segments(false);
         assertThat(segments.size(), equalTo(2));
-        assertThat(replicaEngine.segmentsStats().getCount(), equalTo(2l));
+        assertThat(replicaEngine.segmentsStats().getCount(), equalTo(2L));
         assertThat(replicaEngine.segmentsStats().getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
         assertThat(replicaEngine.segmentsStats().getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
-        assertThat(replicaEngine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0l));
+        assertThat(replicaEngine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0L));
         assertThat(replicaEngine.segmentsStats().getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
         assertThat(replicaEngine.segmentsStats().getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
         assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
@@ -393,7 +393,7 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(2));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(2l));
+        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(2L));
         assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -416,7 +416,7 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(3));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(3l));
+        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(3L));
         assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataImplTestCase.java
@@ -206,7 +206,7 @@ public abstract class AbstractFieldDataImplTestCase extends AbstractFieldDataTes
         IndexFieldData indexFieldData = getForField("value");
         AtomicFieldData fieldData = indexFieldData.load(refreshReader());
         // Some impls (FST) return size 0 and some (PagedBytes) do take size in the case no actual data is loaded
-        assertThat(fieldData.ramBytesUsed(), greaterThanOrEqualTo(0l));
+        assertThat(fieldData.ramBytesUsed(), greaterThanOrEqualTo(0L));
 
         SortedBinaryDocValues bytesValues = fieldData.getBytesValues();
 

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -174,7 +174,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
         AtomicFieldData previous = null;
         for (int i = 0; i < max; i++) {
             AtomicFieldData current = fieldData.load(readerContext);
-            assertThat(current.ramBytesUsed(), equalTo(0l));
+            assertThat(current.ramBytesUsed(), equalTo(0L));
             if (previous != null) {
                 assertThat(current, not(sameInstance(previous)));
             }

--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -485,17 +485,17 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         values.setDocument(0);
         assertThat(values.cardinality(), equalTo(2));
         long ord = values.nextOrd();
-        assertThat(ord, equalTo(3l));
+        assertThat(ord, equalTo(3L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("02"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(5l));
+        assertThat(ord, equalTo(5L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("04"));
         values.setDocument(1);
         assertThat(values.cardinality(), equalTo(0));
         values.setDocument(2);
         assertThat(values.cardinality(), equalTo(1));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(4l));
+        assertThat(ord, equalTo(4L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("03"));
 
         // Second segment
@@ -506,37 +506,37 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         values.setDocument(0);
         assertThat(values.cardinality(), equalTo(3));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(5l));
+        assertThat(ord, equalTo(5L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("04"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(6l));
+        assertThat(ord, equalTo(6L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("05"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(7l));
+        assertThat(ord, equalTo(7L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("06"));
         values.setDocument(1);
         assertThat(values.cardinality(), equalTo(3));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(7l));
+        assertThat(ord, equalTo(7L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("06"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(8l));
+        assertThat(ord, equalTo(8L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("07"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(9l));
+        assertThat(ord, equalTo(9L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("08"));
         values.setDocument(2);
         assertThat(values.cardinality(), equalTo(0));
         values.setDocument(3);
         assertThat(values.cardinality(), equalTo(3));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(9l));
+        assertThat(ord, equalTo(9L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("08"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(10l));
+        assertThat(ord, equalTo(10L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("09"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(11l));
+        assertThat(ord, equalTo(11L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("10"));
 
         // Third segment
@@ -548,13 +548,13 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         values.setDocument(0);
         assertThat(values.cardinality(), equalTo(3));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(0l));
+        assertThat(ord, equalTo(0L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("!08"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(1l));
+        assertThat(ord, equalTo(1L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("!09"));
         ord = values.nextOrd();
-        assertThat(ord, equalTo(2l));
+        assertThat(ord, equalTo(2L));
         assertThat(values.lookupOrd(ord).utf8ToString(), equalTo("!10"));
     }
 
@@ -620,6 +620,6 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         assertThat(ifd.loadGlobal(topLevelReader), not(sameInstance(globalOrdinals)));
 
         ifdService.clear();
-        assertThat(indicesFieldDataCache.getCache().weight(), equalTo(0l));
+        assertThat(indicesFieldDataCache.getCache().weight(), equalTo(0L));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/fielddata/FieldDataLoadingIT.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/FieldDataLoadingIT.java
@@ -43,7 +43,7 @@ public class FieldDataLoadingIT extends ESIntegTestCase {
         client().admin().indices().prepareRefresh("test").get();
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
     }
 
     public void testEagerGlobalOrdinalsFieldDataLoading() throws Exception {
@@ -60,7 +60,7 @@ public class FieldDataLoadingIT extends ESIntegTestCase {
         client().admin().indices().prepareRefresh("test").get();
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/boost/CustomBoostMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/boost/CustomBoostMappingTests.java
@@ -59,7 +59,7 @@ public class CustomBoostMappingTests extends ESSingleNodeTestCase {
 
         ParsedDocument doc = mapper.parse("test", "type", "1", XContentFactory.jsonBuilder().startObject()
                 .startObject("s_field").field("value", "s_value").field("boost", 2.0f).endObject()
-                .startObject("l_field").field("value", 1l).field("boost", 3.0f).endObject()
+                .startObject("l_field").field("value", 1L).field("boost", 3.0f).endObject()
                 .startObject("i_field").field("value", 1).field("boost", 4.0f).endObject()
                 .startObject("sh_field").field("value", 1).field("boost", 5.0f).endObject()
                 .startObject("b_field").field("value", 1).field("boost", 6.0f).endObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/lucene/StoredNumericValuesTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/lucene/StoredNumericValuesTests.java
@@ -80,9 +80,9 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
         Document doc2 = new Document();
         doc2.add(new StoredField("field1", new BytesRef(Numbers.intToBytes(1))));
         doc2.add(new StoredField("field2", new BytesRef(Numbers.floatToBytes(1.1f))));
-        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(1l))));
-        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(2l))));
-        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(3l))));
+        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(1L))));
+        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(2L))));
+        doc2.add(new StoredField("field3", new BytesRef(Numbers.longToBytes(3L))));
         writer.addDocument(doc2);
 
         DirectoryReader reader = DirectoryReader.open(writer, true);
@@ -98,9 +98,9 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
         assertThat(fieldsVisitor.fields().get("field2").size(), equalTo(1));
         assertThat((Float) fieldsVisitor.fields().get("field2").get(0), equalTo(1.1f));
         assertThat(fieldsVisitor.fields().get("field3").size(), equalTo(3));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(0), equalTo(1l));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(1), equalTo(2l));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(2), equalTo(3l));
+        assertThat((Long) fieldsVisitor.fields().get("field3").get(0), equalTo(1L));
+        assertThat((Long) fieldsVisitor.fields().get("field3").get(1), equalTo(2L));
+        assertThat((Long) fieldsVisitor.fields().get("field3").get(2), equalTo(3L));
 
         // Make sure the doc gets loaded as if it was stored in the new way
         fieldsVisitor.reset();
@@ -112,9 +112,9 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
         assertThat(fieldsVisitor.fields().get("field2").size(), equalTo(1));
         assertThat((Float) fieldsVisitor.fields().get("field2").get(0), equalTo(1.1f));
         assertThat(fieldsVisitor.fields().get("field3").size(), equalTo(3));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(0), equalTo(1l));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(1), equalTo(2l));
-        assertThat((Long) fieldsVisitor.fields().get("field3").get(2), equalTo(3l));
+        assertThat((Long) fieldsVisitor.fields().get("field3").get(0), equalTo(1L));
+        assertThat((Long) fieldsVisitor.fields().get("field3").get(1), equalTo(2L));
+        assertThat((Long) fieldsVisitor.fields().get("field3").get(2), equalTo(3L));
 
         reader.close();
         writer.close();

--- a/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/multifield/MultiFieldsIntegrationIT.java
@@ -67,11 +67,11 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("my-index")
                 .setQuery(matchQuery("title", "multi"))
                 .get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch("my-index")
                 .setQuery(matchQuery("title.not_analyzed", "Multi fields"))
                 .get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         assertAcked(
                 client().admin().indices().preparePutMapping("my-index").setType("my-type")
@@ -98,7 +98,7 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("my-index")
                 .setQuery(matchQuery("title.uncased", "Multi"))
                 .get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testGeoPointMultiField() throws Exception {
@@ -127,9 +127,9 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
         SearchResponse countResponse = client().prepareSearch("my-index").setSize(0)
                 .setQuery(constantScoreQuery(geoDistanceQuery("a").point(51, 19).distance(50, DistanceUnit.KILOMETERS)))
                 .get();
-        assertThat(countResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(countResponse.getHits().totalHits(), equalTo(1L));
         countResponse = client().prepareSearch("my-index").setSize(0).setQuery(matchQuery("a.b", point.toString())).get();
-        assertThat(countResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(countResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testTokenCountMultiField() throws Exception {
@@ -167,7 +167,7 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
 
         client().prepareIndex("my-index", "my-type", "1").setSource("a", "my tokens").setRefresh(true).get();
         SearchResponse countResponse = client().prepareSearch("my-index").setSize(0).setQuery(matchQuery("a.b", "my tokens")).get();
-        assertThat(countResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(countResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testCompletionMultiField() throws Exception {
@@ -192,7 +192,7 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
 
         client().prepareIndex("my-index", "my-type", "1").setSource("a", "complete me").setRefresh(true).get();
         SearchResponse countResponse = client().prepareSearch("my-index").setSize(0).setQuery(matchQuery("a.b", "complete me")).get();
-        assertThat(countResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(countResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testIpMultiField() throws Exception {
@@ -217,7 +217,7 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
 
         client().prepareIndex("my-index", "my-type", "1").setSource("a", "127.0.0.1").setRefresh(true).get();
         SearchResponse countResponse = client().prepareSearch("my-index").setSize(0).setQuery(matchQuery("a.b", "127.0.0.1")).get();
-        assertThat(countResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(countResponse.getHits().totalHits(), equalTo(1L));
     }
 
     private XContentBuilder createMappingSource(String fieldType) throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
@@ -141,8 +141,8 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
         Query parsedQuery = parseQuery(query).toQuery(createShardContext());
         assertThat(parsedQuery, instanceOf(NumericRangeQuery.class));
         NumericRangeQuery fuzzyQuery = (NumericRangeQuery) parsedQuery;
-        assertThat(fuzzyQuery.getMin().longValue(), equalTo(7l));
-        assertThat(fuzzyQuery.getMax().longValue(), equalTo(17l));
+        assertThat(fuzzyQuery.getMin().longValue(), equalTo(7L));
+        assertThat(fuzzyQuery.getMax().longValue(), equalTo(17L));
     }
 
     public void testFromJson() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -302,8 +302,8 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query query = queryStringQuery("12~0.2").defaultField(INT_FIELD_NAME).toQuery(createShardContext());
         NumericRangeQuery fuzzyQuery = (NumericRangeQuery) query;
-        assertThat(fuzzyQuery.getMin().longValue(), equalTo(12l));
-        assertThat(fuzzyQuery.getMax().longValue(), equalTo(12l));
+        assertThat(fuzzyQuery.getMin().longValue(), equalTo(12L));
+        assertThat(fuzzyQuery.getMax().longValue(), equalTo(12L));
     }
 
     public void testTimezone() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -242,7 +242,7 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
             TermsQueryBuilder builder = new TermsQueryBuilder("foo", new long[]{1, 3, 4});
             TermsQueryBuilder copy = assertSerialization(builder);
             List<Object> values = copy.values();
-            assertEquals(Arrays.asList(1l, 3l, 4l), values);
+            assertEquals(Arrays.asList(1L, 3L, 4L), values);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/plugin/CustomQueryParserIT.java
+++ b/core/src/test/java/org/elasticsearch/index/query/plugin/CustomQueryParserIT.java
@@ -59,11 +59,11 @@ public class CustomQueryParserIT extends ESIntegTestCase {
     }
 
     public void testCustomDummyQuery() {
-        assertHitCount(client().prepareSearch("index").setQuery(new DummyQueryParserPlugin.DummyQueryBuilder()).get(), 1l);
+        assertHitCount(client().prepareSearch("index").setQuery(new DummyQueryParserPlugin.DummyQueryBuilder()).get(), 1L);
     }
 
     public void testCustomDummyQueryWithinBooleanQuery() {
-        assertHitCount(client().prepareSearch("index").setQuery(new BoolQueryBuilder().must(new DummyQueryParserPlugin.DummyQueryBuilder())).get(), 1l);
+        assertHitCount(client().prepareSearch("index").setQuery(new BoolQueryBuilder().must(new DummyQueryParserPlugin.DummyQueryBuilder())).get(), 1L);
     }
 
     private static QueryShardContext queryShardContext() {

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -441,7 +441,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         client().prepareIndex("test", "bar", "1").setSource("{}").setRefresh(true).get();
         client().admin().indices().prepareFlush("test").get();
         SearchResponse response = client().prepareSearch("test").get();
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexService test = indicesService.indexService("test");
         IndexShard shard = test.getShardOrNull(0);
@@ -456,7 +456,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         createIndex("test");
         ensureGreen("test");
         response = client().prepareSearch("test").get();
-        assertHitCount(response, 0l);
+        assertHitCount(response, 0L);
     }
 
     public void testIndexDirIsDeletedWhenShardRemoved() throws Exception {
@@ -470,7 +470,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
         ensureGreen("test");
         client().prepareIndex("test", "bar", "1").setSource("{}").setRefresh(true).get();
         SearchResponse response = client().prepareSearch("test").get();
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
         client().admin().indices().prepareDelete("test").get();
         assertPathHasBeenCleared(idxPath);
     }
@@ -995,7 +995,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
             MappedFieldType foo = newShard.mapperService().fullName("foo");
             IndexFieldData.Global ifd = shard.indexFieldDataService().getForField(foo);
             FieldDataStats before = shard.fieldData().stats("foo");
-            assertThat(before.getMemorySizeInBytes(), equalTo(0l));
+            assertThat(before.getMemorySizeInBytes(), equalTo(0L));
             FieldDataStats after = null;
             try (Engine.Searcher searcher = newShard.acquireSearcher("test")) {
                 assumeTrue("we have to have more than one segment", searcher.getDirectoryReader().leaves().size() > 1);
@@ -1003,7 +1003,7 @@ public class IndexShardTests extends ESSingleNodeTestCase {
                 after = shard.fieldData().stats("foo");
                 assertEquals(after.getEvictions(), before.getEvictions());
                 // If a field doesn't exist an empty IndexFieldData is returned and that isn't cached:
-                assertThat(after.getMemorySizeInBytes(), equalTo(0l));
+                assertThat(after.getMemorySizeInBytes(), equalTo(0L));
             }
             assertEquals(shard.fieldData().stats("foo").getEvictions(), before.getEvictions());
             assertEquals(shard.fieldData().stats("foo").getMemorySizeInBytes(), after.getMemorySizeInBytes());

--- a/core/src/test/java/org/elasticsearch/index/store/ExceptionRetryIT.java
+++ b/core/src/test/java/org/elasticsearch/index/store/ExceptionRetryIT.java
@@ -122,7 +122,7 @@ public class ExceptionRetryIT extends ESIntegTestCase {
             if (!uniqueIds.add(searchResponse.getHits().getHits()[i].getId())) {
                 if (!found_duplicate_already) {
                     SearchResponse dupIdResponse = client().prepareSearch("index").setQuery(termQuery("_id", searchResponse.getHits().getHits()[i].getId())).setExplain(true).get();
-                    assertThat(dupIdResponse.getHits().totalHits(), greaterThan(1l));
+                    assertThat(dupIdResponse.getHits().totalHits(), greaterThan(1L));
                     logger.info("found a duplicate id:");
                     for (SearchHit hit : dupIdResponse.getHits()) {
                         logger.info("Doc {} was found on shard {}", hit.getId(), hit.getShard().getShardId());
@@ -134,7 +134,7 @@ public class ExceptionRetryIT extends ESIntegTestCase {
             }
         }
         assertSearchResponse(searchResponse);
-        assertThat(dupCounter, equalTo(0l));
+        assertThat(dupCounter, equalTo(0L));
         assertHitCount(searchResponse, numDocs);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -791,7 +791,7 @@ public class StoreTests extends ESTestCase {
     public void assertDeleteContent(Store store, DirectoryService service) throws IOException {
         deleteContent(store.directory());
         assertThat(Arrays.toString(store.directory().listAll()), store.directory().listAll().length, equalTo(0));
-        assertThat(store.stats().sizeInBytes(), equalTo(0l));
+        assertThat(store.stats().sizeInBytes(), equalTo(0L));
         assertThat(service.newDirectory().listAll().length, equalTo(0));
     }
 

--- a/core/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
@@ -102,7 +102,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
         IndicesStatsResponse indicesStats = client().admin().indices().prepareStats().execute().actionGet();
 
         // check current
-        assertThat(indicesStats.getTotal().getSuggest().getCurrent(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getSuggest().getCurrent(), equalTo(0L));
 
         // check suggest count
         assertThat(indicesStats.getTotal().getSuggest().getCount(), equalTo((long) (suggestAllIdx * totalShards + suggestIdx1 * shardsIdx1 + suggestIdx2 * shardsIdx2)));
@@ -111,7 +111,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
 
         logger.info("iter {}, iter1 {}, iter2 {}, {}", suggestAllIdx, suggestIdx1, suggestIdx2, endTime - startTime);
         // check suggest time
-        assertThat(indicesStats.getTotal().getSuggest().getTimeInMillis(), greaterThan(0l));
+        assertThat(indicesStats.getTotal().getSuggest().getTimeInMillis(), greaterThan(0L));
         // the upperbound is num shards * total time since we do searches in parallel
         assertThat(indicesStats.getTotal().getSuggest().getTimeInMillis(), lessThanOrEqualTo(totalShards * (endTime - startTime)));
 
@@ -123,12 +123,12 @@ public class SuggestStatsIT extends ESIntegTestCase {
             SuggestStats suggestStats = stat.getIndices().getSuggest();
             logger.info("evaluating {}", stat.getNode());
             if (nodeIdsWithIndex.contains(stat.getNode().getId())) {
-                assertThat(suggestStats.getCount(), greaterThan(0l));
-                assertThat(suggestStats.getTimeInMillis(), greaterThan(0l));
+                assertThat(suggestStats.getCount(), greaterThan(0L));
+                assertThat(suggestStats.getTimeInMillis(), greaterThan(0L));
                 num++;
             } else {
-                assertThat(suggestStats.getCount(), equalTo(0l));
-                assertThat(suggestStats.getTimeInMillis(), equalTo(0l));
+                assertThat(suggestStats.getCount(), equalTo(0L));
+                assertThat(suggestStats.getTimeInMillis(), equalTo(0L));
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -288,7 +288,7 @@ public class TranslogTests extends ESTestCase {
     public void testStats() throws IOException {
         final long firstOperationPosition = translog.getFirstOperationPosition();
         TranslogStats stats = stats();
-        assertThat(stats.estimatedNumberOfOperations(), equalTo(0l));
+        assertThat(stats.estimatedNumberOfOperations(), equalTo(0L));
         long lastSize = stats.getTranslogSizeInBytes();
         assertThat((int) firstOperationPosition, greaterThan(CodecUtil.headerLength(TranslogWriter.TRANSLOG_CODEC)));
         assertThat(lastSize, equalTo(firstOperationPosition));
@@ -296,14 +296,14 @@ public class TranslogTests extends ESTestCase {
         translog.add(new Translog.Index("test", "1", new byte[]{1}));
         stats = stats();
         total.add(stats);
-        assertThat(stats.estimatedNumberOfOperations(), equalTo(1l));
+        assertThat(stats.estimatedNumberOfOperations(), equalTo(1L));
         assertThat(stats.getTranslogSizeInBytes(), greaterThan(lastSize));
         lastSize = stats.getTranslogSizeInBytes();
 
         translog.add(new Translog.Delete(newUid("2")));
         stats = stats();
         total.add(stats);
-        assertThat(stats.estimatedNumberOfOperations(), equalTo(2l));
+        assertThat(stats.estimatedNumberOfOperations(), equalTo(2L));
         assertThat(stats.getTranslogSizeInBytes(), greaterThan(lastSize));
         lastSize = stats.getTranslogSizeInBytes();
 
@@ -311,13 +311,13 @@ public class TranslogTests extends ESTestCase {
         translog.prepareCommit();
         stats = stats();
         total.add(stats);
-        assertThat(stats.estimatedNumberOfOperations(), equalTo(3l));
+        assertThat(stats.estimatedNumberOfOperations(), equalTo(3L));
         assertThat(stats.getTranslogSizeInBytes(), greaterThan(lastSize));
 
         translog.commit();
         stats = stats();
         total.add(stats);
-        assertThat(stats.estimatedNumberOfOperations(), equalTo(0l));
+        assertThat(stats.estimatedNumberOfOperations(), equalTo(0L));
         assertThat(stats.getTranslogSizeInBytes(), equalTo(firstOperationPosition));
         assertEquals(6, total.estimatedNumberOfOperations());
         assertEquals(431, total.getTranslogSizeInBytes());
@@ -983,7 +983,7 @@ public class TranslogTests extends ESTestCase {
             if (op == prepareOp) {
                 translogGeneration = translog.getGeneration();
                 translog.prepareCommit();
-                assertEquals("expected this to be the first commit", 1l, translogGeneration.translogFileGeneration);
+                assertEquals("expected this to be the first commit", 1L, translogGeneration.translogFileGeneration);
                 assertNotNull(translogGeneration.translogUUID);
             }
         }
@@ -1034,7 +1034,7 @@ public class TranslogTests extends ESTestCase {
             if (op == prepareOp) {
                 translogGeneration = translog.getGeneration();
                 translog.prepareCommit();
-                assertEquals("expected this to be the first commit", 1l, translogGeneration.translogFileGeneration);
+                assertEquals("expected this to be the first commit", 1L, translogGeneration.translogFileGeneration);
                 assertNotNull(translogGeneration.translogUUID);
             }
         }
@@ -1090,7 +1090,7 @@ public class TranslogTests extends ESTestCase {
             if (op == prepareOp) {
                 translogGeneration = translog.getGeneration();
                 translog.prepareCommit();
-                assertEquals("expected this to be the first commit", 1l, translogGeneration.translogFileGeneration);
+                assertEquals("expected this to be the first commit", 1L, translogGeneration.translogFileGeneration);
                 assertNotNull(translogGeneration.translogUUID);
             }
         }

--- a/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -472,19 +472,19 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .setQuery(matchAllQuery())
                 .execute().actionGet();
-        assertHitCount(response, 0l);
+        assertHitCount(response, 0L);
 
         response = client().prepareSearch("test2","test3").setQuery(matchAllQuery())
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .execute().actionGet();
-        assertHitCount(response, 0l);
+        assertHitCount(response, 0L);
 
         //you should still be able to run empty searches without things blowing up
         response  = client().prepareSearch()
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .setQuery(matchAllQuery())
                 .execute().actionGet();
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
     }
 
     public void testAllMissingStrict() throws Exception {

--- a/core/src/test/java/org/elasticsearch/indices/cache/query/IndicesRequestCacheIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/cache/query/IndicesRequestCacheIT.java
@@ -54,7 +54,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertSearchResponse(r1);
 
         // The cached is actually used
-        assertThat(client().admin().indices().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(client().admin().indices().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0L));
 
         for (int i = 0; i < 10; ++i) {
             final SearchResponse r2 = client().prepareSearch("index").setSize(0).setSearchType(SearchType.QUERY_THEN_FETCH)

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -349,10 +349,10 @@ public class IndexRecoveryIT extends ESIntegTestCase {
             assertThat(recoveryStats.currentAsSource(), equalTo(0));
             assertThat(recoveryStats.currentAsTarget(), equalTo(0));
             if (nodeStats.getNode().name().equals(nodeA)) {
-                assertThat("node A throttling should be >0", recoveryStats.throttleTime().millis(), greaterThan(0l));
+                assertThat("node A throttling should be >0", recoveryStats.throttleTime().millis(), greaterThan(0L));
             }
             if (nodeStats.getNode().name().equals(nodeB)) {
-                assertThat("node B throttling should be >0 ", recoveryStats.throttleTime().millis(), greaterThan(0l));
+                assertThat("node B throttling should be >0 ", recoveryStats.throttleTime().millis(), greaterThan(0L));
             }
         }
 
@@ -368,10 +368,10 @@ public class IndexRecoveryIT extends ESIntegTestCase {
             assertThat(recoveryStats.currentAsSource(), equalTo(0));
             assertThat(recoveryStats.currentAsTarget(), equalTo(0));
             if (nodeStats.getNode().name().equals(nodeA)) {
-                assertThat("node A throttling should be >0", recoveryStats.throttleTime().millis(), greaterThan(0l));
+                assertThat("node A throttling should be >0", recoveryStats.throttleTime().millis(), greaterThan(0L));
             }
             if (nodeStats.getNode().name().equals(nodeB)) {
-                assertThat("node B throttling should be >0 ", recoveryStats.throttleTime().millis(), greaterThan(0l));
+                assertThat("node B throttling should be >0 ", recoveryStats.throttleTime().millis(), greaterThan(0L));
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryStateTests.java
@@ -148,8 +148,8 @@ public class RecoveryStateTests extends ESTestCase {
         }
 
         timer.start();
-        assertThat(timer.startTime(), greaterThan(0l));
-        assertThat(timer.stopTime(), equalTo(0l));
+        assertThat(timer.startTime(), greaterThan(0L));
+        assertThat(timer.stopTime(), equalTo(0L));
         Timer lastRead = streamer.serializeDeserialize();
         final long time = lastRead.time();
         assertThat(time, lessThanOrEqualTo(timer.time()));
@@ -164,7 +164,7 @@ public class RecoveryStateTests extends ESTestCase {
         if (randomBoolean()) {
             timer.stop();
             assertThat(timer.stopTime(), greaterThanOrEqualTo(timer.startTime()));
-            assertThat(timer.time(), greaterThan(0l));
+            assertThat(timer.time(), greaterThan(0L));
             lastRead = streamer.serializeDeserialize();
             assertThat(lastRead.startTime(), equalTo(timer.startTime()));
             assertThat(lastRead.time(), equalTo(timer.time()));
@@ -172,13 +172,13 @@ public class RecoveryStateTests extends ESTestCase {
         }
 
         timer.reset();
-        assertThat(timer.startTime(), equalTo(0l));
-        assertThat(timer.time(), equalTo(0l));
-        assertThat(timer.stopTime(), equalTo(0l));
+        assertThat(timer.startTime(), equalTo(0L));
+        assertThat(timer.time(), equalTo(0L));
+        assertThat(timer.stopTime(), equalTo(0L));
         lastRead = streamer.serializeDeserialize();
-        assertThat(lastRead.startTime(), equalTo(0l));
-        assertThat(lastRead.time(), equalTo(0l));
-        assertThat(lastRead.stopTime(), equalTo(0l));
+        assertThat(lastRead.startTime(), equalTo(0L));
+        assertThat(lastRead.time(), equalTo(0L));
+        assertThat(lastRead.stopTime(), equalTo(0L));
 
     }
 
@@ -242,7 +242,7 @@ public class RecoveryStateTests extends ESTestCase {
         assertThat(index.reusedFileCount(), equalTo(totalReused));
         assertThat(index.totalRecoverFiles(), equalTo(filesToRecover.size()));
         assertThat(index.recoveredFileCount(), equalTo(0));
-        assertThat(index.recoveredBytes(), equalTo(0l));
+        assertThat(index.recoveredBytes(), equalTo(0L));
         assertThat(index.recoveredFilesPercent(), equalTo(filesToRecover.size() == 0 ? 100.0f : 0.0f));
         assertThat(index.recoveredBytesPercent(), equalTo(filesToRecover.size() == 0 ? 100.0f : 0.0f));
 
@@ -296,7 +296,7 @@ public class RecoveryStateTests extends ESTestCase {
         if (completeRecovery) {
             assertThat(filesToRecover.size(), equalTo(0));
             index.stop();
-            assertThat(index.time(), greaterThanOrEqualTo(0l));
+            assertThat(index.time(), greaterThanOrEqualTo(0L));
         }
 
         logger.info("testing serialized information");
@@ -457,15 +457,15 @@ public class RecoveryStateTests extends ESTestCase {
 
         // we don't need to test the time aspect, it's done in the timer test
         verifyIndex.start();
-        assertThat(verifyIndex.checkIndexTime(), equalTo(0l));
+        assertThat(verifyIndex.checkIndexTime(), equalTo(0L));
         // force one
         VerifyIndex lastRead = streamer.serializeDeserialize();
-        assertThat(lastRead.checkIndexTime(), equalTo(0l));
+        assertThat(lastRead.checkIndexTime(), equalTo(0L));
 
         long took = randomLong();
         if (took < 0) {
             took = -took;
-            took = Math.max(0l, took);
+            took = Math.max(0L, took);
 
         }
         verifyIndex.checkIndexTime(took);

--- a/core/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
@@ -46,7 +46,7 @@ public class StartRecoveryRequestTests extends ESTestCase {
                 true,
                 Store.MetadataSnapshot.EMPTY,
                 RecoveryState.Type.RELOCATION,
-                1l
+                1L
 
         );
         ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();

--- a/core/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -68,7 +68,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
 
         for (int i = 0; i < 10; i++) {
             SearchResponse countResponse = client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get();
-            assertHitCount(countResponse, 10l);
+            assertHitCount(countResponse, 10L);
         }
 
         logger.info("Increasing the number of replicas from 1 to 2");
@@ -98,7 +98,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
 
         for (int i = 0; i < 10; i++) {
             SearchResponse countResponse = client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get();
-            assertHitCount(countResponse, 10l);
+            assertHitCount(countResponse, 10L);
         }
 
         logger.info("Decreasing number of replicas from 2 to 0");

--- a/core/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -205,7 +205,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         // No merge IO throttling should have happened:
         NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).get();
         for(NodeStats stats : nodesStats.getNodes()) {
-            assertThat(stats.getIndices().getStore().getThrottleTime().getMillis(), equalTo(0l));
+            assertThat(stats.getIndices().getStore().getThrottleTime().getMillis(), equalTo(0L));
         }
 
         logger.info("test: set low merge throttling");

--- a/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -92,18 +92,18 @@ public class IndexStatsIT extends ESIntegTestCase {
         client().admin().indices().prepareRefresh().execute().actionGet();
 
         NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
-        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0L));
         IndicesStatsResponse indicesStats = client().admin().indices().prepareStats("test").clear().setFieldData(true).execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
 
         // sort to load it to field data...
         client().prepareSearch().addSort("field", SortOrder.ASC).execute().actionGet();
         client().prepareSearch().addSort("field", SortOrder.ASC).execute().actionGet();
 
         nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
-        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
         indicesStats = client().admin().indices().prepareStats("test").clear().setFieldData(true).execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
 
         // sort to load it to field data...
         client().prepareSearch().addSort("field2", SortOrder.ASC).execute().actionGet();
@@ -111,20 +111,20 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         // now check the per field stats
         nodesStats = client().admin().cluster().prepareNodesStats().setIndices(new CommonStatsFlags().set(CommonStatsFlags.Flag.FieldData, true).fieldDataFields("*")).execute().actionGet();
-        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
-        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getFields().get("field") + nodesStats.getNodes()[1].getIndices().getFieldData().getFields().get("field"), greaterThan(0l));
+        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
+        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getFields().get("field") + nodesStats.getNodes()[1].getIndices().getFieldData().getFields().get("field"), greaterThan(0L));
         assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getFields().get("field") + nodesStats.getNodes()[1].getIndices().getFieldData().getFields().get("field"), lessThan(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes()));
 
         indicesStats = client().admin().indices().prepareStats("test").clear().setFieldData(true).setFieldDataFields("*").execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
-        assertThat(indicesStats.getTotal().getFieldData().getFields().get("field"), greaterThan(0l));
+        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getFieldData().getFields().get("field"), greaterThan(0L));
         assertThat(indicesStats.getTotal().getFieldData().getFields().get("field"), lessThan(indicesStats.getTotal().getFieldData().getMemorySizeInBytes()));
 
         client().admin().indices().prepareClearCache().setFieldDataCache(true).execute().actionGet();
         nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).execute().actionGet();
-        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0L));
         indicesStats = client().admin().indices().prepareStats("test").clear().setFieldData(true).execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
 
     }
 
@@ -140,14 +140,14 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true)
                 .execute().actionGet();
-        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0l));
-        assertThat(nodesStats.getNodes()[0].getIndices().getQueryCache().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0L));
+        assertThat(nodesStats.getNodes()[0].getIndices().getQueryCache().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0L));
 
         IndicesStatsResponse indicesStats = client().admin().indices().prepareStats("test")
                 .clear().setFieldData(true).setQueryCache(true)
                 .execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0l));
-        assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
+        assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), equalTo(0L));
 
         // sort to load it to field data and filter to load filter cache
         client().prepareSearch()
@@ -161,27 +161,27 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true)
                 .execute().actionGet();
-        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
-        assertThat(nodesStats.getNodes()[0].getIndices().getQueryCache().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getQueryCache().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
+        assertThat(nodesStats.getNodes()[0].getIndices().getQueryCache().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getQueryCache().getMemorySizeInBytes(), greaterThan(0L));
 
         indicesStats = client().admin().indices().prepareStats("test")
                 .clear().setFieldData(true).setQueryCache(true)
                 .execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
-        assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), greaterThan(0L));
 
         client().admin().indices().prepareClearCache().execute().actionGet();
         Thread.sleep(100); // Make sure the filter cache entries have been removed...
         nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true)
                 .execute().actionGet();
-        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0l));
-        assertThat(nodesStats.getNodes()[0].getIndices().getQueryCache().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(nodesStats.getNodes()[0].getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0L));
+        assertThat(nodesStats.getNodes()[0].getIndices().getQueryCache().getMemorySizeInBytes() + nodesStats.getNodes()[1].getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0L));
 
         indicesStats = client().admin().indices().prepareStats("test")
                 .clear().setFieldData(true).setQueryCache(true)
                 .execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0l));
-        assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
+        assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), equalTo(0L));
     }
 
     public void testQueryCache() throws Exception {
@@ -218,15 +218,15 @@ public class IndexStatsIT extends ESIntegTestCase {
             }
         }
 
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0l));
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(), equalTo(0l));
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMissCount(), equalTo(0l));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0L));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(), equalTo(0L));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMissCount(), equalTo(0L));
         for (int i = 0; i < 10; i++) {
             assertThat(client().prepareSearch("idx").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).get().getHits().getTotalHits(), equalTo((long) numDocs));
-            assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0l));
+            assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0L));
         }
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(), greaterThan(0l));
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMissCount(), greaterThan(0l));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(), greaterThan(0L));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMissCount(), greaterThan(0L));
 
         // index the data again...
         IndexRequestBuilder[] builders = new IndexRequestBuilder[numDocs];
@@ -242,25 +242,25 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertBusy(new Runnable() {
             @Override
             public void run() {
-                assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0l));
+                assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0L));
             }
         });
 
         for (int i = 0; i < 10; i++) {
             assertThat(client().prepareSearch("idx").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).get().getHits().getTotalHits(), equalTo((long) numDocs));
-            assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0l));
+            assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0L));
         }
 
         client().admin().indices().prepareClearCache().setRequestCache(true).get(); // clean the cache
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0L));
 
         // test explicit request parameter
 
         assertThat(client().prepareSearch("idx").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).setRequestCache(false).get().getHits().getTotalHits(), equalTo((long) numDocs));
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0L));
 
         assertThat(client().prepareSearch("idx").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).setRequestCache(true).get().getHits().getTotalHits(), equalTo((long) numDocs));
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0L));
 
         // set the index level setting to false, and see that the reverse works
 
@@ -268,10 +268,10 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().prepareUpdateSettings("idx").setSettings(Settings.builder().put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), false)));
 
         assertThat(client().prepareSearch("idx").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).get().getHits().getTotalHits(), equalTo((long) numDocs));
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), equalTo(0L));
 
         assertThat(client().prepareSearch("idx").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).setRequestCache(true).get().getHits().getTotalHits(), equalTo((long) numDocs));
-        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(client().admin().indices().prepareStats("idx").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(), greaterThan(0L));
     }
 
     public void testNonThrottleStats() throws Exception {
@@ -303,7 +303,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         //nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).get();
 
         stats = client().admin().indices().prepareStats().execute().actionGet();
-        assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis(), equalTo(0l));
+        assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis(), equalTo(0L));
     }
 
     public void testThrottleStats() throws Exception {
@@ -370,33 +370,33 @@ public class IndexStatsIT extends ESIntegTestCase {
         long totalExpectedWrites = test1ExpectedWrites + test2ExpectedWrites;
 
         IndicesStatsResponse stats = client().admin().indices().prepareStats().execute().actionGet();
-        assertThat(stats.getPrimaries().getDocs().getCount(), equalTo(3l));
+        assertThat(stats.getPrimaries().getDocs().getCount(), equalTo(3L));
         assertThat(stats.getTotal().getDocs().getCount(), equalTo(totalExpectedWrites));
-        assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexCount(), equalTo(3l));
-        assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexFailedCount(), equalTo(0l));
+        assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexCount(), equalTo(3L));
+        assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexFailedCount(), equalTo(0L));
         assertThat(stats.getPrimaries().getIndexing().getTotal().isThrottled(), equalTo(false));
-        assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis(), equalTo(0l));
+        assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis(), equalTo(0L));
         assertThat(stats.getTotal().getIndexing().getTotal().getIndexCount(), equalTo(totalExpectedWrites));
         assertThat(stats.getTotal().getStore(), notNullValue());
         assertThat(stats.getTotal().getMerge(), notNullValue());
         assertThat(stats.getTotal().getFlush(), notNullValue());
         assertThat(stats.getTotal().getRefresh(), notNullValue());
 
-        assertThat(stats.getIndex("test1").getPrimaries().getDocs().getCount(), equalTo(2l));
+        assertThat(stats.getIndex("test1").getPrimaries().getDocs().getCount(), equalTo(2L));
         assertThat(stats.getIndex("test1").getTotal().getDocs().getCount(), equalTo(test1ExpectedWrites));
         assertThat(stats.getIndex("test1").getPrimaries().getStore(), notNullValue());
         assertThat(stats.getIndex("test1").getPrimaries().getMerge(), notNullValue());
         assertThat(stats.getIndex("test1").getPrimaries().getFlush(), notNullValue());
         assertThat(stats.getIndex("test1").getPrimaries().getRefresh(), notNullValue());
 
-        assertThat(stats.getIndex("test2").getPrimaries().getDocs().getCount(), equalTo(1l));
+        assertThat(stats.getIndex("test2").getPrimaries().getDocs().getCount(), equalTo(1L));
         assertThat(stats.getIndex("test2").getTotal().getDocs().getCount(), equalTo(test2ExpectedWrites));
 
         // make sure that number of requests in progress is 0
-        assertThat(stats.getIndex("test1").getTotal().getIndexing().getTotal().getIndexCurrent(), equalTo(0l));
-        assertThat(stats.getIndex("test1").getTotal().getIndexing().getTotal().getDeleteCurrent(), equalTo(0l));
-        assertThat(stats.getIndex("test1").getTotal().getSearch().getTotal().getFetchCurrent(), equalTo(0l));
-        assertThat(stats.getIndex("test1").getTotal().getSearch().getTotal().getQueryCurrent(), equalTo(0l));
+        assertThat(stats.getIndex("test1").getTotal().getIndexing().getTotal().getIndexCurrent(), equalTo(0L));
+        assertThat(stats.getIndex("test1").getTotal().getIndexing().getTotal().getDeleteCurrent(), equalTo(0L));
+        assertThat(stats.getIndex("test1").getTotal().getSearch().getTotal().getFetchCurrent(), equalTo(0L));
+        assertThat(stats.getIndex("test1").getTotal().getSearch().getTotal().getQueryCurrent(), equalTo(0L));
 
         // check flags
         stats = client().admin().indices().prepareStats().clear()
@@ -414,32 +414,32 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         // check types
         stats = client().admin().indices().prepareStats().setTypes("type1", "type").execute().actionGet();
-        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getIndexCount(), equalTo(1l));
-        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type").getIndexCount(), equalTo(1l));
-        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getIndexFailedCount(), equalTo(0l));
+        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getIndexCount(), equalTo(1L));
+        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type").getIndexCount(), equalTo(1L));
+        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getIndexFailedCount(), equalTo(0L));
         assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type2"), nullValue());
-        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getIndexCurrent(), equalTo(0l));
-        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getDeleteCurrent(), equalTo(0l));
+        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getIndexCurrent(), equalTo(0L));
+        assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getDeleteCurrent(), equalTo(0L));
 
 
-        assertThat(stats.getTotal().getGet().getCount(), equalTo(0l));
+        assertThat(stats.getTotal().getGet().getCount(), equalTo(0L));
         // check get
         GetResponse getResponse = client().prepareGet("test1", "type1", "1").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
 
         stats = client().admin().indices().prepareStats().execute().actionGet();
-        assertThat(stats.getTotal().getGet().getCount(), equalTo(1l));
-        assertThat(stats.getTotal().getGet().getExistsCount(), equalTo(1l));
-        assertThat(stats.getTotal().getGet().getMissingCount(), equalTo(0l));
+        assertThat(stats.getTotal().getGet().getCount(), equalTo(1L));
+        assertThat(stats.getTotal().getGet().getExistsCount(), equalTo(1L));
+        assertThat(stats.getTotal().getGet().getMissingCount(), equalTo(0L));
 
         // missing get
         getResponse = client().prepareGet("test1", "type1", "2").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
 
         stats = client().admin().indices().prepareStats().execute().actionGet();
-        assertThat(stats.getTotal().getGet().getCount(), equalTo(2l));
-        assertThat(stats.getTotal().getGet().getExistsCount(), equalTo(1l));
-        assertThat(stats.getTotal().getGet().getMissingCount(), equalTo(1l));
+        assertThat(stats.getTotal().getGet().getCount(), equalTo(2L));
+        assertThat(stats.getTotal().getGet().getExistsCount(), equalTo(1L));
+        assertThat(stats.getTotal().getGet().getMissingCount(), equalTo(1L));
 
         // clear all
         stats = client().admin().indices().prepareStats()
@@ -476,8 +476,8 @@ public class IndexStatsIT extends ESIntegTestCase {
         } catch (VersionConflictEngineException e) {}
 
         stats = client().admin().indices().prepareStats().setTypes("type1", "type2").execute().actionGet();
-        assertThat(stats.getIndex("test1").getTotal().getIndexing().getTotal().getIndexFailedCount(), equalTo(2l));
-        assertThat(stats.getIndex("test2").getTotal().getIndexing().getTotal().getIndexFailedCount(), equalTo(1l));
+        assertThat(stats.getIndex("test1").getTotal().getIndexing().getTotal().getIndexFailedCount(), equalTo(2L));
+        assertThat(stats.getIndex("test2").getTotal().getIndexing().getTotal().getIndexFailedCount(), equalTo(1L));
         assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type1").getIndexFailedCount(), equalTo(1L));
         assertThat(stats.getPrimaries().getIndexing().getTypeStats().get("type2").getIndexFailedCount(), equalTo(1L));
         assertThat(stats.getTotal().getIndexing().getTotal().getIndexFailedCount(), equalTo(3L));
@@ -516,7 +516,7 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .execute().actionGet();
 
         assertThat(stats.getTotal().getMerge(), notNullValue());
-        assertThat(stats.getTotal().getMerge().getTotal(), greaterThan(0l));
+        assertThat(stats.getTotal().getMerge().getTotal(), greaterThan(0L));
     }
 
     public void testSegmentsStats() {
@@ -531,9 +531,9 @@ public class IndexStatsIT extends ESIntegTestCase {
         }
 
         IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).get();
-        assertThat(stats.getTotal().getSegments().getIndexWriterMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getTotal().getSegments().getIndexWriterMaxMemoryInBytes(), greaterThan(0l));
-        assertThat(stats.getTotal().getSegments().getVersionMapMemoryInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().getSegments().getIndexWriterMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getTotal().getSegments().getIndexWriterMaxMemoryInBytes(), greaterThan(0L));
+        assertThat(stats.getTotal().getSegments().getVersionMapMemoryInBytes(), greaterThan(0L));
 
         client().admin().indices().prepareFlush().get();
         client().admin().indices().prepareForceMerge().setMaxNumSegments(1).execute().actionGet();
@@ -542,7 +542,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertThat(stats.getTotal().getSegments(), notNullValue());
         assertThat(stats.getTotal().getSegments().getCount(), equalTo((long) test1.totalNumShards));
         assumeTrue("test doesn't work with 4.6.0", org.elasticsearch.Version.CURRENT.luceneVersion != Version.LUCENE_4_6_0);
-        assertThat(stats.getTotal().getSegments().getMemoryInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().getSegments().getMemoryInBytes(), greaterThan(0L));
     }
 
     public void testAllFlags() throws Exception {
@@ -713,33 +713,33 @@ public class IndexStatsIT extends ESIntegTestCase {
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
         IndicesStatsResponse stats = builder.execute().actionGet();
 
-        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields(), is(nullValue()));
 
         stats = builder.setFieldDataFields("bar").execute().actionGet();
-        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields().containsKey("bar"), is(true));
-        assertThat(stats.getTotal().fieldData.getFields().get("bar"), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getFields().get("bar"), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields().containsKey("baz"), is(false));
 
         stats = builder.setFieldDataFields("bar", "baz").execute().actionGet();
-        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields().containsKey("bar"), is(true));
-        assertThat(stats.getTotal().fieldData.getFields().get("bar"), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getFields().get("bar"), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields().containsKey("baz"), is(true));
-        assertThat(stats.getTotal().fieldData.getFields().get("baz"), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getFields().get("baz"), greaterThan(0L));
 
         stats = builder.setFieldDataFields("*").execute().actionGet();
-        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields().containsKey("bar"), is(true));
-        assertThat(stats.getTotal().fieldData.getFields().get("bar"), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getFields().get("bar"), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields().containsKey("baz"), is(true));
-        assertThat(stats.getTotal().fieldData.getFields().get("baz"), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getFields().get("baz"), greaterThan(0L));
 
         stats = builder.setFieldDataFields("*r").execute().actionGet();
-        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getMemorySizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields().containsKey("bar"), is(true));
-        assertThat(stats.getTotal().fieldData.getFields().get("bar"), greaterThan(0l));
+        assertThat(stats.getTotal().fieldData.getFields().get("bar"), greaterThan(0L));
         assertThat(stats.getTotal().fieldData.getFields().containsKey("baz"), is(false));
 
     }
@@ -758,33 +758,33 @@ public class IndexStatsIT extends ESIntegTestCase {
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
         IndicesStatsResponse stats = builder.execute().actionGet();
 
-        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields(), is(nullValue()));
 
         stats = builder.setCompletionFields("bar.completion").execute().actionGet();
-        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsKey("bar.completion"), is(true));
-        assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsKey("baz.completion"), is(false));
 
         stats = builder.setCompletionFields("bar.completion", "baz.completion").execute().actionGet();
-        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsKey("bar.completion"), is(true));
-        assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsKey("baz.completion"), is(true));
-        assertThat(stats.getTotal().completion.getFields().get("baz.completion"), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getFields().get("baz.completion"), greaterThan(0L));
 
         stats = builder.setCompletionFields("*").execute().actionGet();
-        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsKey("bar.completion"), is(true));
-        assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsKey("baz.completion"), is(true));
-        assertThat(stats.getTotal().completion.getFields().get("baz.completion"), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getFields().get("baz.completion"), greaterThan(0L));
 
         stats = builder.setCompletionFields("*r*").execute().actionGet();
-        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsKey("bar.completion"), is(true));
-        assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0l));
+        assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsKey("baz.completion"), is(false));
 
     }
@@ -802,23 +802,23 @@ public class IndexStatsIT extends ESIntegTestCase {
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
         IndicesStatsResponse stats = builder.execute().actionGet();
 
-        assertThat(stats.getTotal().search.getTotal().getQueryCount(), greaterThan(0l));
+        assertThat(stats.getTotal().search.getTotal().getQueryCount(), greaterThan(0L));
         assertThat(stats.getTotal().search.getGroupStats(), is(nullValue()));
 
         stats = builder.setGroups("bar").execute().actionGet();
-        assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0l));
+        assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0L));
         assertThat(stats.getTotal().search.getGroupStats().containsKey("baz"), is(false));
 
         stats = builder.setGroups("bar", "baz").execute().actionGet();
-        assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0l));
-        assertThat(stats.getTotal().search.getGroupStats().get("baz").getQueryCount(), greaterThan(0l));
+        assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0L));
+        assertThat(stats.getTotal().search.getGroupStats().get("baz").getQueryCount(), greaterThan(0L));
 
         stats = builder.setGroups("*").execute().actionGet();
-        assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0l));
-        assertThat(stats.getTotal().search.getGroupStats().get("baz").getQueryCount(), greaterThan(0l));
+        assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0L));
+        assertThat(stats.getTotal().search.getGroupStats().get("baz").getQueryCount(), greaterThan(0L));
 
         stats = builder.setGroups("*r").execute().actionGet();
-        assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0l));
+        assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0L));
         assertThat(stats.getTotal().search.getGroupStats().containsKey("baz"), is(false));
 
     }
@@ -836,23 +836,23 @@ public class IndexStatsIT extends ESIntegTestCase {
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
         IndicesStatsResponse stats = builder.execute().actionGet();
 
-        assertThat(stats.getTotal().indexing.getTotal().getIndexCount(), greaterThan(0l));
+        assertThat(stats.getTotal().indexing.getTotal().getIndexCount(), greaterThan(0L));
         assertThat(stats.getTotal().indexing.getTypeStats(), is(nullValue()));
 
         stats = builder.setTypes("bar").execute().actionGet();
-        assertThat(stats.getTotal().indexing.getTypeStats().get("bar").getIndexCount(), greaterThan(0l));
+        assertThat(stats.getTotal().indexing.getTypeStats().get("bar").getIndexCount(), greaterThan(0L));
         assertThat(stats.getTotal().indexing.getTypeStats().containsKey("baz"), is(false));
 
         stats = builder.setTypes("bar", "baz").execute().actionGet();
-        assertThat(stats.getTotal().indexing.getTypeStats().get("bar").getIndexCount(), greaterThan(0l));
-        assertThat(stats.getTotal().indexing.getTypeStats().get("baz").getIndexCount(), greaterThan(0l));
+        assertThat(stats.getTotal().indexing.getTypeStats().get("bar").getIndexCount(), greaterThan(0L));
+        assertThat(stats.getTotal().indexing.getTypeStats().get("baz").getIndexCount(), greaterThan(0L));
 
         stats = builder.setTypes("*").execute().actionGet();
-        assertThat(stats.getTotal().indexing.getTypeStats().get("bar").getIndexCount(), greaterThan(0l));
-        assertThat(stats.getTotal().indexing.getTypeStats().get("baz").getIndexCount(), greaterThan(0l));
+        assertThat(stats.getTotal().indexing.getTypeStats().get("bar").getIndexCount(), greaterThan(0L));
+        assertThat(stats.getTotal().indexing.getTypeStats().get("baz").getIndexCount(), greaterThan(0L));
 
         stats = builder.setTypes("*r").execute().actionGet();
-        assertThat(stats.getTotal().indexing.getTypeStats().get("bar").getIndexCount(), greaterThan(0l));
+        assertThat(stats.getTotal().indexing.getTypeStats().get("bar").getIndexCount(), greaterThan(0L));
         assertThat(stats.getTotal().indexing.getTypeStats().containsKey("baz"), is(false));
 
     }

--- a/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -369,21 +369,21 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test_index").get();
-        assertHitCount(searchResponse, 5l);
+        assertHitCount(searchResponse, 5L);
 
         searchResponse = client().prepareSearch("simple_alias").get();
-        assertHitCount(searchResponse, 5l);
+        assertHitCount(searchResponse, 5L);
 
         searchResponse = client().prepareSearch("templated_alias-test_index").get();
-        assertHitCount(searchResponse, 5l);
+        assertHitCount(searchResponse, 5L);
 
         searchResponse = client().prepareSearch("filtered_alias").get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).type(), equalTo("type2"));
 
         // Search the complex filter alias
         searchResponse = client().prepareSearch("complex_filtered_alias").get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
 
         Set<String> types = new HashSet<>();
         for (SearchHit searchHit : searchResponse.getHits().getHits()) {
@@ -421,10 +421,10 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test_index").get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         searchResponse = client().prepareSearch("my_alias").get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).type(), equalTo("type2"));
     }
 
@@ -456,13 +456,13 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test_index").get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         searchResponse = client().prepareSearch("alias1").get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         searchResponse = client().prepareSearch("alias2").get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).type(), equalTo("type2"));
     }
 
@@ -627,7 +627,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertThat(response.getItems()[0].getIndex(), equalTo("a2"));
         assertThat(response.getItems()[0].getType(), equalTo("test"));
         assertThat(response.getItems()[0].getId(), equalTo("test"));
-        assertThat(response.getItems()[0].getVersion(), equalTo(1l));
+        assertThat(response.getItems()[0].getVersion(), equalTo(1L));
 
         client().prepareIndex("b1", "test", "test").setSource("{}").get();
         response = client().prepareBulk().add(new IndexRequest("b2", "test", "test").source("{}")).get();
@@ -636,7 +636,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertThat(response.getItems()[0].getIndex(), equalTo("b2"));
         assertThat(response.getItems()[0].getType(), equalTo("test"));
         assertThat(response.getItems()[0].getId(), equalTo("test"));
-        assertThat(response.getItems()[0].getVersion(), equalTo(1l));
+        assertThat(response.getItems()[0].getVersion(), equalTo(1L));
 
         client().prepareIndex("c1", "test", "test").setSource("{}").get();
         response = client().prepareBulk().add(new IndexRequest("c2", "test", "test").source("{}")).get();
@@ -645,7 +645,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertThat(response.getItems()[0].getIndex(), equalTo("c2"));
         assertThat(response.getItems()[0].getType(), equalTo("test"));
         assertThat(response.getItems()[0].getId(), equalTo("test"));
-        assertThat(response.getItems()[0].getVersion(), equalTo(1l));
+        assertThat(response.getItems()[0].getVersion(), equalTo(1L));
 
         // Before 2.0 alias filters were parsed at alias creation time, in order
         // for filters to work correctly ES required that fields mentioned in those
@@ -661,7 +661,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertThat(response.hasFailures(), is(false));
         assertThat(response.getItems()[0].isFailed(), equalTo(false));
         assertThat(response.getItems()[0].getId(), equalTo("test"));
-        assertThat(response.getItems()[0].getVersion(), equalTo(1l));
+        assertThat(response.getItems()[0].getVersion(), equalTo(1L));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/percolator/ConcurrentPercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/ConcurrentPercolatorIT.java
@@ -210,7 +210,7 @@ public class ConcurrentPercolatorIT extends ESIntegTestCase {
                                     throw new IllegalStateException("Illegal x=" + x);
                             }
                             assertThat(response.getId(), equalTo(id));
-                            assertThat(response.getVersion(), equalTo(1l));
+                            assertThat(response.getVersion(), equalTo(1L));
                         }
                     } catch (Throwable t) {
                         exceptionsHolder.add(t);

--- a/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/MultiPercolatorIT.java
@@ -96,7 +96,7 @@ public class MultiPercolatorIT extends ESIntegTestCase {
                 .execute().actionGet();
 
         MultiPercolateResponse.Item item = response.getItems()[0];
-        assertMatchCount(item.getResponse(), 2l);
+        assertMatchCount(item.getResponse(), 2L);
         assertThat(item.getResponse().getMatches(), arrayWithSize(2));
         assertThat(item.getErrorMessage(), nullValue());
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("1", "4"));
@@ -104,18 +104,18 @@ public class MultiPercolatorIT extends ESIntegTestCase {
         item = response.getItems()[1];
         assertThat(item.getErrorMessage(), nullValue());
 
-        assertMatchCount(item.getResponse(), 2l);
+        assertMatchCount(item.getResponse(), 2L);
         assertThat(item.getResponse().getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
 
         item = response.getItems()[2];
         assertThat(item.getErrorMessage(), nullValue());
-        assertMatchCount(item.getResponse(), 4l);
+        assertMatchCount(item.getResponse(), 4L);
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4"));
 
         item = response.getItems()[3];
         assertThat(item.getErrorMessage(), nullValue());
-        assertMatchCount(item.getResponse(), 1l);
+        assertMatchCount(item.getResponse(), 1L);
         assertThat(item.getResponse().getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContaining("4"));
 
@@ -175,7 +175,7 @@ public class MultiPercolatorIT extends ESIntegTestCase {
                 .execute().actionGet();
 
         MultiPercolateResponse.Item item = response.getItems()[0];
-        assertMatchCount(item.getResponse(), 2l);
+        assertMatchCount(item.getResponse(), 2L);
         assertThat(item.getResponse().getMatches(), arrayWithSize(2));
         assertThat(item.getErrorMessage(), nullValue());
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("1", "4"));
@@ -183,18 +183,18 @@ public class MultiPercolatorIT extends ESIntegTestCase {
         item = response.getItems()[1];
         assertThat(item.getErrorMessage(), nullValue());
 
-        assertMatchCount(item.getResponse(), 2l);
+        assertMatchCount(item.getResponse(), 2L);
         assertThat(item.getResponse().getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
 
         item = response.getItems()[2];
         assertThat(item.getErrorMessage(), nullValue());
-        assertMatchCount(item.getResponse(), 4l);
+        assertMatchCount(item.getResponse(), 4L);
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4"));
 
         item = response.getItems()[3];
         assertThat(item.getErrorMessage(), nullValue());
-        assertMatchCount(item.getResponse(), 1l);
+        assertMatchCount(item.getResponse(), 1L);
         assertThat(item.getResponse().getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(item.getResponse().getMatches(), "test"), arrayContaining("4"));
 

--- a/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
@@ -135,7 +135,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "b").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "4"));
 
@@ -144,7 +144,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setPercolateDoc(docBuilder().setDoc(yamlBuilder().startObject().field("field1", "c").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
 
@@ -153,7 +153,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setPercolateDoc(docBuilder().setDoc(smileBuilder().startObject().field("field1", "b c").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response, 4l);
+        assertMatchCount(response, 4L);
         assertThat(response.getMatches(), arrayWithSize(4));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4"));
 
@@ -162,7 +162,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "d").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContaining("4"));
 
@@ -190,7 +190,7 @@ public class PercolatorIT extends ESIntegTestCase {
         PercolateResponse response = client().preparePercolate().setSource(doc)
                 .setIndices("test").setDocumentType("type1")
                 .execute().actionGet();
-        assertMatchCount(response, 0l);
+        assertMatchCount(response, 0L);
         assertThat(response.getMatches(), emptyArray());
 
         // add first query...
@@ -202,7 +202,7 @@ public class PercolatorIT extends ESIntegTestCase {
         response = client().preparePercolate()
                 .setIndices("test").setDocumentType("type1")
                 .setSource(doc).execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContaining("test1"));
 
@@ -216,7 +216,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type1")
                 .setSource(doc)
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("test1", "test2"));
 
@@ -226,7 +226,7 @@ public class PercolatorIT extends ESIntegTestCase {
         response = client().preparePercolate()
                 .setIndices("test").setDocumentType("type1")
                 .setSource(doc).execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContaining("test1"));
     }
@@ -252,7 +252,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().startObject("doc").field("field1", "value").endObject().endObject()))
                 .setSize(100)
                 .execute().actionGet();
-        assertMatchCount(response, 100l);
+        assertMatchCount(response, 100L);
         assertThat(response.getMatches(), arrayWithSize(100));
 
         logger.info("--> Percolate doc with routing=0");
@@ -262,7 +262,7 @@ public class PercolatorIT extends ESIntegTestCase {
                         .setSize(100)
                         .setRouting("0")
                         .execute().actionGet();
-        assertMatchCount(response, 50l);
+        assertMatchCount(response, 50L);
         assertThat(response.getMatches(), arrayWithSize(50));
 
         logger.info("--> Percolate doc with routing=1");
@@ -272,7 +272,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setSize(100)
                 .setRouting("1")
                 .execute().actionGet();
-        assertMatchCount(response, 50l);
+        assertMatchCount(response, 50L);
         assertThat(response.getMatches(), arrayWithSize(50));
     }
 
@@ -339,7 +339,7 @@ public class PercolatorIT extends ESIntegTestCase {
                         .field("query", termQuery("source", "productizer"))
                         .endObject())
                 .execute().actionGet();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
 
     }
@@ -361,7 +361,7 @@ public class PercolatorIT extends ESIntegTestCase {
         SearchResponse countResponse = client().prepareSearch().setSize(0)
                 .setQuery(matchAllQuery()).setTypes(PercolatorService.TYPE_NAME)
                 .execute().actionGet();
-        assertThat(countResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(countResponse.getHits().totalHits(), equalTo(1L));
 
 
         for (int i = 0; i < 10; i++) {
@@ -369,7 +369,7 @@ public class PercolatorIT extends ESIntegTestCase {
                     .setIndices("test").setDocumentType("type1")
                     .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value1").endObject().endObject())
                     .execute().actionGet();
-            assertMatchCount(percolate, 1l);
+            assertMatchCount(percolate, 1L);
             assertThat(percolate.getMatches(), arrayWithSize(1));
         }
 
@@ -379,7 +379,7 @@ public class PercolatorIT extends ESIntegTestCase {
                     .setPreference("_local")
                     .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value1").endObject().endObject())
                     .execute().actionGet();
-            assertMatchCount(percolate, 1l);
+            assertMatchCount(percolate, 1L);
             assertThat(percolate.getMatches(), arrayWithSize(1));
         }
 
@@ -390,7 +390,7 @@ public class PercolatorIT extends ESIntegTestCase {
         countResponse = client().prepareSearch().setSize(0)
                 .setQuery(matchAllQuery()).setTypes(PercolatorService.TYPE_NAME)
                 .execute().actionGet();
-        assertHitCount(countResponse, 0l);
+        assertHitCount(countResponse, 0L);
     }
 
     public void testMultiplePercolators() throws Exception {
@@ -419,7 +419,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type1")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value1").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(percolate.getMatches(), "test"), arrayContaining("kuku"));
 
@@ -427,7 +427,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type1")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value2").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(percolate.getMatches(), "test"), arrayContaining("bubu"));
 
@@ -453,7 +453,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type1")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value1").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(percolate.getMatches(), "test"), arrayContaining("kuku"));
 
@@ -470,7 +470,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type1")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value2").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(percolate.getMatches(), "test"), arrayContaining("bubu"));
 
@@ -490,7 +490,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type1")
                 .setSource(sourceBuilder)
                 .execute().actionGet();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(percolate.getMatches(), "test"), arrayContaining("susu"));
 
@@ -503,7 +503,7 @@ public class PercolatorIT extends ESIntegTestCase {
                         .field("field1", "value1")
                         .endObject().endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(percolate, 0l);
+        assertMatchCount(percolate, 0L);
         assertThat(percolate.getMatches(), emptyArray());
     }
 
@@ -522,16 +522,16 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field", "val").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContaining("1"));
 
         NumShards numShards = getNumShards("test");
 
         IndicesStatsResponse indicesResponse = client().admin().indices().prepareStats("test").execute().actionGet();
         assertThat(indicesResponse.getTotal().getPercolate().getCount(), equalTo((long) numShards.numPrimaries));
-        assertThat(indicesResponse.getTotal().getPercolate().getCurrent(), equalTo(0l));
+        assertThat(indicesResponse.getTotal().getPercolate().getCurrent(), equalTo(0L));
         assertThat(indicesResponse.getTotal().getPercolate().getNumQueries(), equalTo((long)numShards.dataCopies)); //number of copies
-        assertThat(indicesResponse.getTotal().getPercolate().getMemorySizeInBytes(), equalTo(-1l));
+        assertThat(indicesResponse.getTotal().getPercolate().getMemorySizeInBytes(), equalTo(-1L));
 
         NodesStatsResponse nodesResponse = client().admin().cluster().prepareNodesStats().execute().actionGet();
         long percolateCount = 0;
@@ -545,15 +545,15 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field", "val").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContaining("1"));
 
         indicesResponse = client().admin().indices().prepareStats().setPercolate(true).execute().actionGet();
         assertThat(indicesResponse.getTotal().getPercolate().getCount(), equalTo((long) numShards.numPrimaries * 2));
-        assertThat(indicesResponse.getTotal().getPercolate().getCurrent(), equalTo(0l));
+        assertThat(indicesResponse.getTotal().getPercolate().getCurrent(), equalTo(0L));
         assertThat(indicesResponse.getTotal().getPercolate().getNumQueries(), equalTo((long)numShards.dataCopies)); //number of copies
-        assertThat(indicesResponse.getTotal().getPercolate().getMemorySizeInBytes(), equalTo(-1l));
+        assertThat(indicesResponse.getTotal().getPercolate().getMemorySizeInBytes(), equalTo(-1L));
 
         percolateCount = 0;
         nodesResponse = client().admin().cluster().prepareNodesStats().execute().actionGet();
@@ -588,7 +588,7 @@ public class PercolatorIT extends ESIntegTestCase {
             percolateCount += nodeStats.getIndices().getPercolate().getCount();
             percolateSumTime += nodeStats.getIndices().getPercolate().getTimeInMillis();
         }
-        assertThat(percolateSumTime, greaterThan(0l));
+        assertThat(percolateSumTime, greaterThan(0L));
     }
 
     public void testPercolatingExistingDocs() throws Exception {
@@ -624,7 +624,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setGetRequest(Requests.getRequest("test").type("type").id("1"))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "4"));
 
@@ -633,7 +633,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setGetRequest(Requests.getRequest("test").type("type").id("2"))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
 
@@ -642,7 +642,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setGetRequest(Requests.getRequest("test").type("type").id("3"))
                 .execute().actionGet();
-        assertMatchCount(response, 4l);
+        assertMatchCount(response, 4L);
         assertThat(response.getMatches(), arrayWithSize(4));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4"));
 
@@ -651,7 +651,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setGetRequest(Requests.getRequest("test").type("type").id("4"))
                 .execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContaining("4"));
     }
@@ -689,7 +689,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setGetRequest(Requests.getRequest("test").type("type").id("1").routing("4"))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "4"));
 
@@ -698,7 +698,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setGetRequest(Requests.getRequest("test").type("type").id("2").routing("3"))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
 
@@ -707,7 +707,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setGetRequest(Requests.getRequest("test").type("type").id("3").routing("2"))
                 .execute().actionGet();
-        assertMatchCount(response, 4l);
+        assertMatchCount(response, 4L);
         assertThat(response.getMatches(), arrayWithSize(4));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4"));
 
@@ -716,7 +716,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setGetRequest(Requests.getRequest("test").type("type").id("4").routing("1"))
                 .execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContaining("4"));
     }
@@ -752,9 +752,9 @@ public class PercolatorIT extends ESIntegTestCase {
         logger.info("--> Percolate existing doc with id 2 and version 1");
         PercolateResponse response = client().preparePercolate()
                 .setIndices("test").setDocumentType("type")
-                .setGetRequest(Requests.getRequest("test").type("type").id("2").version(1l))
+                .setGetRequest(Requests.getRequest("test").type("type").id("2").version(1L))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
 
@@ -762,7 +762,7 @@ public class PercolatorIT extends ESIntegTestCase {
         try {
             client().preparePercolate()
                     .setIndices("test").setDocumentType("type")
-                    .setGetRequest(Requests.getRequest("test").type("type").id("2").version(2l))
+                    .setGetRequest(Requests.getRequest("test").type("type").id("2").version(2L))
                     .execute().actionGet();
             fail("Error should have been thrown");
         } catch (VersionConflictEngineException e) {
@@ -774,9 +774,9 @@ public class PercolatorIT extends ESIntegTestCase {
         logger.info("--> Percolate existing doc with id 2 and version 2");
         response = client().preparePercolate()
                 .setIndices("test").setDocumentType("type")
-                .setGetRequest(Requests.getRequest("test").type("type").id("2").version(2l))
+                .setGetRequest(Requests.getRequest("test").type("type").id("2").version(2L))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("2", "4"));
     }
@@ -799,7 +799,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test1").setDocumentType("type")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
 
         logger.info("--> Percolate doc to index test2");
@@ -807,7 +807,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test2").setDocumentType("type")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
 
         logger.info("--> Percolate doc to index test1 and test2");
@@ -815,7 +815,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test1", "test2").setDocumentType("type")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(response, 10l);
+        assertMatchCount(response, 10L);
         assertThat(response.getMatches(), arrayWithSize(10));
 
         logger.info("--> Percolate doc to index test2 and test3, with ignore missing");
@@ -824,7 +824,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
 
         logger.info("--> Adding aliases");
@@ -841,7 +841,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("my-alias1").setDocumentType("type")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(response, 10l);
+        assertMatchCount(response, 10L);
         assertThat(response.getMatches(), arrayWithSize(10));
         for (PercolateResponse.Match match : response) {
             assertThat(match.getIndex().string(), anyOf(equalTo("test1"), equalTo("test2")));
@@ -852,7 +852,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("my-alias2").setDocumentType("type")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", "value").endObject().endObject())
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
         for (PercolateResponse.Match match : response) {
             assertThat(match.getIndex().string(), equalTo("test2"));
@@ -883,7 +883,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
                 .get();
         assertNoFailures(response);
-        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getCount(), equalTo(1L));
         assertThat(response.getMatches()[0].getId().string(), equalTo("1"));
 
         response = client().preparePercolate()
@@ -892,7 +892,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
                 .get();
         assertNoFailures(response);
-        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getCount(), equalTo(1L));
         assertThat(response.getMatches()[0].getId().string(), equalTo("2"));
 
 
@@ -902,7 +902,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateDoc(new PercolateSourceBuilder.DocBuilder().setDoc("{}"))
                 .get();
         assertNoFailures(response);
-        assertThat(response.getCount(), equalTo(0l));
+        assertThat(response.getCount(), equalTo(0L));
 
         // Testing that the alias filter and the filter specified while percolating are both taken into account.
         response = client().preparePercolate()
@@ -912,7 +912,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateQuery(QueryBuilders.matchAllQuery())
                 .get();
         assertNoFailures(response);
-        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getCount(), equalTo(1L));
         assertThat(response.getMatches()[0].getId().string(), equalTo("1"));
 
         response = client().preparePercolate()
@@ -922,7 +922,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateQuery(QueryBuilders.matchAllQuery())
                 .get();
         assertNoFailures(response);
-        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getCount(), equalTo(1L));
         assertThat(response.getMatches()[0].getId().string(), equalTo("2"));
 
 
@@ -933,7 +933,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateQuery(QueryBuilders.matchAllQuery())
                 .get();
         assertNoFailures(response);
-        assertThat(response.getCount(), equalTo(0l));
+        assertThat(response.getCount(), equalTo(0L));
     }
 
     public void testCountPercolation() throws Exception {
@@ -966,7 +966,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type").setOnlyCount(true)
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "b").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), nullValue());
 
         logger.info("--> Count percolate doc with field1=c");
@@ -974,7 +974,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type").setOnlyCount(true)
                 .setPercolateDoc(docBuilder().setDoc(yamlBuilder().startObject().field("field1", "c").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), nullValue());
 
         logger.info("--> Count percolate doc with field1=b c");
@@ -982,7 +982,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type").setOnlyCount(true)
                 .setPercolateDoc(docBuilder().setDoc(smileBuilder().startObject().field("field1", "b c").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response, 4l);
+        assertMatchCount(response, 4L);
         assertThat(response.getMatches(), nullValue());
 
         logger.info("--> Count percolate doc with field1=d");
@@ -990,7 +990,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type").setOnlyCount(true)
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "d").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), nullValue());
 
         logger.info("--> Count percolate non existing doc");
@@ -1037,7 +1037,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type").setOnlyCount(true)
                 .setGetRequest(Requests.getRequest("test").type("type").id("1"))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), nullValue());
 
         logger.info("--> Count percolate existing doc with id 2");
@@ -1045,7 +1045,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type").setOnlyCount(true)
                 .setGetRequest(Requests.getRequest("test").type("type").id("2"))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), nullValue());
 
         logger.info("--> Count percolate existing doc with id 3");
@@ -1053,7 +1053,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type").setOnlyCount(true)
                 .setGetRequest(Requests.getRequest("test").type("type").id("3"))
                 .execute().actionGet();
-        assertMatchCount(response, 4l);
+        assertMatchCount(response, 4L);
         assertThat(response.getMatches(), nullValue());
 
         logger.info("--> Count percolate existing doc with id 4");
@@ -1061,7 +1061,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type").setOnlyCount(true)
                 .setGetRequest(Requests.getRequest("test").type("type").id("4"))
                 .execute().actionGet();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), nullValue());
     }
 
@@ -1264,7 +1264,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateDoc(docBuilder().setDoc("field", "value"))
                 .setPercolateQuery(QueryBuilders.functionScoreQuery(matchAllQuery(), fieldValueFactorFunction("level")))
                 .execute().actionGet();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches()[0].getId().string(), equalTo("2"));
         assertThat(response.getMatches()[0].getScore(), equalTo(2f));
         assertThat(response.getMatches()[1].getId().string(), equalTo("1"));
@@ -1308,7 +1308,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateDoc(docBuilder().setDoc("field", "value"))
                 .setPercolateQuery(QueryBuilders.functionScoreQuery(matchAllQuery(), fieldValueFactorFunction("level")))
                 .execute().actionGet();
-        assertMatchCount(response, 0l);
+        assertMatchCount(response, 0L);
     }
 
     public void testPercolatorWithHighlighting() throws Exception {
@@ -1346,7 +1346,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "The quick brown fox jumps over the lazy dog").endObject()))
                 .setHighlightBuilder(new HighlightBuilder().field("field1"))
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4", "5"));
 
@@ -1372,7 +1372,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setHighlightBuilder(new HighlightBuilder().field("field1"))
                 .setPercolateQuery(matchAllQuery())
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4", "5"));
 
@@ -1431,7 +1431,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateQuery(functionScoreQuery(new WeightBuilder().setWeight(5.5f)))
                 .setSortByScore(true)
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4", "5"));
 
@@ -1463,7 +1463,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateQuery(functionScoreQuery(new WeightBuilder().setWeight(5.5f)))
                 .setSortByScore(true)
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4", "5"));
 
@@ -1501,7 +1501,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateQuery(functionScoreQuery(new WeightBuilder().setWeight(5.5f)))
                 .setSortByScore(true)
                 .execute().actionGet();
-        assertMatchCount(response, 5l);
+        assertMatchCount(response, 5L);
         assertThat(response.getMatches(), arrayWithSize(5));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4", "5"));
 
@@ -1547,7 +1547,7 @@ public class PercolatorIT extends ESIntegTestCase {
                         .endObject())
                 .execute().actionGet();
         assertNoFailures(percolate);
-        assertMatchCount(percolate, 0l);
+        assertMatchCount(percolate, 0L);
     }
 
     public void testNestedPercolation() throws IOException {
@@ -1597,7 +1597,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field", "value").endObject()))
                 .setPercolateQuery(QueryBuilders.matchAllQuery())
                 .get();
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), arrayWithSize(1));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1"));
     }
@@ -1644,7 +1644,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("my-type")
                 .setPercolateDoc(docBuilder().setDoc("timestamp", System.currentTimeMillis()))
                 .get();
-        assertMatchCount(response, 2l);
+        assertMatchCount(response, 2L);
         assertThat(response.getMatches(), arrayWithSize(2));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2"));
     }
@@ -1799,7 +1799,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("doc")
                 .setPercolateDoc(docBuilder().setDoc(doc))
                 .get();
-        assertMatchCount(response, 3l);
+        assertMatchCount(response, 3L);
         Set<String> expectedIds = new HashSet<>();
         expectedIds.add("q1");
         expectedIds.add("q4");
@@ -1812,12 +1812,12 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("doc")
                 .setPercolateDoc(docBuilder().setDoc(doc))
                 .get();
-        assertMatchCount(response, 3l);
+        assertMatchCount(response, 3L);
         response = client().preparePercolate().setScore(randomBoolean()).setSortByScore(randomBoolean()).setOnlyCount(randomBoolean()).setSize(10).setPercolateQuery(QueryBuilders.termQuery("text", "foo"))
                 .setIndices("test").setDocumentType("doc")
                 .setPercolateDoc(docBuilder().setDoc(doc))
                 .get();
-        assertMatchCount(response, 3l);
+        assertMatchCount(response, 3L);
     }
 
     public void testMapUnmappedFieldAsString() throws IOException{
@@ -1835,7 +1835,7 @@ public class PercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type")
                 .setPercolateDoc(docBuilder().setDoc(jsonBuilder().startObject().field("field1", "value").endObject()))
                 .execute().actionGet();
-        assertMatchCount(response1, 1l);
+        assertMatchCount(response1, 1L);
         assertThat(response1.getMatches(), arrayWithSize(1));
     }
 

--- a/core/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/RecoveryPercolatorIT.java
@@ -99,7 +99,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
                         .field("field1", "value1")
                         .endObject().endObject())
                 .get();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
     }
 
@@ -116,7 +116,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
                 .setRefresh(true)
                 .get();
 
-        assertThat(client().prepareSearch().setSize(0).setTypes(PercolatorService.TYPE_NAME).setQuery(matchAllQuery()).get().getHits().totalHits(), equalTo(1l));
+        assertThat(client().prepareSearch().setSize(0).setTypes(PercolatorService.TYPE_NAME).setQuery(matchAllQuery()).get().getHits().totalHits(), equalTo(1L));
 
         PercolateResponse percolate = client().preparePercolate()
                 .setIndices("test").setDocumentType("type1")
@@ -124,7 +124,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
                         .field("field1", "value1")
                         .endObject().endObject())
                 .get();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
 
         internalCluster().rollingRestart();
@@ -134,7 +134,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
         logger.info("Done Cluster Health, status " + clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         SearchResponse countResponse = client().prepareSearch().setSize(0).setTypes(PercolatorService.TYPE_NAME).setQuery(matchAllQuery()).get();
-        assertHitCount(countResponse, 1l);
+        assertHitCount(countResponse, 1L);
 
         DeleteIndexResponse actionGet = client().admin().indices().prepareDelete("test").get();
         assertThat(actionGet.isAcknowledged(), equalTo(true));
@@ -142,7 +142,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
         clusterHealth = client().admin().cluster().health(clusterHealthRequest().waitForYellowStatus().waitForActiveShards(1)).actionGet();
         logger.info("Done Cluster Health, status " + clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
-        assertThat(client().prepareSearch().setSize(0).setTypes(PercolatorService.TYPE_NAME).setQuery(matchAllQuery()).get().getHits().totalHits(), equalTo(0l));
+        assertThat(client().prepareSearch().setSize(0).setTypes(PercolatorService.TYPE_NAME).setQuery(matchAllQuery()).get().getHits().totalHits(), equalTo(0L));
 
         percolate = client().preparePercolate()
                 .setIndices("test").setDocumentType("type1")
@@ -150,7 +150,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
                         .field("field1", "value1")
                         .endObject().endObject())
                 .get();
-        assertMatchCount(percolate, 0l);
+        assertMatchCount(percolate, 0L);
         assertThat(percolate.getMatches(), emptyArray());
 
         logger.info("--> register a query");
@@ -162,7 +162,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
                 .setRefresh(true)
                 .get();
 
-        assertThat(client().prepareSearch().setSize(0).setTypes(PercolatorService.TYPE_NAME).setQuery(matchAllQuery()).get().getHits().totalHits(), equalTo(1l));
+        assertThat(client().prepareSearch().setSize(0).setTypes(PercolatorService.TYPE_NAME).setQuery(matchAllQuery()).get().getHits().totalHits(), equalTo(1L));
 
         percolate = client().preparePercolate()
                 .setIndices("test").setDocumentType("type1")
@@ -170,7 +170,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
                         .field("field1", "value1")
                         .endObject().endObject())
                 .get();
-        assertMatchCount(percolate, 1l);
+        assertMatchCount(percolate, 1L);
         assertThat(percolate.getMatches(), arrayWithSize(1));
     }
 
@@ -202,7 +202,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type1")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", 95).endObject().endObject())
                 .get();
-        assertMatchCount(response, 6l);
+        assertMatchCount(response, 6L);
         assertThat(response.getMatches(), arrayWithSize(6));
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("95", "96", "97", "98", "99", "100"));
 
@@ -216,7 +216,7 @@ public class RecoveryPercolatorIT extends ESIntegTestCase {
                 .setIndices("test").setDocumentType("type1")
                 .setSource(jsonBuilder().startObject().startObject("doc").field("field1", 100).endObject().endObject()).get();
 
-        assertMatchCount(response, 1l);
+        assertMatchCount(response, 1L);
         assertThat(response.getMatches(), arrayWithSize(1));
         assertThat(response.getMatches()[0].getId().string(), equalTo("100"));
     }

--- a/core/src/test/java/org/elasticsearch/percolator/TTLPercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/TTLPercolatorIT.java
@@ -148,7 +148,7 @@ public class TTLPercolatorIT extends ESIntegTestCase {
                         .endObject()
                         .endObject()
                 ).execute().actionGet();
-        assertMatchCount(percolateResponse, 0l);
+        assertMatchCount(percolateResponse, 0L);
         assertThat(percolateResponse.getMatches(), emptyArray());
     }
 

--- a/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -91,7 +91,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         logger.info("--> refreshing and checking data");
         refresh();
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000l);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000L);
         }
 
         // now start shutting nodes down
@@ -109,7 +109,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         logger.info("--> stopped two nodes, verifying data");
         refresh();
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000l);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000L);
         }
 
         // closing the 3rd node
@@ -127,7 +127,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         logger.info("--> one node left, verifying data");
         refresh();
         for (int i = 0; i < 10; i++) {
-            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000l);
+            assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get(), 2000L);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -121,7 +121,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> verifying count");
         client().admin().indices().prepareRefresh().execute().actionGet();
-        assertThat(client().prepareSearch("test").setSize(0).execute().actionGet().getHits().totalHits(), equalTo(20l));
+        assertThat(client().prepareSearch("test").setSize(0).execute().actionGet().getHits().totalHits(), equalTo(20L));
 
         logger.info("--> start another node");
         final String node_2 = internalCluster().startNode();
@@ -140,7 +140,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> verifying count again...");
         client().admin().indices().prepareRefresh().execute().actionGet();
-        assertThat(client().prepareSearch("test").setSize(0).execute().actionGet().getHits().totalHits(), equalTo(20l));
+        assertThat(client().prepareSearch("test").setSize(0).execute().actionGet().getHits().totalHits(), equalTo(20L));
     }
 
     public void testRelocationWhileIndexingRandom() throws Exception {

--- a/core/src/test/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
+++ b/core/src/test/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
@@ -54,7 +54,7 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
             client().prepareIndex("test-0", "type1", "2").setSource("field1", "quick brown"),
             client().prepareIndex("test-0", "type1", "3").setSource("field1", "quick"));
         refresh("test-*");
-        assertHitCount(client().prepareSearch().setIndices("alias-*").setIndicesOptions(IndicesOptions.lenientExpandOpen()).setQuery(matchQuery("_all", "quick")).get(), 3l);
+        assertHitCount(client().prepareSearch().setIndices("alias-*").setIndicesOptions(IndicesOptions.lenientExpandOpen()).setQuery(matchQuery("_all", "quick")).get(), 3L);
     }
 
     public void testResolveIndexRouting() throws Exception {

--- a/core/src/test/java/org/elasticsearch/routing/AliasRoutingIT.java
+++ b/core/src/test/java/org/elasticsearch/routing/AliasRoutingIT.java
@@ -122,23 +122,23 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine one");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> search with wrong routing, should not find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
-            assertThat(client().prepareSearch("alias1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
-            assertThat(client().prepareSearch("alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
+            assertThat(client().prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
+            assertThat(client().prepareSearch("alias1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
+            assertThat(client().prepareSearch("alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
         }
 
         logger.info("--> search with correct routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch("alias0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch("alias0").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch("alias0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch("alias0").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> indexing with id [2], and routing [1] using alias");
@@ -146,50 +146,50 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
 
         logger.info("--> search with 0 routing, should find one");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch("alias0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch("alias0").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch("alias0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch("alias0").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> search with 1 routing, should find one");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch("alias1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch("alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch("alias1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch("alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> search with 0,1 routings , should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch("alias01").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch("alias01").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch().setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch("alias01").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch("alias01").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
 
         logger.info("--> search with two routing aliases , should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch("alias0", "alias1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch("alias0", "alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch("alias0", "alias1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch("alias0", "alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
 
         logger.info("--> search with alias0, alias1 and alias01, should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch("alias0", "alias1", "alias01").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch("alias0", "alias1", "alias01").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch("alias0", "alias1", "alias01").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch("alias0", "alias1", "alias01").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
 
         logger.info("--> search with test, alias0 and alias1, should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch("test", "alias0", "alias1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch("test", "alias0", "alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch("test", "alias0", "alias1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch("test", "alias0", "alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
 
     }
@@ -231,20 +231,20 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with alias-a1,alias-b0, should not find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch("alias-a1", "alias-b0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
-            assertThat(client().prepareSearch("alias-a1", "alias-b0").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
+            assertThat(client().prepareSearch("alias-a1", "alias-b0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
+            assertThat(client().prepareSearch("alias-a1", "alias-b0").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
         }
 
         logger.info("--> search with alias-ab, should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch("alias-ab").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch("alias-ab").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch("alias-ab").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch("alias-ab").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
 
         logger.info("--> search with alias-a0,alias-b1 should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch("alias-a0", "alias-b1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch("alias-a0", "alias-b1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch("alias-a0", "alias-b1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch("alias-a0", "alias-b1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
     }
 
@@ -268,7 +268,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search all on index_* should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch("index_*").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch("index_*").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
     }
 
@@ -313,8 +313,8 @@ public class AliasRoutingIT extends ESIntegTestCase {
         logger.info("--> verifying get and search with routing, should find");
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test", "type1", "0").setRouting("3").execute().actionGet().isExists(), equalTo(true));
-            assertThat(client().prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> creating alias with routing [4]");
@@ -323,8 +323,8 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> verifying search with wrong routing should not find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
-            assertThat(client().prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
+            assertThat(client().prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
+            assertThat(client().prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
         }
 
         logger.info("--> creating alias with search routing [3,4] and index routing 4");
@@ -339,8 +339,8 @@ public class AliasRoutingIT extends ESIntegTestCase {
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test", "type1", "0").setRouting("3").execute().actionGet().isExists(), equalTo(true));
             assertThat(client().prepareGet("test", "type1", "1").setRouting("4").execute().actionGet().isExists(), equalTo(true));
-            assertThat(client().prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/routing/SimpleRoutingIT.java
+++ b/core/src/test/java/org/elasticsearch/routing/SimpleRoutingIT.java
@@ -107,19 +107,19 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine one");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> search with wrong routing, should not find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0l));
+            assertThat(client().prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(0L));
         }
 
         logger.info("--> search with correct routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> indexing with id [2], and routing [1]");
@@ -127,32 +127,32 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
 
         logger.info("--> search with 0 routing, should find one");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> search with 1 routing, should find one");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1l));
+            assertThat(client().prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(1L));
         }
 
         logger.info("--> search with 0,1 routings , should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch().setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
 
         logger.info("--> search with 0,1,0 routings , should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareSearch().setRouting("0", "1", "0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
-            assertThat(client().prepareSearch().setSize(0).setRouting("0", "1", "0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2l));
+            assertThat(client().prepareSearch().setRouting("0", "1", "0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
+            assertThat(client().prepareSearch().setSize(0).setRouting("0", "1", "0").setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(2L));
         }
     }
 
@@ -300,7 +300,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "type1", "1").setRouting("0")
                 .setDoc("field1", "value1").get();
         assertThat(updateResponse.getId(), equalTo("1"));
-        assertThat(updateResponse.getVersion(), equalTo(2l));
+        assertThat(updateResponse.getVersion(), equalTo(2L));
 
         try {
             client().prepareUpdate(indexOrAlias(), "type1", "1").setDoc("field1", "value1").get();

--- a/core/src/test/java/org/elasticsearch/script/ScriptFieldIT.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptFieldIT.java
@@ -44,7 +44,7 @@ public class ScriptFieldIT extends ESIntegTestCase {
     }
 
     static int[] intArray = { Integer.MAX_VALUE, Integer.MIN_VALUE, 3 };
-    static long[] longArray = { Long.MAX_VALUE, Long.MIN_VALUE, 9223372036854775807l };
+    static long[] longArray = { Long.MAX_VALUE, Long.MIN_VALUE, 9223372036854775807L };
     static float[] floatArray = { Float.MAX_VALUE, Float.MIN_VALUE, 3.3f };
     static double[] doubleArray = { Double.MAX_VALUE, Double.MIN_VALUE, 3.3d };
 

--- a/core/src/test/java/org/elasticsearch/script/ScriptParameterParserTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptParameterParserTests.java
@@ -891,7 +891,7 @@ public class ScriptParameterParserTests extends ESTestCase {
 
     public void testConfigMultipleParametersInlineWrongType() throws IOException {
         Map<String, Object> config = new HashMap<>();
-        config.put("foo", 1l);
+        config.put("foo", 1L);
         config.put("bar_file", "barScriptValue");
         config.put("baz_id", "bazScriptValue");
         config.put("lang", "myLang");
@@ -917,7 +917,7 @@ public class ScriptParameterParserTests extends ESTestCase {
     public void testConfigMultipleParametersFileWrongType() throws IOException {
         Map<String, Object> config = new HashMap<>();
         config.put("foo", "fooScriptValue");
-        config.put("bar_file", 1l);
+        config.put("bar_file", 1L);
         config.put("baz_id", "bazScriptValue");
         config.put("lang", "myLang");
         Set<String> parameters = new HashSet<>();
@@ -944,7 +944,7 @@ public class ScriptParameterParserTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("foo", "fooScriptValue");
         config.put("bar_file", "barScriptValue");
-        config.put("baz_id", 1l);
+        config.put("baz_id", 1L);
         config.put("lang", "myLang");
         Set<String> parameters = new HashSet<>();
         parameters.add("foo");
@@ -970,7 +970,7 @@ public class ScriptParameterParserTests extends ESTestCase {
         config.put("foo", "fooScriptValue");
         config.put("bar_file", "barScriptValue");
         config.put("baz_id", "bazScriptValue");
-        config.put("lang", 1l);
+        config.put("lang", 1L);
         Set<String> parameters = new HashSet<>();
         parameters.add("foo");
         parameters.add("bar");

--- a/core/src/test/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -50,7 +50,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
             client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value").execute().actionGet();
         }
         IndicesStatsResponse indicesStats = client().admin().indices().prepareStats().execute().actionGet();
-        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0L));
         refresh();
 
         int numSearches = 10;
@@ -71,6 +71,6 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         }
         awaitBusy(() -> client().admin().indices().prepareStats().execute().actionGet().getTotal().getSearch().getOpenContexts() == 0, 1, TimeUnit.SECONDS);
         indicesStats = client().admin().indices().prepareStats().execute().actionGet();
-        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0L));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsBinaryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsBinaryIT.java
@@ -85,7 +85,7 @@ public class AggregationsBinaryIT extends ESIntegTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Aggregations subAggs = bucket.getAggregations();
             assertThat(subAggs, notNullValue());
             assertThat(subAggs.asList().size(), equalTo(1));
@@ -95,7 +95,7 @@ public class AggregationsBinaryIT extends ESIntegTestCase {
             assertThat(subTermsBuckets, notNullValue());
             assertThat(subTermsBuckets.size(), equalTo(1));
             assertThat(((Number) subTermsBuckets.get(0).getKey()).intValue(), equalTo(i));
-            assertThat(subTermsBuckets.get(0).getDocCount(), equalTo(1l));
+            assertThat(subTermsBuckets.get(0).getDocCount(), equalTo(1L));
         }
     }
 
@@ -126,7 +126,7 @@ public class AggregationsBinaryIT extends ESIntegTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Aggregations subAggs = bucket.getAggregations();
             assertThat(subAggs, notNullValue());
             assertThat(subAggs.asList().size(), equalTo(1));
@@ -136,7 +136,7 @@ public class AggregationsBinaryIT extends ESIntegTestCase {
             assertThat(subTermsBuckets, notNullValue());
             assertThat(subTermsBuckets.size(), equalTo(1));
             assertThat(((Number) subTermsBuckets.get(0).getKey()).intValue(), equalTo(i));
-            assertThat(subTermsBuckets.get(0).getDocCount(), equalTo(1l));
+            assertThat(subTermsBuckets.get(0).getDocCount(), equalTo(1L));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/CombiIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/CombiIT.java
@@ -131,7 +131,7 @@ public class CombiIT extends ESIntegTestCase {
                                 .collectMode(aggCollectionMode )))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), Matchers.equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), Matchers.equalTo(0L));
         Histogram values = searchResponse.getAggregations().get("values");
         assertThat(values, notNullValue());
         assertThat(values.getBuckets().isEmpty(), is(true));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenIT.java
@@ -195,13 +195,13 @@ public class ChildrenIT extends ESIntegTestCase {
 
         Terms.Bucket categoryBucket = categoryTerms.getBucketByKey("a");
         assertThat(categoryBucket.getKeyAsString(), equalTo("a"));
-        assertThat(categoryBucket.getDocCount(), equalTo(3l));
+        assertThat(categoryBucket.getDocCount(), equalTo(3L));
 
         Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
         assertThat(childrenBucket.getName(), equalTo("to_comment"));
-        assertThat(childrenBucket.getDocCount(), equalTo(2l));
+        assertThat(childrenBucket.getDocCount(), equalTo(2L));
         TopHits topHits = childrenBucket.getAggregations().get("top_comments");
-        assertThat(topHits.getHits().totalHits(), equalTo(2l));
+        assertThat(topHits.getHits().totalHits(), equalTo(2L));
         assertThat(topHits.getHits().getAt(0).getId(), equalTo("a"));
         assertThat(topHits.getHits().getAt(0).getType(), equalTo("comment"));
         assertThat(topHits.getHits().getAt(1).getId(), equalTo("c"));
@@ -209,25 +209,25 @@ public class ChildrenIT extends ESIntegTestCase {
 
         categoryBucket = categoryTerms.getBucketByKey("b");
         assertThat(categoryBucket.getKeyAsString(), equalTo("b"));
-        assertThat(categoryBucket.getDocCount(), equalTo(2l));
+        assertThat(categoryBucket.getDocCount(), equalTo(2L));
 
         childrenBucket = categoryBucket.getAggregations().get("to_comment");
         assertThat(childrenBucket.getName(), equalTo("to_comment"));
-        assertThat(childrenBucket.getDocCount(), equalTo(1l));
+        assertThat(childrenBucket.getDocCount(), equalTo(1L));
         topHits = childrenBucket.getAggregations().get("top_comments");
-        assertThat(topHits.getHits().totalHits(), equalTo(1l));
+        assertThat(topHits.getHits().totalHits(), equalTo(1L));
         assertThat(topHits.getHits().getAt(0).getId(), equalTo("c"));
         assertThat(topHits.getHits().getAt(0).getType(), equalTo("comment"));
 
         categoryBucket = categoryTerms.getBucketByKey("c");
         assertThat(categoryBucket.getKeyAsString(), equalTo("c"));
-        assertThat(categoryBucket.getDocCount(), equalTo(2l));
+        assertThat(categoryBucket.getDocCount(), equalTo(2L));
 
         childrenBucket = categoryBucket.getAggregations().get("to_comment");
         assertThat(childrenBucket.getName(), equalTo("to_comment"));
-        assertThat(childrenBucket.getDocCount(), equalTo(1l));
+        assertThat(childrenBucket.getDocCount(), equalTo(1L));
         topHits = childrenBucket.getAggregations().get("top_comments");
-        assertThat(topHits.getHits().totalHits(), equalTo(1l));
+        assertThat(topHits.getHits().totalHits(), equalTo(1L));
         assertThat(topHits.getHits().getAt(0).getId(), equalTo("c"));
         assertThat(topHits.getHits().getAt(0).getType(), equalTo("comment"));
     }
@@ -255,7 +255,7 @@ public class ChildrenIT extends ESIntegTestCase {
 
             assertNoFailures(searchResponse);
             Children children = searchResponse.getAggregations().get("children");
-            assertThat(children.getDocCount(), equalTo(4l));
+            assertThat(children.getDocCount(), equalTo(4L));
 
             Sum count = children.getAggregations().get("counts");
             assertThat(count.getValue(), equalTo(4.));
@@ -271,7 +271,7 @@ public class ChildrenIT extends ESIntegTestCase {
                     .setDoc("count", 1)
                     .setDetectNoop(false)
                     .get();
-            assertThat(updateResponse.getVersion(), greaterThan(1l));
+            assertThat(updateResponse.getVersion(), greaterThan(1L));
             refresh();
         }
     }
@@ -285,7 +285,7 @@ public class ChildrenIT extends ESIntegTestCase {
 
         Children children = searchResponse.getAggregations().get("non-existing");
         assertThat(children.getName(), equalTo("non-existing"));
-        assertThat(children.getDocCount(), equalTo(0l));
+        assertThat(children.getDocCount(), equalTo(0L));
     }
 
     public void testPostCollection() throws Exception {
@@ -328,23 +328,23 @@ public class ChildrenIT extends ESIntegTestCase {
         assertHitCount(response, 1);
 
         Children childrenAgg = response.getAggregations().get("my-refinements");
-        assertThat(childrenAgg.getDocCount(), equalTo(7l));
+        assertThat(childrenAgg.getDocCount(), equalTo(7L));
 
         Terms termsAgg = childrenAgg.getAggregations().get("my-colors");
         assertThat(termsAgg.getBuckets().size(), equalTo(4));
-        assertThat(termsAgg.getBucketByKey("black").getDocCount(), equalTo(3l));
-        assertThat(termsAgg.getBucketByKey("blue").getDocCount(), equalTo(2l));
-        assertThat(termsAgg.getBucketByKey("green").getDocCount(), equalTo(1l));
-        assertThat(termsAgg.getBucketByKey("orange").getDocCount(), equalTo(1l));
+        assertThat(termsAgg.getBucketByKey("black").getDocCount(), equalTo(3L));
+        assertThat(termsAgg.getBucketByKey("blue").getDocCount(), equalTo(2L));
+        assertThat(termsAgg.getBucketByKey("green").getDocCount(), equalTo(1L));
+        assertThat(termsAgg.getBucketByKey("orange").getDocCount(), equalTo(1L));
 
         termsAgg = childrenAgg.getAggregations().get("my-sizes");
         assertThat(termsAgg.getBuckets().size(), equalTo(6));
-        assertThat(termsAgg.getBucketByKey("36").getDocCount(), equalTo(2l));
-        assertThat(termsAgg.getBucketByKey("32").getDocCount(), equalTo(1l));
-        assertThat(termsAgg.getBucketByKey("34").getDocCount(), equalTo(1l));
-        assertThat(termsAgg.getBucketByKey("38").getDocCount(), equalTo(1l));
-        assertThat(termsAgg.getBucketByKey("40").getDocCount(), equalTo(1l));
-        assertThat(termsAgg.getBucketByKey("44").getDocCount(), equalTo(1l));
+        assertThat(termsAgg.getBucketByKey("36").getDocCount(), equalTo(2L));
+        assertThat(termsAgg.getBucketByKey("32").getDocCount(), equalTo(1L));
+        assertThat(termsAgg.getBucketByKey("34").getDocCount(), equalTo(1L));
+        assertThat(termsAgg.getBucketByKey("38").getDocCount(), equalTo(1L));
+        assertThat(termsAgg.getBucketByKey("40").getDocCount(), equalTo(1L));
+        assertThat(termsAgg.getBucketByKey("44").getDocCount(), equalTo(1L));
     }
 
     public void testHierarchicalChildrenAggs() {
@@ -383,14 +383,14 @@ public class ChildrenIT extends ESIntegTestCase {
 
         Children children = response.getAggregations().get(parentType);
         assertThat(children.getName(), equalTo(parentType));
-        assertThat(children.getDocCount(), equalTo(1l));
+        assertThat(children.getDocCount(), equalTo(1L));
         children = children.getAggregations().get(childType);
         assertThat(children.getName(), equalTo(childType));
-        assertThat(children.getDocCount(), equalTo(1l));
+        assertThat(children.getDocCount(), equalTo(1L));
         Terms terms = children.getAggregations().get("name");
         assertThat(terms.getBuckets().size(), equalTo(1));
         assertThat(terms.getBuckets().get(0).getKey().toString(), equalTo("brussels"));
-        assertThat(terms.getBuckets().get(0).getDocCount(), equalTo(1l));
+        assertThat(terms.getBuckets().get(0).getDocCount(), equalTo(1L));
     }
 
     public void testPostCollectAllLeafReaders() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -178,21 +178,21 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 2, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
     public void testSingleValuedFieldWithTimeZone() throws Exception {
@@ -213,42 +213,42 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 2, 1, 23, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 2, 14, 23, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 3, 1, 23, 0, DateTimeZone.UTC);
         bucket = buckets.get(3);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 3, 14, 23, 0, DateTimeZone.UTC);
         bucket = buckets.get(4);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 3, 22, 23, 0, DateTimeZone.UTC);
         bucket = buckets.get(5);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
     }
 
     public void testSingleValuedFieldOrderedByKeyAsc() throws Exception {
@@ -362,12 +362,12 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(1.0));
         assertThat((DateTime) propertiesKeys[0], equalTo(key));
-        assertThat((long) propertiesDocCounts[0], equalTo(1l));
+        assertThat((long) propertiesDocCounts[0], equalTo(1L));
         assertThat((double) propertiesCounts[0], equalTo(1.0));
 
         key = new DateTime(2012, 2, 1, 0, 0, DateTimeZone.UTC);
@@ -375,12 +375,12 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(5.0));
         assertThat((DateTime) propertiesKeys[1], equalTo(key));
-        assertThat((long) propertiesDocCounts[1], equalTo(2l));
+        assertThat((long) propertiesDocCounts[1], equalTo(2L));
         assertThat((double) propertiesCounts[1], equalTo(5.0));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
@@ -388,12 +388,12 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(15.0));
         assertThat((DateTime) propertiesKeys[2], equalTo(key));
-        assertThat((long) propertiesDocCounts[2], equalTo(3l));
+        assertThat((long) propertiesDocCounts[2], equalTo(3L));
         assertThat((double) propertiesCounts[2], equalTo(15.0));
     }
 
@@ -416,7 +416,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) new DateTime(2012, 1, 2, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -426,7 +426,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) new DateTime(2012, 2, 15, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -436,7 +436,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) new DateTime(2012, 3, 23, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -555,21 +555,21 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         key = new DateTime(2012, 4, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
     /*
@@ -599,28 +599,28 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 2, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
 
         key = new DateTime(2012, 4, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(3);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
     public void testMultiValuedFieldOrderedByKeyDesc() throws Exception {
@@ -643,19 +643,19 @@ public class DateHistogramIT extends ESIntegTestCase {
 
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(3);
         assertThat(bucket, notNullValue());
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
     }
 
     /**
@@ -688,28 +688,28 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         key = new DateTime(2012, 4, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
 
         key = new DateTime(2012, 5, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(3);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
     /**
@@ -742,7 +742,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat((long) max.getValue(), equalTo(new DateTime(2012, 3, 3, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -752,7 +752,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat((long) max.getValue(), equalTo(new DateTime(2012, 4, 16, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -762,7 +762,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat((long) max.getValue(), equalTo(new DateTime(2012, 5, 24, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -772,7 +772,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat((long) max.getValue(), equalTo(new DateTime(2012, 5, 24, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -804,21 +804,21 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 2, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
     public void testScriptSingleValueWithSubAggregatorInherited() throws Exception {
@@ -840,7 +840,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) new DateTime(2012, 1, 2, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -850,7 +850,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) new DateTime(2012, 2, 15, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -860,7 +860,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) new DateTime(2012, 3, 23, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -884,28 +884,28 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 2, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
 
         key = new DateTime(2012, 4, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(3);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
 
@@ -938,7 +938,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat((long) max.getValue(), equalTo(new DateTime(2012, 2, 3, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -948,7 +948,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat((long) max.getValue(), equalTo(new DateTime(2012, 3, 16, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -958,7 +958,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat((long) max.getValue(), equalTo(new DateTime(2012, 4, 24, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -968,7 +968,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat((long) max.getValue(), equalTo(new DateTime(2012, 4, 24, 0, 0, DateTimeZone.UTC).getMillis()));
@@ -1005,30 +1005,30 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 2, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(dateHistogram("date_histo").interval(1)))
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(dateHistogram("date_histo").interval(1)))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         List<? extends Histogram.Bucket> buckets = histo.getBuckets();
@@ -1064,7 +1064,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                         .format("yyyy-MM-dd:HH-mm-ssZZ"))
                 .execute().actionGet();
 
-        assertThat(response.getHits().getTotalHits(), equalTo(5l));
+        assertThat(response.getHits().getTotalHits(), equalTo(5L));
 
         Histogram histo = response.getAggregations().get("date_histo");
         List<? extends Histogram.Bucket> buckets = histo.getBuckets();
@@ -1073,12 +1073,12 @@ public class DateHistogramIT extends ESIntegTestCase {
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo("2014-03-10:00-00-00-02:00"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo("2014-03-11:00-00-00-02:00"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
     public void testSingleValueFieldWithExtendedBounds() throws Exception {
@@ -1234,7 +1234,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 ).execute().actionGet();
         assertSearchResponse(response);
 
-        assertThat("Expected 24 buckets for one day aggregation with hourly interval", response.getHits().totalHits(), equalTo(2l));
+        assertThat("Expected 24 buckets for one day aggregation with hourly interval", response.getHits().totalHits(), equalTo(2L));
 
         Histogram histo = response.getAggregations().get("histo");
         assertThat(histo, notNullValue());
@@ -1247,9 +1247,9 @@ public class DateHistogramIT extends ESIntegTestCase {
             assertThat(bucket, notNullValue());
             assertThat("InternalBucket " + i + " had wrong key", (DateTime) bucket.getKey(), equalTo(new DateTime(timeZoneStartToday.getMillis() + (i * 60 * 60 * 1000), DateTimeZone.UTC)));
             if (i == 0 || i == 12) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(0l));
+                assertThat(bucket.getDocCount(), equalTo(0L));
             }
         }
         internalCluster().wipeIndices("test12278");
@@ -1282,7 +1282,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
     }
 
     public void testIssue6965() {
@@ -1305,21 +1305,21 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         key = new DateTime(2012, 1, 31, 23, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         key = new DateTime(2012, 2, 29, 23, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
         assertThat(((DateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
     }
 
     public void testDSTBoundaryIssue9491() throws InterruptedException, ExecutionException {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -95,14 +95,14 @@ public class DateHistogramOffsetIT extends ESIntegTestCase {
                         .interval(DateHistogramInterval.DAY))
                 .execute().actionGet();
 
-        assertThat(response.getHits().getTotalHits(), equalTo(5l));
+        assertThat(response.getHits().getTotalHits(), equalTo(5L));
 
         Histogram histo = response.getAggregations().get("date_histo");
         List<? extends Histogram.Bucket> buckets = histo.getBuckets();
         assertThat(buckets.size(), equalTo(2));
 
-        checkBucketFor(buckets.get(0), new DateTime(2014, 3, 10, 2, 0, DateTimeZone.UTC), 2l);
-        checkBucketFor(buckets.get(1), new DateTime(2014, 3, 11, 2, 0, DateTimeZone.UTC), 3l);
+        checkBucketFor(buckets.get(0), new DateTime(2014, 3, 10, 2, 0, DateTimeZone.UTC), 2L);
+        checkBucketFor(buckets.get(1), new DateTime(2014, 3, 11, 2, 0, DateTimeZone.UTC), 3L);
     }
 
     public void testSingleValueWithNegativeOffset() throws Exception {
@@ -117,14 +117,14 @@ public class DateHistogramOffsetIT extends ESIntegTestCase {
                         .interval(DateHistogramInterval.DAY))
                 .execute().actionGet();
 
-        assertThat(response.getHits().getTotalHits(), equalTo(5l));
+        assertThat(response.getHits().getTotalHits(), equalTo(5L));
 
         Histogram histo = response.getAggregations().get("date_histo");
         List<? extends Histogram.Bucket> buckets = histo.getBuckets();
         assertThat(buckets.size(), equalTo(2));
 
-        checkBucketFor(buckets.get(0), new DateTime(2014, 3, 9, 22, 0, DateTimeZone.UTC), 2l);
-        checkBucketFor(buckets.get(1), new DateTime(2014, 3, 10, 22, 0, DateTimeZone.UTC), 3l);
+        checkBucketFor(buckets.get(0), new DateTime(2014, 3, 9, 22, 0, DateTimeZone.UTC), 2L);
+        checkBucketFor(buckets.get(1), new DateTime(2014, 3, 10, 22, 0, DateTimeZone.UTC), 3L);
     }
 
     /**
@@ -144,7 +144,7 @@ public class DateHistogramOffsetIT extends ESIntegTestCase {
                         .interval(DateHistogramInterval.DAY))
                 .execute().actionGet();
 
-        assertThat(response.getHits().getTotalHits(), equalTo(24l));
+        assertThat(response.getHits().getTotalHits(), equalTo(24L));
 
         Histogram histo = response.getAggregations().get("date_histo");
         List<? extends Histogram.Bucket> buckets = histo.getBuckets();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterIT.java
@@ -184,11 +184,11 @@ public class FilterIT extends ESIntegTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(filter("filter").filter(matchAllQuery())))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -197,6 +197,6 @@ public class FilterIT extends ESIntegTestCase {
         Filter filter = bucket.getAggregations().get("filter");
         assertThat(filter, Matchers.notNullValue());
         assertThat(filter.getName(), equalTo("filter"));
-        assertThat(filter.getDocCount(), is(0l));
+        assertThat(filter.getDocCount(), is(0L));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersIT.java
@@ -250,11 +250,11 @@ public class FiltersIT extends ESIntegTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(filters("filters").filter("all", matchAllQuery())))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -265,7 +265,7 @@ public class FiltersIT extends ESIntegTestCase {
         Filters.Bucket all = filters.getBucketByKey("all");
         assertThat(all, Matchers.notNullValue());
         assertThat(all.getKeyAsString(), equalTo("all"));
-        assertThat(all.getDocCount(), is(0l));
+        assertThat(all.getDocCount(), is(0L));
     }
 
     public void testSimpleNonKeyed() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -165,7 +165,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(500.0));
         assertThat(bucket.getFromAsString(), equalTo("0.0"));
         assertThat(bucket.getToAsString(), equalTo("500.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -174,7 +174,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(1000.0));
         assertThat(bucket.getFromAsString(), equalTo("500.0"));
         assertThat(bucket.getToAsString(), equalTo("1000.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -183,7 +183,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("1000.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
     }
 
     public void testSimpleWithCustomKeys() throws Exception {
@@ -213,7 +213,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(500.0));
         assertThat(bucket.getFromAsString(), equalTo("0.0"));
         assertThat(bucket.getToAsString(), equalTo("500.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -222,7 +222,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(1000.0));
         assertThat(bucket.getFromAsString(), equalTo("500.0"));
         assertThat(bucket.getToAsString(), equalTo("1000.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -231,7 +231,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("1000.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
     }
 
     public void testUnmapped() throws Exception {
@@ -263,7 +263,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(500.0));
         assertThat(bucket.getFromAsString(), equalTo("0.0"));
         assertThat(bucket.getToAsString(), equalTo("500.0"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -272,7 +272,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(1000.0));
         assertThat(bucket.getFromAsString(), equalTo("500.0"));
         assertThat(bucket.getToAsString(), equalTo("1000.0"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -281,7 +281,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("1000.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
     }
 
     public void testPartiallyUnmapped() throws Exception {
@@ -311,7 +311,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(500.0));
         assertThat(bucket.getFromAsString(), equalTo("0.0"));
         assertThat(bucket.getToAsString(), equalTo("500.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -320,7 +320,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(1000.0));
         assertThat(bucket.getFromAsString(), equalTo("500.0"));
         assertThat(bucket.getToAsString(), equalTo("1000.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -329,7 +329,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("1000.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
     }
 
     public void testWithSubAggregation() throws Exception {
@@ -364,7 +364,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(500.0));
         assertThat(bucket.getFromAsString(), equalTo("0.0"));
         assertThat(bucket.getToAsString(), equalTo("500.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         Terms cities = bucket.getAggregations().get("cities");
         assertThat(cities, Matchers.notNullValue());
@@ -374,7 +374,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         }
         assertThat(names.contains("utrecht") && names.contains("haarlem"), is(true));
         assertThat((String) propertiesKeys[0], equalTo("*-500.0"));
-        assertThat((long) propertiesDocCounts[0], equalTo(2l));
+        assertThat((long) propertiesDocCounts[0], equalTo(2L));
         assertThat((Terms) propertiesCities[0], sameInstance(cities));
 
         bucket = buckets.get(1);
@@ -384,7 +384,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(1000.0));
         assertThat(bucket.getFromAsString(), equalTo("500.0"));
         assertThat(bucket.getToAsString(), equalTo("1000.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         cities = bucket.getAggregations().get("cities");
         assertThat(cities, Matchers.notNullValue());
@@ -394,7 +394,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         }
         assertThat(names.contains("berlin") && names.contains("prague"), is(true));
         assertThat((String) propertiesKeys[1], equalTo("500.0-1000.0"));
-        assertThat((long) propertiesDocCounts[1], equalTo(2l));
+        assertThat((long) propertiesDocCounts[1], equalTo(2L));
         assertThat((Terms) propertiesCities[1], sameInstance(cities));
 
         bucket = buckets.get(2);
@@ -404,7 +404,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("1000.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         cities = bucket.getAggregations().get("cities");
         assertThat(cities, Matchers.notNullValue());
@@ -414,18 +414,18 @@ public class GeoDistanceIT extends ESIntegTestCase {
         }
         assertThat(names.contains("tel-aviv"), is(true));
         assertThat((String) propertiesKeys[2], equalTo("1000.0-*"));
-        assertThat((long) propertiesDocCounts[2], equalTo(1l));
+        assertThat((long) propertiesDocCounts[2], equalTo(1L));
         assertThat((Terms) propertiesCities[2], sameInstance(cities));
     }
 
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(geoDistance("geo_dist").field("location").point("52.3760, 4.894").addRange("0-100", 0.0, 100.0)))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -442,7 +442,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) buckets.get(0).getTo()).doubleValue(), equalTo(100.0));
         assertThat(buckets.get(0).getFromAsString(), equalTo("0.0"));
         assertThat(buckets.get(0).getToAsString(), equalTo("100.0"));
-        assertThat(buckets.get(0).getDocCount(), equalTo(0l));
+        assertThat(buckets.get(0).getDocCount(), equalTo(0L));
     }
 
     public void testMultiValues() throws Exception {
@@ -472,7 +472,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(500.0));
         assertThat(bucket.getFromAsString(), equalTo("0.0"));
         assertThat(bucket.getToAsString(), equalTo("500.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -481,7 +481,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(1000.0));
         assertThat(bucket.getFromAsString(), equalTo("500.0"));
         assertThat(bucket.getToAsString(), equalTo("1000.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -490,7 +490,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("1000.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
     }
 
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingIT.java
@@ -184,11 +184,11 @@ public class MissingIT extends ESIntegTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(missing("missing")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -197,7 +197,7 @@ public class MissingIT extends ESIntegTestCase {
         Missing missing = bucket.getAggregations().get("missing");
         assertThat(missing, Matchers.notNullValue());
         assertThat(missing.getName(), equalTo("missing"));
-        assertThat(missing.getDocCount(), is(0l));
+        assertThat(missing.getDocCount(), is(0L));
     }
 
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
@@ -212,7 +212,7 @@ public class NestedIT extends ESIntegTestCase {
         Nested nested = searchResponse.getAggregations().get("nested");
         assertThat(nested, Matchers.notNullValue());
         assertThat(nested.getName(), equalTo("nested"));
-        assertThat(nested.getDocCount(), is(0l));
+        assertThat(nested.getDocCount(), is(0L));
     }
 
     public void testNestedWithSubTermsAgg() throws Exception {
@@ -308,23 +308,23 @@ public class NestedIT extends ESIntegTestCase {
         Nested level1 = response.getAggregations().get("level1");
         assertThat(level1, notNullValue());
         assertThat(level1.getName(), equalTo("level1"));
-        assertThat(level1.getDocCount(), equalTo(2l));
+        assertThat(level1.getDocCount(), equalTo(2L));
 
         StringTerms a = level1.getAggregations().get("a");
         Terms.Bucket bBucket = a.getBucketByKey("a");
-        assertThat(bBucket.getDocCount(), equalTo(1l));
+        assertThat(bBucket.getDocCount(), equalTo(1L));
 
         Nested level2 = bBucket.getAggregations().get("level2");
-        assertThat(level2.getDocCount(), equalTo(1l));
+        assertThat(level2.getDocCount(), equalTo(1L));
         Sum sum = level2.getAggregations().get("sum");
         assertThat(sum.getValue(), equalTo(2d));
 
         a = level1.getAggregations().get("a");
         bBucket = a.getBucketByKey("b");
-        assertThat(bBucket.getDocCount(), equalTo(1l));
+        assertThat(bBucket.getDocCount(), equalTo(1L));
 
         level2 = bBucket.getAggregations().get("level2");
-        assertThat(level2.getDocCount(), equalTo(1l));
+        assertThat(level2.getDocCount(), equalTo(1L));
         sum = level2.getAggregations().get("sum");
         assertThat(sum.getValue(), equalTo(2d));
     }
@@ -332,11 +332,11 @@ public class NestedIT extends ESIntegTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(nested("nested").path("nested")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -345,7 +345,7 @@ public class NestedIT extends ESIntegTestCase {
         Nested nested = bucket.getAggregations().get("nested");
         assertThat(nested, Matchers.notNullValue());
         assertThat(nested.getName(), equalTo("nested"));
-        assertThat(nested.getDocCount(), is(0l));
+        assertThat(nested.getDocCount(), is(0L));
     }
 
     public void testNestedOnObjectField() throws Exception {
@@ -424,36 +424,36 @@ public class NestedIT extends ESIntegTestCase {
         Terms startDate = response.getAggregations().get("startDate");
         assertThat(startDate.getBuckets().size(), equalTo(2));
         Terms.Bucket bucket = startDate.getBucketByKey("2014-11-01T00:00:00.000Z");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Terms endDate = bucket.getAggregations().get("endDate");
         bucket = endDate.getBucketByKey("2014-11-30T00:00:00.000Z");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Terms period = bucket.getAggregations().get("period");
         bucket = period.getBucketByKey("2014-11");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Nested comments = bucket.getAggregations().get("ctxt_idfier_nested");
-        assertThat(comments.getDocCount(), equalTo(2l));
+        assertThat(comments.getDocCount(), equalTo(2L));
         Filter filter = comments.getAggregations().get("comment_filter");
-        assertThat(filter.getDocCount(), equalTo(1l));
+        assertThat(filter.getDocCount(), equalTo(1L));
         Nested nestedTags = filter.getAggregations().get("nested_tags");
-        assertThat(nestedTags.getDocCount(), equalTo(0l)); // This must be 0
+        assertThat(nestedTags.getDocCount(), equalTo(0L)); // This must be 0
         Terms tags = nestedTags.getAggregations().get("tag");
         assertThat(tags.getBuckets().size(), equalTo(0)); // and this must be empty
 
         bucket = startDate.getBucketByKey("2014-12-01T00:00:00.000Z");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         endDate = bucket.getAggregations().get("endDate");
         bucket = endDate.getBucketByKey("2014-12-31T00:00:00.000Z");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         period = bucket.getAggregations().get("period");
         bucket = period.getBucketByKey("2014-12");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         comments = bucket.getAggregations().get("ctxt_idfier_nested");
-        assertThat(comments.getDocCount(), equalTo(2l));
+        assertThat(comments.getDocCount(), equalTo(2L));
         filter = comments.getAggregations().get("comment_filter");
-        assertThat(filter.getDocCount(), equalTo(1l));
+        assertThat(filter.getDocCount(), equalTo(1L));
         nestedTags = filter.getAggregations().get("nested_tags");
-        assertThat(nestedTags.getDocCount(), equalTo(0l)); // This must be 0
+        assertThat(nestedTags.getDocCount(), equalTo(0L)); // This must be 0
         tags = nestedTags.getAggregations().get("tag");
         assertThat(tags.getBuckets().size(), equalTo(0)); // and this must be empty
     }
@@ -500,47 +500,47 @@ public class NestedIT extends ESIntegTestCase {
         assertThat(category.getBuckets().size(), equalTo(4));
 
         Terms.Bucket bucket = category.getBucketByKey("1");
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Nested property = bucket.getAggregations().get("property");
-        assertThat(property.getDocCount(), equalTo(6l));
+        assertThat(property.getDocCount(), equalTo(6L));
         Terms propertyId = property.getAggregations().get("property_id");
         assertThat(propertyId.getBuckets().size(), equalTo(5));
-        assertThat(propertyId.getBucketByKey("1").getDocCount(), equalTo(2l));
-        assertThat(propertyId.getBucketByKey("2").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("3").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("4").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("5").getDocCount(), equalTo(1l));
+        assertThat(propertyId.getBucketByKey("1").getDocCount(), equalTo(2L));
+        assertThat(propertyId.getBucketByKey("2").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("3").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("4").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("5").getDocCount(), equalTo(1L));
 
         bucket = category.getBucketByKey("2");
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         property = bucket.getAggregations().get("property");
-        assertThat(property.getDocCount(), equalTo(6l));
+        assertThat(property.getDocCount(), equalTo(6L));
         propertyId = property.getAggregations().get("property_id");
         assertThat(propertyId.getBuckets().size(), equalTo(5));
-        assertThat(propertyId.getBucketByKey("1").getDocCount(), equalTo(2l));
-        assertThat(propertyId.getBucketByKey("2").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("3").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("4").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("5").getDocCount(), equalTo(1l));
+        assertThat(propertyId.getBucketByKey("1").getDocCount(), equalTo(2L));
+        assertThat(propertyId.getBucketByKey("2").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("3").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("4").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("5").getDocCount(), equalTo(1L));
 
         bucket = category.getBucketByKey("3");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         property = bucket.getAggregations().get("property");
-        assertThat(property.getDocCount(), equalTo(3l));
+        assertThat(property.getDocCount(), equalTo(3L));
         propertyId = property.getAggregations().get("property_id");
         assertThat(propertyId.getBuckets().size(), equalTo(3));
-        assertThat(propertyId.getBucketByKey("1").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("2").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("3").getDocCount(), equalTo(1l));
+        assertThat(propertyId.getBucketByKey("1").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("2").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("3").getDocCount(), equalTo(1L));
 
         bucket = category.getBucketByKey("4");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         property = bucket.getAggregations().get("property");
-        assertThat(property.getDocCount(), equalTo(3l));
+        assertThat(property.getDocCount(), equalTo(3L));
         propertyId = property.getAggregations().get("property_id");
         assertThat(propertyId.getBuckets().size(), equalTo(3));
-        assertThat(propertyId.getBucketByKey("1").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("2").getDocCount(), equalTo(1l));
-        assertThat(propertyId.getBucketByKey("3").getDocCount(), equalTo(1l));
+        assertThat(propertyId.getBucketByKey("1").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("2").getDocCount(), equalTo(1L));
+        assertThat(propertyId.getBucketByKey("3").getDocCount(), equalTo(1L));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ParentIdAggIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ParentIdAggIT.java
@@ -48,10 +48,10 @@ public class ParentIdAggIT extends ESIntegTestCase {
         refresh();
         ensureGreen("testidx");
         SearchResponse searchResponse = client().prepareSearch("testidx").setTypes("childtype").setQuery(matchAllQuery()).addAggregation(AggregationBuilders.terms("children").field("_parent#parenttype")).get();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         assertSearchResponse(searchResponse);
         assertThat(searchResponse.getAggregations().getAsMap().get("children"), instanceOf(Terms.class));
         Terms terms = (Terms) searchResponse.getAggregations().getAsMap().get("children");
-        assertThat(terms.getBuckets().iterator().next().getDocCount(), equalTo(2l));
+        assertThat(terms.getBuckets().iterator().next().getDocCount(), equalTo(2L));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ReverseNestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ReverseNestedIT.java
@@ -156,7 +156,7 @@ public class ReverseNestedIT extends ESIntegTestCase {
         Nested nested = response.getAggregations().get("nested1");
         assertThat(nested, notNullValue());
         assertThat(nested.getName(), equalTo("nested1"));
-        assertThat(nested.getDocCount(), equalTo(25l));
+        assertThat(nested.getDocCount(), equalTo(25L));
         assertThat(nested.getAggregations().asList().isEmpty(), is(false));
 
         Terms usernames = nested.getAggregations().get("field2");
@@ -167,161 +167,161 @@ public class ReverseNestedIT extends ESIntegTestCase {
         // nested.field2: 1
         Terms.Bucket bucket = usernameBuckets.get(0);
         assertThat(bucket.getKeyAsString(), equalTo("1"));
-        assertThat(bucket.getDocCount(), equalTo(6l));
+        assertThat(bucket.getDocCount(), equalTo(6L));
         ReverseNested reverseNested = bucket.getAggregations().get("nested1_to_field1");
-        assertThat((long) reverseNested.getProperty("_count"), equalTo(5l));
+        assertThat((long) reverseNested.getProperty("_count"), equalTo(5L));
         Terms tags = reverseNested.getAggregations().get("field1");
         assertThat((Terms) reverseNested.getProperty("field1"), sameInstance(tags));
         List<Terms.Bucket> tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(6));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(4l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(4L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("a"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(3l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(3L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("e"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(4).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(4).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(4).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(5).getKeyAsString(), equalTo("x"));
-        assertThat(tagsBuckets.get(5).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(5).getDocCount(), equalTo(1L));
 
         // nested.field2: 4
         bucket = usernameBuckets.get(1);
         assertThat(bucket.getKeyAsString(), equalTo("4"));
-        assertThat(bucket.getDocCount(), equalTo(4l));
+        assertThat(bucket.getDocCount(), equalTo(4L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(5));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("a"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(3l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(3L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(4).getKeyAsString(), equalTo("e"));
-        assertThat(tagsBuckets.get(4).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(4).getDocCount(), equalTo(1L));
 
         // nested.field2: 7
         bucket = usernameBuckets.get(2);
         assertThat(bucket.getKeyAsString(), equalTo("7"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(5));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("e"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("a"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(4).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(4).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(4).getDocCount(), equalTo(1L));
 
         // nested.field2: 2
         bucket = usernameBuckets.get(3);
         assertThat(bucket.getKeyAsString(), equalTo("2"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(3));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("a"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1L));
 
         // nested.field2: 3
         bucket = usernameBuckets.get(4);
         assertThat(bucket.getKeyAsString(), equalTo("3"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(3));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("a"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1L));
 
         // nested.field2: 5
         bucket = usernameBuckets.get(5);
         assertThat(bucket.getKeyAsString(), equalTo("5"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(4));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("z"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
 
         // nested.field2: 6
         bucket = usernameBuckets.get(6);
         assertThat(bucket.getKeyAsString(), equalTo("6"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(4));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("y"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
 
         // nested.field2: 8
         bucket = usernameBuckets.get(7);
         assertThat(bucket.getKeyAsString(), equalTo("8"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(4));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(2L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("e"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("x"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
 
         // nested.field2: 9
         bucket = usernameBuckets.get(8);
         assertThat(bucket.getKeyAsString(), equalTo("9"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(4));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("e"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("z"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
     }
 
     public void testSimpleNested1ToRootToNested2() throws Exception {
@@ -337,13 +337,13 @@ public class ReverseNestedIT extends ESIntegTestCase {
         assertSearchResponse(response);
         Nested nested = response.getAggregations().get("nested1");
         assertThat(nested.getName(), equalTo("nested1"));
-        assertThat(nested.getDocCount(), equalTo(9l));
+        assertThat(nested.getDocCount(), equalTo(9L));
         ReverseNested reverseNested = nested.getAggregations().get("nested1_to_root");
         assertThat(reverseNested.getName(), equalTo("nested1_to_root"));
-        assertThat(reverseNested.getDocCount(), equalTo(4l));
+        assertThat(reverseNested.getDocCount(), equalTo(4L));
         nested = reverseNested.getAggregations().get("root_to_nested2");
         assertThat(nested.getName(), equalTo("root_to_nested2"));
-        assertThat(nested.getDocCount(), equalTo(27l));
+        assertThat(nested.getDocCount(), equalTo(27L));
     }
 
     public void testSimpleReverseNestedToNested1() throws Exception {
@@ -368,7 +368,7 @@ public class ReverseNestedIT extends ESIntegTestCase {
         Nested nested = response.getAggregations().get("nested1");
         assertThat(nested, notNullValue());
         assertThat(nested.getName(), equalTo("nested1"));
-        assertThat(nested.getDocCount(), equalTo(27l));
+        assertThat(nested.getDocCount(), equalTo(27L));
         assertThat(nested.getAggregations().asList().isEmpty(), is(false));
 
         Terms usernames = nested.getAggregations().get("field2");
@@ -378,73 +378,73 @@ public class ReverseNestedIT extends ESIntegTestCase {
 
         Terms.Bucket bucket = usernameBuckets.get(0);
         assertThat(bucket.getKeyAsString(), equalTo("0"));
-        assertThat(bucket.getDocCount(), equalTo(12l));
+        assertThat(bucket.getDocCount(), equalTo(12L));
         ReverseNested reverseNested = bucket.getAggregations().get("nested1_to_field1");
-        assertThat(reverseNested.getDocCount(), equalTo(5l));
+        assertThat(reverseNested.getDocCount(), equalTo(5L));
         Terms tags = reverseNested.getAggregations().get("field1");
         List<Terms.Bucket> tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(2));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("a"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(3l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(3L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(2l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(2L));
 
         bucket = usernameBuckets.get(1);
         assertThat(bucket.getKeyAsString(), equalTo("1"));
-        assertThat(bucket.getDocCount(), equalTo(6l));
+        assertThat(bucket.getDocCount(), equalTo(6L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
-        assertThat(reverseNested.getDocCount(), equalTo(4l));
+        assertThat(reverseNested.getDocCount(), equalTo(4L));
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(4));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("a"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("e"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
 
         bucket = usernameBuckets.get(2);
         assertThat(bucket.getKeyAsString(), equalTo("2"));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
-        assertThat(reverseNested.getDocCount(), equalTo(4l));
+        assertThat(reverseNested.getDocCount(), equalTo(4L));
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(4));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("a"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("b"));
-        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(1).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(2).getKeyAsString(), equalTo("c"));
-        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(2).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(3).getKeyAsString(), equalTo("e"));
-        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(3).getDocCount(), equalTo(1L));
 
         bucket = usernameBuckets.get(3);
         assertThat(bucket.getKeyAsString(), equalTo("3"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
-        assertThat(reverseNested.getDocCount(), equalTo(2l));
+        assertThat(reverseNested.getDocCount(), equalTo(2L));
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(2));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("f"));
 
         bucket = usernameBuckets.get(4);
         assertThat(bucket.getKeyAsString(), equalTo("4"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         reverseNested = bucket.getAggregations().get("nested1_to_field1");
-        assertThat(reverseNested.getDocCount(), equalTo(2l));
+        assertThat(reverseNested.getDocCount(), equalTo(2L));
         tags = reverseNested.getAggregations().get("field1");
         tagsBuckets = new ArrayList<>(tags.getBuckets());
         assertThat(tagsBuckets.size(), equalTo(2));
         assertThat(tagsBuckets.get(0).getKeyAsString(), equalTo("d"));
-        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1l));
+        assertThat(tagsBuckets.get(0).getDocCount(), equalTo(1L));
         assertThat(tagsBuckets.get(1).getKeyAsString(), equalTo("f"));
     }
 
@@ -478,7 +478,7 @@ public class ReverseNestedIT extends ESIntegTestCase {
         assertThat(nested.getName(), equalTo("nested2"));
 
         ReverseNested reverseNested = nested.getAggregations().get("incorrect");
-        assertThat(reverseNested.getDocCount(), is(0l));
+        assertThat(reverseNested.getDocCount(), is(0L));
     }
 
     public void testSameParentDocHavingMultipleBuckets() throws Exception {
@@ -574,21 +574,21 @@ public class ReverseNestedIT extends ESIntegTestCase {
         assertHitCount(response, 1);
 
         Nested nested0 = response.getAggregations().get("nested_0");
-        assertThat(nested0.getDocCount(), equalTo(3l));
+        assertThat(nested0.getDocCount(), equalTo(3L));
         Terms terms = nested0.getAggregations().get("group_by_category");
         assertThat(terms.getBuckets().size(), equalTo(3));
         for (String bucketName : new String[]{"abc", "klm", "xyz"}) {
             logger.info("Checking results for bucket {}", bucketName);
             Terms.Bucket bucket = terms.getBucketByKey(bucketName);
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             ReverseNested toRoot = bucket.getAggregations().get("to_root");
-            assertThat(toRoot.getDocCount(), equalTo(1l));
+            assertThat(toRoot.getDocCount(), equalTo(1L));
             Nested nested1 = toRoot.getAggregations().get("nested_1");
-            assertThat(nested1.getDocCount(), equalTo(5l));
+            assertThat(nested1.getDocCount(), equalTo(5L));
             Filter filterByBar = nested1.getAggregations().get("filter_by_sku");
-            assertThat(filterByBar.getDocCount(), equalTo(3l));
+            assertThat(filterByBar.getDocCount(), equalTo(3L));
             ValueCount barCount = filterByBar.getAggregations().get("sku_count");
-            assertThat(barCount.getValue(), equalTo(3l));
+            assertThat(barCount.getValue(), equalTo(3L));
         }
 
         response = client().prepareSearch("idx3")
@@ -615,27 +615,27 @@ public class ReverseNestedIT extends ESIntegTestCase {
         assertHitCount(response, 1);
 
         nested0 = response.getAggregations().get("nested_0");
-        assertThat(nested0.getDocCount(), equalTo(3l));
+        assertThat(nested0.getDocCount(), equalTo(3L));
         terms = nested0.getAggregations().get("group_by_category");
         assertThat(terms.getBuckets().size(), equalTo(3));
         for (String bucketName : new String[]{"abc", "klm", "xyz"}) {
             logger.info("Checking results for bucket {}", bucketName);
             Terms.Bucket bucket = terms.getBucketByKey(bucketName);
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             ReverseNested toRoot = bucket.getAggregations().get("to_root");
-            assertThat(toRoot.getDocCount(), equalTo(1l));
+            assertThat(toRoot.getDocCount(), equalTo(1L));
             Nested nested1 = toRoot.getAggregations().get("nested_1");
-            assertThat(nested1.getDocCount(), equalTo(5l));
+            assertThat(nested1.getDocCount(), equalTo(5L));
             Filter filterByBar = nested1.getAggregations().get("filter_by_sku");
-            assertThat(filterByBar.getDocCount(), equalTo(3l));
+            assertThat(filterByBar.getDocCount(), equalTo(3L));
             Nested nested2 = filterByBar.getAggregations().get("nested_2");
-            assertThat(nested2.getDocCount(), equalTo(8l));
+            assertThat(nested2.getDocCount(), equalTo(8L));
             Filter filterBarColor = nested2.getAggregations().get("filter_sku_color");
-            assertThat(filterBarColor.getDocCount(), equalTo(2l));
+            assertThat(filterBarColor.getDocCount(), equalTo(2L));
             ReverseNested reverseToBar = filterBarColor.getAggregations().get("reverse_to_sku");
-            assertThat(reverseToBar.getDocCount(), equalTo(2l));
+            assertThat(reverseToBar.getDocCount(), equalTo(2L));
             ValueCount barCount = reverseToBar.getAggregations().get("sku_count");
-            assertThat(barCount.getValue(), equalTo(2l));
+            assertThat(barCount.getValue(), equalTo(2L));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
@@ -137,7 +137,7 @@ public class SamplerIT extends ESIntegTestCase {
         for (Terms.Bucket testBucket : testBuckets) {
             maxBooksPerAuthor = Math.max(testBucket.getDocCount(), maxBooksPerAuthor);
         }
-        assertThat(maxBooksPerAuthor, equalTo(3l));
+        assertThat(maxBooksPerAuthor, equalTo(3L));
     }
 
     public void testSimpleDiversity() throws Exception {
@@ -232,7 +232,7 @@ public class SamplerIT extends ESIntegTestCase {
                 .actionGet();
         assertSearchResponse(response);
         Sampler sample = response.getAggregations().get("sample");
-        assertThat(sample.getDocCount(), equalTo(0l));
+        assertThat(sample.getDocCount(), equalTo(0L));
         Terms authors = sample.getAggregations().get("authors");
         assertThat(authors.getBuckets().size(), equalTo(0));
     }
@@ -249,7 +249,7 @@ public class SamplerIT extends ESIntegTestCase {
                 .actionGet();
         assertSearchResponse(response);
         Sampler sample = response.getAggregations().get("sample");
-        assertThat(sample.getDocCount(), greaterThan(0l));
+        assertThat(sample.getDocCount(), greaterThan(0L));
         Terms authors = sample.getAggregations().get("authors");
         assertThat(authors.getBuckets().size(), greaterThan(0));
     }
@@ -264,7 +264,7 @@ public class SamplerIT extends ESIntegTestCase {
                 .execute().actionGet();
         assertSearchResponse(response);
         Sampler sample = response.getAggregations().get("sample");
-        assertThat(sample.getDocCount(), greaterThan(0l));
+        assertThat(sample.getDocCount(), greaterThan(0L));
         Terms authors = sample.getAggregations().get("authors");
         assertThat(authors.getBuckets().size(), greaterThan(0));
     }
@@ -279,7 +279,7 @@ public class SamplerIT extends ESIntegTestCase {
                 .setQuery(new TermQueryBuilder("genre", "fantasy")).setFrom(0).setSize(60).addAggregation(sampleAgg).execute().actionGet();
         assertSearchResponse(response);
         Sampler sample = response.getAggregations().get("sample");
-        assertThat(sample.getDocCount(), equalTo(0l));
+        assertThat(sample.getDocCount(), equalTo(0L));
         Terms authors = sample.getAggregations().get("authors");
         assertNull(authors);
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTermsIT.java
@@ -46,9 +46,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<String, Long> expected = new HashMap<>();
-        expected.put("1", 8l);
-        expected.put("3", 8l);
-        expected.put("2", 5l);
+        expected.put("1", 8L);
+        expected.put("3", 8L);
+        expected.put("2", 5L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsString())));
         }
@@ -69,9 +69,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<String, Long> expected = new HashMap<>();
-        expected.put("1", 8l);
-        expected.put("3", 8l);
-        expected.put("2", 4l);
+        expected.put("1", 8L);
+        expected.put("3", 8L);
+        expected.put("2", 4L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsString())));
         }
@@ -93,9 +93,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3)); // we still only return 3 entries (based on the 'size' param)
         Map<String, Long> expected = new HashMap<>();
-        expected.put("1", 8l);
-        expected.put("3", 8l);
-        expected.put("2", 5l); // <-- count is now fixed
+        expected.put("1", 8L);
+        expected.put("3", 8L);
+        expected.put("2", 5L); // <-- count is now fixed
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsString())));
         }
@@ -117,9 +117,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3)); // we still only return 3 entries (based on the 'size' param)
         Map<String, Long> expected = new HashMap<>();
-        expected.put("1", 5l);
-        expected.put("2", 4l);
-        expected.put("3", 3l); // <-- count is now fixed
+        expected.put("1", 5L);
+        expected.put("2", 4L);
+        expected.put("3", 3L); // <-- count is now fixed
         for (Terms.Bucket bucket: buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKey())));
         }
@@ -140,9 +140,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<String, Long> expected = new HashMap<>();
-        expected.put("1", 8l);
-        expected.put("2", 5l);
-        expected.put("3", 8l);
+        expected.put("1", 8L);
+        expected.put("2", 5L);
+        expected.put("3", 8L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsString())));
         }
@@ -163,9 +163,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 8l);
-        expected.put(3, 8l);
-        expected.put(2, 5l);
+        expected.put(1, 8L);
+        expected.put(3, 8L);
+        expected.put(2, 5L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -186,9 +186,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 8l);
-        expected.put(3, 8l);
-        expected.put(2, 4l);
+        expected.put(1, 8L);
+        expected.put(3, 8L);
+        expected.put(2, 4L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -209,9 +209,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3)); // we still only return 3 entries (based on the 'size' param)
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 8l);
-        expected.put(3, 8l);
-        expected.put(2, 5l); // <-- count is now fixed
+        expected.put(1, 8L);
+        expected.put(3, 8L);
+        expected.put(2, 5L); // <-- count is now fixed
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -233,9 +233,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3)); // we still only return 3 entries (based on the 'size' param)
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 5l);
-        expected.put(2, 4l);
-        expected.put(3, 3l);
+        expected.put(1, 5L);
+        expected.put(2, 4L);
+        expected.put(3, 3L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -256,9 +256,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 8l);
-        expected.put(2, 5l);
-        expected.put(3, 8l);
+        expected.put(1, 8L);
+        expected.put(2, 5L);
+        expected.put(3, 8L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -279,9 +279,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 8l);
-        expected.put(3, 8l);
-        expected.put(2, 5l);
+        expected.put(1, 8L);
+        expected.put(3, 8L);
+        expected.put(2, 5L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -302,9 +302,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 8l);
-        expected.put(3, 8l);
-        expected.put(2, 4l);
+        expected.put(1, 8L);
+        expected.put(3, 8L);
+        expected.put(2, 4L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -325,9 +325,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 8l);
-        expected.put(3, 8l);
-        expected.put(2, 5l); // <-- count is now fixed
+        expected.put(1, 8L);
+        expected.put(3, 8L);
+        expected.put(2, 5L); // <-- count is now fixed
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -348,9 +348,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 5l);
-        expected.put(2, 4l);
-        expected.put(3, 3l);
+        expected.put(1, 5L);
+        expected.put(2, 4L);
+        expected.put(3, 3L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }
@@ -371,9 +371,9 @@ public class ShardSizeTermsIT extends ShardSizeTestCase {
         Collection<Terms.Bucket> buckets = terms.getBuckets();
         assertThat(buckets.size(), equalTo(3));
         Map<Integer, Long> expected = new HashMap<>();
-        expected.put(1, 8l);
-        expected.put(2, 5l);
-        expected.put(3, 8l);
+        expected.put(1, 8L);
+        expected.put(2, 5L);
+        expected.put(3, 8L);
         for (Terms.Bucket bucket : buckets) {
             assertThat(bucket.getDocCount(), equalTo(expected.get(bucket.getKeyAsNumber().intValue())));
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTestCase.java
@@ -93,11 +93,11 @@ public abstract class ShardSizeTestCase extends ESIntegTestCase {
         SearchResponse resp = client().prepareSearch("idx").setTypes("type").setRouting(routing1).setQuery(matchAllQuery()).execute().actionGet();
         assertSearchResponse(resp);
         long totalOnOne = resp.getHits().getTotalHits();
-        assertThat(totalOnOne, is(15l));
+        assertThat(totalOnOne, is(15L));
         resp = client().prepareSearch("idx").setTypes("type").setRouting(routing2).setQuery(matchAllQuery()).execute().actionGet();
         assertSearchResponse(resp);
         long totalOnTwo = resp.getHits().getTotalHits();
-        assertThat(totalOnTwo, is(12l));
+        assertThat(totalOnTwo, is(12L));
     }
 
     protected List<IndexRequestBuilder> indexDoc(String shard, String key, int times) throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -101,12 +101,12 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
         Terms accurateTerms = accurateResponse.getAggregations().get("terms");
         assertThat(accurateTerms, notNullValue());
         assertThat(accurateTerms.getName(), equalTo("terms"));
-        assertThat(accurateTerms.getDocCountError(), equalTo(0l));
+        assertThat(accurateTerms.getDocCountError(), equalTo(0L));
 
         Terms testTerms = testResponse.getAggregations().get("terms");
         assertThat(testTerms, notNullValue());
         assertThat(testTerms.getName(), equalTo("terms"));
-        assertThat(testTerms.getDocCountError(), greaterThanOrEqualTo(0l));
+        assertThat(testTerms.getDocCountError(), greaterThanOrEqualTo(0L));
         Collection<Bucket> testBuckets = testTerms.getBuckets();
         assertThat(testBuckets.size(), lessThanOrEqualTo(size));
         assertThat(accurateTerms.getBuckets().size(), greaterThanOrEqualTo(testBuckets.size()));
@@ -115,7 +115,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             assertThat(testBucket, notNullValue());
             Terms.Bucket accurateBucket = accurateTerms.getBucketByKey(testBucket.getKeyAsString());
             assertThat(accurateBucket, notNullValue());
-            assertThat(accurateBucket.getDocCountError(), equalTo(0l));
+            assertThat(accurateBucket.getDocCountError(), equalTo(0L));
             assertThat(testBucket.getDocCountError(), lessThanOrEqualTo(testTerms.getDocCountError()));
             assertThat(testBucket.getDocCount() + testBucket.getDocCountError(), greaterThanOrEqualTo(accurateBucket.getDocCount()));
             assertThat(testBucket.getDocCount() - testBucket.getDocCountError(), lessThanOrEqualTo(accurateBucket.getDocCount()));
@@ -135,12 +135,12 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
         Terms accurateTerms = accurateResponse.getAggregations().get("terms");
         assertThat(accurateTerms, notNullValue());
         assertThat(accurateTerms.getName(), equalTo("terms"));
-        assertThat(accurateTerms.getDocCountError(), equalTo(0l));
+        assertThat(accurateTerms.getDocCountError(), equalTo(0L));
 
         Terms testTerms = testResponse.getAggregations().get("terms");
         assertThat(testTerms, notNullValue());
         assertThat(testTerms.getName(), equalTo("terms"));
-        assertThat(testTerms.getDocCountError(), equalTo(0l));
+        assertThat(testTerms.getDocCountError(), equalTo(0L));
         Collection<Bucket> testBuckets = testTerms.getBuckets();
         assertThat(testBuckets.size(), lessThanOrEqualTo(size));
         assertThat(accurateTerms.getBuckets().size(), greaterThanOrEqualTo(testBuckets.size()));
@@ -149,8 +149,8 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             assertThat(testBucket, notNullValue());
             Terms.Bucket accurateBucket = accurateTerms.getBucketByKey(testBucket.getKeyAsString());
             assertThat(accurateBucket, notNullValue());
-            assertThat(accurateBucket.getDocCountError(), equalTo(0l));
-            assertThat(testBucket.getDocCountError(), equalTo(0l));
+            assertThat(accurateBucket.getDocCountError(), equalTo(0L));
+            assertThat(testBucket.getDocCountError(), equalTo(0L));
         }
     }
 
@@ -158,13 +158,13 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
         Terms testTerms = testResponse.getAggregations().get("terms");
         assertThat(testTerms, notNullValue());
         assertThat(testTerms.getName(), equalTo("terms"));
-        assertThat(testTerms.getDocCountError(), equalTo(0l));
+        assertThat(testTerms.getDocCountError(), equalTo(0L));
         Collection<Bucket> testBuckets = testTerms.getBuckets();
         assertThat(testBuckets.size(), lessThanOrEqualTo(size));
 
         for (Terms.Bucket testBucket : testBuckets) {
             assertThat(testBucket, notNullValue());
-            assertThat(testBucket.getDocCountError(), equalTo(0l));
+            assertThat(testBucket.getDocCountError(), equalTo(0L));
         }
     }
 
@@ -172,12 +172,12 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
         Terms accurateTerms = accurateResponse.getAggregations().get("terms");
         assertThat(accurateTerms, notNullValue());
         assertThat(accurateTerms.getName(), equalTo("terms"));
-        assertThat(accurateTerms.getDocCountError(), equalTo(0l));
+        assertThat(accurateTerms.getDocCountError(), equalTo(0L));
 
         Terms testTerms = testResponse.getAggregations().get("terms");
         assertThat(testTerms, notNullValue());
         assertThat(testTerms.getName(), equalTo("terms"));
-        assertThat(testTerms.getDocCountError(),anyOf(equalTo(-1l), equalTo(0l)));
+        assertThat(testTerms.getDocCountError(),anyOf(equalTo(-1L), equalTo(0L)));
         Collection<Bucket> testBuckets = testTerms.getBuckets();
         assertThat(testBuckets.size(), lessThanOrEqualTo(size));
         assertThat(accurateTerms.getBuckets().size(), greaterThanOrEqualTo(testBuckets.size()));
@@ -186,8 +186,8 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
             assertThat(testBucket, notNullValue());
             Terms.Bucket accurateBucket = accurateTerms.getBucketByKey(testBucket.getKeyAsString());
             assertThat(accurateBucket, notNullValue());
-            assertThat(accurateBucket.getDocCountError(), equalTo(0l));
-            assertThat(testBucket.getDocCountError(), anyOf(equalTo(-1l), equalTo(0l)));
+            assertThat(accurateBucket.getDocCountError(), equalTo(0L));
+            assertThat(testBucket.getDocCountError(), anyOf(equalTo(-1L), equalTo(0L)));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -140,7 +140,7 @@ public class NestedAggregatorTests extends ESSingleNodeTestCase {
 
         Nested nested = (Nested) aggs[0].buildAggregation(0);
         // The bug manifests if 6 docs are returned, because currentRootDoc isn't reset the previous child docs from the first segment are emitted as hits.
-        assertThat(nested.getDocCount(), equalTo(4l));
+        assertThat(nested.getDocCount(), equalTo(4L));
 
         directoryReader.close();
         directory.close();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -103,8 +103,8 @@ public class SignificanceHeuristicTests extends ESTestCase {
         assertThat(originalBucket.getKeyAsString(), equalTo(streamedBucket.getKeyAsString()));
         assertThat(originalBucket.getSupersetDf(), equalTo(streamedBucket.getSupersetDf()));
         assertThat(originalBucket.getSubsetDf(), equalTo(streamedBucket.getSubsetDf()));
-        assertThat(streamedBucket.getSubsetSize(), equalTo(10l));
-        assertThat(streamedBucket.getSupersetSize(), equalTo(20l));
+        assertThat(streamedBucket.getSubsetSize(), equalTo(10L));
+        assertThat(streamedBucket.getSupersetSize(), equalTo(20L));
     }
 
     InternalSignificantTerms[] getRandomSignificantTerms(SignificanceHeuristic heuristic) {
@@ -139,14 +139,14 @@ public class SignificanceHeuristicTests extends ESTestCase {
         List<InternalAggregation> aggs = createInternalAggregations();
         SignificantTerms reducedAgg = (SignificantTerms) aggs.get(0).doReduce(aggs, null);
         assertThat(reducedAgg.getBuckets().size(), equalTo(2));
-        assertThat(reducedAgg.getBuckets().get(0).getSubsetDf(), equalTo(8l));
-        assertThat(reducedAgg.getBuckets().get(0).getSubsetSize(), equalTo(16l));
-        assertThat(reducedAgg.getBuckets().get(0).getSupersetDf(), equalTo(10l));
-        assertThat(reducedAgg.getBuckets().get(0).getSupersetSize(), equalTo(30l));
-        assertThat(reducedAgg.getBuckets().get(1).getSubsetDf(), equalTo(8l));
-        assertThat(reducedAgg.getBuckets().get(1).getSubsetSize(), equalTo(16l));
-        assertThat(reducedAgg.getBuckets().get(1).getSupersetDf(), equalTo(10l));
-        assertThat(reducedAgg.getBuckets().get(1).getSupersetSize(), equalTo(30l));
+        assertThat(reducedAgg.getBuckets().get(0).getSubsetDf(), equalTo(8L));
+        assertThat(reducedAgg.getBuckets().get(0).getSubsetSize(), equalTo(16L));
+        assertThat(reducedAgg.getBuckets().get(0).getSupersetDf(), equalTo(10L));
+        assertThat(reducedAgg.getBuckets().get(0).getSupersetSize(), equalTo(30L));
+        assertThat(reducedAgg.getBuckets().get(1).getSubsetDf(), equalTo(8L));
+        assertThat(reducedAgg.getBuckets().get(1).getSubsetSize(), equalTo(16L));
+        assertThat(reducedAgg.getBuckets().get(1).getSupersetDf(), equalTo(10L));
+        assertThat(reducedAgg.getBuckets().get(1).getSupersetSize(), equalTo(30L));
     }
 
     // Create aggregations as they might come from three different shards and return as list.
@@ -252,7 +252,7 @@ public class SignificanceHeuristicTests extends ESTestCase {
         stParser.nextToken();
         SignificantTermsAggregatorFactory aggregatorFactory = (SignificantTermsAggregatorFactory) new SignificantTermsParser(heuristicParserMapper).parse("testagg", stParser, searchContext);
         stParser.nextToken();
-        assertThat(aggregatorFactory.getBucketCountThresholds().getMinDocCount(), equalTo(200l));
+        assertThat(aggregatorFactory.getBucketCountThresholds().getMinDocCount(), equalTo(200L));
         assertThat(stParser.currentToken(), equalTo(null));
         stParser.close();
         return aggregatorFactory.getSignificanceHeuristic();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -199,7 +199,7 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
             Long value = hitField.getValue();
             assertThat("Hit " + i + " has wrong value", value.intValue(), equalTo(i));
         }
-        assertThat(totalHits, equalTo(2000l));
+        assertThat(totalHits, equalTo(2000L));
     }
 
     private void updateGeohashBucketsCentroid(final GeoPoint location) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
@@ -72,10 +72,10 @@ public class AvgIT extends AbstractNumericTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(avg("avg")))
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(avg("avg")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -94,7 +94,7 @@ public class AvgIT extends AbstractNumericTestCase {
                 .addAggregation(avg("avg").field("value"))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         Avg avg = searchResponse.getAggregations().get("avg");
         assertThat(avg, notNullValue());
@@ -128,7 +128,7 @@ public class AvgIT extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
@@ -166,7 +166,7 @@ public class GeoBoundsIT extends AbstractGeoTestCase {
                         .wrapLongitude(false))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
         GeoBounds geoBounds = searchResponse.getAggregations().get(aggName);
         assertThat(geoBounds, notNullValue());
         assertThat(geoBounds.getName(), equalTo(aggName));
@@ -238,7 +238,7 @@ public class GeoBoundsIT extends AbstractGeoTestCase {
         for (int i = 0; i < 10; i++) {
             Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
-            assertThat("InternalBucket " + bucket.getKey() + " has wrong number of documents", bucket.getDocCount(), equalTo(1l));
+            assertThat("InternalBucket " + bucket.getKey() + " has wrong number of documents", bucket.getDocCount(), equalTo(1L));
             GeoBounds geoBounds = bucket.getAggregations().get(aggName);
             assertThat(geoBounds, notNullValue());
             assertThat(geoBounds.getName(), equalTo(aggName));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -53,7 +53,7 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
         assertSearchResponse(response);
 
         GeoCentroid geoCentroid = response.getAggregations().get(aggName);
-        assertThat(response.getHits().getTotalHits(), equalTo(0l));
+        assertThat(response.getHits().getTotalHits(), equalTo(0L));
         assertThat(geoCentroid, notNullValue());
         assertThat(geoCentroid.getName(), equalTo(aggName));
         GeoPoint centroid = geoCentroid.centroid();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -69,10 +69,10 @@ public class SumIT extends AbstractNumericTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(sum("sum")))
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(sum("sum")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -91,7 +91,7 @@ public class SumIT extends AbstractNumericTestCase {
                 .addAggregation(sum("sum").field("value"))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         Sum sum = searchResponse.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -138,7 +138,7 @@ public class SumIT extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -210,7 +210,7 @@ public class TopHitsIT extends ESIntegTestCase {
                 client().prepareIndex("articles", "article", "1")
                         .setSource(jsonBuilder().startObject().field("title", "title 1").field("body", "some text").startArray("comments")
                                 .startObject()
-                                    .field("user", "a").field("date", 1l).field("message", "some comment")
+                                    .field("user", "a").field("date", 1L).field("message", "some comment")
                                     .startArray("reviewers")
                                         .startObject().field("name", "user a").endObject()
                                         .startObject().field("name", "user b").endObject()
@@ -218,7 +218,7 @@ public class TopHitsIT extends ESIntegTestCase {
                                     .endArray()
                                 .endObject()
                                 .startObject()
-                                    .field("user", "b").field("date", 2l).field("message", "some other comment")
+                                    .field("user", "b").field("date", 2L).field("message", "some other comment")
                                     .startArray("reviewers")
                                         .startObject().field("name", "user c").endObject()
                                         .startObject().field("name", "user d").endObject()
@@ -231,12 +231,12 @@ public class TopHitsIT extends ESIntegTestCase {
                 client().prepareIndex("articles", "article", "2")
                         .setSource(jsonBuilder().startObject().field("title", "title 2").field("body", "some different text").startArray("comments")
                                 .startObject()
-                                    .field("user", "b").field("date", 3l).field("message", "some comment")
+                                    .field("user", "b").field("date", 3L).field("message", "some comment")
                                     .startArray("reviewers")
                                         .startObject().field("name", "user f").endObject()
                                     .endArray()
                                 .endObject()
-                                .startObject().field("user", "c").field("date", 4l).field("message", "some other comment").endObject()
+                                .startObject().field("user", "c").field("date", 4L).field("message", "some other comment").endObject()
                                 .endArray().endObject())
         );
 
@@ -273,10 +273,10 @@ public class TopHitsIT extends ESIntegTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(10l));
+            assertThat(bucket.getDocCount(), equalTo(10L));
             TopHits topHits = bucket.getAggregations().get("hits");
             SearchHits hits = topHits.getHits();
-            assertThat(hits.totalHits(), equalTo(10l));
+            assertThat(hits.totalHits(), equalTo(10L));
             assertThat(hits.getHits().length, equalTo(3));
             higestSortValue += 10;
             assertThat((Long) hits.getAt(0).sortValues()[0], equalTo(higestSortValue));
@@ -299,7 +299,7 @@ public class TopHitsIT extends ESIntegTestCase {
 
         assertSearchResponse(response);
 
-        assertThat(response.getHits().getTotalHits(), equalTo(8l));
+        assertThat(response.getHits().getTotalHits(), equalTo(8L));
         assertThat(response.getHits().hits().length, equalTo(0));
         assertThat(response.getHits().maxScore(), equalTo(0f));
         Terms terms = response.getAggregations().get("terms");
@@ -335,7 +335,7 @@ public class TopHitsIT extends ESIntegTestCase {
 
         assertSearchResponse(response);
 
-        assertThat(response.getHits().getTotalHits(), equalTo(8l));
+        assertThat(response.getHits().getTotalHits(), equalTo(8L));
         assertThat(response.getHits().hits().length, equalTo(0));
         assertThat(response.getHits().maxScore(), equalTo(0f));
         terms = response.getAggregations().get("terms");
@@ -366,10 +366,10 @@ public class TopHitsIT extends ESIntegTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(10l));
+            assertThat(bucket.getDocCount(), equalTo(10L));
             TopHits topHits = bucket.getAggregations().get("hits");
             SearchHits hits = topHits.getHits();
-            assertThat(hits.totalHits(), equalTo(10l));
+            assertThat(hits.totalHits(), equalTo(10L));
             assertThat(hits.getHits().length, equalTo(3));
 
             assertThat(hits.getAt(0).sourceAsMap().size(), equalTo(4));
@@ -428,7 +428,7 @@ public class TopHitsIT extends ESIntegTestCase {
 
         Terms.Bucket bucket = terms.getBucketByKey("val0");
         assertThat(bucket, notNullValue());
-        assertThat(bucket.getDocCount(), equalTo(10l));
+        assertThat(bucket.getDocCount(), equalTo(10L));
         TopHits topHits = bucket.getAggregations().get("hits");
         SearchHits hits = topHits.getHits();
         assertThat(hits.totalHits(), equalTo(controlHits.totalHits()));
@@ -465,10 +465,10 @@ public class TopHitsIT extends ESIntegTestCase {
         int currentBucket = 4;
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(key(bucket), equalTo("val" + currentBucket--));
-            assertThat(bucket.getDocCount(), equalTo(10l));
+            assertThat(bucket.getDocCount(), equalTo(10L));
             TopHits topHits = bucket.getAggregations().get("hits");
             SearchHits hits = topHits.getHits();
-            assertThat(hits.totalHits(), equalTo(10l));
+            assertThat(hits.totalHits(), equalTo(10L));
             assertThat(hits.getHits().length, equalTo(3));
             assertThat((Long) hits.getAt(0).sortValues()[0], equalTo(higestSortValue));
             assertThat((Long) hits.getAt(1).sortValues()[0], equalTo(higestSortValue - 1));
@@ -501,7 +501,7 @@ public class TopHitsIT extends ESIntegTestCase {
         assertThat(key(bucket), equalTo("b"));
         TopHits topHits = bucket.getAggregations().get("hits");
         SearchHits hits = topHits.getHits();
-        assertThat(hits.totalHits(), equalTo(4l));
+        assertThat(hits.totalHits(), equalTo(4L));
         assertThat(hits.getHits().length, equalTo(1));
         assertThat(hits.getAt(0).id(), equalTo("6"));
 
@@ -509,7 +509,7 @@ public class TopHitsIT extends ESIntegTestCase {
         assertThat(key(bucket), equalTo("c"));
         topHits = bucket.getAggregations().get("hits");
         hits = topHits.getHits();
-        assertThat(hits.totalHits(), equalTo(3l));
+        assertThat(hits.totalHits(), equalTo(3L));
         assertThat(hits.getHits().length, equalTo(1));
         assertThat(hits.getAt(0).id(), equalTo("9"));
 
@@ -517,7 +517,7 @@ public class TopHitsIT extends ESIntegTestCase {
         assertThat(key(bucket), equalTo("a"));
         topHits = bucket.getAggregations().get("hits");
         hits = topHits.getHits();
-        assertThat(hits.totalHits(), equalTo(2l));
+        assertThat(hits.totalHits(), equalTo(2L));
         assertThat(hits.getHits().length, equalTo(1));
         assertThat(hits.getAt(0).id(), equalTo("2"));
     }
@@ -550,7 +550,7 @@ public class TopHitsIT extends ESIntegTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             TopHits topHits = bucket.getAggregations().get("hits");
             SearchHits hits = topHits.getHits();
-            assertThat(hits.totalHits(), equalTo(10l));
+            assertThat(hits.totalHits(), equalTo(10L));
             assertThat(hits.getHits().length, equalTo(1));
 
             SearchHit hit = hits.getAt(0);
@@ -562,7 +562,7 @@ public class TopHitsIT extends ESIntegTestCase {
             assertThat(explanation.toString(), containsString("text:text"));
 
             long version = hit.version();
-            assertThat(version, equalTo(1l));
+            assertThat(version, equalTo(1L));
 
             assertThat(hit.matchedQueries()[0], equalTo("test"));
 
@@ -637,7 +637,7 @@ public class TopHitsIT extends ESIntegTestCase {
         TopHits hits = response.getAggregations().get("hits");
         assertThat(hits, notNullValue());
         assertThat(hits.getName(), equalTo("hits"));
-        assertThat(hits.getHits().totalHits(), equalTo(0l));
+        assertThat(hits.getHits().totalHits(), equalTo(0L));
     }
 
     public void testTrackScores() throws Exception {
@@ -703,23 +703,23 @@ public class TopHitsIT extends ESIntegTestCase {
                 .get();
 
         Nested nested = searchResponse.getAggregations().get("to-comments");
-        assertThat(nested.getDocCount(), equalTo(4l));
+        assertThat(nested.getDocCount(), equalTo(4L));
 
         Terms terms = nested.getAggregations().get("users");
         Terms.Bucket bucket = terms.getBucketByKey("a");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         TopHits topHits = bucket.getAggregations().get("top-comments");
         SearchHits searchHits = topHits.getHits();
-        assertThat(searchHits.totalHits(), equalTo(1l));
+        assertThat(searchHits.totalHits(), equalTo(1L));
         assertThat(searchHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(searchHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
         assertThat((Integer) searchHits.getAt(0).getSource().get("date"), equalTo(1));
 
         bucket = terms.getBucketByKey("b");
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         topHits = bucket.getAggregations().get("top-comments");
         searchHits = topHits.getHits();
-        assertThat(searchHits.totalHits(), equalTo(2l));
+        assertThat(searchHits.totalHits(), equalTo(2L));
         assertThat(searchHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(searchHits.getAt(0).getNestedIdentity().getOffset(), equalTo(1));
         assertThat((Integer) searchHits.getAt(0).getSource().get("date"), equalTo(2));
@@ -728,10 +728,10 @@ public class TopHitsIT extends ESIntegTestCase {
         assertThat((Integer) searchHits.getAt(1).getSource().get("date"), equalTo(3));
 
         bucket = terms.getBucketByKey("c");
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         topHits = bucket.getAggregations().get("top-comments");
         searchHits = topHits.getHits();
-        assertThat(searchHits.totalHits(), equalTo(1l));
+        assertThat(searchHits.totalHits(), equalTo(1L));
         assertThat(searchHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(searchHits.getAt(0).getNestedIdentity().getOffset(), equalTo(1));
         assertThat((Integer) searchHits.getAt(0).getSource().get("date"), equalTo(4));
@@ -754,10 +754,10 @@ public class TopHitsIT extends ESIntegTestCase {
         assertNoFailures(searchResponse);
 
         Nested toComments = searchResponse.getAggregations().get("to-comments");
-        assertThat(toComments.getDocCount(), equalTo(4l));
+        assertThat(toComments.getDocCount(), equalTo(4L));
 
         TopHits topComments = toComments.getAggregations().get("top-comments");
-        assertThat(topComments.getHits().totalHits(), equalTo(4l));
+        assertThat(topComments.getHits().totalHits(), equalTo(4L));
         assertThat(topComments.getHits().getHits().length, equalTo(4));
 
         assertThat(topComments.getHits().getAt(0).getId(), equalTo("2"));
@@ -781,10 +781,10 @@ public class TopHitsIT extends ESIntegTestCase {
         assertThat(topComments.getHits().getAt(3).getNestedIdentity().getChild(), nullValue());
 
         Nested toReviewers = toComments.getAggregations().get("to-reviewers");
-        assertThat(toReviewers.getDocCount(), equalTo(7l));
+        assertThat(toReviewers.getDocCount(), equalTo(7L));
 
         TopHits topReviewers = toReviewers.getAggregations().get("top-reviewers");
-        assertThat(topReviewers.getHits().totalHits(), equalTo(7l));
+        assertThat(topReviewers.getHits().totalHits(), equalTo(7L));
         assertThat(topReviewers.getHits().getHits().length, equalTo(7));
 
         assertThat(topReviewers.getHits().getAt(0).getId(), equalTo("1"));
@@ -855,10 +855,10 @@ public class TopHitsIT extends ESIntegTestCase {
                                         .setVersion(true).addSort("comments.date", SortOrder.ASC))).get();
         assertHitCount(searchResponse, 2);
         Nested nested = searchResponse.getAggregations().get("to-comments");
-        assertThat(nested.getDocCount(), equalTo(4l));
+        assertThat(nested.getDocCount(), equalTo(4L));
 
         SearchHits hits = ((TopHits) nested.getAggregations().get("top-comments")).getHits();
-        assertThat(hits.totalHits(), equalTo(4l));
+        assertThat(hits.totalHits(), equalTo(4L));
         SearchHit searchHit = hits.getAt(0);
         assertThat(searchHit.getId(), equalTo("1"));
         assertThat(searchHit.getNestedIdentity().getField().string(), equalTo("comments"));
@@ -875,7 +875,7 @@ public class TopHitsIT extends ESIntegTestCase {
 
         // Returns the version of the root document. Nested docs don't have a separate version
         long version = searchHit.version();
-        assertThat(version, equalTo(1l));
+        assertThat(version, equalTo(1L));
 
         assertThat(searchHit.matchedQueries(), arrayContaining("test"));
 
@@ -909,7 +909,7 @@ public class TopHitsIT extends ESIntegTestCase {
         Histogram histogram = searchResponse.getAggregations().get("dates");
         for (int i = 0; i < numArticles; i += 5) {
             Histogram.Bucket bucket = histogram.getBuckets().get(i / 5);
-            assertThat(bucket.getDocCount(), equalTo(5l));
+            assertThat(bucket.getDocCount(), equalTo(5L));
 
             long numNestedDocs = 10 + (5 * i);
             Nested nested = bucket.getAggregations().get("to-comments");

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -85,12 +85,12 @@ public class ValueCountIT extends ESIntegTestCase {
                 .addAggregation(count("count").field("value"))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         ValueCount valueCount = searchResponse.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(0l));
+        assertThat(valueCount.getValue(), equalTo(0L));
     }
 
     public void testSingleValuedField() throws Exception {
@@ -104,7 +104,7 @@ public class ValueCountIT extends ESIntegTestCase {
         ValueCount valueCount = searchResponse.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(10l));
+        assertThat(valueCount.getValue(), equalTo(10L));
     }
 
     public void testSingleValuedFieldGetProperty() throws Exception {
@@ -116,14 +116,14 @@ public class ValueCountIT extends ESIntegTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
         ValueCount valueCount = global.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(10l));
+        assertThat(valueCount.getValue(), equalTo(10L));
         assertThat((ValueCount) global.getProperty("count"), equalTo(valueCount));
         assertThat((double) global.getProperty("count.value"), equalTo(10d));
         assertThat((double) valueCount.getProperty("value"), equalTo(10d));
@@ -140,7 +140,7 @@ public class ValueCountIT extends ESIntegTestCase {
         ValueCount valueCount = searchResponse.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(10l));
+        assertThat(valueCount.getValue(), equalTo(10L));
     }
 
     public void testMultiValuedField() throws Exception {
@@ -154,7 +154,7 @@ public class ValueCountIT extends ESIntegTestCase {
         ValueCount valueCount = searchResponse.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(20l));
+        assertThat(valueCount.getValue(), equalTo(20L));
     }
 
     public void testSingleValuedScript() throws Exception {
@@ -166,7 +166,7 @@ public class ValueCountIT extends ESIntegTestCase {
         ValueCount valueCount = searchResponse.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(10l));
+        assertThat(valueCount.getValue(), equalTo(10L));
     }
 
     public void testMultiValuedScript() throws Exception {
@@ -178,7 +178,7 @@ public class ValueCountIT extends ESIntegTestCase {
         ValueCount valueCount = searchResponse.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(20l));
+        assertThat(valueCount.getValue(), equalTo(20L));
     }
 
     public void testSingleValuedScriptWithParams() throws Exception {
@@ -191,7 +191,7 @@ public class ValueCountIT extends ESIntegTestCase {
         ValueCount valueCount = searchResponse.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(10l));
+        assertThat(valueCount.getValue(), equalTo(10L));
     }
 
     public void testMultiValuedScriptWithParams() throws Exception {
@@ -204,7 +204,7 @@ public class ValueCountIT extends ESIntegTestCase {
         ValueCount valueCount = searchResponse.getAggregations().get("count");
         assertThat(valueCount, notNullValue());
         assertThat(valueCount.getName(), equalTo("count"));
-        assertThat(valueCount.getValue(), equalTo(20l));
+        assertThat(valueCount.getValue(), equalTo(20L));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketIT.java
@@ -189,7 +189,7 @@ public class AvgBucketIT extends ESIntegTestCase {
             Terms.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0l));
+            assertThat(bucket.getDocCount(), greaterThan(0L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             count++;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -123,7 +123,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, nullValue());
 
@@ -131,7 +131,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());
         assertThat(docCountDeriv.value(), equalTo(1d));
@@ -140,7 +140,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());
         assertThat(docCountDeriv.value(), equalTo(1d));
@@ -166,7 +166,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Derivative docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, nullValue());
 
@@ -174,7 +174,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());
         assertThat(docCountDeriv.value(), closeTo(1d, 0.00001));
@@ -184,7 +184,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());
         assertThat(docCountDeriv.value(), closeTo(1d, 0.00001));
@@ -214,7 +214,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -222,14 +222,14 @@ public class DateDerivativeIT extends ESIntegTestCase {
         SimpleValue deriv = bucket.getAggregations().get("deriv");
         assertThat(deriv, nullValue());
         assertThat((DateTime) propertiesKeys[0], equalTo(key));
-        assertThat((long) propertiesDocCounts[0], equalTo(1l));
+        assertThat((long) propertiesDocCounts[0], equalTo(1L));
         assertThat((double) propertiesCounts[0], equalTo(1.0));
 
         key = new DateTime(2012, 2, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -239,14 +239,14 @@ public class DateDerivativeIT extends ESIntegTestCase {
         assertThat(deriv.value(), equalTo(4.0));
         assertThat((double) bucket.getProperty("histo", AggregationPath.parse("deriv.value").getPathElementsAsStringList()), equalTo(4.0));
         assertThat((DateTime) propertiesKeys[1], equalTo(key));
-        assertThat((long) propertiesDocCounts[1], equalTo(2l));
+        assertThat((long) propertiesDocCounts[1], equalTo(2L));
         assertThat((double) propertiesCounts[1], equalTo(5.0));
 
         key = new DateTime(2012, 3, 1, 0, 0, DateTimeZone.UTC);
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
@@ -256,7 +256,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         assertThat(deriv.value(), equalTo(10.0));
         assertThat((double) bucket.getProperty("histo", AggregationPath.parse("deriv.value").getPathElementsAsStringList()), equalTo(10.0));
         assertThat((DateTime) propertiesKeys[2], equalTo(key));
-        assertThat((long) propertiesDocCounts[2], equalTo(3l));
+        assertThat((long) propertiesDocCounts[2], equalTo(3L));
         assertThat((double) propertiesCounts[2], equalTo(15.0));
     }
 
@@ -279,7 +279,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(true));
         SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, nullValue());
@@ -288,7 +288,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());
@@ -298,7 +298,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());
@@ -308,7 +308,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(3);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());
@@ -349,7 +349,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(true));
         SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, nullValue());
@@ -358,7 +358,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());
@@ -368,7 +368,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
         assertThat((DateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
         docCountDeriv = bucket.getAggregations().get("deriv");
         assertThat(docCountDeriv, notNullValue());

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeIT.java
@@ -123,7 +123,7 @@ public class DerivativeIT extends ESIntegTestCase {
         }
 
         // setup for index with empty buckets
-        valueCounts_empty = new Long[] { 1l, 1l, 2l, 0l, 2l, 2l, 0l, 0l, 0l, 3l, 2l, 1l };
+        valueCounts_empty = new Long[] { 1L, 1L, 2L, 0L, 2L, 2L, 0L, 0L, 0L, 3L, 2L, 1L };
         firstDerivValueCounts_empty = new Double[] { null, 0d, 1d, -2d, 2d, 0d, -2d, 0d, 0d, 3d, -1d, -1d };
 
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
@@ -145,7 +145,7 @@ public class DerivativeIT extends ESIntegTestCase {
             valueCounts_empty_rnd[i] = (long) randomIntBetween(1, 10);
             // make approximately half of the buckets empty
             if (randomBoolean())
-                valueCounts_empty_rnd[i] = 0l;
+                valueCounts_empty_rnd[i] = 0L;
             for (int docs = 0; docs < valueCounts_empty_rnd[i]; docs++) {
                 builders.add(client().prepareIndex("empty_bucket_idx_rnd", "type").setSource(newDocBuilder(i)));
                 numDocsEmptyIdx_rnd++;
@@ -411,7 +411,7 @@ public class DerivativeIT extends ESIntegTestCase {
                 .setQuery(matchAllQuery())
                 .addAggregation(
                         histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1)
-                                .extendedBounds(0l, (long) numBuckets_empty_rnd - 1)
+                                .extendedBounds(0L, (long) numBuckets_empty_rnd - 1)
                                 .subAggregation(derivative("deriv").setBucketsPaths("_count").gapPolicy(randomFrom(GapPolicy.values()))))
                 .execute().actionGet();
 
@@ -550,7 +550,7 @@ public class DerivativeIT extends ESIntegTestCase {
                 .setQuery(matchAllQuery())
                 .addAggregation(
                         histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1)
-                                .extendedBounds(0l, (long) numBuckets_empty_rnd - 1)
+                                .extendedBounds(0L, (long) numBuckets_empty_rnd - 1)
                                 .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
                                 .subAggregation(derivative("deriv").setBucketsPaths("sum").gapPolicy(gapPolicy))).execute().actionGet();
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
@@ -212,7 +212,7 @@ public class ExtendedStatsBucketIT extends ESIntegTestCase {
             Terms.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0l));
+            assertThat(bucket.getDocCount(), greaterThan(0L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             count++;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/MaxBucketIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/MaxBucketIT.java
@@ -203,7 +203,7 @@ public class MaxBucketIT extends ESIntegTestCase {
             Terms.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0l));
+            assertThat(bucket.getDocCount(), greaterThan(0L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             if (sum.value() > maxValue) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/MinBucketIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/MinBucketIT.java
@@ -200,7 +200,7 @@ public class MinBucketIT extends ESIntegTestCase {
             Terms.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0l));
+            assertThat(bucket.getDocCount(), greaterThan(0L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             if (sum.value() < minValue) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -203,7 +203,7 @@ public class PercentilesBucketIT extends ESIntegTestCase {
             Terms.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0l));
+            assertThat(bucket.getDocCount(), greaterThan(0L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             values[i] = sum.value();
@@ -240,7 +240,7 @@ public class PercentilesBucketIT extends ESIntegTestCase {
             Terms.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0l));
+            assertThat(bucket.getDocCount(), greaterThan(0L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             values[i] = sum.value();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/StatsBucketIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/StatsBucketIT.java
@@ -204,7 +204,7 @@ public class StatsBucketIT extends ESIntegTestCase {
             Terms.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0l));
+            assertThat(bucket.getDocCount(), greaterThan(0L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             count++;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/SumBucketIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/SumBucketIT.java
@@ -182,7 +182,7 @@ public class SumBucketIT extends ESIntegTestCase {
             Terms.Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0l));
+            assertThat(bucket.getDocCount(), greaterThan(0L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             bucketSum += sum.value();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/moving/avg/MovAvgIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/moving/avg/MovAvgIT.java
@@ -686,7 +686,7 @@ public class MovAvgIT extends ESIntegTestCase {
             Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((long) bucket.getKey(), equalTo((long) i - 10));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Avg avgAgg = bucket.getAggregations().get("avg");
             assertThat(avgAgg, notNullValue());
             assertThat(avgAgg.value(), equalTo(10d));
@@ -699,7 +699,7 @@ public class MovAvgIT extends ESIntegTestCase {
             Bucket bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((long) bucket.getKey(), equalTo((long) i - 10));
-            assertThat(bucket.getDocCount(), equalTo(0l));
+            assertThat(bucket.getDocCount(), equalTo(0L));
             Avg avgAgg = bucket.getAggregations().get("avg");
             assertThat(avgAgg, nullValue());
             SimpleValue movAvgAgg = bucket.getAggregations().get("movavg_values");
@@ -919,7 +919,7 @@ public class MovAvgIT extends ESIntegTestCase {
         Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat((long) bucket.getKey(), equalTo((long) 0));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         Avg avgAgg = bucket.getAggregations().get("avg");
         assertThat(avgAgg, notNullValue());
@@ -938,7 +938,7 @@ public class MovAvgIT extends ESIntegTestCase {
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat((long) bucket.getKey(), equalTo(1L));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         avgAgg = bucket.getAggregations().get("avg");
         assertThat(avgAgg, notNullValue());
@@ -959,7 +959,7 @@ public class MovAvgIT extends ESIntegTestCase {
             bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((long) bucket.getKey(), equalTo((long) i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             avgAgg = bucket.getAggregations().get("avg");
             assertThat(avgAgg, notNullValue());
@@ -983,7 +983,7 @@ public class MovAvgIT extends ESIntegTestCase {
             bucket = buckets.get(i);
             assertThat(bucket, notNullValue());
             assertThat((long) bucket.getKey(), equalTo((long) i));
-            assertThat(bucket.getDocCount(), equalTo(0l));
+            assertThat(bucket.getDocCount(), equalTo(0L));
 
             avgAgg = bucket.getAggregations().get("avg");
             assertThat(avgAgg, nullValue());

--- a/core/src/test/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
@@ -140,7 +140,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test").setSearchType(DFS_QUERY_THEN_FETCH).setQuery(termQuery("multi", "test")).setSize(60).setExplain(true).setScroll(TimeValue.timeValueSeconds(30)).get();
         while (true) {
             assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
             SearchHit[] hits = searchResponse.getHits().hits();
             if (hits.length == 0) {
                 break; // finished
@@ -164,7 +164,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test").setSearchType(DFS_QUERY_THEN_FETCH).setQuery(termQuery("multi", "test")).setSize(60).setExplain(true).addSort("age", SortOrder.ASC).setScroll(TimeValue.timeValueSeconds(30)).get();
         while (true) {
             assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
             SearchHit[] hits = searchResponse.getHits().hits();
             if (hits.length == 0) {
                 break; // finished
@@ -188,7 +188,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test").setSearchType(QUERY_THEN_FETCH).setQuery(termQuery("multi", "test")).setSize(60).setExplain(true).addSort("nid", SortOrder.DESC).setScroll(TimeValue.timeValueSeconds(30)).get();
         while (true) {
             assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
             SearchHit[] hits = searchResponse.getHits().hits();
             if (hits.length == 0) {
                 break; // finished
@@ -216,7 +216,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source.from(0).size(60)).searchType(QUERY_THEN_FETCH)).actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
         assertThat(searchResponse.getHits().hits().length, equalTo(60));
         for (int i = 0; i < 60; i++) {
             SearchHit hit = searchResponse.getHits().hits()[i];
@@ -224,7 +224,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         }
         searchResponse = client().search(searchRequest("test").source(source.from(60).size(60)).searchType(QUERY_THEN_FETCH)).actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
         assertThat(searchResponse.getHits().hits().length, equalTo(40));
         for (int i = 0; i < 40; i++) {
             SearchHit hit = searchResponse.getHits().hits()[i];
@@ -240,7 +240,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(termQuery("multi", "test")).setSize(60).setExplain(true).addSort("age", SortOrder.ASC).setScroll(TimeValue.timeValueSeconds(30)).get();
         while (true) {
             assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
             SearchHit[] hits = searchResponse.getHits().hits();
             if (hits.length == 0) {
                 break; // finished
@@ -271,7 +271,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(QUERY_AND_FETCH).scroll(new Scroll(timeValueMinutes(10)))).actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
         assertThat(searchResponse.getHits().hits().length, equalTo(60)); // 20 per shard
         for (int i = 0; i < 60; i++) {
             SearchHit hit = searchResponse.getHits().hits()[i];
@@ -284,7 +284,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
         do {
             searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll("10m").get();
-            assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
             assertThat(searchResponse.getHits().hits().length, lessThanOrEqualTo(40));
             for (int i = 0; i < searchResponse.getHits().hits().length; i++) {
                 SearchHit hit = searchResponse.getHits().hits()[i];
@@ -312,7 +312,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         //SearchResponse searchResponse = client().search(searchRequest("test").source(source).searchType(DFS_QUERY_AND_FETCH).scroll(new Scroll(timeValueMinutes(10)))).actionGet();
         SearchResponse searchResponse = client().prepareSearch("test").setSearchType(DFS_QUERY_AND_FETCH).setScroll("10m").setSource(source).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
         assertThat(searchResponse.getHits().hits().length, equalTo(60)); // 20 per shard
         for (int i = 0; i < 60; i++) {
             SearchHit hit = searchResponse.getHits().hits()[i];
@@ -325,7 +325,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
         do {
             searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll("10m").get();
 
-            assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
             assertThat(searchResponse.getHits().hits().length, lessThanOrEqualTo(40));
             for (int i = 0; i < searchResponse.getHits().hits().length; i++) {
                 SearchHit hit = searchResponse.getHits().hits()[i];
@@ -349,13 +349,13 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().search(searchRequest("test").source(sourceBuilder)).actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(100l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(100L));
 
         Global global = searchResponse.getAggregations().get("global");
         Filter all = global.getAggregations().get("all");
         Filter test1 = searchResponse.getAggregations().get("test1");
-        assertThat(test1.getDocCount(), equalTo(1l));
-        assertThat(all.getDocCount(), equalTo(100l));
+        assertThat(test1.getDocCount(), equalTo(1L));
+        assertThat(all.getDocCount(), equalTo(100L));
     }
 
     public void testFailedSearchWithWrongQuery() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/child/ChildQuerySearchIT.java
@@ -136,33 +136,33 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                                         boolQuery().must(termQuery("c_field", "c_value1"))
                                                 .filter(hasChildQuery("grandchild", termQuery("gc_field", "gc_value1")))))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(boolQuery().must(matchAllQuery()).filter(hasParentQuery("parent", termQuery("p_field", "p_value1")))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("c1"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(boolQuery().must(matchAllQuery()).filter(hasParentQuery("child", termQuery("c_field", "c_value1")))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("gc1"));
 
         searchResponse = client().prepareSearch("test").setQuery(hasParentQuery("parent", termQuery("p_field", "p_value1"))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("c1"));
 
         searchResponse = client().prepareSearch("test").setQuery(hasParentQuery("child", termQuery("c_field", "c_value1"))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("gc1"));
     }
 
@@ -180,7 +180,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("test", matchQuery("foo", 1))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
 
     }
@@ -204,14 +204,14 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(idsQuery("child").addIds("c1")).fields("_parent").execute()
                 .actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("c1"));
         assertThat(searchResponse.getHits().getAt(0).field("_parent").value().toString(), equalTo("p1"));
 
         // TEST matching on parent
         searchResponse = client().prepareSearch("test").setQuery(termQuery("_parent#parent", "p1")).fields("_parent").get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("c1"), equalTo("c2")));
         assertThat(searchResponse.getHits().getAt(0).field("_parent").value().toString(), equalTo("p1"));
         assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("c1"), equalTo("c2")));
@@ -219,7 +219,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("_parent#parent:p1")).fields("_parent").get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("c1"), equalTo("c2")));
         assertThat(searchResponse.getHits().getAt(0).field("_parent").value().toString(), equalTo("p1"));
         assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("c1"), equalTo("c2")));
@@ -228,17 +228,17 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         // HAS CHILD
         searchResponse = client().prepareSearch("test").setQuery(randomHasChild("child", "c_field", "yellow"))
                 .get();
-        assertHitCount(searchResponse, 1l);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertHitCount(searchResponse, 1L);
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
 
         searchResponse = client().prepareSearch("test").setQuery(randomHasChild("child", "c_field", "blue")).execute()
                 .actionGet();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p2"));
 
         searchResponse = client().prepareSearch("test").setQuery(randomHasChild("child", "c_field", "red")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("p2"), equalTo("p1")));
         assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("p2"), equalTo("p1")));
 
@@ -246,13 +246,13 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomHasParent("parent", "p_field", "p_value2")).get();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("c3"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("c4"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomHasParent("parent", "p_field", "p_value1")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("c1"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("c2"));
     }
@@ -372,18 +372,18 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", termQuery("c_field", "yellow"))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
 
         searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", termQuery("c_field", "blue"))).execute()
                 .actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p2"));
 
         searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", termQuery("c_field", "red"))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("p2"), equalTo("p1")));
         assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("p2"), equalTo("p1")));
 
@@ -392,19 +392,19 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "yellow")))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
 
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "blue"))))
                 .get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p2"));
 
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "red"))))
                 .get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("p2"), equalTo("p1")));
         assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("p2"), equalTo("p1")));
     }
@@ -432,7 +432,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                         AggregationBuilders.filter("filter").filter(boolQuery().should(termQuery("c_field", "red")).should(termQuery("c_field", "yellow"))).subAggregation(
                                 AggregationBuilders.terms("facet1").field("c_field")))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().getAt(0).id(), anyOf(equalTo("p2"), equalTo("p1")));
         assertThat(searchResponse.getHits().getAt(1).id(), anyOf(equalTo("p2"), equalTo("p1")));
 
@@ -464,7 +464,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "yellow")))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
         assertThat(searchResponse.getHits().getAt(0).sourceAsString(), containsString("\"p_value1\""));
 
@@ -476,7 +476,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "yellow")))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
         assertThat(searchResponse.getHits().getAt(0).sourceAsString(), containsString("\"p_value1_updated\""));
     }
@@ -523,12 +523,12 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(boolQuery().must(matchAllQuery()).filter(hasChildQuery("child", matchAllQuery()))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(boolQuery().must(matchAllQuery()).filter(hasParentQuery("parent", matchAllQuery()))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testCountApiUsage() throws Exception {
@@ -544,19 +544,19 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         SearchResponse countResponse = client().prepareSearch("test").setSize(0).setQuery(hasChildQuery("child", termQuery("c_field", "1")).scoreMode(ScoreMode.Max))
                 .get();
-        assertHitCount(countResponse, 1l);
+        assertHitCount(countResponse, 1L);
 
         countResponse = client().prepareSearch("test").setSize(0).setQuery(hasParentQuery("parent", termQuery("p_field", "1")).score(true))
                 .get();
-        assertHitCount(countResponse, 1l);
+        assertHitCount(countResponse, 1L);
 
         countResponse = client().prepareSearch("test").setSize(0).setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "1"))))
                 .get();
-        assertHitCount(countResponse, 1l);
+        assertHitCount(countResponse, 1L);
 
         countResponse = client().prepareSearch("test").setSize(0).setQuery(constantScoreQuery(hasParentQuery("parent", termQuery("p_field", "1"))))
                 .get();
-        assertHitCount(countResponse, 1l);
+        assertHitCount(countResponse, 1L);
     }
 
     public void testExplainUsage() throws Exception {
@@ -574,14 +574,14 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                 .setExplain(true)
                 .setQuery(hasChildQuery("child", termQuery("c_field", "1")).scoreMode(ScoreMode.Max))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).explanation().getDescription(), equalTo("Score based on join value p1"));
 
         searchResponse = client().prepareSearch("test")
                 .setExplain(true)
                 .setQuery(hasParentQuery("parent", termQuery("p_field", "1")).score(true))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).explanation().getDescription(), equalTo("Score based on join value p1"));
 
         ExplainResponse explainResponse = client().prepareExplain("test", "parent", parentId)
@@ -664,7 +664,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                                         fieldValueFactorFunction("c_field1"))
                                         .boostMode(CombineFunction.REPLACE)).scoreMode(ScoreMode.Total)).get();
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("1"));
         assertThat(response.getHits().hits()[0].score(), equalTo(6f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -681,7 +681,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                                         fieldValueFactorFunction("c_field1"))
                                         .boostMode(CombineFunction.REPLACE)).scoreMode(ScoreMode.Max)).get();
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(4f));
         assertThat(response.getHits().hits()[1].id(), equalTo("2"));
@@ -698,7 +698,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                                         fieldValueFactorFunction("c_field1"))
                                         .boostMode(CombineFunction.REPLACE)).scoreMode(ScoreMode.Avg)).get();
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(4f));
         assertThat(response.getHits().hits()[1].id(), equalTo("2"));
@@ -716,7 +716,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                                         .boostMode(CombineFunction.REPLACE)).score(true))
                 .addSort(SortBuilders.fieldSort("c_field3")).addSort(SortBuilders.scoreSort()).get();
 
-        assertThat(response.getHits().totalHits(), equalTo(7l));
+        assertThat(response.getHits().totalHits(), equalTo(7L));
         assertThat(response.getHits().hits()[0].id(), equalTo("13"));
         assertThat(response.getHits().hits()[0].score(), equalTo(5f));
         assertThat(response.getHits().hits()[1].id(), equalTo("14"));
@@ -743,28 +743,28 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("test")
                 .setQuery(QueryBuilders.hasChildQuery("child", matchQuery("text", "value"))).get();
         assertNoFailures(response);
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
 
         client().prepareIndex("test", "child1").setSource(jsonBuilder().startObject().field("text", "value").endObject()).setRefresh(true)
                 .get();
 
         response = client().prepareSearch("test").setQuery(QueryBuilders.hasChildQuery("child", matchQuery("text", "value"))).get();
         assertNoFailures(response);
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
 
         response = client().prepareSearch("test").setQuery(QueryBuilders.hasChildQuery("child", matchQuery("text", "value")).scoreMode(ScoreMode.Max))
                 .get();
         assertNoFailures(response);
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
 
         response = client().prepareSearch("test").setQuery(QueryBuilders.hasParentQuery("child", matchQuery("text", "value"))).get();
         assertNoFailures(response);
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
 
         response = client().prepareSearch("test").setQuery(QueryBuilders.hasParentQuery("child", matchQuery("text", "value")).score(true))
                 .get();
         assertNoFailures(response);
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
     }
 
     public void testHasChildAndHasParentFilter_withFilter() throws Exception {
@@ -783,13 +783,13 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(boolQuery().must(matchAllQuery()).filter(hasChildQuery("child", termQuery("c_field", 1)))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits()[0].id(), equalTo("1"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(boolQuery().must(matchAllQuery()).filter(hasParentQuery("parent", termQuery("p_field", 1)))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits()[0].id(), equalTo("2"));
     }
 
@@ -888,7 +888,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(hasChildQuery("child", termQuery("c_field", "yellow")).scoreMode(ScoreMode.Total)).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
         assertThat(searchResponse.getHits().getAt(0).sourceAsString(), containsString("\"p_value1\""));
 
@@ -898,7 +898,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                         boolQuery().must(matchQuery("c_field", "x")).must(
                                 hasParentQuery("parent", termQuery("p_field", "p_value2")).score(true))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("c3"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("c4"));
 
@@ -914,7 +914,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", termQuery("c_field", "yellow")).scoreMode(ScoreMode.Total))
                 .get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p1"));
         assertThat(searchResponse.getHits().getAt(0).sourceAsString(), containsString("\"p_value1\""));
 
@@ -924,7 +924,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                         boolQuery().must(matchQuery("c_field", "x")).must(
                                 hasParentQuery("parent", termQuery("p_field", "p_value2")).score(true))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().getAt(0).id(), Matchers.anyOf(equalTo("c3"), equalTo("c4")));
         assertThat(searchResponse.getHits().getAt(1).id(), Matchers.anyOf(equalTo("c3"), equalTo("c4")));
     }
@@ -949,7 +949,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                 .setMinScore(3) // Score needs to be 3 or above!
                 .get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("p2"));
         assertThat(searchResponse.getHits().getAt(0).score(), equalTo(3.0f));
     }
@@ -1038,7 +1038,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                 .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "blue"))))
                 .get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         client().prepareIndex("test", "child", "c2").setParent("p2").setSource("c_field", "blue").get();
         client().admin().indices().prepareRefresh("test").get();
@@ -1047,7 +1047,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                 .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "blue"))))
                 .get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
     }
 
     private QueryBuilder randomHasChild(String type, String field, String value) {
@@ -1107,7 +1107,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                         )
                 )
         ).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("grandissue").setQuery(
                 boolQuery().must(
@@ -1124,7 +1124,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                         )
                 )
         ).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testIndexChildDocWithNoParentMapping() throws IOException {
@@ -1206,13 +1206,13 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                 .setQuery(boolQuery().must(QueryBuilders.hasChildQuery("child", termQuery("c_field", "blue")).scoreMode(scoreMode)).filter(boolQuery().mustNot(termQuery("p_field", "3"))))
                 .get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(boolQuery().must(QueryBuilders.hasChildQuery("child", termQuery("c_field", "red")).scoreMode(scoreMode)).filter(boolQuery().mustNot(termQuery("p_field", "3"))))
                 .get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
     }
 
     public void testNamedFilters() throws Exception {
@@ -1228,25 +1228,25 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(hasChildQuery("child", termQuery("c_field", "1")).scoreMode(ScoreMode.Max).queryName("test"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("test"));
 
         searchResponse = client().prepareSearch("test").setQuery(hasParentQuery("parent", termQuery("p_field", "1")).score(true).queryName("test"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("test"));
 
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "1")).queryName("test")))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("test"));
 
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(hasParentQuery("parent", termQuery("p_field", "1")).queryName("test")))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("test"));
     }
@@ -1363,7 +1363,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                             .must(QueryBuilders.hasChildQuery("child", matchQuery("c_field", "red")))
                             .must(matchAllQuery())))
                     .get();
-            assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+            assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         }
 
 
@@ -1376,7 +1376,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                         .must(matchAllQuery())))
                 .get();
 
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testParentChildQueriesViaScrollApi() throws Exception {
@@ -1408,10 +1408,10 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                     .actionGet();
 
             assertNoFailures(scrollResponse);
-            assertThat(scrollResponse.getHits().totalHits(), equalTo(10l));
+            assertThat(scrollResponse.getHits().totalHits(), equalTo(10L));
             int scannedDocs = 0;
             do {
-                assertThat(scrollResponse.getHits().totalHits(), equalTo(10l));
+                assertThat(scrollResponse.getHits().totalHits(), equalTo(10L));
                 scannedDocs += scrollResponse.getHits().getHits().length;
                 scrollResponse = client()
                         .prepareSearchScroll(scrollResponse.getScrollId())
@@ -1456,7 +1456,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
                 .setQuery(multiMatchQuery("1", "_parent#type1"))
                 .get();
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
     }
 
@@ -1475,22 +1475,22 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(hasParentQuery("parent", boolQuery().mustNot(termQuery("field1", "a")))))
                 .get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(hasParentQuery("parent", constantScoreQuery(boolQuery().mustNot(termQuery("field1", "a")))))
                 .get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(hasParentQuery("parent", termQuery("field1", "a"))))
                 .get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(hasParentQuery("parent", constantScoreQuery(termQuery("field1", "a"))))
                 .get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
     }
 
     private List<IndexRequestBuilder> createMinMaxDocBuilders() {
@@ -1562,7 +1562,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         // Score mode = NONE
         response = minMaxQuery(ScoreMode.None, 0, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("2"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1572,7 +1572,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.None, 1, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("2"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1582,7 +1582,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.None, 2, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
         assertThat(response.getHits().hits()[1].id(), equalTo("4"));
@@ -1590,17 +1590,17 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.None, 3, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
 
         response = minMaxQuery(ScoreMode.None, 4, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
 
         response = minMaxQuery(ScoreMode.None, 0, 4);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("2"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1610,7 +1610,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.None, 0, 3);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("2"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1620,7 +1620,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.None, 0, 2);
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("2"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1628,7 +1628,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.None, 2, 2);
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1f));
 
@@ -1642,7 +1642,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         // Score mode = SUM
         response = minMaxQuery(ScoreMode.Total, 0, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(6f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1652,7 +1652,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Total, 1, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(6f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1662,7 +1662,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Total, 2, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(6f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1670,17 +1670,17 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Total, 3, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(6f));
 
         response = minMaxQuery(ScoreMode.Total, 4, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
 
         response = minMaxQuery(ScoreMode.Total, 0, 4);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(6f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1690,7 +1690,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Total, 0, 3);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(6f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1700,7 +1700,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Total, 0, 2);
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
         assertThat(response.getHits().hits()[1].id(), equalTo("2"));
@@ -1708,7 +1708,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Total, 2, 2);
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
 
@@ -1722,7 +1722,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         // Score mode = MAX
         response = minMaxQuery(ScoreMode.Max, 0, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1732,7 +1732,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Max, 1, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1742,7 +1742,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Max, 2, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1750,17 +1750,17 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Max, 3, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
 
         response = minMaxQuery(ScoreMode.Max, 4, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
 
         response = minMaxQuery(ScoreMode.Max, 0, 4);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1770,7 +1770,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Max, 0, 3);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(3f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1780,7 +1780,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Max, 0, 2);
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
         assertThat(response.getHits().hits()[1].id(), equalTo("2"));
@@ -1788,7 +1788,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Max, 2, 2);
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
 
@@ -1802,7 +1802,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
         // Score mode = AVG
         response = minMaxQuery(ScoreMode.Avg, 0, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1812,7 +1812,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Avg, 1, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1822,7 +1822,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Avg, 2, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1830,17 +1830,17 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Avg, 3, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
 
         response = minMaxQuery(ScoreMode.Avg, 4, 0);
 
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
 
         response = minMaxQuery(ScoreMode.Avg, 0, 4);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1850,7 +1850,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Avg, 0, 3);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().hits()[0].id(), equalTo("4"));
         assertThat(response.getHits().hits()[0].score(), equalTo(2f));
         assertThat(response.getHits().hits()[1].id(), equalTo("3"));
@@ -1860,7 +1860,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Avg, 0, 2);
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1.5f));
         assertThat(response.getHits().hits()[1].id(), equalTo("2"));
@@ -1868,7 +1868,7 @@ public class ChildQuerySearchIT extends ESIntegTestCase {
 
         response = minMaxQuery(ScoreMode.Avg, 2, 2);
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().hits()[0].id(), equalTo("3"));
         assertThat(response.getHits().hits()[0].score(), equalTo(1.5f));
 

--- a/core/src/test/java/org/elasticsearch/search/child/ParentFieldLoadingIT.java
+++ b/core/src/test/java/org/elasticsearch/search/child/ParentFieldLoadingIT.java
@@ -73,7 +73,7 @@ public class ParentFieldLoadingIT extends ESIntegTestCase {
         refresh();
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), equalTo(0L));
 
         logger.info("testing default loading...");
         assertAcked(client().admin().indices().prepareDelete("test").get());
@@ -88,7 +88,7 @@ public class ParentFieldLoadingIT extends ESIntegTestCase {
         refresh();
 
         response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), equalTo(0L));
 
         logger.info("testing eager loading...");
         assertAcked(client().admin().indices().prepareDelete("test").get());
@@ -103,7 +103,7 @@ public class ParentFieldLoadingIT extends ESIntegTestCase {
         refresh();
 
         response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), equalTo(0L));
 
         logger.info("testing eager global ordinals loading...");
         assertAcked(client().admin().indices().prepareDelete("test").get());
@@ -121,7 +121,7 @@ public class ParentFieldLoadingIT extends ESIntegTestCase {
         refresh();
 
         response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
     }
 
     public void testChangingEagerParentFieldLoadingAtRuntime() throws Exception {
@@ -136,7 +136,7 @@ public class ParentFieldLoadingIT extends ESIntegTestCase {
         refresh();
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), equalTo(0l));
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), equalTo(0L));
 
         PutMappingResponse putMappingResponse = client().admin().indices().preparePutMapping("test").setType("child")
                 .setSource(childMapping(MappedFieldType.Loading.EAGER_GLOBAL_ORDINALS))
@@ -169,7 +169,7 @@ public class ParentFieldLoadingIT extends ESIntegTestCase {
         client().prepareIndex("test", "dummy", "dummy").setSource("{}").get();
         refresh();
         response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0l));
+        assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
     }
 
     private XContentBuilder childMapping(MappedFieldType.Loading loading) throws IOException {

--- a/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -80,7 +80,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
 
         ElasticsearchAssertions.assertNoFailures(response);
         SearchHits hits = response.getHits();
-        assertThat(hits.getTotalHits(), equalTo(20l));
+        assertThat(hits.getTotalHits(), equalTo(20L));
         int idCounter = 19;
         for (SearchHit hit : hits.getHits()) {
             assertThat(hit.getId(), equalTo(Integer.toString(idCounter)));

--- a/core/src/test/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -119,7 +119,7 @@ public class QueryRescorerIT extends ESIntegTestCase {
                         RescoreBuilder.queryRescorer(QueryBuilders.matchPhraseQuery("field1", "quick brown").slop(2).boost(4.0f))
                                 .setRescoreQueryWeight(2), 5).execute().actionGet();
 
-        assertThat(searchResponse.getHits().totalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getHits()[0].getId(), equalTo("1"));
         assertThat(searchResponse.getHits().getHits()[1].getId(), equalTo("3"));
         assertThat(searchResponse.getHits().getHits()[2].getId(), equalTo("2"));

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoBoundingBoxIT.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoBoundingBoxIT.java
@@ -109,7 +109,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch() // from NY
                 .setQuery(geoBoundingBoxQuery("location").setCorners(40.73, -74.1, 40.717, -73.99))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().hits().length, equalTo(2));
         for (SearchHit hit : searchResponse.getHits()) {
             assertThat(hit.id(), anyOf(equalTo("1"), equalTo("3"), equalTo("5")));
@@ -118,7 +118,7 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch() // from NY
                 .setQuery(geoBoundingBoxQuery("location").setCorners(40.73, -74.1, 40.717, -73.99).type("indexed"))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().hits().length, equalTo(2));
         for (SearchHit hit : searchResponse.getHits()) {
             assertThat(hit.id(), anyOf(equalTo("1"), equalTo("3"), equalTo("5")));
@@ -182,52 +182,52 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(geoBoundingBoxQuery("location").setCorners(41, -11, 40, 9))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("2"));
         searchResponse = client().prepareSearch()
                 .setQuery(geoBoundingBoxQuery("location").setCorners(41, -11, 40, 9).type("indexed"))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("2"));
 
         searchResponse = client().prepareSearch()
                 .setQuery(geoBoundingBoxQuery("location").setCorners(41, -9, 40, 11))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("3"));
         searchResponse = client().prepareSearch()
                 .setQuery(geoBoundingBoxQuery("location").setCorners(41, -9, 40, 11).type("indexed"))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("3"));
 
         searchResponse = client().prepareSearch()
                 .setQuery(geoBoundingBoxQuery("location").setCorners(11, 171, 1, -169))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("5"));
         searchResponse = client().prepareSearch()
                 .setQuery(geoBoundingBoxQuery("location").setCorners(11, 171, 1, -169).type("indexed"))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("5"));
 
         searchResponse = client().prepareSearch()
                 .setQuery(geoBoundingBoxQuery("location").setCorners(9, 169, -1, -171))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("9"));
         searchResponse = client().prepareSearch()
                 .setQuery(geoBoundingBoxQuery("location").setCorners(9, 169, -1, -171).type("indexed"))
                 .execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("9"));
     }
@@ -265,26 +265,26 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
                         boolQuery().must(termQuery("userid", 880)).filter(
                                 geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch()
                 .setQuery(
                         boolQuery().must(termQuery("userid", 880)).filter(
                                 geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875).type("indexed"))
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch()
                 .setQuery(
                         boolQuery().must(termQuery("userid", 534)).filter(
                                 geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch()
                 .setQuery(
                         boolQuery().must(termQuery("userid", 534)).filter(
                                 geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875).type("indexed"))
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testCompleteLonRange() throws Exception {
@@ -319,43 +319,43 @@ public class GeoBoundingBoxIT extends ESIntegTestCase {
                 .setQuery(
                         geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, -180, -50, 180)
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch()
                 .setQuery(
                         geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, -180, -50, 180).type("indexed")
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch()
                 .setQuery(
                         geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, -180, -90, 180)
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         searchResponse = client().prepareSearch()
                 .setQuery(
                         geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, -180, -90, 180).type("indexed")
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
 
         searchResponse = client().prepareSearch()
                 .setQuery(
                         geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, 0, -50, 360)
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch()
                 .setQuery(
                         geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(50, 0, -50, 360).type("indexed")
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch()
                 .setQuery(
                         geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360)
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         searchResponse = client().prepareSearch()
                 .setQuery(
                         geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360).type("indexed")
                 ).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
     }
 }
 

--- a/core/src/test/java/org/elasticsearch/search/geo/GeoShapeQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/search/geo/GeoShapeQueryTests.java
@@ -104,7 +104,7 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
                 .execute().actionGet();
 
         assertSearchResponse(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
 
@@ -113,7 +113,7 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
                 .execute().actionGet();
 
         assertSearchResponse(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
     }
@@ -150,7 +150,7 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
                 .execute().actionGet();
 
         assertSearchResponse(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("blakely"));
     }
@@ -183,7 +183,7 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
                 .execute().actionGet();
 
         assertSearchResponse(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
 
@@ -192,7 +192,7 @@ public class GeoShapeQueryTests extends ESSingleNodeTestCase {
                 .execute().actionGet();
 
         assertSearchResponse(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
     }

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
@@ -1659,7 +1659,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .get();
         // Highlighting of numeric fields is not supported, but it should not raise errors
         // (this behavior is consistent with version 0.20)
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
     }
 
     // Issue #3200
@@ -1680,7 +1680,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .setQuery(QueryBuilders.matchQuery("text", "test").type(MatchQuery.Type.BOOLEAN))
                 .highlighter(new HighlightBuilder().field("text")).execute().actionGet();
         // PatternAnalyzer will throw an exception if it is resetted twice
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
     }
 
     public void testHighlightUsesHighlightQuery() throws IOException {
@@ -2118,7 +2118,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                         .field(new HighlightBuilder.Field("field1").numOfFragments(0).preTags("<field1>").postTags("</field1>")));
 
         searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         for (SearchHit searchHit : searchResponse.getHits()) {
             if ("1".equals(searchHit.id())) {
@@ -2167,7 +2167,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                             .field(new Field("field1").requireFieldMatch(true).preTags("<field1>").postTags("</field1>")));
             logger.info("Running multi-match type: [" + matchQueryType + "] highlight with type: [" + highlighterType + "]");
             SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-            assertHitCount(searchResponse, 1l);
+            assertHitCount(searchResponse, 1L);
             assertHighlight(searchResponse, 0, "field1", 0, anyOf(equalTo("<field1>The quick brown fox</field1> jumps over"),
                     equalTo("<field1>The</field1> <field1>quick</field1> <field1>brown</field1> <field1>fox</field1> jumps over")));
         }
@@ -2240,7 +2240,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .setQuery(matchQuery("title", "This is a Test"))
 .highlighter(new HighlightBuilder().field("title")).get();
 
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         SearchHit hit = searchResponse.getHits().getAt(0);
         //stopwords are not highlighted since not indexed
         assertHighlight(hit, "title", 0, 1, equalTo("this is a <em>test</em> ."));
@@ -2249,7 +2249,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(matchQuery("title.key", "this is a test"))
                 .highlighter(new HighlightBuilder().field("title.key")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         //stopwords are now highlighted since we used only whitespace analyzer here
         assertHighlight(searchResponse, 0, "title.key", 0, 1, equalTo("<em>this</em> <em>is</em> <em>a</em> <em>test</em> ."));
@@ -2349,7 +2349,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         SearchSourceBuilder source = searchSource().query(commonTermsQuery("field2", "quick brown").cutoffFrequency(100))
                 .highlighter(highlight().field("field2").preTags("<x>").postTags("</x>"));
         SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog!"));
     }
@@ -2423,7 +2423,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         source = searchSource().query(wildcardQuery("field2", "qu*k"))
                 .highlighter(highlight().field("field2"));
         searchResponse = client().prepareSearch("test").setSource(source).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         assertHighlight(searchResponse, 0, "field2", 0, 1, equalTo("The <em>quick</em> brown fox jumps over the lazy dog!"));
     }

--- a/core/src/test/java/org/elasticsearch/search/indicesboost/SimpleIndicesBoostSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/indicesboost/SimpleIndicesBoostSearchIT.java
@@ -63,7 +63,7 @@ public class SimpleIndicesBoostSearchIT extends ESIntegTestCase {
                 .source(searchSource().explain(true).indexBoost("test1", indexBoost).query(termQuery("test", "value")))
         ).actionGet();
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         logger.info("Hit[0] {} Explanation {}", response.getHits().getAt(0).index(), response.getHits().getAt(0).explanation());
         logger.info("Hit[1] {} Explanation {}", response.getHits().getAt(1).index(), response.getHits().getAt(1).explanation());
         assertThat(response.getHits().getAt(0).index(), equalTo("test1"));
@@ -75,7 +75,7 @@ public class SimpleIndicesBoostSearchIT extends ESIntegTestCase {
                 .source(searchSource().explain(true).indexBoost("test2", indexBoost).query(termQuery("test", "value")))
         ).actionGet();
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         logger.info("Hit[0] {} Explanation {}", response.getHits().getAt(0).index(), response.getHits().getAt(0).explanation());
         logger.info("Hit[1] {} Explanation {}", response.getHits().getAt(1).index(), response.getHits().getAt(1).explanation());
         assertThat(response.getHits().getAt(0).index(), equalTo("test2"));
@@ -89,7 +89,7 @@ public class SimpleIndicesBoostSearchIT extends ESIntegTestCase {
                 .source(searchSource().explain(true).indexBoost("test1", indexBoost).query(termQuery("test", "value")))
         ).actionGet();
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         logger.info("Hit[0] {} Explanation {}", response.getHits().getAt(0).index(), response.getHits().getAt(0).explanation());
         logger.info("Hit[1] {} Explanation {}", response.getHits().getAt(1).index(), response.getHits().getAt(1).explanation());
         assertThat(response.getHits().getAt(0).index(), equalTo("test1"));
@@ -101,7 +101,7 @@ public class SimpleIndicesBoostSearchIT extends ESIntegTestCase {
                 .source(searchSource().explain(true).indexBoost("test2", indexBoost).query(termQuery("test", "value")))
         ).actionGet();
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         logger.info("Hit[0] {} Explanation {}", response.getHits().getAt(0).index(), response.getHits().getAt(0).explanation());
         logger.info("Hit[1] {} Explanation {}", response.getHits().getAt(1).index(), response.getHits().getAt(1).explanation());
         assertThat(response.getHits().getAt(0).index(), equalTo("test2"));

--- a/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/innerhits/InnerHitsIT.java
@@ -128,7 +128,7 @@ public class InnerHitsIT extends ESIntegTestCase {
             assertSearchHit(response, 1, hasId("1"));
             assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
             SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.totalHits(), equalTo(2l));
+            assertThat(innerHits.totalHits(), equalTo(2L));
             assertThat(innerHits.getHits().length, equalTo(2));
             assertThat(innerHits.getAt(0).getId(), equalTo("1"));
             assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
@@ -160,7 +160,7 @@ public class InnerHitsIT extends ESIntegTestCase {
             assertThat(response.getHits().getAt(0).getShard(), notNullValue());
             assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
             SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.totalHits(), equalTo(3l));
+            assertThat(innerHits.totalHits(), equalTo(3L));
             assertThat(innerHits.getHits().length, equalTo(3));
             assertThat(innerHits.getAt(0).getId(), equalTo("2"));
             assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
@@ -198,7 +198,7 @@ public class InnerHitsIT extends ESIntegTestCase {
             SearchResponse response = client().search(searchRequest).actionGet();
             assertNoFailures(response);
             SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comments");
-            assertThat(innerHits.getTotalHits(), equalTo(2l));
+            assertThat(innerHits.getTotalHits(), equalTo(2L));
             assertThat(innerHits.getHits().length, equalTo(1));
             assertThat(innerHits.getAt(0).getHighlightFields().get("comments.message").getFragments()[0].string(), equalTo("<em>fox</em> eat quick"));
             assertThat(innerHits.getAt(0).explanation().toString(), containsString("weight(comments.message:fox in"));
@@ -320,7 +320,7 @@ public class InnerHitsIT extends ESIntegTestCase {
 
             assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
             SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.totalHits(), equalTo(2l));
+            assertThat(innerHits.totalHits(), equalTo(2L));
 
             assertThat(innerHits.getAt(0).getId(), equalTo("1"));
             assertThat(innerHits.getAt(0).type(), equalTo("comment"));
@@ -347,7 +347,7 @@ public class InnerHitsIT extends ESIntegTestCase {
 
             assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
             SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.totalHits(), equalTo(3l));
+            assertThat(innerHits.totalHits(), equalTo(3L));
 
             assertThat(innerHits.getAt(0).getId(), equalTo("4"));
             assertThat(innerHits.getAt(0).type(), equalTo("comment"));
@@ -530,14 +530,14 @@ public class InnerHitsIT extends ESIntegTestCase {
         SearchHit searchHit = response.getHits().getAt(0);
         assertThat(searchHit.getId(), equalTo("1"));
         assertThat(searchHit.getType(), equalTo("answer"));
-        assertThat(searchHit.getInnerHits().get("question").getTotalHits(), equalTo(1l));
+        assertThat(searchHit.getInnerHits().get("question").getTotalHits(), equalTo(1L));
         assertThat(searchHit.getInnerHits().get("question").getAt(0).getType(), equalTo("question"));
         assertThat(searchHit.getInnerHits().get("question").getAt(0).id(), equalTo("1"));
 
         searchHit = response.getHits().getAt(1);
         assertThat(searchHit.getId(), equalTo("2"));
         assertThat(searchHit.getType(), equalTo("answer"));
-        assertThat(searchHit.getInnerHits().get("question").getTotalHits(), equalTo(1l));
+        assertThat(searchHit.getInnerHits().get("question").getTotalHits(), equalTo(1L));
         assertThat(searchHit.getInnerHits().get("question").getAt(0).getType(), equalTo("question"));
         assertThat(searchHit.getInnerHits().get("question").getAt(0).id(), equalTo("2"));
     }
@@ -575,12 +575,12 @@ public class InnerHitsIT extends ESIntegTestCase {
 
         assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
         SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getAt(0).getId(), equalTo("1"));
         assertThat(innerHits.getAt(0).type(), equalTo("comment"));
 
         innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getAt(0).getId(), equalTo("1"));
         assertThat(innerHits.getAt(0).type(), equalTo("remark"));
 
@@ -601,12 +601,12 @@ public class InnerHitsIT extends ESIntegTestCase {
 
         assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
         innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getAt(0).getId(), equalTo("2"));
         assertThat(innerHits.getAt(0).type(), equalTo("comment"));
 
         innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getAt(0).getId(), equalTo("2"));
         assertThat(innerHits.getAt(0).type(), equalTo("remark"));
     }
@@ -668,13 +668,13 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertSearchHit(response, 1, hasId("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
         SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getHits().length, equalTo(1));
         assertThat(innerHits.getAt(0).getId(), equalTo("1"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
         innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getHits().length, equalTo(1));
         assertThat(innerHits.getAt(0).getId(), equalTo("1"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
@@ -691,7 +691,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertSearchHit(response, 1, hasId("2"));
         assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
         innerHits = response.getHits().getAt(0).getInnerHits().get("comments.remarks");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getHits().length, equalTo(1));
         assertThat(innerHits.getAt(0).getId(), equalTo("2"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
@@ -714,13 +714,13 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertSearchHit(response, 1, hasId("2"));
         assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
         innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getHits().length, equalTo(1));
         assertThat(innerHits.getAt(0).getId(), equalTo("2"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(0));
         innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-        assertThat(innerHits.totalHits(), equalTo(1l));
+        assertThat(innerHits.totalHits(), equalTo(1L));
         assertThat(innerHits.getHits().length, equalTo(1));
         assertThat(innerHits.getAt(0).getId(), equalTo("2"));
         assertThat(innerHits.getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
@@ -746,7 +746,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertNoFailures(response);
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
@@ -783,7 +783,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertNoFailures(response);
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
@@ -822,7 +822,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertNoFailures(response);
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
@@ -861,7 +861,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertNoFailures(response);
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
@@ -899,7 +899,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertNoFailures(response);
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getField().string(), equalTo("comments"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
@@ -940,7 +940,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertNoFailures(response);
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getField().string(), equalTo("comments.messages"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
@@ -952,7 +952,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertNoFailures(response);
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getField().string(), equalTo("comments.messages"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getOffset(), equalTo(1));
@@ -971,7 +971,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertNoFailures(response);
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).id(), equalTo("1"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getField().string(), equalTo("comments.messages"));
         assertThat(response.getHits().getAt(0).getInnerHits().get("comments.messages").getAt(0).getNestedIdentity().getOffset(), equalTo(0));
@@ -1024,34 +1024,34 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertThat(response.getHits().getAt(0).getId(), equalTo("duke"));
 
         SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("earls");
-        assertThat(innerHits.getTotalHits(), equalTo(4l));
+        assertThat(innerHits.getTotalHits(), equalTo(4L));
         assertThat(innerHits.getAt(0).getId(), equalTo("earl1"));
         assertThat(innerHits.getAt(1).getId(), equalTo("earl2"));
         assertThat(innerHits.getAt(2).getId(), equalTo("earl3"));
         assertThat(innerHits.getAt(3).getId(), equalTo("earl4"));
 
         SearchHits innerInnerHits = innerHits.getAt(0).getInnerHits().get("barons");
-        assertThat(innerInnerHits.totalHits(), equalTo(1l));
+        assertThat(innerInnerHits.totalHits(), equalTo(1L));
         assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron1"));
 
         innerInnerHits = innerHits.getAt(1).getInnerHits().get("barons");
-        assertThat(innerInnerHits.totalHits(), equalTo(1l));
+        assertThat(innerInnerHits.totalHits(), equalTo(1L));
         assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron2"));
 
         innerInnerHits = innerHits.getAt(2).getInnerHits().get("barons");
-        assertThat(innerInnerHits.totalHits(), equalTo(1l));
+        assertThat(innerInnerHits.totalHits(), equalTo(1L));
         assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron3"));
 
         innerInnerHits = innerHits.getAt(3).getInnerHits().get("barons");
-        assertThat(innerInnerHits.totalHits(), equalTo(1l));
+        assertThat(innerInnerHits.totalHits(), equalTo(1L));
         assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron4"));
 
         innerHits = response.getHits().getAt(0).getInnerHits().get("princes");
-        assertThat(innerHits.getTotalHits(), equalTo(1l));
+        assertThat(innerHits.getTotalHits(), equalTo(1L));
         assertThat(innerHits.getAt(0).getId(), equalTo("prince"));
 
         innerInnerHits = innerHits.getAt(0).getInnerHits().get("kings");
-        assertThat(innerInnerHits.totalHits(), equalTo(1l));
+        assertThat(innerInnerHits.totalHits(), equalTo(1L));
         assertThat(innerInnerHits.getAt(0).getId(), equalTo("king"));
     }
 
@@ -1132,7 +1132,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         assertAllSuccessful(searchResponse);
         assertThat(searchResponse.getHits().totalHits(), equalTo((long) numDocs));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("0"));
-        assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getTotalHits(), equalTo(2L));
         assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getAt(0).getMatchedQueries()[0], equalTo("test1"));
         assertThat(searchResponse.getHits().getAt(0).getInnerHits().get("nested1").getAt(1).getMatchedQueries().length, equalTo(1));
@@ -1140,13 +1140,13 @@ public class InnerHitsIT extends ESIntegTestCase {
 
 
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("1"));
-        assertThat(searchResponse.getHits().getAt(1).getInnerHits().get("nested1").getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getAt(1).getInnerHits().get("nested1").getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(1).getInnerHits().get("nested1").getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(1).getInnerHits().get("nested1").getAt(0).getMatchedQueries()[0], equalTo("test2"));
 
         for (int i = 2; i < numDocs; i++) {
             assertThat(searchResponse.getHits().getAt(i).id(), equalTo(String.valueOf(i)));
-            assertThat(searchResponse.getHits().getAt(i).getInnerHits().get("nested1").getTotalHits(), equalTo(1l));
+            assertThat(searchResponse.getHits().getAt(i).getInnerHits().get("nested1").getTotalHits(), equalTo(1L));
             assertThat(searchResponse.getHits().getAt(i).getInnerHits().get("nested1").getAt(0).getMatchedQueries().length, equalTo(1));
             assertThat(searchResponse.getHits().getAt(i).getInnerHits().get("nested1").getAt(0).getMatchedQueries()[0], equalTo("test3"));
         }
@@ -1168,12 +1168,12 @@ public class InnerHitsIT extends ESIntegTestCase {
                 .get();
         assertHitCount(response, 2);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
 
         assertThat(response.getHits().getAt(1).id(), equalTo("2"));
-        assertThat(response.getHits().getAt(1).getInnerHits().get("child").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(1).getInnerHits().get("child").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
 
@@ -1183,7 +1183,7 @@ public class InnerHitsIT extends ESIntegTestCase {
                 .get();
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits(), equalTo(1l));
+        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
         assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name2"));
     }

--- a/core/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesIT.java
+++ b/core/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesIT.java
@@ -54,7 +54,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(boolQuery().must(matchAllQuery()).filter(boolQuery().should(rangeQuery("number").lte(2).queryName("test1")).should(rangeQuery("number").gt(2).queryName("test2")))).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1") || hit.id().equals("2")) {
                 assertThat(hit.matchedQueries().length, equalTo(1));
@@ -69,7 +69,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
 
         searchResponse = client().prepareSearch()
                 .setQuery(boolQuery().should(rangeQuery("number").lte(2).queryName("test1")).should(rangeQuery("number").gt(2).queryName("test2"))).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1") || hit.id().equals("2")) {
                 assertThat(hit.matchedQueries().length, equalTo(1));
@@ -97,7 +97,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
                 .setPostFilter(boolQuery().should(
                         termQuery("name", "test").queryName("name")).should(
                         termQuery("title", "title1").queryName("title"))).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1")) {
                 assertThat(hit.matchedQueries().length, equalTo(2));
@@ -117,7 +117,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
                         .should(termQuery("name", "test").queryName("name"))
                         .should(termQuery("title", "title1").queryName("title"))).get();
 
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1")) {
                 assertThat(hit.matchedQueries().length, equalTo(2));
@@ -144,7 +144,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(boolQuery().must(matchAllQuery()).filter(termsQuery("title", "title1", "title2", "title3").queryName("title")))
                         .setPostFilter(termQuery("name", "test").queryName("name")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1") || hit.id().equals("2") || hit.id().equals("3")) {
                 assertThat(hit.matchedQueries().length, equalTo(2));
@@ -158,7 +158,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(termsQuery("title", "title1", "title2", "title3").queryName("title"))
                 .setPostFilter(matchQuery("name", "test").queryName("name")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1") || hit.id().equals("2") || hit.id().equals("3")) {
                 assertThat(hit.matchedQueries().length, equalTo(2));
@@ -185,7 +185,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
                                 indicesQuery(termQuery("title", "title1").queryName("title1"), "test1")
                                         .noMatchQuery(termQuery("title", "title2").queryName("title2")).queryName("indices_filter")).should(
                                 termQuery("title", "title3").queryName("title3")).queryName("or"))).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1")) {
@@ -217,7 +217,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(QueryBuilders.regexpQuery("title", "title1").queryName("regex")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1")) {
@@ -238,7 +238,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(QueryBuilders.prefixQuery("title", "title").queryName("prefix")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1")) {
@@ -260,7 +260,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(QueryBuilders.fuzzyQuery("title", "titel1").queryName("fuzzy")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1")) {
@@ -281,7 +281,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(QueryBuilders.wildcardQuery("title", "titl*").queryName("wildcard")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1")) {
@@ -302,7 +302,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(QueryBuilders.spanFirstQuery(QueryBuilders.spanTermQuery("title", "title1"), 10).queryName("span")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         for (SearchHit hit : searchResponse.getHits()) {
             if (hit.id().equals("1")) {
@@ -338,7 +338,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
                     .setPreference("_primary")
                     .get();
 
-            assertHitCount(searchResponse, 2l);
+            assertHitCount(searchResponse, 2L);
             for (SearchHit hit : searchResponse.getHits()) {
                 if (hit.id().equals("1")) {
                     assertThat(hit.matchedQueries().length, equalTo(1));
@@ -368,7 +368,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
             SearchResponse searchResponse = client().prepareSearch()
                     .setQuery(query)
                     .get();
-            assertHitCount(searchResponse, 1l);
+            assertHitCount(searchResponse, 1L);
             assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("abc"));
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
+++ b/core/src/test/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
@@ -79,7 +79,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         logger.info("Running moreLikeThis");
         SearchResponse response = client().prepareSearch().setQuery(
                 new MoreLikeThisQueryBuilder(null, new Item[] {new Item("test", "type1", "1")}).minTermFreq(1).minDocFreq(1)).get();
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
     }
 
     public void testSimpleMoreLikeOnLongField() throws Exception {
@@ -89,7 +89,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         assertThat(ensureGreen(), equalTo(ClusterHealthStatus.GREEN));
 
         logger.info("Indexing...");
-        client().index(indexRequest("test").type("type1").id("1").source(jsonBuilder().startObject().field("some_long", 1367484649580l).endObject())).actionGet();
+        client().index(indexRequest("test").type("type1").id("1").source(jsonBuilder().startObject().field("some_long", 1367484649580L).endObject())).actionGet();
         client().index(indexRequest("test").type("type2").id("2").source(jsonBuilder().startObject().field("some_long", 0).endObject())).actionGet();
         client().index(indexRequest("test").type("type1").id("3").source(jsonBuilder().startObject().field("some_long", -666).endObject())).actionGet();
 
@@ -98,7 +98,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         logger.info("Running moreLikeThis");
         SearchResponse response = client().prepareSearch().setQuery(
                 new MoreLikeThisQueryBuilder(null, new Item[] {new Item("test", "type1", "1")}).minTermFreq(1).minDocFreq(1)).get();
-        assertHitCount(response, 0l);
+        assertHitCount(response, 0L);
     }
 
     public void testMoreLikeThisWithAliases() throws Exception {
@@ -124,24 +124,24 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         logger.info("Running moreLikeThis on index");
         SearchResponse response = client().prepareSearch().setQuery(
                 new MoreLikeThisQueryBuilder(null, new Item[] {new Item("test", "type1", "1")}).minTermFreq(1).minDocFreq(1)).get();
-        assertHitCount(response, 2l);
+        assertHitCount(response, 2L);
 
         logger.info("Running moreLikeThis on beta shard");
         response = client().prepareSearch("beta").setQuery(
                 new MoreLikeThisQueryBuilder(null, new Item[] {new Item("test", "type1", "1")}).minTermFreq(1).minDocFreq(1)).get();
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
         assertThat(response.getHits().getAt(0).id(), equalTo("3"));
 
         logger.info("Running moreLikeThis on release shard");
         response = client().prepareSearch("release").setQuery(
                 new MoreLikeThisQueryBuilder(null, new Item[] {new Item("test", "type1", "1")}).minTermFreq(1).minDocFreq(1)).get();
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
         assertThat(response.getHits().getAt(0).id(), equalTo("2"));
 
         logger.info("Running moreLikeThis on alias with node client");
         response = internalCluster().clientNodeClient().prepareSearch("beta").setQuery(
                 new MoreLikeThisQueryBuilder(null, new Item[] {new Item("test", "type1", "1")}).minTermFreq(1).minDocFreq(1)).get();
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
         assertThat(response.getHits().getAt(0).id(), equalTo("3"));
     }
 
@@ -234,7 +234,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         // Implicit list of fields -> ignore numeric fields
         SearchResponse searchResponse = client().prepareSearch().setQuery(
                 new MoreLikeThisQueryBuilder(null, new Item[] {new Item("test", "type", "1")}).minTermFreq(1).minDocFreq(1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         // Explicit list of fields including numeric fields -> fail
         assertThrows(client().prepareSearch().setQuery(
@@ -242,11 +242,11 @@ public class MoreLikeThisIT extends ESIntegTestCase {
 
         // mlt query with no field -> OK
         searchResponse = client().prepareSearch().setQuery(moreLikeThisQuery(new String[] {"index"}).minTermFreq(1).minDocFreq(1)).execute().actionGet();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         // mlt query with string fields
         searchResponse = client().prepareSearch().setQuery(moreLikeThisQuery(new String[]{"string_value"}, new String[] {"index"}, null).minTermFreq(1).minDocFreq(1)).execute().actionGet();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         // mlt query with at least a numeric field -> fail by default
         assertThrows(client().prepareSearch().setQuery(moreLikeThisQuery(new String[] {"string_value", "int_value"}, new String[] {"index"}, null)), SearchPhaseExecutionException.class);
@@ -257,7 +257,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
 
         // mlt query with at least a numeric field but fail_on_unsupported_field set to false
         searchResponse = client().prepareSearch().setQuery(moreLikeThisQuery(new String[] {"string_value", "int_value"}, new String[] {"index"}, null).minTermFreq(1).minDocFreq(1).failOnUnsupportedField(false)).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         // mlt field query on a numeric field -> failure by default
         assertThrows(client().prepareSearch().setQuery(moreLikeThisQuery(new String[] {"int_value"}, new String[] {"42"}, null).minTermFreq(1).minDocFreq(1)), SearchPhaseExecutionException.class);
@@ -268,7 +268,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
 
         // mlt field query on a numeric field but fail_on_unsupported_field set to false
         searchResponse = client().prepareSearch().setQuery(moreLikeThisQuery(new String[] {"int_value"}, new String[] {"42"}, null).minTermFreq(1).minDocFreq(1).failOnUnsupportedField(false)).execute().actionGet();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testSimpleMoreLikeInclude() throws Exception {
@@ -327,7 +327,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         logger.info("Running MoreLikeThis");
         MoreLikeThisQueryBuilder queryBuilder = QueryBuilders.moreLikeThisQuery(new String[] {"text"}, null, ids("1")).include(true).minTermFreq(1).minDocFreq(1);
         SearchResponse mltResponse = client().prepareSearch().setTypes("type1").setQuery(queryBuilder).execute().actionGet();
-        assertHitCount(mltResponse, 3l);
+        assertHitCount(mltResponse, 3L);
     }
 
     public void testSimpleMoreLikeThisIdsMultipleTypes() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/msearch/SimpleMultiSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/msearch/SimpleMultiSearchIT.java
@@ -48,9 +48,9 @@ public class SimpleMultiSearchIT extends ESIntegTestCase {
            assertNoFailures(item.getResponse());
         }
         assertThat(response.getResponses().length, equalTo(3));
-        assertHitCount(response.getResponses()[0].getResponse(), 1l);
-        assertHitCount(response.getResponses()[1].getResponse(), 1l);
-        assertHitCount(response.getResponses()[2].getResponse(), 2l);
+        assertHitCount(response.getResponses()[0].getResponse(), 1L);
+        assertHitCount(response.getResponses()[1].getResponse(), 1L);
+        assertHitCount(response.getResponses()[2].getResponse(), 2L);
         assertFirstHit(response.getResponses()[0].getResponse(), hasId("1"));
         assertFirstHit(response.getResponses()[1].getResponse(), hasId("2"));
     }

--- a/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
@@ -59,9 +59,9 @@ public class SimpleNestedIT extends ESIntegTestCase {
 
         // check on no data, see it works
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(termQuery("_all", "n_value1_1")).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(0L));
         searchResponse = client().prepareSearch("test").setQuery(termQuery("n_field1", "n_value1_1")).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(0L));
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("field1", "value1")
@@ -89,24 +89,24 @@ public class SimpleNestedIT extends ESIntegTestCase {
 
         // check that _all is working on nested docs
         searchResponse = client().prepareSearch("test").setQuery(termQuery("_all", "n_value1_1")).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch("test").setQuery(termQuery("n_field1", "n_value1_1")).execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(0L));
 
         // search for something that matches the nested doc, and see that we don't find the nested doc
         searchResponse = client().prepareSearch("test").setQuery(matchAllQuery()).get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch("test").setQuery(termQuery("n_field1", "n_value1_1")).get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(0L));
 
         // now, do a nested query
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1", termQuery("nested1.n_field1", "n_value1_1"))).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1", termQuery("nested1.n_field1", "n_value1_1"))).setSearchType(SearchType.DFS_QUERY_THEN_FETCH).get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         // add another doc, one that would match if it was not nested...
 
@@ -131,19 +131,19 @@ public class SimpleNestedIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.n_field1", "n_value1_1")).must(termQuery("nested1.n_field2", "n_value2_1")))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         // filter
         searchResponse = client().prepareSearch("test").setQuery(boolQuery().must(matchAllQuery()).mustNot(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.n_field1", "n_value1_1")).must(termQuery("nested1.n_field2", "n_value2_1"))))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         // check with type prefix
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.n_field1", "n_value1_1")).must(termQuery("nested1.n_field2", "n_value2_1")))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         // check delete, so all is gone...
         DeleteResponse deleteResponse = client().prepareDelete("test", "type1", "2").execute().actionGet();
@@ -155,11 +155,11 @@ public class SimpleNestedIT extends ESIntegTestCase {
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1", termQuery("nested1.n_field1", "n_value1_1"))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test").setTypes("type1", "type2").setQuery(nestedQuery("nested1", termQuery("nested1.n_field1", "n_value1_1"))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testMultiNested() throws Exception {
@@ -193,42 +193,42 @@ public class SimpleNestedIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 termQuery("nested1.field1", "1"))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1.nested2",
                 termQuery("nested1.nested2.field2", "2"))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.field1", "1")).must(nestedQuery("nested1.nested2", termQuery("nested1.nested2.field2", "2"))))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.field1", "1")).must(nestedQuery("nested1.nested2", termQuery("nested1.nested2.field2", "3"))))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.field1", "1")).must(nestedQuery("nested1.nested2", termQuery("nested1.nested2.field2", "4"))))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(0L));
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.field1", "1")).must(nestedQuery("nested1.nested2", termQuery("nested1.nested2.field2", "5"))))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(0L));
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.field1", "4")).must(nestedQuery("nested1.nested2", termQuery("nested1.nested2.field2", "5"))))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch("test").setQuery(nestedQuery("nested1",
                 boolQuery().must(termQuery("nested1.field1", "4")).must(nestedQuery("nested1.nested2", termQuery("nested1.nested2.field2", "2"))))).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(0L));
     }
 
     // When IncludeNestedDocsQuery is wrapped in a FilteredQuery then a in-finite loop occurs b/c of a bug in IncludeNestedDocsQuery#advance()
@@ -314,7 +314,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
                 .setExplain(true)
                 .execute().actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         Explanation explanation = searchResponse.getHits().hits()[0].explanation();
         assertThat(explanation.getValue(), equalTo(2f));
         assertThat(explanation.toString(), startsWith("2.0 = sum of:\n  2.0 = Score based on child doc range from 0 to 1\n"));
@@ -531,96 +531,96 @@ public class SimpleNestedIT extends ESIntegTestCase {
 
         // sum: 11
         client().prepareIndex("test", "type1", Integer.toString(1)).setSource(jsonBuilder().startObject()
-                .field("grand_parent_values", 1l)
+                .field("grand_parent_values", 1L)
                 .startObject("parent")
                 .field("filter", false)
-                .field("parent_values", 1l)
+                .field("parent_values", 1L)
                 .startObject("child")
                 .field("filter", true)
-                .field("child_values", 1l)
+                .field("child_values", 1L)
                 .startObject("child_obj")
-                .field("value", 1l)
+                .field("value", 1L)
                 .endObject()
                 .endObject()
                 .startObject("child")
                 .field("filter", false)
-                .field("child_values", 6l)
+                .field("child_values", 6L)
                 .endObject()
                 .endObject()
                 .startObject("parent")
                 .field("filter", true)
-                .field("parent_values", 2l)
+                .field("parent_values", 2L)
                 .startObject("child")
                 .field("filter", false)
-                .field("child_values", -1l)
+                .field("child_values", -1L)
                 .endObject()
                 .startObject("child")
                 .field("filter", false)
-                .field("child_values", 5l)
+                .field("child_values", 5L)
                 .endObject()
                 .endObject()
                 .endObject()).execute().actionGet();
 
         // sum: 7
         client().prepareIndex("test", "type1", Integer.toString(2)).setSource(jsonBuilder().startObject()
-                .field("grand_parent_values", 2l)
+                .field("grand_parent_values", 2L)
                 .startObject("parent")
                 .field("filter", false)
-                .field("parent_values", 2l)
+                .field("parent_values", 2L)
                 .startObject("child")
                 .field("filter", true)
-                .field("child_values", 2l)
+                .field("child_values", 2L)
                 .startObject("child_obj")
-                .field("value", 2l)
+                .field("value", 2L)
                 .endObject()
                 .endObject()
                 .startObject("child")
                 .field("filter", false)
-                .field("child_values", 4l)
+                .field("child_values", 4L)
                 .endObject()
                 .endObject()
                 .startObject("parent")
-                .field("parent_values", 3l)
+                .field("parent_values", 3L)
                 .field("filter", true)
                 .startObject("child")
-                .field("child_values", -2l)
+                .field("child_values", -2L)
                 .field("filter", false)
                 .endObject()
                 .startObject("child")
                 .field("filter", false)
-                .field("child_values", 3l)
+                .field("child_values", 3L)
                 .endObject()
                 .endObject()
                 .endObject()).execute().actionGet();
 
         // sum: 2
         client().prepareIndex("test", "type1", Integer.toString(3)).setSource(jsonBuilder().startObject()
-                .field("grand_parent_values", 3l)
+                .field("grand_parent_values", 3L)
                 .startObject("parent")
-                .field("parent_values", 3l)
+                .field("parent_values", 3L)
                 .field("filter", false)
                 .startObject("child")
                 .field("filter", true)
-                .field("child_values", 3l)
+                .field("child_values", 3L)
                 .startObject("child_obj")
-                .field("value", 3l)
+                .field("value", 3L)
                 .endObject()
                 .endObject()
                 .startObject("child")
                 .field("filter", false)
-                .field("child_values", 1l)
+                .field("child_values", 1L)
                 .endObject()
                 .endObject()
                 .startObject("parent")
-                .field("parent_values", 4l)
+                .field("parent_values", 4L)
                 .field("filter", true)
                 .startObject("child")
                 .field("filter", false)
-                .field("child_values", -3l)
+                .field("child_values", -3L)
                 .endObject()
                 .startObject("child")
                 .field("filter", false)
-                .field("child_values", 1l)
+                .field("child_values", 1L)
                 .endObject()
                 .endObject()
                 .endObject()).execute().actionGet();
@@ -1019,7 +1019,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
 
         // No nested mapping yet, there shouldn't be anything in the fixed bit set cache
         ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
-        assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0l));
+        assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0L));
 
         // Now add nested mapping
         assertAcked(
@@ -1040,21 +1040,21 @@ public class SimpleNestedIT extends ESIntegTestCase {
 
         if (loadFixedBitSeLazily) {
             clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
-            assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0l));
+            assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0L));
 
             // only when querying with nested the fixed bitsets are loaded
             SearchResponse searchResponse = client().prepareSearch("test")
                     .setQuery(nestedQuery("array1", termQuery("array1.field1", "value1")))
                     .get();
             assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().totalHits(), equalTo(5l));
+            assertThat(searchResponse.getHits().totalHits(), equalTo(5L));
         }
         clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
-        assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), greaterThan(0l));
+        assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), greaterThan(0L));
 
         assertAcked(client().admin().indices().prepareDelete("test"));
         clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
-        assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0l));
+        assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0L));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/preference/SearchPreferenceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/preference/SearchPreferenceIT.java
@@ -95,29 +95,29 @@ public class SearchPreferenceIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_local").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_local").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_primary").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_primary").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_replica").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_replica").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_replica_first").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_replica_first").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("1234").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setPreference("1234").execute().actionGet();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
     }
 
     public void testReplicaPreference() throws Exception {
@@ -135,13 +135,13 @@ public class SearchPreferenceIT extends ESIntegTestCase {
         }
 
         SearchResponse resp = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_replica_first").execute().actionGet();
-        assertThat(resp.getHits().totalHits(), equalTo(1l));
+        assertThat(resp.getHits().totalHits(), equalTo(1L));
 
         client().admin().indices().prepareUpdateSettings("test").setSettings("number_of_replicas=1").get();
         ensureGreen("test");
 
         resp = client().prepareSearch().setQuery(matchAllQuery()).setPreference("_replica").execute().actionGet();
-        assertThat(resp.getHits().totalHits(), equalTo(1l));
+        assertThat(resp.getHits().totalHits(), equalTo(1L));
     }
 
     public void testThatSpecifyingNonExistingNodesReturnsUsefulError() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -197,13 +197,13 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
                         .operator(Operator.AND).type(type))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
                         .operator(Operator.AND).type(type))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
     }
 
@@ -212,18 +212,18 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                 .setQuery(randomizeType(multiMatchQuery("Man the Ultimate", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
                         .operator(Operator.OR).type(MatchQuery.Type.PHRASE))).get();
         assertFirstHit(searchResponse, hasId("ultimate2"));
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("Captain", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
                         .operator(Operator.OR).type(MatchQuery.Type.PHRASE))).get();
-        assertThat(searchResponse.getHits().getTotalHits(), greaterThan(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), greaterThan(1L));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("the Ul", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
                         .operator(Operator.OR).type(MatchQuery.Type.PHRASE_PREFIX))).get();
         assertSearchHits(searchResponse, "ultimate2", "ultimate1");
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
     }
 
     public void testSingleField() throws NoSuchFieldException, IllegalAccessException {
@@ -318,13 +318,13 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
                         .operator(Operator.AND).cutoffFrequency(cutoffFrequency).type(type))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
                         .operator(Operator.AND).cutoffFrequency(cutoffFrequency).type(type))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
@@ -332,7 +332,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                         .operator(Operator.AND).cutoffFrequency(cutoffFrequency)
                         .analyzer("category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theother"));
     }
 
@@ -455,7 +455,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                 .setQuery(randomizeType(multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .operator(Operator.AND))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
@@ -463,7 +463,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .analyzer("category")
                         .operator(Operator.AND))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
@@ -471,7 +471,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .analyzer("category")
                         .operator(Operator.AND))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
 
         searchResponse = client().prepareSearch("test")
@@ -479,7 +479,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .analyzer("category")
                         .operator(Operator.AND))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
 
 
@@ -549,21 +549,21 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .analyzer("category")
                         .operator(Operator.AND))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("theone"));
         // counter example
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category")
                         .type(randomBoolean() ? MultiMatchQueryBuilder.Type.CROSS_FIELDS : MultiMatchQueryBuilder.DEFAULT_TYPE)
                         .operator(Operator.AND))).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         // counter example
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("captain america marvel hero", "first_name", "last_name", "category")
                         .type(randomBoolean() ? MultiMatchQueryBuilder.Type.CROSS_FIELDS : MultiMatchQueryBuilder.DEFAULT_TYPE)
                         .operator(Operator.AND))).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         // test if boosts work
         searchResponse = client().prepareSearch("test")

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -129,7 +129,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type1", "2").setSource("field1", "quick brown"),
                 client().prepareIndex("test", "type1", "3").setSource("field1", "quick"));
 
-        assertHitCount(client().prepareSearch().setQuery(matchQuery("_all", "quick")).get(), 3l);
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("_all", "quick")).get(), 3L);
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("_all", "quick")).setExplain(true).get();
         SearchHit[] hits = searchResponse.getHits().hits();
         assertThat(hits.length, equalTo(3));
@@ -141,7 +141,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type1", "2").setSource("field1", "quick brown"),
                 client().prepareIndex("test", "type1", "3").setSource("field1", "quick"));
 
-        assertHitCount(client().prepareSearch().setQuery(matchQuery("_all", "quick")).get(), 3l);
+        assertHitCount(client().prepareSearch().setQuery(matchQuery("_all", "quick")).get(), 3L);
         searchResponse = client().prepareSearch().setQuery(matchQuery("_all", "quick")).get();
         hits = searchResponse.getHits().hits();
         assertThat(hits.length, equalTo(3));
@@ -156,8 +156,8 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type1", "2").setSource("field1", "quick brown"),
                 client().prepareIndex("test", "type1", "3").setSource("field1", "quick"));
 
-        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("quick")).get(), 3l);
-        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("")).get(), 0l); // return no docs
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("quick")).get(), 3L);
+        assertHitCount(client().prepareSearch().setQuery(queryStringQuery("")).get(), 0L); // return no docs
     }
 
     // see https://github.com/elasticsearch/elasticsearch/issues/3177
@@ -178,7 +178,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                                         matchAllQuery()).must(
                                         boolQuery().mustNot(boolQuery().must(termQuery("field1", "value1")).must(
                                                 termQuery("field1", "value2"))))).get(),
-                3l);
+                3L);
         assertHitCount(
                 client().prepareSearch()
                         .setQuery(
@@ -187,10 +187,10 @@ public class SearchQueryIT extends ESIntegTestCase {
                                                 .should(termQuery("field1", "value3"))).filter(
                                         boolQuery().mustNot(boolQuery().must(termQuery("field1", "value1")).must(
                                                 termQuery("field1", "value2"))))).get(),
-                3l);
+                3L);
         assertHitCount(
                 client().prepareSearch().setQuery(matchAllQuery()).setPostFilter(boolQuery().mustNot(termQuery("field1", "value3"))).get(),
-                2l);
+                2L);
     }
 
     public void testIndexOptions() throws Exception {
@@ -201,7 +201,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type1", "2").setSource("field1", "quick lazy huge brown fox", "field2", "quick lazy huge brown fox"));
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("field2", "quick brown").type(Type.PHRASE).slop(0)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         assertFailures(client().prepareSearch().setQuery(matchQuery("field1", "quick brown").type(Type.PHRASE).slop(0)),
                     RestStatus.INTERNAL_SERVER_ERROR,
@@ -215,7 +215,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("field1", "quick brown fox", "field2", "quick brown fox"), client().prepareIndex("test", "type1", "2").setSource("field1", "quick lazy huge brown fox", "field2", "quick lazy huge brown fox"));
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("field1", "quick"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         for (SearchHit searchHit : searchResponse.getHits().hits()) {
             assertSearchHit(searchHit, hasScore(1.0f));
         }
@@ -223,17 +223,17 @@ public class SearchQueryIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test").setQuery(
                 boolQuery().must(matchAllQuery()).must(
                 constantScoreQuery(matchQuery("field1", "quick")).boost(1.0f + getRandom().nextFloat()))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasScore(searchResponse.getHits().getAt(1).score()));
 
         client().prepareSearch("test").setQuery(constantScoreQuery(matchQuery("field1", "quick")).boost(1.0f + getRandom().nextFloat())).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasScore(searchResponse.getHits().getAt(1).score()));
 
         searchResponse = client().prepareSearch("test").setQuery(
                 constantScoreQuery(boolQuery().must(matchAllQuery()).must(
                 constantScoreQuery(matchQuery("field1", "quick")).boost(1.0f + (random.nextBoolean()? 0.0f : random.nextFloat()))))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasScore(searchResponse.getHits().getAt(1).score()));
         for (SearchHit searchHit : searchResponse.getHits().hits()) {
             assertSearchHit(searchHit, hasScore(1.0f));
@@ -280,11 +280,11 @@ public class SearchQueryIT extends ESIntegTestCase {
         int iters = scaledRandomIntBetween(100, 200);
         for (int i = 0; i < iters; i++) {
             SearchResponse searchResponse = client().prepareSearch("test").setQuery(queryStringQuery("*:*^10.0").boost(10.0f)).get();
-            assertHitCount(searchResponse, 2l);
+            assertHitCount(searchResponse, 2L);
 
             searchResponse = client().prepareSearch("test").setQuery(
                     boolQuery().must(matchAllQuery()).must(constantScoreQuery(matchAllQuery()))).get();
-            assertHitCount(searchResponse, 2l);
+            assertHitCount(searchResponse, 2L);
             assertThat((double)searchResponse.getHits().getAt(0).score(), closeTo(Math.sqrt(2), 0.1));
             assertThat((double)searchResponse.getHits().getAt(1).score(),closeTo(Math.sqrt(2), 0.1));
         }
@@ -298,7 +298,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type1", "2").setSource("message", "hello world", "comment", "test comment"));
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(commonTermsQuery("_all", "test")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("2"));
         assertSecondHit(searchResponse, hasId("1"));
         assertThat(searchResponse.getHits().getHits()[0].getScore(), greaterThan(searchResponse.getHits().getHits()[1].getScore()));
@@ -314,44 +314,44 @@ public class SearchQueryIT extends ESIntegTestCase {
 
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.OR)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the quick brown").cutoffFrequency(3).lowFreqOperator(Operator.AND)).get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         // Default
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the quick brown").cutoffFrequency(3)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the huge fox").lowFreqMinimumShouldMatch("2")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("3")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("4")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         // Default
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the lazy fox brown").cutoffFrequency(1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the quick brown").cutoffFrequency(3).analyzer("stop")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         // stop drops "the" since its a stopword
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("3"));
@@ -359,18 +359,18 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         // try the same with match query
         searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(Operator.AND)).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(Operator.OR)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the quick brown").cutoffFrequency(3).operator(Operator.AND).analyzer("stop")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         // stop drops "the" since its a stopword
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("3"));
@@ -378,7 +378,7 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         // try the same with multi match query
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery("the quick brown", "field1", "field2").cutoffFrequency(3).operator(Operator.AND)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertFirstHit(searchResponse, hasId("3")); // better score due to different query stats
         assertSecondHit(searchResponse, hasId("1"));
         assertThirdHit(searchResponse, hasId("2"));
@@ -401,44 +401,44 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type1", "2").setSource("field1", "the quick lazy huge brown fox jumps over the tree") );
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the fast brown").cutoffFrequency(3).lowFreqOperator(Operator.OR)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the fast brown").cutoffFrequency(3).lowFreqOperator(Operator.AND)).get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(2L));
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         // Default
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the fast brown").cutoffFrequency(3)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the fast huge fox").lowFreqMinimumShouldMatch("3")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the fast lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("5")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the fast lazy fox brown").cutoffFrequency(1).highFreqMinimumShouldMatch("6")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         // Default
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the fast lazy fox brown").cutoffFrequency(1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(commonTermsQuery("field1", "the quick brown").cutoffFrequency(3).analyzer("stop")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         // stop drops "the" since its a stopword
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("3"));
@@ -446,31 +446,31 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         // try the same with match query
         searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(Operator.AND)).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(Operator.OR)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThirdHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).operator(Operator.AND).analyzer("stop")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         // stop drops "the" since its a stopword
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("3"));
         assertThirdHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(matchQuery("field1", "the fast brown").cutoffFrequency(3).minimumShouldMatch("3")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         // try the same with multi match query
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery("the fast brown", "field1", "field2").cutoffFrequency(3).operator(Operator.AND)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertFirstHit(searchResponse, hasId("3")); // better score due to different query stats
         assertSecondHit(searchResponse, hasId("1"));
         assertThirdHit(searchResponse, hasId("2"));
@@ -483,19 +483,19 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("value*").analyzeWildcard(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("*ue*").analyzeWildcard(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("*ue_1").analyzeWildcard(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("val*e_1").analyzeWildcard(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("v?l*e?1").analyzeWildcard(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
     }
 
     public void testLowercaseExpandedTerms() {
@@ -505,17 +505,17 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("VALUE_3~1").lowercaseExpandedTerms(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("VALUE_3~1").lowercaseExpandedTerms(false)).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("ValUE_*").lowercaseExpandedTerms(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("vAl*E_1")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("[VALUE_1 TO VALUE_3]")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("[VALUE_1 TO VALUE_3]").lowercaseExpandedTerms(false)).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     // Issue #3540
@@ -532,10 +532,10 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("past:[now-2M/d TO now/d]")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("future:[now/d TO now+2M/d]").lowercaseExpandedTerms(false)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         try {
             client().prepareSearch().setQuery(queryStringQuery("future:[now/D TO now+2M/d]").lowercaseExpandedTerms(false)).get();
@@ -562,7 +562,7 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("past:[now-1m/m TO now+1m/m]")
                 .timeZone(timeZone.getID())).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
     }
 
     // Issue #10477
@@ -581,25 +581,25 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(queryStringQuery("past:[2015-04-06T00:00:00+0200 TO 2015-04-06T23:00:00+0200]"))
                 .get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         // Same timezone set with time_zone
         searchResponse = client().prepareSearch()
                 .setQuery(queryStringQuery("past:[2015-04-06T00:00:00 TO 2015-04-06T23:00:00]").timeZone("+0200"))
                 .get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         // We set a timezone which will give no result
         searchResponse = client().prepareSearch()
                 .setQuery(queryStringQuery("past:[2015-04-06T00:00:00-0200 TO 2015-04-06T23:00:00-0200]"))
                 .get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         // Same timezone set with time_zone but another timezone is set directly within dates which has the precedence
         searchResponse = client().prepareSearch()
                 .setQuery(queryStringQuery("past:[2015-04-06T00:00:00-0200 TO 2015-04-06T23:00:00-0200]").timeZone("+0200"))
                 .get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testTypeFilter() throws Exception {
@@ -610,13 +610,13 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type2", "2").setSource("field1", "value1"),
                 client().prepareIndex("test", "type2", "3").setSource("field1", "value1"));
 
-        assertHitCount(client().prepareSearch().setQuery(typeQuery("type1")).get(), 2l);
-        assertHitCount(client().prepareSearch().setQuery(typeQuery("type2")).get(), 3l);
+        assertHitCount(client().prepareSearch().setQuery(typeQuery("type1")).get(), 2L);
+        assertHitCount(client().prepareSearch().setQuery(typeQuery("type2")).get(), 3L);
 
-        assertHitCount(client().prepareSearch().setTypes("type1").setQuery(matchAllQuery()).get(), 2l);
-        assertHitCount(client().prepareSearch().setTypes("type2").setQuery(matchAllQuery()).get(), 3l);
+        assertHitCount(client().prepareSearch().setTypes("type1").setQuery(matchAllQuery()).get(), 2L);
+        assertHitCount(client().prepareSearch().setTypes("type2").setQuery(matchAllQuery()).get(), 3L);
 
-        assertHitCount(client().prepareSearch().setTypes("type1", "type2").setQuery(matchAllQuery()).get(), 5l);
+        assertHitCount(client().prepareSearch().setTypes("type1", "type2").setQuery(matchAllQuery()).get(), 5L);
     }
 
     public void testIdsQueryTestsIdIndexed() throws Exception {
@@ -627,29 +627,29 @@ public class SearchQueryIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type1", "3").setSource("field1", "value3"));
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(constantScoreQuery(idsQuery("type1").addIds("1", "3"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         // no type
         searchResponse = client().prepareSearch().setQuery(constantScoreQuery(idsQuery().addIds("1", "3"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         searchResponse = client().prepareSearch().setQuery(idsQuery("type1").addIds("1", "3")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         // no type
         searchResponse = client().prepareSearch().setQuery(idsQuery().addIds("1", "3")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         searchResponse = client().prepareSearch().setQuery(idsQuery("type1").addIds("7", "10")).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         // repeat..., with terms
         searchResponse = client().prepareSearch().setTypes("type1").setQuery(constantScoreQuery(termsQuery("_id", "1", "3"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
     }
 
@@ -668,19 +668,19 @@ public class SearchQueryIT extends ESIntegTestCase {
         for (String indexName : indexNames) {
             SearchResponse request = client().prepareSearch().setQuery(constantScoreQuery(termQuery("_index", indexName))).get();
             SearchResponse searchResponse = assertSearchResponse(request);
-            assertHitCount(searchResponse, 1l);
+            assertHitCount(searchResponse, 1L);
             assertSearchHits(searchResponse, indexName + "1");
         }
         for (String indexName : indexNames) {
             SearchResponse request = client().prepareSearch().setQuery(constantScoreQuery(termsQuery("_index", indexName))).get();
             SearchResponse searchResponse = assertSearchResponse(request);
-            assertHitCount(searchResponse, 1l);
+            assertHitCount(searchResponse, 1L);
             assertSearchHits(searchResponse, indexName + "1");
         }
         for (String indexName : indexNames) {
             SearchResponse request = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("_index", indexName))).get();
             SearchResponse searchResponse = assertSearchResponse(request);
-            assertHitCount(searchResponse, 1l);
+            assertHitCount(searchResponse, 1L);
             assertSearchHits(searchResponse, indexName + "1");
         }
         {
@@ -701,33 +701,33 @@ public class SearchQueryIT extends ESIntegTestCase {
 
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(existsQuery("field1")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
         searchResponse = client().prepareSearch().setQuery(constantScoreQuery(existsQuery("field1"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("_exists_:field1")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
         searchResponse = client().prepareSearch().setQuery(existsQuery("field2")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         searchResponse = client().prepareSearch().setQuery(existsQuery("field3")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("4"));
 
         // wildcard check
         searchResponse = client().prepareSearch().setQuery(existsQuery("x*")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
         // object check
         searchResponse = client().prepareSearch().setQuery(existsQuery("obj1")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
     }
 
@@ -737,13 +737,13 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1_1", "field2", "value2_1").setRefresh(true).get();
 
         WrapperQueryBuilder wrapper = new WrapperQueryBuilder("{ \"term\" : { \"field1\" : \"value1_1\" } }");
-        assertHitCount(client().prepareSearch().setQuery(wrapper).get(), 1l);
+        assertHitCount(client().prepareSearch().setQuery(wrapper).get(), 1L);
 
         BoolQueryBuilder bool = boolQuery().must(wrapper).must(new TermQueryBuilder("field2", "value2_1"));
-        assertHitCount(client().prepareSearch().setQuery(bool).get(), 1l);
+        assertHitCount(client().prepareSearch().setQuery(bool).get(), 1L);
 
         WrapperQueryBuilder wrapperFilter = wrapperQuery("{ \"term\" : { \"field1\" : \"value1_1\" } }");
-        assertHitCount(client().prepareSearch().setPostFilter(wrapperFilter).get(), 1l);
+        assertHitCount(client().prepareSearch().setPostFilter(wrapperFilter).get(), 1L);
     }
 
     public void testFiltersWithCustomCacheKey() throws Exception {
@@ -752,31 +752,31 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
     }
 
     public void testMatchQueryNumeric() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type1", "long", "type=long", "double", "type=double"));
 
-        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("long", 1l, "double", 1.0d),
-                client().prepareIndex("test", "type1", "2").setSource("long", 2l, "double", 2.0d),
-                client().prepareIndex("test", "type1", "3").setSource("long", 3l, "double", 3.0d));
+        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("long", 1L, "double", 1.0d),
+                client().prepareIndex("test", "type1", "2").setSource("long", 2L, "double", 2.0d),
+                client().prepareIndex("test", "type1", "3").setSource("long", 3L, "double", 3.0d));
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("long", "1")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         searchResponse = client().prepareSearch().setQuery(matchQuery("double", "2")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
         try {
             client().prepareSearch().setQuery(matchQuery("double", "2 3 4")).get();
@@ -798,7 +798,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch().setQuery(builder)
                 .addAggregation(AggregationBuilders.terms("field1").field("field1")).get();
 
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         // this uses dismax so scores are equal and the order can be arbitrary
         assertSearchHits(searchResponse, "1", "2");
 
@@ -807,7 +807,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .setQuery(builder)
                 .get();
 
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
         client().admin().indices().prepareRefresh("test").get();
@@ -816,21 +816,21 @@ public class SearchQueryIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
                 .setQuery(builder)
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         refresh();
         builder = multiMatchQuery("value1", "field1").field("field3", 1.5f)
                 .operator(Operator.AND); // Operator only applies on terms inside a field! Fields are always OR-ed together.
         searchResponse = client().prepareSearch().setQuery(builder).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "1");
 
         client().admin().indices().prepareRefresh("test").get();
         builder = multiMatchQuery("value1").field("field1").field("field3", 1.5f)
                 .operator(Operator.AND); // Operator only applies on terms inside a field! Fields are always OR-ed together.
         searchResponse = client().prepareSearch().setQuery(builder).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "1");
 
         // Test lenient
@@ -845,7 +845,7 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         builder.lenient(true);
         searchResponse = client().prepareSearch().setQuery(builder).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
     }
 
@@ -860,17 +860,17 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .must(matchQuery("field1", "a").zeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE))
                 .must(matchQuery("field1", "value1").zeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE));
         SearchResponse searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         boolQuery = boolQuery()
                 .must(matchQuery("field1", "a").zeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL))
                 .must(matchQuery("field1", "value1").zeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL));
         searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         boolQuery = boolQuery().must(matchQuery("field1", "a").zeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL));
         searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
     }
 
     public void testMultiMatchQueryZeroTermsQuery() {
@@ -885,17 +885,17 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .must(multiMatchQuery("a", "field1", "field2").zeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE))
                 .must(multiMatchQuery("value1", "field1", "field2").zeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE)); // Fields are ORed together
         SearchResponse searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         boolQuery = boolQuery()
                 .must(multiMatchQuery("a", "field1", "field2").zeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL))
                 .must(multiMatchQuery("value4", "field1", "field2").zeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL));
         searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         boolQuery = boolQuery().must(multiMatchQuery("a", "field1").zeroTermsQuery(MatchQuery.ZeroTermsQuery.ALL));
         searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
     }
 
     public void testMultiMatchQueryMinShouldMatch() {
@@ -911,41 +911,41 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(multiMatchQuery)
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         multiMatchQuery.minimumShouldMatch("30%");
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         multiMatchQuery.useDisMax(false);
         multiMatchQuery.minimumShouldMatch("70%");
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         multiMatchQuery.minimumShouldMatch("30%");
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
 
         multiMatchQuery = multiMatchQuery("value1 value2 bar", "field1");
         multiMatchQuery.minimumShouldMatch("100%");
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         multiMatchQuery.minimumShouldMatch("70%");
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         // Min should match > # optional clauses returns no docs.
         multiMatchQuery = multiMatchQuery("value1 value2 value3", "field1", "field2");
         multiMatchQuery.minimumShouldMatch("4");
         searchResponse = client().prepareSearch().setQuery(multiMatchQuery).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testBoolQueryMinShouldMatchBiggerThanNumberOfShouldClauses() throws IOException {
@@ -961,7 +961,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .should(termQuery("field1", "value2"))
                 .minimumNumberShouldMatch(3));
         SearchResponse searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         boolQuery = boolQuery()
@@ -973,7 +973,7 @@ public class SearchQueryIT extends ESIntegTestCase {
             // Only one should clause is defined, returns no docs.
             .minimumNumberShouldMatch(2);
         searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         boolQuery = boolQuery()
             .should(termQuery("field1", "value1"))
@@ -983,7 +983,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .minimumNumberShouldMatch(3))
             .minimumNumberShouldMatch(1);
         searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         boolQuery = boolQuery()
@@ -993,7 +993,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .should(termQuery("field1", "value2"))
                 .minimumNumberShouldMatch(3));
         searchResponse = client().prepareSearch().setQuery(boolQuery).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testFuzzyQueryString() {
@@ -1004,15 +1004,15 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("str:kimcy~1")).get();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:11~1")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("date:2012-02-02~1d")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
     }
 
@@ -1026,14 +1026,14 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(queryStringQuery("\"phrase match\"").field("important", boost).field("less_important")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThat((double)searchResponse.getHits().getAt(0).score(), closeTo(boost * searchResponse.getHits().getAt(1).score(), .1));
 
         searchResponse = client().prepareSearch()
                 .setQuery(queryStringQuery("\"phrase match\"").field("important", boost).field("less_important").useDisMax(false)).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("1"));
         assertSecondHit(searchResponse, hasId("2"));
         assertThat((double)searchResponse.getHits().getAt(0).score(), closeTo(boost * searchResponse.getHits().getAt(1).score(), .1));
@@ -1046,27 +1046,27 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:>19")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:>20")).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:>=20")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:>11")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:<20")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:<=20")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("+num:>11 +num:<20")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
     }
 
     public void testEmptytermsQuery() throws Exception {
@@ -1079,77 +1079,77 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("term", new String[0]))).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch("test").setQuery(idsQuery()).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testTermsQuery() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type", "str", "type=string", "lng", "type=long", "dbl", "type=double"));
 
         indexRandom(true,
-                client().prepareIndex("test", "type", "1").setSource("str", "1", "lng", 1l, "dbl", 1.0d),
-                client().prepareIndex("test", "type", "2").setSource("str", "2", "lng", 2l, "dbl", 2.0d),
-                client().prepareIndex("test", "type", "3").setSource("str", "3", "lng", 3l, "dbl", 3.0d),
-                client().prepareIndex("test", "type", "4").setSource("str", "4", "lng", 4l, "dbl", 4.0d));
+                client().prepareIndex("test", "type", "1").setSource("str", "1", "lng", 1L, "dbl", 1.0d),
+                client().prepareIndex("test", "type", "2").setSource("str", "2", "lng", 2L, "dbl", 2.0d),
+                client().prepareIndex("test", "type", "3").setSource("str", "3", "lng", 3L, "dbl", 3.0d),
+                client().prepareIndex("test", "type", "4").setSource("str", "4", "lng", 4L, "dbl", 4.0d));
 
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("str", "1", "4"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "4");
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("lng", new long[] {2, 3}))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "2", "3");
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("dbl", new double[]{2, 3}))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "2", "3");
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("lng", new int[] {1, 3}))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("dbl", new float[] {2, 4}))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "2", "4");
 
         // test partial matching
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("str", "2", "5"))).get();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("dbl", new double[] {2, 5}))).get();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("lng", new long[] {2, 5}))).get();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         // test valid type, but no matching terms
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("str", "5", "6"))).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("dbl", new double[] {5, 6}))).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(constantScoreQuery(termsQuery("lng", new long[] {5, 6}))).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testTermsLookupFilter() throws Exception {
@@ -1189,54 +1189,54 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("term" , new TermsLookup("lookup", "type", "1", "terms"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         // same as above, just on the _id...
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("_id", new TermsLookup("lookup", "type", "1", "terms"))
                 ).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         // another search with same parameters...
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "type", "1", "terms"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "type", "2", "terms"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "type", "3", "terms"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "2", "4");
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("term", new TermsLookup("lookup", "type", "4", "terms"))).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "type", "1", "arr.term"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "3");
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "type", "2", "arr.term"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("term", new TermsLookup("lookup2", "type", "3", "arr.term"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "2", "4");
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termsLookupQuery("not_exists", new TermsLookup("lookup2", "type", "3", "arr.term"))).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testBasicQueryById() throws Exception {
@@ -1247,27 +1247,27 @@ public class SearchQueryIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(idsQuery("type1", "type2").addIds("1", "2")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertThat(searchResponse.getHits().hits().length, equalTo(2));
 
         searchResponse = client().prepareSearch().setQuery(idsQuery().addIds("1")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
 
         searchResponse = client().prepareSearch().setQuery(idsQuery().addIds("1", "2")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertThat(searchResponse.getHits().hits().length, equalTo(2));
 
         searchResponse = client().prepareSearch().setQuery(idsQuery("type1").addIds("1", "2")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
 
         searchResponse = client().prepareSearch().setQuery(idsQuery(Strings.EMPTY_ARRAY).addIds("1")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
 
         searchResponse = client().prepareSearch().setQuery(idsQuery("type1", "type2", "type3").addIds("1", "2", "3", "4")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertThat(searchResponse.getHits().hits().length, equalTo(2));
     }
 
@@ -1291,82 +1291,82 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse;
         logger.info("--> term query on 1");
         searchResponse = client().prepareSearch("test").setQuery(termQuery("num_byte", 1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termQuery("num_short", 1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termQuery("num_integer", 1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termQuery("num_long", 1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termQuery("num_float", 1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termQuery("num_double", 1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         logger.info("--> terms query on 1");
         searchResponse = client().prepareSearch("test").setQuery(termsQuery("num_byte", new int[]{1})).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termsQuery("num_short", new int[]{1})).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termsQuery("num_integer", new int[]{1})).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termsQuery("num_long", new int[]{1})).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termsQuery("num_float", new double[]{1})).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(termsQuery("num_double", new double[]{1})).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         logger.info("--> term filter on 1");
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termQuery("num_byte", 1))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termQuery("num_short", 1))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termQuery("num_integer", 1))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termQuery("num_long", 1))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termQuery("num_float", 1))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termQuery("num_double", 1))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
 
         logger.info("--> terms filter on 1");
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("num_byte", new int[]{1}))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("num_short", new int[]{1}))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("num_integer", new int[]{1}))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("num_long", new int[]{1}))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("num_float", new int[]{1}))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
         searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("num_double", new int[]{1}))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
     }
 
@@ -1388,7 +1388,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                         .should(rangeQuery("num_long").from(1).to(2))
                         .should(rangeQuery("num_long").from(3).to(4))
         ).get();
-        assertHitCount(searchResponse, 4l);
+        assertHitCount(searchResponse, 4L);
 
         // This made 2826 fail! (only with bit based filters)
         searchResponse = client().prepareSearch("test").setPostFilter(
@@ -1396,7 +1396,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                         .should(rangeQuery("num_long").from(1).to(2))
                         .should(rangeQuery("num_long").from(3).to(4))
         ).get();
-        assertHitCount(searchResponse, 4l);
+        assertHitCount(searchResponse, 4L);
 
         // This made #2979 fail!
         searchResponse = client().prepareSearch("test").setPostFilter(
@@ -1405,7 +1405,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                         .should(rangeQuery("num_long").from(1).to(2))
                         .should(rangeQuery("num_long").from(3).to(4))
         ).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
     }
 
     // see #2926
@@ -1422,13 +1422,13 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchAllQuery())
                 .setSearchType(SearchType.DFS_QUERY_THEN_FETCH).get();
-        assertHitCount(searchResponse, 4l);
+        assertHitCount(searchResponse, 4L);
 
         searchResponse = client().prepareSearch("test").setQuery(
                 boolQuery()
                         .mustNot(matchQuery("description", "anything").type(Type.BOOLEAN))
         ).setSearchType(SearchType.DFS_QUERY_THEN_FETCH).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
     }
 
     // see #2994
@@ -1443,12 +1443,12 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(spanOrQuery(spanTermQuery("description", "bar"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test").setQuery(
                 spanNearQuery(spanTermQuery("description", "foo"), 3)
                         .clause(spanTermQuery("description", "other"))).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
     }
 
     @SuppressWarnings("deprecation") // fuzzy queries will be removed in 4.0
@@ -1493,17 +1493,17 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(spanNotQuery(spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                         .clause(QueryBuilders.spanTermQuery("description", "fox")), spanTermQuery("description", "brown"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(spanNotQuery(spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                         .clause(QueryBuilders.spanTermQuery("description", "fox")), spanTermQuery("description", "sleeping")).dist(5)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(spanNotQuery(spanNearQuery(QueryBuilders.spanTermQuery("description", "quick"), 1)
                         .clause(QueryBuilders.spanTermQuery("description", "fox")), spanTermQuery("description", "jumped")).pre(1).post(1)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
     }
 
     public void testSimpleDFSQuery() throws IOException {
@@ -1691,7 +1691,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .setQuery(
                         queryStringQuery("foo.baz").useDisMax(false).defaultOperator(Operator.AND)
                                 .field("field1").field("field2")).get();
-        assertHitCount(response, 1l);
+        assertHitCount(response, 1L);
     }
 
     // see #3797
@@ -1703,15 +1703,15 @@ public class SearchQueryIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(multiMatchQuery("value2", "field2").field("field1", 2).lenient(true).useDisMax(false)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(multiMatchQuery("value2", "field2").field("field1", 2).lenient(true).useDisMax(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(multiMatchQuery("value2").field("field2", 2).lenient(true)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
     }
 
     public void testAllFieldEmptyMapping() throws Exception {
@@ -1742,24 +1742,24 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("index1", "index2", "index3")
                 .setQuery(indicesQuery(matchQuery("text", "value1"), "index1")
                         .noMatchQuery(matchQuery("text", "value2"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
         //default no match query is match_all
         searchResponse = client().prepareSearch("index1", "index2", "index3")
                 .setQuery(indicesQuery(matchQuery("text", "value1"), "index1")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertSearchHits(searchResponse, "1", "2", "3");
         searchResponse = client().prepareSearch("index1", "index2", "index3")
                 .setQuery(indicesQuery(matchQuery("text", "value1"), "index1")
                         .noMatchQuery(QueryBuilders.matchAllQuery())).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertSearchHits(searchResponse, "1", "2", "3");
 
         searchResponse = client().prepareSearch("index1", "index2", "index3")
                 .setQuery(indicesQuery(matchQuery("text", "value1"), "index1")
                         .noMatchQuery("none")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("1"));
     }
 
@@ -1791,7 +1791,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("related", "simple")
                 .setQuery(indicesQuery(hasChildQuery("child", matchQuery("text", "value2")), "related")
                         .noMatchQuery(matchQuery("text", "value1"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
     }
 
@@ -1812,7 +1812,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 indicesQuery(termQuery("field", "missing"), "test1", "test2", "test3")
                         .noMatchQuery(termQuery("field", "match"))).get();
 
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
 
         for (SearchHit hit : searchResponse.getHits().getHits()) {
             if ("index1".equals(hit.index())) {
@@ -1831,7 +1831,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 indicesQuery(termQuery("field", "missing"), "test1")
                         .noMatchQuery(termQuery("field", "match"))).get();
 
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
 
         for (SearchHit hit : searchResponse.getHits().getHits()) {
             if ("index1".equals(hit.index())) {
@@ -1850,7 +1850,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 indicesQuery(termQuery("field", "missing"), "index1", "test1")
                         .noMatchQuery(termQuery("field", "match"))).get();
 
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         for (SearchHit hit : searchResponse.getHits().getHits()) {
             if ("index2".equals(hit.index())) {
@@ -1933,51 +1933,51 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2014-01-01T00:00:00").to("2014-01-01T00:59:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("1"));
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2013-12-31T23:00:00").to("2013-12-31T23:59:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("2"));
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2014-01-01T01:00:00").to("2014-01-01T01:59:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("3"));
 
         // We explicitly define a time zone in the from/to dates so whatever the time zone is, it won't be used
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2014-01-01T00:00:00Z").to("2014-01-01T00:59:00Z").timeZone("+10:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("1"));
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2013-12-31T23:00:00Z").to("2013-12-31T23:59:00Z").timeZone("+10:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("2"));
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2014-01-01T01:00:00Z").to("2014-01-01T01:59:00Z").timeZone("+10:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("3"));
 
         // We define a time zone to be applied to the filter and from/to have no time zone
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2014-01-01T03:00:00").to("2014-01-01T03:59:00").timeZone("+03:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("1"));
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2014-01-01T02:00:00").to("2014-01-01T02:59:00").timeZone("+03:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("2"));
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2014-01-01T04:00:00").to("2014-01-01T04:59:00").timeZone("+03:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("3"));
 
         // When we use long values, it means we have ms since epoch UTC based so we don't apply any transformation
@@ -1993,13 +1993,13 @@ public class SearchQueryIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("2014-01-01").to("2014-01-01T00:59:00").timeZone("-01:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("3"));
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(QueryBuilders.rangeQuery("date").from("now/d-1d").timeZone("+01:00"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertThat(searchResponse.getHits().getAt(0).getId(), is("4"));
 
         // A Range Filter on a numeric field with a TimeZone should raise an exception
@@ -2018,7 +2018,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         client().prepareIndex("test", "type1", "1").setSource("{}").get();
 
         refresh();
-        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1l);
+        assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
     }
 
     // see #5120
@@ -2042,32 +2042,32 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(matchQuery("meta", "1234"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(matchQuery("meta", "1234.56"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termQuery("meta", "A1234"))
                 .get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(termQuery("meta", "a1234"))
                 .get();
-        assertHitCount(searchResponse, 0l); // it's upper case
+        assertHitCount(searchResponse, 0L); // it's upper case
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(matchQuery("meta", "A1234").analyzer("my_ngram_analyzer"))
                 .get(); // force ngram analyzer
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test")
                 .setQuery(matchQuery("meta", "a1234").analyzer("my_ngram_analyzer"))
                 .get(); // this one returns a hit since it's default operator is OR
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
     }
 
     public void testMatchPhrasePrefixQuery() throws ExecutionException, InterruptedException {
@@ -2077,13 +2077,13 @@ public class SearchQueryIT extends ESIntegTestCase {
 
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("field", "Johnnie la").slop(between(2,5)).type(Type.PHRASE_PREFIX)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
         searchResponse = client().prepareSearch().setQuery(matchQuery("field", "trying").type(Type.PHRASE_PREFIX)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "2");
         searchResponse = client().prepareSearch().setQuery(matchQuery("field", "try").type(Type.PHRASE_PREFIX)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "2");
     }
 
@@ -2096,7 +2096,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                 .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
                 .setQuery(QueryBuilders.queryStringQuery("xyz").boost(100))
                 .get();
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
 
         float first = response.getHits().getAt(0).getScore();
@@ -2106,7 +2106,7 @@ public class SearchQueryIT extends ESIntegTestCase {
                     .setQuery(QueryBuilders.queryStringQuery("xyz").boost(100))
                     .get();
 
-            assertThat(response.getHits().totalHits(), equalTo(1l));
+            assertThat(response.getHits().totalHits(), equalTo(1L));
             assertThat(response.getHits().getAt(0).id(), equalTo("1"));
             float actual = response.getHits().getAt(0).getScore();
             assertThat(i + " expected: " + first + " actual: " + actual, Float.compare(first, actual), equalTo(0));

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -62,7 +62,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
                 client().prepareIndex("test", "type1", "6").setSource("otherbody", "spaghetti"));
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertSearchHits(searchResponse, "1", "2", "3");
 
         // Tests boost value setting. In this case doc 1 should always be ranked above the other
@@ -71,32 +71,32 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
                 boolQuery()
                     .should(simpleQueryStringQuery("\"foo bar\"").boost(10.0f))
                     .should(termQuery("body", "eggplant"))).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo bar").defaultOperator(Operator.AND)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("\"quux baz\" +(eggplant | spaghetti)")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "4", "5");
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("eggplants").analyzer("snowball")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("4"));
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("spaghetti").field("body", 1000.0f).field("otherbody", 2.0f).queryName("myquery")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("5"));
         assertSearchHits(searchResponse, "5", "6");
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("myquery"));
 
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("spaghetti").field("*body")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "5", "6");
     }
 
@@ -112,17 +112,17 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
 
         logger.info("--> query 1");
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").minimumShouldMatch("2")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "4");
 
         logger.info("--> query 2");
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").field("body").field("body2").minimumShouldMatch("2")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "4");
 
         logger.info("--> query 3");
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body").field("body2").minimumShouldMatch("70%")).get();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "4");
 
         indexRandom(true, false,
@@ -133,17 +133,17 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
 
         logger.info("--> query 4");
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").field("body").field("body2").minimumShouldMatch("2")).get();
-        assertHitCount(searchResponse, 4l);
+        assertHitCount(searchResponse, 4L);
         assertSearchHits(searchResponse, "3", "4", "7", "8");
 
         logger.info("--> query 5");
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar").minimumShouldMatch("2")).get();
-        assertHitCount(searchResponse, 5l);
+        assertHitCount(searchResponse, 5L);
         assertSearchHits(searchResponse, "3", "4", "6", "7", "8");
 
         logger.info("--> query 6");
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body2").field("other").minimumShouldMatch("70%")).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertSearchHits(searchResponse, "6", "7", "8");
     }
 
@@ -153,21 +153,21 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("Professio*")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("Professio*").lowercaseExpandedTerms(false)).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("Professionan~1")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("Professionan~1").lowercaseExpandedTerms(false)).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
     }
 
     public void testQueryStringLocale() {
@@ -176,17 +176,17 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("BILL*")).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
         searchResponse = client().prepareSearch().setQuery(queryStringQuery("body:BILL*")).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("BILL*").locale(new Locale("tr", "TR"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
         searchResponse = client().prepareSearch().setQuery(
                 queryStringQuery("body:BILL*").locale(new Locale("tr", "TR"))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
     }
 
@@ -210,22 +210,22 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo bar baz").field("body")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setTypes("type1").setQuery(
                 simpleQueryStringQuery("foo bar baz").field("body")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo bar baz").field("body.sub")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setTypes("type1").setQuery(
                 simpleQueryStringQuery("foo bar baz").field("body.sub")).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
     }
 
@@ -241,42 +241,42 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo bar").flags(SimpleQueryStringFlag.ALL)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertSearchHits(searchResponse, "1", "2", "3");
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo | bar")
                         .defaultOperator(Operator.AND)
                         .flags(SimpleQueryStringFlag.OR)).get();
-        assertHitCount(searchResponse, 3l);
+        assertHitCount(searchResponse, 3L);
         assertSearchHits(searchResponse, "1", "2", "3");
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("foo | bar")
                         .defaultOperator(Operator.AND)
                         .flags(SimpleQueryStringFlag.NONE)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("3"));
 
         searchResponse = client().prepareSearch().setQuery(
                 simpleQueryStringQuery("baz | egg*")
                         .defaultOperator(Operator.AND)
                         .flags(SimpleQueryStringFlag.NONE)).get();
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client()
                 .prepareSearch()
                 .setSource(
                         new SearchSourceBuilder().query(QueryBuilders.simpleQueryStringQuery("foo|bar").defaultOperator(Operator.AND)
                                 .flags(SimpleQueryStringFlag.NONE))).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client()
                 .prepareSearch()
                 .setQuery(
                         simpleQueryStringQuery("baz | egg*").defaultOperator(Operator.AND).flags(SimpleQueryStringFlag.WHITESPACE,
                                 SimpleQueryStringFlag.PREFIX)).get();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("4"));
     }
 
@@ -288,12 +288,12 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo").field("field")).get();
         assertFailures(searchResponse);
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
 
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo").field("field").lenient(true)).get();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
     }
 
@@ -332,7 +332,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("Köln*").analyzeWildcard(true).field("location")).get();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -92,7 +92,7 @@ public class SearchScrollIT extends ESIntegTestCase {
         try {
             long counter = 0;
 
-            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100L));
             assertThat(searchResponse.getHits().hits().length, equalTo(35));
             for (SearchHit hit : searchResponse.getHits()) {
                 assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter++));
@@ -102,7 +102,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                     .setScroll(TimeValue.timeValueMinutes(2))
                     .execute().actionGet();
 
-            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100L));
             assertThat(searchResponse.getHits().hits().length, equalTo(35));
             for (SearchHit hit : searchResponse.getHits()) {
                 assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter++));
@@ -112,7 +112,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                     .setScroll(TimeValue.timeValueMinutes(2))
                     .execute().actionGet();
 
-            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100L));
             assertThat(searchResponse.getHits().hits().length, equalTo(30));
             for (SearchHit hit : searchResponse.getHits()) {
                 assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter++));
@@ -150,7 +150,7 @@ public class SearchScrollIT extends ESIntegTestCase {
         try {
             long counter = 0;
 
-            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100L));
             assertThat(searchResponse.getHits().hits().length, equalTo(3));
             for (SearchHit hit : searchResponse.getHits()) {
                 assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter++));
@@ -161,7 +161,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                         .setScroll(TimeValue.timeValueMinutes(2))
                         .execute().actionGet();
 
-                assertThat(searchResponse.getHits().getTotalHits(), equalTo(100l));
+                assertThat(searchResponse.getHits().getTotalHits(), equalTo(100L));
                 assertThat(searchResponse.getHits().hits().length, equalTo(3));
                 for (SearchHit hit : searchResponse.getHits()) {
                     assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter++));
@@ -173,7 +173,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                     .setScroll(TimeValue.timeValueMinutes(2))
                     .execute().actionGet();
 
-            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100L));
             assertThat(searchResponse.getHits().hits().length, equalTo(1));
             for (SearchHit hit : searchResponse.getHits()) {
                 assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter++));
@@ -184,7 +184,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                     .setScroll(TimeValue.timeValueMinutes(2))
                     .execute().actionGet();
 
-            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100l));
+            assertThat(searchResponse.getHits().getTotalHits(), equalTo(100L));
             assertThat(searchResponse.getHits().hits().length, equalTo(0));
             for (SearchHit hit : searchResponse.getHits()) {
                 assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter++));
@@ -206,11 +206,11 @@ public class SearchScrollIT extends ESIntegTestCase {
 
         client().admin().indices().prepareRefresh().execute().actionGet();
 
-        assertThat(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(500l));
-        assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).execute().actionGet().getHits().totalHits(), equalTo(500l));
-        assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).execute().actionGet().getHits().totalHits(), equalTo(500l));
-        assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "update")).execute().actionGet().getHits().totalHits(), equalTo(0l));
-        assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "update")).execute().actionGet().getHits().totalHits(), equalTo(0l));
+        assertThat(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(500L));
+        assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).execute().actionGet().getHits().totalHits(), equalTo(500L));
+        assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).execute().actionGet().getHits().totalHits(), equalTo(500L));
+        assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "update")).execute().actionGet().getHits().totalHits(), equalTo(0L));
+        assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "update")).execute().actionGet().getHits().totalHits(), equalTo(0L));
 
         SearchResponse searchResponse = client().prepareSearch()
                 .setQuery(queryStringQuery("user:kimchy"))
@@ -229,11 +229,11 @@ public class SearchScrollIT extends ESIntegTestCase {
             } while (searchResponse.getHits().hits().length > 0);
 
             client().admin().indices().prepareRefresh().execute().actionGet();
-            assertThat(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(500l));
-            assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).execute().actionGet().getHits().totalHits(), equalTo(0l));
-            assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).execute().actionGet().getHits().totalHits(), equalTo(0l));
-            assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "update")).execute().actionGet().getHits().totalHits(), equalTo(500l));
-            assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "update")).execute().actionGet().getHits().totalHits(), equalTo(500l));
+            assertThat(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet().getHits().totalHits(), equalTo(500L));
+            assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).execute().actionGet().getHits().totalHits(), equalTo(0L));
+            assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).execute().actionGet().getHits().totalHits(), equalTo(0L));
+            assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "update")).execute().actionGet().getHits().totalHits(), equalTo(500L));
+            assertThat(client().prepareSearch().setSize(0).setQuery(termQuery("message", "update")).execute().actionGet().getHits().totalHits(), equalTo(500L));
         } finally {
             clearScroll(searchResponse.getScrollId());
         }
@@ -270,13 +270,13 @@ public class SearchScrollIT extends ESIntegTestCase {
         long counter1 = 0;
         long counter2 = 0;
 
-        assertThat(searchResponse1.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse1.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse1.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse1.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter1++));
         }
 
-        assertThat(searchResponse2.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse2.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse2.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse2.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter2++));
@@ -290,13 +290,13 @@ public class SearchScrollIT extends ESIntegTestCase {
                 .setScroll(TimeValue.timeValueMinutes(2))
                 .execute().actionGet();
 
-        assertThat(searchResponse1.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse1.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse1.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse1.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter1++));
         }
 
-        assertThat(searchResponse2.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse2.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse2.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse2.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter2++));
@@ -318,7 +318,7 @@ public class SearchScrollIT extends ESIntegTestCase {
     public void testClearNonExistentScrollId() throws Exception {
         createIndex("idx");
         ClearScrollResponse response = client().prepareClearScroll()
-                .addScrollId("cXVlcnlUaGVuRmV0Y2g7MzsyOlpBRC1qOUhrUjhhZ0NtQWUxU2FuWlE7MjpRcjRaNEJ2R1JZV1VEMW02ZGF1LW5ROzI6S0xUal9lZDRTd3lWNUhUU2VSb01CQTswOw==")
+                .addScrollId("cXVlcnlUaGVuRmV0Y2g7MzsyOlpBRC1qOUhrUjhhZ0NtQWUxU2FuWlE7MjpRcjRaNEJ2R1JZV1VEMW02ZGF1LW5ROzI6S0xUal9LZDRTd3LWNUhUU2VSb01CQTswOw==")
                 .get();
         // Whether we actually clear a scroll, we can't know, since that information isn't serialized in the
         // free search context response, which is returned from each node we want to clear a particular scroll.
@@ -381,13 +381,13 @@ public class SearchScrollIT extends ESIntegTestCase {
         long counter1 = 0;
         long counter2 = 0;
 
-        assertThat(searchResponse1.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse1.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse1.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse1.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter1++));
         }
 
-        assertThat(searchResponse2.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse2.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse2.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse2.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter2++));
@@ -401,13 +401,13 @@ public class SearchScrollIT extends ESIntegTestCase {
                 .setScroll(TimeValue.timeValueMinutes(2))
                 .execute().actionGet();
 
-        assertThat(searchResponse1.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse1.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse1.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse1.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter1++));
         }
 
-        assertThat(searchResponse2.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse2.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse2.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse2.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter2++));
@@ -439,7 +439,7 @@ public class SearchScrollIT extends ESIntegTestCase {
 
             SearchResponse response = builder.execute().actionGet();
             try {
-                ElasticsearchAssertions.assertHitCount(response, 1l);
+                ElasticsearchAssertions.assertHitCount(response, 1L);
             } finally {
                 String scrollId = response.getScrollId();
                 if (scrollId != null) {
@@ -586,7 +586,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                 .addSort("field", SortOrder.ASC)
                 .execute().actionGet();
         long counter = 0;
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(100l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(100L));
         assertThat(searchResponse.getHits().hits().length, equalTo(35));
         for (SearchHit hit : searchResponse.getHits()) {
             assertThat(((Number) hit.sortValues()[0]).longValue(), equalTo(counter++));

--- a/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollWithFailingNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollWithFailingNodesIT.java
@@ -84,7 +84,7 @@ public class SearchScrollWithFailingNodesIT extends ESIntegTestCase {
                     .get();
             assertAllSuccessful(searchResponse);
         } while (searchResponse.getHits().hits().length > 0);
-        assertThat(numHits, equalTo(100l));
+        assertThat(numHits, equalTo(100L));
         clearScroll("_all");
 
         internalCluster().stopRandomNonMasterNode();
@@ -104,7 +104,7 @@ public class SearchScrollWithFailingNodesIT extends ESIntegTestCase {
                     .get();
             assertThat(searchResponse.getSuccessfulShards(), equalTo(numberOfSuccessfulShards));
         } while (searchResponse.getHits().hits().length > 0);
-        assertThat(numHits, greaterThan(0l));
+        assertThat(numHits, greaterThan(0L));
 
         clearScroll(searchResponse.getScrollId());
     }

--- a/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -85,7 +85,7 @@ public class SimpleSearchIT extends ESIntegTestCase {
             }
             // id is not indexed, but lets see that we automatically convert to
             SearchResponse searchResponse = client().prepareSearch().setQuery(QueryBuilders.matchAllQuery()).setPreference(randomPreference).get();
-            assertHitCount(searchResponse, 6l);
+            assertHitCount(searchResponse, 6L);
 
         }
     }
@@ -106,7 +106,7 @@ public class SimpleSearchIT extends ESIntegTestCase {
                 .setQuery(boolQuery().must(rangeQuery("from").lt("192.168.0.7")).must(rangeQuery("to").gt("192.168.0.7")))
                 .execute().actionGet();
 
-        assertHitCount(search, 1l);
+        assertHitCount(search, 1L);
     }
 
     public void testIpCidr() throws Exception {
@@ -138,27 +138,27 @@ public class SimpleSearchIT extends ESIntegTestCase {
         search = client().prepareSearch()
                 .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.168.0.1/32")))
                 .execute().actionGet();
-        assertHitCount(search, 1l);
+        assertHitCount(search, 1L);
 
         search = client().prepareSearch()
                 .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.168.0.0/24")))
                 .execute().actionGet();
-        assertHitCount(search, 3l);
+        assertHitCount(search, 3L);
 
         search = client().prepareSearch()
                 .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.0.0.0/8")))
                 .execute().actionGet();
-        assertHitCount(search, 4l);
+        assertHitCount(search, 4L);
 
         search = client().prepareSearch()
                 .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "0.0.0.0/0")))
                 .execute().actionGet();
-        assertHitCount(search, 4l);
+        assertHitCount(search, 4L);
 
         search = client().prepareSearch()
                 .setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.168.1.5/32")))
                 .execute().actionGet();
-        assertHitCount(search, 0l);
+        assertHitCount(search, 0L);
 
         assertFailures(client().prepareSearch().setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "0/0/0/0/0"))),
                 RestStatus.BAD_REQUEST,
@@ -171,17 +171,17 @@ public class SimpleSearchIT extends ESIntegTestCase {
         client().prepareIndex("test", "type", "XXX1").setSource("field", "value").setRefresh(true).execute().actionGet();
         // id is not indexed, but lets see that we automatically convert to
         SearchResponse searchResponse = client().prepareSearch().setQuery(QueryBuilders.termQuery("_id", "XXX1")).execute().actionGet();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch().setQuery(QueryBuilders.queryStringQuery("_id:XXX1")).execute().actionGet();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         // id is not index, but we can automatically support prefix as well
         searchResponse = client().prepareSearch().setQuery(QueryBuilders.prefixQuery("_id", "XXX")).execute().actionGet();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch().setQuery(QueryBuilders.queryStringQuery("_id:XXX*").lowercaseExpandedTerms(false)).execute().actionGet();
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
     }
 
     public void testSimpleDateRange() throws Exception {
@@ -192,22 +192,22 @@ public class SimpleSearchIT extends ESIntegTestCase {
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-03||+2d").lte("2010-01-04||+2d/d")).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-05T02:00").lte("2010-01-06T02:00")).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
 
         searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gte("2010-01-05T02:00").lt("2010-01-06T02:00")).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1l);
+        assertHitCount(searchResponse, 1L);
 
         searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("field").gt("2010-01-05T02:00").lt("2010-01-06T02:00")).execute().actionGet();
         assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 0l);
+        assertHitCount(searchResponse, 0L);
 
         searchResponse = client().prepareSearch("test").setQuery(QueryBuilders.queryStringQuery("field:[2010-01-03||+2d TO 2010-01-04||+2d/d]")).execute().actionGet();
-        assertHitCount(searchResponse, 2l);
+        assertHitCount(searchResponse, 2L);
     }
 
     public void testLocaleDependentDate() throws Exception {
@@ -236,13 +236,13 @@ public class SimpleSearchIT extends ESIntegTestCase {
             SearchResponse searchResponse = client().prepareSearch("test")
                     .setQuery(QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Do, 07 Dez 2000 00:00:00 -0800"))
                     .execute().actionGet();
-            assertHitCount(searchResponse, 10l);
+            assertHitCount(searchResponse, 10L);
 
 
             searchResponse = client().prepareSearch("test")
                     .setQuery(QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Fr, 08 Dez 2000 00:00:00 -0800"))
                     .execute().actionGet();
-            assertHitCount(searchResponse, 20l);
+            assertHitCount(searchResponse, 20L);
 
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -293,12 +293,12 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         Map<String, List<Object>> firstPayload = options.get(0).getPayload();
         assertThat(firstPayload.keySet(), containsInAnyOrder("title", "count"));
         assertThat((String) firstPayload.get("title").get(0), equalTo("title2"));
-        assertThat((long) firstPayload.get("count").get(0), equalTo(2l));
+        assertThat((long) firstPayload.get("count").get(0), equalTo(2L));
 
         Map<String, List<Object>> secondPayload = options.get(1).getPayload();
         assertThat(secondPayload.keySet(), containsInAnyOrder("title", "count"));
         assertThat((String) secondPayload.get("title").get(0), equalTo("title1"));
-        assertThat((long) secondPayload.get("count").get(0), equalTo(1l));
+        assertThat((long) secondPayload.get("count").get(0), equalTo(1L));
     }
 
     public void testSuggestWithPayload() throws Exception {
@@ -378,7 +378,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         PercolateResponse response = client().preparePercolate().setIndices(INDEX).setDocumentType(TYPE)
                 .setGetRequest(Requests.getRequest(INDEX).type(TYPE).id("1"))
                 .execute().actionGet();
-        assertThat(response.getCount(), equalTo(1l));
+        assertThat(response.getCount(), equalTo(1L));
     }
 
     public void testThatWeightsAreWorking() throws Exception {
@@ -438,7 +438,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         CompletionSuggestion.Entry.Option prefixOption = (CompletionSuggestion.Entry.Option) option;
 
         assertThat(prefixOption.getText().string(), equalTo("testing"));
-        assertThat((long) prefixOption.getScore(), equalTo(10l));
+        assertThat((long) prefixOption.getScore(), equalTo(10L));
     }
 
 
@@ -1045,7 +1045,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         refresh();
 
         assertSuggestions("b");
-        assertThat(2l, equalTo(client().prepareSearch(INDEX).setSize(0).get().getHits().totalHits()));
+        assertThat(2L, equalTo(client().prepareSearch(INDEX).setSize(0).get().getHits().totalHits()));
         for (IndexShardSegments seg : client().admin().indices().prepareSegments().get().getIndices().get(INDEX)) {
             ShardSegments[] shards = seg.getShards();
             for (ShardSegments shardSegments : shards) {

--- a/core/src/test/java/org/elasticsearch/similarity/SimilarityIT.java
+++ b/core/src/test/java/org/elasticsearch/similarity/SimilarityIT.java
@@ -63,11 +63,11 @@ public class SimilarityIT extends ESIntegTestCase {
                 .setRefresh(true).execute().actionGet();
 
         SearchResponse bm25SearchResponse = client().prepareSearch().setQuery(matchQuery("field1", "quick brown fox")).execute().actionGet();
-        assertThat(bm25SearchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(bm25SearchResponse.getHits().totalHits(), equalTo(1L));
         float bm25Score = bm25SearchResponse.getHits().hits()[0].score();
 
         SearchResponse defaultSearchResponse = client().prepareSearch().setQuery(matchQuery("field2", "quick brown fox")).execute().actionGet();
-        assertThat(defaultSearchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(defaultSearchResponse.getHits().totalHits(), equalTo(1L));
         float defaultScore = defaultSearchResponse.getHits().hits()[0].score();
 
         assertThat(bm25Score, not(equalTo(defaultScore)));

--- a/core/src/test/java/org/elasticsearch/threadpool/ThreadPoolSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/ThreadPoolSerializationTests.java
@@ -63,7 +63,7 @@ public class ThreadPoolSerializationTests extends ESTestCase {
         ThreadPool.Info newInfo = new ThreadPool.Info();
         newInfo.readFrom(input);
 
-        assertThat(newInfo.getQueueSize().singles(), is(10000l));
+        assertThat(newInfo.getQueueSize().singles(), is(10000L));
     }
 
     public void testThatNegativeQueueSizesCanBeSerialized() throws Exception {

--- a/core/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -379,7 +379,7 @@ public class UpdateThreadPoolSettingsTests extends ESTestCase {
                     assertEquals(info.getThreadPoolType(), ThreadPool.ThreadPoolType.FIXED);
                     assertThat(info.getMin(), equalTo(1));
                     assertThat(info.getMax(), equalTo(1));
-                    assertThat(info.getQueueSize().singles(), equalTo(1l));
+                    assertThat(info.getQueueSize().singles(), equalTo(1L));
                 } else {
                     for (Field field : Names.class.getFields()) {
                         if (info.getName().equalsIgnoreCase(field.getName())) {
@@ -411,7 +411,7 @@ public class UpdateThreadPoolSettingsTests extends ESTestCase {
                     foundPool2 = true;
                     assertThat(info.getMax(), equalTo(10));
                     assertThat(info.getMin(), equalTo(10));
-                    assertThat(info.getQueueSize().singles(), equalTo(1l));
+                    assertThat(info.getQueueSize().singles(), equalTo(1L));
                     assertEquals(info.getThreadPoolType(), ThreadPool.ThreadPoolType.FIXED);
                 } else {
                     for (Field field : Names.class.getFields()) {

--- a/core/src/test/java/org/elasticsearch/timestamp/SimpleTimestampIT.java
+++ b/core/src/test/java/org/elasticsearch/timestamp/SimpleTimestampIT.java
@@ -74,7 +74,7 @@ public class SimpleTimestampIT extends ESIntegTestCase {
 
         getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(false).execute().actionGet();
         timestamp = ((Number) getResponse.getField("_timestamp").getValue()).longValue();
-        assertThat(timestamp, equalTo(10l));
+        assertThat(timestamp, equalTo(10L));
         // verify its the same timestamp when going the replica
         getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(false).execute().actionGet();
         assertThat(((Number) getResponse.getField("_timestamp").getValue()).longValue(), equalTo(timestamp));
@@ -84,7 +84,7 @@ public class SimpleTimestampIT extends ESIntegTestCase {
 
         getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(false).execute().actionGet();
         timestamp = ((Number) getResponse.getField("_timestamp").getValue()).longValue();
-        assertThat(timestamp, equalTo(20l));
+        assertThat(timestamp, equalTo(20L));
         // verify its the same timestamp when going the replica
         getResponse = client().prepareGet("test", "type1", "1").setFields("_timestamp").setRealtime(false).execute().actionGet();
         assertThat(((Number) getResponse.getField("_timestamp").getValue()).longValue(), equalTo(timestamp));

--- a/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
+++ b/core/src/test/java/org/elasticsearch/transport/ContextAndHeaderTransportIT.java
@@ -229,7 +229,7 @@ public class ContextAndHeaderTransportIT extends ESIntegTestCase {
 
         GetRequest getRequest = client.prepareGet(lookupIndex, "type", "1").request();
         PercolateResponse response = client.preparePercolate().setDocumentType("type").setGetRequest(getRequest).get();
-        assertThat(response.getCount(), is(1l));
+        assertThat(response.getCount(), is(1L));
 
         assertGetRequestsContainHeaders();
     }

--- a/core/src/test/java/org/elasticsearch/transport/netty/NettyScheduledPingTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/netty/NettyScheduledPingTests.java
@@ -69,12 +69,12 @@ public class NettyScheduledPingTests extends ESTestCase {
         assertBusy(new Runnable() {
             @Override
             public void run() {
-                assertThat(nettyA.scheduledPing.successfulPings.count(), greaterThan(100l));
-                assertThat(nettyB.scheduledPing.successfulPings.count(), greaterThan(100l));
+                assertThat(nettyA.scheduledPing.successfulPings.count(), greaterThan(100L));
+                assertThat(nettyB.scheduledPing.successfulPings.count(), greaterThan(100L));
             }
         });
-        assertThat(nettyA.scheduledPing.failedPings.count(), equalTo(0l));
-        assertThat(nettyB.scheduledPing.failedPings.count(), equalTo(0l));
+        assertThat(nettyA.scheduledPing.failedPings.count(), equalTo(0L));
+        assertThat(nettyB.scheduledPing.failedPings.count(), equalTo(0L));
 
         serviceA.registerRequestHandler("sayHello", TransportRequest.Empty::new, ThreadPool.Names.GENERIC, new TransportRequestHandler<TransportRequest.Empty>() {
             @Override
@@ -118,12 +118,12 @@ public class NettyScheduledPingTests extends ESTestCase {
         assertBusy(new Runnable() {
             @Override
             public void run() {
-                assertThat(nettyA.scheduledPing.successfulPings.count(), greaterThan(200l));
-                assertThat(nettyB.scheduledPing.successfulPings.count(), greaterThan(200l));
+                assertThat(nettyA.scheduledPing.successfulPings.count(), greaterThan(200L));
+                assertThat(nettyB.scheduledPing.successfulPings.count(), greaterThan(200L));
             }
         });
-        assertThat(nettyA.scheduledPing.failedPings.count(), equalTo(0l));
-        assertThat(nettyB.scheduledPing.failedPings.count(), equalTo(0l));
+        assertThat(nettyA.scheduledPing.failedPings.count(), equalTo(0L));
+        assertThat(nettyB.scheduledPing.failedPings.count(), equalTo(0L));
 
         Releasables.close(serviceA, serviceB);
         terminate(threadPool);

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -297,8 +297,8 @@ public class TribeIT extends ESIntegTestCase {
         tribeClient.admin().indices().prepareRefresh().get();
 
         logger.info("verify they are there");
-        assertHitCount(tribeClient.prepareSearch().setSize(0).get(), 2l);
-        assertHitCount(tribeClient.prepareSearch().get(), 2l);
+        assertHitCount(tribeClient.prepareSearch().setSize(0).get(), 2L);
+        assertHitCount(tribeClient.prepareSearch().get(), 2L);
         assertBusy(new Runnable() {
             @Override
             public void run() {
@@ -316,8 +316,8 @@ public class TribeIT extends ESIntegTestCase {
 
 
         logger.info("verify they are there");
-        assertHitCount(tribeClient.prepareSearch().setSize(0).get(), 4l);
-        assertHitCount(tribeClient.prepareSearch().get(), 4l);
+        assertHitCount(tribeClient.prepareSearch().setSize(0).get(), 4L);
+        assertHitCount(tribeClient.prepareSearch().get(), 4L);
         assertBusy(new Runnable() {
             @Override
             public void run() {

--- a/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
+++ b/core/src/test/java/org/elasticsearch/ttl/SimpleTTLIT.java
@@ -111,7 +111,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
             ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
             assertThat(ttl0, lessThanOrEqualTo(providedTTLValue - (currentTime - now)));
         } else {
-            assertThat(providedTTLValue - (currentTime - now), lessThanOrEqualTo(0l));
+            assertThat(providedTTLValue - (currentTime - now), lessThanOrEqualTo(0L));
         }
         // verify the ttl is still decreasing when going to the replica
         currentTime = System.currentTimeMillis();
@@ -120,7 +120,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
             ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
             assertThat(ttl0, lessThanOrEqualTo(providedTTLValue - (currentTime - now)));
         } else {
-            assertThat(providedTTLValue - (currentTime - now), lessThanOrEqualTo(0l));
+            assertThat(providedTTLValue - (currentTime - now), lessThanOrEqualTo(0L));
         }
         // non realtime get (stored)
         currentTime = System.currentTimeMillis();
@@ -129,7 +129,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
             ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
             assertThat(ttl0, lessThanOrEqualTo(providedTTLValue - (currentTime - now)));
         } else {
-            assertThat(providedTTLValue - (currentTime - now), lessThanOrEqualTo(0l));
+            assertThat(providedTTLValue - (currentTime - now), lessThanOrEqualTo(0L));
         }
         // non realtime get going the replica
         currentTime = System.currentTimeMillis();
@@ -138,7 +138,7 @@ public class SimpleTTLIT extends ESIntegTestCase {
             ttl0 = ((Number) getResponse.getField("_ttl").getValue()).longValue();
             assertThat(ttl0, lessThanOrEqualTo(providedTTLValue - (currentTime - now)));
         } else {
-            assertThat(providedTTLValue - (currentTime - now), lessThanOrEqualTo(0l));
+            assertThat(providedTTLValue - (currentTime - now), lessThanOrEqualTo(0L));
         }
 
         // no TTL provided so no TTL fetched

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -598,13 +598,13 @@ public class UpdateIT extends ESIntegTestCase {
 
         client().prepareUpdate(indexOrAlias(), "type", "1")
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2"))).setVersion(1).get();
-        assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(2l));
+        assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(2L));
 
         // and again with a higher version..
         client().prepareUpdate(indexOrAlias(), "type", "1")
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v3"))).setVersion(2).get();
 
-        assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(3l));
+        assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(3L));
 
         // after delete
         client().prepareDelete("test", "type", "1").get();
@@ -628,7 +628,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setVersion(10).setVersionType(VersionType.FORCE).get();
 
         GetResponse get = get("test", "type", "2");
-        assertThat(get.getVersion(), equalTo(10l));
+        assertThat(get.getVersion(), equalTo(10L));
         assertThat((String) get.getSource().get("text"), equalTo("v10"));
 
         // upserts - the combination with versions is a bit weird. Test are here to ensure we do not change our behavior unintentionally
@@ -638,7 +638,7 @@ public class UpdateIT extends ESIntegTestCase {
                 .setScript(new Script("", ScriptService.ScriptType.INLINE, "put_values", Collections.singletonMap("text", "v2")))
                 .setVersion(10).setUpsert("{ \"text\": \"v0\" }").get();
         get = get("test", "type", "3");
-        assertThat(get.getVersion(), equalTo(1l));
+        assertThat(get.getVersion(), equalTo(1L));
         assertThat((String) get.getSource().get("text"), equalTo("v0"));
 
         // retry on conflict is rejected:

--- a/core/src/test/java/org/elasticsearch/versioning/SimpleVersioningIT.java
+++ b/core/src/test/java/org/elasticsearch/versioning/SimpleVersioningIT.java
@@ -75,23 +75,23 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen("test"); // we are testing force here which doesn't work if we are recovering at the same time - zzzzz...
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(12).setVersionType(VersionType.FORCE).get();
-        assertThat(indexResponse.getVersion(), equalTo(12l));
+        assertThat(indexResponse.getVersion(), equalTo(12L));
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").setVersion(12).setVersionType(VersionType.FORCE).get();
-        assertThat(indexResponse.getVersion(), equalTo(12l));
+        assertThat(indexResponse.getVersion(), equalTo(12L));
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").setVersion(14).setVersionType(VersionType.FORCE).get();
-        assertThat(indexResponse.getVersion(), equalTo(14l));
+        assertThat(indexResponse.getVersion(), equalTo(14L));
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(13).setVersionType(VersionType.FORCE).get();
-        assertThat(indexResponse.getVersion(), equalTo(13l));
+        assertThat(indexResponse.getVersion(), equalTo(13L));
 
         client().admin().indices().prepareRefresh().execute().actionGet();
         if (randomBoolean()) {
             refresh();
         }
         for (int i = 0; i < 10; i++) {
-            assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(13l));
+            assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(13L));
         }
 
         // deleting with a lower version works.
@@ -105,13 +105,13 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         createIndex("test");
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(12).setVersionType(VersionType.EXTERNAL_GTE).get();
-        assertThat(indexResponse.getVersion(), equalTo(12l));
+        assertThat(indexResponse.getVersion(), equalTo(12L));
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").setVersion(12).setVersionType(VersionType.EXTERNAL_GTE).get();
-        assertThat(indexResponse.getVersion(), equalTo(12l));
+        assertThat(indexResponse.getVersion(), equalTo(12L));
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").setVersion(14).setVersionType(VersionType.EXTERNAL_GTE).get();
-        assertThat(indexResponse.getVersion(), equalTo(14l));
+        assertThat(indexResponse.getVersion(), equalTo(14L));
 
         assertThrows(client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(13).setVersionType(VersionType.EXTERNAL_GTE),
                 VersionConflictEngineException.class);
@@ -121,7 +121,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             refresh();
         }
         for (int i = 0; i < 10; i++) {
-            assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(14l));
+            assertThat(client().prepareGet("test", "type", "1").get().getVersion(), equalTo(14L));
         }
 
         // deleting with a lower version fails.
@@ -144,7 +144,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // But delete with a higher version is OK.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL_GTE).execute().actionGet();
         assertThat(deleteResponse.isFound(), equalTo(false));
-        assertThat(deleteResponse.getVersion(), equalTo(18l));
+        assertThat(deleteResponse.getVersion(), equalTo(18L));
     }
 
     public void testExternalVersioning() throws Exception {
@@ -152,10 +152,10 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         ensureGreen();
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(12).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(12l));
+        assertThat(indexResponse.getVersion(), equalTo(12L));
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(14).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(14l));
+        assertThat(indexResponse.getVersion(), equalTo(14L));
 
         assertThrows(client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(13).setVersionType(VersionType.EXTERNAL).execute(),
                 VersionConflictEngineException.class);
@@ -164,7 +164,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             refresh();
         }
         for (int i = 0; i < 10; i++) {
-            assertThat(client().prepareGet("test", "type", "1").execute().actionGet().getVersion(), equalTo(14l));
+            assertThat(client().prepareGet("test", "type", "1").execute().actionGet().getVersion(), equalTo(14L));
         }
 
         // deleting with a lower version fails.
@@ -175,7 +175,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // Delete with a higher version deletes all versions up to the given one.
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).execute().actionGet();
         assertThat(deleteResponse.isFound(), equalTo(true));
-        assertThat(deleteResponse.getVersion(), equalTo(17l));
+        assertThat(deleteResponse.getVersion(), equalTo(17L));
 
         // Deleting with a lower version keeps on failing after a delete.
         assertThrows(
@@ -186,17 +186,17 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // But delete with a higher version is OK.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(18).setVersionType(VersionType.EXTERNAL).execute().actionGet();
         assertThat(deleteResponse.isFound(), equalTo(false));
-        assertThat(deleteResponse.getVersion(), equalTo(18l));
+        assertThat(deleteResponse.getVersion(), equalTo(18L));
 
 
         // TODO: This behavior breaks rest api returning http status 201, good news is that it this is only the case until deletes GC kicks in.
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(19).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(19l));
+        assertThat(indexResponse.getVersion(), equalTo(19L));
 
 
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(20).setVersionType(VersionType.EXTERNAL).execute().actionGet();
         assertThat(deleteResponse.isFound(), equalTo(true));
-        assertThat(deleteResponse.getVersion(), equalTo(20l));
+        assertThat(deleteResponse.getVersion(), equalTo(20L));
 
         // Make sure that the next delete will be GC. Note we do it on the index settings so it will be cleaned up
         HashMap<String, Object> newSettings = new HashMap<>();
@@ -207,7 +207,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         // And now we have previous version return -1
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(20).setVersionType(VersionType.EXTERNAL).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(20l));
+        assertThat(indexResponse.getVersion(), equalTo(20L));
     }
 
     public void testRequireUnitsOnUpdateSettings() throws Exception {
@@ -233,7 +233,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1")
                 .setCreate(true).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(1l));
+        assertThat(indexResponse.getVersion(), equalTo(1L));
     }
 
     public void testInternalVersioning() throws Exception {
@@ -241,10 +241,10 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         ensureGreen();
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(1l));
+        assertThat(indexResponse.getVersion(), equalTo(1L));
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").setVersion(1).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(2l));
+        assertThat(indexResponse.getVersion(), equalTo(2L));
 
         assertThrows(
                 client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setVersion(1).execute(),
@@ -264,13 +264,13 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         client().admin().indices().prepareRefresh().execute().actionGet();
         for (int i = 0; i < 10; i++) {
-            assertThat(client().prepareGet("test", "type", "1").execute().actionGet().getVersion(), equalTo(2l));
+            assertThat(client().prepareGet("test", "type", "1").execute().actionGet().getVersion(), equalTo(2L));
         }
 
         // search with versioning
         for (int i = 0; i < 10; i++) {
             SearchResponse searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setVersion(true).execute().actionGet();
-            assertThat(searchResponse.getHits().getAt(0).version(), equalTo(2l));
+            assertThat(searchResponse.getHits().getAt(0).version(), equalTo(2L));
         }
 
         // search without versioning
@@ -281,7 +281,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "type", "1").setVersion(2).execute().actionGet();
         assertThat(deleteResponse.isFound(), equalTo(true));
-        assertThat(deleteResponse.getVersion(), equalTo(3l));
+        assertThat(deleteResponse.getVersion(), equalTo(3L));
 
         assertThrows(client().prepareDelete("test", "type", "1").setVersion(2).execute(), VersionConflictEngineException.class);
 
@@ -290,7 +290,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // and thus the transaction is increased.
         deleteResponse = client().prepareDelete("test", "type", "1").setVersion(3).execute().actionGet();
         assertThat(deleteResponse.isFound(), equalTo(false));
-        assertThat(deleteResponse.getVersion(), equalTo(4l));
+        assertThat(deleteResponse.getVersion(), equalTo(4L));
     }
 
     public void testSimpleVersioningWithFlush() throws Exception {
@@ -298,12 +298,12 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         ensureGreen();
 
         IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(1l));
+        assertThat(indexResponse.getVersion(), equalTo(1L));
 
         client().admin().indices().prepareFlush().execute().actionGet();
 
         indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").setVersion(1).execute().actionGet();
-        assertThat(indexResponse.getVersion(), equalTo(2l));
+        assertThat(indexResponse.getVersion(), equalTo(2L));
 
         client().admin().indices().prepareFlush().execute().actionGet();
 
@@ -321,12 +321,12 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         client().admin().indices().prepareRefresh().execute().actionGet();
         for (int i = 0; i < 10; i++) {
-            assertThat(client().prepareGet("test", "type", "1").execute().actionGet().getVersion(), equalTo(2l));
+            assertThat(client().prepareGet("test", "type", "1").execute().actionGet().getVersion(), equalTo(2L));
         }
 
         for (int i = 0; i < 10; i++) {
             SearchResponse searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setVersion(true).execute().actionGet();
-            assertThat(searchResponse.getHits().getAt(0).version(), equalTo(2l));
+            assertThat(searchResponse.getHits().getAt(0).version(), equalTo(2L));
         }
     }
 
@@ -338,7 +338,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(1));
         IndexResponse indexResponse = bulkResponse.getItems()[0].getResponse();
-        assertThat(indexResponse.getVersion(), equalTo(1l));
+        assertThat(indexResponse.getVersion(), equalTo(1L));
     }
 
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BucketSelectorTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BucketSelectorTests.java
@@ -467,7 +467,7 @@ public class BucketSelectorTests extends ESIntegTestCase {
     public void testEmptyBuckets() {
         SearchResponse response = client().prepareSearch("idx_with_gaps")
                 .addAggregation(histogram("histo").field(FIELD_1_NAME).interval(1)
-                        .subAggregation(histogram("inner_histo").field(FIELD_1_NAME).interval(1).extendedBounds(1l, 4l).minDocCount(0)
+                        .subAggregation(histogram("inner_histo").field(FIELD_1_NAME).interval(1).extendedBounds(1L, 4L).minDocCount(0)
                                 .subAggregation(derivative("derivative").setBucketsPaths("_count").gapPolicy(GapPolicy.INSERT_ZEROS))))
                 .execute().actionGet();
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
@@ -95,26 +95,26 @@ public class BulkTests extends ESIntegTestCase {
             assertThat(bulkItemResponse.getIndex(), equalTo("test"));
         }
         assertThat(((UpdateResponse) bulkResponse.getItems()[0].getResponse()).getId(), equalTo("1"));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[0].getResponse()).getVersion(), equalTo(2l));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[0].getResponse()).getVersion(), equalTo(2L));
         assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getId(), equalTo("2"));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(2l));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(2L));
         assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getId(), equalTo("3"));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(2l));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(2L));
 
         GetResponse getResponse = client().prepareGet().setIndex("test").setType("type1").setId("1").setFields("field").execute()
                 .actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
-        assertThat(getResponse.getVersion(), equalTo(2l));
-        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(2l));
+        assertThat(getResponse.getVersion(), equalTo(2L));
+        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(2L));
 
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").setFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
-        assertThat(getResponse.getVersion(), equalTo(2l));
-        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(3l));
+        assertThat(getResponse.getVersion(), equalTo(2L));
+        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(3L));
 
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("3").setFields("field1").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
-        assertThat(getResponse.getVersion(), equalTo(2l));
+        assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(getResponse.getField("field1").getValue().toString(), equalTo("test"));
 
         bulkResponse = client()
@@ -131,27 +131,27 @@ public class BulkTests extends ESIntegTestCase {
         assertThat(bulkResponse.hasFailures(), equalTo(true));
         assertThat(bulkResponse.getItems().length, equalTo(3));
         assertThat(((UpdateResponse) bulkResponse.getItems()[0].getResponse()).getId(), equalTo("6"));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[0].getResponse()).getVersion(), equalTo(1l));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[0].getResponse()).getVersion(), equalTo(1L));
         assertThat(bulkResponse.getItems()[1].getResponse(), nullValue());
         assertThat(bulkResponse.getItems()[1].getFailure().getIndex(), equalTo("test"));
         assertThat(bulkResponse.getItems()[1].getFailure().getId(), equalTo("7"));
         assertThat(bulkResponse.getItems()[1].getFailure().getMessage(), containsString("document missing"));
         assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getId(), equalTo("2"));
         assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getIndex(), equalTo("test"));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(3l));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(3L));
 
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("6").setFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
-        assertThat(getResponse.getVersion(), equalTo(1l));
-        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(0l));
+        assertThat(getResponse.getVersion(), equalTo(1L));
+        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(0L));
 
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("7").setFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(false));
 
         getResponse = client().prepareGet().setIndex("test").setType("type1").setId("2").setFields("field").execute().actionGet();
         assertThat(getResponse.isExists(), equalTo(true));
-        assertThat(getResponse.getVersion(), equalTo(3l));
-        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(4l));
+        assertThat(getResponse.getVersion(), equalTo(3L));
+        assertThat(((Long) getResponse.getField("field").getValue()), equalTo(4L));
     }
 
     public void testBulkVersioning() throws Exception {
@@ -163,20 +163,20 @@ public class BulkTests extends ESIntegTestCase {
                 .add(client().prepareIndex("test", "type", "1").setSource("field", "2")).get();
 
         assertTrue(((IndexResponse) bulkResponse.getItems()[0].getResponse()).isCreated());
-        assertThat(((IndexResponse) bulkResponse.getItems()[0].getResponse()).getVersion(), equalTo(1l));
+        assertThat(((IndexResponse) bulkResponse.getItems()[0].getResponse()).getVersion(), equalTo(1L));
         assertTrue(((IndexResponse) bulkResponse.getItems()[1].getResponse()).isCreated());
-        assertThat(((IndexResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(1l));
+        assertThat(((IndexResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(1L));
         assertFalse(((IndexResponse) bulkResponse.getItems()[2].getResponse()).isCreated());
-        assertThat(((IndexResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(2l));
+        assertThat(((IndexResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(2L));
 
         bulkResponse = client().prepareBulk()
-                .add(client().prepareUpdate("test", "type", "1").setVersion(4l).setDoc("field", "2"))
+                .add(client().prepareUpdate("test", "type", "1").setVersion(4L).setDoc("field", "2"))
                 .add(client().prepareUpdate("test", "type", "2").setDoc("field", "2"))
-                .add(client().prepareUpdate("test", "type", "1").setVersion(2l).setDoc("field", "3")).get();
+                .add(client().prepareUpdate("test", "type", "1").setVersion(2L).setDoc("field", "3")).get();
 
         assertThat(bulkResponse.getItems()[0].getFailureMessage(), containsString("version conflict"));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(2l));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(3l));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(2L));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(3L));
 
         bulkResponse = client().prepareBulk()
                 .add(client().prepareIndex("test", "type", "e1").setSource("field", "1").setVersion(10).setVersionType(VersionType.EXTERNAL))
@@ -184,11 +184,11 @@ public class BulkTests extends ESIntegTestCase {
                 .add(client().prepareIndex("test", "type", "e1").setSource("field", "2").setVersion(12).setVersionType(VersionType.EXTERNAL)).get();
 
         assertTrue(((IndexResponse) bulkResponse.getItems()[0].getResponse()).isCreated());
-        assertThat(((IndexResponse) bulkResponse.getItems()[0].getResponse()).getVersion(), equalTo(10l));
+        assertThat(((IndexResponse) bulkResponse.getItems()[0].getResponse()).getVersion(), equalTo(10L));
         assertTrue(((IndexResponse) bulkResponse.getItems()[1].getResponse()).isCreated());
-        assertThat(((IndexResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(10l));
+        assertThat(((IndexResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(10L));
         assertFalse(((IndexResponse) bulkResponse.getItems()[2].getResponse()).isCreated());
-        assertThat(((IndexResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(12l));
+        assertThat(((IndexResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(12L));
 
         bulkResponse = client().prepareBulk()
                 .add(client().prepareUpdate("test", "type", "e1").setDoc("field", "2").setVersion(10)) // INTERNAL
@@ -196,8 +196,8 @@ public class BulkTests extends ESIntegTestCase {
                 .add(client().prepareUpdate("test", "type", "e1").setDoc("field", "4").setVersion(20).setVersionType(VersionType.INTERNAL)).get();
 
         assertThat(bulkResponse.getItems()[0].getFailureMessage(), containsString("version conflict"));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(20l));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(21l));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(20L));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[2].getResponse()).getVersion(), equalTo(21L));
     }
 
     public void testBulkUpdateMalformedScripts() throws Exception {
@@ -229,7 +229,7 @@ public class BulkTests extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[0].getResponse(), nullValue());
 
         assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getId(), equalTo("2"));
-        assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(2l));
+        assertThat(((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getVersion(), equalTo(2L));
         assertThat(((Integer) ((UpdateResponse) bulkResponse.getItems()[1].getResponse()).getGetResult().field("field").getValue()),
                 equalTo(2));
         assertThat(bulkResponse.getItems()[1].getFailure(), nullValue());
@@ -262,12 +262,12 @@ public class BulkTests extends ESIntegTestCase {
         assertThat(response.getItems().length, equalTo(numDocs));
         for (int i = 0; i < numDocs; i++) {
             assertThat(response.getItems()[i].getId(), equalTo(Integer.toString(i)));
-            assertThat(response.getItems()[i].getVersion(), equalTo(1l));
+            assertThat(response.getItems()[i].getVersion(), equalTo(1L));
             assertThat(response.getItems()[i].getIndex(), equalTo("test"));
             assertThat(response.getItems()[i].getType(), equalTo("type1"));
             assertThat(response.getItems()[i].getOpType(), equalTo("update"));
             assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getId(), equalTo(Integer.toString(i)));
-            assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getVersion(), equalTo(1l));
+            assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getVersion(), equalTo(1L));
             assertThat(((Integer) ((UpdateResponse) response.getItems()[i].getResponse()).getGetResult().field("counter").getValue()),
                     equalTo(1));
 
@@ -275,8 +275,8 @@ public class BulkTests extends ESIntegTestCase {
                 GetResponse getResponse = client().prepareGet("test", "type1", Integer.toString(i)).setFields("counter").execute()
                         .actionGet();
                 assertThat(getResponse.isExists(), equalTo(true));
-                assertThat(getResponse.getVersion(), equalTo(1l));
-                assertThat((Long) getResponse.getField("counter").getValue(), equalTo(1l));
+                assertThat(getResponse.getVersion(), equalTo(1L));
+                assertThat((Long) getResponse.getField("counter").getValue(), equalTo(1L));
             }
         }
 
@@ -301,12 +301,12 @@ public class BulkTests extends ESIntegTestCase {
         assertThat(response.getItems().length, equalTo(numDocs));
         for (int i = 0; i < numDocs; i++) {
             assertThat(response.getItems()[i].getId(), equalTo(Integer.toString(i)));
-            assertThat(response.getItems()[i].getVersion(), equalTo(2l));
+            assertThat(response.getItems()[i].getVersion(), equalTo(2L));
             assertThat(response.getItems()[i].getIndex(), equalTo("test"));
             assertThat(response.getItems()[i].getType(), equalTo("type1"));
             assertThat(response.getItems()[i].getOpType(), equalTo("update"));
             assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getId(), equalTo(Integer.toString(i)));
-            assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getVersion(), equalTo(2l));
+            assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getVersion(), equalTo(2L));
             assertThat(((Integer) ((UpdateResponse) response.getItems()[i].getResponse()).getGetResult().field("counter").getValue()),
                     equalTo(2));
         }
@@ -327,7 +327,7 @@ public class BulkTests extends ESIntegTestCase {
                 assertThat(response.getItems()[i].getFailure().getMessage(), containsString("document missing"));
             } else {
                 assertThat(response.getItems()[i].getId(), equalTo(Integer.toString(id)));
-                assertThat(response.getItems()[i].getVersion(), equalTo(3l));
+                assertThat(response.getItems()[i].getVersion(), equalTo(3L));
                 assertThat(response.getItems()[i].getIndex(), equalTo("test"));
                 assertThat(response.getItems()[i].getType(), equalTo("type1"));
                 assertThat(response.getItems()[i].getOpType(), equalTo("update"));

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/DateRangeTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/DateRangeTests.java
@@ -175,7 +175,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -184,7 +184,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -193,7 +193,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     public void testSingleValueFieldWithStringDates() throws Exception {
@@ -221,7 +221,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -230,7 +230,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -239,7 +239,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     public void testSingleValueFieldWithStringDatesWithCustomFormat() throws Exception {
@@ -268,7 +268,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -277,7 +277,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -286,7 +286,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     public void testSingleValueFieldWithDateMath() throws Exception {
@@ -314,7 +314,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -323,7 +323,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -332,7 +332,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     public void testSingleValueFieldWithCustomKey() throws Exception {
@@ -360,7 +360,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -369,7 +369,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -378,7 +378,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     /*
@@ -419,12 +419,12 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo((double) 1 + 2));
         assertThat((String) propertiesKeys[0], equalTo("r1"));
-        assertThat((long) propertiesDocCounts[0], equalTo(2l));
+        assertThat((long) propertiesDocCounts[0], equalTo(2L));
         assertThat((double) propertiesCounts[0], equalTo((double) 1 + 2));
 
         bucket = buckets.get(1);
@@ -434,12 +434,12 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo((double) 3 + 4));
         assertThat((String) propertiesKeys[1], equalTo("r2"));
-        assertThat((long) propertiesDocCounts[1], equalTo(2l));
+        assertThat((long) propertiesDocCounts[1], equalTo(2L));
         assertThat((double) propertiesCounts[1], equalTo((double) 3 + 4));
 
         bucket = buckets.get(2);
@@ -449,11 +449,11 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat((String) propertiesKeys[2], equalTo("r3"));
-        assertThat((long) propertiesDocCounts[2], equalTo(numDocs - 4l));
+        assertThat((long) propertiesDocCounts[2], equalTo(numDocs - 4L));
     }
 
     public void testSingleValuedFieldWithSubAggregationInherited() throws Exception {
@@ -482,7 +482,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Min min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
         assertThat(min.getValue(), equalTo((double) date(1, 2).getMillis()));
@@ -494,7 +494,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
         assertThat(min.getValue(), equalTo((double) date(2, 15).getMillis()));
@@ -506,7 +506,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
         min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
         assertThat(min.getValue(), equalTo((double) date(3, 15).getMillis()));
@@ -546,7 +546,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -555,7 +555,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -564,7 +564,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 2l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 2L));
     }
 
     /*
@@ -600,7 +600,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -609,7 +609,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -618,7 +618,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 1l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 1L));
     }
 
 
@@ -655,7 +655,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) date(3, 3).getMillis()));
@@ -667,7 +667,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) date(4, 3).getMillis()));
@@ -679,7 +679,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 1l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 1L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
     }
@@ -709,7 +709,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -718,7 +718,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -727,7 +727,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     public void testScriptSingleValueWithSubAggregatorInherited() throws Exception {
@@ -753,7 +753,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) date(2, 2).getMillis()));
@@ -765,7 +765,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) date(3, 2).getMillis()));
@@ -777,7 +777,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
     }
@@ -815,7 +815,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -824,7 +824,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -833,7 +833,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 2l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 2L));
     }
 
     public void testScriptMultiValuedWithAggregatorInherited() throws Exception {
@@ -858,7 +858,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Min min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
         assertThat(min.getValue(), equalTo((double) date(1, 2).getMillis()));
@@ -870,7 +870,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
         assertThat(min.getValue(), equalTo((double) date(2, 2).getMillis()));
@@ -882,7 +882,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 2l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 2L));
         min = bucket.getAggregations().get("min");
         assertThat(min, notNullValue());
         assertThat(min.getValue(), equalTo((double) date(2, 15).getMillis()));
@@ -915,7 +915,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -924,7 +924,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -933,7 +933,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
     }
 
     public void testUnmappedWithStringDates() throws Exception {
@@ -961,7 +961,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -970,7 +970,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -979,7 +979,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
     }
 
     public void testPartiallyUnmapped() throws Exception {
@@ -1007,7 +1007,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(2, 15)));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -1016,7 +1016,7 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), equalTo(date(3, 15)));
         assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -1025,16 +1025,16 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(((DateTime) bucket.getTo()), nullValue());
         assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(dateRange("date_range").addRange("0-1", 0, 1)))
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(dateRange("date_range").addRange("0-1", 0, 1)))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -1047,9 +1047,9 @@ public class DateRangeTests extends ESIntegTestCase {
         assertThat(dateRange.getName(), equalTo("date_range"));
         assertThat(buckets.size(), is(1));
         assertThat((String) buckets.get(0).getKey(), equalTo("0-1"));
-        assertThat(((DateTime) buckets.get(0).getFrom()).getMillis(), equalTo(0l));
-        assertThat(((DateTime) buckets.get(0).getTo()).getMillis(), equalTo(1l));
-        assertThat(buckets.get(0).getDocCount(), equalTo(0l));
+        assertThat(((DateTime) buckets.get(0).getFrom()).getMillis(), equalTo(0L));
+        assertThat(((DateTime) buckets.get(0).getTo()).getMillis(), equalTo(1L));
+        assertThat(buckets.get(0).getDocCount(), equalTo(0L));
         assertThat(buckets.get(0).getAggregations().asList().isEmpty(), is(true));
     }
 }

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/DoubleTermsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/DoubleTermsTests.java
@@ -122,43 +122,43 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
         expectedMultiSortBuckets = new HashMap<>();
         Map<String, Object> bucketProps = new HashMap<>();
         bucketProps.put("_term", 1d);
-        bucketProps.put("_count", 3l);
+        bucketProps.put("_count", 3L);
         bucketProps.put("avg_l", 1d);
         bucketProps.put("sum_d", 6d);
         expectedMultiSortBuckets.put((Double) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", 2d);
-        bucketProps.put("_count", 3l);
+        bucketProps.put("_count", 3L);
         bucketProps.put("avg_l", 2d);
         bucketProps.put("sum_d", 6d);
         expectedMultiSortBuckets.put((Double) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", 3d);
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 3d);
         bucketProps.put("sum_d", 3d);
         expectedMultiSortBuckets.put((Double) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", 4d);
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 3d);
         bucketProps.put("sum_d", 4d);
         expectedMultiSortBuckets.put((Double) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", 5d);
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 3d);
         expectedMultiSortBuckets.put((Double) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", 6d);
-        bucketProps.put("_count", 1l);
+        bucketProps.put("_count", 1L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 1d);
         expectedMultiSortBuckets.put((Double) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", 7d);
-        bucketProps.put("_count", 1l);
+        bucketProps.put("_count", 1L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 1d);
         expectedMultiSortBuckets.put((Double) bucketProps.get("_term"), bucketProps);
@@ -270,7 +270,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double)i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -296,7 +296,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -326,7 +326,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
         for (int i = 0; i < expecteds.length; i++) {
             Terms.Bucket bucket = terms.getBucketByKey("" + expecteds[i]);
             assertThat(bucket, notNullValue());
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -351,7 +351,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double)i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             i++;
         }
     }
@@ -377,7 +377,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             i--;
         }
     }
@@ -406,13 +406,13 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
-            assertThat((long) sum.getValue(), equalTo(i+i+1l));
+            assertThat((long) sum.getValue(), equalTo(i+i+1L));
             assertThat((double) propertiesKeys[i], equalTo((double) i));
-            assertThat((long) propertiesDocCounts[i], equalTo(1l));
-            assertThat((double) propertiesCounts[i], equalTo((double) i + i + 1l));
+            assertThat((long) propertiesDocCounts[i], equalTo(1L));
+            assertThat((double) propertiesCounts[i], equalTo((double) i + i + 1L));
         }
     }
 
@@ -437,7 +437,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             assertThat(sum.getValue(), equalTo((double) i));
@@ -465,7 +465,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (i+1d)));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i + 1));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -490,9 +490,9 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -519,9 +519,9 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (i+1d)));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i + 1));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -546,7 +546,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
         assertThat(bucket, notNullValue());
         assertThat(key(bucket), equalTo("1.0"));
         assertThat(bucket.getKeyAsNumber().intValue(), equalTo(1));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
     }
 
     /*
@@ -623,7 +623,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -648,7 +648,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             assertThat(sum.getValue(), equalTo((double) i));
@@ -676,9 +676,9 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -779,18 +779,18 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double) i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L).minDocCount(0)
                         .subAggregation(terms("terms")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -824,7 +824,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + (double) i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double)i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
             assertThat(avg.getValue(), equalTo((double) i));
@@ -857,7 +857,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + (double) i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double)i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
@@ -870,7 +870,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             for (Terms.Bucket subBucket : subTermsAgg.getBuckets()) {
                 assertThat(subBucket, notNullValue());
                 assertThat(key(subBucket), equalTo(String.valueOf(j)));
-                assertThat(subBucket.getDocCount(), equalTo(1l));
+                assertThat(subBucket.getDocCount(), equalTo(1L));
                 j++;
             }
         }
@@ -899,18 +899,18 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
         Terms.Bucket tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "0" : "1"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
         Filter filter = tag.getAggregations().get("filter");
         assertThat(filter, notNullValue());
-        assertThat(filter.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter.getDocCount(), equalTo(asc ? 2L : 3L));
 
         tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "1" : "0"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
         filter = tag.getAggregations().get("filter");
         assertThat(filter, notNullValue());
-        assertThat(filter.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter.getDocCount(), equalTo(asc ? 3L : 2L));
     }
 
     public void testSingleValuedFieldOrderedBySubAggregationAscMultiHierarchyLevels() throws Exception {
@@ -944,13 +944,13 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
         Terms.Bucket tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "1" : "0"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter2 = filter1.getAggregations().get("filter2");
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
         Max max = filter2.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo(asc ? 2.0 : 4.0));
@@ -958,13 +958,13 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
         tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "0" : "1"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
         filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
         filter2 = filter1.getAggregations().get("filter2");
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
         max = filter2.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo(asc ? 4.0 : 2.0));
@@ -1070,7 +1070,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + (double) i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double)i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
@@ -1099,7 +1099,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + (double) i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double)i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Stats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
@@ -1128,7 +1128,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + (double) i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double)i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Stats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
@@ -1157,7 +1157,7 @@ public class DoubleTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + (double) i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (double)i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             ExtendedStats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ExtendedStatsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ExtendedStatsTests.java
@@ -71,10 +71,10 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(extendedStats("stats")))
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(extendedStats("stats")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -84,7 +84,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats, notNullValue());
         assertThat(stats.getName(), equalTo("stats"));
         assertThat(stats.getSumOfSquares(), equalTo(0.0));
-        assertThat(stats.getCount(), equalTo(0l));
+        assertThat(stats.getCount(), equalTo(0L));
         assertThat(stats.getSum(), equalTo(0.0));
         assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
@@ -101,7 +101,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
                 .addAggregation(extendedStats("stats").field("value"))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         ExtendedStats stats = searchResponse.getAggregations().get("stats");
         assertThat(stats, notNullValue());
@@ -110,7 +110,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(stats.getSum(), equalTo(0.0));
-        assertThat(stats.getCount(), equalTo(0l));
+        assertThat(stats.getCount(), equalTo(0L));
         assertThat(stats.getSumOfSquares(), equalTo(0.0));
         assertThat(stats.getVariance(), equalTo(Double.NaN));
         assertThat(stats.getStdDeviation(), equalTo(Double.NaN));
@@ -135,7 +135,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1+4+9+16+25+36+49+64+81+100));
         assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
@@ -159,7 +159,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1+4+9+16+25+36+49+64+81+100));
         assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
@@ -184,7 +184,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMaxAsString(), equalTo("0010.0"));
         assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
         assertThat(stats.getSumAsString(), equalTo("0055.0"));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getCountAsString(), equalTo("0010.0"));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
         assertThat(stats.getSumOfSquaresAsString(), equalTo("0385.0"));
@@ -205,7 +205,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
@@ -258,7 +258,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1+4+9+16+25+36+49+64+81+100));
         assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
@@ -282,7 +282,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 4+9+16+25+36+49+64+81+100+121));
         assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
@@ -310,7 +310,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 4+9+16+25+36+49+64+81+100+121));
         assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
@@ -334,7 +334,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(12.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11+3+4+5+6+7+8+9+10+11+12));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 4+9+16+25+36+49+64+81+100+121+9+16+25+36+49+64+81+100+121+144));
         assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
@@ -358,7 +358,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10+2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1+4+9+16+25+36+49+64+81+100+4+9+16+25+36+49+64+81+100+121));
         assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 11)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 11)));
@@ -386,7 +386,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10+2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1+4+9+16+25+36+49+64+81+100+4+9+16+25+36+49+64+81+100+121));
         assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 11)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 11)));
@@ -410,7 +410,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1+4+9+16+25+36+49+64+81+100));
         assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10)));
@@ -437,7 +437,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 4+9+16+25+36+49+64+81+100+121));
         assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8 ,9, 10, 11)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8 ,9, 10, 11)));
@@ -461,7 +461,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(12.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11+3+4+5+6+7+8+9+10+11+12));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 4+9+16+25+36+49+64+81+100+121+9+16+25+36+49+64+81+100+121+144));
         assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8 ,9, 10, 11, 3, 4, 5, 6, 7, 8 ,9, 10, 11, 12)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8 ,9, 10, 11, 3, 4, 5, 6, 7, 8 ,9, 10, 11, 12)));
@@ -490,7 +490,7 @@ public class ExtendedStatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(0.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10+0+1+2+3+4+5+6+7+8+9));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1+4+9+16+25+36+49+64+81+100+0+1+4+9+16+25+36+49+64+81));
         assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8 ,9)));
         assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8 ,9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8 ,9)));

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/FunctionScoreTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/FunctionScoreTests.java
@@ -94,7 +94,7 @@ public class FunctionScoreTests extends ESIntegTestCase {
         assertSearchResponse(response);
         assertThat(response.getHits().getAt(0).score(), equalTo(1.0f));
         assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getKeyAsString(), equalTo("1.0"));
-        assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getDocCount(), is(1l));
+        assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getDocCount(), is(1L));
     }
 
     public void testMinScoreFunctionScoreBasic() throws IOException {
@@ -109,9 +109,9 @@ public class FunctionScoreTests extends ESIntegTestCase {
                                 functionScoreQuery(scriptFunction(new Script(Float.toString(score)))).setMinScore(minScore)))
         ).actionGet();
         if (score < minScore) {
-            assertThat(searchResponse.getHits().getTotalHits(), is(0l));
+            assertThat(searchResponse.getHits().getTotalHits(), is(0L));
         } else {
-            assertThat(searchResponse.getHits().getTotalHits(), is(1l));
+            assertThat(searchResponse.getHits().getTotalHits(), is(1L));
         }
 
         searchResponse = client().search(
@@ -121,9 +121,9 @@ public class FunctionScoreTests extends ESIntegTestCase {
                         }).scoreMode(FiltersFunctionScoreQuery.ScoreMode.AVG).setMinScore(minScore)))
                 ).actionGet();
         if (score < minScore) {
-            assertThat(searchResponse.getHits().getTotalHits(), is(0l));
+            assertThat(searchResponse.getHits().getTotalHits(), is(0L));
         } else {
-            assertThat(searchResponse.getHits().getTotalHits(), is(1l));
+            assertThat(searchResponse.getHits().getTotalHits(), is(1L));
         }
     }
 
@@ -188,7 +188,7 @@ public class FunctionScoreTests extends ESIntegTestCase {
                         searchSource().explain(true).query(
                                 functionScoreQuery(termQuery("text", "text")).boostMode(boostMode).setMinScore(0.1f)))).get();
         assertSearchResponse(response);
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).getScore(), equalTo(expectedScore));
 
         response = client().search(
@@ -197,7 +197,7 @@ public class FunctionScoreTests extends ESIntegTestCase {
                                 functionScoreQuery(termQuery("text", "text")).boostMode(boostMode).setMinScore(2f)))).get();
 
         assertSearchResponse(response);
-        assertThat(response.getHits().totalHits(), equalTo(0l));
+        assertThat(response.getHits().totalHits(), equalTo(0L));
     }
 }
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HDRPercentileRanksTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HDRPercentileRanksTests.java
@@ -118,13 +118,13 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                 .addAggregation(
                         histogram("histo")
                                 .field("value")
-                                .interval(1l)
+                                .interval(1L)
                                 .minDocCount(0)
                                 .subAggregation(
                                         percentileRanks("percentile_ranks").method(PercentilesMethod.HDR)
                                                 .numberOfSignificantValueDigits(sigDigits).percentiles(10, 15))).execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -147,7 +147,7 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                         percentileRanks("percentile_ranks").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
                                 .field("value").percentiles(0, 10, 15, 100)).execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         PercentileRanks reversePercentiles = searchResponse.getAggregations().get("percentile_ranks");
         assertThat(reversePercentiles, notNullValue());
@@ -192,7 +192,7 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
@@ -427,7 +427,7 @@ public class HDRPercentileRanksTests extends AbstractNumericTestCase {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        histogram("histo").field("value").interval(2l)
+                        histogram("histo").field("value").interval(2L)
                                 .subAggregation(
                                         percentileRanks("percentile_ranks").method(PercentilesMethod.HDR)
                                                 .numberOfSignificantValueDigits(sigDigits).percentiles(99))

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HDRPercentilesTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HDRPercentilesTests.java
@@ -119,14 +119,14 @@ public class HDRPercentilesTests extends AbstractNumericTestCase {
                 .addAggregation(
                         histogram("histo")
                                 .field("value")
-                                .interval(1l)
+                                .interval(1L)
                                 .minDocCount(0)
                                 .subAggregation(
                                         percentiles("percentiles").numberOfSignificantValueDigits(sigDigits).method(PercentilesMethod.HDR)
                                                 .percentiles(10,
                                                 15))).execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -149,7 +149,7 @@ public class HDRPercentilesTests extends AbstractNumericTestCase {
                         percentiles("percentiles").numberOfSignificantValueDigits(sigDigits).method(PercentilesMethod.HDR).field("value")
                                 .percentiles(0, 10, 15, 100)).execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
         assertThat(percentiles, notNullValue());
@@ -196,7 +196,7 @@ public class HDRPercentilesTests extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
@@ -417,7 +417,7 @@ public class HDRPercentilesTests extends AbstractNumericTestCase {
                 .prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        histogram("histo").field("value").interval(2l)
+                        histogram("histo").field("value").interval(2L)
                                 .subAggregation(
                                         percentiles("percentiles").method(PercentilesMethod.HDR).numberOfSignificantValueDigits(sigDigits)
                                                 .percentiles(99))

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HistogramTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/HistogramTests.java
@@ -909,12 +909,12 @@ public class HistogramTests extends ESIntegTestCase {
         Histogram.Bucket bucket = buckets.get(0);
         assertThat(bucket, notNullValue());
         assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) -1 * 2 * interval));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
         assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) -1 * interval));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         for (int i = 2; i < numValueBuckets + 2; ++i) {
             bucket = buckets.get(i);
@@ -927,11 +927,11 @@ public class HistogramTests extends ESIntegTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1l).minDocCount(0)
-                        .subAggregation(histogram("sub_histo").interval(1l)))
+                .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L).minDocCount(0)
+                        .subAggregation(histogram("sub_histo").interval(1L)))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         List<? extends Bucket> buckets = histo.getBuckets();

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IPv4RangeTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IPv4RangeTests.java
@@ -146,7 +146,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -155,7 +155,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -164,7 +164,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(55l));
+        assertThat(bucket.getDocCount(), equalTo(55L));
     }
 
     public void testSingleValueFieldWithMaskRange() throws Exception {
@@ -191,7 +191,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.0"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.128")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.128"));
-        assertThat(bucket.getDocCount(), equalTo(128l));
+        assertThat(bucket.getDocCount(), equalTo(128L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -200,7 +200,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), equalTo("10.0.0.128"));
         assertThat((long) ((Number) bucket.getTo()).doubleValue(), equalTo(IpFieldMapper.ipToLong("10.0.1.0"))); // range is exclusive on the to side
         assertThat(bucket.getToAsString(), equalTo("10.0.1.0"));
-        assertThat(bucket.getDocCount(), equalTo(127l)); // include 10.0.0.128
+        assertThat(bucket.getDocCount(), equalTo(127L)); // include 10.0.0.128
     }
 
     public void testSingleValueFieldWithCustomKey() throws Exception {
@@ -228,7 +228,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -237,7 +237,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -246,7 +246,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(55l));
+        assertThat(bucket.getDocCount(), equalTo(55L));
     }
 
     public void testSingleValuedFieldWithSubAggregation() throws Exception {
@@ -278,12 +278,12 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo((double) 100));
         assertThat((String) propertiesKeys[0], equalTo("*-10.0.0.100"));
-        assertThat((long) propertiesDocCounts[0], equalTo(100l));
+        assertThat((long) propertiesDocCounts[0], equalTo(100L));
         assertThat((double) propertiesCounts[0], equalTo((double) 100));
 
         bucket = buckets.get(1);
@@ -293,12 +293,12 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo((double) 200));
         assertThat((String) propertiesKeys[1], equalTo("10.0.0.100-10.0.0.200"));
-        assertThat((long) propertiesDocCounts[1], equalTo(100l));
+        assertThat((long) propertiesDocCounts[1], equalTo(100L));
         assertThat((double) propertiesCounts[1], equalTo((double) 200));
 
         bucket = buckets.get(2);
@@ -308,12 +308,12 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(55l));
+        assertThat(bucket.getDocCount(), equalTo(55L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo((double) 55*3));
         assertThat((String) propertiesKeys[2], equalTo("10.0.0.200-*"));
-        assertThat((long) propertiesDocCounts[2], equalTo(55l));
+        assertThat((long) propertiesDocCounts[2], equalTo(55L));
         assertThat((double) propertiesCounts[2], equalTo((double) 55 * 3));
     }
 
@@ -343,7 +343,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.99")));
@@ -355,7 +355,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.199")));
@@ -367,7 +367,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(55l));
+        assertThat(bucket.getDocCount(), equalTo(55L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.254")));
@@ -395,7 +395,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -404,7 +404,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -413,7 +413,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(55l));
+        assertThat(bucket.getDocCount(), equalTo(55L));
     }
 
     /*
@@ -458,7 +458,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -467,7 +467,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(101l));
+        assertThat(bucket.getDocCount(), equalTo(101L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -476,7 +476,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(56l));
+        assertThat(bucket.getDocCount(), equalTo(56L));
     }
 
     public void testMultiValuedFieldWithValueScript() throws Exception {
@@ -502,7 +502,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -511,7 +511,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(101l));
+        assertThat(bucket.getDocCount(), equalTo(101L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -520,7 +520,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(56l));
+        assertThat(bucket.getDocCount(), equalTo(56L));
     }
 
     public void testMultiValuedFieldWithValueScriptWithInheritedSubAggregator() throws Exception {
@@ -546,7 +546,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, Matchers.notNullValue());
         assertThat((long) max.getValue(), equalTo(IpFieldMapper.ipToLong("10.0.0.100")));
@@ -558,7 +558,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(101l));
+        assertThat(bucket.getDocCount(), equalTo(101L));
         max = bucket.getAggregations().get("max");
         assertThat(max, Matchers.notNullValue());
         assertThat((long) max.getValue(), equalTo(IpFieldMapper.ipToLong("10.0.0.200")));
@@ -570,7 +570,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(56l));
+        assertThat(bucket.getDocCount(), equalTo(56L));
         max = bucket.getAggregations().get("max");
         assertThat(max, Matchers.notNullValue());
         assertThat((long) max.getValue(), equalTo(IpFieldMapper.ipToLong("10.0.0.255")));
@@ -599,7 +599,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -608,7 +608,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -617,7 +617,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(55l));
+        assertThat(bucket.getDocCount(), equalTo(55L));
     }
 
     public void testScriptSingleValueWithSubAggregatorInherited() throws Exception {
@@ -644,7 +644,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.99")));
@@ -656,7 +656,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.199")));
@@ -668,7 +668,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(55l));
+        assertThat(bucket.getDocCount(), equalTo(55L));
         max = bucket.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.254")));
@@ -697,7 +697,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -706,7 +706,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(101l));
+        assertThat(bucket.getDocCount(), equalTo(101L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -715,7 +715,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(56l));
+        assertThat(bucket.getDocCount(), equalTo(56L));
     }
 
     public void testScriptMultiValuedWithAggregatorInherited() throws Exception {
@@ -742,7 +742,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
         Max max = bucket.getAggregations().get("max");
         assertThat(max, Matchers.notNullValue());
         assertThat((long) max.getValue(), equalTo(IpFieldMapper.ipToLong("10.0.0.100")));
@@ -754,7 +754,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(101l));
+        assertThat(bucket.getDocCount(), equalTo(101L));
         max = bucket.getAggregations().get("max");
         assertThat(max, Matchers.notNullValue());
         assertThat((long) max.getValue(), equalTo(IpFieldMapper.ipToLong("10.0.0.200")));
@@ -766,7 +766,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(56l));
+        assertThat(bucket.getDocCount(), equalTo(56L));
         max = bucket.getAggregations().get("max");
         assertThat(max, Matchers.notNullValue());
         assertThat((long) max.getValue(), equalTo(IpFieldMapper.ipToLong("10.0.0.255")));
@@ -797,7 +797,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -806,7 +806,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -815,7 +815,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
     }
 
     public void testPartiallyUnmapped() throws Exception {
@@ -843,7 +843,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("10.0.0.100"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -852,7 +852,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.100")));
         assertThat(bucket.getToAsString(), equalTo("10.0.0.200"));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
-        assertThat(bucket.getDocCount(), equalTo(100l));
+        assertThat(bucket.getDocCount(), equalTo(100L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -861,17 +861,17 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo((double) IpFieldMapper.ipToLong("10.0.0.200")));
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(55l));
+        assertThat(bucket.getDocCount(), equalTo(55L));
     }
 
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(ipRange("ip_range").field("ip").addRange("r1", "10.0.0.1", "10.0.0.10")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -886,7 +886,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat((String) buckets.get(0).getKey(), equalTo("r1"));
         assertThat(buckets.get(0).getFromAsString(), equalTo("10.0.0.1"));
         assertThat(buckets.get(0).getToAsString(), equalTo("10.0.0.10"));
-        assertThat(buckets.get(0).getDocCount(), equalTo(0l));
+        assertThat(buckets.get(0).getDocCount(), equalTo(0L));
     }
 
     public void testMask0() {
@@ -909,7 +909,7 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
-        assertEquals(255l, bucket.getDocCount());
+        assertEquals(255L, bucket.getDocCount());
     }
 
     public void testMask0SpecialIps() {
@@ -929,6 +929,6 @@ public class IPv4RangeTests extends ESIntegTestCase {
         assertThat(range.getBuckets().size(), equalTo(1));
 
         Range.Bucket bucket = buckets.get(0);
-        assertEquals(4l, bucket.getDocCount());
+        assertEquals(4L, bucket.getDocCount());
     }
 }

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndexLookupTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndexLookupTests.java
@@ -474,23 +474,23 @@ public class IndexLookupTests extends ESIntegTestCase {
 
         // check doc frequencies for 'c'
         script = new Script("term = _index['float_payload_field']['c']; if (term != null) {term.df()}");
-        expectedResults.put("1", 1l);
-        expectedResults.put("2", 1l);
-        expectedResults.put("3", 1l);
-        expectedResults.put("4", 1l);
-        expectedResults.put("5", 1l);
-        expectedResults.put("6", 1l);
+        expectedResults.put("1", 1L);
+        expectedResults.put("2", 1L);
+        expectedResults.put("3", 1L);
+        expectedResults.put("4", 1L);
+        expectedResults.put("5", 1L);
+        expectedResults.put("6", 1L);
         checkValueInEachDoc(script, expectedResults, 6);
         expectedResults.clear();
 
         // check doc frequencies for term that does not exist
         script = new Script("term = _index['float_payload_field']['non_existent_term']; if (term != null) {term.df()}");
-        expectedResults.put("1", 0l);
-        expectedResults.put("2", 0l);
-        expectedResults.put("3", 0l);
-        expectedResults.put("4", 0l);
-        expectedResults.put("5", 0l);
-        expectedResults.put("6", 0l);
+        expectedResults.put("1", 0L);
+        expectedResults.put("2", 0L);
+        expectedResults.put("3", 0L);
+        expectedResults.put("4", 0L);
+        expectedResults.put("5", 0L);
+        expectedResults.put("6", 0L);
         checkValueInEachDoc(script, expectedResults, 6);
         expectedResults.clear();
 
@@ -507,12 +507,12 @@ public class IndexLookupTests extends ESIntegTestCase {
 
         // check total term frequencies for 'a'
         script = new Script("term = _index['float_payload_field']['a']; if (term != null) {term.ttf()}");
-        expectedResults.put("1", 4l);
-        expectedResults.put("2", 4l);
-        expectedResults.put("3", 4l);
-        expectedResults.put("4", 4l);
-        expectedResults.put("5", 4l);
-        expectedResults.put("6", 4l);
+        expectedResults.put("1", 4L);
+        expectedResults.put("2", 4L);
+        expectedResults.put("3", 4L);
+        expectedResults.put("4", 4L);
+        expectedResults.put("5", 4L);
+        expectedResults.put("6", 4L);
         checkValueInEachDoc(script, expectedResults, 6);
         expectedResults.clear();
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndicesRequestTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/IndicesRequestTests.java
@@ -592,7 +592,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
         SearchRequest searchRequest = new SearchRequest(randomIndicesOrAliases).searchType(SearchType.QUERY_THEN_FETCH);
         SearchResponse searchResponse = internalCluster().clientNodeClient().search(searchRequest).actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), greaterThan(0l));
+        assertThat(searchResponse.getHits().totalHits(), greaterThan(0L));
 
         clearInterceptedActions();
         assertSameIndices(searchRequest, SearchServiceTransportAction.QUERY_ACTION_NAME, SearchServiceTransportAction.FETCH_ID_ACTION_NAME);
@@ -613,7 +613,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
         SearchRequest searchRequest = new SearchRequest(randomIndicesOrAliases).searchType(SearchType.DFS_QUERY_THEN_FETCH);
         SearchResponse searchResponse = internalCluster().clientNodeClient().search(searchRequest).actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), greaterThan(0l));
+        assertThat(searchResponse.getHits().totalHits(), greaterThan(0L));
 
         clearInterceptedActions();
         assertSameIndices(searchRequest, SearchServiceTransportAction.DFS_ACTION_NAME, SearchServiceTransportAction.QUERY_ID_ACTION_NAME,
@@ -635,7 +635,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
         SearchRequest searchRequest = new SearchRequest(randomIndicesOrAliases).searchType(SearchType.QUERY_AND_FETCH);
         SearchResponse searchResponse = internalCluster().clientNodeClient().search(searchRequest).actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), greaterThan(0l));
+        assertThat(searchResponse.getHits().totalHits(), greaterThan(0L));
 
         clearInterceptedActions();
         assertSameIndices(searchRequest, SearchServiceTransportAction.QUERY_FETCH_ACTION_NAME);
@@ -656,7 +656,7 @@ public class IndicesRequestTests extends ESIntegTestCase {
         SearchRequest searchRequest = new SearchRequest(randomIndicesOrAliases).searchType(SearchType.DFS_QUERY_AND_FETCH);
         SearchResponse searchResponse = internalCluster().clientNodeClient().search(searchRequest).actionGet();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), greaterThan(0l));
+        assertThat(searchResponse.getHits().totalHits(), greaterThan(0L));
 
         clearInterceptedActions();
         assertSameIndices(searchRequest, SearchServiceTransportAction.QUERY_QUERY_FETCH_ACTION_NAME);

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/LongTermsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/LongTermsTests.java
@@ -123,44 +123,44 @@ public class LongTermsTests extends AbstractTermsTestCase {
     private void getMultiSortDocs(List<IndexRequestBuilder> builders) throws IOException {
         expectedMultiSortBuckets = new HashMap<>();
         Map<String, Object> bucketProps = new HashMap<>();
-        bucketProps.put("_term", 1l);
-        bucketProps.put("_count", 3l);
+        bucketProps.put("_term", 1L);
+        bucketProps.put("_count", 3L);
         bucketProps.put("avg_l", 1d);
         bucketProps.put("sum_d", 6d);
         expectedMultiSortBuckets.put((Long) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
-        bucketProps.put("_term", 2l);
-        bucketProps.put("_count", 3l);
+        bucketProps.put("_term", 2L);
+        bucketProps.put("_count", 3L);
         bucketProps.put("avg_l", 2d);
         bucketProps.put("sum_d", 6d);
         expectedMultiSortBuckets.put((Long) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
-        bucketProps.put("_term", 3l);
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_term", 3L);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 3d);
         bucketProps.put("sum_d", 3d);
         expectedMultiSortBuckets.put((Long) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
-        bucketProps.put("_term", 4l);
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_term", 4L);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 3d);
         bucketProps.put("sum_d", 4d);
         expectedMultiSortBuckets.put((Long) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
-        bucketProps.put("_term", 5l);
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_term", 5L);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 3d);
         expectedMultiSortBuckets.put((Long) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
-        bucketProps.put("_term", 6l);
-        bucketProps.put("_count", 1l);
+        bucketProps.put("_term", 6L);
+        bucketProps.put("_count", 1L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 1d);
         expectedMultiSortBuckets.put((Long) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
-        bucketProps.put("_term", 7l);
-        bucketProps.put("_count", 1l);
+        bucketProps.put("_term", 7L);
+        bucketProps.put("_count", 1L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 1d);
         expectedMultiSortBuckets.put((Long) bucketProps.get("_term"), bucketProps);
@@ -272,7 +272,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -302,7 +302,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
         for (int i = 0; i < expecteds.length; i++) {
             Terms.Bucket bucket = terms.getBucketByKey("" + expecteds[i]);
             assertThat(bucket, notNullValue());
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -328,7 +328,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -351,7 +351,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             i++;
         }
     }
@@ -377,7 +377,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             i--;
         }
     }
@@ -406,13 +406,13 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
-            assertThat((long) sum.getValue(), equalTo(i+i+1l));
+            assertThat((long) sum.getValue(), equalTo(i+i+1L));
             assertThat((long) propertiesKeys[i], equalTo((long) i));
-            assertThat((long) propertiesDocCounts[i], equalTo(1l));
-            assertThat((double) propertiesCounts[i], equalTo((double) i + i + 1l));
+            assertThat((long) propertiesDocCounts[i], equalTo(1L));
+            assertThat((double) propertiesCounts[i], equalTo((double) i + i + 1L));
         }
     }
 
@@ -437,7 +437,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             assertThat(sum.getValue(), equalTo((double) i));
@@ -465,7 +465,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + (i+1d)));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i+1));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -490,9 +490,9 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -519,9 +519,9 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + (i-1d)));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i-1));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -546,7 +546,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
         assertThat(bucket, notNullValue());
         assertThat(key(bucket), equalTo("1.0"));
         assertThat(bucket.getKeyAsNumber().intValue(), equalTo(1));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
     }
 
     /*
@@ -624,7 +624,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -649,7 +649,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Sum sum = bucket.getAggregations().get("sum");
             assertThat(sum, notNullValue());
             assertThat(sum.getValue(), equalTo((double) i));
@@ -678,9 +678,9 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -775,18 +775,18 @@ public class LongTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
             assertThat(bucket.getKeyAsNumber().intValue(), equalTo(i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L).minDocCount(0)
                         .subAggregation(terms("terms")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -820,7 +820,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
             assertThat(avg.getValue(), equalTo((double) i));
@@ -850,7 +850,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
@@ -863,7 +863,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             for (Terms.Bucket subBucket : subTermsAgg.getBuckets()) {
                 assertThat(subBucket, notNullValue());
                 assertThat(key(subBucket), equalTo(String.valueOf(j)));
-                assertThat(subBucket.getDocCount(), equalTo(1l));
+                assertThat(subBucket.getDocCount(), equalTo(1L));
                 j++;
             }
         }
@@ -892,18 +892,18 @@ public class LongTermsTests extends AbstractTermsTestCase {
         Terms.Bucket tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "0" : "1"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
         Filter filter = tag.getAggregations().get("filter");
         assertThat(filter, notNullValue());
-        assertThat(filter.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter.getDocCount(), equalTo(asc ? 2L : 3L));
 
         tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "1" : "0"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
         filter = tag.getAggregations().get("filter");
         assertThat(filter, notNullValue());
-        assertThat(filter.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter.getDocCount(), equalTo(asc ? 3L : 2L));
     }
 
     public void testSingleValuedFieldOrderedBySubAggregationAscMultiHierarchyLevels() throws Exception {
@@ -934,13 +934,13 @@ public class LongTermsTests extends AbstractTermsTestCase {
         Terms.Bucket tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "1" : "0"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter2 = filter1.getAggregations().get("filter2");
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
         Max max = filter2.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo(asc ? 2.0 : 4.0));
@@ -948,13 +948,13 @@ public class LongTermsTests extends AbstractTermsTestCase {
         tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "0" : "1"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
         filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
         filter2 = filter1.getAggregations().get("filter2");
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
         max = filter2.getAggregations().get("max");
         assertThat(max, notNullValue());
         assertThat(max.getValue(), equalTo(asc ? 4.0 : 2.0));
@@ -1061,7 +1061,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
@@ -1091,7 +1091,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Stats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
@@ -1121,7 +1121,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Stats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
@@ -1151,7 +1151,7 @@ public class LongTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             ExtendedStats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/MaxTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/MaxTests.java
@@ -54,10 +54,10 @@ public class MaxTests extends AbstractNumericTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(max("max")))
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(max("max")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -76,7 +76,7 @@ public class MaxTests extends AbstractNumericTestCase {
                 .addAggregation(max("max").field("value"))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         Max max = searchResponse.getAggregations().get("max");
         assertThat(max, notNullValue());
@@ -122,7 +122,7 @@ public class MaxTests extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/MinTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/MinTests.java
@@ -54,10 +54,10 @@ public class MinTests extends AbstractNumericTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(min("min")))
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(min("min")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -76,7 +76,7 @@ public class MinTests extends AbstractNumericTestCase {
                 .addAggregation(min("min").field("value"))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         Min min = searchResponse.getAggregations().get("min");
         assertThat(min, notNullValue());
@@ -123,7 +123,7 @@ public class MinTests extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/RangeTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/RangeTests.java
@@ -180,7 +180,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -189,7 +189,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -224,7 +224,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -233,7 +233,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3"));
         assertThat(bucket.getToAsString(), equalTo("6"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -270,7 +270,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -279,7 +279,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -320,12 +320,12 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(3.0)); // 1 + 2
         assertThat((String) propertiesKeys[0], equalTo("*-3.0"));
-        assertThat((long) propertiesDocCounts[0], equalTo(2l));
+        assertThat((long) propertiesDocCounts[0], equalTo(2L));
         assertThat((double) propertiesCounts[0], equalTo(3.0));
 
         bucket = buckets.get(1);
@@ -335,12 +335,12 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getValue(), equalTo(12.0)); // 3 + 4 + 5
         assertThat((String) propertiesKeys[1], equalTo("3.0-6.0"));
-        assertThat((long) propertiesDocCounts[1], equalTo(3l));
+        assertThat((long) propertiesDocCounts[1], equalTo(3L));
         assertThat((double) propertiesCounts[1], equalTo(12.0));
 
         bucket = buckets.get(2);
@@ -350,7 +350,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 5L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         long total = 0;
@@ -359,7 +359,7 @@ public class RangeTests extends ESIntegTestCase {
         }
         assertThat(sum.getValue(), equalTo((double) total));
         assertThat((String) propertiesKeys[2], equalTo("6.0-*"));
-        assertThat((long) propertiesDocCounts[2], equalTo(numDocs - 5l));
+        assertThat((long) propertiesDocCounts[2], equalTo(numDocs - 5L));
         assertThat((double) propertiesCounts[2], equalTo((double) total));
     }
 
@@ -389,7 +389,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Avg avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
         assertThat(avg.getValue(), equalTo(1.5)); // (1 + 2) / 2
@@ -401,7 +401,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
         assertThat(avg.getValue(), equalTo(4.0)); // (3 + 4 + 5) / 3
@@ -413,7 +413,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 5L));
         avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
         long total = 0;
@@ -445,7 +445,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(1l)); // 2
+        assertThat(bucket.getDocCount(), equalTo(1L)); // 2
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -454,7 +454,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(3l)); // 3, 4, 5
+        assertThat(bucket.getDocCount(), equalTo(3L)); // 3, 4, 5
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -463,7 +463,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     /*
@@ -504,7 +504,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -513,7 +513,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(4l));
+        assertThat(bucket.getDocCount(), equalTo(4L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -522,7 +522,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     /*
@@ -561,7 +561,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -570,7 +570,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(4l));
+        assertThat(bucket.getDocCount(), equalTo(4L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -579,7 +579,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 3l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 3L));
     }
 
     /*
@@ -622,7 +622,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(1l));
+        assertThat(bucket.getDocCount(), equalTo(1L));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getName(), equalTo("sum"));
@@ -635,7 +635,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(4l));
+        assertThat(bucket.getDocCount(), equalTo(4L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getName(), equalTo("sum"));
@@ -682,7 +682,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -691,7 +691,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -700,7 +700,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 5L));
     }
 
     public void testScriptSingleValueWithSubAggregatorInherited() throws Exception {
@@ -726,7 +726,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Avg avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
         assertThat(avg.getValue(), equalTo(1.5)); // (1 + 2) / 2
@@ -738,7 +738,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
         avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
         assertThat(avg.getValue(), equalTo(4.0)); // (3 + 4 + 5) / 3
@@ -750,7 +750,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 5L));
         avg = bucket.getAggregations().get("avg");
         assertThat(avg, notNullValue());
         long total = 0;
@@ -784,7 +784,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(-1.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("-1.0"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -793,7 +793,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("1000.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
     }
 
     public void testScriptMultiValued() throws Exception {
@@ -819,7 +819,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -828,7 +828,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(4l));
+        assertThat(bucket.getDocCount(), equalTo(4L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -837,7 +837,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
     }
 
     /*
@@ -880,7 +880,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
         Sum sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getName(), equalTo("sum"));
@@ -893,7 +893,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(4l));
+        assertThat(bucket.getDocCount(), equalTo(4L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getName(), equalTo("sum"));
@@ -906,7 +906,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
         sum = bucket.getAggregations().get("sum");
         assertThat(sum, notNullValue());
         assertThat(sum.getName(), equalTo("sum"));
@@ -942,7 +942,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -951,7 +951,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -960,7 +960,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(0l));
+        assertThat(bucket.getDocCount(), equalTo(0L));
     }
 
     public void testPartiallyUnmapped() throws Exception {
@@ -990,7 +990,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(3.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("3.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -999,7 +999,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(3l));
+        assertThat(bucket.getDocCount(), equalTo(3L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -1008,7 +1008,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("6.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 5l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 5L));
     }
 
     public void testOverlappingRanges() throws Exception {
@@ -1037,7 +1037,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(5.0));
         assertThat(bucket.getFromAsString(), nullValue());
         assertThat(bucket.getToAsString(), equalTo("5.0"));
-        assertThat(bucket.getDocCount(), equalTo(4l));
+        assertThat(bucket.getDocCount(), equalTo(4L));
 
         bucket = buckets.get(1);
         assertThat(bucket, notNullValue());
@@ -1046,7 +1046,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
         assertThat(bucket.getFromAsString(), equalTo("3.0"));
         assertThat(bucket.getToAsString(), equalTo("6.0"));
-        assertThat(bucket.getDocCount(), equalTo(4l));
+        assertThat(bucket.getDocCount(), equalTo(4L));
 
         bucket = buckets.get(2);
         assertThat(bucket, notNullValue());
@@ -1055,7 +1055,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(5.0));
         assertThat(bucket.getFromAsString(), equalTo("4.0"));
         assertThat(bucket.getToAsString(), equalTo("5.0"));
-        assertThat(bucket.getDocCount(), equalTo(2l));
+        assertThat(bucket.getDocCount(), equalTo(2L));
 
         bucket = buckets.get(3);
         assertThat(bucket, notNullValue());
@@ -1064,17 +1064,17 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(bucket.getFromAsString(), equalTo("4.0"));
         assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 2l));
+        assertThat(bucket.getDocCount(), equalTo(numDocs - 2L));
     }
 
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L).minDocCount(0)
                         .subAggregation(range("range").addRange("0-2", 0.0, 2.0)))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -1091,7 +1091,7 @@ public class RangeTests extends ESIntegTestCase {
         assertThat(((Number) buckets.get(0).getTo()).doubleValue(), equalTo(2.0));
         assertThat(buckets.get(0).getFromAsString(), equalTo("0.0"));
         assertThat(buckets.get(0).getToAsString(), equalTo("2.0"));
-        assertThat(buckets.get(0).getDocCount(), equalTo(0l));
+        assertThat(buckets.get(0).getDocCount(), equalTo(0L));
 
     }
 }

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptQuerySearchTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptQuerySearchTests.java
@@ -78,7 +78,7 @@ public class ScriptQuerySearchTests extends ESIntegTestCase {
                 .setQuery(scriptQuery(new Script("doc['num1'].value > 1"))).addSort("num1", SortOrder.ASC)
                 .addScriptField("sNum1", new Script("doc['num1'].value")).execute().actionGet();
 
-        assertThat(response.getHits().totalHits(), equalTo(2l));
+        assertThat(response.getHits().totalHits(), equalTo(2L));
         assertThat(response.getHits().getAt(0).id(), equalTo("2"));
         assertThat((Double) response.getHits().getAt(0).fields().get("sNum1").values().get(0), equalTo(2.0));
         assertThat(response.getHits().getAt(1).id(), equalTo("3"));
@@ -93,7 +93,7 @@ public class ScriptQuerySearchTests extends ESIntegTestCase {
                 .setQuery(scriptQuery(new Script("doc['num1'].value > param1", ScriptType.INLINE, null, params)))
                 .addSort("num1", SortOrder.ASC).addScriptField("sNum1", new Script("doc['num1'].value")).execute().actionGet();
 
-        assertThat(response.getHits().totalHits(), equalTo(1l));
+        assertThat(response.getHits().totalHits(), equalTo(1L));
         assertThat(response.getHits().getAt(0).id(), equalTo("3"));
         assertThat((Double) response.getHits().getAt(0).fields().get("sNum1").values().get(0), equalTo(3.0));
 
@@ -106,7 +106,7 @@ public class ScriptQuerySearchTests extends ESIntegTestCase {
                         scriptQuery(new Script("doc['num1'].value > param1", ScriptType.INLINE, null, params)))
                 .addSort("num1", SortOrder.ASC).addScriptField("sNum1", new Script("doc['num1'].value")).execute().actionGet();
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
         assertThat((Double) response.getHits().getAt(0).fields().get("sNum1").values().get(0), equalTo(1.0));
         assertThat(response.getHits().getAt(1).id(), equalTo("2"));

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptedMetricTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptedMetricTests.java
@@ -279,7 +279,7 @@ public class ScriptedMetricTests extends ESIntegTestCase {
                 // A particular shard may not have any documents stored on it so
                 // we have to assume the lower bound may be 0. The check at the
                 // bottom of the test method will make sure the count is correct
-                assertThat(numberValue.longValue(), allOf(greaterThanOrEqualTo(0l), lessThanOrEqualTo(numDocs)));
+                assertThat(numberValue.longValue(), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo(numDocs)));
                 totalCount += numberValue.longValue();
             }
         }
@@ -329,7 +329,7 @@ public class ScriptedMetricTests extends ESIntegTestCase {
                 // A particular shard may not have any documents stored on it so
                 // we have to assume the lower bound may be 0. The check at the
                 // bottom of the test method will make sure the count is correct
-                assertThat(numberValue.longValue(), allOf(greaterThanOrEqualTo(0l), lessThanOrEqualTo(numDocs * 3)));
+                assertThat(numberValue.longValue(), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo(numDocs * 3)));
                 totalCount += numberValue.longValue();
             }
         }
@@ -687,7 +687,7 @@ public class ScriptedMetricTests extends ESIntegTestCase {
         assertThat(buckets, notNullValue());
         for (Bucket b : buckets) {
             assertThat(b, notNullValue());
-            assertThat(b.getDocCount(), equalTo(1l));
+            assertThat(b.getDocCount(), equalTo(1L));
             Aggregations subAggs = b.getAggregations();
             assertThat(subAggs, notNullValue());
             assertThat(subAggs.asList().size(), equalTo(1));
@@ -703,7 +703,7 @@ public class ScriptedMetricTests extends ESIntegTestCase {
             Object object = aggregationList.get(0);
             assertThat(object, notNullValue());
             assertThat(object, instanceOf(Number.class));
-            assertThat(((Number) object).longValue(), equalTo(3l));
+            assertThat(((Number) object).longValue(), equalTo(3L));
         }
     }
 
@@ -716,7 +716,7 @@ public class ScriptedMetricTests extends ESIntegTestCase {
 
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(
                         scriptedMetric("scripted")
                                 .params(params)
@@ -730,7 +730,7 @@ public class ScriptedMetricTests extends ESIntegTestCase {
                                                                 "newaggregation = []; sum = 0;for (aggregation in _aggs) { for (a in aggregation) { sum += a} }; newaggregation.add(sum); return newaggregation"))))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SearchFieldsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SearchFieldsTests.java
@@ -103,33 +103,33 @@ public class SearchFieldsTests extends ESIntegTestCase {
         client().admin().indices().prepareRefresh().execute().actionGet();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("field1").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().get("field1").value().toString(), equalTo("value1"));
 
         // field2 is not stored, check that it is not extracted from source.
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("field2").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(0));
         assertThat(searchResponse.getHits().getAt(0).fields().get("field2"), nullValue());
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("field3").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().get("field3").value().toString(), equalTo("value3"));
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("*3").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().get("field3").value().toString(), equalTo("value3"));
 
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("*3").addField("field1").addField("field2").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(2));
         assertThat(searchResponse.getHits().getAt(0).fields().get("field3").value().toString(), equalTo("value3"));
@@ -137,20 +137,20 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("field*").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(2));
         assertThat(searchResponse.getHits().getAt(0).fields().get("field3").value().toString(), equalTo("value3"));
         assertThat(searchResponse.getHits().getAt(0).fields().get("field1").value().toString(), equalTo("value1"));
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("f*3").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).fields().get("field3").value().toString(), equalTo("value3"));
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("*").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).source(), nullValue());
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(2));
@@ -158,7 +158,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
         assertThat(searchResponse.getHits().getAt(0).fields().get("field3").value().toString(), equalTo("value3"));
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).addField("*").addField("_source").execute().actionGet();
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         assertThat(searchResponse.getHits().getAt(0).source(), notNullValue());
         assertThat(searchResponse.getHits().getAt(0).fields().size(), equalTo(2));
@@ -200,7 +200,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
         assertNoFailures(response);
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().getAt(0).isSourceEmpty(), equalTo(true));
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
         Set<String> fields = new HashSet<>(response.getHits().getAt(0).fields().keySet());
@@ -208,21 +208,21 @@ public class SearchFieldsTests extends ESIntegTestCase {
         assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
         assertThat((Double) response.getHits().getAt(0).fields().get("sNum1").values().get(0), equalTo(1.0));
         assertThat((Double) response.getHits().getAt(0).fields().get("sNum1_field").values().get(0), equalTo(1.0));
-        assertThat((Long) response.getHits().getAt(0).fields().get("date1").values().get(0), equalTo(0l));
+        assertThat((Long) response.getHits().getAt(0).fields().get("date1").values().get(0), equalTo(0L));
         assertThat(response.getHits().getAt(1).id(), equalTo("2"));
         fields = new HashSet<>(response.getHits().getAt(0).fields().keySet());
         fields.remove(TimestampFieldMapper.NAME); // randomly enabled via templates
         assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
         assertThat((Double) response.getHits().getAt(1).fields().get("sNum1").values().get(0), equalTo(2.0));
         assertThat((Double) response.getHits().getAt(1).fields().get("sNum1_field").values().get(0), equalTo(2.0));
-        assertThat((Long) response.getHits().getAt(1).fields().get("date1").values().get(0), equalTo(25000l));
+        assertThat((Long) response.getHits().getAt(1).fields().get("date1").values().get(0), equalTo(25000L));
         assertThat(response.getHits().getAt(2).id(), equalTo("3"));
         fields = new HashSet<>(response.getHits().getAt(0).fields().keySet());
         fields.remove(TimestampFieldMapper.NAME); // randomly enabled via templates
         assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
         assertThat((Double) response.getHits().getAt(2).fields().get("sNum1").values().get(0), equalTo(3.0));
         assertThat((Double) response.getHits().getAt(2).fields().get("sNum1_field").values().get(0), equalTo(3.0));
-        assertThat((Long) response.getHits().getAt(2).fields().get("date1").values().get(0), equalTo(120000l));
+        assertThat((Long) response.getHits().getAt(2).fields().get("date1").values().get(0), equalTo(120000L));
 
         logger.info("running doc['num1'].value * factor");
         Map<String, Object> params = MapBuilder.<String, Object>newMapBuilder().put("factor", 2.0).map();
@@ -232,7 +232,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
                 .addScriptField("sNum1", new Script("doc['num1'].value * factor", ScriptType.INLINE, null, params))
                 .execute().actionGet();
 
-        assertThat(response.getHits().totalHits(), equalTo(3l));
+        assertThat(response.getHits().totalHits(), equalTo(3L));
         assertThat(response.getHits().getAt(0).id(), equalTo("1"));
         fields = new HashSet<>(response.getHits().getAt(0).fields().keySet());
         fields.remove(TimestampFieldMapper.NAME); // randomly enabled via templates
@@ -408,7 +408,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
                 .field("byte_field", (byte) 1)
                 .field("short_field", (short) 2)
                 .field("integer_field", 3)
-                .field("long_field", 4l)
+                .field("long_field", 4L)
                 .field("float_field", 5.0f)
                 .field("double_field", 6.0d)
                 .field("date_field", Joda.forPattern("dateOptionalTime").printer().print(new DateTime(2012, 3, 22, 0, 0, DateTimeZone.UTC)))
@@ -430,7 +430,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
                 .addField("binary_field")
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         Set<String> fields = new HashSet<>(searchResponse.getHits().getAt(0).fields().keySet());
         fields.remove(TimestampFieldMapper.NAME); // randomly enabled via templates
@@ -441,7 +441,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
         assertThat(searchResponse.getHits().getAt(0).fields().get("byte_field").value().toString(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(0).fields().get("short_field").value().toString(), equalTo("2"));
         assertThat(searchResponse.getHits().getAt(0).fields().get("integer_field").value(), equalTo((Object) 3));
-        assertThat(searchResponse.getHits().getAt(0).fields().get("long_field").value(), equalTo((Object) 4l));
+        assertThat(searchResponse.getHits().getAt(0).fields().get("long_field").value(), equalTo((Object) 4L));
         assertThat(searchResponse.getHits().getAt(0).fields().get("float_field").value(), equalTo((Object) 5.0f));
         assertThat(searchResponse.getHits().getAt(0).fields().get("double_field").value(), equalTo((Object) 6.0d));
         String dateTime = Joda.forPattern("dateOptionalTime").printer().print(new DateTime(2012, 3, 22, 0, 0, DateTimeZone.UTC));
@@ -463,7 +463,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
                 .addField("field1").addField("_routing")
                 .get();
 
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).field("field1"), nullValue());
         assertThat(searchResponse.getHits().getAt(0).field("_routing").isMetadataField(), equalTo(true));
         assertThat(searchResponse.getHits().getAt(0).field("_routing").getValue().toString(), equalTo("1"));
@@ -523,14 +523,14 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
         String field = "field1.field2.field3.field4";
         SearchResponse searchResponse = client().prepareSearch("my-index").setTypes("my-type1").addField(field).get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).field(field).isMetadataField(), equalTo(false));
         assertThat(searchResponse.getHits().getAt(0).field(field).getValues().size(), equalTo(2));
         assertThat(searchResponse.getHits().getAt(0).field(field).getValues().get(0).toString(), equalTo("value1"));
         assertThat(searchResponse.getHits().getAt(0).field(field).getValues().get(1).toString(), equalTo("value2"));
 
         searchResponse = client().prepareSearch("my-index").setTypes("my-type2").addField(field).get();
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).field(field).isMetadataField(), equalTo(false));
         assertThat(searchResponse.getHits().getAt(0).field(field).getValues().size(), equalTo(2));
         assertThat(searchResponse.getHits().getAt(0).field(field).getValues().get(0).toString(), equalTo("value1"));
@@ -573,7 +573,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
                 .field("byte_field", (byte) 1)
                 .field("short_field", (short) 2)
                 .field("integer_field", 3)
-                .field("long_field", 4l)
+                .field("long_field", 4L)
                 .field("float_field", 5.0f)
                 .field("double_field", 6.0d)
                 .field("date_field", Joda.forPattern("dateOptionalTime").printer().print(new DateTime(2012, 3, 22, 0, 0, DateTimeZone.UTC)))
@@ -594,7 +594,7 @@ public class SearchFieldsTests extends ESIntegTestCase {
                 .addFieldDataField("boolean_field");
         SearchResponse searchResponse = builder.execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().hits().length, equalTo(1));
         Set<String> fields = new HashSet<>(searchResponse.getHits().getAt(0).fields().keySet());
         fields.remove(TimestampFieldMapper.NAME); // randomly enabled via templates
@@ -603,8 +603,8 @@ public class SearchFieldsTests extends ESIntegTestCase {
 
         assertThat(searchResponse.getHits().getAt(0).fields().get("byte_field").value().toString(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(0).fields().get("short_field").value().toString(), equalTo("2"));
-        assertThat(searchResponse.getHits().getAt(0).fields().get("integer_field").value(), equalTo((Object) 3l));
-        assertThat(searchResponse.getHits().getAt(0).fields().get("long_field").value(), equalTo((Object) 4l));
+        assertThat(searchResponse.getHits().getAt(0).fields().get("integer_field").value(), equalTo((Object) 3L));
+        assertThat(searchResponse.getHits().getAt(0).fields().get("long_field").value(), equalTo((Object) 4L));
         assertThat(searchResponse.getHits().getAt(0).fields().get("float_field").value(), equalTo((Object) 5.0));
         assertThat(searchResponse.getHits().getAt(0).fields().get("double_field").value(), equalTo((Object) 6.0d));
         assertThat(searchResponse.getHits().getAt(0).fields().get("date_field").value(), equalTo((Object) 1332374400000L));

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SearchStatsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SearchStatsTests.java
@@ -117,18 +117,18 @@ public class SearchStatsTests extends ESIntegTestCase {
 
         IndicesStatsResponse indicesStats = client().admin().indices().prepareStats().execute().actionGet();
         logger.debug("###### indices search stats: " + indicesStats.getTotal().getSearch());
-        assertThat(indicesStats.getTotal().getSearch().getTotal().getQueryCount(), greaterThan(0l));
-        assertThat(indicesStats.getTotal().getSearch().getTotal().getQueryTimeInMillis(), greaterThan(0l));
-        assertThat(indicesStats.getTotal().getSearch().getTotal().getFetchCount(), greaterThan(0l));
-        assertThat(indicesStats.getTotal().getSearch().getTotal().getFetchTimeInMillis(), greaterThan(0l));
+        assertThat(indicesStats.getTotal().getSearch().getTotal().getQueryCount(), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getSearch().getTotal().getQueryTimeInMillis(), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getSearch().getTotal().getFetchCount(), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getSearch().getTotal().getFetchTimeInMillis(), greaterThan(0L));
         assertThat(indicesStats.getTotal().getSearch().getGroupStats(), nullValue());
 
         indicesStats = client().admin().indices().prepareStats().setGroups("group1").execute().actionGet();
         assertThat(indicesStats.getTotal().getSearch().getGroupStats(), notNullValue());
-        assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getQueryCount(), greaterThan(0l));
-        assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getQueryTimeInMillis(), greaterThan(0l));
-        assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getFetchCount(), greaterThan(0l));
-        assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getFetchTimeInMillis(), greaterThan(0l));
+        assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getQueryCount(), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getQueryTimeInMillis(), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getFetchCount(), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getFetchTimeInMillis(), greaterThan(0L));
         NodesStatsResponse nodeStats = client().admin().cluster().prepareNodesStats().execute().actionGet();
         NodeStats[] nodes = nodeStats.getNodes();
         Set<String> nodeIdsWithIndex = nodeIdsWithIndex("test1", "test2");
@@ -136,12 +136,12 @@ public class SearchStatsTests extends ESIntegTestCase {
         for (NodeStats stat : nodes) {
             Stats total = stat.getIndices().getSearch().getTotal();
             if (nodeIdsWithIndex.contains(stat.getNode().getId())) {
-                assertThat(total.getQueryCount(), greaterThan(0l));
-                assertThat(total.getQueryTimeInMillis(), greaterThan(0l));
+                assertThat(total.getQueryCount(), greaterThan(0L));
+                assertThat(total.getQueryTimeInMillis(), greaterThan(0L));
                 num++;
             } else {
-                assertThat(total.getQueryCount(), equalTo(0l));
-                assertThat(total.getQueryTimeInMillis(), equalTo(0l));
+                assertThat(total.getQueryCount(), equalTo(0L));
+                assertThat(total.getQueryTimeInMillis(), equalTo(0L));
             }
         }
 
@@ -186,7 +186,7 @@ public class SearchStatsTests extends ESIntegTestCase {
         client().admin().indices().prepareRefresh(index).execute().actionGet();
 
         IndicesStatsResponse indicesStats = client().admin().indices().prepareStats(index).execute().actionGet();
-        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0L));
 
         int size = scaledRandomIntBetween(1, docs);
         SearchResponse searchResponse = client().prepareSearch()
@@ -228,9 +228,9 @@ public class SearchStatsTests extends ESIntegTestCase {
 
         indicesStats = client().admin().indices().prepareStats().execute().actionGet();
         stats = indicesStats.getTotal().getSearch().getTotal();
-        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0l));
+        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0L));
         assertThat(stats.getScrollCount(), equalTo((long)numAssignedShards(index)));
-        assertThat(stats.getScrollTimeInMillis(), greaterThan(0l));
+        assertThat(stats.getScrollTimeInMillis(), greaterThan(0L));
     }
 
     protected int numAssignedShards(String... indices) {

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SimpleSortTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/SimpleSortTests.java
@@ -690,7 +690,7 @@ public class SimpleSortTests extends ESIntegTestCase {
         size = 1 + random.nextInt(10);
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setSize(size).addSort("long_value", SortOrder.DESC).execute()
                 .actionGet();
-        assertHitCount(searchResponse, 10l);
+        assertHitCount(searchResponse, 10L);
         assertHitCount(searchResponse, 10);
         assertThat(searchResponse.getHits().hits().length, equalTo(size));
         for (int i = 0; i < size; i++) {
@@ -705,7 +705,7 @@ public class SimpleSortTests extends ESIntegTestCase {
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setSize(size).addSort("float_value", SortOrder.ASC).execute()
                 .actionGet();
 
-        assertHitCount(searchResponse, 10l);
+        assertHitCount(searchResponse, 10L);
         assertThat(searchResponse.getHits().hits().length, equalTo(size));
         for (int i = 0; i < size; i++) {
             assertThat(searchResponse.getHits().getAt(i).id(), equalTo(Integer.toString(i)));
@@ -731,7 +731,7 @@ public class SimpleSortTests extends ESIntegTestCase {
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setSize(size).addSort("double_value", SortOrder.ASC).execute()
                 .actionGet();
 
-        assertHitCount(searchResponse, 10l);
+        assertHitCount(searchResponse, 10L);
         assertThat(searchResponse.getHits().hits().length, equalTo(size));
         for (int i = 0; i < size; i++) {
             assertThat(searchResponse.getHits().getAt(i).id(), equalTo(Integer.toString(i)));
@@ -743,7 +743,7 @@ public class SimpleSortTests extends ESIntegTestCase {
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setSize(size).addSort("double_value", SortOrder.DESC).execute()
                 .actionGet();
 
-        assertHitCount(searchResponse, 10l);
+        assertHitCount(searchResponse, 10L);
         assertThat(searchResponse.getHits().hits().length, equalTo(size));
         for (int i = 0; i < size; i++) {
             assertThat(searchResponse.getHits().getAt(i).id(), equalTo(Integer.toString(9 - i)));
@@ -809,7 +809,7 @@ public class SimpleSortTests extends ESIntegTestCase {
 
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(20l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(20L));
         for (int i = 0; i < 10; i++) {
             assertThat("res: " + i + " id: " + searchResponse.getHits().getAt(i).getId(), (Long) searchResponse.getHits().getAt(i).field("min").value(), equalTo((long) i));
         }
@@ -822,7 +822,7 @@ public class SimpleSortTests extends ESIntegTestCase {
 
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(20l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(20L));
         for (int i = 0; i < 10; i++) {
             assertThat("res: " + i + " id: " + searchResponse.getHits().getAt(i).getId(), (Double) searchResponse.getHits().getAt(i).field("min").value(), equalTo((double) i));
         }
@@ -836,7 +836,7 @@ public class SimpleSortTests extends ESIntegTestCase {
 
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(20l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(20L));
         for (int i = 0; i < 10; i++) {
             assertThat("res: " + i + " id: " + searchResponse.getHits().getAt(i).getId(), (Integer) searchResponse.getHits().getAt(i).field("min").value(), equalTo(i));
         }
@@ -850,7 +850,7 @@ public class SimpleSortTests extends ESIntegTestCase {
 
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(20l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(20L));
         for (int i = 0; i < 10; i++) {
             assertThat("res: " + i + " id: " + searchResponse.getHits().getAt(i).getId(), (Double) searchResponse.getHits().getAt(i).field("min").value(), closeTo((double) i, TOLERANCE));
         }
@@ -893,7 +893,7 @@ public class SimpleSortTests extends ESIntegTestCase {
 
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).field("id").value(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(1).field("id").value(), equalTo("3"));
         assertThat(searchResponse.getHits().getAt(2).field("id").value(), equalTo("2"));
@@ -906,7 +906,7 @@ public class SimpleSortTests extends ESIntegTestCase {
 
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).field("id").value(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(1).field("id").value(), equalTo("3"));
         assertThat(searchResponse.getHits().getAt(2).field("id").value(), equalTo("2"));
@@ -925,7 +925,7 @@ public class SimpleSortTests extends ESIntegTestCase {
         }
         assertThat(searchResponse.getFailedShards(), equalTo(0));
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).field("id").value(), equalTo("3"));
         assertThat(searchResponse.getHits().getAt(1).field("id").value(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(2).field("id").value(), equalTo("2"));
@@ -945,7 +945,7 @@ public class SimpleSortTests extends ESIntegTestCase {
         }
         assertThat(searchResponse.getFailedShards(), equalTo(0));
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
         assertThat(searchResponse.getHits().getAt(0).field("id").value(), equalTo("2"));
     }
 
@@ -993,7 +993,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .execute().actionGet();
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("3"));
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo("2"));
@@ -1005,7 +1005,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .execute().actionGet();
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("3"));
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo("2"));
@@ -1017,7 +1017,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .execute().actionGet();
         assertNoFailures(searchResponse);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("2"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo("3"));
@@ -1068,7 +1068,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .execute().actionGet();
         assertThat(Arrays.toString(searchResponse.getShardFailures()), searchResponse.getFailedShards(), equalTo(0));
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("3"));
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo("2"));
@@ -1080,7 +1080,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .execute().actionGet();
         assertThat(Arrays.toString(searchResponse.getShardFailures()), searchResponse.getFailedShards(), equalTo(0));
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("3"));
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo("2"));
@@ -1092,7 +1092,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .execute().actionGet();
         assertThat(Arrays.toString(searchResponse.getShardFailures()), searchResponse.getFailedShards(), equalTo(0));
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("2"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo("3"));
@@ -1104,7 +1104,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .execute().actionGet();
         assertThat(Arrays.toString(searchResponse.getShardFailures()), searchResponse.getFailedShards(), equalTo(0));
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo("1"));
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo("2"));
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo("3"));
@@ -1155,7 +1155,7 @@ public class SimpleSortTests extends ESIntegTestCase {
         ensureGreen();
 
         client().prepareIndex("test", "type1", Integer.toString(1)).setSource(jsonBuilder().startObject()
-                .array("long_values", 1l, 5l, 10l, 8l)
+                .array("long_values", 1L, 5L, 10L, 8L)
                 .array("int_values", 1, 5, 10, 8)
                 .array("short_values", 1, 5, 10, 8)
                 .array("byte_values", 1, 5, 10, 8)
@@ -1164,7 +1164,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .array("string_values", "01", "05", "10", "08")
                 .endObject()).execute().actionGet();
         client().prepareIndex("test", "type1", Integer.toString(2)).setSource(jsonBuilder().startObject()
-                .array("long_values", 11l, 15l, 20l, 7l)
+                .array("long_values", 11L, 15L, 20L, 7L)
                 .array("int_values", 11, 15, 20, 7)
                 .array("short_values", 11, 15, 20, 7)
                 .array("byte_values", 11, 15, 20, 7)
@@ -1173,7 +1173,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .array("string_values", "11", "15", "20", "07")
                 .endObject()).execute().actionGet();
         client().prepareIndex("test", "type1", Integer.toString(3)).setSource(jsonBuilder().startObject()
-                .array("long_values", 2l, 1l, 3l, -4l)
+                .array("long_values", 2L, 1L, 3L, -4L)
                 .array("int_values", 2, 1, 3, -4)
                 .array("short_values", 2, 1, 3, -4)
                 .array("byte_values", 2, 1, 3, -4)
@@ -1190,17 +1190,17 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("long_values", SortOrder.ASC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(3)));
-        assertThat(((Number) searchResponse.getHits().getAt(0).sortValues()[0]).longValue(), equalTo(-4l));
+        assertThat(((Number) searchResponse.getHits().getAt(0).sortValues()[0]).longValue(), equalTo(-4L));
 
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo(Integer.toString(1)));
-        assertThat(((Number) searchResponse.getHits().getAt(1).sortValues()[0]).longValue(), equalTo(1l));
+        assertThat(((Number) searchResponse.getHits().getAt(1).sortValues()[0]).longValue(), equalTo(1L));
 
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo(Integer.toString(2)));
-        assertThat(((Number) searchResponse.getHits().getAt(2).sortValues()[0]).longValue(), equalTo(7l));
+        assertThat(((Number) searchResponse.getHits().getAt(2).sortValues()[0]).longValue(), equalTo(7L));
 
         searchResponse = client().prepareSearch()
                 .setQuery(matchAllQuery())
@@ -1208,17 +1208,17 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("long_values", SortOrder.DESC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(2)));
-        assertThat(((Number) searchResponse.getHits().getAt(0).sortValues()[0]).longValue(), equalTo(20l));
+        assertThat(((Number) searchResponse.getHits().getAt(0).sortValues()[0]).longValue(), equalTo(20L));
 
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo(Integer.toString(1)));
-        assertThat(((Number) searchResponse.getHits().getAt(1).sortValues()[0]).longValue(), equalTo(10l));
+        assertThat(((Number) searchResponse.getHits().getAt(1).sortValues()[0]).longValue(), equalTo(10L));
 
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo(Integer.toString(3)));
-        assertThat(((Number) searchResponse.getHits().getAt(2).sortValues()[0]).longValue(), equalTo(3l));
+        assertThat(((Number) searchResponse.getHits().getAt(2).sortValues()[0]).longValue(), equalTo(3L));
 
         searchResponse = client().prepareSearch()
                 .setQuery(matchAllQuery())
@@ -1226,17 +1226,17 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort(SortBuilders.fieldSort("long_values").order(SortOrder.DESC).sortMode("sum"))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(2)));
-        assertThat(((Number) searchResponse.getHits().getAt(0).sortValues()[0]).longValue(), equalTo(53l));
+        assertThat(((Number) searchResponse.getHits().getAt(0).sortValues()[0]).longValue(), equalTo(53L));
 
         assertThat(searchResponse.getHits().getAt(1).id(), equalTo(Integer.toString(1)));
-        assertThat(((Number) searchResponse.getHits().getAt(1).sortValues()[0]).longValue(), equalTo(24l));
+        assertThat(((Number) searchResponse.getHits().getAt(1).sortValues()[0]).longValue(), equalTo(24L));
 
         assertThat(searchResponse.getHits().getAt(2).id(), equalTo(Integer.toString(3)));
-        assertThat(((Number) searchResponse.getHits().getAt(2).sortValues()[0]).longValue(), equalTo(2l));
+        assertThat(((Number) searchResponse.getHits().getAt(2).sortValues()[0]).longValue(), equalTo(2L));
 
         searchResponse = client().prepareSearch()
                 .setQuery(matchAllQuery())
@@ -1244,7 +1244,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("int_values", SortOrder.ASC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(3)));
@@ -1262,7 +1262,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("int_values", SortOrder.DESC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(2)));
@@ -1280,7 +1280,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("short_values", SortOrder.ASC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(3)));
@@ -1298,7 +1298,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("short_values", SortOrder.DESC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(2)));
@@ -1316,7 +1316,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("byte_values", SortOrder.ASC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(3)));
@@ -1334,7 +1334,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("byte_values", SortOrder.DESC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(2)));
@@ -1352,7 +1352,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("float_values", SortOrder.ASC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(3)));
@@ -1370,7 +1370,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("float_values", SortOrder.DESC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(2)));
@@ -1388,7 +1388,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("double_values", SortOrder.ASC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(3)));
@@ -1406,7 +1406,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("double_values", SortOrder.DESC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(2)));
@@ -1424,7 +1424,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("string_values", SortOrder.ASC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(3)));
@@ -1442,7 +1442,7 @@ public class SimpleSortTests extends ESIntegTestCase {
                 .addSort("string_values", SortOrder.DESC)
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(3L));
         assertThat(searchResponse.getHits().hits().length, equalTo(3));
 
         assertThat(searchResponse.getHits().getAt(0).id(), equalTo(Integer.toString(2)));

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/StatsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/StatsTests.java
@@ -57,12 +57,12 @@ public class StatsTests extends AbstractNumericTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0).subAggregation(stats("stats")))
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(stats("stats")))
                 .execute().actionGet();
 
         assertShardExecutionState(searchResponse, 0);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -71,7 +71,7 @@ public class StatsTests extends AbstractNumericTestCase {
         Stats stats = bucket.getAggregations().get("stats");
         assertThat(stats, notNullValue());
         assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getCount(), equalTo(0l));
+        assertThat(stats.getCount(), equalTo(0L));
         assertThat(stats.getSum(), equalTo(0.0));
         assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
@@ -87,7 +87,7 @@ public class StatsTests extends AbstractNumericTestCase {
 
         assertShardExecutionState(searchResponse, 0);
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         Stats stats = searchResponse.getAggregations().get("stats");
         assertThat(stats, notNullValue());
@@ -96,7 +96,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
         assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
         assertThat(stats.getSum(), equalTo(0.0));
-        assertThat(stats.getCount(), equalTo(0l));
+        assertThat(stats.getCount(), equalTo(0L));
     }
 
     @Override
@@ -117,7 +117,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
     }
 
     public void testSingleValuedField_WithFormatter() throws Exception {
@@ -138,7 +138,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMaxAsString(), equalTo("0010.0"));
         assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
         assertThat(stats.getSumAsString(), equalTo("0055.0"));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
         assertThat(stats.getCountAsString(), equalTo("0010.0"));
     }
 
@@ -152,7 +152,7 @@ public class StatsTests extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
@@ -197,7 +197,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
     }
 
     @Override
@@ -218,7 +218,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
     }
 
     @Override
@@ -241,7 +241,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
     }
 
     @Override
@@ -262,7 +262,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(12.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11+3+4+5+6+7+8+9+10+11+12));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
     }
 
     @Override
@@ -283,7 +283,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10+2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
     }
 
     @Override
@@ -306,7 +306,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10+2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
     }
 
     @Override
@@ -327,7 +327,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(1.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
     }
 
     @Override
@@ -350,7 +350,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(11.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11));
-        assertThat(stats.getCount(), equalTo(10l));
+        assertThat(stats.getCount(), equalTo(10L));
     }
 
     @Override
@@ -371,7 +371,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(2.0));
         assertThat(stats.getMax(), equalTo(12.0));
         assertThat(stats.getSum(), equalTo((double) 2+3+4+5+6+7+8+9+10+11+3+4+5+6+7+8+9+10+11+12));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
     }
 
     @Override
@@ -396,7 +396,7 @@ public class StatsTests extends AbstractNumericTestCase {
         assertThat(stats.getMin(), equalTo(0.0));
         assertThat(stats.getMax(), equalTo(10.0));
         assertThat(stats.getSum(), equalTo((double) 1+2+3+4+5+6+7+8+9+10+0+1+2+3+4+5+6+7+8+9));
-        assertThat(stats.getCount(), equalTo(20l));
+        assertThat(stats.getCount(), equalTo(20L));
     }
 
 

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/StringTermsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/StringTermsTests.java
@@ -121,43 +121,43 @@ public class StringTermsTests extends AbstractTermsTestCase {
         expectedMultiSortBuckets = new HashMap<>();
         Map<String, Object> bucketProps = new HashMap<>();
         bucketProps.put("_term", "val1");
-        bucketProps.put("_count", 3l);
+        bucketProps.put("_count", 3L);
         bucketProps.put("avg_l", 1d);
         bucketProps.put("sum_d", 6d);
         expectedMultiSortBuckets.put((String) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", "val2");
-        bucketProps.put("_count", 3l);
+        bucketProps.put("_count", 3L);
         bucketProps.put("avg_l", 2d);
         bucketProps.put("sum_d", 6d);
         expectedMultiSortBuckets.put((String) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", "val3");
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 3d);
         bucketProps.put("sum_d", 3d);
         expectedMultiSortBuckets.put((String) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", "val4");
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 3d);
         bucketProps.put("sum_d", 4d);
         expectedMultiSortBuckets.put((String) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", "val5");
-        bucketProps.put("_count", 2l);
+        bucketProps.put("_count", 2L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 3d);
         expectedMultiSortBuckets.put((String) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", "val6");
-        bucketProps.put("_count", 1l);
+        bucketProps.put("_count", 1L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 1d);
         expectedMultiSortBuckets.put((String) bucketProps.get("_term"), bucketProps);
         bucketProps = new HashMap<>();
         bucketProps.put("_term", "val7");
-        bucketProps.put("_count", 1l);
+        bucketProps.put("_count", 1L);
         bucketProps.put("avg_l", 5d);
         bucketProps.put("sum_d", 1d);
         expectedMultiSortBuckets.put((String) bucketProps.get("_term"), bucketProps);
@@ -231,9 +231,9 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             assertThat((String) propertiesKeys[i], equalTo("val" + i));
-            assertThat((long) propertiesDocCounts[i], equalTo(1l));
+            assertThat((long) propertiesDocCounts[i], equalTo(1L));
         }
     }
 
@@ -259,7 +259,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
                 Terms.Bucket bucket = terms.getBucketByKey("val" + i);
                 assertThat(bucket, notNullValue());
                 assertThat(key(bucket), equalTo("val" + i));
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             }
         }
     }
@@ -286,7 +286,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val00" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val00" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
 
         // include and exclude
@@ -311,7 +311,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val00" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val00" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
 
         // exclude without include
@@ -335,7 +335,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val00" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val00" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -360,7 +360,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey(incVal);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo(incVal));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
 
         // include and exclude
@@ -388,7 +388,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val00" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val00" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
 
         // Check case with only exact term exclude clauses
@@ -415,7 +415,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + nf.format(i));
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + nf.format(i)));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
 
     }
@@ -440,7 +440,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + Strings.padStart(i + "", 3, '0'));
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + Strings.padStart(i + "", 3, '0')));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -464,7 +464,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             i++;
         }
     }
@@ -489,7 +489,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             i--;
         }
     }
@@ -517,12 +517,12 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             ValueCount valueCount = bucket.getAggregations().get("count");
             assertThat(valueCount, notNullValue());
-            assertThat(valueCount.getValue(), equalTo(2l));
+            assertThat(valueCount.getValue(), equalTo(2L));
             assertThat((String) propertiesKeys[i], equalTo("val" + i));
-            assertThat((long) propertiesDocCounts[i], equalTo(1l));
+            assertThat((long) propertiesDocCounts[i], equalTo(1L));
             assertThat((double) propertiesCounts[i], equalTo(2.0));
         }
     }
@@ -547,10 +547,10 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             ValueCount valueCount = bucket.getAggregations().get("count");
             assertThat(valueCount, notNullValue());
-            assertThat(valueCount.getValue(), equalTo(1l));
+            assertThat(valueCount.getValue(), equalTo(1L));
         }
     }
 
@@ -574,7 +574,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("foo_val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("foo_val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -597,7 +597,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         Terms.Bucket bucket = terms.getBucketByKey("val");
         assertThat(bucket, notNullValue());
         assertThat(key(bucket), equalTo("val"));
-        assertThat(bucket.getDocCount(), equalTo(5l));
+        assertThat(bucket.getDocCount(), equalTo(5L));
     }
 
     public void testMultiValuedField() throws Exception {
@@ -620,9 +620,9 @@ public class StringTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -647,9 +647,9 @@ public class StringTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -675,9 +675,9 @@ public class StringTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("foo_val" + i));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -715,15 +715,15 @@ public class StringTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("foo_val" + i));
             if (i == 0 | i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
                 ValueCount valueCount = bucket.getAggregations().get("count");
                 assertThat(valueCount, notNullValue());
-                assertThat(valueCount.getValue(), equalTo(2l));
+                assertThat(valueCount.getValue(), equalTo(2L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
                 ValueCount valueCount = bucket.getAggregations().get("count");
                 assertThat(valueCount, notNullValue());
-                assertThat("term[" + key(bucket) + "]", valueCount.getValue(), equalTo(4l));
+                assertThat("term[" + key(bucket) + "]", valueCount.getValue(), equalTo(4L));
             }
         }
     }
@@ -747,7 +747,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -770,7 +770,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -794,10 +794,10 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             ValueCount valueCount = bucket.getAggregations().get("count");
             assertThat(valueCount, notNullValue());
-            assertThat(valueCount.getValue(), equalTo(1l));
+            assertThat(valueCount.getValue(), equalTo(1L));
         }
     }
 
@@ -821,9 +821,9 @@ public class StringTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
             if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
             }
         }
     }
@@ -849,15 +849,15 @@ public class StringTermsTests extends AbstractTermsTestCase {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
             if (i == 0 | i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1l));
+                assertThat(bucket.getDocCount(), equalTo(1L));
                 ValueCount valueCount = bucket.getAggregations().get("count");
                 assertThat(valueCount, notNullValue());
-                assertThat(valueCount.getValue(), equalTo(2l));
+                assertThat(valueCount.getValue(), equalTo(2L));
             } else {
-                assertThat(bucket.getDocCount(), equalTo(2l));
+                assertThat(bucket.getDocCount(), equalTo(2L));
                 ValueCount valueCount = bucket.getAggregations().get("count");
                 assertThat(valueCount, notNullValue());
-                assertThat(valueCount.getValue(), equalTo(4l));
+                assertThat(valueCount.getValue(), equalTo(4L));
             }
         }
     }
@@ -897,7 +897,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             Terms.Bucket bucket = terms.getBucketByKey("val" + i);
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
         }
     }
 
@@ -933,10 +933,10 @@ public class StringTermsTests extends AbstractTermsTestCase {
                 .prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1l).minDocCount(0).subAggregation(terms("terms")))
+                        histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L).minDocCount(0).subAggregation(terms("terms")))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, Matchers.notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -969,7 +969,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
             assertThat(avg.getValue(), equalTo((double) i));
@@ -1028,18 +1028,18 @@ public class StringTermsTests extends AbstractTermsTestCase {
         Terms.Bucket tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "less" : "more"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
         Filter filter = tag.getAggregations().get("filter");
         assertThat(filter, notNullValue());
-        assertThat(filter.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter.getDocCount(), equalTo(asc ? 2L : 3L));
 
         tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "more" : "less"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
         filter = tag.getAggregations().get("filter");
         assertThat(filter, notNullValue());
-        assertThat(filter.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter.getDocCount(), equalTo(asc ? 3L : 2L));
     }
 
     public void testSingleValuedFieldOrderedBySubAggregationAscMultiHierarchyLevels() throws Exception {
@@ -1073,13 +1073,13 @@ public class StringTermsTests extends AbstractTermsTestCase {
         Terms.Bucket tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "more" : "less"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter2 = filter1.getAggregations().get("filter2");
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
         Stats stats = filter2.getAggregations().get("stats");
         assertThat(stats, notNullValue());
         assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
@@ -1087,13 +1087,13 @@ public class StringTermsTests extends AbstractTermsTestCase {
         tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "less" : "more"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
         filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
         filter2 = filter1.getAggregations().get("filter2");
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
         stats = filter2.getAggregations().get("stats");
         assertThat(stats, notNullValue());
         assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
@@ -1136,13 +1136,13 @@ public class StringTermsTests extends AbstractTermsTestCase {
         Terms.Bucket tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "more" : "less"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter2 = filter1.getAggregations().get(filter2Name);
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
         Stats stats = filter2.getAggregations().get(statsName);
         assertThat(stats, notNullValue());
         assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
@@ -1150,13 +1150,13 @@ public class StringTermsTests extends AbstractTermsTestCase {
         tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "less" : "more"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
         filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
         filter2 = filter1.getAggregations().get(filter2Name);
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
         stats = filter2.getAggregations().get(statsName);
         assertThat(stats, notNullValue());
         assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
@@ -1199,13 +1199,13 @@ public class StringTermsTests extends AbstractTermsTestCase {
         Terms.Bucket tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "more" : "less"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
         Filter filter2 = filter1.getAggregations().get(filter2Name);
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 3l : 2l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
         Stats stats = filter2.getAggregations().get(statsName);
         assertThat(stats, notNullValue());
         assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
@@ -1213,13 +1213,13 @@ public class StringTermsTests extends AbstractTermsTestCase {
         tag = iters.next();
         assertThat(tag, notNullValue());
         assertThat(key(tag), equalTo(asc ? "less" : "more"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
         filter1 = tag.getAggregations().get("filter1");
         assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
         filter2 = filter1.getAggregations().get(filter2Name);
         assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 2l : 3l));
+        assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
         stats = filter2.getAggregations().get(statsName);
         assertThat(stats, notNullValue());
         assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
@@ -1324,7 +1324,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Avg avg = bucket.getAggregations().get("avg_i");
             assertThat(avg, notNullValue());
@@ -1355,7 +1355,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Stats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
@@ -1385,7 +1385,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             Stats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
@@ -1417,7 +1417,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             ExtendedStats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
@@ -1451,7 +1451,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
         for (Terms.Bucket bucket : terms.getBuckets()) {
             assertThat(bucket, notNullValue());
             assertThat(key(bucket), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1l));
+            assertThat(bucket.getDocCount(), equalTo(1L));
 
             ExtendedStats stats = bucket.getAggregations().get("stats");
             assertThat(stats, notNullValue());
@@ -1464,7 +1464,7 @@ public class StringTermsTests extends AbstractTermsTestCase {
             for (Terms.Bucket subBucket : subTermsAgg.getBuckets()) {
                 assertThat(subBucket, notNullValue());
                 assertThat(key(subBucket), equalTo("val" + j));
-                assertThat(subBucket.getDocCount(), equalTo(1l));
+                assertThat(subBucket.getDocCount(), equalTo(1L));
                 j++;
             }
             i++;

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/TDigestPercentileRanksTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/TDigestPercentileRanksTests.java
@@ -115,12 +115,12 @@ public class TDigestPercentileRanksTests extends AbstractNumericTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(randomCompression(percentileRanks("percentile_ranks"))
                                 .percentiles(10, 15)))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -142,7 +142,7 @@ public class TDigestPercentileRanksTests extends AbstractNumericTestCase {
                         .percentiles(0, 10, 15, 100))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         PercentileRanks reversePercentiles = searchResponse.getAggregations().get("percentile_ranks");
         assertThat(reversePercentiles, notNullValue());
@@ -185,7 +185,7 @@ public class TDigestPercentileRanksTests extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
@@ -404,7 +404,7 @@ public class TDigestPercentileRanksTests extends AbstractNumericTestCase {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        histogram("histo").field("value").interval(2l)
+                        histogram("histo").field("value").interval(2L)
                             .subAggregation(randomCompression(percentileRanks("percentile_ranks").percentiles(99)))
                             .order(Order.aggregation("percentile_ranks", "99", asc)))
                 .execute().actionGet();

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/TDigestPercentilesTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/TDigestPercentilesTests.java
@@ -115,12 +115,12 @@ public class TDigestPercentilesTests extends AbstractNumericTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse searchResponse = client().prepareSearch("empty_bucket_idx")
                 .setQuery(matchAllQuery())
-                .addAggregation(histogram("histo").field("value").interval(1l).minDocCount(0)
+                .addAggregation(histogram("histo").field("value").interval(1L).minDocCount(0)
                         .subAggregation(randomCompression(percentiles("percentiles"))
                                 .percentiles(10, 15)))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(2L));
         Histogram histo = searchResponse.getAggregations().get("histo");
         assertThat(histo, notNullValue());
         Histogram.Bucket bucket = histo.getBuckets().get(1);
@@ -142,7 +142,7 @@ public class TDigestPercentilesTests extends AbstractNumericTestCase {
                         .percentiles(0, 10, 15, 100))
                 .execute().actionGet();
 
-        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0l));
+        assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
         assertThat(percentiles, notNullValue());
@@ -184,7 +184,7 @@ public class TDigestPercentilesTests extends AbstractNumericTestCase {
         Global global = searchResponse.getAggregations().get("global");
         assertThat(global, notNullValue());
         assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10l));
+        assertThat(global.getDocCount(), equalTo(10L));
         assertThat(global.getAggregations(), notNullValue());
         assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
@@ -388,7 +388,7 @@ public class TDigestPercentilesTests extends AbstractNumericTestCase {
         SearchResponse searchResponse = client().prepareSearch("idx")
                 .setQuery(matchAllQuery())
                 .addAggregation(
-                        histogram("histo").field("value").interval(2l)
+                        histogram("histo").field("value").interval(2L)
                             .subAggregation(randomCompression(percentiles("percentiles").percentiles(99)))
                             .order(Order.aggregation("percentiles", "99", asc)))
                 .execute().actionGet();

--- a/plugins/delete-by-query/src/test/java/org/elasticsearch/plugin/deletebyquery/DeleteByQueryTests.java
+++ b/plugins/delete-by-query/src/test/java/org/elasticsearch/plugin/deletebyquery/DeleteByQueryTests.java
@@ -72,7 +72,7 @@ public class DeleteByQueryTests extends ESIntegTestCase {
     public void testDeleteByQueryWithNoIndices() throws Exception {
         DeleteByQueryRequestBuilder delete = newDeleteByQuery().setQuery(QueryBuilders.matchAllQuery());
         delete.setIndicesOptions(IndicesOptions.fromOptions(false, true, true, false));
-        assertDBQResponse(delete.get(), 0L, 0l, 0l, 0l);
+        assertDBQResponse(delete.get(), 0L, 0L, 0L, 0L);
         assertSearchContextsClosed();
     }
 
@@ -85,7 +85,7 @@ public class DeleteByQueryTests extends ESIntegTestCase {
         assertHitCount(client().prepareSearch("test").setSize(0).get(), docs);
 
         DeleteByQueryRequestBuilder delete = newDeleteByQuery().setIndices("t*").setQuery(QueryBuilders.matchAllQuery());
-        assertDBQResponse(delete.get(), docs, docs, 0l, 0l);
+        assertDBQResponse(delete.get(), docs, docs, 0L, 0L);
         refresh();
         assertHitCount(client().prepareSearch("test").setSize(0).get(), 0);
         assertSearchContextsClosed();
@@ -124,7 +124,7 @@ public class DeleteByQueryTests extends ESIntegTestCase {
         refresh();
 
         // Checks that the DBQ response returns the expected number of deletions
-        assertDBQResponse(response, deletions, deletions, 0l, 0l);
+        assertDBQResponse(response, deletions, deletions, 0L, 0L);
         assertNotNull(response.getIndices());
         assertThat(response.getIndices().length, equalTo(indices));
 
@@ -160,7 +160,7 @@ public class DeleteByQueryTests extends ESIntegTestCase {
         }
 
         delete.setIndicesOptions(IndicesOptions.lenientExpandOpen());
-        assertDBQResponse(delete.get(), 1L, 1L, 0l, 0l);
+        assertDBQResponse(delete.get(), 1L, 1L, 0L, 0L);
         refresh();
         assertHitCount(client().prepareSearch("test").setSize(0).get(), 0);
         assertSearchContextsClosed();
@@ -178,7 +178,7 @@ public class DeleteByQueryTests extends ESIntegTestCase {
         assertHitCount(client().prepareSearch().setSize(0).setTypes("type2").get(), docs);
 
         DeleteByQueryRequestBuilder delete = newDeleteByQuery().setTypes("type1").setQuery(QueryBuilders.matchAllQuery());
-        assertDBQResponse(delete.get(), docs, docs, 0l, 0l);
+        assertDBQResponse(delete.get(), docs, docs, 0L, 0L);
         refresh();
 
         assertHitCount(client().prepareSearch().setSize(0).get(), docs);
@@ -208,7 +208,7 @@ public class DeleteByQueryTests extends ESIntegTestCase {
 
         logger.info("--> delete all documents with routing [{}] with a delete-by-query", routing);
         DeleteByQueryRequestBuilder delete = newDeleteByQuery().setRouting(routing).setQuery(QueryBuilders.matchAllQuery());
-        assertDBQResponse(delete.get(), expected, expected, 0l, 0l);
+        assertDBQResponse(delete.get(), expected, expected, 0L, 0L);
         refresh();
 
         assertHitCount(client().prepareSearch().setSize(0).get(), docs - expected);
@@ -231,7 +231,7 @@ public class DeleteByQueryTests extends ESIntegTestCase {
         assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get(), numDocs);
 
         DeleteByQueryRequestBuilder delete = newDeleteByQuery().setIndices("alias").setQuery(QueryBuilders.matchQuery("_id", Integer.toString(n)));
-        assertDBQResponse(delete.get(), 1L, 1L, 0l, 0l);
+        assertDBQResponse(delete.get(), 1L, 1L, 0L, 0L);
         refresh();
         assertHitCount(client().prepareSearch("test").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get(), numDocs - 1);
         assertSearchContextsClosed();
@@ -244,7 +244,7 @@ public class DeleteByQueryTests extends ESIntegTestCase {
         assertHitCount(client().prepareSearch("test").setSize(0).get(), 1);
 
         DeleteByQueryRequestBuilder delete = newDeleteByQuery().setIndices("test").setQuery(QueryBuilders.rangeQuery("d").to("now-1h"));
-        assertDBQResponse(delete.get(), 1L, 1L, 0l, 0l);
+        assertDBQResponse(delete.get(), 1L, 1L, 0L, 0L);
         refresh();
         assertHitCount(client().prepareSearch("test").setSize(0).get(), 0);
         assertSearchContextsClosed();
@@ -267,12 +267,12 @@ public class DeleteByQueryTests extends ESIntegTestCase {
         assertThat(searchResponse.getHits().totalHits(), equalTo((long) numDocs + 1));
 
         DeleteByQueryResponse delete = newDeleteByQuery().setIndices("test").setQuery(QueryBuilders.termQuery("field", "value")).get();
-        assertDBQResponse(delete, numDocs, numDocs, 0l, 0l);
+        assertDBQResponse(delete, numDocs, numDocs, 0L, 0L);
 
         refresh();
         searchResponse = client().prepareSearch("test").get();
         assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().totalHits(), equalTo(1l));
+        assertThat(searchResponse.getHits().totalHits(), equalTo(1L));
         assertSearchContextsClosed();
     }
 

--- a/plugins/lang-painless/src/test/java/org/elasticsearch/painless/FieldTests.java
+++ b/plugins/lang-painless/src/test/java/org/elasticsearch/painless/FieldTests.java
@@ -29,7 +29,7 @@ public class FieldTests extends ScriptTestCase {
         public char c = 'c';
         public int i = 2;
         public int si = -1;
-        public long j = 3l;
+        public long j = 3L;
         public float f = 4.0f;
         public double d = 5.0;
         public String t = "s";

--- a/test/framework/src/main/java/org/elasticsearch/test/CorruptionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/CorruptionUtils.java
@@ -80,7 +80,7 @@ public final class CorruptionUtils {
             long checksumAfterCorruption;
             long actualChecksumAfterCorruption;
             try (ChecksumIndexInput input = dir.openChecksumInput(fileToCorrupt.getFileName().toString(), IOContext.DEFAULT)) {
-                assertThat(input.getFilePointer(), is(0l));
+                assertThat(input.getFilePointer(), is(0L));
                 input.seek(input.length() - 8); // one long is the checksum... 8 bytes
                 checksumAfterCorruption = input.getChecksum();
                 actualChecksumAfterCorruption = input.readLong();

--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -159,9 +159,9 @@ public final class ExternalTestCluster extends TestCluster {
                 // because checking it requires a network request, which in
                 // turn increments the breaker, making it non-0
 
-                assertThat("Fielddata size must be 0 on node: " + stats.getNode(), stats.getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0l));
-                assertThat("Query cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0l));
-                assertThat("FixedBitSet cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getSegments().getBitsetMemoryInBytes(), equalTo(0l));
+                assertThat("Fielddata size must be 0 on node: " + stats.getNode(), stats.getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0L));
+                assertThat("Query cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0L));
+                assertThat("FixedBitSet cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getSegments().getBitsetMemoryInBytes(), equalTo(0L));
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1847,9 +1847,9 @@ public final class InternalTestCluster extends TestCluster {
 
                 NodeService nodeService = getInstanceFromNode(NodeService.class, nodeAndClient.node);
                 NodeStats stats = nodeService.stats(CommonStatsFlags.ALL, false, false, false, false, false, false, false, false, false, false);
-                assertThat("Fielddata size must be 0 on node: " + stats.getNode(), stats.getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0l));
-                assertThat("Query cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0l));
-                assertThat("FixedBitSet cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getSegments().getBitsetMemoryInBytes(), equalTo(0l));
+                assertThat("Fielddata size must be 0 on node: " + stats.getNode(), stats.getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0L));
+                assertThat("Query cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getQueryCache().getMemorySizeInBytes(), equalTo(0L));
+                assertThat("FixedBitSet cache size must be 0 on node: " + stats.getNode(), stats.getIndices().getSegments().getBitsetMemoryInBytes(), equalTo(0L));
             }
         }
     }


### PR DESCRIPTION
This commit removes and forbids the use of lowercase ells ('l') in long
literals because they are often hard to distinguish from the digit
representing one ('1').

Relates #16279
