### PR TITLE
Use 256m for bwc nodes

### DIFF
--- a/qa/backwards/shared/src/main/java/org/elasticsearch/test/ExternalNodeService.java
+++ b/qa/backwards/shared/src/main/java/org/elasticsearch/test/ExternalNodeService.java
@@ -346,6 +346,7 @@ public class ExternalNodeService {
             }
             logger.debug("Starting elasticsearch with {}", startReproduction);
             ProcessBuilder builder = new ProcessBuilder(command);
+            builder.environment().put("ES_HEAP_SIZE", "256m");
             builder.inheritIO();
             Process process = null;
             String pid = null;


### PR DESCRIPTION
The default allows up to 1g which is a ton for jenkins machines.
