### PR TITLE
Add ingest plugins to Elasticsearch plugin docs

### DIFF
--- a/docs/plugins/index.asciidoc
+++ b/docs/plugins/index.asciidoc
@@ -47,6 +47,8 @@ include::analysis.asciidoc[]
 
 include::discovery.asciidoc[]
 
+include::ingest.asciidoc[]
+
 include::management.asciidoc[]
 
 include::mapper.asciidoc[]

--- a/docs/plugins/ingest-attachment.asciidoc
+++ b/docs/plugins/ingest-attachment.asciidoc
@@ -1,5 +1,5 @@
 [[ingest-attachment]]
-== Ingest Attachment Processor Plugin
+=== Ingest Attachment Processor Plugin
 
 The ingest attachment plugin lets Elasticsearch extract file attachments in common formats (such as PPT, XLS, PDF)
 using the Apache text extraction library http://lucene.apache.org/tika/[Tika].

--- a/docs/plugins/ingest-geoip.asciidoc
+++ b/docs/plugins/ingest-geoip.asciidoc
@@ -1,5 +1,5 @@
 [[ingest-geoip]]
-== Ingest Geoip Processor Plugin
+=== Ingest Geoip Processor Plugin
 
 The GeoIP processor adds information about the geographical location of IP addresses, based on data from the Maxmind databases.
 This processor adds this information by default under the `geoip` field.
@@ -19,10 +19,11 @@ is located at `$ES_HOME/config/ingest/geoip` and holds the shipped databases too
 | `source_field`         | yes       | -                                                                                  | The field to get the ip address or hostname from for the geographical lookup.
 | `target_field`         | no        | geoip                                                                              | The field that will hold the geographical information looked up from the Maxmind database.
 | `database_file`        | no        | GeoLite2-City.mmdb                                                                 | The database filename in the geoip config directory. The ingest-geoip plugin ships with the GeoLite2-City.mmdb and GeoLite2-Country.mmdb files.
-| `fields`               | no        | [`continent_name`, `country_iso_code`, `region_name`, `city_name`, `location`] <1> | Controls what properties are added to the `target_field` based on the geoip lookup.
+| `fields`               | no        | [`continent_name`, `country_iso_code`, `region_name`, `city_name`, `location`] *   | Controls what properties are added to the `target_field` based on the geoip lookup.
 |======
 
-<1> Depends on what is available in `database_field`:
+*Depends on what is available in `database_field`:
+
 * If the GeoLite2 City database is used then the following fields may be added under the `target_field`: `ip`,
 `country_iso_code`, `country_name`, `continent_name`, `region_name`, `city_name`, `timezone`, `latitude`, `longitude`
 and `location`. The fields actually added depend on what has been found and which fields were configured in `fields`.

--- a/docs/plugins/ingest.asciidoc
+++ b/docs/plugins/ingest.asciidoc
@@ -1,0 +1,26 @@
+[[ingest]]
+== Ingest Plugins
+
+The ingest plugins extend Elaticsearch by providing additional ingest node capabilities.
+
+[float]
+=== Core Ingest Plugins
+
+The core ingest plugins are:
+
+<<ingest-attachment>>::
+
+The ingest attachment plugin lets Elasticsearch extract file attachments in common formats (such as PPT, XLS, and PDF) by
+using the Apache text extraction library http://lucene.apache.org/tika/[Tika].
+
+<<ingest-geoip>>::
+
+The GeoIP processor adds information about the geographical location of IP addresses, based on data from the Maxmind databases.
+This processor adds this information by default under the `geoip` field.
++
+The ingest-geoip plugin ships by default with the GeoLite2 City and GeoLite2 Country geoip2 databases from Maxmind made available
+under the CCA-ShareAlike 3.0 license. For more details see, http://dev.maxmind.com/geoip/geoip2/geolite2/. 
+
+include::ingest-attachment.asciidoc[]
+
+include::ingest-geoip.asciidoc[]


### PR DESCRIPTION
Summary of changes:
- Added new container topic called ingest.asciidoc to group the ingest plugins together
- Added ingest.asciidoc to index.asciidoc
- Changed heading levels to get the TOC structure to work
- Removed the callout tag for the table because it was causing syntax errors. I'll need to find another way to show this because I don't think callouts are supported in asciidoc tables.

@debadair Please verify that I've added the content in the correct place. Just getting the content to build; I will edit the content later.
