### PR TITLE
Fix calling ensureOpen() on the wrong directory

### DIFF
--- a/plugins/cloud-azure/src/main/java/org/apache/lucene/store/SmbDirectoryWrapper.java
+++ b/plugins/cloud-azure/src/main/java/org/apache/lucene/store/SmbDirectoryWrapper.java
@@ -43,8 +43,7 @@ public final class SmbDirectoryWrapper extends FilterDirectory {
 
     @Override
     public IndexOutput createOutput(String name, IOContext context) throws IOException {
-        fsDirectory.ensureOpen();
-        fsDirectory.ensureCanWrite(name);
+        this.ensureOpen();
         return new SmbFSIndexOutput(name);
     }
 

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/SmbDirectoryWrapper.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/SmbDirectoryWrapper.java
@@ -17,13 +17,18 @@
  * under the License.
  */
 
-package org.apache.lucene.store;
+package org.elasticsearch.cloud.azure;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.OutputStreamIndexOutput;
 
 /**
  * This class is used to wrap an existing {@link org.apache.lucene.store.FSDirectory} so that

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsDirectoryService.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsDirectoryService.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.store.smbmmapfs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.MMapDirectory;
-import org.apache.lucene.store.SmbDirectoryWrapper;
+import org.elasticsearch.cloud.azure.SmbDirectoryWrapper;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.shard.ShardPath;

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsDirectoryService.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsDirectoryService.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.store.smbsimplefs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.SimpleFSDirectory;
-import org.apache.lucene.store.SmbDirectoryWrapper;
+import org.elasticsearch.cloud.azure.SmbDirectoryWrapper;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.shard.ShardPath;

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/ESBaseDirectoryTestCase.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/ESBaseDirectoryTestCase.java
@@ -1,4 +1,4 @@
-package org.apache.lucene.store;
+package org.elasticsearch.cloud.azure;
 
 /*
  * Licensed to Elasticsearch under one or more contributor
@@ -19,6 +19,7 @@ package org.apache.lucene.store;
  * under the License.
  */
 
+import org.apache.lucene.store.BaseDirectoryTestCase;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.bootstrap.BootstrapForTesting;

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/SmbMMapDirectoryTests.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/SmbMMapDirectoryTests.java
@@ -17,15 +17,17 @@
  * under the License.
  */
 
-package org.apache.lucene.store;
+package org.elasticsearch.cloud.azure;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
 
-public class SmbSimpleFSDirectoryTests extends ESBaseDirectoryTestCase {
+public class SmbMMapDirectoryTests extends ESBaseDirectoryTestCase {
 
     @Override
     protected Directory getDirectory(Path file) throws IOException {
-        return new SmbDirectoryWrapper(new SimpleFSDirectory(file));
+        return new SmbDirectoryWrapper(new MMapDirectory(file));
     }
 }

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/SmbSimpleFSDirectoryTests.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/SmbSimpleFSDirectoryTests.java
@@ -17,15 +17,17 @@
  * under the License.
  */
 
-package org.apache.lucene.store;
+package org.elasticsearch.cloud.azure;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.SimpleFSDirectory;
 
-public class SmbMMapDirectoryTests extends ESBaseDirectoryTestCase {
+public class SmbSimpleFSDirectoryTests extends ESBaseDirectoryTestCase {
 
     @Override
     protected Directory getDirectory(Path file) throws IOException {
-        return new SmbDirectoryWrapper(new MMapDirectory(file));
+        return new SmbDirectoryWrapper(new SimpleFSDirectory(file));
     }
 }

--- a/plugins/cloud-azure/src/test/resources/rest-api-spec/test/cloud_azure/15_index_creation.yaml
+++ b/plugins/cloud-azure/src/test/resources/rest-api-spec/test/cloud_azure/15_index_creation.yaml
@@ -1,0 +1,30 @@
+"Test the smb_mmap_fs directory wrapper":
+  - do:
+      indices.create:
+        index: smb-test
+        body:
+          index:
+            store.type: smb_mmap_fs
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      index:
+        index:  smb-test
+        type:   doc
+        id:     1
+        body:   { foo: bar }
+
+  - do:
+      get:
+        index:  smb-test
+        type:   doc
+        id:     1
+
+  - match:   { _index:   smb-test }
+  - match:   { _type:    doc }
+  - match:   { _id:      "1"}
+  - match:   { _version: 1}
+  - match:   { _source: { foo: bar }}


### PR DESCRIPTION
Also removes `ensureCanWrite` since this already passes the
`TRUNCATE_EXISTING` flag when opening.

Adds a REST test that fails without this fix due to the classloader
isolation.

Additionally, move `SmbDirectoryWrapper` into an elasticsearch package instead of a lucene one, so this would be found at compile time instead of runtime.
