### PR TITLE
Teach reindex to stop when cancelled

### DIFF
--- a/core/src/main/java/org/elasticsearch/tasks/CancellableTask.java
+++ b/core/src/main/java/org/elasticsearch/tasks/CancellableTask.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.tasks;
 
+import org.elasticsearch.common.Nullable;
+
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -56,4 +58,11 @@ public class CancellableTask extends Task {
         return reason.get() != null;
     }
 
+    /**
+     * The reason the task was cancelled or null if it hasn't been cancelled.
+     */
+    @Nullable
+    public String getReasonCancelled() {
+        return reason.get();
+    }
 }

--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkIndexByScrollResponse.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/BulkIndexByScrollResponse.java
@@ -82,6 +82,13 @@ public class BulkIndexByScrollResponse extends ActionResponse implements ToXCont
     }
 
     /**
+     * The reason that the request was canceled or null if it hasn't been.
+     */
+    public String getReasonCancelled() {
+        return status.getReasonCancelled();
+    }
+
+    /**
      * All of the indexing failures. Version conflicts are only included if the request sets abortOnVersionConflict to true (the
      * default).
      */

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AbstractBulkIndexByScrollResponseMatcher.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AbstractBulkIndexByScrollResponseMatcher.java
@@ -24,6 +24,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 public abstract class AbstractBulkIndexByScrollResponseMatcher<
                 Response extends BulkIndexByScrollResponse,
@@ -36,6 +37,7 @@ public abstract class AbstractBulkIndexByScrollResponseMatcher<
     private Matcher<Integer> batchesMatcher;
     private Matcher<Long> versionConflictsMatcher = equalTo(0L);
     private Matcher<Integer> failuresMatcher = equalTo(0);
+    private Matcher<String> reasonCancelledMatcher = nullValue(String.class);
 
     protected abstract Self self();
 
@@ -93,13 +95,18 @@ public abstract class AbstractBulkIndexByScrollResponseMatcher<
         return failures(equalTo(failures));
     }
 
+    public Self reasonCancelled(Matcher<String> reasonCancelledMatcher) {
+        this.reasonCancelledMatcher = reasonCancelledMatcher;
+        return self();
+    }
 
     @Override
     protected boolean matchesSafely(Response item) {
         return updatedMatcher.matches(item.getUpdated()) &&
             (batchesMatcher == null || batchesMatcher.matches(item.getBatches())) &&
             versionConflictsMatcher.matches(item.getVersionConflicts()) &&
-            failuresMatcher.matches(item.getIndexingFailures().size());
+            failuresMatcher.matches(item.getIndexingFailures().size()) &&
+            reasonCancelledMatcher.matches(item.getReasonCancelled());
     }
 
     @Override
@@ -110,5 +117,6 @@ public abstract class AbstractBulkIndexByScrollResponseMatcher<
         }
         description.appendText(" and versionConflicts matches ").appendDescriptionOf(versionConflictsMatcher);
         description.appendText(" and failures size matches ").appendDescriptionOf(failuresMatcher);
+        description.appendText(" and reason cancelled matches ").appendDescriptionOf(reasonCancelledMatcher);
     }
 }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/BulkByScrollTaskTests.java
@@ -101,13 +101,13 @@ public class BulkByScrollTaskTests extends ESTestCase {
     }
 
     public void testStatusHatesNegatives() {
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(-1, 0, 0, 0, 0, 0, 0, 0));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, -1, 0, 0, 0, 0, 0, 0));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, -1, 0, 0, 0, 0, 0));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, -1, 0, 0, 0, 0));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, -1, 0, 0, 0));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, -1, 0, 0));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, -1, 0));
-        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, 0, -1));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(-1, 0, 0, 0, 0, 0, 0, 0, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, -1, 0, 0, 0, 0, 0, 0, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, -1, 0, 0, 0, 0, 0, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, -1, 0, 0, 0, 0, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, -1, 0, 0, 0, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, -1, 0, 0, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, -1, 0, null));
+        expectThrows(IllegalArgumentException.class, () -> new BulkByScrollTask.Status(0, 0, 0, 0, 0, 0, 0, -1, null));
     }
 }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/CancelTestUtils.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/CancelTestUtils.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.reindex;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ListenableActionFuture;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.TaskInfo;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.NativeScriptFactory;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptService.ScriptType;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.test.ESIntegTestCase.client;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Utilities for testing reindex and update-by-query cancelation. This whole class isn't thread safe. Luckily we run out tests in separate
