### PR TITLE
Remove unneeded quoting when adding tests.jvm.argline to mvn reproduction line

### DIFF
--- a/core/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/core/src/test/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -21,7 +21,6 @@ package org.elasticsearch.test.junit.listeners;
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.ReproduceErrorMessageBuilder;
 import com.carrotsearch.randomizedtesting.TraceFormatting;
-
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -184,7 +183,7 @@ public class ReproduceInfoPrinter extends RunListener {
 
         public ReproduceErrorMessageBuilder appendESProperties() {
             if (System.getProperty("tests.jvm.argline") != null && !System.getProperty("tests.jvm.argline").isEmpty()) {
-                appendOpt("tests.jvm.argline", "\"" + System.getProperty("tests.jvm.argline") + "\"");
+                appendOpt("tests.jvm.argline", System.getProperty("tests.jvm.argline"));
             }
             appendOpt("tests.locale", Locale.getDefault().toLanguageTag());
             appendOpt("tests.timezone", TimeZone.getDefault().getID());


### PR DESCRIPTION
…
Current it results in double quotes that gives you the wrong thing:

```
mvn verify -Pdev -Dskip.unit.tests...  -Dtests.jvm.argline=""-server -XX:+UseConcMarkSweepGC -XX:-UseCompressedOops -Djava.net.preferIPv4Stack=true"" ....
```
