### PR TITLE
add support for STS authentication using security_token

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -185,6 +185,13 @@ The following settings are supported:
     The secret key to use for authentication. Defaults to value of
     `cloud.aws.secret_key`.
 
+`security_token`::
+
+    The security token to use for STS authentication. May only be provided using
+    the `PUT _snapshot/my_s3_repository` due to the nature of STS credentials having
+    a maximum lifetime of 36 hours. For more information about using this form of authentication,
+    see http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[AWS Security Token Service]
+
 `chunk_size`::
 
     Big files can be broken down into chunks during snapshotting if needed.

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -43,6 +43,7 @@ public interface AwsS3Service extends LifecycleComponent<AwsS3Service> {
     final class CLOUD_S3 {
         public static final String KEY = "cloud.aws.s3.access_key";
         public static final String SECRET = "cloud.aws.s3.secret_key";
+        public static final String TOKEN = "cloud.aws.s3.security_token";
         public static final String PROTOCOL = "cloud.aws.s3.protocol";
         public static final String PROXY_HOST = "cloud.aws.s3.proxy.host";
         public static final String PROXY_PORT = "cloud.aws.s3.proxy.port";

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
@@ -285,6 +285,24 @@ abstract public class AbstractS3SnapshotRestoreTest extends AbstractAwsTestCase 
         assertRepositoryIsOperational(client, "test-repo");
     }
 
+    public void testRepositoryWithCustomCredentialsAndToken() {
+        Client client = client();
+        Settings bucketSettings = internalCluster().getInstance(Settings.class).getByPrefix("repositories.s3.private-bucket.");
+        logger.info("-->  creating s3 repository with bucket[{}] and path [{}]", bucketSettings.get("bucket"), basePath);
+        PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
+                .setType("s3").setSettings(Settings.settingsBuilder()
+                        .put("base_path", basePath)
+                        .put("region", bucketSettings.get("region"))
+                        .put("access_key", bucketSettings.get("access_key"))
+                        .put("secret_key", bucketSettings.get("secret_key"))
+                        .put("security_token", bucketSettings.get("security_token"))
+                        .put("bucket", bucketSettings.get("bucket"))
+                        ).get();
+        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+
+        assertRepositoryIsOperational(client, "test-repo");
+    }
+
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch-cloud-aws/issues/211")
     public void testRepositoryWithCustomEndpointProtocol() {
         Client client = client();


### PR DESCRIPTION
The following change addresses https://github.com/elastic/elasticsearch/issues/16428 by adding support for using AWS STS authentication when registering a repository using the `PUT /_snapshot/REPOSITORY` endpoint. 

Because STS credentials expire, I did not see a need to also add support for having it be provided via `elasticsearch.yaml` configuration file. 

For more information about this form of authentication, see [explicit-credentials](http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#credentials-explicit) and [BasicSessionCredentials](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/?com/amazonaws/auth/BasicSessionCredentials.html).
