### PR TITLE
Equal default min and max heap settings

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -436,6 +436,7 @@ task run(type: RunTask) {}
  * </dl>
  */
 Map<String, String> expansionsForDistribution(distributionType) {
+  String heapSize = '512m'
   String footer = "# Built for ${project.name}-${project.version} " +
       "(${distributionType})"
   Map<String, Object> expansions = [
@@ -455,8 +456,8 @@ Map<String, String> expansionsForDistribution(distributionType) {
       'def': '',
     ],
 
-    'heap.min': '256m',
-    'heap.max': '1g',
+    'heap.min': "${heapSize}",
+    'heap.max': "${heapSize}",
 
     'stopping.timeout': [
       'rpm': 86400,


### PR DESCRIPTION
Today we encourage users to set their minimum and maximum heap settings
equal to each other to prevent the heap from resizing. Yet, the default
heap settings do not start Elasticsearch in this fashion. This commit
addresses this discrepancy by setting the default min heap to '1g' and
the default max heap to the default min heap.
