### PR TITLE
Fix calling ensureOpen() on the wrong directory (master forwardport)

### DIFF
--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/SmbDirectoryWrapper.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/SmbDirectoryWrapper.java
@@ -17,13 +17,18 @@
  * under the License.
  */
 
-package org.apache.lucene.store;
+package org.elasticsearch.index.store;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.OutputStreamIndexOutput;
 
 /**
  * This class is used to wrap an existing {@link org.apache.lucene.store.FSDirectory} so that
@@ -43,14 +48,10 @@ public final class SmbDirectoryWrapper extends FilterDirectory {
 
     @Override
     public IndexOutput createOutput(String name, IOContext context) throws IOException {
-        fsDirectory.ensureOpen();
-        fsDirectory.ensureCanWrite(name);
+        this.ensureOpen();
         return new SmbFSIndexOutput(name);
     }
 
-    /**
-     * Copied from final inner class {@link org.apache.lucene.store.FSDirectory.FSIndexOutput}
-     */
     final class SmbFSIndexOutput extends OutputStreamIndexOutput {
         /**
          * The maximum chunk size is 8192 bytes, because {@link java.io.FileOutputStream} mallocs

--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsDirectoryService.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsDirectoryService.java
@@ -22,11 +22,11 @@ package org.elasticsearch.index.store.smbmmapfs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.MMapDirectory;
-import org.apache.lucene.store.SmbDirectoryWrapper;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.store.FsDirectoryService;
 import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.index.store.SmbDirectoryWrapper;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsDirectoryService.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsDirectoryService.java
@@ -22,11 +22,11 @@ package org.elasticsearch.index.store.smbsimplefs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.SimpleFSDirectory;
-import org.apache.lucene.store.SmbDirectoryWrapper;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.store.FsDirectoryService;
 import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.index.store.SmbDirectoryWrapper;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/ESBaseDirectoryTestCase.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/ESBaseDirectoryTestCase.java
@@ -1,4 +1,4 @@
-package org.apache.lucene.store;
+package org.elastiscearch.index.store;
 
 /*
  * Licensed to Elasticsearch under one or more contributor
@@ -21,6 +21,7 @@ package org.apache.lucene.store;
 
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import org.apache.lucene.store.BaseDirectoryTestCase;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.bootstrap.BootstrapForTesting;

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SmbMMapDirectoryTests.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SmbMMapDirectoryTests.java
@@ -17,15 +17,18 @@
  * under the License.
  */
 
-package org.apache.lucene.store;
+package org.elastiscearch.index.store;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.elasticsearch.index.store.SmbDirectoryWrapper;
 
-public class SmbSimpleFSDirectoryTests extends ESBaseDirectoryTestCase {
+public class SmbMMapDirectoryTests extends ESBaseDirectoryTestCase {
 
     @Override
     protected Directory getDirectory(Path file) throws IOException {
-        return new SmbDirectoryWrapper(new SimpleFSDirectory(file));
+        return new SmbDirectoryWrapper(new MMapDirectory(file));
     }
 }

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SmbSimpleFSDirectoryTests.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SmbSimpleFSDirectoryTests.java
@@ -17,15 +17,18 @@
  * under the License.
  */
 
-package org.apache.lucene.store;
+package org.elastiscearch.index.store;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.SimpleFSDirectory;
+import org.elasticsearch.index.store.SmbDirectoryWrapper;
 
-public class SmbMMapDirectoryTests extends ESBaseDirectoryTestCase {
+public class SmbSimpleFSDirectoryTests extends ESBaseDirectoryTestCase {
 
     @Override
     protected Directory getDirectory(Path file) throws IOException {
-        return new SmbDirectoryWrapper(new MMapDirectory(file));
+        return new SmbDirectoryWrapper(new SimpleFSDirectory(file));
     }
 }

--- a/plugins/store-smb/src/test/resources/rest-api-spec/test/store_smb/15_index_creation.yaml
+++ b/plugins/store-smb/src/test/resources/rest-api-spec/test/store_smb/15_index_creation.yaml
@@ -1,0 +1,30 @@
+"Test the smb_mmap_fs directory wrapper":
+  - do:
+      indices.create:
+        index: smb-test
+        body:
+          index:
+            store.type: smb_mmap_fs
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      index:
+        index:  smb-test
+        type:   doc
+        id:     1
+        body:   { foo: bar }
+
+  - do:
+      get:
+        index:  smb-test
+        type:   doc
+        id:     1
+
+  - match:   { _index:   smb-test }
+  - match:   { _type:    doc }
+  - match:   { _id:      "1"}
+  - match:   { _version: 1}
+  - match:   { _source: { foo: bar }}


### PR DESCRIPTION
Also removes ensureCanWrite since this already passes the
TRUNCATE_EXISTING flag when opening.

Adds a REST test that fails without this fix due to the classloader
isolation.

Additionally, move SmbDirectoryWrapper into an elasticsearch package instead of a lucene one, so this would be found at compile time instead of runtime.

Forward-port of #16383
