### PR TITLE
Shard state action request logging

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -435,13 +435,14 @@ public class ShardStateAction extends AbstractComponent {
 
         @Override
         public String toString() {
-            return String.format(
-                Locale.ROOT,
-                "failed shard [%s], source shard [%s], message [%s], failure [%s]",
-                shardRouting,
-                sourceShardRouting,
-                message,
-                ExceptionsHelper.detailedMessage(failure));
+            List<String> components = new ArrayList<>(4);
+            components.add("failed shard [" + shardRouting + "]");
+            components.add("source shard [" + sourceShardRouting + "]");
+            components.add("message [" + message + "]");
+            if (failure != null) {
+                components.add("failure [" + ExceptionsHelper.detailedMessage(failure) + "]");
+            }
+            return String.join(", ", components);
         }
     }
 


### PR DESCRIPTION
This commit modifies the string representation of a shard state action
request. The issue being addressed is that the previous logging would
log `failure: [Unknown]` for shard started actions but this just leads
to confusion that there is a failure but its cause is unknown.
