### PR TITLE
[Test]: Allow REST tests to specify custom indices and templates to be deleted

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestReportLogger.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestReportLogger.groovy
@@ -124,7 +124,7 @@ class TestReportLogger extends TestsSummaryEventListener implements AggregatedEv
                 formatDurationInSeconds(e.getNoEventDuration()) + " at: " +
                 (e.getDescription() == null ? "<unknown>" : formatDescription(e.getDescription())))
         try {
-            playBeat();
+            //playBeat();
         } catch (Exception nosound) { /* handling exceptions with style */ }
         slowTestsFound = true
     }

--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestReportLogger.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestReportLogger.groovy
@@ -124,7 +124,7 @@ class TestReportLogger extends TestsSummaryEventListener implements AggregatedEv
                 formatDurationInSeconds(e.getNoEventDuration()) + " at: " +
                 (e.getDescription() == null ? "<unknown>" : formatDescription(e.getDescription())))
         try {
-            //playBeat();
+            playBeat();
         } catch (Exception nosound) { /* handling exceptions with style */ }
         slowTestsFound = true
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -267,8 +267,8 @@ public abstract class ESRestTestCase extends ESTestCase {
     public void wipeCluster() throws Exception {
         // wipe indices
         String deleteIndices = "*";
-        if (excludeIndices().size() > 0) {
-            deleteIndices = deleteIndices + "," + Strings.collectionToDelimitedString(excludeIndices(), ",", "-", "");
+        if (excludeIndicesFromDeletion().size() > 0) {
+            deleteIndices = deleteIndices + "," + Strings.collectionToDelimitedString(excludeIndicesFromDeletion(), ",", "-", "");
         }
 
         Map<String, String> deleteIndicesArgs = new HashMap<>();
@@ -284,7 +284,7 @@ public abstract class ESRestTestCase extends ESTestCase {
 
         // wipe index templates
         Set<String> deletions = new HashSet<>();
-        if (excludeTemplates().isEmpty()) {
+        if (excludeTemplatesFromDeletion().isEmpty()) {
             deletions.add("*");
         } else {
             try {
@@ -292,7 +292,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                 RestResponse response = adminExecutionContext.callApi("indices.get_template", Collections.emptyMap(),
                         Collections.emptyList(), Collections.emptyMap());
                 try (XContentParser parser = XContentType.JSON.xContent().createParser(response.getBodyAsString())) {
-                    String[] exclusions = excludeTemplates().toArray(new String[]{});
+                    String[] exclusions = excludeTemplatesFromDeletion().toArray(new String[]{});
                     for (String template : parser.map().keySet()) {
                         if (Regex.simpleMatch(exclusions, template) == false) {
                             // If the template name does not match an exclusion,
@@ -324,14 +324,14 @@ public abstract class ESRestTestCase extends ESTestCase {
     /**
      * @return An exclude list of indices that will not be removed in between tests.
      */
-    protected List<String> excludeIndices() {
+    protected List<String> excludeIndicesFromDeletion() {
         return Collections.emptyList();
     }
 
     /**
      * @return An exclude list of index templates that will not be removed in between tests.
      */
-    protected List<String> excludeTemplates() {
+    protected List<String> excludeTemplatesFromDeletion() {
         return Collections.emptyList();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -268,7 +268,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         // wipe indices
         String deleteIndices = "*";
         if (excludeIndices().size() > 0) {
-            deleteIndices = Strings.collectionToDelimitedString(excludeIndices(), ",", "-", "");
+            deleteIndices = deleteIndices + "," + Strings.collectionToDelimitedString(excludeIndices(), ",", "-", "");
         }
 
         Map<String, String> deleteIndicesArgs = new HashMap<>();
@@ -323,10 +323,10 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     /**
-     * @return An exclude set of indices that will not be removed in between tests.
+     * @return An exclude list of indices that will not be removed in between tests.
      */
-    protected Set<String> excludeIndices() {
-        return Collections.emptySet();
+    protected List<String> excludeIndices() {
+        return Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
It could be nice to be able to specify custom indices and/or template name to be deleted between REST tests.
