### PR TITLE
Add settings filtering to node info requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/node/service/NodeService.java
+++ b/core/src/main/java/org/elasticsearch/node/service/NodeService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpServer;
@@ -61,6 +62,7 @@ public class NodeService extends AbstractComponent implements Closeable {
     private final PluginsService pluginService;
     private final CircuitBreakerService circuitBreakerService;
     private final IngestService ingestService;
+    private final SettingsFilter settingsFilter;
     private ScriptService scriptService;
 
     @Nullable
@@ -73,10 +75,10 @@ public class NodeService extends AbstractComponent implements Closeable {
     private final Discovery discovery;
 
     @Inject
-    public NodeService(Settings settings, Environment environment, ThreadPool threadPool, MonitorService monitorService,
+    public NodeService(Settings settings, ThreadPool threadPool, MonitorService monitorService,
                        Discovery discovery, TransportService transportService, IndicesService indicesService,
                        PluginsService pluginService, CircuitBreakerService circuitBreakerService, Version version,
-                       ProcessorsRegistry processorsRegistry, ClusterService clusterService) {
+                       ProcessorsRegistry processorsRegistry, ClusterService clusterService, SettingsFilter settingsFilter) {
         super(settings);
         this.threadPool = threadPool;
         this.monitorService = monitorService;
@@ -88,6 +90,7 @@ public class NodeService extends AbstractComponent implements Closeable {
         this.pluginService = pluginService;
         this.circuitBreakerService = circuitBreakerService;
         this.ingestService = new IngestService(settings, threadPool, processorsRegistry);
+        this.settingsFilter = settingsFilter;
         clusterService.add(ingestService.getPipelineStore());
     }
 
@@ -137,7 +140,7 @@ public class NodeService extends AbstractComponent implements Closeable {
     public NodeInfo info(boolean settings, boolean os, boolean process, boolean jvm, boolean threadPool,
                          boolean transport, boolean http, boolean plugin) {
         return new NodeInfo(version, Build.CURRENT, discovery.localNode(), serviceAttributes,
-                settings ? this.settings : null,
+                settings ? settingsFilter.filter(this.settings) : null,
                 os ? monitorService.osService().info() : null,
                 process ? monitorService.processService().info() : null,
                 jvm ? monitorService.jvmService().info() : null,

--- a/core/src/test/java/org/elasticsearch/cluster/settings/SettingsFilteringIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/settings/SettingsFilteringIT.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.cluster.settings;
 
+import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Inject;
@@ -64,8 +66,16 @@ public class SettingsFilteringIT extends ESIntegTestCase {
             return "Settings Filtering Plugin";
         }
 
+        @Override
+        public Settings additionalSettings() {
+            return Settings.builder().put("some.node.setting", true).put("some.other.node.setting", true).build();
+        }
+
         public void onModule(SettingsModule module) {
             module.registerSetting(Setting.groupSetting("index.filter_test.", false, Setting.Scope.INDEX));
+            module.registerSetting(Setting.boolSetting("some.node.setting", false,  false, Setting.Scope.CLUSTER));
+            module.registerSetting(Setting.boolSetting("some.other.node.setting", false,  false, Setting.Scope.CLUSTER));
+            module.registerSettingsFilter("some.node.setting");
             module.registerSettingsFilter("index.filter_test.foo");
             module.registerSettingsFilter("index.filter_test.bar*");
         }
@@ -87,5 +97,16 @@ public class SettingsFilteringIT extends ESIntegTestCase {
         assertThat(settings.get("index.filter_test.bar2"), nullValue());
         assertThat(settings.get("index.filter_test.notbar"), equalTo("test"));
         assertThat(settings.get("index.filter_test.notfoo"), equalTo("test"));
+    }
+
+    public void testNodeInfoIsFiltered() {
+        NodesInfoResponse nodeInfos = client().admin().cluster().prepareNodesInfo().clear().setSettings(true).get();
+        for(NodeInfo info : nodeInfos.getNodes()) {
+            Settings settings = info.getSettings();
+            assertNotNull(settings);
+            assertNull(settings.get("some.node.setting"));
+            assertTrue(settings.getAsBoolean("some.other.node.setting", false));
+            assertEquals(settings.get("node.name"), info.getNode().getName());
+        }
     }
 }


### PR DESCRIPTION
Today we don't filter settings in NodeInfo so transport clients get unfiltered settings.