+ * jvms.
+ */
+public class CancelTestUtils {
+    public static Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(ReindexPlugin.class, StickyScriptPlugin.class);
+    }
+
+    private static final CyclicBarrier barrier = new CyclicBarrier(2);
+
+    public static <Request extends AbstractBulkIndexByScrollRequest<Request>,
+                    Response extends ActionResponse,
+                    Builder extends AbstractBulkIndexByScrollRequestBuilder<Request, Response, Builder>>
+            Response testCancel(ESIntegTestCase test, Builder request, String actionToCancel) throws Exception {
+
+        test.indexRandom(true, client().prepareIndex("source", "test", "1").setSource("foo", "a"),
+                client().prepareIndex("source", "test", "2").setSource("foo", "a"));
+
+        request.source("source").script(new Script("sticky", ScriptType.INLINE, "native", emptyMap()));
+        request.source().setSize(1);
+        ListenableActionFuture<Response> response = request.execute();
+
+        // Wait until the script is on the first document.
+        barrier.await(30, TimeUnit.SECONDS);
+
+        // Let just one document through.
+        barrier.await(30, TimeUnit.SECONDS);
+
+        // Wait until the script is on the second document.
+        barrier.await(30, TimeUnit.SECONDS);
+
+        // Cancel the request while the script is running. This will prevent the request from being sent at all.
+        List<TaskInfo> cancelledTasks = client().admin().cluster().prepareCancelTasks().setActions(actionToCancel).get().getTasks();
+        assertThat(cancelledTasks, hasSize(1));
+
+        // Now let the next document through. It won't be sent because the request is cancelled but we need to unblock the script.
+        barrier.await();
+
+        // Now we can just wait on the request and make sure it was actually cancelled half way through.
+        return response.get();
+    }
+
+    public static class StickyScriptPlugin extends Plugin {
+        @Override
+        public String name() {
+            return "sticky-script";
+        }
+
+        @Override
+        public String description() {
+            return "installs a script that \"sticks\" when it runs for testing reindex";
+        }
+
+        public void onModule(ScriptModule module) {
+            module.registerScript("sticky", StickyScriptFactory.class);
+        }
+    }
+
+    public static class StickyScriptFactory implements NativeScriptFactory {
+        @Override
+        public ExecutableScript newScript(Map<String, Object> params) {
+            return new ExecutableScript() {
+                private Map<String, Object> source;
+                @Override
+                @SuppressWarnings("unchecked") // Safe because _ctx always has this shape
+                public void setNextVar(String name, Object value) {
+                    if ("ctx".equals(name)) {
+                        Map<String, Object> ctx = (Map<String, Object>) value;
+                        source = (Map<String, Object>) ctx.get("_source");
+                    } else {
+                        throw new IllegalArgumentException("Unexpected var:  " + name);
+                    }
+                }
+
+                @Override
+                public Object run() {
+                    try {
+                        // Tell the test we've started a document.
+                        barrier.await(30, TimeUnit.SECONDS);
+
+                        // Wait for the test to tell us to proceed.
+                        barrier.await(30, TimeUnit.SECONDS);
+
+                        // Make some change to the source so that update-by-query tests can make sure only one document was changed.
+                        source.put("giraffes", "giraffes");
+                        return null;
+                    } catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
+        }
+    }
+}

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexCancelTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/ReindexCancelTests.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.reindex;
+
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.Collection;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests that you can actually cancel a reindex request and all the plumbing works. Doesn't test all of the different cancellation places -
+ * that is the responsibility of {@link AsyncBulkByScrollActionTests} which have more precise control to simulate failures but do not
+ * exercise important portion of the stack like transport and task management.
+ */
+public class ReindexCancelTests extends ReindexTestCase {
+    public void testCancel() throws Exception {
+        ReindexResponse response = CancelTestUtils.testCancel(this, reindex().destination("dest", "test"), ReindexAction.NAME);
+
+        assertThat(response, responseMatcher().created(1).reasonCancelled(equalTo("by user request")));
+        refresh("dest");
+        assertHitCount(client().prepareSearch("dest").setSize(0).get(), 1);
+    }
+
+    @Override
+    protected int numberOfShards() {
+        return 1;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CancelTestUtils.nodePlugins();
+    }
+}

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/RoundTripTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/RoundTripTests.java
@@ -118,7 +118,8 @@ public class RoundTripTests extends ESTestCase {
 
     private BulkByScrollTask.Status randomStatus() {
         return new BulkByScrollTask.Status(randomPositiveLong(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong(),
-                randomPositiveInt(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong());
+                randomPositiveInt(), randomPositiveLong(), randomPositiveLong(), randomPositiveLong(),
+                random().nextBoolean() ? null : randomSimpleString(random()));
     }
 
     private List<Failure> randomIndexingFailures() {

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/UpdateByQueryCancelTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/UpdateByQueryCancelTests.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.reindex;
+
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.Collection;
+
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests that you can actually cancel an update-by-query request and all the plumbing works. Doesn't test all of the different cancellation
+ * places - that is the responsibility of {@link AsyncBulkByScrollActionTests} which have more precise control to simulate failures but do
+ * not exercise important portion of the stack like transport and task management.
+ */
+public class UpdateByQueryCancelTests extends UpdateByQueryTestCase {
+    public void testCancel() throws Exception {
+        BulkIndexByScrollResponse response = CancelTestUtils.testCancel(this, request(), UpdateByQueryAction.NAME);
+
+        assertThat(response, responseMatcher().updated(1).reasonCancelled(equalTo("by user request")));
+        refresh("source");
+        assertHitCount(client().prepareSearch("source").setSize(0).setQuery(matchQuery("giraffes", "giraffes")).get(), 1);
+    }
+
+    @Override
+    protected int numberOfShards() {
+        return 1;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CancelTestUtils.nodePlugins();
+    }
+}

--- a/qa/smoke-test-reindex-with-groovy/src/test/resources/rest-api-spec/test/reindex/20_broken.yaml
+++ b/qa/smoke-test-reindex-with-groovy/src/test/resources/rest-api-spec/test/reindex/20_broken.yaml
@@ -1,0 +1,23 @@
+---
+"Totally broken scripts report the error properly":
+  - do:
+      index:
+        index:  twitter
+        type:   tweet
+        id:     1
+        body:   { "user": "kimchy" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      catch: request
+      reindex:
+        refresh: true
+        body:
+          source:
+            index: twitter
+          dest:
+            index: new_twitter
+          script:
+            inline: syntax errors are fun!
+  - match: {error.reason: 'Failed to compile inline script [syntax errors are fun!] using lang [groovy]'}

--- a/qa/smoke-test-reindex-with-groovy/src/test/resources/rest-api-spec/test/update-by-query/20_broken.yaml
+++ b/qa/smoke-test-reindex-with-groovy/src/test/resources/rest-api-spec/test/update-by-query/20_broken.yaml
@@ -1,0 +1,20 @@
+---
+"Totally broken scripts report the error properly":
+  - do:
+      index:
+        index:  twitter
+        type:   tweet
+        id:     1
+        body:   { "user": "kimchy" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      catch: request
+      update-by-query:
+        index:   twitter
+        refresh: true
+        body:
+          script:
+            inline: syntax errors are fun!
+  - match: {error.reason: 'Failed to compile inline script [syntax errors are fun!] using lang [groovy]'}


### PR DESCRIPTION
All we do is check the cancelled flag and stop the request at a few key
points.

Adds the cancellation cause to the status so any request that is cancelled
but doesn't die can be seen in the task list.
