### PR TITLE
Rename index folder to index_uuid

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/health/ClusterStateHealth.java
+++ b/core/src/main/java/org/elasticsearch/cluster/health/ClusterStateHealth.java
@@ -79,7 +79,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, S
      * @param clusterState The current cluster state. Must not be null.
      */
     public ClusterStateHealth(ClusterState clusterState) {
-        this(clusterState, clusterState.metaData().concreteAllIndices());
+        this(clusterState, clusterState.metaData().getConcreteAllIndices());
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -432,7 +432,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
         if (routing != null) {
             Set<String> r = Strings.splitStringByCommaToSet(routing);
             Map<String, Set<String>> routings = new HashMap<>();
-            String[] concreteIndices = metaData.concreteAllIndices();
+            String[] concreteIndices = metaData.getConcreteAllIndices();
             for (String index : concreteIndices) {
                 routings.put(index, r);
             }
@@ -472,7 +472,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
      */
     boolean isPatternMatchingAllIndices(MetaData metaData, String[] indicesOrAliases, String[] concreteIndices) {
         // if we end up matching on all indices, check, if its a wildcard parameter, or a "-something" structure
-        if (concreteIndices.length == metaData.concreteAllIndices().length && indicesOrAliases.length > 0) {
+        if (concreteIndices.length == metaData.getConcreteAllIndices().length && indicesOrAliases.length > 0) {
 
             //we might have something like /-test1,+test1 that would identify all indices
             //or something like /-test1 with test1 index missing and IndicesOptions.lenient()
@@ -728,11 +728,11 @@ public class IndexNameExpressionResolver extends AbstractComponent {
 
         private List<String> resolveEmptyOrTrivialWildcard(IndicesOptions options, MetaData metaData, boolean assertEmpty) {
             if (options.expandWildcardsOpen() && options.expandWildcardsClosed()) {
-                return Arrays.asList(metaData.concreteAllIndices());
+                return Arrays.asList(metaData.getConcreteAllIndices());
             } else if (options.expandWildcardsOpen()) {
-                return Arrays.asList(metaData.concreteAllOpenIndices());
+                return Arrays.asList(metaData.getConcreteAllOpenIndices());
             } else if (options.expandWildcardsClosed()) {
-                return Arrays.asList(metaData.concreteAllClosedIndices());
+                return Arrays.asList(metaData.getConcreteAllClosedIndices());
             } else {
                 assert assertEmpty : "Shouldn't end up here";
                 return Collections.emptyList();

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -370,24 +370,12 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
     /**
      * Returns all the concrete indices.
      */
-    public String[] concreteAllIndices() {
-        return allIndices;
-    }
-
     public String[] getConcreteAllIndices() {
-        return concreteAllIndices();
-    }
-
-    public String[] concreteAllOpenIndices() {
-        return allOpenIndices;
+        return allIndices;
     }
 
     public String[] getConcreteAllOpenIndices() {
         return allOpenIndices;
-    }
-
-    public String[] concreteAllClosedIndices() {
-        return allClosedIndices;
     }
 
     public String[] getConcreteAllClosedIndices() {
@@ -795,9 +783,9 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
                     metaData.getIndices(),
                     metaData.getTemplates(),
                     metaData.getCustoms(),
-                    metaData.concreteAllIndices(),
-                    metaData.concreteAllOpenIndices(),
-                    metaData.concreteAllClosedIndices(),
+                    metaData.getConcreteAllIndices(),
+                    metaData.getConcreteAllOpenIndices(),
+                    metaData.getConcreteAllClosedIndices(),
                     metaData.getAliasAndIndexLookup());
         } else {
             // No changes:

--- a/core/src/main/java/org/elasticsearch/common/util/IndexFolderUpgrader.java
+++ b/core/src/main/java/org/elasticsearch/common/util/IndexFolderUpgrader.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.gateway.MetaDataStateFormat;
+import org.elasticsearch.gateway.MetaStateService;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Renames index folders from {index.name} to {index.uuid}
+ */
+public class IndexFolderUpgrader {
+    private final NodeEnvironment nodeEnv;
+    private final Settings settings;
+    private final ESLogger logger = Loggers.getLogger(IndexFolderUpgrader.class);
+    private final MetaDataStateFormat<IndexMetaData> indexStateFormat = readOnlyIndexMetaDataStateFormat();
+
+    /**
+     * Creates a new upgrader instance
+     * @param settings node settings
+     * @param nodeEnv the node env to operate on
+     */
+    IndexFolderUpgrader(Settings settings, NodeEnvironment nodeEnv) {
+        this.settings = settings;
+        this.nodeEnv = nodeEnv;
+    }
+
+    /**
+     * Moves the index folder found in <code>source</code> to <code>target</code>
+     */
+    void upgrade(final Index index, final Path source, final Path target) throws IOException {
+        boolean success = false;
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+            success = true;
+        } catch (NoSuchFileException | FileNotFoundException exception) {
+            // thrown when the source is non-existent because the folder was renamed
+            // by another node (shared FS) after we checked if the target exists
+            logger.error("multiple nodes trying to upgrade [{}] in parallel, retry upgrading with single node",
+                exception, target);
+            throw exception;
+        } finally {
+            if (success) {
+                logger.info("{} moved from [{}] to [{}]", index, source, target);
+                logger.trace("{} syncing directory [{}]", index, target);
+                IOUtils.fsync(target, true);
+            }
+        }
+    }
+
+    /**
+     * Renames <code>indexFolderName</code> index folders found in node paths and custom path
+     * iff {@link #needsUpgrade(Index, String)} is true.
+     * Index folder in custom paths are renamed first followed by index folders in each node path.
+     */
+    void upgrade(final String indexFolderName) throws IOException {
+        for (NodeEnvironment.NodePath nodePath : nodeEnv.nodePaths()) {
+            final Path indexFolderPath = nodePath.indicesPath.resolve(indexFolderName);
+            final IndexMetaData indexMetaData = indexStateFormat.loadLatestState(logger, indexFolderPath);
+            if (indexMetaData != null) {
+                final Index index = indexMetaData.getIndex();
+                if (needsUpgrade(index, indexFolderName)) {
+                    logger.info("{} upgrading [{}] to new naming convention", index, indexFolderPath);
+                    final IndexSettings indexSettings = new IndexSettings(indexMetaData, settings);
+                    if (indexSettings.hasCustomDataPath()) {
+                        // we rename index folder in custom path before renaming them in any node path
+                        // to have the index state under a not-yet-upgraded index folder, which we use to
+                        // continue renaming after a incomplete upgrade.
+                        final Path customLocationSource = nodeEnv.resolveBaseCustomLocation(indexSettings)
+                            .resolve(indexFolderName);
+                        final Path customLocationTarget = customLocationSource.resolveSibling(index.getUUID());
+                        // we rename the folder in custom path only the first time we encounter a state
+                        // in a node path, which needs upgrading, it is a no-op for subsequent node paths
+                        if (Files.exists(customLocationSource) // might not exist if no data was written for this index
+                            && Files.exists(customLocationTarget) == false) {
+                            upgrade(index, customLocationSource, customLocationTarget);
+                        } else {
+                            logger.info("[{}] no upgrade needed - already upgraded", customLocationTarget);
+                        }
+                    }
+                    upgrade(index, indexFolderPath, indexFolderPath.resolveSibling(index.getUUID()));
+                } else {
+                    logger.debug("[{}] no upgrade needed - already upgraded", indexFolderPath);
+                }
+            } else {
+                logger.warn("[{}] no index state found - ignoring", indexFolderPath);
+            }
+        }
+    }
+
+    /**
+     * Upgrades all indices found under <code>nodeEnv</code>. Already upgraded indices are ignored.
+     */
+    public static void upgradeIndicesIfNeeded(final Settings settings, final NodeEnvironment nodeEnv) throws IOException {
+        final IndexFolderUpgrader upgrader = new IndexFolderUpgrader(settings, nodeEnv);
+        for (String indexFolderName : nodeEnv.availableIndexFolders()) {
+            upgrader.upgrade(indexFolderName);
+        }
+    }
+
+    static boolean needsUpgrade(Index index, String indexFolderName) {
+        return indexFolderName.equals(index.getUUID()) == false;
+    }
+
+    static MetaDataStateFormat<IndexMetaData> readOnlyIndexMetaDataStateFormat() {
+        // NOTE: XContentType param is not used as we use the format read from the serialized index state
+        return new MetaDataStateFormat<IndexMetaData>(XContentType.SMILE, MetaStateService.INDEX_STATE_FILE_PREFIX) {
+
+            @Override
+            public void toXContent(XContentBuilder builder, IndexMetaData state) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public IndexMetaData fromXContent(XContentParser parser) throws IOException {
+                return IndexMetaData.Builder.fromXContent(parser);
+            }
+        };
+    }
+}

--- a/core/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.gateway;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -26,12 +27,17 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
@@ -47,7 +53,7 @@ public class DanglingIndicesState extends AbstractComponent {
     private final MetaStateService metaStateService;
     private final LocalAllocateDangledIndices allocateDangledIndices;
 
-    private final Map<String, IndexMetaData> danglingIndices = ConcurrentCollections.newConcurrentMap();
+    private final Map<Index, IndexMetaData> danglingIndices = ConcurrentCollections.newConcurrentMap();
 
     @Inject
     public DanglingIndicesState(Settings settings, NodeEnvironment nodeEnv, MetaStateService metaStateService,
@@ -74,7 +80,7 @@ public class DanglingIndicesState extends AbstractComponent {
     /**
      * The current set of dangling indices.
      */
-    Map<String, IndexMetaData> getDanglingIndices() {
+    Map<Index, IndexMetaData> getDanglingIndices() {
         // This might be a good use case for CopyOnWriteHashMap
         return unmodifiableMap(new HashMap<>(danglingIndices));
     }
@@ -83,10 +89,16 @@ public class DanglingIndicesState extends AbstractComponent {
      * Cleans dangling indices if they are already allocated on the provided meta data.
      */
     void cleanupAllocatedDangledIndices(MetaData metaData) {
-        for (String danglingIndex : danglingIndices.keySet()) {
-            if (metaData.hasIndex(danglingIndex)) {
-                logger.debug("[{}] no longer dangling (created), removing from dangling list", danglingIndex);
-                danglingIndices.remove(danglingIndex);
+        for (Index index : danglingIndices.keySet()) {
+            final IndexMetaData indexMetaData = metaData.index(index);
+            if (indexMetaData != null && indexMetaData.getIndex().getName().equals(index.getName())) {
+                if (indexMetaData.getIndex().getUUID().equals(index.getUUID()) == false) {
+                    logger.warn("[{}] can not be imported as a dangling index, as there is already another index " +
+                        "with the same name but a different uuid. local index will be ignored (but not deleted)", index);
+                } else {
+                    logger.debug("[{}] no longer dangling (created), removing from dangling list", index);
+                }
+                danglingIndices.remove(index);
             }
         }
     }
@@ -104,36 +116,30 @@ public class DanglingIndicesState extends AbstractComponent {
      * that have state on disk, but are not part of the provided meta data, or not detected
      * as dangled already.
      */
-    Map<String, IndexMetaData> findNewDanglingIndices(MetaData metaData) {
-        final Set<String> indices;
+    Map<Index, IndexMetaData> findNewDanglingIndices(MetaData metaData) {
+        final Set<String> excludeIndexPathIds = new HashSet<>(metaData.indices().size() + danglingIndices.size());
+        for (ObjectCursor<IndexMetaData> cursor : metaData.indices().values()) {
+            excludeIndexPathIds.add(cursor.value.getIndex().getUUID());
+        }
+        excludeIndexPathIds.addAll(danglingIndices.keySet().stream().map(Index::getUUID).collect(Collectors.toList()));
         try {
-            indices = nodeEnv.findAllIndices();
-        } catch (Throwable e) {
+            final List<IndexMetaData> indexMetaDataList = metaStateService.loadIndicesStates(excludeIndexPathIds::contains);
+            Map<Index, IndexMetaData> newIndices = new HashMap<>(indexMetaDataList.size());
+            for (IndexMetaData indexMetaData : indexMetaDataList) {
+                if (metaData.hasIndex(indexMetaData.getIndex().getName())) {
+                    logger.warn("[{}] can not be imported as a dangling index, as index with same name already exists in cluster metadata",
+                        indexMetaData.getIndex());
+                } else {
+                    logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, auto import to cluster state",
+                        indexMetaData.getIndex());
+                    newIndices.put(indexMetaData.getIndex(), indexMetaData);
+                }
+            }
+            return newIndices;
+        } catch (IOException e) {
             logger.warn("failed to list dangling indices", e);
             return emptyMap();
         }
-
-        Map<String, IndexMetaData>  newIndices = new HashMap<>();
-        for (String indexName : indices) {
-            if (metaData.hasIndex(indexName) == false && danglingIndices.containsKey(indexName) == false) {
-                try {
-                    IndexMetaData indexMetaData = metaStateService.loadIndexState(indexName);
-                    if (indexMetaData != null) {
-                        logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, auto import to cluster state", indexName);
-                        if (!indexMetaData.getIndex().getName().equals(indexName)) {
-                            logger.info("dangled index directory name is [{}], state name is [{}], renaming to directory name", indexName, indexMetaData.getIndex());
-                            indexMetaData = IndexMetaData.builder(indexMetaData).index(indexName).build();
-                        }
-                        newIndices.put(indexName, indexMetaData);
-                    } else {
-                        logger.debug("[{}] dangling index directory detected, but no state found", indexName);
-                    }
-                } catch (Throwable t) {
-                    logger.warn("[{}] failed to load index state for detected dangled index", t, indexName);
-                }
-            }
-        }
-        return newIndices;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
 
 public final class ShardPath {
@@ -37,22 +36,20 @@ public final class ShardPath {
     public static final String TRANSLOG_FOLDER_NAME = "translog";
 
     private final Path path;
-    private final String indexUUID;
     private final ShardId shardId;
     private final Path shardStatePath;
     private final boolean isCustomDataPath;
 
-    public ShardPath(boolean isCustomDataPath, Path dataPath, Path shardStatePath, String indexUUID, ShardId shardId) {
+    public ShardPath(boolean isCustomDataPath, Path dataPath, Path shardStatePath, ShardId shardId) {
         assert dataPath.getFileName().toString().equals(Integer.toString(shardId.id())) : "dataPath must end with the shard ID but didn't: " + dataPath.toString();
         assert shardStatePath.getFileName().toString().equals(Integer.toString(shardId.id())) : "shardStatePath must end with the shard ID but didn't: " + dataPath.toString();
-        assert dataPath.getParent().getFileName().toString().equals(shardId.getIndexName()) : "dataPath must end with index/shardID but didn't: " + dataPath.toString();
-        assert shardStatePath.getParent().getFileName().toString().equals(shardId.getIndexName()) : "shardStatePath must end with index/shardID but didn't: " + dataPath.toString();
+        assert dataPath.getParent().getFileName().toString().equals(shardId.getIndex().getUUID()) : "dataPath must end with index path id but didn't: " + dataPath.toString();
+        assert shardStatePath.getParent().getFileName().toString().equals(shardId.getIndex().getUUID()) : "shardStatePath must end with index path id but didn't: " + dataPath.toString();
         if (isCustomDataPath && dataPath.equals(shardStatePath)) {
             throw new IllegalArgumentException("shard state path must be different to the data path when using custom data paths");
         }
         this.isCustomDataPath = isCustomDataPath;
         this.path = dataPath;
-        this.indexUUID = indexUUID;
         this.shardId = shardId;
         this.shardStatePath = shardStatePath;
     }
@@ -71,10 +68,6 @@ public final class ShardPath {
 
     public boolean exists() {
         return Files.exists(path);
-    }
-
-    public String getIndexUUID() {
-        return indexUUID;
     }
 
     public ShardId getShardId() {
@@ -144,7 +137,7 @@ public final class ShardPath {
                 dataPath = statePath;
             }
             logger.debug("{} loaded data path [{}], state path [{}]", shardId, dataPath, statePath);
-            return new ShardPath(indexSettings.hasCustomDataPath(), dataPath, statePath, indexUUID, shardId);
+            return new ShardPath(indexSettings.hasCustomDataPath(), dataPath, statePath, shardId);
         }
     }
 
@@ -168,34 +161,6 @@ public final class ShardPath {
         }
     }
 
-    /** Maps each path.data path to a "guess" of how many bytes the shards allocated to that path might additionally use over their
-     *  lifetime; we do this so a bunch of newly allocated shards won't just all go the path with the most free space at this moment. */
-    private static Map<Path,Long> getEstimatedReservedBytes(NodeEnvironment env, long avgShardSizeInBytes, Iterable<IndexShard> shards) throws IOException {
-        long totFreeSpace = 0;
-        for (NodeEnvironment.NodePath nodePath : env.nodePaths()) {
-            totFreeSpace += nodePath.fileStore.getUsableSpace();
-        }
-
-        // Very rough heuristic of how much disk space we expect the shard will use over its lifetime, the max of current average
-        // shard size across the cluster and 5% of the total available free space on this node:
-        long estShardSizeInBytes = Math.max(avgShardSizeInBytes, (long) (totFreeSpace/20.0));
-
-        // Collate predicted (guessed!) disk usage on each path.data:
-        Map<Path,Long> reservedBytes = new HashMap<>();
-        for (IndexShard shard : shards) {
-            Path dataPath = NodeEnvironment.shardStatePathToDataPath(shard.shardPath().getShardStatePath());
-
-            // Remove indices/<index>/<shardID> subdirs from the statePath to get back to the path.data/<lockID>:
-            Long curBytes = reservedBytes.get(dataPath);
-            if (curBytes == null) {
-                curBytes = 0L;
-            }
-            reservedBytes.put(dataPath, curBytes + estShardSizeInBytes);
-        }       
-
-        return reservedBytes;
-    }
-
     public static ShardPath selectNewPathForShard(NodeEnvironment env, ShardId shardId, IndexSettings indexSettings,
                                                   long avgShardSizeInBytes, Map<Path,Integer> dataPathToShardCount) throws IOException {
 
@@ -206,7 +171,6 @@ public final class ShardPath {
             dataPath = env.resolveCustomLocation(indexSettings, shardId);
             statePath = env.nodePaths()[0].resolve(shardId);
         } else {
-
             long totFreeSpace = 0;
             for (NodeEnvironment.NodePath nodePath : env.nodePaths()) {
                 totFreeSpace += nodePath.fileStore.getUsableSpace();
@@ -241,9 +205,7 @@ public final class ShardPath {
             statePath = bestPath.resolve(shardId);
             dataPath = statePath;
         }
-
-        final String indexUUID = indexSettings.getUUID();
-        return new ShardPath(indexSettings.hasCustomDataPath(), dataPath, statePath, indexUUID, shardId);
+        return new ShardPath(indexSettings.hasCustomDataPath(), dataPath, statePath, shardId);
     }
 
     @Override
@@ -258,9 +220,6 @@ public final class ShardPath {
         if (shardId != null ? !shardId.equals(shardPath.shardId) : shardPath.shardId != null) {
             return false;
         }
-        if (indexUUID != null ? !indexUUID.equals(shardPath.indexUUID) : shardPath.indexUUID != null) {
-            return false;
-        }
         if (path != null ? !path.equals(shardPath.path) : shardPath.path != null) {
             return false;
         }
@@ -271,7 +230,6 @@ public final class ShardPath {
     @Override
     public int hashCode() {
         int result = path != null ? path.hashCode() : 0;
-        result = 31 * result + (indexUUID != null ? indexUUID.hashCode() : 0);
         result = 31 * result + (shardId != null ? shardId.hashCode() : 0);
         return result;
     }
@@ -280,7 +238,6 @@ public final class ShardPath {
     public String toString() {
         return "ShardPath{" +
                 "path=" + path +
-                ", indexUUID='" + indexUUID + '\'' +
                 ", shard=" + shardId +
                 '}';
     }

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -531,7 +531,7 @@ public class IndicesService extends AbstractLifecycleComponent<IndicesService> i
             }
             // this is a pure protection to make sure this index doesn't get re-imported as a dangling index.
             // we should in the future rather write a tombstone rather than wiping the metadata.
-            MetaDataStateFormat.deleteMetaState(nodeEnv.indexPaths(index.getName()));
+            MetaDataStateFormat.deleteMetaState(nodeEnv.indexPaths(index));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -92,22 +92,22 @@ public class DiskUsageTests extends ESTestCase {
     }
 
     public void testFillShardLevelInfo() {
-        final Index index = new Index("test", "_na_");
+        final Index index = new Index("test", "0xdeadbeef");
         ShardRouting test_0 = ShardRouting.newUnassigned(index, 0, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_0, "node1");
         ShardRoutingHelper.moveToStarted(test_0);
-        Path test0Path = createTempDir().resolve("indices").resolve("test").resolve("0");
+        Path test0Path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve("0");
         CommonStats commonStats0 = new CommonStats();
         commonStats0.store = new StoreStats(100, 1);
         ShardRouting test_1 = ShardRouting.newUnassigned(index, 1, null, false, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));
         ShardRoutingHelper.initialize(test_1, "node2");
         ShardRoutingHelper.moveToStarted(test_1);
-        Path test1Path = createTempDir().resolve("indices").resolve("test").resolve("1");
+        Path test1Path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve("1");
         CommonStats commonStats1 = new CommonStats();
         commonStats1.store = new StoreStats(1000, 1);
         ShardStats[] stats  = new ShardStats[] {
-                new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, "0xdeadbeef", test_0.shardId()), commonStats0 , null),
-                new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, "0xdeadbeef", test_1.shardId()), commonStats1 , null)
+                new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, test_0.shardId()), commonStats0 , null),
+                new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats1 , null)
         };
         ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<ShardRouting, String> routingToPath = ImmutableOpenMap.builder();

--- a/core/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
@@ -22,8 +22,10 @@ package org.elasticsearch.cluster.allocation;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -42,6 +44,7 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -226,9 +229,10 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         assertThat(state.getRoutingNodes().node(state.nodes().resolveNode(node_1).id()).get(0).state(), equalTo(ShardRoutingState.STARTED));
 
         client().prepareIndex("test", "type", "1").setSource("field", "value").setRefresh(true).execute().actionGet();
+        final Index index = resolveIndex("test");
 
         logger.info("--> closing all nodes");
-        Path[] shardLocation = internalCluster().getInstance(NodeEnvironment.class, node_1).availableShardPaths(new ShardId("test", "_na_", 0));
+        Path[] shardLocation = internalCluster().getInstance(NodeEnvironment.class, node_1).availableShardPaths(new ShardId(index, 0));
         assertThat(FileSystemUtils.exists(shardLocation), equalTo(true)); // make sure the data is there!
         internalCluster().closeNonSharedNodes(false); // don't wipe data directories the index needs to be there!
 

--- a/core/src/test/java/org/elasticsearch/common/util/IndexFolderUpgraderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/IndexFolderUpgraderTests.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestUtil;
+import org.elasticsearch.Version;
+import org.elasticsearch.bwcompat.OldIndexBackwardsCompatibilityIT;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.AllocationId;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.gateway.MetaDataStateFormat;
+import org.elasticsearch.gateway.MetaStateService;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.index.shard.ShardStateMetaData;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.core.Is.is;
+
+@LuceneTestCase.SuppressFileSystems("ExtrasFS")
+public class IndexFolderUpgraderTests extends ESTestCase {
+
+    private static MetaDataStateFormat<IndexMetaData> indexMetaDataStateFormat =
+        new MetaDataStateFormat<IndexMetaData>(XContentType.SMILE, MetaStateService.INDEX_STATE_FILE_PREFIX) {
+
+        @Override
+        public void toXContent(XContentBuilder builder, IndexMetaData state) throws IOException {
+            IndexMetaData.Builder.toXContent(state, builder, ToXContent.EMPTY_PARAMS);
+        }
+
+        @Override
+        public IndexMetaData fromXContent(XContentParser parser) throws IOException {
+            return IndexMetaData.Builder.fromXContent(parser);
+        }
+    };
+
+    /**
+     * tests custom data paths are upgraded
+     */
+    public void testUpgradeCustomDataPath() throws IOException {
+        Path customPath = createTempDir();
+        final Settings nodeSettings = Settings.builder()
+            .put(NodeEnvironment.ADD_NODE_ID_TO_CUSTOM_PATH.getKey(), randomBoolean())
+            .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), customPath.toAbsolutePath().toString()).build();
+        try (NodeEnvironment nodeEnv = newNodeEnvironment(nodeSettings)) {
+            final Index index = new Index(randomAsciiOfLength(10), Strings.randomBase64UUID());
+            Settings settings = Settings.builder()
+                .put(nodeSettings)
+                .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_0_0)
+                .put(IndexMetaData.SETTING_DATA_PATH, customPath.toAbsolutePath().toString())
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 5))
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build();
+            IndexMetaData indexState = IndexMetaData.builder(index.getName()).settings(settings).build();
+            int numIdxFiles = randomIntBetween(1, 5);
+            int numTranslogFiles = randomIntBetween(1, 5);
+            IndexSettings indexSettings = new IndexSettings(indexState, nodeSettings);
+            writeIndex(nodeEnv, indexSettings, numIdxFiles, numTranslogFiles);
+            IndexFolderUpgrader helper = new IndexFolderUpgrader(settings, nodeEnv);
+            helper.upgrade(indexSettings.getIndex().getName());
+            checkIndex(nodeEnv, indexSettings, numIdxFiles, numTranslogFiles);
+        }
+    }
+
+    /**
+     * tests upgrade on partially upgraded index, when we crash while upgrading
+     */
+    public void testPartialUpgradeCustomDataPath() throws IOException {
+        Path customPath = createTempDir();
+        final Settings nodeSettings = Settings.builder()
+            .put(NodeEnvironment.ADD_NODE_ID_TO_CUSTOM_PATH.getKey(), randomBoolean())
+            .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), customPath.toAbsolutePath().toString()).build();
+        try (NodeEnvironment nodeEnv = newNodeEnvironment(nodeSettings)) {
+            final Index index = new Index(randomAsciiOfLength(10), Strings.randomBase64UUID());
+            Settings settings = Settings.builder()
+                .put(nodeSettings)
+                .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_0_0)
+                .put(IndexMetaData.SETTING_DATA_PATH, customPath.toAbsolutePath().toString())
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 5))
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build();
+            IndexMetaData indexState = IndexMetaData.builder(index.getName()).settings(settings).build();
+            int numIdxFiles = randomIntBetween(1, 5);
+            int numTranslogFiles = randomIntBetween(1, 5);
+            IndexSettings indexSettings = new IndexSettings(indexState, nodeSettings);
+            writeIndex(nodeEnv, indexSettings, numIdxFiles, numTranslogFiles);
+            IndexFolderUpgrader helper = new IndexFolderUpgrader(settings, nodeEnv) {
+                @Override
+                void upgrade(Index index, Path source, Path target) throws IOException {
+                    if(randomBoolean()) {
+                        throw new FileNotFoundException("simulated");
+                    }
+                }
+            };
+            // only upgrade some paths
+            try {
+                helper.upgrade(index.getName());
+            } catch (IOException e) {
+                assertTrue(e instanceof FileNotFoundException);
+            }
+            helper = new IndexFolderUpgrader(settings, nodeEnv);
+            // try to upgrade again
+            helper.upgrade(indexSettings.getIndex().getName());
+            checkIndex(nodeEnv, indexSettings, numIdxFiles, numTranslogFiles);
+        }
+    }
+
+    public void testUpgrade() throws IOException {
+        final Settings nodeSettings = Settings.builder()
+            .put(NodeEnvironment.ADD_NODE_ID_TO_CUSTOM_PATH.getKey(), randomBoolean()).build();
+        try (NodeEnvironment nodeEnv = newNodeEnvironment(nodeSettings)) {
+            final Index index = new Index(randomAsciiOfLength(10), Strings.randomBase64UUID());
+            Settings settings = Settings.builder()
+                .put(nodeSettings)
+                .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_0_0)
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 5))
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build();
+            IndexMetaData indexState = IndexMetaData.builder(index.getName()).settings(settings).build();
+            int numIdxFiles = randomIntBetween(1, 5);
+            int numTranslogFiles = randomIntBetween(1, 5);
+            IndexSettings indexSettings = new IndexSettings(indexState, nodeSettings);
+            writeIndex(nodeEnv, indexSettings, numIdxFiles, numTranslogFiles);
+            IndexFolderUpgrader helper = new IndexFolderUpgrader(settings, nodeEnv);
+            helper.upgrade(indexSettings.getIndex().getName());
+            checkIndex(nodeEnv, indexSettings, numIdxFiles, numTranslogFiles);
+        }
+    }
+
+    public void testUpgradeIndices() throws IOException {
+        final Settings nodeSettings = Settings.builder()
+            .put(NodeEnvironment.ADD_NODE_ID_TO_CUSTOM_PATH.getKey(), randomBoolean()).build();
+        try (NodeEnvironment nodeEnv = newNodeEnvironment(nodeSettings)) {
+            Map<IndexSettings, Tuple<Integer, Integer>>  indexSettingsMap = new HashMap<>();
+            for (int i = 0; i < randomIntBetween(2, 5); i++) {
+                final Index index = new Index(randomAsciiOfLength(10), Strings.randomBase64UUID());
+                Settings settings = Settings.builder()
+                    .put(nodeSettings)
+                    .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
+                    .put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_0_0)
+                    .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 5))
+                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .build();
+                IndexMetaData indexState = IndexMetaData.builder(index.getName()).settings(settings).build();
+                Tuple<Integer, Integer> fileCounts = new Tuple<>(randomIntBetween(1, 5), randomIntBetween(1, 5));
+                IndexSettings indexSettings = new IndexSettings(indexState, nodeSettings);
+                indexSettingsMap.put(indexSettings, fileCounts);
+                writeIndex(nodeEnv, indexSettings, fileCounts.v1(), fileCounts.v2());
+            }
+            IndexFolderUpgrader.upgradeIndicesIfNeeded(nodeSettings, nodeEnv);
+            for (Map.Entry<IndexSettings, Tuple<Integer, Integer>> entry : indexSettingsMap.entrySet()) {
+                checkIndex(nodeEnv, entry.getKey(), entry.getValue().v1(), entry.getValue().v2());
+            }
+        }
+    }
+
+    /**
+     * Run upgrade on a real bwc index
+     */
+    public void testUpgradeRealIndex() throws IOException, URISyntaxException {
+        List<Path> indexes = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(getBwcIndicesPath(), "index-*.zip")) {
+            for (Path path : stream) {
+                indexes.add(path);
+            }
+        }
+        CollectionUtil.introSort(indexes, (o1, o2) -> o1.getFileName().compareTo(o2.getFileName()));
+        final Path path = randomFrom(indexes);
+        final String indexName = path.getFileName().toString().replace(".zip", "").toLowerCase(Locale.ROOT);
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment()) {
+            Path unzipDir = createTempDir();
+            Path unzipDataDir = unzipDir.resolve("data");
+            // decompress the index
+            try (InputStream stream = Files.newInputStream(path)) {
+                TestUtil.unzip(stream, unzipDir);
+            }
+            // check it is unique
+            assertTrue(Files.exists(unzipDataDir));
+            Path[] list = FileSystemUtils.files(unzipDataDir);
+            if (list.length != 1) {
+                throw new IllegalStateException("Backwards index must contain exactly one cluster but was " + list.length);
+            }
+            // the bwc scripts packs the indices under this path
+            Path src = list[0].resolve("nodes/0/indices/" + indexName);
+            assertTrue("[" + path + "] missing index dir: " + src.toString(), Files.exists(src));
+            final Path indicesPath = randomFrom(nodeEnvironment.nodePaths()).indicesPath;
+            logger.info("--> injecting index [{}] into [{}]", indexName, indicesPath);
+            OldIndexBackwardsCompatibilityIT.copyIndex(logger, src, indexName, indicesPath);
+            IndexFolderUpgrader.upgradeIndicesIfNeeded(Settings.EMPTY, nodeEnvironment);
+
+            // ensure old index folder is deleted
+            Set<String> indexFolders = nodeEnvironment.availableIndexFolders();
+            assertEquals(indexFolders.size(), 1);
+
+            // ensure index metadata is moved
+            IndexMetaData indexMetaData = indexMetaDataStateFormat.loadLatestState(logger,
+                nodeEnvironment.resolveIndexFolder(indexFolders.iterator().next()));
+            assertNotNull(indexMetaData);
+            Index index = indexMetaData.getIndex();
+            assertEquals(index.getName(), indexName);
+
+            Set<ShardId> shardIds = nodeEnvironment.findAllShardIds(index);
+            // ensure all shards are moved
+            assertEquals(shardIds.size(), indexMetaData.getNumberOfShards());
+            for (ShardId shardId : shardIds) {
+                final ShardPath shardPath = ShardPath.loadShardPath(logger, nodeEnvironment, shardId,
+                    new IndexSettings(indexMetaData, Settings.EMPTY));
+                final Path translog = shardPath.resolveTranslog();
+                final Path idx = shardPath.resolveIndex();
+                final Path state = shardPath.getShardStatePath().resolve(MetaDataStateFormat.STATE_DIR_NAME);
+                assertTrue(shardPath.exists());
+                assertTrue(Files.exists(translog));
+                assertTrue(Files.exists(idx));
+                assertTrue(Files.exists(state));
+            }
+        }
+    }
+
+    public void testNeedsUpgrade() throws IOException {
+        final Index index = new Index("foo", Strings.randomBase64UUID());
+        IndexMetaData indexState = IndexMetaData.builder(index.getName())
+            .settings(Settings.builder()
+                .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        try (NodeEnvironment nodeEnvironment = newNodeEnvironment()) {
+            indexMetaDataStateFormat.write(indexState, 1, nodeEnvironment.indexPaths(index));
+            assertFalse(IndexFolderUpgrader.needsUpgrade(index, index.getUUID()));
+        }
+    }
+
+    private void checkIndex(NodeEnvironment nodeEnv, IndexSettings indexSettings,
+                            int numIdxFiles, int numTranslogFiles) throws IOException {
+        final Index index = indexSettings.getIndex();
+        // ensure index state can be loaded
+        IndexMetaData loadLatestState = indexMetaDataStateFormat.loadLatestState(logger, nodeEnv.indexPaths(index));
+        assertNotNull(loadLatestState);
+        assertEquals(loadLatestState.getIndex(), index);
+        for (int shardId = 0; shardId < indexSettings.getNumberOfShards(); shardId++) {
+            // ensure shard path can be loaded
+            ShardPath targetShardPath = ShardPath.loadShardPath(logger, nodeEnv, new ShardId(index, shardId), indexSettings);
+            assertNotNull(targetShardPath);
+            // ensure shard contents are copied over
+            final Path translog = targetShardPath.resolveTranslog();
+            final Path idx = targetShardPath.resolveIndex();
+
+            // ensure index and translog files are copied over
+            assertEquals(numTranslogFiles, FileSystemUtils.files(translog).length);
+            assertEquals(numIdxFiles, FileSystemUtils.files(idx).length);
+            Path[] files = FileSystemUtils.files(translog);
+            final HashSet<Path> translogFiles = new HashSet<>(Arrays.asList(files));
+            for (int i = 0; i < numTranslogFiles; i++) {
+                final String name = Integer.toString(i);
+                translogFiles.contains(translog.resolve(name + ".translog"));
+                byte[] content = Files.readAllBytes(translog.resolve(name + ".translog"));
+                assertEquals(name , new String(content, StandardCharsets.UTF_8));
+            }
+            Path[] indexFileList = FileSystemUtils.files(idx);
+            final HashSet<Path> idxFiles = new HashSet<>(Arrays.asList(indexFileList));
+            for (int i = 0; i < numIdxFiles; i++) {
+                final String name = Integer.toString(i);
+                idxFiles.contains(idx.resolve(name + ".tst"));
+                byte[] content = Files.readAllBytes(idx.resolve(name + ".tst"));
+                assertEquals(name, new String(content, StandardCharsets.UTF_8));
+            }
+        }
+    }
+
+    private void writeIndex(NodeEnvironment nodeEnv, IndexSettings indexSettings,
+                            int numIdxFiles, int numTranslogFiles) throws IOException {
+        NodeEnvironment.NodePath[] nodePaths = nodeEnv.nodePaths();
+        Path[] oldIndexPaths = new Path[nodePaths.length];
+        for (int i = 0; i < nodePaths.length; i++) {
+            oldIndexPaths[i] = nodePaths[i].indicesPath.resolve(indexSettings.getIndex().getName());
+        }
+        indexMetaDataStateFormat.write(indexSettings.getIndexMetaData(), 1, oldIndexPaths);
+        for (int id = 0; id < indexSettings.getNumberOfShards(); id++) {
+            Path oldIndexPath = randomFrom(oldIndexPaths);
+            ShardId shardId = new ShardId(indexSettings.getIndex(), id);
+            if (indexSettings.hasCustomDataPath()) {
+                Path customIndexPath = nodeEnv.resolveBaseCustomLocation(indexSettings).resolve(indexSettings.getIndex().getName());
+                writeShard(shardId, customIndexPath, numIdxFiles, numTranslogFiles);
+            } else {
+                writeShard(shardId, oldIndexPath, numIdxFiles, numTranslogFiles);
+            }
+            ShardStateMetaData state = new ShardStateMetaData(true, indexSettings.getUUID(), AllocationId.newInitializing());
+            ShardStateMetaData.FORMAT.write(state, 1, oldIndexPath.resolve(String.valueOf(shardId.getId())));
+        }
+    }
+
+    private void writeShard(ShardId shardId, Path indexLocation,
+                            final int numIdxFiles, final int numTranslogFiles) throws IOException {
+        Path oldShardDataPath = indexLocation.resolve(String.valueOf(shardId.getId()));
+        final Path translogPath = oldShardDataPath.resolve(ShardPath.TRANSLOG_FOLDER_NAME);
+        final Path idxPath = oldShardDataPath.resolve(ShardPath.INDEX_FOLDER_NAME);
+        Files.createDirectories(translogPath);
+        Files.createDirectories(idxPath);
+        for (int i = 0; i < numIdxFiles; i++) {
+            String filename = Integer.toString(i);
+            try (BufferedWriter w = Files.newBufferedWriter(idxPath.resolve(filename + ".tst"),
+                StandardCharsets.UTF_8)) {
+                w.write(filename);
+            }
+        }
+        for (int i = 0; i < numTranslogFiles; i++) {
+            String filename = Integer.toString(i);
+            try (BufferedWriter w = Files.newBufferedWriter(translogPath.resolve(filename + ".translog"),
+                StandardCharsets.UTF_8)) {
+                w.write(filename);
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.gateway.MetaDataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
@@ -36,7 +37,11 @@ import org.elasticsearch.test.IndexSettingsModule;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -129,21 +134,22 @@ public class NodeEnvironmentTests extends ESTestCase {
     public void testShardLock() throws IOException {
         final NodeEnvironment env = newNodeEnvironment();
 
-        ShardLock fooLock = env.shardLock(new ShardId("foo", "_na_", 0));
-        assertEquals(new ShardId("foo", "_na_", 0), fooLock.getShardId());
+        Index index = new Index("foo", "fooUUID");
+        ShardLock fooLock = env.shardLock(new ShardId(index, 0));
+        assertEquals(new ShardId(index, 0), fooLock.getShardId());
 
         try {
-            env.shardLock(new ShardId("foo", "_na_", 0));
+            env.shardLock(new ShardId(index, 0));
             fail("shard is locked");
         } catch (LockObtainFailedException ex) {
             // expected
         }
-        for (Path path : env.indexPaths("foo")) {
+        for (Path path : env.indexPaths(index)) {
             Files.createDirectories(path.resolve("0"));
             Files.createDirectories(path.resolve("1"));
         }
         try {
-            env.lockAllForIndex(new Index("foo", "_na_"), idxSettings, randomIntBetween(0, 10));
+            env.lockAllForIndex(index, idxSettings, randomIntBetween(0, 10));
             fail("shard 0 is locked");
         } catch (LockObtainFailedException ex) {
             // expected
@@ -151,11 +157,11 @@ public class NodeEnvironmentTests extends ESTestCase {
 
         fooLock.close();
         // can lock again?
-        env.shardLock(new ShardId("foo", "_na_", 0)).close();
+        env.shardLock(new ShardId(index, 0)).close();
 
-        List<ShardLock> locks = env.lockAllForIndex(new Index("foo", "_na_"), idxSettings, randomIntBetween(0, 10));
+        List<ShardLock> locks = env.lockAllForIndex(index, idxSettings, randomIntBetween(0, 10));
         try {
-            env.shardLock(new ShardId("foo", "_na_", 0));
+            env.shardLock(new ShardId(index, 0));
             fail("shard is locked");
         } catch (LockObtainFailedException ex) {
             // expected
@@ -165,18 +171,45 @@ public class NodeEnvironmentTests extends ESTestCase {
         env.close();
     }
 
-    public void testGetAllIndices() throws Exception {
+    public void testAvailableIndexFolders() throws Exception {
         final NodeEnvironment env = newNodeEnvironment();
         final int numIndices = randomIntBetween(1, 10);
+        Set<String> actualPaths = new HashSet<>();
         for (int i = 0; i < numIndices; i++) {
-            for (Path path : env.indexPaths("foo" + i)) {
-                Files.createDirectories(path);
+            Index index = new Index("foo" + i, "fooUUID" + i);
+            for (Path path : env.indexPaths(index)) {
+                Files.createDirectories(path.resolve(MetaDataStateFormat.STATE_DIR_NAME));
+                actualPaths.add(path.getFileName().toString());
             }
         }
-        Set<String> indices = env.findAllIndices();
-        assertEquals(indices.size(), numIndices);
+
+        assertThat(actualPaths, equalTo(env.availableIndexFolders()));
+        assertTrue("LockedShards: " + env.lockedShards(), env.lockedShards().isEmpty());
+        env.close();
+    }
+
+    public void testResolveIndexFolders() throws Exception {
+        final NodeEnvironment env = newNodeEnvironment();
+        final int numIndices = randomIntBetween(1, 10);
+        Map<String, List<Path>> actualIndexDataPaths = new HashMap<>();
         for (int i = 0; i < numIndices; i++) {
-            assertTrue(indices.contains("foo" + i));
+            Index index = new Index("foo" + i, "fooUUID" + i);
+            Path[] indexPaths = env.indexPaths(index);
+            for (Path path : indexPaths) {
+                Files.createDirectories(path);
+                String fileName = path.getFileName().toString();
+                List<Path> paths = actualIndexDataPaths.get(fileName);
+                if (paths == null) {
+                    paths = new ArrayList<>();
+                }
+                paths.add(path);
+                actualIndexDataPaths.put(fileName, paths);
+            }
+        }
+        for (Map.Entry<String, List<Path>> actualIndexDataPathEntry : actualIndexDataPaths.entrySet()) {
+            List<Path> actual = actualIndexDataPathEntry.getValue();
+            Path[] actualPaths = actual.toArray(new Path[actual.size()]);
+            assertThat(actualPaths, equalTo(env.resolveIndexFolder(actualIndexDataPathEntry.getKey())));
         }
         assertTrue("LockedShards: " + env.lockedShards(), env.lockedShards().isEmpty());
         env.close();
@@ -184,44 +217,45 @@ public class NodeEnvironmentTests extends ESTestCase {
 
     public void testDeleteSafe() throws IOException, InterruptedException {
         final NodeEnvironment env = newNodeEnvironment();
-        ShardLock fooLock = env.shardLock(new ShardId("foo", "_na_", 0));
-        assertEquals(new ShardId("foo", "_na_", 0), fooLock.getShardId());
+        final Index index = new Index("foo", "fooUUID");
+        ShardLock fooLock = env.shardLock(new ShardId(index, 0));
+        assertEquals(new ShardId(index, 0), fooLock.getShardId());
 
 
-        for (Path path : env.indexPaths("foo")) {
+        for (Path path : env.indexPaths(index)) {
             Files.createDirectories(path.resolve("0"));
             Files.createDirectories(path.resolve("1"));
         }
 
         try {
-            env.deleteShardDirectorySafe(new ShardId("foo", "_na_", 0), idxSettings);
+            env.deleteShardDirectorySafe(new ShardId(index, 0), idxSettings);
             fail("shard is locked");
         } catch (LockObtainFailedException ex) {
             // expected
         }
 
-        for (Path path : env.indexPaths("foo")) {
+        for (Path path : env.indexPaths(index)) {
             assertTrue(Files.exists(path.resolve("0")));
             assertTrue(Files.exists(path.resolve("1")));
 
         }
 
-        env.deleteShardDirectorySafe(new ShardId("foo", "_na_", 1), idxSettings);
+        env.deleteShardDirectorySafe(new ShardId(index, 1), idxSettings);
 
-        for (Path path : env.indexPaths("foo")) {
+        for (Path path : env.indexPaths(index)) {
             assertTrue(Files.exists(path.resolve("0")));
             assertFalse(Files.exists(path.resolve("1")));
         }
 
         try {
-            env.deleteIndexDirectorySafe(new Index("foo", "_na_"), randomIntBetween(0, 10), idxSettings);
+            env.deleteIndexDirectorySafe(index, randomIntBetween(0, 10), idxSettings);
             fail("shard is locked");
         } catch (LockObtainFailedException ex) {
             // expected
         }
         fooLock.close();
 
-        for (Path path : env.indexPaths("foo")) {
+        for (Path path : env.indexPaths(index)) {
             assertTrue(Files.exists(path));
         }
 
@@ -242,7 +276,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                 @Override
                 protected void doRun() throws Exception {
                     start.await();
-                    try (ShardLock autoCloses = env.shardLock(new ShardId("foo", "_na_", 0))) {
+                    try (ShardLock autoCloses = env.shardLock(new ShardId(index, 0))) {
                         blockLatch.countDown();
                         Thread.sleep(randomIntBetween(1, 10));
                     }
@@ -257,11 +291,11 @@ public class NodeEnvironmentTests extends ESTestCase {
         start.countDown();
         blockLatch.await();
 
-        env.deleteIndexDirectorySafe(new Index("foo", "_na_"), 5000, idxSettings);
+        env.deleteIndexDirectorySafe(index, 5000, idxSettings);
 
         assertNull(threadException.get());
 
-        for (Path path : env.indexPaths("foo")) {
+        for (Path path : env.indexPaths(index)) {
             assertFalse(Files.exists(path));
         }
         latch.await();
@@ -300,7 +334,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                     for (int i = 0; i < iters; i++) {
                         int shard = randomIntBetween(0, counts.length - 1);
                         try {
-                            try (ShardLock autoCloses = env.shardLock(new ShardId("foo", "_na_", shard), scaledRandomIntBetween(0, 10))) {
+                            try (ShardLock autoCloses = env.shardLock(new ShardId("foo", "fooUUID", shard), scaledRandomIntBetween(0, 10))) {
                                 counts[shard].value++;
                                 countsAtomic[shard].incrementAndGet();
                                 assertEquals(flipFlop[shard].incrementAndGet(), 1);
@@ -334,37 +368,38 @@ public class NodeEnvironmentTests extends ESTestCase {
         String[] dataPaths = tmpPaths();
         NodeEnvironment env = newNodeEnvironment(dataPaths, "/tmp", Settings.EMPTY);
 
-        IndexSettings s1 = IndexSettingsModule.newIndexSettings("myindex", Settings.EMPTY);
-        IndexSettings s2 = IndexSettingsModule.newIndexSettings("myindex", Settings.builder().put(IndexMetaData.SETTING_DATA_PATH, "/tmp/foo").build());
-        Index index = new Index("myindex", "_na_");
+        final Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_INDEX_UUID, "myindexUUID").build();
+        IndexSettings s1 = IndexSettingsModule.newIndexSettings("myindex", indexSettings);
+        IndexSettings s2 = IndexSettingsModule.newIndexSettings("myindex", Settings.builder().put(indexSettings).put(IndexMetaData.SETTING_DATA_PATH, "/tmp/foo").build());
+        Index index = new Index("myindex", "myindexUUID");
         ShardId sid = new ShardId(index, 0);
 
         assertFalse("no settings should mean no custom data path", s1.hasCustomDataPath());
         assertTrue("settings with path_data should have a custom data path", s2.hasCustomDataPath());
 
         assertThat(env.availableShardPaths(sid), equalTo(env.availableShardPaths(sid)));
-        assertThat(env.resolveCustomLocation(s2, sid), equalTo(PathUtils.get("/tmp/foo/0/myindex/0")));
+        assertThat(env.resolveCustomLocation(s2, sid), equalTo(PathUtils.get("/tmp/foo/0/" + index.getUUID() + "/0")));
 
         assertThat("shard paths with a custom data_path should contain only regular paths",
                 env.availableShardPaths(sid),
-                equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/myindex/0")));
+                equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/" + index.getUUID() + "/0")));
 
         assertThat("index paths uses the regular template",
-                env.indexPaths(index.getName()), equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/myindex")));
+                env.indexPaths(index), equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/" + index.getUUID())));
 
         env.close();
         NodeEnvironment env2 = newNodeEnvironment(dataPaths, "/tmp",
                 Settings.builder().put(NodeEnvironment.ADD_NODE_ID_TO_CUSTOM_PATH.getKey(), false).build());
 
         assertThat(env2.availableShardPaths(sid), equalTo(env2.availableShardPaths(sid)));
-        assertThat(env2.resolveCustomLocation(s2, sid), equalTo(PathUtils.get("/tmp/foo/myindex/0")));
+        assertThat(env2.resolveCustomLocation(s2, sid), equalTo(PathUtils.get("/tmp/foo/" + index.getUUID() + "/0")));
 
         assertThat("shard paths with a custom data_path should contain only regular paths",
                 env2.availableShardPaths(sid),
-                equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/myindex/0")));
+                equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/" + index.getUUID() + "/0")));
 
         assertThat("index paths uses the regular template",
-                env2.indexPaths(index.getName()), equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/myindex")));
+                env2.indexPaths(index), equalTo(stringsToPaths(dataPaths, "elasticsearch/nodes/0/indices/" + index.getUUID())));
 
         env2.close();
     }

--- a/core/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
@@ -29,6 +29,7 @@ import org.hamcrest.Matchers;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -53,6 +54,47 @@ public class DanglingIndicesStateTests extends ESTestCase {
             assertTrue(danglingState.getDanglingIndices().isEmpty());
         }
     }
+    public void testDanglingIndicesDiscovery() throws Exception {
+        try (NodeEnvironment env = newNodeEnvironment()) {
+            MetaStateService metaStateService = new MetaStateService(Settings.EMPTY, env);
+            DanglingIndicesState danglingState = new DanglingIndicesState(Settings.EMPTY, env, metaStateService, null);
+
+            assertTrue(danglingState.getDanglingIndices().isEmpty());
+            MetaData metaData = MetaData.builder().build();
+            final Settings.Builder settings = Settings.builder().put(indexSettings).put(IndexMetaData.SETTING_INDEX_UUID, "test1UUID");
+            IndexMetaData dangledIndex = IndexMetaData.builder("test1").settings(settings).build();
+            metaStateService.writeIndex("test_write", dangledIndex);
+            Map<Index, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
+            assertTrue(newDanglingIndices.containsKey(dangledIndex.getIndex()));
+            metaData = MetaData.builder().put(dangledIndex, false).build();
+            newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
+            assertFalse(newDanglingIndices.containsKey(dangledIndex.getIndex()));
+        }
+    }
+
+    public void testInvalidIndexFolder() throws Exception {
+        try (NodeEnvironment env = newNodeEnvironment()) {
+            MetaStateService metaStateService = new MetaStateService(Settings.EMPTY, env);
+            DanglingIndicesState danglingState = new DanglingIndicesState(Settings.EMPTY, env, metaStateService, null);
+
+            MetaData metaData = MetaData.builder().build();
+            final String uuid = "test1UUID";
+            final Settings.Builder settings = Settings.builder().put(indexSettings).put(IndexMetaData.SETTING_INDEX_UUID, uuid);
+            IndexMetaData dangledIndex = IndexMetaData.builder("test1").settings(settings).build();
+            metaStateService.writeIndex("test_write", dangledIndex);
+            for (Path path : env.resolveIndexFolder(uuid)) {
+                if (Files.exists(path)) {
+                    Files.move(path, path.resolveSibling("invalidUUID"), StandardCopyOption.ATOMIC_MOVE);
+                }
+            }
+            try {
+                danglingState.findNewDanglingIndices(metaData);
+                fail("no exception thrown for invalid folder name");
+            } catch (IllegalStateException e) {
+                assertThat(e.getMessage(), equalTo("[invalidUUID] invalid index folder name, rename to [test1UUID]"));
+            }
+        }
+    }
 
     public void testDanglingProcessing() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
@@ -61,15 +103,16 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
             MetaData metaData = MetaData.builder().build();
 
-            IndexMetaData dangledIndex = IndexMetaData.builder("test1").settings(indexSettings).build();
-            metaStateService.writeIndex("test_write", dangledIndex, null);
+            final Settings.Builder settings = Settings.builder().put(indexSettings).put(IndexMetaData.SETTING_INDEX_UUID, "test1UUID");
+            IndexMetaData dangledIndex = IndexMetaData.builder("test1").settings(settings).build();
+            metaStateService.writeIndex("test_write", dangledIndex);
 
             // check that several runs when not in the metadata still keep the dangled index around
             int numberOfChecks = randomIntBetween(1, 10);
             for (int i = 0; i < numberOfChecks; i++) {
-                Map<String, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
+                Map<Index, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
                 assertThat(newDanglingIndices.size(), equalTo(1));
-                assertThat(newDanglingIndices.keySet(), Matchers.hasItems("test1"));
+                assertThat(newDanglingIndices.keySet(), Matchers.hasItems(dangledIndex.getIndex()));
                 assertTrue(danglingState.getDanglingIndices().isEmpty());
             }
 
@@ -77,7 +120,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
                 danglingState.findNewAndAddDanglingIndices(metaData);
 
                 assertThat(danglingState.getDanglingIndices().size(), equalTo(1));
-                assertThat(danglingState.getDanglingIndices().keySet(), Matchers.hasItems("test1"));
+                assertThat(danglingState.getDanglingIndices().keySet(), Matchers.hasItems(dangledIndex.getIndex()));
             }
 
             // simulate allocation to the metadata
@@ -85,35 +128,15 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
             // check that several runs when in the metadata, but not cleaned yet, still keeps dangled
             for (int i = 0; i < numberOfChecks; i++) {
-                Map<String, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
+                Map<Index, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
                 assertTrue(newDanglingIndices.isEmpty());
 
                 assertThat(danglingState.getDanglingIndices().size(), equalTo(1));
-                assertThat(danglingState.getDanglingIndices().keySet(), Matchers.hasItems("test1"));
+                assertThat(danglingState.getDanglingIndices().keySet(), Matchers.hasItems(dangledIndex.getIndex()));
             }
 
             danglingState.cleanupAllocatedDangledIndices(metaData);
             assertTrue(danglingState.getDanglingIndices().isEmpty());
-        }
-    }
-
-    public void testRenameOfIndexState() throws Exception {
-        try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(Settings.EMPTY, env);
-            DanglingIndicesState danglingState = new DanglingIndicesState(Settings.EMPTY, env, metaStateService, null);
-
-            MetaData metaData = MetaData.builder().build();
-
-            IndexMetaData dangledIndex = IndexMetaData.builder("test1").settings(indexSettings).build();
-            metaStateService.writeIndex("test_write", dangledIndex, null);
-
-            for (Path path : env.indexPaths("test1")) {
-                Files.move(path, path.getParent().resolve("test1_renamed"));
-            }
-
-            Map<String, IndexMetaData> newDanglingIndices = danglingState.findNewDanglingIndices(metaData);
-            assertThat(newDanglingIndices.size(), equalTo(1));
-            assertThat(newDanglingIndices.keySet(), Matchers.hasItems("test1_renamed"));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/gateway/MetaStateServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaStateServiceTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -43,15 +44,15 @@ public class MetaStateServiceTests extends ESTestCase {
             MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
 
             IndexMetaData index = IndexMetaData.builder("test1").settings(indexSettings).build();
-            metaStateService.writeIndex("test_write", index, null);
-            assertThat(metaStateService.loadIndexState("test1"), equalTo(index));
+            metaStateService.writeIndex("test_write", index);
+            assertThat(metaStateService.loadIndexState(index.getIndex()), equalTo(index));
         }
     }
 
     public void testLoadMissingIndex() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
             MetaStateService metaStateService = new MetaStateService(randomSettings(), env);
-            assertThat(metaStateService.loadIndexState("test1"), nullValue());
+            assertThat(metaStateService.loadIndexState(new Index("test1", "test1UUID")), nullValue());
         }
     }
 
@@ -94,7 +95,7 @@ public class MetaStateServiceTests extends ESTestCase {
                     .build();
 
             metaStateService.writeGlobalState("test_write", metaData);
-            metaStateService.writeIndex("test_write", index, null);
+            metaStateService.writeIndex("test_write", index);
 
             MetaData loadedState = metaStateService.loadFullState();
             assertThat(loadedState.persistentSettings(), equalTo(metaData.persistentSettings()));

--- a/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 
@@ -42,13 +43,13 @@ public class ShardPathTests extends ESTestCase {
             Settings.Builder builder = settingsBuilder().put(IndexMetaData.SETTING_INDEX_UUID, "0xDEADBEEF")
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
             Settings settings = builder.build();
-            ShardId shardId = new ShardId("foo", "_na_", 0);
+            ShardId shardId = new ShardId("foo", "0xDEADBEEF", 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);
             ShardStateMetaData.FORMAT.write(new ShardStateMetaData(2, true, "0xDEADBEEF", AllocationId.newInitializing()), 2, path);
             ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
             assertEquals(path, shardPath.getDataPath());
-            assertEquals("0xDEADBEEF", shardPath.getIndexUUID());
+            assertEquals("0xDEADBEEF", shardPath.getShardId().getIndex().getUUID());
             assertEquals("foo", shardPath.getShardId().getIndexName());
             assertEquals(path.resolve("translog"), shardPath.resolveTranslog());
             assertEquals(path.resolve("index"), shardPath.resolveIndex());
@@ -57,14 +58,15 @@ public class ShardPathTests extends ESTestCase {
 
     public void testFailLoadShardPathOnMultiState() throws IOException {
         try (final NodeEnvironment env = newNodeEnvironment(settingsBuilder().build())) {
-            Settings.Builder builder = settingsBuilder().put(IndexMetaData.SETTING_INDEX_UUID, "0xDEADBEEF")
+            final String indexUUID = "0xDEADBEEF";
+            Settings.Builder builder = settingsBuilder().put(IndexMetaData.SETTING_INDEX_UUID, indexUUID)
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
             Settings settings = builder.build();
-            ShardId shardId = new ShardId("foo", "_na_", 0);
+            ShardId shardId = new ShardId("foo", indexUUID, 0);
             Path[] paths = env.availableShardPaths(shardId);
             assumeTrue("This test tests multi data.path but we only got one", paths.length > 1);
             int id = randomIntBetween(1, 10);
-            ShardStateMetaData.FORMAT.write(new ShardStateMetaData(id, true, "0xDEADBEEF", AllocationId.newInitializing()), id, paths);
+            ShardStateMetaData.FORMAT.write(new ShardStateMetaData(id, true, indexUUID, AllocationId.newInitializing()), id, paths);
             ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
             fail("Expected IllegalStateException");
         } catch (IllegalStateException e) {
@@ -77,7 +79,7 @@ public class ShardPathTests extends ESTestCase {
             Settings.Builder builder = settingsBuilder().put(IndexMetaData.SETTING_INDEX_UUID, "foobar")
                     .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
             Settings settings = builder.build();
-            ShardId shardId = new ShardId("foo", "_na_", 0);
+            ShardId shardId = new ShardId("foo", "foobar", 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);
             int id = randomIntBetween(1, 10);
@@ -90,9 +92,10 @@ public class ShardPathTests extends ESTestCase {
     }
 
     public void testIllegalCustomDataPath() {
-        final Path path = createTempDir().resolve("foo").resolve("0");
+        Index index = new Index("foo", "foo");
+        final Path path = createTempDir().resolve(index.getUUID()).resolve("0");
         try {
-            new ShardPath(true, path, path, "foo", new ShardId("foo", "_na_", 0));
+            new ShardPath(true, path, path, new ShardId(index, 0));
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), is("shard state path must be different to the data path when using custom data paths"));
@@ -100,8 +103,9 @@ public class ShardPathTests extends ESTestCase {
     }
 
     public void testValidCtor() {
-        final Path path = createTempDir().resolve("foo").resolve("0");
-        ShardPath shardPath = new ShardPath(false, path, path, "foo", new ShardId("foo", "_na_", 0));
+        Index index = new Index("foo", "foo");
+        final Path path = createTempDir().resolve(index.getUUID()).resolve("0");
+        ShardPath shardPath = new ShardPath(false, path, path, new ShardId(index, 0));
         assertFalse(shardPath.isCustomDataPath());
         assertEquals(shardPath.getDataPath(), path);
         assertEquals(shardPath.getShardStatePath(), path);
@@ -111,8 +115,9 @@ public class ShardPathTests extends ESTestCase {
         boolean useCustomDataPath = randomBoolean();
         final Settings indexSettings;
         final Settings nodeSettings;
+        final String indexUUID = "0xDEADBEEF";
         Settings.Builder indexSettingsBuilder = settingsBuilder()
-                .put(IndexMetaData.SETTING_INDEX_UUID, "0xDEADBEEF")
+                .put(IndexMetaData.SETTING_INDEX_UUID, indexUUID)
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
         final Path customPath;
         if (useCustomDataPath) {
@@ -132,10 +137,10 @@ public class ShardPathTests extends ESTestCase {
             nodeSettings = Settings.EMPTY;
         }
         try (final NodeEnvironment env = newNodeEnvironment(nodeSettings)) {
-            ShardId shardId = new ShardId("foo", "_na_", 0);
+            ShardId shardId = new ShardId("foo", indexUUID, 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);
-            ShardStateMetaData.FORMAT.write(new ShardStateMetaData(2, true, "0xDEADBEEF", AllocationId.newInitializing()), 2, path);
+            ShardStateMetaData.FORMAT.write(new ShardStateMetaData(2, true, indexUUID, AllocationId.newInitializing()), 2, path);
             ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), indexSettings));
             boolean found = false;
             for (Path p : env.nodeDataPaths()) {

--- a/core/src/test/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/core/src/test/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.MockEngineFactoryPlugin;
 import org.elasticsearch.monitor.fs.FsInfo;
@@ -110,6 +111,7 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
     private void corruptRandomTranslogFiles() throws IOException {
         ClusterState state = client().admin().cluster().prepareState().get().getState();
         GroupShardsIterator shardIterators = state.getRoutingNodes().getRoutingTable().activePrimaryShardsGrouped(new String[]{"test"}, false);
+        final Index test = state.metaData().index("test").getIndex();
         List<ShardIterator> iterators = iterableAsArrayList(shardIterators);
         ShardIterator shardIterator = RandomPicks.randomFrom(getRandom(), iterators);
         ShardRouting shardRouting = shardIterator.nextOrNull();
@@ -121,7 +123,7 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
         Set<Path> files = new TreeSet<>(); // treeset makes sure iteration order is deterministic
         for (FsInfo.Path fsPath : nodeStatses.getNodes()[0].getFs()) {
             String path = fsPath.getPath();
-            final String relativeDataLocationPath =  "indices/test/" + Integer.toString(shardRouting.getId()) + "/translog";
+            final String relativeDataLocationPath =  "indices/"+ test.getUUID() +"/" + Integer.toString(shardRouting.getId()) + "/translog";
             Path file = PathUtils.get(path).resolve(relativeDataLocationPath);
             if (Files.exists(file)) {
                 logger.info("--> path: {}", file);

--- a/core/src/test/java/org/elasticsearch/index/store/FsDirectoryServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/FsDirectoryServiceTests.java
@@ -46,9 +46,9 @@ public class FsDirectoryServiceTests extends ESTestCase {
         IndexSettings settings = IndexSettingsModule.newIndexSettings("foo", build);
         IndexStoreConfig config = new IndexStoreConfig(build);
         IndexStore store = new IndexStore(settings, config);
-        Path tempDir = createTempDir().resolve("foo").resolve("0");
+        Path tempDir = createTempDir().resolve(settings.getUUID()).resolve("0");
         Files.createDirectories(tempDir);
-        ShardPath path = new ShardPath(false, tempDir, tempDir, settings.getUUID(), new ShardId(settings.getIndex(), 0));
+        ShardPath path = new ShardPath(false, tempDir, tempDir, new ShardId(settings.getIndex(), 0));
         FsDirectoryService fsDirectoryService = new FsDirectoryService(settings, store, path);
         Directory directory = fsDirectoryService.newDirectory();
         assertTrue(directory instanceof RateLimitedFSDirectory);
@@ -62,9 +62,9 @@ public class FsDirectoryServiceTests extends ESTestCase {
         IndexSettings settings = IndexSettingsModule.newIndexSettings("foo", build);
         IndexStoreConfig config = new IndexStoreConfig(build);
         IndexStore store = new IndexStore(settings, config);
-        Path tempDir = createTempDir().resolve("foo").resolve("0");
+        Path tempDir = createTempDir().resolve(settings.getUUID()).resolve("0");
         Files.createDirectories(tempDir);
-        ShardPath path = new ShardPath(false, tempDir, tempDir, settings.getUUID(), new ShardId(settings.getIndex(), 0));
+        ShardPath path = new ShardPath(false, tempDir, tempDir, new ShardId(settings.getIndex(), 0));
         FsDirectoryService fsDirectoryService = new FsDirectoryService(settings, store, path);
         Directory directory = fsDirectoryService.newDirectory();
         assertTrue(directory instanceof RateLimitedFSDirectory);

--- a/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/index/store/IndexStoreTests.java
@@ -47,13 +47,14 @@ import java.util.Locale;
 public class IndexStoreTests extends ESTestCase {
 
     public void testStoreDirectory() throws IOException {
-        final Path tempDir = createTempDir().resolve("foo").resolve("0");
+        Index index = new Index("foo", "fooUUID");
+        final Path tempDir = createTempDir().resolve(index.getUUID()).resolve("0");
         final IndexModule.Type[] values = IndexModule.Type.values();
         final IndexModule.Type type = RandomPicks.randomFrom(random(), values);
         Settings settings = Settings.settingsBuilder().put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), type.name().toLowerCase(Locale.ROOT))
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("foo", settings);
-        FsDirectoryService service = new FsDirectoryService(indexSettings, null, new ShardPath(false, tempDir, tempDir, "foo", new ShardId("foo", "_na_", 0)));
+        FsDirectoryService service = new FsDirectoryService(indexSettings, null, new ShardPath(false, tempDir, tempDir, new ShardId(index, 0)));
         try (final Directory directory = service.newFSDirectory(tempDir, NoLockFactory.INSTANCE)) {
             switch (type) {
                 case NIOFS:
@@ -84,8 +85,9 @@ public class IndexStoreTests extends ESTestCase {
     }
 
     public void testStoreDirectoryDefault() throws IOException {
-        final Path tempDir = createTempDir().resolve("foo").resolve("0");
-        FsDirectoryService service = new FsDirectoryService(IndexSettingsModule.newIndexSettings("foo", Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build()), null, new ShardPath(false, tempDir, tempDir, "foo", new ShardId("foo", "_na_", 0)));
+        Index index = new Index("bar", "foo");
+        final Path tempDir = createTempDir().resolve(index.getUUID()).resolve("0");
+        FsDirectoryService service = new FsDirectoryService(IndexSettingsModule.newIndexSettings("bar", Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build()), null, new ShardPath(false, tempDir, tempDir, new ShardId(index, 0)));
         try (final Directory directory = service.newFSDirectory(tempDir, NoLockFactory.INSTANCE)) {
             if (Constants.WINDOWS) {
                 assertTrue(directory.toString(), directory instanceof MMapDirectory || directory instanceof SimpleFSDirectory);

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -112,12 +112,14 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
                                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1))
         );
         ensureGreen("test");
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        Index index = state.metaData().index("test").getIndex();
 
         logger.info("--> making sure that shard and its replica are allocated on node_1 and node_2");
-        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_1, "test")), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_2, "test")), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_2, index, 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(true));
 
         logger.info("--> starting node server3");
         final String node_3 = internalCluster().startNode(Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false));
@@ -128,12 +130,12 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
                 .get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
-        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_1, "test")), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_2, "test")), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_3, "test", 0)), equalTo(false));
-        assertThat(Files.exists(indexDirectory(node_3, "test")), equalTo(false));
+        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_2, index, 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_3, index, 0)), equalTo(false));
+        assertThat(Files.exists(indexDirectory(node_3, index)), equalTo(false));
 
         logger.info("--> move shard from node_1 to node_3, and wait for relocation to finish");
 
@@ -161,12 +163,12 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
                 .get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
-        assertThat(waitForShardDeletion(node_1, "test", 0), equalTo(false));
-        assertThat(waitForIndexDeletion(node_1, "test"), equalTo(false));
-        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_2, "test")), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_3, "test", 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_3, "test")), equalTo(true));
+        assertThat(waitForShardDeletion(node_1, index, 0), equalTo(false));
+        assertThat(waitForIndexDeletion(node_1, index), equalTo(false));
+        assertThat(Files.exists(shardDirectory(node_2, index, 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_3, index, 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_3, index)), equalTo(true));
 
     }
 
@@ -180,16 +182,18 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
                                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0))
         );
         ensureGreen("test");
-        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_1, "test")), equalTo(true));
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        Index index = state.metaData().index("test").getIndex();
+        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
 
         final String node_2 = internalCluster().startDataOnlyNode(Settings.builder().build());
         assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("2").get().isTimedOut());
 
-        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
-        assertThat(Files.exists(indexDirectory(node_1, "test")), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(false));
-        assertThat(Files.exists(indexDirectory(node_2, "test")), equalTo(false));
+        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
+        assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_2, index, 0)), equalTo(false));
+        assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(false));
 
         // add a transport delegate that will prevent the shard active request to succeed the first time after relocation has finished.
         // node_1 will then wait for the next cluster state change before it tries a next attempt to delete the shard.
@@ -220,14 +224,14 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         // it must still delete the shard, even if it cannot find it anymore in indicesservice
         client().admin().indices().prepareDelete("test").get();
 
-        assertThat(waitForShardDeletion(node_1, "test", 0), equalTo(false));
-        assertThat(waitForIndexDeletion(node_1, "test"), equalTo(false));
-        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(false));
-        assertThat(Files.exists(indexDirectory(node_1, "test")), equalTo(false));
-        assertThat(waitForShardDeletion(node_2, "test", 0), equalTo(false));
-        assertThat(waitForIndexDeletion(node_2, "test"), equalTo(false));
-        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(false));
-        assertThat(Files.exists(indexDirectory(node_2, "test")), equalTo(false));
+        assertThat(waitForShardDeletion(node_1, index, 0), equalTo(false));
+        assertThat(waitForIndexDeletion(node_1, index), equalTo(false));
+        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(false));
+        assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(false));
+        assertThat(waitForShardDeletion(node_2, index, 0), equalTo(false));
+        assertThat(waitForIndexDeletion(node_2, index), equalTo(false));
+        assertThat(Files.exists(shardDirectory(node_2, index, 0)), equalTo(false));
+        assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(false));
     }
 
     public void testShardsCleanup() throws Exception {
@@ -241,9 +245,11 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         );
         ensureGreen("test");
 
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        Index index = state.metaData().index("test").getIndex();
         logger.info("--> making sure that shard and its replica are allocated on node_1 and node_2");
