### PR TITLE
test framework 2.2.0 -> 2.3.2

### DIFF
--- a/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -35,7 +35,7 @@ grant codeBase "${codebase.lucene-test-framework-5.5.0-snapshot-4de5f1d.jar}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-grant codeBase "${codebase.randomizedtesting-runner-2.2.0.jar}" {
+grant codeBase "${codebase.randomizedtesting-runner-2.3.2.jar}" {
   // optionally needed for access to private test methods (e.g. beforeClass)
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed to fail tests on uncaught exceptions from other threads
@@ -44,7 +44,7 @@ grant codeBase "${codebase.randomizedtesting-runner-2.2.0.jar}" {
   permission org.elasticsearch.ThreadPermission "modifyArbitraryThreadGroup";
 };
 
-grant codeBase "${codebase.junit4-ant-2.2.0.jar}" {
+grant codeBase "${codebase.junit4-ant-2.3.2.jar}" {
   // needed for stream redirection
   permission java.lang.RuntimePermission "setIO";
 };

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <lucene.version>5.5.0</lucene.version>
         <lucene.snapshot.revision>4de5f1d</lucene.snapshot.revision>
         <lucene.maven.version>5.5.0-snapshot-${lucene.snapshot.revision}</lucene.maven.version>
-        <testframework.version>2.2.0</testframework.version>
+        <testframework.version>2.3.2</testframework.version>
         <securemock.version>1.1</securemock.version>
         <securesm.version>1.0</securesm.version>
 


### PR DESCRIPTION
We should upgrade to 2.3.2 (which is what lucene is using) just for consistency. We have been using it in master for a while.

I don't wish to rework the maven build here to "clean this up" better even though its messy how we have includes/excludes. 3.0 is clean and lucene is now clean (https://issues.apache.org/jira/browse/LUCENE-6953) so lets just do this the simple way.
