### PR TITLE
Do not publish modules

### DIFF
--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -40,4 +40,8 @@ subprojects {
       throw new InvalidModelException("Modules cannot disable isolation")
     }
   }
+
+  // these are implementation details of our build, no need to publish them!
+  install.enabled = false
+  uploadArchives.enabled = false
 }


### PR DESCRIPTION
Modules are an internal implementation detail of our build, and there is
no need to publish them with gradle. This change disables publishing of
all modules.
