### PR TITLE
Remove _source 'disable' from the create-index documentation

### DIFF
--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -77,7 +77,6 @@ curl -XPOST localhost:9200/test -d '{
     },
     "mappings" : {
         "type1" : {
-            "_source" : { "enabled" : false },
             "properties" : {
                 "field1" : { "type" : "string", "index" : "not_analyzed" }
             }


### PR DESCRIPTION
As we recommend users not to disable _source and were even thinking about removing this feature, I think we should remove this from the docs.
