### PR TITLE
Make single node utility methods non-static

### DIFF
--- a/core/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -37,8 +37,8 @@ import java.util.Arrays;
 
 public class BigArraysTests extends ESSingleNodeTestCase {
 
-    public static BigArrays randombigArrays() {
-        final PageCacheRecycler recycler = randomBoolean() ? null : ESSingleNodeTestCase.getInstanceFromNode(PageCacheRecycler.class);
+    private BigArrays randombigArrays() {
+        final PageCacheRecycler recycler = randomBoolean() ? null : getInstanceFromNode(PageCacheRecycler.class);
         return new MockBigArrays(recycler, new NoneCircuitBreakerService());
     }
 

--- a/core/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -25,6 +25,8 @@ import com.carrotsearch.hppc.cursors.ObjectLongCursor;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.util.HashMap;
@@ -38,13 +40,18 @@ public class BytesRefHashTests extends ESSingleNodeTestCase {
 
     BytesRefHash hash;
 
+    private BigArrays randombigArrays() {
+        final PageCacheRecycler recycler = randomBoolean() ? null : getInstanceFromNode(PageCacheRecycler.class);
+        return new MockBigArrays(recycler, new NoneCircuitBreakerService());
+    }
+
     private void newHash() {
         if (hash != null) {
             hash.close();
         }
         // Test high load factors to make sure that collision resolution works fine
         final float maxLoadFactor = 0.6f + randomFloat() * 0.39f;
-        hash = new BytesRefHash(randomIntBetween(0, 100), maxLoadFactor, BigArraysTests.randombigArrays());
+        hash = new BytesRefHash(randomIntBetween(0, 100), maxLoadFactor, randombigArrays());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/common/util/LongHashTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/LongHashTests.java
@@ -22,6 +22,8 @@ package org.elasticsearch.common.util;
 import com.carrotsearch.hppc.LongLongHashMap;
 import com.carrotsearch.hppc.LongLongMap;
 import com.carrotsearch.hppc.cursors.LongLongCursor;
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.util.HashMap;
@@ -33,6 +35,11 @@ import java.util.Set;
 public class LongHashTests extends ESSingleNodeTestCase {
     LongHash hash;
 
+    private BigArrays randombigArrays() {
+        final PageCacheRecycler recycler = randomBoolean() ? null : getInstanceFromNode(PageCacheRecycler.class);
+        return new MockBigArrays(recycler, new NoneCircuitBreakerService());
+    }
+
     private void newHash() {
         if (hash != null) {
             hash.close();
@@ -40,7 +47,7 @@ public class LongHashTests extends ESSingleNodeTestCase {
 
         // Test high load factors to make sure that collision resolution works fine
         final float maxLoadFactor = 0.6f + randomFloat() * 0.39f;
-        hash = new LongHash(randomIntBetween(0, 100), maxLoadFactor, BigArraysTests.randombigArrays());
+        hash = new LongHash(randomIntBetween(0, 100), maxLoadFactor, randombigArrays());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/common/util/LongObjectHashMapTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/LongObjectHashMapTests.java
@@ -20,12 +20,20 @@
 package org.elasticsearch.common.util;
 
 import com.carrotsearch.hppc.LongObjectHashMap;
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 public class LongObjectHashMapTests extends ESSingleNodeTestCase {
+
+    private BigArrays randombigArrays() {
+        final PageCacheRecycler recycler = randomBoolean() ? null : getInstanceFromNode(PageCacheRecycler.class);
+        return new MockBigArrays(recycler, new NoneCircuitBreakerService());
+    }
+
     public void testDuel() {
         final LongObjectHashMap<Object> map1 = new LongObjectHashMap<>();
-        final LongObjectPagedHashMap<Object> map2 = new LongObjectPagedHashMap<>(randomInt(42), 0.6f + randomFloat() * 0.39f, BigArraysTests.randombigArrays());
+        final LongObjectPagedHashMap<Object> map2 = new LongObjectPagedHashMap<>(randomInt(42), 0.6f + randomFloat() * 0.39f, randombigArrays());
         final int maxKey = randomIntBetween(1, 10000);
         final int iters = scaledRandomIntBetween(10000, 100000);
         for (int i = 0; i < iters; ++i) {

--- a/core/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
@@ -115,7 +115,7 @@ public class SimpleThreadPoolIT extends ESIntegTestCase {
         for (String threadName : threadNames) {
             // ignore some shared threads we know that are created within the same VM, like the shared discovery one
             // or the ones that are occasionally come up from ESSingleNodeTestCase
-            if (threadName.contains("[" + ESSingleNodeTestCase.nodeName() + "]")
+            if (threadName.contains("[node_s_0]") // TODO: this can't possibly be right! single node and integ test are unrelated!
                     || threadName.contains("Keep-Alive-Timer")) {
                 continue;
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -183,49 +183,49 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     /**
      * Returns a client to the single-node cluster.
      */
-    public static Client client() {
+    public Client client() {
         return NODE.client();
     }
 
     /**
      * Returns the single test nodes name.
      */
-    public static String nodeName() {
+    public String nodeName() {
         return "node_s_0";
     }
 
     /**
      * Return a reference to the singleton node.
      */
-    protected static Node node() {
+    protected Node node() {
         return NODE;
     }
 
     /**
      * Get an instance for a particular class using the injector of the singleton node.
      */
-    protected static <T> T getInstanceFromNode(Class<T> clazz) {
+    protected <T> T getInstanceFromNode(Class<T> clazz) {
         return NODE.injector().getInstance(clazz);
     }
 
     /**
      * Create a new index on the singleton node with empty index settings.
      */
-    protected static IndexService createIndex(String index) {
+    protected IndexService createIndex(String index) {
         return createIndex(index, Settings.EMPTY);
     }
 
     /**
      * Create a new index on the singleton node with the provided index settings.
      */
-    protected static IndexService createIndex(String index, Settings settings) {
+    protected IndexService createIndex(String index, Settings settings) {
         return createIndex(index, settings, null, (XContentBuilder) null);
     }
 
     /**
      * Create a new index on the singleton node with the provided index settings.
      */
-    protected static IndexService createIndex(String index, Settings settings, String type, XContentBuilder mappings) {
+    protected IndexService createIndex(String index, Settings settings, String type, XContentBuilder mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
         if (type != null && mappings != null) {
             createIndexRequestBuilder.addMapping(type, mappings);
@@ -236,7 +236,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     /**
      * Create a new index on the singleton node with the provided index settings.
      */
-    protected static IndexService createIndex(String index, Settings settings, String type, Object... mappings) {
+    protected IndexService createIndex(String index, Settings settings, String type, Object... mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
         if (type != null && mappings != null) {
             createIndexRequestBuilder.addMapping(type, mappings);
@@ -244,7 +244,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
         return createIndex(index, createIndexRequestBuilder);
     }
 
-    protected static IndexService createIndex(String index, CreateIndexRequestBuilder createIndexRequestBuilder) {
+    protected IndexService createIndex(String index, CreateIndexRequestBuilder createIndexRequestBuilder) {
         assertAcked(createIndexRequestBuilder.get());
         // Wait for the index to be allocated so that cluster state updates don't override
         // changes that would have been done locally
@@ -259,7 +259,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     /**
      * Create a new search context.
      */
-    protected static SearchContext createSearchContext(IndexService indexService) {
+    protected SearchContext createSearchContext(IndexService indexService) {
         BigArrays bigArrays = indexService.getIndexServices().getBigArrays();
         ThreadPool threadPool = indexService.getIndexServices().getThreadPool();
         PageCacheRecycler pageCacheRecycler = node().injector().getInstance(PageCacheRecycler.class);


### PR DESCRIPTION
With the recent change to allow ESSingleNodeTestCase to specify plugins
and Version for the node, node creation became lazy, where it now
happens before the first test to run. However, there were many static
methods on ESSingleNodeTestCase that still try to access the node. This
change makes those methods non-static.