-        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_2, "test", 0)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_2, index, 0)), equalTo(true));
 
         logger.info("--> starting node server3");
         String node_3 = internalCluster().startNode();
@@ -255,10 +261,10 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
         logger.info("--> making sure that shard is not allocated on server3");
-        assertThat(waitForShardDeletion(node_3, "test", 0), equalTo(false));
+        assertThat(waitForShardDeletion(node_3, index, 0), equalTo(false));
 
-        Path server2Shard = shardDirectory(node_2, "test", 0);
-        logger.info("--> stopping node {}", node_2);
+        Path server2Shard = shardDirectory(node_2, index, 0);
+        logger.info("--> stopping node " + node_2);
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(node_2));
 
         logger.info("--> running cluster_health");
@@ -273,9 +279,9 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         assertThat(Files.exists(server2Shard), equalTo(true));
 
         logger.info("--> making sure that shard and its replica exist on server1, server2 and server3");
-        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
         assertThat(Files.exists(server2Shard), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_3, "test", 0)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_3, index, 0)), equalTo(true));
 
         logger.info("--> starting node node_4");
         final String node_4 = internalCluster().startNode();
@@ -284,9 +290,9 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         ensureGreen();
 
         logger.info("--> making sure that shard and its replica are allocated on server1 and server3 but not on server2");
