### PR TITLE
Register bootstrap settings

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.logging.log4j.LogConfigurator;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -148,10 +149,11 @@ final class Bootstrap {
     }
 
     private void setup(boolean addShutdownHook, Settings settings, Environment environment) throws Exception {
-        initializeNatives(environment.tmpFile(),
-                          settings.getAsBoolean("bootstrap.mlockall", false),
-                          settings.getAsBoolean("bootstrap.seccomp", true),
-                          settings.getAsBoolean("bootstrap.ctrlhandler", true));
+        initializeNatives(
+                environment.tmpFile(),
+                BootstrapSettings.MLOCKALL_SETTING.get(settings),
+                BootstrapSettings.SECCOMP_SETTING.get(settings),
+                BootstrapSettings.CTRLHANDLER_SETTING.get(settings));
 
         // initialize probes before the security manager is installed
         initializeProbes();
@@ -186,22 +188,11 @@ final class Bootstrap {
         node = new Node(nodeSettings);
     }
 
-    /**
-     * option for elasticsearch.yml etc to turn off our security manager completely,
-     * for example if you want to have your own configuration or just disable.
-     */
-    // TODO: remove this: http://www.openbsd.org/papers/hackfest2015-pledge/mgp00005.jpg
-    static final String SECURITY_SETTING = "security.manager.enabled";
-    /**
-     * option for elasticsearch.yml to fully respect the system policy, including bad defaults
-     * from java.
-     */
-    // TODO: remove this hack when insecure defaults are removed from java
-    static final String SECURITY_FILTER_BAD_DEFAULTS_SETTING = "security.manager.filter_bad_defaults";
+
 
     private void setupSecurity(Settings settings, Environment environment) throws Exception {
-        if (settings.getAsBoolean(SECURITY_SETTING, true)) {
-            Security.configure(environment, settings.getAsBoolean(SECURITY_FILTER_BAD_DEFAULTS_SETTING, true));
+        if (BootstrapSettings.SECURITY_MANAGER_ENABLED_SETTING.get(settings)) {
+            Security.configure(environment, BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING.get(settings));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapSettings.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapSettings.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Scope;
+
+public class BootstrapSettings {
+
+    // TODO: remove this: http://www.openbsd.org/papers/hackfest2015-pledge/mgp00005.jpg
+    /**
+     * option to turn off our security manager completely, for example
+     * if you want to have your own configuration or just disable
+     */
+    public static final Setting<Boolean> SECURITY_MANAGER_ENABLED_SETTING =
+            Setting.boolSetting("security.manager.enabled", true, false, Scope.CLUSTER);
+
+    // TODO: remove this hack when insecure defaults are removed from java
+    public static final Setting<Boolean> SECURITY_FILTER_BAD_DEFAULTS_SETTING =
+            Setting.boolSetting("security.manager.filter_bad_defaults", true, false, Scope.CLUSTER);
+
+    public static final Setting<Boolean> MLOCKALL_SETTING = Setting.boolSetting("bootstrap.mlockall", false, false, Scope.CLUSTER);
+    public static final Setting<Boolean> SECCOMP_SETTING = Setting.boolSetting("bootstrap.seccomp", true, false, Scope.CLUSTER);
+    public static final Setting<Boolean> CTRLHANDLER_SETTING = Setting.boolSetting("bootstrap.ctrlhandler", true, false, Scope.CLUSTER);
+
+}

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -88,6 +88,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.transport.netty.NettyTransport;
 import org.elasticsearch.tribe.TribeService;
+import org.elasticsearch.bootstrap.BootstrapSettings;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -378,6 +379,11 @@ public final class ClusterSettings extends AbstractScopedSettings {
             PageCacheRecycler.WEIGHT_LONG_SETTING,
             PageCacheRecycler.WEIGHT_OBJECTS_SETTING,
             PageCacheRecycler.TYPE_SETTING,
-            PluginsService.MANDATORY_SETTING
+            PluginsService.MANDATORY_SETTING,
+            BootstrapSettings.SECURITY_MANAGER_ENABLED_SETTING,
+            BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING,
+            BootstrapSettings.MLOCKALL_SETTING,
+            BootstrapSettings.SECCOMP_SETTING,
+            BootstrapSettings.CTRLHANDLER_SETTING
         )));
 }

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapSettingsTests.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+public class BootstrapSettingsTests extends ESTestCase {
+
+    public void testDefaultSettings() {
+        assertTrue(BootstrapSettings.SECURITY_MANAGER_ENABLED_SETTING.get(Settings.EMPTY));
+        assertTrue(BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING.get(Settings.EMPTY));
+        assertFalse(BootstrapSettings.MLOCKALL_SETTING.get(Settings.EMPTY));
+        assertTrue(BootstrapSettings.SECCOMP_SETTING.get(Settings.EMPTY));
+        assertTrue(BootstrapSettings.CTRLHANDLER_SETTING.get(Settings.EMPTY));
+    }
+
+}


### PR DESCRIPTION
This commit registers bootstrap settings used on startup. Without
registration, setting any of these settings causes node startup to
fail. By registering these settings (rather than clearing) after use, we
enable them to be visible in any APIs that show all settings.
