### PR TITLE
Remove dead support for Java Service Wrapper

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -254,10 +254,6 @@ final class Bootstrap {
         INSTANCE = new Bootstrap();
 
         boolean foreground = !"false".equals(System.getProperty("es.foreground", System.getProperty("es-foreground")));
-        // handle the wrapper system property, if its a service, don't run as a service
-        if (System.getProperty("wrapper.service", "XXX").equalsIgnoreCase("true")) {
-            foreground = false;
-        }
 
         Environment environment = initialSettings(foreground);
         Settings settings = environment.settings();


### PR DESCRIPTION
This commit removes bootstrap support for [Java Service Wrapper](http://wrapper.tanukisoftware.com/doc/english/download.jsp). The
implementation of this has been moved to its own [repository](https://github.com/elastic/elasticsearch-servicewrapper) where it was
deprecated, does not work with Elasticsearch 2.x, and is untested and
therefore unmaintained.

Relates #154, #243
