### PR TITLE
Changes "that is" to "for example".

### DIFF
--- a/docs/reference/aggregations/pipeline.asciidoc
+++ b/docs/reference/aggregations/pipeline.asciidoc
@@ -22,7 +22,7 @@ parameter to indicate the paths to the required metrics. The syntax for defining
 
 Pipeline aggregations cannot have sub-aggregations but depending on the type it can reference another pipeline in the `buckets_path`
 allowing pipeline aggregations to be chained.  For example, you can chain together two derivatives to calculate the second derivative
-(e.g. a derivative of a derivative).
+(i.e. a derivative of a derivative).
 
 NOTE: Because pipeline aggregations only add to the output, when chaining pipeline aggregations the output of each pipeline aggregation 
 will be included in the final output.


### PR DESCRIPTION
"Derivative of a derivative" and "second derivative" are synonyms, so the text should read id est (i.e.) instead of exempli gratia (e.g.).
