### PR TITLE
Plugin cli: Improve maven coordinates detection

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -160,9 +160,9 @@ class InstallPluginCommand extends CliTool.Command {
             return downloadZipAndChecksum(url, tmpDir);
         }
 
-        // now try as maven coordinates, a valid URL would only have a single colon
+        // now try as maven coordinates, a valid URL would only have a colon and slash
         String[] coordinates = pluginId.split(":");
-        if (coordinates.length == 3) {
+        if (coordinates.length == 3 && pluginId.contains("/") == false) {
             String mavenUrl = String.format(Locale.ROOT, "https://repo1.maven.org/maven2/%1$s/%2$s/%3$s/%2$s-%3$s.zip",
                 coordinates[0].replace(".", "/") /* groupId */, coordinates[1] /* artifactId */, coordinates[2] /* version */);
             terminal.println("-> Downloading " + pluginId + " from maven central");

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.plugins;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
@@ -203,6 +204,14 @@ public class InstallPluginCommandTests extends ESTestCase {
         Files.copy(new URL(pluginZip).openStream(), pluginZipWithSpaces, StandardCopyOption.REPLACE_EXISTING);
         installPlugin(pluginZipWithSpaces.toUri().toURL().toString(), env);
         assertPlugin("fake", pluginDir, env);
+    }
+
+    public void testMalformedUrlNotMaven() throws Exception {
+        // has two colons, so it appears similar to maven coordinates
+        MalformedURLException e = expectThrows(MalformedURLException.class, () -> {
+            installPlugin("://host:1234", createEnv());
+        });
+        assertTrue(e.getMessage(), e.getMessage().contains("no protocol"));
     }
 
     public void testPluginsDirMissing() throws Exception {


### PR DESCRIPTION
Identifying when a plugin id is maven coordinates is currently done by
checking if the plugin id contains 2 colons. However, a valid url could
have 2 colons, for example when a port is specified. This change adds
another check, ensuring the plugin id with maven coordinates does not
contain a slash, which only a url would have.

closes #16376
