### PR TITLE
Log warning if max file descriptors too low

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.store.FsDirectoryService;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.fs.FsProbe;
 import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.monitor.process.ProcessProbe;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -221,6 +222,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
 
         maybeLogPathDetails();
         maybeLogHeapDetails();
+        maybeWarnFileDescriptors();
 
         applySegmentInfosTrace(settings);
     }
@@ -311,6 +313,20 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         ByteSizeValue maxHeapSize = jvmInfo.getMem().getHeapMax();
         String useCompressedOops = jvmInfo.useCompressedOops();
         logger.info("heap size [{}], compressed ordinary object pointers [{}]", maxHeapSize, useCompressedOops);
+    }
+
+    private void maybeWarnFileDescriptors() {
+        long maxFileDescriptorCount = ProcessProbe.getInstance().getMaxFileDescriptorCount();
+        if (maxFileDescriptorCount == -1) {
+            return;
+        }
+        int fileDescriptorCountThreshold = (1 << 16);
+        if (maxFileDescriptorCount < fileDescriptorCountThreshold) {
+            logger.warn(
+                    "max file descriptors [{}] for elasticsearch process likely too low, consider increasing to [{}]",
+                    maxFileDescriptorCount,
+                    fileDescriptorCountThreshold);
+        }
     }
 
     @SuppressForbidden(reason = "System.out.*")

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -323,7 +323,7 @@ public class NodeEnvironment extends AbstractComponent implements Closeable {
         int fileDescriptorCountThreshold = (1 << 16);
         if (maxFileDescriptorCount < fileDescriptorCountThreshold) {
             logger.warn(
-                    "max file descriptors [{}] for elasticsearch process likely too low, consider increasing to [{}]",
+                    "max file descriptors [{}] for elasticsearch process likely too low, consider increasing to at least [{}]",
                     maxFileDescriptorCount,
                     fileDescriptorCountThreshold);
         }


### PR DESCRIPTION
This commit adds logging for a warning message if the max file
descriptor count is too low.
