### PR TITLE
Enforce builds are against JDK 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
                             <configuration>
                                 <rules>
                                     <requireJavaVersion>
-                                        <version>[${maven.compiler.source},)</version>
+                                        <version>[1.7, 1.8)</version>
                                     </requireJavaVersion>
                                 </rules>
                             </configuration>


### PR DESCRIPTION
This commit addresses an issue where builds against JDK 8 will succeed
but the artifacts produced will fail when run against JDK 7 (the minimum
required for the 2.x line). While the language level was set to Java 7,
the required Java version was only bounded below by 1.7 (but not bounded
above) and thus methods and classes from JDK 8 could slip in but go
undetected.
