### PR TITLE
Remove detect_noop from REST spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -82,10 +82,6 @@
           "type": "enum",
           "options": ["internal", "force"],
           "description": "Specific version type"
-        },
-        "detect_noop": {
-          "type": "boolean",
-          "description": "Specifying as true will cause Elasticsearch to check if there are changes and, if there aren’t, turn the update request into a noop."
         }
       }
     },


### PR DESCRIPTION
Unless this should be supported as a query string parameter instead, right now it only works when specified in the body.
