### PR TITLE
Fail early on JDK with compiler bug

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -119,10 +119,19 @@ class BuildPlugin implements Plugin<Project> {
             // TODO: remove when the build requires Java 9
             if (javaVersionEnum == JavaVersion.VERSION_1_8) {
                 if (Objects.equals("Oracle Corporation", javaVendor)) {
-                    def matcher = javaVersion =~ /1\.8\.0_(\d+)/
-                    int update = matcher[0][1].toInteger()
-                    if (update < 40) {
-                        throw new GradleException("JDK ${javaVendor} ${javaVersion} has compiler bug JDK-8052388, update your JDK to at least 8u40")
+                    def matcher = javaVersion =~ /1\.8\.0(?:_(\d+))?/
+                    if (matcher.matches()) {
+                        int update;
+                        if (matcher.group(1) == null) {
+                            update = 0
+                        } else {
+                            update = matcher.group(1).toInteger()
+                        }
+                        if (update < 40) {
+                            throw new GradleException("JDK ${javaVendor} ${javaVersion} has compiler bug JDK-8052388, update your JDK to at least 8u40")
+                        }
+                    } else {
+                        println "Unable to detect JDK update version for JDK ${javaVendor} ${javaVersion}; your JDK might be subject to compiler bug JDK-8052388!"
                     }
                 }
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -131,8 +131,6 @@ class BuildPlugin implements Plugin<Project> {
                         if (update < 40) {
                             throw new GradleException("JDK ${javaVendor} ${javaVersion} has compiler bug JDK-8052388, update your JDK to at least 8u40")
                         }
-                    } else {
-                        println "Unable to detect JDK update version for JDK ${javaVendor} ${javaVersion}; your JDK might be subject to compiler bug JDK-8052388!"
                     }
                 }
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -116,7 +116,8 @@ class BuildPlugin implements Plugin<Project> {
                 throw new GradleException("Java ${minimumJava} or above is required to build Elasticsearch")
             }
 
-            // TODO: remove when the build requires Java 9
+            // this block of code detecting buggy JDK 8 compiler versions can be removed when minimum Java version is incremented
+            assert minimumJava == JavaVersion.VERSION_1_8 : "Remove JDK compiler bug detection only applicable to JDK 8"
             if (javaVersionEnum == JavaVersion.VERSION_1_8) {
                 if (Objects.equals("Oracle Corporation", javaVendor)) {
                     def matcher = javaVersion =~ /1\.8\.0(?:_(\d+))?/

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -117,7 +117,7 @@ class BuildPlugin implements Plugin<Project> {
             }
 
             // TODO: remove when the build requires Java 9
-            if (javaVersionEnum.compareTo(JavaVersion.VERSION_1_8) == 0) {
+            if (javaVersionEnum == JavaVersion.VERSION_1_8) {
                 if (Objects.equals("Oracle Corporation", javaVendor)) {
                     def matcher = javaVersion =~ /1\.8\.0_(\d+)/
                     int update = matcher[0][1].toInteger()


### PR DESCRIPTION
Early versions of JDK 8 have a compiler bug that prevents assignment to
a definitely unassigned final variable inside the body of a lambda. This
commit adds an early-out to the build process which also gives a useful
error message.

Relates #16097, relates #16362 
