### PR TITLE
Add reindex progress indicator

### DIFF
--- a/docs/plugins/reindex.asciidoc
+++ b/docs/plugins/reindex.asciidoc
@@ -529,7 +529,7 @@ The number of documents that were successfully created. This is not returned by
 [float]
 === Response body
 
-While `_reindex` and `_update_by_query` is running you can fetch its status
+While `_reindex` and `_update_by_query` are running you can fetch their status
 using the task list API. This will fetch `_reindex`:
 
 [source,js]
@@ -546,7 +546,7 @@ POST /_tasks/*/*byquery?pretty&detailed=true
 --------------------------------------------------
 // AUTOSENSE
 
-Those fetch all running reindexes and the response looks like:
+The responses looks like:
 
 [source,js]
 --------------------------------------------------

--- a/docs/plugins/reindex.asciidoc
+++ b/docs/plugins/reindex.asciidoc
@@ -530,7 +530,7 @@ The number of documents that were successfully created. This is not returned by
 === Response body
 
 While `_reindex` and `_update_by_query` are running you can fetch their status
-using the task list API. This will fetch `_reindex`:
+using the {ref}/task/list.html[Task List APIs]. This will fetch `_reindex`:
 
 [source,js]
 --------------------------------------------------
@@ -566,7 +566,7 @@ The responses looks like:
         "id" : 36619,
         "type" : "transport",
         "action" : "indices:data/write/update/byquery",
-        "status" : {
+        "status" : {    <1>
           "total" : 6154,
           "updated" : 3500,
           "created" : 0,
@@ -583,10 +583,11 @@ The responses looks like:
 }
 --------------------------------------------------
 
-The actual status is the `status` object. It is just like the response json
-with the important addition of the `total` field. That is the total number
+<1> this object contains the actual status. It is just like the response json
+with the important addition of the `total` field. `total` is the total number
 of operations that the reindex expects to perform. You can estimate the
-progess by adding the `updated`, `created`, and `deleted` fields.
+progress by adding the `updated`, `created`, and `deleted` fields. The request
+will finish when their sum is equal to the `total` field.
 
 
 [float]

--- a/docs/plugins/reindex.asciidoc
+++ b/docs/plugins/reindex.asciidoc
@@ -573,8 +573,7 @@ The responses looks like:
           "deleted" : 0,
           "batches" : 36,
           "version_conflicts" : 0,
-          "noops" : 0,
-          "failures" : [ ]
+          "noops" : 0
         },
         "description" : "update-by-query [test][test]"
       } ]

--- a/docs/plugins/reindex.asciidoc
+++ b/docs/plugins/reindex.asciidoc
@@ -527,6 +527,69 @@ The number of documents that were successfully created. This is not returned by
 `_update_by_query` because it isn't allowed to create documents.
 
 [float]
+=== Response body
+
+While `_reindex` and `_update_by_query` is running you can fetch its status
+using the task list API. This will fetch `_reindex`:
+
+[source,js]
+--------------------------------------------------
+POST /_tasks/*/*reindex?pretty&detailed=true
+--------------------------------------------------
+// AUTOSENSE
+
+and this will fetch `_update_by_query`:
+
+[source,js]
+--------------------------------------------------
+POST /_tasks/*/*byquery?pretty&detailed=true
+--------------------------------------------------
+// AUTOSENSE
+
+Those fetch all running reindexes and the response looks like:
+
+[source,js]
+--------------------------------------------------
+{
+  "nodes" : {
+    "r1A2WoRbTwKZ516z6NEs5A" : {
+      "name" : "Tyrannus",
+      "transport_address" : "127.0.0.1:9300",
+      "host" : "127.0.0.1",
+      "ip" : "127.0.0.1:9300",
+      "attributes" : {
+        "testattr" : "test",
+        "portsfile" : "true"
+      },
+      "tasks" : [ {
+        "node" : "r1A2WoRbTwKZ516z6NEs5A",
+        "id" : 36619,
+        "type" : "transport",
+        "action" : "indices:data/write/update/byquery",
+        "status" : {
+          "total" : 6154,
+          "updated" : 3500,
+          "created" : 0,
+          "deleted" : 0,
+          "batches" : 36,
+          "version_conflicts" : 0,
+          "noops" : 0,
+          "failures" : [ ]
+        },
+        "description" : "update-by-query [test][test]"
+      } ]
+    }
+  }
+}
+--------------------------------------------------
+
+The actual status is the `status` object. It is just like the response json
+with the important addition of the `total` field. That is the total number
+of operations that the reindex expects to perform. You can estimate the
+progess by adding the `updated`, `created`, and `deleted` fields.
+
+
+[float]
 === Examples
 
 Below are some examples of how you might use this plugin:

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkByScrollAction.java
@@ -19,16 +19,6 @@
 
 package org.elasticsearch.plugin.reindex;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
@@ -46,13 +36,23 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-
+import static org.elasticsearch.common.unit.TimeValue.timeValueNanos;
 import static org.elasticsearch.plugin.reindex.AbstractBulkByScrollRequest.SIZE_ALL_MATCHES;
 import static org.elasticsearch.rest.RestStatus.CONFLICT;
 import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
@@ -92,7 +92,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
 
     protected abstract BulkRequest buildBulk(Iterable<SearchHit> docs);
 
-    protected abstract Response buildResponse(long took);
+    protected abstract Response buildResponse(TimeValue took);
 
     public void start() {
         initialSearch();
@@ -326,7 +326,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
             });
         }
         if (failure == null) {
-            listener.onResponse(buildResponse(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime.get())));
+            listener.onResponse(buildResponse(timeValueNanos(System.nanoTime() - startTime.get())));
         } else {
             listener.onFailure(failure);
         }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkByScrollAction.java
@@ -19,6 +19,16 @@
 
 package org.elasticsearch.plugin.reindex;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
@@ -32,7 +42,6 @@ import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
-import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogger;
@@ -41,20 +50,9 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
 import static java.lang.Math.max;
-import static java.util.Collections.unmodifiableList;
+import static java.lang.Math.min;
+
 import static org.elasticsearch.plugin.reindex.AbstractBulkByScrollRequest.SIZE_ALL_MATCHES;
 import static org.elasticsearch.rest.RestStatus.CONFLICT;
 import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
@@ -65,16 +63,10 @@ import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
  */
 public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBulkByScrollRequest<Request>, Response> {
     protected final Request mainRequest;
+    protected final BulkByScrollTask task;
 
     private final AtomicLong startTime = new AtomicLong(-1);
-    private final AtomicLong updated = new AtomicLong(0);
-    private final AtomicLong created = new AtomicLong(0);
-    private final AtomicLong deleted = new AtomicLong(0);
-    private final AtomicInteger batches = new AtomicInteger(0);
-    private final AtomicLong versionConflicts = new AtomicLong(0);
     private final AtomicReference<String> scroll = new AtomicReference<>();
-    private final List<Failure> indexingFailures = new CopyOnWriteArrayList<>();
-    private final List<ShardSearchFailure> searchFailures = new CopyOnWriteArrayList<>();
     private final Set<String> destinationIndices = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private final ESLogger logger;
@@ -83,8 +75,9 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
     private final SearchRequest firstSearchRequest;
     private final ActionListener<Response> listener;
 
-    public AbstractAsyncBulkByScrollAction(ESLogger logger, Client client, ThreadPool threadPool, Request mainRequest,
-            SearchRequest firstSearchRequest, ActionListener<Response> listener) {
+    public AbstractAsyncBulkByScrollAction(BulkByScrollTask task, ESLogger logger, Client client, ThreadPool threadPool,
+            Request mainRequest, SearchRequest firstSearchRequest, ActionListener<Response> listener) {
+        this.task = task;
         this.logger = logger;
         this.client = client;
         this.threadPool = threadPool;
@@ -101,48 +94,8 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
         initialSearch();
     }
 
-    /**
-     * Count of documents updated.
-     */
-    public long updated() {
-        return updated.get();
-    }
-
-    /**
-     * Count of documents created.
-     */
-    public long created() {
-        return created.get();
-    }
-
-    /**
-     * Count of successful delete operations.
-     */
-    public long deleted() {
-        return deleted.get();
-    }
-
-    /**
-     * The number of scan responses this request has processed.
-     */
-    public int batches() {
-        return batches.get();
-    }
-
-    public long versionConflicts() {
-        return versionConflicts.get();
-    }
-
-    public long successfullyProcessed() {
-        return updated.get() + created.get() + deleted.get();
-    }
-
-    public List<Failure> indexingFailures() {
-        return unmodifiableList(indexingFailures);
-    }
-
-    public List<ShardSearchFailure> searchFailures() {
-        return unmodifiableList(searchFailures);
+    public BulkByScrollTask getTask() {
+        return task;
     }
 
     private void initialSearch() {
@@ -179,10 +132,15 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
     void onScrollResponse(SearchResponse searchResponse) {
         scroll.set(searchResponse.getScrollId());
         if (searchResponse.getShardFailures() != null && searchResponse.getShardFailures().length > 0) {
-            Collections.addAll(searchFailures, searchResponse.getShardFailures());
+            task.addSearchFailures(searchResponse.getShardFailures());
             startNormalTermination();
             return;
         }
+        long total = searchResponse.getHits().totalHits();
+        if (mainRequest.getSize() >= 0) {
+            total = min(total, mainRequest.getSize());
+        }
+        task.setTotal(total);
         threadPool.generic().execute(new AbstractRunnable() {
             @Override
             protected void doRun() throws Exception {
@@ -193,11 +151,11 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
                         startNormalTermination();
                         return;
                     }
-                    batches.incrementAndGet();
+                    task.countBatch();
                     List<SearchHit> docsIterable = Arrays.asList(docs);
                     if (mainRequest.getSize() != SIZE_ALL_MATCHES) {
                         // Truncate the docs if we have more than the request size
-                        long remaining = max(0, mainRequest.getSize() - successfullyProcessed());
+                        long remaining = max(0, mainRequest.getSize() - task.getSuccessfullyProcessed());
                         if (remaining < docs.length) {
                             docsIterable = docsIterable.subList(0, (int) remaining);
                         }
@@ -255,13 +213,13 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
                 case "create":
                     IndexResponse ir = item.getResponse();
                     if (ir.isCreated()) {
-                        created.incrementAndGet();
+                        task.countCreated();
                     } else {
-                        updated.incrementAndGet();
+                        task.countUpdated();
                     }
                     break;
                 case "delete":
-                    deleted.incrementAndGet();
+                    task.countDeleted();
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown op type:  " + item.getOpType());
@@ -271,12 +229,12 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
             }
             destinationIndices.addAll(destinationIndicesThisBatch);
 
-            if (false == indexingFailures.isEmpty()) {
+            if (false == task.getIndexingFailures().isEmpty()) {
                 startNormalTermination();
                 return;
             }
 
-            if (mainRequest.getSize() != SIZE_ALL_MATCHES && successfullyProcessed() >= mainRequest.getSize()) {
+            if (mainRequest.getSize() != SIZE_ALL_MATCHES && task.getSuccessfullyProcessed() >= mainRequest.getSize()) {
                 // We've processed all the requested docs.
                 startNormalTermination();
                 return;
@@ -305,12 +263,12 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
 
     private void recordFailure(Failure failure) {
         if (failure.getStatus() == CONFLICT) {
-            versionConflicts.incrementAndGet();
+            task.countVersionConflict();
             if (false == mainRequest.isAbortOnVersionConflict()) {
                 return;
             }
         }
-        indexingFailures.add(failure);
+        task.addIndexingFailure(failure);
     }
 
     void startNormalTermination() {

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkByScrollAction.java
@@ -62,6 +62,10 @@ import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
  * results.
  */
 public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBulkByScrollRequest<Request>, Response> {
+    /**
+     * The request for this action. Named mainRequest because we create lots of <code>request</code> variables all representing child
+     * requests of this mainRequest.
+     */
     protected final Request mainRequest;
     protected final BulkByScrollTask task;
 

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkIndexByScrollAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkIndexByScrollAction.java
@@ -19,10 +19,6 @@
 
 package org.elasticsearch.plugin.reindex;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -45,6 +41,10 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 import static java.util.Collections.emptyMap;
 

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkIndexByScrollAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkIndexByScrollAction.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.plugin.reindex;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -42,11 +46,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
-
 import static java.util.Collections.emptyMap;
 
 /**
@@ -56,13 +55,13 @@ import static java.util.Collections.emptyMap;
 public abstract class AbstractAsyncBulkIndexByScrollAction<Request extends AbstractBulkIndexByScrollRequest<Request>, Response extends BulkIndexByScrollResponse>
         extends AbstractAsyncBulkByScrollAction<Request, Response> {
 
-    private final AtomicLong noops = new AtomicLong(0);
     private final ScriptService scriptService;
     private final CompiledScript script;
 
-    public AbstractAsyncBulkIndexByScrollAction(ESLogger logger, ScriptService scriptService, Client client, ThreadPool threadPool,
-            Request mainRequest, SearchRequest firstSearchRequest, ActionListener<Response> listener) {
-        super(logger, client, threadPool, mainRequest, firstSearchRequest, listener);
+    public AbstractAsyncBulkIndexByScrollAction(BulkByScrollTask task, ESLogger logger, ScriptService scriptService,
+            Client client, ThreadPool threadPool, Request mainRequest, SearchRequest firstSearchRequest,
+            ActionListener<Response> listener) {
+        super(task, logger, client, threadPool, mainRequest, firstSearchRequest, listener);
         this.scriptService = scriptService;
         if (mainRequest.getScript() == null) {
             script = null;
@@ -77,13 +76,6 @@ public abstract class AbstractAsyncBulkIndexByScrollAction<Request extends Abstr
      * applyScript functions that can be overridden.
      */
     protected abstract IndexRequest buildIndexRequest(SearchHit doc);
-
-    /**
-     * The number of noops (skipped bulk items) as part of this request.
-     */
-    public long noops() {
-        return noops.get();
-    }
 
     @Override
     protected BulkRequest buildBulk(Iterable<SearchHit> docs) {
@@ -171,7 +163,7 @@ public abstract class AbstractAsyncBulkIndexByScrollAction<Request extends Abstr
             throw new IllegalArgumentException("Script cleared op!");
         }
         if ("noop".equals(newOp)) {
-            noops.incrementAndGet();
+            task.countNoop();
             return false;
         }
         if (false == "update".equals(newOp)) {

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractBaseReindexRestHandler.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractBaseReindexRestHandler.java
@@ -37,8 +37,8 @@ import org.elasticsearch.tasks.Task;
 
 import java.io.IOException;
 
-public abstract class AbstractBaseReindexRestHandler<Request extends ActionRequest<Request>, Response extends BulkIndexByScrollResponse, TA extends TransportAction<Request, Response>>
-        extends BaseRestHandler {
+public abstract class AbstractBaseReindexRestHandler<Request extends ActionRequest<Request>, Response extends BulkIndexByScrollResponse,
+        TA extends TransportAction<Request, Response>> extends BaseRestHandler {
     protected final IndicesQueriesRegistry indicesQueriesRegistry;
     private final ClusterService clusterService;
     private final TA action;

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractBulkByScrollRequest.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractBulkByScrollRequest.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.plugin.reindex;
 
+import java.io.IOException;
+import java.util.Arrays;
+
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.WriteConsistencyLevel;
@@ -28,9 +31,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-
-import java.io.IOException;
-import java.util.Arrays;
+import org.elasticsearch.tasks.Task;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -206,6 +207,11 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
     }
 
     @Override
+    public Task createTask(long id, String type, String action) {
+        return new BulkByScrollTask(id, type, action, this::getDescription);
+    }
+
+    @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         source = new SearchRequest();
@@ -239,7 +245,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
             b.append("[all indices]");
         }
         if (source.types() != null && source.types().length != 0) {
-            b.append(source.types());
+            b.append(Arrays.toString(source.types()));
         }
     }
 

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractBulkByScrollRequest.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractBulkByScrollRequest.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.plugin.reindex;
 
-import java.io.IOException;
-import java.util.Arrays;
-
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.WriteConsistencyLevel;
@@ -32,6 +29,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.Task;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
@@ -267,6 +267,10 @@ public class BulkByScrollTask extends Task {
             return noops;
         }
 
+        /**
+         * All of the indexing failures. Version conflicts are only included if the request sets abortOnVersionConflict to true (the
+         * default).
+         */
         public List<Failure> getIndexingFailures() {
             return indexingFailures;
         }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.reindex;
+
+import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.tasks.Task;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.Math.min;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+import static org.elasticsearch.action.search.ShardSearchFailure.readShardSearchFailure;
+
+/**
+ * Task storing information about a currently running BulkByScroll request.
+ */
+public class BulkByScrollTask extends Task {
+    private final AtomicLong total = new AtomicLong(-1);
+    private final AtomicLong updated = new AtomicLong(0);
+    private final AtomicLong created = new AtomicLong(0);
+    private final AtomicLong deleted = new AtomicLong(0);
+    private final AtomicLong noops = new AtomicLong(0);
+    private final AtomicInteger batch = new AtomicInteger(0);
+    private final AtomicLong versionConflicts = new AtomicLong(0);
+    private final List<Failure> indexingFailures = new CopyOnWriteArrayList<>();
+    private final List<ShardSearchFailure> searchFailures = new CopyOnWriteArrayList<>();
+
+    public BulkByScrollTask(long id, String type, String action, Provider<String> description) {
+        super(id, type, action, description);
+    }
+
+    @Override
+    public Status getStatus() {
+        return new Status(total.get(), updated.get(), created.get(), deleted.get(), batch.get(), versionConflicts.get(), noops.get(),
+                unmodifiableList(new ArrayList<>(indexingFailures)), unmodifiableList(new ArrayList<>(searchFailures)));
+    }
+
+    /**
+     * Total number of successfully processed documents.
+     */
+    public long getSuccessfullyProcessed() {
+        return updated.get() + created.get() + deleted.get();
+    }
+
+    /**
+     * All indexing failures.
+     */
+    public List<Failure> getIndexingFailures() {
+        return unmodifiableList(indexingFailures);
+    }
+
+    public static class Status implements Task.Status {
+        public static final Status PROTOTYPE = new Status(0, 0, 0, 0, 0, 0, 0, emptyList(), emptyList());
+
+        private final long total;
+        private final long updated;
+        private final long created;
+        private final long deleted;
+        private final int batches;
+        private final long versionConflicts;
+        private final long noops;
+        private final List<Failure> indexingFailures;
+        private final List<ShardSearchFailure> searchFailures;
+
+        public Status(long total, long updated, long created, long deleted, int batches, long versionConflicts, long noops,
+                List<Failure> indexingFailures, List<ShardSearchFailure> searchFailures) {
+            this.total = total;
+            this.updated = updated;
+            this.created = created;
+            this.deleted = deleted;
+            this.batches = batches;
+            this.versionConflicts = versionConflicts;
+            this.noops = noops;
+            this.indexingFailures = indexingFailures;
+            this.searchFailures = searchFailures;
+        }
+
+        public Status(StreamInput in) throws IOException {
+            total = in.readVLong();
+            updated = in.readVLong();
+            created = in.readVLong();
+            deleted = in.readVLong();
+            batches = in.readVInt();
+            versionConflicts = in.readVLong();
+            noops = in.readVLong();
+            int indexingFailuresCount = in.readVInt();
+            List<Failure> indexingFailures = new ArrayList<>(indexingFailuresCount);
+            for (int i = 0; i < indexingFailuresCount; i++) {
+                indexingFailures.add(Failure.PROTOTYPE.readFrom(in));
+            }
+            this.indexingFailures = unmodifiableList(indexingFailures);
+            int searchFailuresCount = in.readVInt();
+            List<ShardSearchFailure> searchFailures = new ArrayList<>(searchFailuresCount);
+            for (int i = 0; i < searchFailuresCount; i++) {
+                searchFailures.add(readShardSearchFailure(in));
+            }
+            this.searchFailures = unmodifiableList(searchFailures);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(total);
+            out.writeVLong(updated);
+            out.writeVLong(created);
+            out.writeVLong(deleted);
+            out.writeVInt(batches);
+            out.writeVLong(versionConflicts);
+            out.writeVLong(noops);
+            out.writeVInt(indexingFailures.size());
+            for (Failure failure: indexingFailures) {
+                failure.writeTo(out);
+            }
+            out.writeVInt(searchFailures.size());
+            for (ShardSearchFailure failure: searchFailures) {
+                failure.writeTo(out);
+            }
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            innerXContent(builder, params, true, true);
+            return builder.endObject();
+        }
+
+        public XContentBuilder innerXContent(XContentBuilder builder, Params params, boolean includeCreated, boolean includeDeleted)
+                throws IOException {
+            builder.field("total", total);
+            builder.field("updated", updated);
+            if (includeCreated) {
+                builder.field("created", created);
+            }
+            if (includeDeleted) {
+                builder.field("deleted", deleted);
+            }
+            builder.field("batches", batches);
+            builder.field("version_conflicts", versionConflicts);
+            builder.field("noops", noops);
+            builder.startArray("failures");
+            for (Failure failure: indexingFailures) {
+                builder.startObject();
+                failure.toXContent(builder, params);
+                builder.endObject();
+            }
+            for (ShardSearchFailure failure: searchFailures) {
+                builder.startObject();
+                failure.toXContent(builder, params);
+                builder.endObject();
+            }
+            builder.endArray();
+            return builder;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("BulkIndexByScrollResponse[");
+            innerToString(builder, true, true);
+            return builder.append(']').toString();
+        }
+
+        public void innerToString(StringBuilder builder, boolean includeCreated, boolean includeDeleted) {
+            builder.append(",updated=").append(updated);
+            if (includeCreated) {
+                builder.append(",created=").append(created);
+            }
+            if (includeDeleted) {
+                builder.append(",deleted=").append(deleted);
+            }
+            builder.append(",batches=").append(batches);
+            builder.append(",versionConflicts=").append(versionConflicts);
+            builder.append(",noops=").append(noops);
+            builder.append(",indexing_failures=").append(getIndexingFailures().subList(0, min(3, getIndexingFailures().size())));
+            builder.append(",search_failures=").append(getSearchFailures().subList(0, min(3, getSearchFailures().size())));
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "bulk-by-scroll";
+        }
+
+        @Override
+        public Status readFrom(StreamInput in) throws IOException {
+            return new Status(in);
+        }
+
+        /**
+         * The total number of documents this request will process. -1 means we don't yet know.
+         */
+        public long getTotal() {
+            return total;
+        }
+
+        /**
+         * Count of documents updated.
+         */
+        public long getUpdated() {
+            return updated;
+        }
+
+        /**
+         * Count of documents created.
+         */
+        public long getCreated() {
+            return created;
+        }
+
+        /**
+         * Count of successful delete operations.
+         */
+        public long getDeleted() {
+            return deleted;
+        }
+
+        /**
+         * Number of scan responses this request has processed.
+         */
+        public int getBatches() {
+            return batches;
+        }
+
+        /**
+         * Number of version conflicts this request has hit.
+         */
+        public long getVersionConflicts() {
+            return versionConflicts;
+        }
+
+        /**
+         * Number of noops (skipped bulk items) as part of this request.
+         */
+        public long getNoops() {
+            return noops;
+        }
+
+        public List<Failure> getIndexingFailures() {
+            return indexingFailures;
+        }
+
+        /**
+         * All search failures.
+         */
+        public List<ShardSearchFailure> getSearchFailures() {
+            return searchFailures;
+        }
+    }
+
+    void addSearchFailures(ShardSearchFailure... shardSearchFailures) {
+        Collections.addAll(searchFailures, shardSearchFailures);
+    }
+
+    void countBatch() {
+        batch.incrementAndGet();
+    }
+
+    void countNoop() {
+        noops.incrementAndGet();
+    }
+
+    void countCreated() {
+        created.incrementAndGet();
+    }
+
+    void countUpdated() {
+        updated.incrementAndGet();
+    }
+
+    void countDeleted() {
+        deleted.incrementAndGet();
+    }
+
+    void countVersionConflict() {
+        versionConflicts.incrementAndGet();
+    }
+
+    void addIndexingFailure(Failure failure) {
+        indexingFailures.add(failure);
+    }
+
+    void setTotal(long totalHits) {
+        total.set(totalHits);
+    }
+}

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
@@ -97,13 +97,13 @@ public class BulkByScrollTask extends Task {
 
         public Status(long total, long updated, long created, long deleted, int batches, long versionConflicts, long noops,
                 List<Failure> indexingFailures, List<ShardSearchFailure> searchFailures) {
-            this.total = total;
-            this.updated = updated;
-            this.created = created;
-            this.deleted = deleted;
-            this.batches = batches;
-            this.versionConflicts = versionConflicts;
-            this.noops = noops;
+            this.total = checkPositive(total, "total");
+            this.updated = checkPositive(updated, "updated");
+            this.created = checkPositive(created, "created");
+            this.deleted = checkPositive(deleted, "deleted");
+            this.batches = checkPositive(batches, "batches");
+            this.versionConflicts = checkPositive(versionConflicts, "versionConflicts");
+            this.noops = checkPositive(noops, "noops");
             this.indexingFailures = indexingFailures;
             this.searchFailures = searchFailures;
         }
@@ -280,6 +280,20 @@ public class BulkByScrollTask extends Task {
          */
         public List<ShardSearchFailure> getSearchFailures() {
             return searchFailures;
+        }
+
+        private int checkPositive(int value, String name) {
+            if (value < 0) {
+                throw new IllegalArgumentException(name + " must be greater than 0 but was [" + value + "]");
+            }
+            return value;
+        }
+
+        private long checkPositive(long value, String name) {
+            if (value < 0) {
+                throw new IllegalArgumentException(name + " must be greater than 0 but was [" + value + "]");
+            }
+            return value;
         }
     }
 

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
@@ -193,7 +193,7 @@ public class BulkByScrollTask extends Task {
         }
 
         public void innerToString(StringBuilder builder, boolean includeCreated, boolean includeDeleted) {
-            builder.append(",updated=").append(updated);
+            builder.append("updated=").append(updated);
             if (includeCreated) {
                 builder.append(",created=").append(created);
             }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkByScrollTask.java
@@ -44,7 +44,11 @@ import static org.elasticsearch.action.search.ShardSearchFailure.readShardSearch
  * Task storing information about a currently running BulkByScroll request.
  */
 public class BulkByScrollTask extends Task {
-    private final AtomicLong total = new AtomicLong(-1);
+    /**
+     * The total number of documents this request will process. 0 means we don't yet know or, possibly, there are actually 0 documents
+     * to process. Its ok that these have the same meaning because any request with 0 actual documents should be quite short lived.
+     */
+    private final AtomicLong total = new AtomicLong(0);
     private final AtomicLong updated = new AtomicLong(0);
     private final AtomicLong created = new AtomicLong(0);
     private final AtomicLong deleted = new AtomicLong(0);
@@ -214,7 +218,8 @@ public class BulkByScrollTask extends Task {
         }
 
         /**
-         * The total number of documents this request will process. -1 means we don't yet know.
+         * The total number of documents this request will process. 0 means we don't yet know or, possibly, there are actually 0 documents
+         * to process. Its ok that these have the same meaning because any request with 0 actual documents should be quite short lived.
          */
         public long getTotal() {
             return total;

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkIndexByScrollResponse.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkIndexByScrollResponse.java
@@ -55,10 +55,6 @@ public class BulkIndexByScrollResponse extends ActionResponse implements ToXCont
         return status;
     }
 
-    public String getWriteableName() {
-        return status.getWriteableName();
-    }
-
     public long getUpdated() {
         return status.getUpdated();
     }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkIndexByScrollResponse.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkIndexByScrollResponse.java
@@ -104,7 +104,7 @@ public class BulkIndexByScrollResponse extends ActionResponse implements ToXCont
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("BulkIndexByScrollResponse[");
-        builder.append("took=").append(took);
+        builder.append("took=").append(took).append(',');
         status.innerToString(builder, false, false);
         return builder.append(']').toString();
     }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkIndexByScrollResponse.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkIndexByScrollResponse.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -36,18 +37,18 @@ import static java.util.Objects.requireNonNull;
  * Response used for actions that index many documents using a scroll request.
  */
 public class BulkIndexByScrollResponse extends ActionResponse implements ToXContent {
-    private long took;
+    private TimeValue took;
     private BulkByScrollTask.Status status;
 
     public BulkIndexByScrollResponse() {
     }
 
-    public BulkIndexByScrollResponse(long took, BulkByScrollTask.Status status) {
+    public BulkIndexByScrollResponse(TimeValue took, BulkByScrollTask.Status status) {
         this.took = took;
-        this.status = requireNonNull(status);
+        this.status = requireNonNull(status, "Null status not supported");
     }
 
-    public long getTook() {
+    public TimeValue getTook() {
         return took;
     }
 
@@ -82,20 +83,20 @@ public class BulkIndexByScrollResponse extends ActionResponse implements ToXCont
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeVLong(took);
+        took.writeTo(out);
         status.writeTo(out);
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        took = in.readVLong();
+        took = TimeValue.readTimeValue(in);
         status = new BulkByScrollTask.Status(in);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field("took", took);
+        builder.field("took", took.millis());
         status.innerXContent(builder, params, false, false);
         return builder;
     }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/ReindexResponse.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/ReindexResponse.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.plugin.reindex;
 
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ public class ReindexResponse extends BulkIndexByScrollResponse {
     public ReindexResponse() {
     }
 
-    public ReindexResponse(long took, BulkByScrollTask.Status status) {
+    public ReindexResponse(TimeValue took, BulkByScrollTask.Status status) {
         super(took, status);
     }
 

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/ReindexResponse.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/ReindexResponse.java
@@ -19,10 +19,14 @@
 
 package org.elasticsearch.plugin.reindex;
 
+import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.plugin.reindex.BulkByScrollTask.Status;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Response for the ReindexAction.
@@ -31,8 +35,8 @@ public class ReindexResponse extends BulkIndexByScrollResponse {
     public ReindexResponse() {
     }
 
-    public ReindexResponse(TimeValue took, BulkByScrollTask.Status status) {
-        super(took, status);
+    public ReindexResponse(TimeValue took, Status status, List<Failure> indexingFailures, List<ShardSearchFailure> searchFailures) {
+        super(took, status, indexingFailures, searchFailures);
     }
 
     public long getCreated() {

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/ReindexResponse.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/ReindexResponse.java
@@ -19,77 +19,38 @@
 
 package org.elasticsearch.plugin.reindex;
 
-import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
-import org.elasticsearch.action.search.ShardSearchFailure;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
 
+/**
+ * Response for the ReindexAction.
+ */
 public class ReindexResponse extends BulkIndexByScrollResponse {
-    static final String CREATED_FIELD = "created";
-
-    private long created;
-
     public ReindexResponse() {
     }
 
-    public ReindexResponse(long took, long created, long updated, int batches, long versionConflicts, long noops, List<Failure> indexingFailures, List<ShardSearchFailure> searchFailures) {
-        super(took, updated, batches, versionConflicts, noops, indexingFailures, searchFailures);
-        this.created = created;
+    public ReindexResponse(long took, BulkByScrollTask.Status status) {
+        super(took, status);
     }
 
     public long getCreated() {
-        return created;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeVLong(created);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        created = in.readVLong();
+        return getStatus().getCreated();
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        super.toXContent(builder, params);
-        builder.field(CREATED_FIELD, created);
+        builder.field("took", getTook());
+        getStatus().innerXContent(builder, params, true, false);
         return builder;
     }
 
     @Override
-    protected String toStringName() {
-        return "ReindexResponse";
-    }
-
-    @Override
-    protected void innerToString(StringBuilder builder) {
-        builder.append(",created=").append(created);
-    }
-
-    /**
-     * Get the first few failures to build a useful for toString.
-     */
-    protected void truncatedFailures(StringBuilder builder) {
-        builder.append(",failures=[");
-        Iterator<Failure> failures = getIndexingFailures().iterator();
-        int written = 0;
-        while (failures.hasNext() && written < 3) {
-            Failure failure = failures.next();
-            builder.append(failure.getMessage());
-            if (written != 0) {
-                builder.append(", ");
-            }
-            written++;
-        }
-        builder.append(']');
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ReindexResponse[");
+        builder.append("took=").append(getTook());
+        getStatus().innerToString(builder, true, false);
+        return builder.append(']').toString();
     }
 }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/ReindexResponse.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/ReindexResponse.java
@@ -49,7 +49,7 @@ public class ReindexResponse extends BulkIndexByScrollResponse {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("ReindexResponse[");
-        builder.append("took=").append(getTook());
+        builder.append("took=").append(getTook()).append(',');
         getStatus().innerToString(builder, true, false);
         return builder.append(']').toString();
     }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportReindexAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportReindexAction.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.plugin.reindex;
 
-import java.util.Objects;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.index.IndexRequest;
@@ -45,8 +43,9 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import static java.util.Objects.requireNonNull;
+import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
 import static org.elasticsearch.index.VersionType.INTERNAL;
 
 public class TransportReindexAction extends HandledTransportAction<ReindexRequest, ReindexResponse> {
@@ -170,7 +169,7 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         }
 
         @Override
-        protected ReindexResponse buildResponse(long took) {
+        protected ReindexResponse buildResponse(TimeValue took) {
             return new ReindexResponse(took, task.getStatus());
         }
 

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportReindexAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportReindexAction.java
@@ -21,8 +21,10 @@ package org.elasticsearch.plugin.reindex;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -43,6 +45,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.List;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -169,8 +172,8 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         }
 
         @Override
-        protected ReindexResponse buildResponse(TimeValue took) {
-            return new ReindexResponse(took, task.getStatus());
+        protected ReindexResponse buildResponse(TimeValue took, List<Failure> indexingFailures, List<ShardSearchFailure> searchFailures) {
+            return new ReindexResponse(took, task.getStatus(), indexingFailures, searchFailures);
         }
 
         /*

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportReindexAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportReindexAction.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.plugin.reindex;
 
+import java.util.Objects;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.index.IndexRequest;
@@ -39,12 +41,12 @@ import org.elasticsearch.index.mapper.internal.TTLFieldMapper;
 import org.elasticsearch.index.mapper.internal.VersionFieldMapper;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.Objects;
-
 import static java.util.Objects.requireNonNull;
+
 import static org.elasticsearch.index.VersionType.INTERNAL;
 
 public class TransportReindexAction extends HandledTransportAction<ReindexRequest, ReindexResponse> {
@@ -66,10 +68,15 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
     }
 
     @Override
-    protected void doExecute(ReindexRequest request, ActionListener<ReindexResponse> listener) {
+    protected void doExecute(Task task, ReindexRequest request, ActionListener<ReindexResponse> listener) {
         validateAgainstAliases(request.getSource(), request.getDestination(), indexNameExpressionResolver, autoCreateIndex,
                 clusterService.state());
-        new AsyncIndexBySearchAction(logger, scriptService, client, threadPool, request, listener).start();
+        new AsyncIndexBySearchAction((BulkByScrollTask) task, logger, scriptService, client, threadPool, request, listener).start();
+    }
+
+    @Override
+    protected void doExecute(ReindexRequest request, ActionListener<ReindexResponse> listener) {
+        throw new UnsupportedOperationException("task required");
     }
 
     /**
@@ -106,9 +113,9 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
      * possible.
      */
     static class AsyncIndexBySearchAction extends AbstractAsyncBulkIndexByScrollAction<ReindexRequest, ReindexResponse> {
-        public AsyncIndexBySearchAction(ESLogger logger, ScriptService scriptService, Client client, ThreadPool threadPool,
+        public AsyncIndexBySearchAction(BulkByScrollTask task, ESLogger logger, ScriptService scriptService, Client client, ThreadPool threadPool,
                 ReindexRequest request, ActionListener<ReindexResponse> listener) {
-            super(logger, scriptService, client, threadPool, request, request.getSource(), listener);
+            super(task, logger, scriptService, client, threadPool, request, request.getSource(), listener);
         }
 
         @Override
@@ -162,17 +169,16 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
             }
         }
 
+        @Override
+        protected ReindexResponse buildResponse(long took) {
+            return new ReindexResponse(took, task.getStatus());
+        }
+
         /*
          * Methods below here handle script updating the index request. They try
          * to be pretty liberal with regards to types because script are often
          * dynamically typed.
          */
-        @Override
-        protected ReindexResponse buildResponse(long took) {
-            return new ReindexResponse(took, created(), updated(), batches(), versionConflicts(), noops(), indexingFailures(),
-                    searchFailures());
-        }
-
         @Override
         protected void scriptChangedIndex(IndexRequest index, Object to) {
             requireNonNull(to, "Can't reindex without a destination index!");

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportUpdateByQueryAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportUpdateByQueryAction.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.mapper.internal.TimestampFieldMapper;
 import org.elasticsearch.index.mapper.internal.TypeFieldMapper;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -56,18 +57,23 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
     }
 
     @Override
-    protected void doExecute(UpdateByQueryRequest request,
+    protected void doExecute(Task task, UpdateByQueryRequest request,
             ActionListener<BulkIndexByScrollResponse> listener) {
-        new AsyncIndexBySearchAction(logger, scriptService, client, threadPool, request, listener).start();
+        new AsyncIndexBySearchAction((BulkByScrollTask) task, logger, scriptService, client, threadPool, request, listener).start();
+    }
+
+    @Override
+    protected void doExecute(UpdateByQueryRequest request, ActionListener<BulkIndexByScrollResponse> listener) {
+        throw new UnsupportedOperationException("task required");
     }
 
     /**
      * Simple implementation of update-by-query using scrolling and bulk.
      */
     static class AsyncIndexBySearchAction extends AbstractAsyncBulkIndexByScrollAction<UpdateByQueryRequest, BulkIndexByScrollResponse> {
-        public AsyncIndexBySearchAction(ESLogger logger, ScriptService scriptService, Client client, ThreadPool threadPool,
+        public AsyncIndexBySearchAction(BulkByScrollTask task, ESLogger logger, ScriptService scriptService, Client client, ThreadPool threadPool,
                 UpdateByQueryRequest request, ActionListener<BulkIndexByScrollResponse> listener) {
-            super(logger, scriptService, client, threadPool, request, request.getSource(), listener);
+            super(task, logger, scriptService, client, threadPool, request, request.getSource(), listener);
         }
 
         @Override
@@ -84,8 +90,7 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
 
         @Override
         protected BulkIndexByScrollResponse buildResponse(long took) {
-            return new BulkIndexByScrollResponse(took, updated(), batches(), versionConflicts(), noops(), indexingFailures(),
-                    searchFailures());
+            return new BulkIndexByScrollResponse(took, task.getStatus());
         }
 
         @Override

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportUpdateByQueryAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportUpdateByQueryAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.internal.IdFieldMapper;
 import org.elasticsearch.index.mapper.internal.IndexFieldMapper;
@@ -89,7 +90,7 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
         }
 
         @Override
-        protected BulkIndexByScrollResponse buildResponse(long took) {
+        protected BulkIndexByScrollResponse buildResponse(TimeValue took) {
             return new BulkIndexByScrollResponse(took, task.getStatus());
         }
 

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportUpdateByQueryAction.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/TransportUpdateByQueryAction.java
@@ -20,7 +20,9 @@
 package org.elasticsearch.plugin.reindex;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
@@ -42,6 +44,8 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import java.util.List;
 
 public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateByQueryRequest, BulkIndexByScrollResponse> {
     private final Client client;
@@ -90,8 +94,9 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
         }
 
         @Override
-        protected BulkIndexByScrollResponse buildResponse(TimeValue took) {
-            return new BulkIndexByScrollResponse(took, task.getStatus());
+        protected BulkIndexByScrollResponse buildResponse(TimeValue took, List<Failure> indexingFailures,
+                List<ShardSearchFailure> searchFailures) {
+            return new BulkIndexByScrollResponse(took, task.getStatus(), indexingFailures, searchFailures);
         }
 
         @Override

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkIndexByScrollActionTestCase.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AbstractAsyncBulkIndexByScrollActionTestCase.java
@@ -28,10 +28,12 @@ import org.junit.Before;
 public abstract class AbstractAsyncBulkIndexByScrollActionTestCase<Request extends AbstractBulkIndexByScrollRequest<Request>, Response extends BulkIndexByScrollResponse>
         extends ESTestCase {
     protected ThreadPool threadPool;
+    protected BulkByScrollTask task;
 
     @Before
     public void setupForTest() {
         threadPool = new ThreadPool(getTestName());
+        task = new BulkByScrollTask(1, "test", "test", () -> "test");
     }
 
     @After

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AsyncBulkByScrollActionTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AsyncBulkByScrollActionTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.FilterClient;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.Index;
@@ -255,7 +256,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         }
 
         @Override
-        protected Object buildResponse(long took) {
+        protected Object buildResponse(TimeValue took) {
+            // Any object will do here because we don't look at the response.
             return new Object();
         }
     }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AsyncBulkByScrollActionTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AsyncBulkByScrollActionTests.java
@@ -101,8 +101,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     public void testScrollResponseSetsTotal() {
-        // Default is -1, meaning unstarted
-        assertEquals(-1, task.getStatus().getTotal());
+        // Default is 0, meaning unstarted
+        assertEquals(0, task.getStatus().getTotal());
 
         long total = randomIntBetween(0, Integer.MAX_VALUE);
         InternalSearchHits hits = new InternalSearchHits(null, total, 0);

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.reindex;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+public class BulkByScrollTaskTests extends ESTestCase {
+    private BulkByScrollTask task;
+
+    public void testBasicData() {
+        assertEquals(1, task.getId());
+        assertEquals("test_type", task.getType());
+        assertEquals("test_action", task.getAction());
+    }
+
+    public void testProgress() {
+        long created = 0;
+        long updated = 0;
+        long deleted = 0;
+        long versionConflicts = 0;
+        long noops = 0;
+        int batch = 0;
+        BulkByScrollTask.Status status = task.getStatus();
+        assertEquals(-1, status.getTotal());
+        assertEquals(created, status.getCreated());
+        assertEquals(updated, status.getUpdated());
+        assertEquals(deleted, status.getDeleted());
+        assertEquals(versionConflicts, status.getVersionConflicts());
+        assertEquals(batch, status.getBatches());
+        assertEquals(noops, status.getNoops());
+
+        long totalHits = randomIntBetween(10, 1000);
+        task.setTotal(totalHits);
+        for (long p = 0; p < totalHits; p++) {
+            status = task.getStatus();
+            assertEquals(totalHits, status.getTotal());
+            assertEquals(created, status.getCreated());
+            assertEquals(updated, status.getUpdated());
+            assertEquals(deleted, status.getDeleted());
+            assertEquals(versionConflicts, status.getVersionConflicts());
+            assertEquals(batch, status.getBatches());
+            assertEquals(noops, status.getNoops());
+
+            if (randomBoolean()) {
+                created++;
+                task.countCreated();
+            } else if (randomBoolean()) {
+                updated++;
+                task.countUpdated();
+            } else {
+                deleted++;
+                task.countDeleted();
+            }
+
+            if (rarely()) {
+                versionConflicts++;
+                task.countVersionConflict();
+            }
+
+            if (rarely()) {
+                batch++;
+                task.countBatch();
+            }
+
+            if (rarely()) {
+                noops++;
+                task.countNoop();
+            }
+        }
+        status = task.getStatus();
+        assertEquals(totalHits, status.getTotal());
+        assertEquals(created, status.getCreated());
+        assertEquals(updated, status.getUpdated());
+        assertEquals(deleted, status.getDeleted());
+        assertEquals(versionConflicts, status.getVersionConflicts());
+        assertEquals(batch, status.getBatches());
+        assertEquals(noops, status.getNoops());
+    }
+
+    @Before
+    public void createTask() {
+        task = new BulkByScrollTask(1, "test_type", "test_action", () -> "test");
+    }
+}

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
@@ -22,6 +22,8 @@ package org.elasticsearch.plugin.reindex;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
+import static java.util.Collections.emptyList;
+
 public class BulkByScrollTaskTests extends ESTestCase {
     private BulkByScrollTask task;
 
@@ -98,5 +100,15 @@ public class BulkByScrollTaskTests extends ESTestCase {
         assertEquals(versionConflicts, status.getVersionConflicts());
         assertEquals(batch, status.getBatches());
         assertEquals(noops, status.getNoops());
+    }
+
+    public void testStatusHatesNegatives() {
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(-1, 0, 0, 0, 0, 0, 0, emptyList(), emptyList()));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, -1, 0, 0, 0, 0, 0, emptyList(), emptyList()));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, -1, 0, 0, 0, 0, emptyList(), emptyList()));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, -1, 0, 0, 0, emptyList(), emptyList()));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, -1, 0, 0, emptyList(), emptyList()));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, -1, 0, emptyList(), emptyList()));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, -1, emptyList(), emptyList()));
     }
 }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
@@ -25,6 +25,11 @@ import org.junit.Before;
 public class BulkByScrollTaskTests extends ESTestCase {
     private BulkByScrollTask task;
 
+    @Before
+    public void createTask() {
+        task = new BulkByScrollTask(1, "test_type", "test_action", () -> "test");
+    }
+
     public void testBasicData() {
         assertEquals(1, task.getId());
         assertEquals("test_type", task.getType());
@@ -93,10 +98,5 @@ public class BulkByScrollTaskTests extends ESTestCase {
         assertEquals(versionConflicts, status.getVersionConflicts());
         assertEquals(batch, status.getBatches());
         assertEquals(noops, status.getNoops());
-    }
-
-    @Before
-    public void createTask() {
-        task = new BulkByScrollTask(1, "test_type", "test_action", () -> "test");
     }
 }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
@@ -44,7 +44,7 @@ public class BulkByScrollTaskTests extends ESTestCase {
         long noops = 0;
         int batch = 0;
         BulkByScrollTask.Status status = task.getStatus();
-        assertEquals(-1, status.getTotal());
+        assertEquals(0, status.getTotal());
         assertEquals(created, status.getCreated());
         assertEquals(updated, status.getUpdated());
         assertEquals(deleted, status.getDeleted());

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
@@ -22,8 +22,6 @@ package org.elasticsearch.plugin.reindex;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
-import static java.util.Collections.emptyList;
-
 public class BulkByScrollTaskTests extends ESTestCase {
     private BulkByScrollTask task;
 
@@ -103,12 +101,12 @@ public class BulkByScrollTaskTests extends ESTestCase {
     }
 
     public void testStatusHatesNegatives() {
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(-1, 0, 0, 0, 0, 0, 0, emptyList(), emptyList()));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, -1, 0, 0, 0, 0, 0, emptyList(), emptyList()));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, -1, 0, 0, 0, 0, emptyList(), emptyList()));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, -1, 0, 0, 0, emptyList(), emptyList()));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, -1, 0, 0, emptyList(), emptyList()));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, -1, 0, emptyList(), emptyList()));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, -1, emptyList(), emptyList()));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(-1, 0, 0, 0, 0, 0, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, -1, 0, 0, 0, 0, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, -1, 0, 0, 0, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, -1, 0, 0, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, -1, 0, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, -1, 0));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, -1));
     }
 }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexBasicTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexBasicTests.java
@@ -19,15 +19,15 @@
 
 package org.elasticsearch.plugin.reindex;
 
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
+import org.elasticsearch.action.index.IndexRequestBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
-import org.elasticsearch.action.index.IndexRequestBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 
 public class ReindexBasicTests extends ReindexTestCase {
     public void testFiltering() throws Exception {

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexMetadataTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexMetadataTests.java
@@ -67,7 +67,7 @@ public class ReindexMetadataTests extends AbstractAsyncBulkIndexbyScrollActionMe
 
     @Override
     protected TransportReindexAction.AsyncIndexBySearchAction action() {
-        return new TransportReindexAction.AsyncIndexBySearchAction(logger, null, null, threadPool, request(), listener());
+        return new TransportReindexAction.AsyncIndexBySearchAction(task, logger, null, null, threadPool, request(), listener());
     }
 
     @Override

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexParentChildTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexParentChildTests.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.plugin.reindex;
 
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+
 import static org.elasticsearch.index.query.QueryBuilders.hasParentQuery;
 import static org.elasticsearch.index.query.QueryBuilders.idsQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.hamcrest.Matchers.equalTo;
-
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 
 /**
  * Index-by-search tests for parent/child.

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexScriptTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexScriptTests.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.plugin.reindex;
 
-import java.util.Map;
-
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.lucene.uid.Versions;
+
+import java.util.Map;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.hamcrest.Matchers.containsString;

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexScriptTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexScriptTests.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.plugin.reindex;
 
+import java.util.Map;
+
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.lucene.uid.Versions;
-
-import java.util.Map;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.hamcrest.Matchers.containsString;
@@ -134,6 +134,6 @@ public class ReindexScriptTests extends AbstractAsyncBulkIndexByScrollActionScri
 
     @Override
     protected AbstractAsyncBulkIndexByScrollAction<ReindexRequest, ReindexResponse> action() {
-        return new TransportReindexAction.AsyncIndexBySearchAction(logger, null, null, threadPool, request(), listener());
+        return new TransportReindexAction.AsyncIndexBySearchAction(task, logger, null, null, threadPool, request(), listener());
     }
 }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/RoundTripTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/RoundTripTests.java
@@ -42,6 +42,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.apache.lucene.util.TestUtil.randomSimpleString;
+import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 
 /**
  * Round trip tests for all Streamable things declared in this plugin.
@@ -98,14 +99,14 @@ public class RoundTripTests extends ESTestCase {
     }
 
     public void testReindexResponse() throws IOException {
-        ReindexResponse response = new ReindexResponse(randomPositiveLong(), randomStatus());
+        ReindexResponse response = new ReindexResponse(timeValueMillis(randomPositiveLong()), randomStatus());
         ReindexResponse tripped = new ReindexResponse();
         roundTrip(response, tripped);
         assertResponseEquals(response, tripped);
     }
 
     public void testBulkIndexByScrollResponse() throws IOException {
-        BulkIndexByScrollResponse response = new BulkIndexByScrollResponse(randomPositiveLong(), randomStatus());
+        BulkIndexByScrollResponse response = new BulkIndexByScrollResponse(timeValueMillis(randomPositiveLong()), randomStatus());
         BulkIndexByScrollResponse tripped = new BulkIndexByScrollResponse();
         roundTrip(response, tripped);
         assertResponseEquals(response, tripped);

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/RoundTripTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/RoundTripTests.java
@@ -67,23 +67,6 @@ public class RoundTripTests extends ESTestCase {
         assertRequestEquals(update, tripped);
     }
 
-    public void testReindexResponse() throws IOException {
-        ReindexResponse response = new ReindexResponse(randomPositiveLong(), randomPositiveLong(), randomPositiveLong(),
-                randomPositiveInt(), randomPositiveLong(), randomPositiveLong(), randomIndexingFailures(), randomSearchFailures());
-        ReindexResponse tripped = new ReindexResponse();
-        roundTrip(response, tripped);
-        assertResponseEquals(response, tripped);
-        assertEquals(response.getCreated(), tripped.getCreated());
-    }
-
-    public void testBulkIndexByScrollResponse() throws IOException {
-        BulkIndexByScrollResponse response = new BulkIndexByScrollResponse(randomPositiveLong(), randomPositiveLong(), randomPositiveInt(),
-                randomPositiveLong(), randomPositiveLong(), randomIndexingFailures(), randomSearchFailures());
-        BulkIndexByScrollResponse tripped = new BulkIndexByScrollResponse();
-        roundTrip(response, tripped);
-        assertResponseEquals(response, tripped);
-    }
-
     private void randomRequest(AbstractBulkIndexByScrollRequest<?> request) {
         request.getSource().indices("test");
         request.getSource().source().size(between(1, 1000));
@@ -106,6 +89,33 @@ public class RoundTripTests extends ESTestCase {
         assertEquals(request.getScript(), tripped.getScript());
     }
 
+    public void testBulkByTaskStatus() throws IOException {
+        BulkByScrollTask.Status status = randomStatus();
+        BytesStreamOutput out = new BytesStreamOutput();
+        status.writeTo(out);
+        BulkByScrollTask.Status tripped = new BulkByScrollTask.Status(out.bytes().streamInput());
+        assertTaskStatusEquals(status, tripped);
+    }
+
+    public void testReindexResponse() throws IOException {
+        ReindexResponse response = new ReindexResponse(randomPositiveLong(), randomStatus());
+        ReindexResponse tripped = new ReindexResponse();
+        roundTrip(response, tripped);
+        assertResponseEquals(response, tripped);
+    }
+
+    public void testBulkIndexByScrollResponse() throws IOException {
+        BulkIndexByScrollResponse response = new BulkIndexByScrollResponse(randomPositiveLong(), randomStatus());
+        BulkIndexByScrollResponse tripped = new BulkIndexByScrollResponse();
+        roundTrip(response, tripped);
+        assertResponseEquals(response, tripped);
+    }
+
+    private BulkByScrollTask.Status randomStatus() {
+        return new BulkByScrollTask.Status(randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong(),
+                randomPositiveInt(), randomPositiveLong(), randomPositiveLong(), randomIndexingFailures(), randomSearchFailures());
+    }
+
     private List<Failure> randomIndexingFailures() {
         return usually() ? emptyList()
                 : singletonList(new Failure(randomSimpleString(random()), randomSimpleString(random()),
@@ -119,25 +129,6 @@ public class RoundTripTests extends ESTestCase {
         Index index = new Index(randomSimpleString(random()), "uuid");
         return singletonList(new ShardSearchFailure(randomSimpleString(random()),
                 new SearchShardTarget(randomSimpleString(random()), index, randomInt()), randomFrom(RestStatus.values())));
-    }
-
-
-    private void assertResponseEquals(BulkIndexByScrollResponse response, BulkIndexByScrollResponse tripped) {
-        assertEquals(response.getTook(), tripped.getTook());
-        assertEquals(response.getUpdated(), tripped.getUpdated());
-        assertEquals(response.getBatches(), tripped.getBatches());
-        assertEquals(response.getVersionConflicts(), tripped.getVersionConflicts());
-        assertEquals(response.getNoops(), tripped.getNoops());
-        assertEquals(response.getIndexingFailures().size(), tripped.getIndexingFailures().size());
-        for (int i = 0; i < response.getIndexingFailures().size(); i++) {
-            Failure expected = response.getIndexingFailures().get(i);
-            Failure actual = tripped.getIndexingFailures().get(i);
-            assertEquals(expected.getIndex(), actual.getIndex());
-            assertEquals(expected.getType(), actual.getType());
-            assertEquals(expected.getId(), actual.getId());
-            assertEquals(expected.getMessage(), actual.getMessage());
-            assertEquals(expected.getStatus(), actual.getStatus());
-        }
     }
 
     private void roundTrip(Streamable example, Streamable empty) throws IOException {
@@ -163,5 +154,36 @@ public class RoundTripTests extends ESTestCase {
 
     private int randomPositiveInt() {
         return randomInt(Integer.MAX_VALUE);
+    }
+
+    private void assertResponseEquals(BulkIndexByScrollResponse expected, BulkIndexByScrollResponse actual) {
+        assertEquals(expected.getTook(), actual.getTook());
+        assertTaskStatusEquals(expected.getStatus(), actual.getStatus());
+    }
+
+    private void assertTaskStatusEquals(BulkByScrollTask.Status expected, BulkByScrollTask.Status actual) {
+        assertEquals(expected.getUpdated(), actual.getUpdated());
+        assertEquals(expected.getBatches(), actual.getBatches());
+        assertEquals(expected.getVersionConflicts(), actual.getVersionConflicts());
+        assertEquals(expected.getNoops(), actual.getNoops());
+        assertEquals(expected.getIndexingFailures().size(), actual.getIndexingFailures().size());
+        for (int i = 0; i < expected.getIndexingFailures().size(); i++) {
+            Failure expectedFailure = expected.getIndexingFailures().get(i);
+            Failure actualFailure = actual.getIndexingFailures().get(i);
+            assertEquals(expectedFailure.getIndex(), actualFailure.getIndex());
+            assertEquals(expectedFailure.getType(), actualFailure.getType());
+            assertEquals(expectedFailure.getId(), actualFailure.getId());
+            assertEquals(expectedFailure.getMessage(), actualFailure.getMessage());
+            assertEquals(expectedFailure.getStatus(), actualFailure.getStatus());
+        }
+        assertEquals(expected.getSearchFailures().size(), actual.getSearchFailures().size());
+        for (int i = 0; i < expected.getSearchFailures().size(); i++) {
+            ShardSearchFailure expectedFailure = expected.getSearchFailures().get(i);
+            ShardSearchFailure actualFailure = actual.getSearchFailures().get(i);
+            assertEquals(expectedFailure.shard(), actualFailure.shard());
+            assertEquals(expectedFailure.status(), actualFailure.status());
+            // We can't use getCause because throwable doesn't implement equals
+            assertEquals(expectedFailure.reason(), actualFailure.reason());
+        }
     }
 }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/RoundTripTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/RoundTripTests.java
@@ -99,14 +99,16 @@ public class RoundTripTests extends ESTestCase {
     }
 
     public void testReindexResponse() throws IOException {
-        ReindexResponse response = new ReindexResponse(timeValueMillis(randomPositiveLong()), randomStatus());
+        ReindexResponse response = new ReindexResponse(timeValueMillis(randomPositiveLong()), randomStatus(), randomIndexingFailures(),
+                randomSearchFailures());
         ReindexResponse tripped = new ReindexResponse();
         roundTrip(response, tripped);
         assertResponseEquals(response, tripped);
     }
 
     public void testBulkIndexByScrollResponse() throws IOException {
-        BulkIndexByScrollResponse response = new BulkIndexByScrollResponse(timeValueMillis(randomPositiveLong()), randomStatus());
+        BulkIndexByScrollResponse response = new BulkIndexByScrollResponse(timeValueMillis(randomPositiveLong()), randomStatus(),
+                randomIndexingFailures(), randomSearchFailures());
         BulkIndexByScrollResponse tripped = new BulkIndexByScrollResponse();
         roundTrip(response, tripped);
         assertResponseEquals(response, tripped);
@@ -114,7 +116,7 @@ public class RoundTripTests extends ESTestCase {
 
     private BulkByScrollTask.Status randomStatus() {
         return new BulkByScrollTask.Status(randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong(),
-                randomPositiveInt(), randomPositiveLong(), randomPositiveLong(), randomIndexingFailures(), randomSearchFailures());
+                randomPositiveInt(), randomPositiveLong(), randomPositiveLong());
     }
 
     private List<Failure> randomIndexingFailures() {
@@ -160,13 +162,6 @@ public class RoundTripTests extends ESTestCase {
     private void assertResponseEquals(BulkIndexByScrollResponse expected, BulkIndexByScrollResponse actual) {
         assertEquals(expected.getTook(), actual.getTook());
         assertTaskStatusEquals(expected.getStatus(), actual.getStatus());
-    }
-
-    private void assertTaskStatusEquals(BulkByScrollTask.Status expected, BulkByScrollTask.Status actual) {
-        assertEquals(expected.getUpdated(), actual.getUpdated());
-        assertEquals(expected.getBatches(), actual.getBatches());
-        assertEquals(expected.getVersionConflicts(), actual.getVersionConflicts());
-        assertEquals(expected.getNoops(), actual.getNoops());
         assertEquals(expected.getIndexingFailures().size(), actual.getIndexingFailures().size());
         for (int i = 0; i < expected.getIndexingFailures().size(); i++) {
             Failure expectedFailure = expected.getIndexingFailures().get(i);
@@ -186,5 +181,12 @@ public class RoundTripTests extends ESTestCase {
             // We can't use getCause because throwable doesn't implement equals
             assertEquals(expectedFailure.reason(), actualFailure.reason());
         }
+    }
+
+    private void assertTaskStatusEquals(BulkByScrollTask.Status expected, BulkByScrollTask.Status actual) {
+        assertEquals(expected.getUpdated(), actual.getUpdated());
+        assertEquals(expected.getBatches(), actual.getBatches());
+        assertEquals(expected.getVersionConflicts(), actual.getVersionConflicts());
+        assertEquals(expected.getNoops(), actual.getNoops());
     }
 }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/UpdateByQueryMetadataTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/UpdateByQueryMetadataTests.java
@@ -33,7 +33,7 @@ public class UpdateByQueryMetadataTests
 
     @Override
     protected TransportUpdateByQueryAction.AsyncIndexBySearchAction action() {
-        return new TransportUpdateByQueryAction.AsyncIndexBySearchAction(logger, null, null, threadPool, request(), listener());
+        return new TransportUpdateByQueryAction.AsyncIndexBySearchAction(task, logger, null, null, threadPool, request(), listener());
     }
 
     @Override

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/UpdateByQueryWithScriptTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/UpdateByQueryWithScriptTests.java
@@ -50,6 +50,7 @@ public class UpdateByQueryWithScriptTests
 
     @Override
     protected AbstractAsyncBulkIndexByScrollAction<UpdateByQueryRequest, BulkIndexByScrollResponse> action() {
-        return new TransportUpdateByQueryAction.AsyncIndexBySearchAction(logger, null, null, threadPool, request(), listener());
+        return new TransportUpdateByQueryAction.AsyncIndexBySearchAction(task, logger, null, null, threadPool,
+                request(), listener());
     }
 }


### PR DESCRIPTION
Adds a progress indicator for reindex and update_by_query requests that you
can fetch like so:

```
curl 'localhost:9200/_tasks/*/*byquery*?pretty&detailed'
```

```
{
  "nodes" : {
    "r1A2WoRbTwKZ516z6NEs5A" : {
      "name" : "Tyrannus",
      "transport_address" : "127.0.0.1:9300",
      "host" : "127.0.0.1",
      "ip" : "127.0.0.1:9300",
      "attributes" : {
        "testattr" : "test",
        "portsfile" : "true"
      },
      "tasks" : [ {
        "node" : "r1A2WoRbTwKZ516z6NEs5A",
        "id" : 36619,
        "type" : "transport",
        "action" : "indices:data/write/update/byquery",
        "status" : {       <---------------------------- Status is this
          "total" : 6154,
          "updated" : 3500,
          "created" : 0,
          "deleted" : 0,
          "batches" : 36,
          "version_conflicts" : 0,
          "noops" : 0,
          "failures" : [ ]
        },
        "description" : "update-by-query [test][test]"
      } ]
    }
  }
}
```

The progress is just (updated + created + deleted) / total
