### PR TITLE
Enforce JDK 7 signatures only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,10 @@
                     <artifactId>maven-remote-resources-plugin</artifactId>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                </plugin>
+                <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
                 </plugin>
@@ -837,6 +841,27 @@
                         <execution>
                             <goals>
                                 <goal>process</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.14</version>
+                    <configuration>
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>java17</artifactId>
+                            <version>1.0</version>
+                        </signature>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>check-java17</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>check</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
This commit adds usage of the animal-sniffer-maven-plugin to ensure that
compiled artifacts are only using signatures from JDK 7. This addresses
an issue where many developers are using JDK 8 locally.
