### PR TITLE
Logs added for support Issue #17983

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -489,7 +489,10 @@ public class PluginManager {
             byte[] buffer = new byte[8192];
             while ((entry = zipInput.getNextEntry()) != null) {
                 Path targetFile = target.resolve(entry.getName());
-
+		if(targetFile.getParent() == null) {
+                	 throw new IOException("Cannot find parent for " + targetFile.getFileName()
+                			 + " on file system " + targetFile.getFileSystem());
+                }
                 // be on the safe side: do not rely on that directories are always extracted
                 // before their children (although this makes sense, but is it guaranteed?)
                 Files.createDirectories(targetFile.getParent());

--- a/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginManager.java
@@ -236,7 +236,7 @@ public class PluginManager {
         // unzip plugin to a staging temp dir, named for the plugin
         Path tmp = Files.createTempDirectory(environment.tmpFile(), null);
         Path root = tmp.resolve(pluginHandle.name);
-        unzipPlugin(pluginFile, root);
+        unzipPlugin(pluginFile, root, terminal);
 
         // find the actual root (in case its unzipped with extra directory wrapping)
         root = findPluginRoot(root);
@@ -481,7 +481,7 @@ public class PluginManager {
         }
     }
 
-    private void unzipPlugin(Path zip, Path target) throws IOException {
+    private void unzipPlugin(Path zip, Path target, Terminal terminal) throws IOException {
         Files.createDirectories(target);
 
         try (ZipInputStream zipInput = new ZipInputStream(Files.newInputStream(zip))) {
@@ -490,8 +490,8 @@ public class PluginManager {
             while ((entry = zipInput.getNextEntry()) != null) {
                 Path targetFile = target.resolve(entry.getName());
 		if(targetFile.getParent() == null) {
-                	 throw new IOException("Cannot find parent for " + targetFile.getFileName()
-                			 + " on file system " + targetFile.getFileSystem());
+                    terminal.println("Cannot find parent for "+ entry.getName()+ " .Ignoring file...");
+ 		    continue;
                 }
                 // be on the safe side: do not rely on that directories are always extracted
                 // before their children (although this makes sense, but is it guaranteed?)


### PR DESCRIPTION
We had a hard time finding on why our custom plugins were not working. A log would have been very useful. Adding a useful log which no parent file is found.

For Eg: 

sudekumar@LM-BLR-00668412:/tmp/check$./elasticsearch-3.0.0-SNAPSHOT/bin/plugin install file:///Users/sudekumar/GIT/EXAMPLE/elasticsearch-ebay-managed-plugin/target/releases/elasticsearch-ebay-managed-2.0.0.zip  -Des.cli.debug=true
-> Installing from file:/Users/sudekumar/GIT/EXAMPLE/elasticsearch-ebay-managed-plugin/target/releases/elasticsearch-ebay-managed-2.0.0.zip...
Trying file:/Users/sudekumar/GIT/EXAMPLE/elasticsearch-ebay-managed-plugin/target/releases/elasticsearch-ebay-managed-2.0.0.zip ...
Downloading ....................................................................................................................................................................................................................................................................DONE
Verifying file:/Users/sudekumar/GIT/EXAMPLE/elasticsearch-ebay-managed-plugin/target/releases/elasticsearch-ebay-managed-2.0.0.zip checksums if available ...
NOTE: Unable to verify checksum for downloaded plugin (unable to find .sha1 or .md5 file to verify)
Cannot find parent for / .Ignoring file...
