### PR TITLE
Detach QueryShardContext from IndexShard and remove obsolete threadlocals

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -164,7 +164,8 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<Valid
     protected ShardValidateQueryResponse shardOperation(ShardValidateQueryRequest request) {
         IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
         IndexShard indexShard = indexService.getShard(request.shardId().id());
-        final QueryShardContext queryShardContext = indexShard.getQueryShardContext();
+        final QueryShardContext queryShardContext = indexService.newQueryShardContext();
+        queryShardContext.setTypes(request.types());
 
         boolean valid;
         String explanation = null;

--- a/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -121,7 +121,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
         SearchContext.setCurrent(context);
 
         try {
-            context.parsedQuery(indexShard.getQueryShardContext().toQuery(request.query()));
+            context.parsedQuery(context.getQueryShardContext().toQuery(request.query()));
             context.preProcess();
             int topLevelDocId = result.docIdAndVersion().docId + result.docIdAndVersion().context.docBase;
             Explanation explanation = context.searcher().explain(context.query(), topLevelDocId);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -53,7 +53,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.NodeServicesProvider;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -336,7 +335,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                                 }
                             }
 
-                            QueryShardContext queryShardContext = indexService.getQueryShardContext();
+                            final QueryShardContext queryShardContext = indexService.newQueryShardContext();
                             for (Alias alias : request.aliases()) {
                                 if (Strings.hasLength(alias.filter())) {
                                     aliasValidator.validateAliasFilter(alias.name(), alias.filter(), queryShardContext);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -117,7 +117,7 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                                     indices.put(indexMetaData.getIndex().getName(), indexService);
                                 }
 
-                                aliasValidator.validateAliasFilter(aliasAction.alias(), filter, indexService.getQueryShardContext());
+                                aliasValidator.validateAliasFilter(aliasAction.alias(), filter, indexService.newQueryShardContext());
                             }
                             AliasMetaData newAliasMd = AliasMetaData.newAliasMetaDataBuilder(
                                     aliasAction.alias())

--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -131,7 +131,7 @@ public final class IndexService extends AbstractIndexComponent implements IndexC
         this.indexSettings = indexSettings;
         this.analysisService = registry.build(indexSettings);
         this.similarityService = similarityService;
-        this.mapperService = new MapperService(indexSettings, analysisService, similarityService, mapperRegistry, IndexService.this::getQueryShardContext);
+        this.mapperService = new MapperService(indexSettings, analysisService, similarityService, mapperRegistry, IndexService.this::newQueryShardContext);
         this.indexFieldData = new IndexFieldDataService(indexSettings, indicesFieldDataCache, nodeServicesProvider.getCircuitBreakerService(), mapperService);
         this.shardStoreDeleter = shardStoreDeleter;
         this.eventListener = eventListener;
@@ -417,7 +417,10 @@ public final class IndexService extends AbstractIndexComponent implements IndexC
         return indexSettings;
     }
 
