### PR TITLE
Make IDEs use separate build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,13 @@
 *.iml
 *.ipr
 *.iws
+build-idea/
 
 # eclipse files
 .project
 .classpath
-eclipse-build
 .settings
+build-eclipse/
 
 # netbeans files
 nb-configuration.xml
@@ -18,7 +19,6 @@ nbactions.xml
 # gradle stuff
 .gradle/
 build/
-generated-resources/
 
 # maven stuff (to be removed when trunk becomes 4.x)
 *-execution-hints.log
@@ -38,5 +38,5 @@ html_docs
 # random old stuff that we should look at the necessity of...
 /tmp/
 backwards/
-
+eclipse-build
 

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ allprojects {
   }
   idea {
     module {
-      // same as for the IntelliJ Gradle tooling integration
       inheritOutputDirs = false
       outputDir = file('build-idea/classes/main')
       testOutputDir = file('build-idea/classes/test')

--- a/build.gradle
+++ b/build.gradle
@@ -75,8 +75,9 @@ subprojects {
 allprojects {
   // injecting groovy property variables into all projects
   project.ext {
-    // for eclipse hacks...
+    // for ide hacks...
     isEclipse = System.getProperty("eclipse.launcher") != null || gradle.startParameter.taskNames.contains('eclipse') || gradle.startParameter.taskNames.contains('cleanEclipse')
+    isIdea = System.getProperty("idea.active") != null || gradle.startParameter.taskNames.contains('idea') || gradle.startParameter.taskNames.contains('cleanIdea')
   }
 }
 
@@ -170,12 +171,15 @@ gradle.projectsEvaluated {
 allprojects {
   apply plugin: 'idea'
 
+  if (isIdea) {
+    project.buildDir = file('build-idea')
+  }
   idea {
     module {
       // same as for the IntelliJ Gradle tooling integration
       inheritOutputDirs = false
-      outputDir = file('build/classes/main')
-      testOutputDir = file('build/classes/test')
+      outputDir = file('build-idea/classes/main')
+      testOutputDir = file('build-idea/classes/test')
 
       iml {
         // fix so that Gradle idea plugin properly generates support for resource folders
@@ -222,14 +226,19 @@ allprojects {
   apply plugin: 'eclipse'
 
   plugins.withType(JavaBasePlugin) {
-    eclipse.classpath.defaultOutputDir = new File(project.buildDir, 'eclipse')
+    File eclipseBuild = project.file('build-eclipse')
+    eclipse.classpath.defaultOutputDir = eclipseBuild
+    if (isEclipse) {
+      // set this so generated dirs will be relative to eclipse build
+      project.buildDir = eclipseBuild
+    }
     eclipse.classpath.file.whenMerged { classpath ->
       // give each source folder a unique corresponding output folder
       int i = 0;
       classpath.entries.findAll { it instanceof SourceFolder }.each { folder ->
         i++;
         // this is *NOT* a path or a file.
-        folder.output = "build/eclipse/" + i
+        folder.output = "build-eclipse/" + i
       }
     }
   }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -78,7 +78,7 @@ extraArchive {
 
 eclipse {
   classpath {
-    defaultOutputDir = new File(file('build'), 'eclipse')
+    defaultOutputDir = file('build-eclipse')
   }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -76,6 +76,14 @@ extraArchive {
   tests = false
 }
 
+idea {
+  module {
+    inheritOutputDirs = false
+    outputDir = file('build-idea/classes/main')
+    testOutputDir = file('build-idea/classes/test')
+  }
+}
+
 eclipse {
   classpath {
     defaultOutputDir = file('build-eclipse')

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.Copy
 class PluginPropertiesTask extends Copy {
 
     PluginPropertiesExtension extension
-    File generatedResourcesDir = new File(project.projectDir, 'generated-resources')
+    File generatedResourcesDir = new File(project.buildDir, 'generated-resources')
 
     PluginPropertiesTask() {
         File templateFile = new File(project.buildDir, 'templates/plugin-descriptor.properties')

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/ESBaseDirectoryTestCase.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/ESBaseDirectoryTestCase.java
@@ -1,4 +1,4 @@
-package org.elastiscearch.index.store;
+package org.elasticsearch.index.store;
 
 /*
  * Licensed to Elasticsearch under one or more contributor

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SmbMMapDirectoryTests.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SmbMMapDirectoryTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elastiscearch.index.store;
+package org.elasticsearch.index.store;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SmbSimpleFSDirectoryTests.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/SmbSimpleFSDirectoryTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elastiscearch.index.store;
+package org.elasticsearch.index.store;
 
 import java.io.IOException;
 import java.nio.file.Path;


### PR DESCRIPTION
We currently put all builds for eclipse and intellij under gradle's normal build dir. However, this means running something like `gradle clean` from the command line wipes the IDEs build out from under it, which can cause huge issues (eg eclipse dying a horrible death of compilation failures that it cannot recover from).

This change makes `build-idea` and `build-eclipse` directories for the respective IDEs. The `generated-resources` for plugins is also moved under the relevant dir, so that dir no longer lives at the root of each project.
