### PR TITLE
Fail build if we define equals but not hashCode

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -37,6 +37,8 @@
     hard to distinguish from the digit 1 (one). -->
     <module name="UpperEll"/>
 
+    <module name="EqualsHashCode" />
+
     <!-- We don't use Java's builtin serialization and we suppress all warning
       about it. The flip side of that coin is that we shouldn't _try_ to use
       it. We can't outright ban it with ForbiddenApis because it complain about

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -116,6 +116,11 @@ public class FieldValueFactorFunction extends ScoreFunction {
                 Objects.equals(this.modifier, fieldValueFactorFunction.modifier);
     }
 
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(boostFactor, field, modifier);
+    }
+
     /**
      * The Type class encapsulates the modification types that can be applied
      * to the score/value product.

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
@@ -25,6 +25,8 @@ import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
+import java.util.Objects;
+
 /**
  * Pseudo randomly generate a score for each {@link LeafScoreFunction#score}.
  */
@@ -91,5 +93,10 @@ public class RandomScoreFunction extends ScoreFunction {
         RandomScoreFunction randomScoreFunction = (RandomScoreFunction) other;
         return this.originalSeed == randomScoreFunction.originalSeed &&
                 this.saltedSeed == randomScoreFunction.saltedSeed;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(originalSeed, saltedSeed);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScoreFunction.java
@@ -66,4 +66,15 @@ public abstract class ScoreFunction {
      * Indicates whether some other {@link ScoreFunction} object of the same type is "equal to" this one.
      */
     protected abstract boolean doEquals(ScoreFunction other);
+
+    @Override
+    public final int hashCode() {
+        /*
+         * Override hashCode here and forward to an abstract method to force extensions of this class to override hashCode in the same
+         * way that we force them to override equals. This also prevents false positives in CheckStyle's EqualsHashCode check.
+         */
+        return Objects.hash(scoreCombiner, doHashCode());
+    }
+
+    protected abstract int doHashCode();
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunction.java
@@ -133,4 +133,9 @@ public class ScriptScoreFunction extends ScoreFunction {
         ScriptScoreFunction scriptScoreFunction = (ScriptScoreFunction) other;
         return Objects.equals(this.sScript, scriptScoreFunction.sScript);
     }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(sScript);
+    }
 }

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/WeightFactorFunction.java
@@ -93,6 +93,11 @@ public class WeightFactorFunction extends ScoreFunction {
                 Objects.equals(this.scoreFunction, weightFactorFunction.scoreFunction);
     }
 
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(weight, scoreFunction);
+    }
+
     private static class ScoreOne extends ScoreFunction {
 
         protected ScoreOne(CombineFunction scoreCombiner) {
@@ -122,6 +127,11 @@ public class WeightFactorFunction extends ScoreFunction {
         @Override
         protected boolean doEquals(ScoreFunction other) {
             return true;
+        }
+
+        @Override
+        protected int doHashCode() {
+            return 0;
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -383,6 +383,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder> ext
             return super.doEquals(other) &&
                     Objects.equals(this.origin, geoFieldDataScoreFunction.origin);
         }
+
+        @Override
+        protected int doHashCode() {
+            return Objects.hash(super.doHashCode(), origin);
+        }
     }
 
     static class NumericFieldDataScoreFunction extends AbstractDistanceScoreFunction {
@@ -532,6 +537,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder> ext
                     Objects.equals(this.mode, distanceScoreFunction.mode) &&
                     Objects.equals(this.func, distanceScoreFunction.func) &&
                     Objects.equals(this.getFieldName(), distanceScoreFunction.getFieldName());
+        }
+
+        @Override
+        protected int doHashCode() {
+            return Objects.hash(scale, offset, mode, func, getFieldName());
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -352,7 +352,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
         }
 
         @Override
-        public final int hashCode() {
+        protected final int doHashCode() {
             return Objects.hash(discount);
         }
 
@@ -442,7 +442,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
         }
 
         @Override
-        public final int hashCode() {
+        protected final int doHashCode() {
             return Objects.hash(alpha);
         }
 
@@ -489,9 +489,17 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            @SuppressWarnings("unchecked")
             SmoothingModel other = (SmoothingModel) obj;
             return doEquals(other);
+        }
+
+        @Override
+        public final int hashCode() {
+            /*
+             * Override hashCode here and forward to an abstract method to force extensions of this class to override hashCode in the same
+             * way that we force them to override equals. This also prevents false positives in CheckStyle's EqualsHashCode check.
+             */
+            return doHashCode();
         }
 
         public abstract SmoothingModel fromXContent(QueryParseContext parseContext) throws IOException;
@@ -502,6 +510,8 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
          * subtype specific implementation of "equals".
          */
         protected abstract boolean doEquals(SmoothingModel other);
+
+        protected abstract int doHashCode();
 
         protected abstract XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException;
     }
@@ -592,7 +602,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
         }
 
         @Override
-        public final int hashCode() {
+        protected final int doHashCode() {
             return Objects.hash(trigramLambda, bigramLambda, unigramLambda);
         }
 


### PR DESCRIPTION
That is like some kind of cardinal sin or something, right?

We had two violations though they weren't super likely to be keys in a hashmap
any time soon.
