### PR TITLE
Relocation source should be marked as relocating before starting recovery to primary relocation target

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySource.java
@@ -93,6 +93,14 @@ public class RecoverySource extends AbstractComponent implements IndexEventListe
             logger.debug("delaying recovery of {} as source node {} is unknown", request.shardId(), request.targetNode());
             throw new DelayRecoveryException("source node does not have the node [" + request.targetNode() + "] in its state yet..");
         }
+
+        ShardRouting routingEntry = shard.routingEntry();
+        if (request.recoveryType() == RecoveryState.Type.PRIMARY_RELOCATION &&
+            (routingEntry.relocating() == false || routingEntry.relocatingNodeId().equals(request.targetNode().getId()) == false)) {
+            logger.debug("delaying recovery of {} as source shard is not marked yet as relocating to {}", request.shardId(), request.targetNode());
+            throw new DelayRecoveryException("source shard is not marked yet as relocating to [" + request.targetNode() + "]");
+        }
+
         ShardRouting targetShardRouting = null;
         for (ShardRouting shardRouting : node) {
             if (shardRouting.shardId().equals(request.shardId())) {


### PR DESCRIPTION
In case of primary relocation, recovery on the target shard can complete before the source index shard even knows that it is relocating. The reason is that in RecoverySource.recover, we decide whether we can start recovery based on current cluster state by accessing clusterService.state(). Important to note is that the state in cluster service is updated before cluster state listeners are executed. RecoverySource can thus verify the relocation target and complete the recovery before the listeners for this new cluster state are finished (in particular, before IndexShard.updateRoutingEntry() is done).
This means that RecoverySource can move IndexShard.state to RELOCATED before the IndexShard.shardRouting is updated with the information that a relocation is taking place.

Fixes build failure: http://build-us-00.elastic.co/job/es_core_master_oracle_6/4615/
