### PR TITLE
Fix _aliases filter and null parameters

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -286,24 +286,25 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             return addValidationError("Must specify at least one alias action", validationException);
         }
         for (AliasActions aliasAction : allAliasActions) {
-            if (aliasAction.aliases.length == 0) {
+            if (CollectionUtils.isEmpty(aliasAction.aliases)) {
                 validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
-                        + "]: aliases may not be empty", validationException);
-            }
-            for (String alias : aliasAction.aliases) {
-                if (!Strings.hasText(alias)) {
-                    validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
-                            + "]: [alias] may not be empty string", validationException);
+                        + "]: Property [alias/aliases] is either missing or null", validationException);
+            } else {
+                for (String alias : aliasAction.aliases) {
+                    if (!Strings.hasText(alias)) {
+                        validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
+                            + "]: [alias/aliases] may not be empty string", validationException);
+                    }
                 }
             }
             if (CollectionUtils.isEmpty(aliasAction.indices)) {
                 validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
-                        + "]: Property [index] was either missing or null", validationException);
+                        + "]: Property [index/indices] is either missing or null", validationException);
             } else {
                 for (String index : aliasAction.indices) {
                     if (!Strings.hasText(index)) {
                         validationException = addValidationError("Alias action [" + aliasAction.actionType().name().toLowerCase(Locale.ENGLISH)
-                                + "]: [index] may not be empty string", validationException);
+                                + "]: [index/indices] may not be empty string", validationException);
                     }
                 }
             }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/alias/RestIndicesAliasesAction.java
@@ -133,7 +133,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
                             }
 
                             if (type == AliasAction.Type.ADD) {
-                                AliasActions aliasActions = new AliasActions(type, indices, aliases);
+                                AliasActions aliasActions = new AliasActions(type, indices, aliases).filter(filter);
                                 if (routingSet) {
                                     aliasActions.routing(routing);
                                 }

--- a/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -21,6 +21,8 @@ package org.elasticsearch.aliases;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
 import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistResponse;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
@@ -54,6 +56,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.client.Requests.createIndexRequest;
 import static org.elasticsearch.client.Requests.indexRequest;
+import static org.elasticsearch.cluster.metadata.AliasAction.Type.ADD;
+import static org.elasticsearch.cluster.metadata.AliasAction.Type.REMOVE;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_METADATA_BLOCK;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_READ_ONLY_BLOCK;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_METADATA;
@@ -588,7 +592,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
                 .addAlias("foobar", "foo"));
 
         assertAcked(admin().indices().prepareAliases()
-                .addAliasAction(new AliasAction(AliasAction.Type.ADD, "foobar", "bac").routing("bla")));
+                .addAliasAction(new AliasAction(ADD, "foobar", "bac").routing("bla")));
 
         logger.info("--> getting bar and baz for index bazbar");
         getResponse = admin().indices().prepareGetAliases("bar", "bac").addIndices("bazbar").get();
@@ -724,8 +728,8 @@ public class IndexAliasesIT extends ESIntegTestCase {
             assertAcked(admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, "alias1")));
             fail("create alias should have failed due to null index");
         } catch (IllegalArgumentException e) {
-            assertThat("Exception text does not contain \"Alias action [add]: [index] may not be empty string\"",
-                    e.getMessage(), containsString("Alias action [add]: [index] may not be empty string"));
+            assertThat("Exception text does not contain \"Alias action [add]: [index/indices] may not be empty string\"",
+                    e.getMessage(), containsString("Alias action [add]: [index/indices] may not be empty string"));
         }
     }
 
@@ -740,8 +744,8 @@ public class IndexAliasesIT extends ESIntegTestCase {
             assertAcked(admin().indices().prepareAliases().addAlias((String) null, "empty-alias"));
             fail("create alias should have failed due to null index");
         } catch (IllegalArgumentException e) {
-            assertThat("Exception text does not contain \"Alias action [add]: [index] may not be empty string\"",
-                    e.getMessage(), containsString("Alias action [add]: [index] may not be empty string"));
+            assertThat("Exception text does not contain \"Alias action [add]: [index/indices] may not be empty string\"",
+                    e.getMessage(), containsString("Alias action [add]: [index/indices] may not be empty string"));
         }
     }
 
@@ -750,7 +754,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction("", "alias1")).get();
             fail("Expected ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("[index] may not be empty string"));
+            assertThat(e.getMessage(), containsString("[index/indices] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(ADD, "", "alias1")).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[index/indices] may not be empty string"));
         }
     }
 
@@ -759,7 +769,19 @@ public class IndexAliasesIT extends ESIntegTestCase {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction("index1", null)).get();
             fail("Expected ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("[alias] may not be empty string"));
+            assertThat(e.getMessage(), containsString("[alias/aliases] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(ADD, "index1", (String)null)).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[alias/aliases] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(ADD, "index1", (String[])null)).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[alias/aliases] is either missing or null"));
         }
     }
 
