### PR TITLE
Add foreground setting

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -308,6 +308,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
             Environment.PATH_SCRIPTS_SETTING,
             Environment.PATH_SHARED_DATA_SETTING,
             Environment.PIDFILE_SETTING,
+            Environment.FOREGROUND_SETTING,
             DiscoveryService.DISCOVERY_SEED_SETTING,
             DiscoveryService.INITIAL_STATE_TIMEOUT_SETTING,
             DiscoveryModule.DISCOVERY_TYPE_SETTING,

--- a/core/src/main/java/org/elasticsearch/env/Environment.java
+++ b/core/src/main/java/org/elasticsearch/env/Environment.java
@@ -56,6 +56,7 @@ public class Environment {
     public static final Setting<List<String>> PATH_REPO_SETTING = Setting.listSetting("path.repo", Collections.emptyList(), Function.identity(), false, Setting.Scope.CLUSTER);
     public static final Setting<String> PATH_SHARED_DATA_SETTING = Setting.simpleString("path.shared_data", false, Setting.Scope.CLUSTER);
     public static final Setting<String> PIDFILE_SETTING = Setting.simpleString("pidfile", false, Setting.Scope.CLUSTER);
+    public static final Setting<String> FOREGROUND_SETTING = Setting.simpleString("foreground", false, Setting.Scope.CLUSTER);
 
     private final Settings settings;
 


### PR DESCRIPTION
I toyed with the idea of renaming it to bootstrap.foreground but we already
have a Setting for pidfile so I figured that is what we meant to do. Without
this the RPM and DEB packages don't start at all.
