### PR TITLE
Drop `@Nullable` on `type` in `Script`

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/Script.java
+++ b/core/src/main/java/org/elasticsearch/script/Script.java
@@ -44,7 +44,7 @@ public class Script implements ToXContent, Streamable {
     private static final ScriptParser PARSER = new ScriptParser();
 
     private String script;
-    private @Nullable ScriptType type;
+    private ScriptType type;
     private @Nullable String lang;
     private @Nullable Map<String, Object> params;
 


### PR DESCRIPTION
`Script.type` is not nullable: https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/script/Script.java#L94