@@ -768,13 +790,26 @@ public class IndexAliasesIT extends ESIntegTestCase {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction("index1", "")).get();
             fail("Expected ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("[alias] may not be empty string"));
+            assertThat(e.getMessage(), containsString("[alias/aliases] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(ADD, "index1", "")).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[alias/aliases] may not be empty string"));
         }
     }
 
     public void testAddAliasNullAliasNullIndex() {
         try {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction(null, null)).get();
+            fail("Should throw " + ActionRequestValidationException.class.getSimpleName());
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.validationErrors(), notNullValue());
+            assertThat(e.validationErrors().size(), equalTo(2));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(ADD, null, (String)null)).get();
             fail("Should throw " + ActionRequestValidationException.class.getSimpleName());
         } catch (ActionRequestValidationException e) {
             assertThat(e.validationErrors(), notNullValue());
@@ -790,6 +825,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
             assertThat(e.validationErrors(), notNullValue());
             assertThat(e.validationErrors().size(), equalTo(2));
         }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(ADD, "", "")).get();
+            fail("Should throw " + ActionRequestValidationException.class.getSimpleName());
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.validationErrors(), notNullValue());
+            assertThat(e.validationErrors().size(), equalTo(2));
+        }
     }
 
     public void testRemoveAliasNullIndex() {
@@ -797,7 +839,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newRemoveAliasAction(null, "alias1")).get();
             fail("Expected ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("[index] may not be empty string"));
+            assertThat(e.getMessage(), containsString("[index/indices] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(REMOVE, null, "alias1")).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[index/indices] may not be empty string"));
         }
     }
 
@@ -806,7 +854,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newRemoveAliasAction("", "alias1")).get();
             fail("Expected ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("[index] may not be empty string"));
+            assertThat(e.getMessage(), containsString("[index/indices] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(REMOVE, "", "alias1")).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[index/indices] may not be empty string"));
         }
     }
 
@@ -815,7 +869,19 @@ public class IndexAliasesIT extends ESIntegTestCase {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newRemoveAliasAction("index1", null)).get();
             fail("Expected ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("[alias] may not be empty string"));
+            assertThat(e.getMessage(), containsString("[alias/aliases] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(REMOVE, "index1", (String)null)).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[alias/aliases] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(REMOVE, "index1", (String[])null)).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[alias/aliases] is either missing or null"));
         }
     }
 
@@ -824,7 +890,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newRemoveAliasAction("index1", "")).get();
             fail("Expected ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
-            assertThat(e.getMessage(), containsString("[alias] may not be empty string"));
+            assertThat(e.getMessage(), containsString("[alias/aliases] may not be empty string"));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(REMOVE, "index1", "")).get();
+            fail("Expected ActionRequestValidationException");
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.getMessage(), containsString("[alias/aliases] may not be empty string"));
         }
     }
 
@@ -836,11 +908,32 @@ public class IndexAliasesIT extends ESIntegTestCase {
             assertThat(e.validationErrors(), notNullValue());
             assertThat(e.validationErrors().size(), equalTo(2));
         }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(REMOVE, null, (String)null)).get();
+            fail("Should throw " + ActionRequestValidationException.class.getSimpleName());
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.validationErrors(), notNullValue());
+            assertThat(e.validationErrors().size(), equalTo(2));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(REMOVE, (String[])null, (String[])null)).get();
+            fail("Should throw " + ActionRequestValidationException.class.getSimpleName());
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.validationErrors(), notNullValue());
+            assertThat(e.validationErrors().size(), equalTo(2));
+        }
     }
 
     public void testRemoveAliasEmptyAliasEmptyIndex() {
         try {
             admin().indices().prepareAliases().addAliasAction(AliasAction.newAddAliasAction("", "")).get();
+            fail("Should throw " + ActionRequestValidationException.class.getSimpleName());
+        } catch (ActionRequestValidationException e) {
+            assertThat(e.validationErrors(), notNullValue());
+            assertThat(e.validationErrors().size(), equalTo(2));
+        }
+        try {
+            admin().indices().prepareAliases().addAliasAction(new AliasActions(REMOVE, "", "")).get();
             fail("Should throw " + ActionRequestValidationException.class.getSimpleName());
         } catch (ActionRequestValidationException e) {
             assertThat(e.validationErrors(), notNullValue());

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/10_basic.yaml
@@ -19,6 +19,9 @@
                 index: test_index
                 alias: test_alias
                 routing: routing_value
+                filter:
+                  ids:
+                    values: ["1", "2", "3"]
 
   - do:
       indices.exists_alias:
@@ -31,7 +34,7 @@
         index: test_index
         name: test_alias
 
-  - match: {test_index.aliases.test_alias: {'index_routing': 'routing_value', 'search_routing': 'routing_value'}}
+  - match: {test_index.aliases.test_alias: {filter: { ids : { values: ["1", "2", "3"]}}, 'index_routing': 'routing_value', 'search_routing': 'routing_value'}}
 
 ---
 "Basic test for multiple aliases":


### PR DESCRIPTION
Fixes 2 issues with the REST `_aliases` endpoint:

`POST /_aliases` ignores the `filter` when filtered aliases are created: Closes #16549
`POST /_aliases` throws NullPointerException instead of validation error with proper error message when `alias` is specified as `null`: Closes #16547
