### PR TITLE
Remove the es.foreground property after it is used

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -263,6 +263,9 @@ final class Bootstrap {
         INSTANCE = new Bootstrap();
 
         boolean foreground = !"false".equals(System.getProperty("es.foreground", System.getProperty("es-foreground")));
+        // Clear these properties because we are done with them. No need to let them leak into the Settings.
+        System.clearProperty("es.foreground");
+        System.clearProperty("es-foreground");
         // handle the wrapper system property, if its a service, don't run as a service
         if (System.getProperty("wrapper.service", "XXX").equalsIgnoreCase("true")) {
             foreground = false;


### PR DESCRIPTION
The strict Settings check was failing if Elasticsearch was being backgrounded
because the backgrounding mechanism is setting a system property that the
Settings infrastructure picks up.
