### PR TITLE
Minor attachment processor improvements

### DIFF
--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
@@ -183,7 +183,6 @@ public final class AttachmentProcessor extends AbstractProcessor {
 
         CONTENT,
         TITLE,
-        NAME,
         AUTHOR,
         KEYWORDS,
         DATE,


### PR DESCRIPTION
Fixed a test that failed a few times: http://build-us-00.elastic.co/job/es_g1gc_master_metal/30241/testReport/junit/org.elasticsearch.ingest.attachment/AttachmentProcessorTests/testEnglishTextDocumentWithRandomFields/

Removed unused NAME field and set the additional fields only once as a map of fields rather than using setFieldValue for each of them.
