### PR TITLE
add support for STS authentication using security_token

### DIFF
--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -64,5 +64,5 @@ public interface AwsS3Service extends LifecycleComponent<AwsS3Service> {
 
     AmazonS3 client(String endpoint, String protocol, String region, String account, String key);
 
-    AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries);
+    AmazonS3 client(String endpoint, String protocol, String region, String account, String key, String token, Integer maxRetries);
 }

--- a/plugins/cloud-aws/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/cloud-aws/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -128,8 +128,14 @@ public class S3Repository extends BlobStoreRepository {
         logger.debug("using bucket [{}], region [{}], endpoint [{}], protocol [{}], chunk_size [{}], server_side_encryption [{}], buffer_size [{}], max_retries [{}], cannedACL [{}], storageClass [{}]",
                 bucket, region, endpoint, protocol, chunkSize, serverSideEncryption, bufferSize, maxRetries, cannedACL, storageClass);
 
-        blobStore = new S3BlobStore(settings, s3Service.client(endpoint, protocol, region, repositorySettings.settings().get("access_key"), repositorySettings.settings().get("secret_key"), maxRetries),
-                bucket, region, serverSideEncryption, bufferSize, maxRetries, cannedACL, storageClass);
+        blobStore = new S3BlobStore(
+            settings,
+            s3Service.client(endpoint, protocol, region,
+                repositorySettings.settings().get("access_key"),
+                repositorySettings.settings().get("secret_key"),
+                repositorySetttings.settings().get("security_token"),
+                maxRetries),
+            bucket, region, serverSideEncryption, bufferSize, maxRetries, cannedACL, storageClass);
 
         String basePath = repositorySettings.settings().get("base_path", settings.get(REPOSITORY_S3.BASE_PATH));
         if (Strings.hasLength(basePath)) {

--- a/plugins/cloud-aws/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
+++ b/plugins/cloud-aws/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
@@ -60,8 +60,8 @@ public class TestAwsS3Service extends InternalAwsS3Service {
     }
 
     @Override
-    public synchronized AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries) {
-        return cachedWrapper(super.client(endpoint, protocol, region, account, key, maxRetries));
+    public synchronized AmazonS3 client(String endpoint, String protocol, String region, String account, String key, String token, Integer maxRetries) {
+        return cachedWrapper(super.client(endpoint, protocol, region, account, key, null, maxRetries));
     }
 
     private AmazonS3 cachedWrapper(AmazonS3 client) {


### PR DESCRIPTION
The following change addresses https://github.com/elastic/elasticsearch/issues/16428 by adding support for using AWS STS authentication when registering a repository using the `PUT /_snapshot/REPOSITORY` endpoint. 

Because STS credentials expire, I did not see a need to also add support for having it be provided via `elasticsearch.yaml` configuration file. 

For more information about this form of authentication, see [explicit-credentials](http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#credentials-explicit) and [BasicSessionCredentials](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/?com/amazonaws/auth/BasicSessionCredentials.html).

An additional [PR](https://github.com/elastic/elasticsearch/pull/16434) has already been submitted which was based on master but I was hoping to get this change available for 2.x as well.
