### PR TITLE
Rename three static class variables.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -38,16 +38,16 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     private ParseFieldMatcher matcher = ParseFieldMatcher.STRICT;
 
-    //Currently this is not a setting that can be changed and is a policy
+    // Currently this is not a setting that can be changed and is a policy
     // that relates to how parsing of things like "boost" are done across
     // the whole of Elasticsearch (eg if String "1.0" is a valid float).
     // The idea behind keeping it as a constant is that we can track
     // references to this policy decision throughout the codebase and find
     // and change any code that needs to apply an alternative policy.
-    public static final boolean DEFAULT_NUMBER_COEERCE_POLICY = true;
+    public static final boolean DEFAULT_NUMBER_COERCE_POLICY = true;
 
-    private static void checkCoerceString(boolean coeerce, Class<? extends Number> clazz) {
-        if (!coeerce) {
+    private static void checkCoerceString(boolean coerce, Class<? extends Number> clazz) {
+        if (!coerce) {
             //Need to throw type IllegalArgumentException as current catch logic in
             //NumberFieldMapper.parseCreateField relies on this for "malformed" value detection
             throw new IllegalArgumentException(clazz.getSimpleName() + " value passed as String");
@@ -102,7 +102,7 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     @Override
     public short shortValue() throws IOException {
-        return shortValue(DEFAULT_NUMBER_COEERCE_POLICY);
+        return shortValue(DEFAULT_NUMBER_COERCE_POLICY);
     }
 
     @Override
@@ -121,7 +121,7 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     @Override
     public int intValue() throws IOException {
-        return intValue(DEFAULT_NUMBER_COEERCE_POLICY);
+        return intValue(DEFAULT_NUMBER_COERCE_POLICY);
     }
 
 
@@ -141,7 +141,7 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     @Override
     public long longValue() throws IOException {
-        return longValue(DEFAULT_NUMBER_COEERCE_POLICY);
+        return longValue(DEFAULT_NUMBER_COERCE_POLICY);
     }
 
     @Override
@@ -160,7 +160,7 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     @Override
     public float floatValue() throws IOException {
-        return floatValue(DEFAULT_NUMBER_COEERCE_POLICY);
+        return floatValue(DEFAULT_NUMBER_COERCE_POLICY);
     }
 
     @Override
@@ -178,7 +178,7 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     @Override
     public double doubleValue() throws IOException {
-        return doubleValue(DEFAULT_NUMBER_COEERCE_POLICY);
+        return doubleValue(DEFAULT_NUMBER_COERCE_POLICY);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/ESBackcompatTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESBackcompatTestCase.java
@@ -104,7 +104,7 @@ public abstract class ESBackcompatTestCase extends ESIntegTestCase {
      */
     private static final String TESTS_COMPATIBILITY = "tests.compatibility";
 
-    private static final Version GLOABL_COMPATIBILITY_VERSION = Version.fromString(compatibilityVersionProperty());
+    private static final Version GLOBAL_COMPATIBILITY_VERSION = Version.fromString(compatibilityVersionProperty());
 
     private static Path backwardsCompatibilityPath() {
         String path = System.getProperty(TESTS_BACKWARDS_COMPATIBILITY_PATH);
@@ -155,7 +155,7 @@ public abstract class ESBackcompatTestCase extends ESIntegTestCase {
      * {@link #compatibilityVersion()}
      */
     public static Version globalCompatibilityVersion() {
-        return GLOABL_COMPATIBILITY_VERSION;
+        return GLOBAL_COMPATIBILITY_VERSION;
     }
 
     private static String compatibilityVersionProperty() {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -163,10 +163,10 @@ public final class InternalTestCluster extends TestCluster {
     private static final int JVM_ORDINAL = Integer.parseInt(System.getProperty(SysGlobals.CHILDVM_SYSPROP_JVM_ID, "0"));
 
     /** a per-JVM unique offset to be used for calculating unique port ranges. */
-    public static final int JVM_BASE_PORT_OFFEST = PORTS_PER_JVM * (JVM_ORDINAL + 1);
+    public static final int JVM_BASE_PORT_OFFSET = PORTS_PER_JVM * (JVM_ORDINAL + 1);
 
     private static final AtomicInteger clusterOrdinal = new AtomicInteger();
-    private final int CLUSTER_BASE_PORT_OFFSET = JVM_BASE_PORT_OFFEST + (clusterOrdinal.getAndIncrement() * PORTS_PER_CLUSTER) % PORTS_PER_JVM;
+    private final int CLUSTER_BASE_PORT_OFFSET = JVM_BASE_PORT_OFFSET + (clusterOrdinal.getAndIncrement() * PORTS_PER_CLUSTER) % PORTS_PER_JVM;
 
     public final int TRANSPORT_BASE_PORT = GLOBAL_TRANSPORT_BASE_PORT + CLUSTER_BASE_PORT_OFFSET;
     public final int HTTP_BASE_PORT = GLOBAL_HTTP_BASE_PORT + CLUSTER_BASE_PORT_OFFSET;

--- a/test/framework/src/main/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/discovery/ClusterDiscoveryConfiguration.java
@@ -102,7 +102,7 @@ public class ClusterDiscoveryConfiguration extends NodeConfigurationSource {
         }
 
         private static int calcBasePort() {
-            return 30000 + InternalTestCluster.JVM_BASE_PORT_OFFEST;
+            return 30000 + InternalTestCluster.JVM_BASE_PORT_OFFSET;
         }
 
         @Override


### PR DESCRIPTION
This PR renames the followings to fix typos.
- DEFAULT_NUMBER_COEERCE_POLICY -> DEFAULT_NUMBER_COERCE_POLICY
- GLOABL_COMPATIBILITY_VERSION        -> GLOBAL_COMPATIBILITY_VERSION
- JVM_BASE_PORT_OFFEST                       -> JVM_BASE_PORT_OFFSET
