### PR TITLE
register signer of class S3Signer with S3SignerType name for ceph integration

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsSigner.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/AwsSigner.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cloud.aws;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.SignerFactory;
+import com.amazonaws.services.s3.internal.S3Signer;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 
@@ -29,7 +30,7 @@ public class AwsSigner {
     private static final ESLogger logger = Loggers.getLogger(AwsSigner.class);
 
     private AwsSigner() {
-
+        SignerFactory.registerSigner("S3SignerType", S3Signer.class);
     }
 
     protected static void validateSignerType(String signer, String endpoint) {


### PR DESCRIPTION
Register signer of class S3Signer with S3SignerType name for ceph integration.

It solves https://github.com/elastic/elasticsearch-cloud-aws/issues/255.

I have created this PR for master branch. I understand it should be cherry-picked also on 2.1.x branch and 2.2.x.