-        assertThat(Files.exists(shardDirectory(node_1, "test", 0)), equalTo(true));
-        assertThat(Files.exists(shardDirectory(node_3, "test", 0)), equalTo(true));
-        assertThat(waitForShardDeletion(node_4, "test", 0), equalTo(false));
+        assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
+        assertThat(Files.exists(shardDirectory(node_3, index, 0)), equalTo(true));
+        assertThat(waitForShardDeletion(node_4, index, 0), equalTo(false));
     }
 
     public void testShardActiveElsewhereDoesNotDeleteAnother() throws Exception {
@@ -426,30 +432,30 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         waitNoPendingTasksOnAll();
         logger.info("Checking if shards aren't removed");
         for (int shard : node2Shards) {
-            assertTrue(waitForShardDeletion(nonMasterNode, "test", shard));
+            assertTrue(waitForShardDeletion(nonMasterNode, index, shard));
         }
     }
 
-    private Path indexDirectory(String server, String index) {
+    private Path indexDirectory(String server, Index index) {
         NodeEnvironment env = internalCluster().getInstance(NodeEnvironment.class, server);
         final Path[] paths = env.indexPaths(index);
         assert paths.length == 1;
         return paths[0];
     }
 
-    private Path shardDirectory(String server, String index, int shard) {
+    private Path shardDirectory(String server, Index index, int shard) {
         NodeEnvironment env = internalCluster().getInstance(NodeEnvironment.class, server);
-        final Path[] paths = env.availableShardPaths(new ShardId(index, "_na_", shard));
+        final Path[] paths = env.availableShardPaths(new ShardId(index, shard));
         assert paths.length == 1;
         return paths[0];
     }
 
-    private boolean waitForShardDeletion(final String server, final String index, final int shard) throws InterruptedException {
+    private boolean waitForShardDeletion(final String server, final Index index, final int shard) throws InterruptedException {
         awaitBusy(() -> !Files.exists(shardDirectory(server, index, shard)));
         return Files.exists(shardDirectory(server, index, shard));
     }
 
-    private boolean waitForIndexDeletion(final String server, final String index) throws InterruptedException {
+    private boolean waitForIndexDeletion(final String server, final Index index) throws InterruptedException {
         awaitBusy(() -> !Files.exists(indexDirectory(server, index)));
         return Files.exists(indexDirectory(server, index));
     }

--- a/docs/reference/migration/migrate_5_0.asciidoc
+++ b/docs/reference/migration/migrate_5_0.asciidoc
@@ -4,6 +4,17 @@
 This section discusses the changes that you need to be aware of when migrating
 your application to Elasticsearch 5.0.
 
+[float]
+=== Indices created before 5.0
+
+Elasticsearch 5.0 can read indices created in version 2.0 and above.  If any
+of your indices were created before 2.0 you will need to upgrade to the
+latest 2.x version of Elasticsearch first, in order to upgrade your indices or
+to delete the old indices. Elasticsearch will not start in the presence of old
+indices. To upgrade 2.x indices, first start a node which have access to all
+the data folders and let it upgrade all the indices before starting up rest of
+the cluster.
+
 [IMPORTANT]
 .Reindex indices from Elasticseach 1.x or before
 =========================================

--- a/plugins/mapper-murmur3/src/test/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapperUpgradeTests.java
+++ b/plugins/mapper-murmur3/src/test/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapperUpgradeTests.java
@@ -52,6 +52,7 @@ public class Murmur3FieldMapperUpgradeTests extends ESIntegTestCase {
 
     public void testUpgradeOldMapping() throws IOException, ExecutionException, InterruptedException {
         final String indexName = "index-mapper-murmur3-2.0.0";
+        final String indexUUID = "1VzJds59TTK7lRu17W0mcg";
         InternalTestCluster.Async<String> master = internalCluster().startNodeAsync();
         Path unzipDir = createTempDir();
         Path unzipDataDir = unzipDir.resolve("data");
@@ -72,6 +73,7 @@ public class Murmur3FieldMapperUpgradeTests extends ESIntegTestCase {
         assertFalse(Files.exists(dataPath));
         Path src = unzipDataDir.resolve(indexName + "/nodes/0/indices");
         Files.move(src, dataPath);
+        Files.move(dataPath.resolve(indexName), dataPath.resolve(indexUUID));
 
         master.get();
         // force reloading dangling indices with a cluster state republish

--- a/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeFieldMapperUpgradeTests.java
+++ b/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeFieldMapperUpgradeTests.java
@@ -53,6 +53,7 @@ public class SizeFieldMapperUpgradeTests extends ESIntegTestCase {
 
     public void testUpgradeOldMapping() throws IOException, ExecutionException, InterruptedException {
         final String indexName = "index-mapper-size-2.0.0";
+        final String indexUUID = "ENCw7sG0SWuTPcH60bHheg";
         InternalTestCluster.Async<String> master = internalCluster().startNodeAsync();
         Path unzipDir = createTempDir();
         Path unzipDataDir = unzipDir.resolve("data");
@@ -73,6 +74,7 @@ public class SizeFieldMapperUpgradeTests extends ESIntegTestCase {
         assertFalse(Files.exists(dataPath));
         Path src = unzipDataDir.resolve(indexName + "/nodes/0/indices");
         Files.move(src, dataPath);
+        Files.move(dataPath.resolve(indexName), dataPath.resolve(indexUUID));
         master.get();
         // force reloading dangling indices with a cluster state republish
         client().admin().cluster().prepareReroute().get();


### PR DESCRIPTION
Following up https://github.com/elastic/elasticsearch/pull/16217 , This PR uses `${data.paths}/nodes/{node.id}/indices/{index.uuid}` 
instead of `${data.paths}/nodes/{node.id}/indices/{index.name}` pattern to store index 
folder on disk.
This way we avoid collision between indices that are named the same (deleted and recreated).

Closes #13265
Closes #13264
Closes #14932
Closes #15853
Closes #14512