-    public QueryShardContext getQueryShardContext() {
+    /**
+     * Creates a new QueryShardContext. The context has not types set yet, if types are required set them via {@link QueryShardContext#setTypes(String...)}
+     */
+    public QueryShardContext newQueryShardContext() {
         return new QueryShardContext(indexSettings, nodeServicesProvider.getClient(), indexCache.bitsetFilterCache(), indexFieldData, mapperService(), similarityService(), nodeServicesProvider.getScriptService(), nodeServicesProvider.getIndicesQueriesRegistry());
     }
 

--- a/core/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/core/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -136,11 +136,11 @@ public final class SearchSlowLog {
         public String toString() {
             StringBuilder sb = new StringBuilder();
             sb.append("took[").append(TimeValue.timeValueNanos(tookInNanos)).append("], took_millis[").append(TimeUnit.NANOSECONDS.toMillis(tookInNanos)).append("], ");
-            if (context.types() == null) {
+            if (context.getQueryShardContext().getTypes() == null) {
                 sb.append("types[], ");
             } else {
                 sb.append("types[");
-                Strings.arrayToDelimitedString(context.types(), ",", sb);
+                Strings.arrayToDelimitedString(context.getQueryShardContext().getTypes(), ",", sb);
                 sb.append("], ");
             }
             if (context.groupStats() == null) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -49,7 +49,6 @@ public class DocumentMapperParser {
 
     final MapperService mapperService;
     final AnalysisService analysisService;
-    private static final ESLogger logger = Loggers.getLogger(DocumentMapperParser.class);
     private final SimilarityService similarityService;
     private final Supplier<QueryShardContext> queryShardContextSupplier;
 

--- a/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasChildQueryBuilder.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.JoinUtil;
 import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -205,13 +206,15 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        String[] previousTypes = QueryShardContext.setTypesWithPrevious(type);
         Query innerQuery;
+        final String[] previousTypes = context.getTypes();
+        context.setTypes(type);
         try {
             innerQuery = query.toQuery(context);
         } finally {
-            QueryShardContext.setTypes(previousTypes);
+            context.setTypes(previousTypes);
         }
+
         if (innerQuery == null) {
             return null;
         }

--- a/core/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/HasParentQueryBuilder.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -119,11 +120,12 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         Query innerQuery;
-        String[] previousTypes = QueryShardContext.setTypesWithPrevious(type);
+        String[] previousTypes = context.getTypes();
+        context.setTypes(type);
         try {
             innerQuery = query.toQuery(context);
         } finally {
-            QueryShardContext.setTypes(previousTypes);
+            context.setTypes(previousTypes);
         }
 
         if (innerQuery == null) {

--- a/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -30,6 +30,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseFieldMatcher;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -74,7 +75,6 @@ import static java.util.Collections.unmodifiableMap;
  */
 public class QueryShardContext {
 
-    private static final ThreadLocal<String[]> typesContext = new ThreadLocal<>();
     private final MapperService mapperService;
     private final ScriptService scriptService;
     private final SimilarityService similarityService;
@@ -82,23 +82,14 @@ public class QueryShardContext {
     private final IndexFieldDataService indexFieldDataService;
     private final IndexSettings indexSettings;
     private final Client client;
+    private String[] types = Strings.EMPTY_ARRAY;
 
-    public static void setTypes(String[] types) {
-        typesContext.set(types);
+    public void setTypes(String... types) {
+        this.types = types;
     }
 
-    public static String[] getTypes() {
-        return typesContext.get();
-    }
-
-    public static String[] setTypesWithPrevious(String... types) {
-        String[] old = typesContext.get();
-        setTypes(types);
-        return old;
-    }
-
-    public static void removeTypes() {
-        typesContext.remove();
+    public String[] getTypes() {
+        return types;
     }
 
     private final Map<String, Query> namedQueries = new HashMap<>();
@@ -126,6 +117,7 @@ public class QueryShardContext {
 
     public QueryShardContext(QueryShardContext source) {
         this(source.indexSettings, source.client, source.bitsetFilterCache, source.indexFieldDataService, source.mapperService, source.similarityService, source.scriptService, source.indicesQueriesRegistry);
+        this.types = source.getTypes();
     }
 
 

--- a/core/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
+++ b/core/src/main/java/org/elasticsearch/index/query/support/NestedInnerQueryParseSupport.java
@@ -61,7 +61,7 @@ public class NestedInnerQueryParseSupport {
     private ObjectMapper parentObjectMapper;
 
     public NestedInnerQueryParseSupport(XContentParser parser, SearchContext searchContext) {
-        shardContext = searchContext.indexShard().getQueryShardContext();
+        shardContext = searchContext.getQueryShardContext();
         parseContext = shardContext.parseContext();
         shardContext.reset(parser);
 

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -139,7 +139,7 @@ public class PercolateContext extends SearchContext {
     }
 
     // for testing:
-    PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, MapperService mapperService) {
+    PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, MapperService mapperService, QueryShardContext queryShardContext) {
         super(null);
         this.searchShardTarget = searchShardTarget;
         this.mapperService = mapperService;
@@ -153,7 +153,7 @@ public class PercolateContext extends SearchContext {
         this.startTime = 0;
         this.numberOfShards = 0;
         this.onlyCount = true;
-        queryShardContext = new QueryShardContext(mapperService.getIndexSettings(), null, null, null, mapperService, null, null, null);
+        this.queryShardContext = queryShardContext;
     }
 
     public IndexSearcher docSearcher() {

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateContext.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.percolator;
 
-import com.carrotsearch.hppc.ObjectObjectAssociativeContainer;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
@@ -32,7 +31,6 @@ import org.elasticsearch.action.percolate.PercolateShardRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cache.recycler.PageCacheRecycler;
 import org.elasticsearch.common.ParseFieldMatcher;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.BigArrays;
@@ -46,6 +44,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
@@ -73,11 +72,11 @@ import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.rescore.RescoreSearchContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  */
@@ -99,14 +98,11 @@ public class PercolateContext extends SearchContext {
     private final long originNanoTime = System.nanoTime();
     private final long startTime;
     private final boolean onlyCount;
-    private String[] types;
-
     private Engine.Searcher docSearcher;
     private Engine.Searcher engineSearcher;
     private ContextIndexSearcher searcher;
 
     private SearchContextHighlight highlight;
-    private SearchLookup searchLookup;
     private ParsedQuery parsedQuery;
     private Query query;
     private Query percolateQuery;
@@ -115,7 +111,9 @@ public class PercolateContext extends SearchContext {
     private QuerySearchResult querySearchResult;
     private Sort sort;
     private final Map<String, FetchSubPhaseContext> subPhaseContexts = new HashMap<>();
+    private final QueryShardContext queryShardContext;
     private final Map<Class<?>, Collector> queryCollectors = new HashMap<>();
+    private SearchLookup searchLookup;
 
     public PercolateContext(PercolateShardRequest request, SearchShardTarget searchShardTarget, IndexShard indexShard,
                             IndexService indexService, PageCacheRecycler pageCacheRecycler,
@@ -126,7 +124,6 @@ public class PercolateContext extends SearchContext {
         this.fieldDataService = indexService.fieldData();
         this.mapperService = indexService.mapperService();
         this.searchShardTarget = searchShardTarget;
-        this.types = new String[]{request.documentType()};
         this.pageCacheRecycler = pageCacheRecycler;
         this.bigArrays = bigArrays.withCircuitBreaking();
         this.querySearchResult = new QuerySearchResult(0, searchShardTarget);
@@ -137,6 +134,8 @@ public class PercolateContext extends SearchContext {
         this.aliasFilter = aliasFilter;
         this.startTime = request.getStartTime();
         this.onlyCount = request.onlyCount();
+        queryShardContext = indexService.newQueryShardContext();
+        queryShardContext.setTypes(request.documentType());
     }
 
     // for testing:
@@ -154,6 +153,7 @@ public class PercolateContext extends SearchContext {
         this.startTime = 0;
         this.numberOfShards = 0;
         this.onlyCount = true;
+        queryShardContext = new QueryShardContext(mapperService.getIndexSettings(), null, null, null, mapperService, null, null, null);
     }
 
     public IndexSearcher docSearcher() {
@@ -162,10 +162,10 @@ public class PercolateContext extends SearchContext {
 
     public void initialize(Engine.Searcher docSearcher, ParsedDocument parsedDocument) {
         this.docSearcher = docSearcher;
-
         IndexReader indexReader = docSearcher.reader();
         LeafReaderContext atomicReaderContext = indexReader.leaves().get(0);
-        LeafSearchLookup leafLookup = lookup().getLeafSearchLookup(atomicReaderContext);
+        this.searchLookup = new SearchLookup(mapperService(), fieldData(),  queryShardContext.getTypes());
+        LeafSearchLookup leafLookup = searchLookup.getLeafSearchLookup(atomicReaderContext);
         leafLookup.setDocument(0);
         leafLookup.source().setSource(parsedDocument.source());
 
@@ -232,10 +232,10 @@ public class PercolateContext extends SearchContext {
 
     @Override
     public SearchLookup lookup() {
-        if (searchLookup == null) {
-            searchLookup = new SearchLookup(mapperService(), fieldData(), types);
-        }
-        return searchLookup;
+        // we cache this since it's really just a single document lookup - check the init method for details
+        assert searchLookup != null : "context is not initialized";
+        assert Arrays.equals(searchLookup.doc().getTypes(), getQueryShardContext().getTypes()) : "types mismatch - can't return lookup";
+        return this.searchLookup;
     }
 
     @Override
@@ -263,16 +263,6 @@ public class PercolateContext extends SearchContext {
     @Override
     public Query query() {
         return query;
-    }
-
-    @Override
-    public String[] types() {
-        return types;
-    }
-
-    public void types(String[] types) {
-        this.types = types;
-        searchLookup = new SearchLookup(mapperService(), fieldData(), types);
     }
 
     @Override
@@ -339,11 +329,6 @@ public class PercolateContext extends SearchContext {
     @Override
     public int numberOfShards() {
         return numberOfShards;
-    }
-
-    @Override
-    public boolean hasTypes() {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -682,6 +667,11 @@ public class PercolateContext extends SearchContext {
     @Override
     public Map<Class<?>, Collector> queryCollectors() {
         return queryCollectors;
+    }
+
+    @Override
+    public QueryShardContext getQueryShardContext() {
+        return queryShardContext;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/percolator/PercolateDocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolateDocumentParser.java
@@ -23,8 +23,6 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.percolate.PercolateShardRequest;
-import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -35,7 +33,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.DocumentMapperForType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
-import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.SearchParseElement;
 import org.elasticsearch.search.aggregations.AggregationPhase;
@@ -78,8 +75,8 @@ public class PercolateDocumentParser {
         // Some queries (function_score query when for decay functions) rely on a SearchContext being set:
         // We switch types because this context needs to be in the context of the percolate queries in the shard and
         // not the in memory percolate doc
-        String[] previousTypes = context.types();
-        context.types(new String[]{PercolatorService.TYPE_NAME});
+        String[] previousTypes = context.getQueryShardContext().getTypes();
+        context.getQueryShardContext().setTypes(PercolatorService.TYPE_NAME);
         try (XContentParser parser = XContentFactory.xContent(source).createParser(source);) {
             String currentFieldName = null;
             XContentParser.Token token;
@@ -176,7 +173,7 @@ public class PercolateDocumentParser {
         } catch (Throwable e) {
             throw new ElasticsearchParseException("failed to parse request", e);
         } finally {
-            context.types(previousTypes);
+            context.getQueryShardContext().setTypes(previousTypes);
         }
 
         if (request.docSource() != null && request.docSource().length() != 0) {

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -191,7 +191,7 @@ public class PercolatorService extends AbstractComponent implements Releasable {
         );
         SearchContext.setCurrent(context);
         try {
-            ParsedDocument parsedDocument = percolateDocumentParser.parse(request, context, percolateIndexService.mapperService(), context.getQueryShardContext());
+            ParsedDocument parsedDocument = percolateDocumentParser.parse(request, context, percolateIndexService.mapperService());
             if (context.searcher().getIndexReader().maxDoc() == 0) {
                 return new PercolateShardResponse(Lucene.EMPTY_TOP_DOCS, Collections.emptyMap(), Collections.emptyMap(), context);
             }

--- a/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
+++ b/core/src/main/java/org/elasticsearch/percolator/PercolatorService.java
@@ -169,8 +169,8 @@ public class PercolatorService extends AbstractComponent implements Releasable {
     }
 
     public PercolateShardResponse percolate(PercolateShardRequest request) throws IOException {
-        IndexService percolateIndexService = indicesService.indexServiceSafe(request.shardId().getIndex());
-        IndexShard indexShard = percolateIndexService.getShard(request.shardId().id());
+        final IndexService percolateIndexService = indicesService.indexServiceSafe(request.shardId().getIndex());
+        final IndexShard indexShard = percolateIndexService.getShard(request.shardId().id());
         indexShard.readAllowed(); // check if we can read the shard...
         PercolatorQueriesRegistry percolateQueryRegistry = indexShard.percolateRegistry();
         percolateQueryRegistry.prePercolate();
@@ -183,7 +183,7 @@ public class PercolatorService extends AbstractComponent implements Releasable {
                 indexShard.shardId().getIndex().getName(),
                 request.indices()
         );
-        Query aliasFilter = percolateIndexService.aliasFilter(indexShard.getQueryShardContext(), filteringAliases);
+        Query aliasFilter = percolateIndexService.aliasFilter(percolateIndexService.newQueryShardContext(), filteringAliases);
 
         SearchShardTarget searchShardTarget = new SearchShardTarget(clusterService.localNode().id(), request.shardId().getIndex(), request.shardId().id());
         final PercolateContext context = new PercolateContext(
@@ -191,8 +191,7 @@ public class PercolatorService extends AbstractComponent implements Releasable {
         );
         SearchContext.setCurrent(context);
         try {
-            ParsedDocument parsedDocument = percolateDocumentParser.parse(request, context, percolateIndexService.mapperService(), percolateIndexService.getQueryShardContext());
-
+            ParsedDocument parsedDocument = percolateDocumentParser.parse(request, context, percolateIndexService.mapperService(), context.getQueryShardContext());
             if (context.searcher().getIndexReader().maxDoc() == 0) {
                 return new PercolateShardResponse(Lucene.EMPTY_TOP_DOCS, Collections.emptyMap(), Collections.emptyMap(), context);
             }

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -646,8 +646,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> imp
         if (source == null) {
             return;
         }
-        final IndexShard indexShard = context.indexShard();
-        QueryShardContext queryShardContext = indexShard.getQueryShardContext();
+        QueryShardContext queryShardContext = context.getQueryShardContext();
         context.from(source.from());
         context.size(source.size());
         ObjectFloatHashMap<String> indexBoostMap = source.indexBoost();
@@ -751,7 +750,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> imp
         if (source.rescores() != null) {
             try {
                 for (RescoreBuilder<?> rescore : source.rescores()) {
-                    context.addRescore(rescore.build(context.indexShard().getQueryShardContext()));
+                    context.addRescore(rescore.build(context.getQueryShardContext()));
                 }
             } catch (IOException e) {
                 throw new SearchContextException(context, "failed to create RescoreSearchContext", e);
@@ -776,7 +775,7 @@ public class SearchService extends AbstractLifecycleComponent<SearchService> imp
         if (source.highlighter() != null) {
             HighlightBuilder highlightBuilder = source.highlighter();
             try {
-                context.highlight(highlightBuilder.build(context.indexShard().getQueryShardContext()));
+                context.highlight(highlightBuilder.build(context.getQueryShardContext()));
             } catch (IOException e) {
                 throw new SearchContextException(context, "failed to create SearchContextHighlighter", e);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -124,7 +124,7 @@ public class AggregationPhase implements SearchPhase {
         if (!globals.isEmpty()) {
             BucketCollector globalsCollector = BucketCollector.wrap(globals);
             Query query = Queries.newMatchAllQuery();
-            Query searchFilter = context.searchFilter(context.types());
+            Query searchFilter = context.searchFilter(context.getQueryShardContext().getTypes());
 
             if (searchFilter != null) {
                 BooleanQuery filtered = new BooleanQuery.Builder()

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterParser.java
@@ -39,7 +39,7 @@ public class FilterParser implements Aggregator.Parser {
 
     @Override
     public AggregatorFactory parse(String aggregationName, XContentParser parser, SearchContext context) throws IOException {
-        ParsedQuery filter = context.indexShard().getQueryShardContext().parseInnerFilter(parser);
+        ParsedQuery filter = context.getQueryShardContext().parseInnerFilter(parser);
 
         return new FilterAggregator.Factory(aggregationName, filter == null ? new MatchAllDocsQuery() : filter.query());
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersParser.java
@@ -82,7 +82,7 @@ public class FiltersParser implements Aggregator.Parser {
                         if (token == XContentParser.Token.FIELD_NAME) {
                             key = parser.currentName();
                         } else {
-                            ParsedQuery filter = context.indexShard().getQueryShardContext().parseInnerFilter(parser);
+                            ParsedQuery filter = context.getQueryShardContext().parseInnerFilter(parser);
                             filters.add(new FiltersAggregator.KeyedFilter(key, filter == null ? Queries.newMatchAllQuery() : filter.query()));
                         }
                     }
@@ -95,7 +95,7 @@ public class FiltersParser implements Aggregator.Parser {
                     keyed = false;
                     int idx = 0;
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        ParsedQuery filter = context.indexShard().getQueryShardContext().parseInnerFilter(parser);
+                        ParsedQuery filter = context.getQueryShardContext().parseInnerFilter(parser);
                         filters.add(new FiltersAggregator.KeyedFilter(String.valueOf(idx), filter == null ? Queries.newMatchAllQuery()
                                 : filter.query()));
                         idx++;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsParametersParser.java
@@ -66,7 +66,7 @@ public class SignificantTermsParametersParser extends AbstractTermsParametersPar
             if (significanceHeuristicParser != null) {
                 significanceHeuristic = significanceHeuristicParser.parse(parser, context.parseFieldMatcher(), context);
             } else if (context.parseFieldMatcher().match(currentFieldName, BACKGROUND_FILTER)) {
-                filter = context.indexShard().getQueryShardContext().parseInnerFilter(parser).query();
+                filter = context.getQueryShardContext().parseInnerFilter(parser).query();
             } else {
                 throw new SearchParseException(context, "Unknown key for a " + token + " in [" + aggregationName + "]: ["
                         + currentFieldName + "].", parser.getTokenLocation());

--- a/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/innerhits/InnerHitsParseElement.java
@@ -59,7 +59,7 @@ public class InnerHitsParseElement implements SearchParseElement {
 
     @Override
     public void parse(XContentParser parser, SearchContext searchContext) throws Exception {
-        QueryShardContext context = searchContext.indexShard().getQueryShardContext();
+        QueryShardContext context = searchContext.getQueryShardContext();
         context.reset(parser);
         Map<String, InnerHitsContext.BaseInnerHits> topLevelInnerHits = parseInnerHits(parser, context, searchContext);
         if (topLevelInnerHits != null) {

--- a/core/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/highlight/HighlighterParseElement.java
@@ -54,7 +54,7 @@ public class HighlighterParseElement implements SearchParseElement {
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
         try {
-            context.highlight(parse(parser, context.indexShard().getQueryShardContext()));
+            context.highlight(parse(parser, context.getQueryShardContext()));
         } catch (IllegalArgumentException ex) {
             throw new SearchParseException(context, "Error while trying to parse Highlighter element in request", parser.getTokenLocation());
         }

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.object.ObjectMapper;
 import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.script.ScriptService;
@@ -115,16 +116,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public int numberOfShards() {
         return in.numberOfShards();
-    }
-
-    @Override
-    public boolean hasTypes() {
-        return in.hasTypes();
-    }
-
-    @Override
-    public String[] types() {
-        return in.types();
     }
 
     @Override
@@ -525,4 +516,8 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public Map<Class<?>, Collector> queryCollectors() { return in.queryCollectors();}
 
+    @Override
+    public QueryShardContext getQueryShardContext() {
+        return in.getQueryShardContext();
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -72,12 +72,10 @@ public abstract class SearchContext implements Releasable {
 
     public static void setCurrent(SearchContext value) {
         current.set(value);
-        QueryShardContext.setTypes(value.types());
     }
 
     public static void removeCurrent() {
         current.remove();
-        QueryShardContext.removeTypes();
     }
 
     public static SearchContext current() {
@@ -133,10 +131,6 @@ public abstract class SearchContext implements Releasable {
     public abstract SearchShardTarget shardTarget();
 
     public abstract int numberOfShards();
-
-    public abstract boolean hasTypes();
-
-    public abstract String[] types();
 
     public abstract float queryBoost();
 
@@ -378,5 +372,7 @@ public abstract class SearchContext implements Releasable {
          */
         CONTEXT
     }
+
+    public abstract QueryShardContext getQueryShardContext();
 
 }

--- a/core/src/main/java/org/elasticsearch/search/lookup/DocLookup.java
+++ b/core/src/main/java/org/elasticsearch/search/lookup/DocLookup.java
@@ -51,4 +51,8 @@ public class DocLookup {
     public LeafDocLookup getLeafDocLookup(LeafReaderContext context) {
         return new LeafDocLookup(mapperService, fieldDataService, types, context);
     }
+
+    public String[] getTypes() {
+        return types;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/query/PostFilterParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/query/PostFilterParseElement.java
@@ -30,7 +30,7 @@ public class PostFilterParseElement implements SearchParseElement {
 
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
-        ParsedQuery postFilter = context.indexShard().getQueryShardContext().parseInnerFilter(parser);
+        ParsedQuery postFilter = context.getQueryShardContext().parseInnerFilter(parser);
         if (postFilter != null) {
             context.parsedPostFilter(postFilter);
         }

--- a/core/src/main/java/org/elasticsearch/search/query/QueryParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QueryParseElement.java
@@ -30,6 +30,6 @@ public class QueryParseElement implements SearchParseElement {
 
     @Override
     public void parse(XContentParser parser, SearchContext context) throws Exception {
-        context.parsedQuery(context.indexShard().getQueryShardContext().parse(parser));
+        context.parsedQuery(context.getQueryShardContext().parse(parser));
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/rescore/RescoreParseElement.java
+++ b/core/src/main/java/org/elasticsearch/search/rescore/RescoreParseElement.java
@@ -36,10 +36,10 @@ public class RescoreParseElement implements SearchParseElement {
     public void parse(XContentParser parser, SearchContext context) throws Exception {
         if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
             while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                context.addRescore(parseSingleRescoreContext(parser, context.indexShard().getQueryShardContext()));
+                context.addRescore(parseSingleRescoreContext(parser, context.getQueryShardContext()));
             }
         } else {
-            context.addRescore(parseSingleRescoreContext(parser, context.indexShard().getQueryShardContext()));
+            context.addRescore(parseSingleRescoreContext(parser, context.getQueryShardContext()));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.query.ParsedQuery;
-import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
@@ -65,7 +64,7 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
     /*
      * More Ideas:
      *   - add ability to find whitespace problems -> we can build a poor mans decompounder with our index based on a automaton?
-     *   - add ability to build different error models maybe based on a confusion matrix?   
+     *   - add ability to build different error models maybe based on a confusion matrix?
      *   - try to combine a token with its subsequent token to find / detect word splits (optional)
      *      - for this to work we need some way to defined the position length of a candidate
      *   - phonetic filters could be interesting here too for candidate selection
@@ -84,8 +83,8 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
             DirectSpellChecker directSpellChecker = SuggestUtils.getDirectSpellChecker(generator);
             Terms terms = MultiFields.getTerms(indexReader, generator.field());
             if (terms !=  null) {
-                gens.add(new DirectCandidateGenerator(directSpellChecker, generator.field(), generator.suggestMode(), 
-                        indexReader, realWordErrorLikelihood, generator.size(), generator.preFilter(), generator.postFilter(), terms));    
+                gens.add(new DirectCandidateGenerator(directSpellChecker, generator.field(), generator.suggestMode(),
+                        indexReader, realWordErrorLikelihood, generator.size(), generator.preFilter(), generator.postFilter(), terms));
             }
         }
         final String suggestField = suggestion.getField();
@@ -119,8 +118,7 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
                     final ExecutableScript executable = scriptService.executable(collateScript, vars);
                     final BytesReference querySource = (BytesReference) executable.run();
                     IndexService indexService = indicesService.indexService(suggestion.getIndex());
-                    IndexShard shard = indexService.getShard(suggestion.getShard());
-                    final ParsedQuery parsedQuery = shard.getQueryShardContext().parse(querySource);
+                    final ParsedQuery parsedQuery = indexService.newQueryShardContext().parse(querySource);
                     collateMatch = Lucene.exists(searcher, parsedQuery.query());
                 }
                 if (!collateMatch && !collatePrune) {
@@ -152,7 +150,7 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
     ScriptService scriptService() {
         return scriptService;
     }
-    
+
     @Override
     public SuggestContextParser getContextParser() {
         return new PhraseSuggestParser(this);

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -42,7 +42,6 @@ class PhraseSuggestionContext extends SuggestionContext {
     private BytesRef preTag;
     private BytesRef postTag;
     private CompiledScript collateQueryScript;
-    private CompiledScript collateFilterScript;
     private Map<String, Object> collateScriptParams = new HashMap<>(1);
 
     private WordScorer.WordScorerFactory scorer;

--- a/core/src/test/java/org/elasticsearch/ESExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ESExceptionTests.java
@@ -194,7 +194,7 @@ public class ESExceptionTests extends ESTestCase {
 
     public void testToXContent() throws IOException {
         {
-            ElasticsearchException ex = new SearchParseException(new TestSearchContext(), "foo", new XContentLocation(1,0));
+            ElasticsearchException ex = new SearchParseException(new TestSearchContext(null), "foo", new XContentLocation(1,0));
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
             ex.toXContent(builder, PARAMS);

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -439,7 +439,7 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testSearchParseException() throws IOException {
-        SearchContext ctx = new TestSearchContext();
+        SearchContext ctx = new TestSearchContext(null);
         SearchParseException ex = serialize(new SearchParseException(ctx, "foo", new XContentLocation(66, 666)));
         assertEquals("foo", ex.getMessage());
         assertEquals(66, ex.getLineNumber());

--- a/core/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -39,7 +39,6 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -87,17 +86,17 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertThat(indexService.getMetaData().getAliases().containsKey("dogs"), equalTo(true));
         assertThat(indexService.getMetaData().getAliases().containsKey("turtles"), equalTo(false));
 
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "cats").toString(), equalTo("animal:cat"));
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "cats", "dogs").toString(), equalTo("animal:cat animal:dog"));
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "cats").toString(), equalTo("animal:cat"));
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "cats", "dogs").toString(), equalTo("animal:cat animal:dog"));
 
         // Non-filtering alias should turn off all filters because filters are ORed
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "all"), nullValue());
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "cats", "all"), nullValue());
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "all", "cats"), nullValue());
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "all"), nullValue());
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "cats", "all"), nullValue());
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "all", "cats"), nullValue());
 
         add(indexService, "cats", filter(termQuery("animal", "feline")));
         add(indexService, "dogs", filter(termQuery("animal", "canine")));
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "dogs", "cats").toString(), equalTo("animal:canine animal:feline"));
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "dogs", "cats").toString(), equalTo("animal:canine animal:feline"));
     }
 
     public void testAliasFilters() throws Exception {
@@ -107,14 +106,14 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         add(indexService, "cats", filter(termQuery("animal", "cat")));
         add(indexService, "dogs", filter(termQuery("animal", "dog")));
 
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext()), nullValue());
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "dogs").toString(), equalTo("animal:dog"));
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "dogs", "cats").toString(), equalTo("animal:dog animal:cat"));
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext()), nullValue());
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "dogs").toString(), equalTo("animal:dog"));
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "dogs", "cats").toString(), equalTo("animal:dog animal:cat"));
 
         add(indexService, "cats", filter(termQuery("animal", "feline")));
         add(indexService, "dogs", filter(termQuery("animal", "canine")));
 
-        assertThat(indexService.aliasFilter(shard.getQueryShardContext(), "dogs", "cats").toString(), equalTo("animal:canine animal:feline"));
+        assertThat(indexService.aliasFilter(indexService.newQueryShardContext(), "dogs", "cats").toString(), equalTo("animal:canine animal:feline"));
     }
 
     public void testRemovedAliasFilter() throws Exception {
@@ -124,7 +123,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         add(indexService, "cats", filter(termQuery("animal", "cat")));
         remove(indexService, "cats");
         try {
-            indexService.aliasFilter(shard.getQueryShardContext(), "cats");
+            indexService.aliasFilter(indexService.newQueryShardContext(), "cats");
             fail("Expected InvalidAliasNameException");
         } catch (InvalidAliasNameException e) {
             assertThat(e.getMessage(), containsString("Invalid alias name [cats]"));
@@ -139,7 +138,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         add(indexService, "dogs", filter(termQuery("animal", "dog")));
 
         try {
-            indexService.aliasFilter(shard.getQueryShardContext(), "unknown");
+            indexService.aliasFilter(indexService.newQueryShardContext(), "unknown");
             fail();
         } catch (InvalidAliasNameException e) {
             // all is well

--- a/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/date/SimpleDateMappingTests.java
@@ -260,7 +260,7 @@ public class SimpleDateMappingTests extends ESSingleNodeTestCase {
 
         NumericRangeQuery<Long> rangeQuery;
         try {
-            SearchContext.setCurrent(new TestSearchContext());
+            SearchContext.setCurrent(new TestSearchContext(null));
             rangeQuery = (NumericRangeQuery<Long>) defaultMapper.mappers().smartNameFieldMapper("date_field").fieldType().rangeQuery("10:00:00", "11:00:00", true, true).rewrite(null);
         } finally {
             SearchContext.removeCurrent();
@@ -286,7 +286,7 @@ public class SimpleDateMappingTests extends ESSingleNodeTestCase {
 
         NumericRangeQuery<Long> rangeQuery;
         try {
-            SearchContext.setCurrent(new TestSearchContext());
+            SearchContext.setCurrent(new TestSearchContext(null));
             rangeQuery = (NumericRangeQuery<Long>) defaultMapper.mappers().smartNameFieldMapper("date_field").fieldType().rangeQuery("Jan 02 10:00:00", "Jan 02 11:00:00", true, true).rewrite(null);
         } finally {
             SearchContext.removeCurrent();

--- a/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/SimpleExternalMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/externalvalues/SimpleExternalMappingTests.java
@@ -63,7 +63,7 @@ public class SimpleExternalMappingTests extends ESSingleNodeTestCase {
                 Collections.singletonMap(ExternalMetadataMapper.CONTENT_TYPE, new ExternalMetadataMapper.TypeParser()));
 
         DocumentMapperParser parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
         DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(
                 XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject(ExternalMetadataMapper.CONTENT_TYPE)
@@ -109,7 +109,7 @@ public class SimpleExternalMappingTests extends ESSingleNodeTestCase {
         MapperRegistry mapperRegistry = new MapperRegistry(mapperParsers, Collections.emptyMap());
 
         DocumentMapperParser parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
 
         DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(
                 XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
@@ -168,7 +168,7 @@ public class SimpleExternalMappingTests extends ESSingleNodeTestCase {
         MapperRegistry mapperRegistry = new MapperRegistry(mapperParsers, Collections.emptyMap());
 
         DocumentMapperParser parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
 
         DocumentMapper documentMapper = parser.parse("type", new CompressedXContent(
                 XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")

--- a/core/src/test/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/internal/FieldNamesFieldMapperTests.java
@@ -236,9 +236,9 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
         IndicesModule indicesModule = new IndicesModule();
         indicesModule.registerMetadataMapper("_dummy", new DummyMetadataFieldMapper.TypeParser());
         final MapperRegistry mapperRegistry = indicesModule.getMapperRegistry();
-        MapperService mapperService = new MapperService(indexService.getIndexSettings(), indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+        MapperService mapperService = new MapperService(indexService.getIndexSettings(), indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
         DocumentMapperParser parser = new DocumentMapperParser(indexService.getIndexSettings(), mapperService,
-                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().endObject().string();
         DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
         ParsedDocument parsedDocument = mapper.parse("index", "type", "id", new BytesArray("{}"));

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractQueryTestCase.java
@@ -332,15 +332,14 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
     }
 
     protected void setSearchContext(String[] types) {
-        TestSearchContext testSearchContext = new TestSearchContext();
-        testSearchContext.setTypes(types);
+        TestSearchContext testSearchContext = new TestSearchContext(queryShardContext);
+        testSearchContext.getQueryShardContext().setTypes(types);
         SearchContext.setCurrent(testSearchContext);
     }
 
     @After
     public void afterTest() {
         clientInvocationHandler.delegate = null;
-        QueryShardContext.removeTypes();
         SearchContext.removeCurrent();
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
@@ -79,7 +79,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
     protected void setSearchContext(String[] types) {
         final MapperService mapperService = queryShardContext().getMapperService();
         final IndexFieldDataService fieldData = indexFieldDataService();
-        TestSearchContext testSearchContext = new TestSearchContext() {
+        TestSearchContext testSearchContext = new TestSearchContext(queryShardContext()) {
 
             @Override
             public MapperService mapperService() {
@@ -91,7 +91,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
                 return fieldData; // need to build / parse inner hits sort fields
             }
         };
-        testSearchContext.setTypes(types);
+        testSearchContext.getQueryShardContext().setTypes(types);
         SearchContext.setCurrent(testSearchContext);
     }
 
@@ -192,11 +192,12 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
 
     public void testToQueryInnerQueryType() throws IOException {
         String[] searchTypes = new String[]{CHILD_TYPE};
-        QueryShardContext.setTypes(searchTypes);
+        QueryShardContext shardContext = createShardContext();
+        shardContext.setTypes(searchTypes);
         HasParentQueryBuilder hasParentQueryBuilder = new HasParentQueryBuilder(PARENT_TYPE, new IdsQueryBuilder().addIds("id"));
-        Query query = hasParentQueryBuilder.toQuery(createShardContext());
+        Query query = hasParentQueryBuilder.toQuery(shardContext);
         //verify that the context types are still the same as the ones we previously set
-        assertThat(QueryShardContext.getTypes(), equalTo(searchTypes));
+        assertThat(shardContext.getTypes(), equalTo(searchTypes));
         HasChildQueryBuilderTests.assertLateParsingQuery(query, PARENT_TYPE, "id");
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -60,7 +60,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
     protected void setSearchContext(String[] types) {
         final MapperService mapperService = queryShardContext().getMapperService();
         final IndexFieldDataService fieldData = indexFieldDataService();
-        TestSearchContext testSearchContext = new TestSearchContext() {
+        TestSearchContext testSearchContext = new TestSearchContext(queryShardContext()) {
 
             @Override
             public MapperService mapperService() {
@@ -72,7 +72,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
                 return fieldData; // need to build / parse inner hits sort fields
             }
         };
-        testSearchContext.setTypes(types);
+        testSearchContext.getQueryShardContext().setTypes(types);
         SearchContext.setCurrent(testSearchContext);
     }
 
@@ -139,45 +139,45 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
 
     public void testFromJson() throws IOException {
         String json =
-                "{\n" + 
-                "  \"nested\" : {\n" + 
-                "    \"query\" : {\n" + 
-                "      \"bool\" : {\n" + 
-                "        \"must\" : [ {\n" + 
-                "          \"match\" : {\n" + 
-                "            \"obj1.name\" : {\n" + 
-                "              \"query\" : \"blue\",\n" + 
-                "              \"type\" : \"boolean\",\n" + 
-                "              \"operator\" : \"OR\",\n" + 
-                "              \"slop\" : 0,\n" + 
-                "              \"prefix_length\" : 0,\n" + 
-                "              \"max_expansions\" : 50,\n" + 
-                "              \"fuzzy_transpositions\" : true,\n" + 
-                "              \"lenient\" : false,\n" + 
-                "              \"zero_terms_query\" : \"NONE\",\n" + 
-                "              \"boost\" : 1.0\n" + 
-                "            }\n" + 
-                "          }\n" + 
-                "        }, {\n" + 
-                "          \"range\" : {\n" + 
-                "            \"obj1.count\" : {\n" + 
-                "              \"from\" : 5,\n" + 
-                "              \"to\" : null,\n" + 
-                "              \"include_lower\" : false,\n" + 
-                "              \"include_upper\" : true,\n" + 
-                "              \"boost\" : 1.0\n" + 
-                "            }\n" + 
-                "          }\n" + 
-                "        } ],\n" + 
-                "        \"disable_coord\" : false,\n" + 
-                "        \"adjust_pure_negative\" : true,\n" + 
-                "        \"boost\" : 1.0\n" + 
-                "      }\n" + 
-                "    },\n" + 
-                "    \"path\" : \"obj1\",\n" + 
-                "    \"score_mode\" : \"avg\",\n" + 
-                "    \"boost\" : 1.0\n" + 
-                "  }\n" + 
+                "{\n" +
+                "  \"nested\" : {\n" +
+                "    \"query\" : {\n" +
+                "      \"bool\" : {\n" +
+                "        \"must\" : [ {\n" +
+                "          \"match\" : {\n" +
+                "            \"obj1.name\" : {\n" +
+                "              \"query\" : \"blue\",\n" +
+                "              \"type\" : \"boolean\",\n" +
+                "              \"operator\" : \"OR\",\n" +
+                "              \"slop\" : 0,\n" +
+                "              \"prefix_length\" : 0,\n" +
+                "              \"max_expansions\" : 50,\n" +
+                "              \"fuzzy_transpositions\" : true,\n" +
+                "              \"lenient\" : false,\n" +
+                "              \"zero_terms_query\" : \"NONE\",\n" +
+                "              \"boost\" : 1.0\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }, {\n" +
+                "          \"range\" : {\n" +
+                "            \"obj1.count\" : {\n" +
+                "              \"from\" : 5,\n" +
+                "              \"to\" : null,\n" +
+                "              \"include_lower\" : false,\n" +
+                "              \"include_upper\" : true,\n" +
+                "              \"boost\" : 1.0\n" +
+                "            }\n" +
+                "          }\n" +
+                "        } ],\n" +
+                "        \"disable_coord\" : false,\n" +
+                "        \"adjust_pure_negative\" : true,\n" +
+                "        \"boost\" : 1.0\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"path\" : \"obj1\",\n" +
+                "    \"score_mode\" : \"avg\",\n" +
+                "    \"boost\" : 1.0\n" +
+                "  }\n" +
                 "}";
 
         NestedQueryBuilder parsed = (NestedQueryBuilder) parseQuery(json);

--- a/core/src/test/java/org/elasticsearch/index/query/ParentIdQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ParentIdQueryBuilderTests.java
@@ -64,7 +64,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
     protected void setSearchContext(String[] types) {
         final MapperService mapperService = queryShardContext().getMapperService();
         final IndexFieldDataService fieldData = indexFieldDataService();
-        TestSearchContext testSearchContext = new TestSearchContext() {
+        TestSearchContext testSearchContext = new TestSearchContext(queryShardContext()) {
 
             @Override
             public MapperService mapperService() {
@@ -76,7 +76,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
                 return fieldData; // need to build / parse inner hits sort fields
             }
         };
-        testSearchContext.setTypes(types);
+        testSearchContext.getQueryShardContext().setTypes(types);
         SearchContext.setCurrent(testSearchContext);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/plugin/CustomQueryParserIT.java
+++ b/core/src/test/java/org/elasticsearch/index/query/plugin/CustomQueryParserIT.java
@@ -68,7 +68,7 @@ public class CustomQueryParserIT extends ESIntegTestCase {
 
     private static QueryShardContext queryShardContext() {
         IndicesService indicesService = internalCluster().getDataNodeInstance(IndicesService.class);
-        return indicesService.indexServiceSafe("index").getQueryShardContext();
+        return indicesService.indexServiceSafe("index").newQueryShardContext();
     }
 
     //see #11120

--- a/core/src/test/java/org/elasticsearch/index/search/MultiMatchQueryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/MultiMatchQueryTests.java
@@ -69,7 +69,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
     }
 
     public void testCrossFieldMultiMatchQuery() throws IOException {
-        QueryShardContext queryShardContext = indexService.getShard(0).getQueryShardContext();
+        QueryShardContext queryShardContext = indexService.newQueryShardContext();
         queryShardContext.setAllowUnmappedFields(true);
         Query parsedQuery = multiMatchQuery("banon").field("name.first", 2).field("name.last", 3).field("foobar").type(MultiMatchQueryBuilder.Type.CROSS_FIELDS).toQuery(queryShardContext);
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {

--- a/core/src/test/java/org/elasticsearch/percolator/PercolateDocumentParserTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolateDocumentParserTests.java
@@ -104,7 +104,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
                 .endObject();
         Mockito.when(request.source()).thenReturn(source.bytes());
 
-        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService);
+        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService, queryShardContext);
         ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
     }
@@ -123,7 +123,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
                 .endObject();
         Mockito.when(request.source()).thenReturn(source.bytes());
 
-        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService);
+        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService, queryShardContext);
         ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
         assertThat(context.percolateQuery(), equalTo(new TermQuery(new Term("field1", "value1"))));
@@ -147,7 +147,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         Mockito.when(request.source()).thenReturn(source.bytes());
         Mockito.when(request.docSource()).thenReturn(docSource.bytes());
 
-        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService);
+        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService, queryShardContext);
         ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
         assertThat(context.percolateQuery(), equalTo(new TermQuery(new Term("field1", "value1"))));
@@ -174,7 +174,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         Mockito.when(request.source()).thenReturn(source.bytes());
         Mockito.when(request.docSource()).thenReturn(docSource.bytes());
 
-        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService);
+        PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService, queryShardContext);
         try {
             parser.parse(request, context, mapperService, queryShardContext);
         } catch (IllegalArgumentException e) {

--- a/core/src/test/java/org/elasticsearch/percolator/PercolateDocumentParserTests.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolateDocumentParserTests.java
@@ -105,7 +105,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         Mockito.when(request.source()).thenReturn(source.bytes());
 
         PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService, queryShardContext);
-        ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
+        ParsedDocument parsedDocument = parser.parse(request, context, mapperService);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
     }
 
@@ -124,7 +124,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         Mockito.when(request.source()).thenReturn(source.bytes());
 
         PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService, queryShardContext);
-        ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
+        ParsedDocument parsedDocument = parser.parse(request, context, mapperService);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
         assertThat(context.percolateQuery(), equalTo(new TermQuery(new Term("field1", "value1"))));
         assertThat(context.trackScores(), is(true));
@@ -148,7 +148,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
         Mockito.when(request.docSource()).thenReturn(docSource.bytes());
 
         PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService, queryShardContext);
-        ParsedDocument parsedDocument = parser.parse(request, context, mapperService, queryShardContext);
+        ParsedDocument parsedDocument = parser.parse(request, context, mapperService);
         assertThat(parsedDocument.rootDoc().get("field1"), equalTo("value1"));
         assertThat(context.percolateQuery(), equalTo(new TermQuery(new Term("field1", "value1"))));
         assertThat(context.trackScores(), is(true));
@@ -176,7 +176,7 @@ public class PercolateDocumentParserTests extends ESTestCase {
 
         PercolateContext context = new PercolateContext(request, new SearchShardTarget("_node", new Index("_index", "_na_"), 0), mapperService, queryShardContext);
         try {
-            parser.parse(request, context, mapperService, queryShardContext);
+            parser.parse(request, context, mapperService);
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), equalTo("Can't specify the document to percolate in the source of the request and as document id"));
         }

--- a/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
+++ b/core/src/test/java/org/elasticsearch/percolator/PercolatorIT.java
@@ -1351,12 +1351,7 @@ public class PercolatorIT extends ESIntegTestCase {
         assertThat(convertFromTextArray(response.getMatches(), "test"), arrayContainingInAnyOrder("1", "2", "3", "4", "5"));
 
         PercolateResponse.Match[] matches = response.getMatches();
-        Arrays.sort(matches, new Comparator<PercolateResponse.Match>() {
-            @Override
-            public int compare(PercolateResponse.Match a, PercolateResponse.Match b) {
-                return a.getId().compareTo(b.getId());
-            }
-        });
+        Arrays.sort(matches, (a, b) -> a.getId().compareTo(b.getId()));
 
         assertThat(matches[0].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick <em>brown</em> <em>fox</em> jumps over the lazy dog"));
         assertThat(matches[1].getHighlightFields().get("field1").fragments()[0].string(), equalTo("The quick brown fox jumps over the <em>lazy</em> <em>dog</em>"));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParserTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParserTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.test.TestSearchContext;
 
 public class GeoHashGridParserTests extends ESTestCase {
     public void testParseValidFromInts() throws Exception {
-        SearchContext searchContext = new TestSearchContext();
+        SearchContext searchContext = new TestSearchContext(null);
         int precision = randomIntBetween(1, 12);
         XContentParser stParser = JsonXContent.jsonXContent.createParser(
                 "{\"field\":\"my_loc\", \"precision\":" + precision + ", \"size\": 500, \"shard_size\": 550}");
@@ -37,7 +37,7 @@ public class GeoHashGridParserTests extends ESTestCase {
     }
 
     public void testParseValidFromStrings() throws Exception {
-        SearchContext searchContext = new TestSearchContext();
+        SearchContext searchContext = new TestSearchContext(null);
         int precision = randomIntBetween(1, 12);
         XContentParser stParser = JsonXContent.jsonXContent.createParser(
                 "{\"field\":\"my_loc\", \"precision\":\"" + precision + "\", \"size\": \"500\", \"shard_size\": \"550\"}");
@@ -47,7 +47,7 @@ public class GeoHashGridParserTests extends ESTestCase {
     }
 
     public void testParseErrorOnNonIntPrecision() throws Exception {
-        SearchContext searchContext = new TestSearchContext();
+        SearchContext searchContext = new TestSearchContext(null);
         XContentParser stParser = JsonXContent.jsonXContent.createParser("{\"field\":\"my_loc\", \"precision\":\"2.0\"}");
         GeoHashGridParser parser = new GeoHashGridParser();
         try {
@@ -59,7 +59,7 @@ public class GeoHashGridParserTests extends ESTestCase {
     }
 
     public void testParseErrorOnBooleanPrecision() throws Exception {
-        SearchContext searchContext = new TestSearchContext();
+        SearchContext searchContext = new TestSearchContext(null);
         XContentParser stParser = JsonXContent.jsonXContent.createParser("{\"field\":\"my_loc\", \"precision\":false}");
         GeoHashGridParser parser = new GeoHashGridParser();
         try {
@@ -71,7 +71,7 @@ public class GeoHashGridParserTests extends ESTestCase {
     }
 
     public void testParseErrorOnPrecisionOutOfRange() throws Exception {
-        SearchContext searchContext = new TestSearchContext();
+        SearchContext searchContext = new TestSearchContext(null);
         XContentParser stParser = JsonXContent.jsonXContent.createParser("{\"field\":\"my_loc\", \"precision\":\"13\"}");
         GeoHashGridParser parser = new GeoHashGridParser();
         try {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -69,6 +69,11 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  */
 public class SignificanceHeuristicTests extends ESTestCase {
     static class SignificantTermsTestSearchContext extends TestSearchContext {
+
+        public SignificantTermsTestSearchContext() {
+            super(null);
+        }
+
         @Override
         public int numberOfShards() {
             return 1;

--- a/core/src/test/java/org/elasticsearch/search/fetch/FieldDataFieldsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/FieldDataFieldsTests.java
@@ -40,7 +40,7 @@ public class FieldDataFieldsTests extends ESTestCase {
         parser.nextToken();
         parser.nextToken();
         parser.nextToken();
-        SearchContext context = new TestSearchContext();
+        SearchContext context = new TestSearchContext(null);
         parseElement.parse(parser, context);
     }
 
@@ -52,7 +52,7 @@ public class FieldDataFieldsTests extends ESTestCase {
         parser.nextToken();
         parser.nextToken();
         parser.nextToken();
-        SearchContext context = new TestSearchContext();
+        SearchContext context = new TestSearchContext(null);
         parseElement.parse(parser, context);
     }
 
@@ -69,7 +69,7 @@ public class FieldDataFieldsTests extends ESTestCase {
         parser.nextToken();
         parser.nextToken();
         parser.nextToken();
-        SearchContext context = new TestSearchContext();
+        SearchContext context = new TestSearchContext(null);
         try {
             parseElement.parse(parser, context);
             fail("Expected IllegalStateException");

--- a/core/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class QueryPhaseTests extends ESTestCase {
 
     private void countTestCase(Query query, IndexReader reader, boolean shouldCollect) throws Exception {
-        TestSearchContext context = new TestSearchContext();
+        TestSearchContext context = new TestSearchContext(null);
         context.parsedQuery(new ParsedQuery(query));
         context.setSize(0);
 
@@ -120,7 +120,7 @@ public class QueryPhaseTests extends ESTestCase {
     }
 
     public void testPostFilterDisablesCountOptimization() throws Exception {
-        TestSearchContext context = new TestSearchContext();
+        TestSearchContext context = new TestSearchContext(null);
         context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
         context.setSize(0);
 
@@ -143,7 +143,7 @@ public class QueryPhaseTests extends ESTestCase {
     }
 
     public void testMinScoreDisablesCountOptimization() throws Exception {
-        TestSearchContext context = new TestSearchContext();
+        TestSearchContext context = new TestSearchContext(null);
         context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
         context.setSize(0);
 

--- a/core/src/test/java/org/elasticsearch/search/sort/SortParserTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/SortParserTests.java
@@ -36,7 +36,7 @@ public class SortParserTests extends ESSingleNodeTestCase {
         mapping.startObject().startObject("type").startObject("properties").startObject("location").field("type", "geo_point").endObject().endObject().endObject().endObject();
         IndexService indexService = createIndex("testidx", Settings.settingsBuilder().build(), "type", mapping);
         TestSearchContext context = (TestSearchContext) createSearchContext(indexService);
-        context.setTypes("type");
+        context.getQueryShardContext().setTypes("type");
 
         XContentBuilder sortBuilder = jsonBuilder();
         sortBuilder.startObject();

--- a/plugins/mapper-murmur3/src/test/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapperTests.java
+++ b/plugins/mapper-murmur3/src/test/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapperTests.java
@@ -60,7 +60,7 @@ public class Murmur3FieldMapperTests extends ESSingleNodeTestCase {
                 Collections.singletonMap(Murmur3FieldMapper.CONTENT_TYPE, new Murmur3FieldMapper.TypeParser()),
                 Collections.emptyMap());
         parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-        indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+        indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
     }
 
     public void testDefaults() throws Exception {
@@ -136,7 +136,7 @@ public class Murmur3FieldMapperTests extends ESSingleNodeTestCase {
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
         indexService = createIndex("test_bwc", settings);
         parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
             .startObject("properties").startObject("field")
                 .field("type", "murmur3")
@@ -152,7 +152,7 @@ public class Murmur3FieldMapperTests extends ESSingleNodeTestCase {
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_1_4_2.id).build();
         indexService = createIndex("test_bwc", settings);
         parser = new DocumentMapperParser(indexService.getIndexSettings(), indexService.mapperService(),
-        indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+        indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
             .startObject("properties").startObject("field")
             .field("type", "murmur3")

--- a/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
+++ b/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
@@ -66,7 +66,7 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
         Map<String, MetadataFieldMapper.TypeParser> metadataMappers = new HashMap<>();
         IndicesModule indices = new IndicesModule();
         indices.registerMetadataMapper(SizeFieldMapper.NAME, new SizeFieldMapper.TypeParser());
-        mapperService = new MapperService(indexService.getIndexSettings(), indexService.analysisService(), indexService.similarityService(), indices.getMapperRegistry(), indexService::getQueryShardContext);
+        mapperService = new MapperService(indexService.getIndexSettings(), indexService.analysisService(), indexService.similarityService(), indices.getMapperRegistry(), indexService::newQueryShardContext);
         parser = mapperService.documentMapperParser();
     }
 
@@ -98,7 +98,7 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
                 Collections.emptyMap(),
                 Collections.singletonMap(SizeFieldMapper.NAME, new SizeFieldMapper.TypeParser()));
         parser = new DocumentMapperParser(indexService.getIndexSettings(), mapperService,
-                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::getQueryShardContext);
+                indexService.analysisService(), indexService.similarityService(), mapperRegistry, indexService::newQueryShardContext);
         DocumentMapper docMapper = parser.parse("type", new CompressedXContent(mapping));
 
         BytesReference source = XContentFactory.jsonBuilder()


### PR DESCRIPTION
IndexShard currently holds an arbitraritly used `getQueryShardContext` that comes
out of a ThreadLocal. It's usage is undefined and arbitraty since there is also
such a method with different semantics on `IndexService` This commit removes the threadLocal on
IndexShard as well as on the context itself. It's types are now a member and the QueryShardContext
lifecycle is managed byt SearchContext which passes the types on from the SearchRequest.

@colings86 can you take a look at this?
