### PR TITLE
hide null-valued metadata fields from WriteableIngestDocument#toXContent

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/WriteableIngestDocument.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/WriteableIngestDocument.java
@@ -69,7 +69,9 @@ final class WriteableIngestDocument implements Writeable<WriteableIngestDocument
         builder.startObject("doc");
         Map<IngestDocument.MetaData, String> metadataMap = ingestDocument.extractMetadata();
         for (Map.Entry<IngestDocument.MetaData, String> metadata : metadataMap.entrySet()) {
-            builder.field(metadata.getKey().getFieldName(), metadata.getValue());
+            if (metadata.getValue() != null) {
+                builder.field(metadata.getKey().getFieldName(), metadata.getValue());
+            }
         }
         builder.field("_source", ingestDocument.getSourceAndMetadata());
         builder.startObject("_ingest");


### PR DESCRIPTION
Currently, null-valued metadata fields show up when rendering IngestDocuments in responses.

e.g.

``` json
{
   "docs": [
      {
         "processor_results": [
            {
               "tag": "processor_2",
               "doc": {
                  "_parent": null,
                  "_timestamp": null,
                  "_routing": null,
                  "_id": "_id",
                  "_index": "_index",
                  "_ttl": null,
                  "_type": "_type",
                  "_source": {
                     "flags": "new|hot|super|fun|interesting"
                  },
                  "_ingest": {
                     "timestamp": "2016-02-09T20:05:27.575+0000"
                  }
               }
            },
...
```

This PR removes such values from the response, rendering the above as follows:

``` json
{
   "docs": [
      {
         "processor_results": [
            {
               "tag": "processor_2",
               "doc": {
                  "_index": "_index",
                  "_id": "_id",
                  "_type": "_type",
                  "_source": {
                     "flags": "new|hot|super|fun|interesting"
                  },
                  "_ingest": {
                     "timestamp": "2016-02-09T20:51:21.137+0000"
                  }
               }
            },
...
```
