### PR TITLE
Allow snapshot deletion concurrent to creation in another repository

### DIFF
--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -886,9 +886,12 @@ public class SnapshotsService extends AbstractLifecycleComponent<SnapshotsServic
                 SnapshotsInProgress.Entry snapshot = snapshots.snapshot(snapshotId);
                 if (snapshot == null) {
                     // This snapshot is not running - continue
-                    if (!snapshots.entries().isEmpty()) {
-                        // However other snapshots are running - cannot continue
-                        throw new ConcurrentSnapshotExecutionException(snapshotId, "another snapshot is currently running cannot delete");
+                    for (SnapshotsInProgress.Entry entry : snapshots.entries()) {
+                        if (snapshotId.getRepository().equals(entry.snapshotId().getRepository())) {
+                            // However other snapshots are running - cannot continue
+                            throw new ConcurrentSnapshotExecutionException(snapshotId,
+                                "another snapshot is currently running cannot delete");
+                        }
                     }
                     return currentState;
                 } else {

--- a/core/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -129,8 +129,12 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     }
 
     public static String blockNodeWithIndex(String index) {
+        return blockNodeWithIndex(index, "test-repo");
+    }
+
+    public static String blockNodeWithIndex(String index, String repo) {
         for(String node : internalCluster().nodesInclude("test-idx")) {
-            ((MockRepository)internalCluster().getInstance(RepositoriesService.class, node).repository("test-repo")).blockOnDataFiles(true);
+            ((MockRepository)internalCluster().getInstance(RepositoriesService.class, node).repository(repo)).blockOnDataFiles(true);
             return node;
         }
         fail("No nodes for the index " + index + " found");
@@ -138,7 +142,11 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     }
 
     public static void unblockNode(String node) {
-        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, node).repository("test-repo")).unblock();
+        unblockNode(node, "test-repo");
+    }
+
+    public static void unblockNode(String node, String repo) {
+        ((MockRepository)internalCluster().getInstance(RepositoriesService.class, node).repository(repo)).unblock();
     }
 
     protected void assertBusyPendingTasks(final String taskPrefix, final int expectedCount) throws Exception {


### PR DESCRIPTION
Allow snapshot deletion to proceed if the in-progress snapshot is being
created in a different repository.
