### PR TITLE
Rework retries in reindex

### DIFF
--- a/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractBulkByScrollRequest.java
+++ b/plugins/reindex/src/main/java/org/elasticsearch/plugin/reindex/AbstractBulkByScrollRequest.java
@@ -76,14 +76,14 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
 
     /**
      * Initial delay after a rejection before retrying a bulk request. With the default maxRetries the total backoff for retrying rejections
-     * is about 25 seconds per bulk request. Once the entire bulk request is successful the retry counter resets.
+     * is about one minute per bulk request. Once the entire bulk request is successful the retry counter resets.
      */
-    private TimeValue retryBackoffInitialTime = timeValueMillis(50);
+    private TimeValue retryBackoffInitialTime = timeValueMillis(500);
 
     /**
      * Total number of retries attempted for rejections. There is no way to ask for unlimited retries.
      */
-    private int maxRetries = 10;
+    private int maxRetries = 11;
 
     public AbstractBulkByScrollRequest() {
     }

--- a/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AsyncBulkByScrollActionTests.java
+++ b/plugins/reindex/src/test/java/org/elasticsearch/plugin/reindex/AsyncBulkByScrollActionTests.java
@@ -356,7 +356,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
          * This is the total number of milliseconds that a reindex made with the default settings will backoff before attempting one final
          * time. If that request is rejected then the whole process fails with a rejected exception.
          */
-        int defaultBackoffBeforeFailing = 24670;
+        int defaultBackoffBeforeFailing = 59460;
         assertEquals(defaultBackoffBeforeFailing, millis);
     }
 


### PR DESCRIPTION
We want 500ms for the first retry and about a minute of total retries.

Closes #16608
