### PR TITLE
Remove copy constructors from request classes and TransportMessage type

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -272,7 +272,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                             list = new ArrayList<>();
                             requestsByShard.put(shardIt.shardId(), list);
                         }
-                        list.add(new BulkItemRequest(i, new DeleteRequest(deleteRequest)));
+                        list.add(new BulkItemRequest(i, deleteRequest));
                     }
                 } else {
                     ShardId shardId = clusterService.operationRouting().indexShards(clusterState, concreteIndex, deleteRequest.type(), deleteRequest.id(), deleteRequest.routing()).shardId();

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.delete;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.DocumentRequest;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
@@ -78,28 +77,6 @@ public class DeleteRequest extends ReplicationRequest<DeleteRequest> implements 
         this.index = index;
         this.type = type;
         this.id = id;
-    }
-
-    /**
-     * Copy constructor that creates a new delete request that is a copy of the one provided as an argument.
-     */
-    public DeleteRequest(DeleteRequest request) {
-        this(request, request);
-    }
-
-    /**
-     * Copy constructor that creates a new delete request that is a copy of the one provided as an argument.
-     * The new request will inherit though headers and context from the original request that caused it.
-     */
-    public DeleteRequest(DeleteRequest request, ActionRequest originalRequest) {
-        super(request);
-        this.type = request.type();
-        this.id = request.id();
-        this.routing = request.routing();
-        this.parent = request.parent();
-        this.refresh = request.refresh();
-        this.version = request.version();
-        this.versionType = request.versionType();
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -68,26 +68,6 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
     }
 
     /**
-     * Copy constructor that creates a new get request that is a copy of the one provided as an argument.
-     * The new request will inherit though headers and context from the original request that caused it.
-     */
-    public GetRequest(GetRequest getRequest) {
-        this.index = getRequest.index;
-        this.type = getRequest.type;
-        this.id = getRequest.id;
-        this.routing = getRequest.routing;
-        this.parent = getRequest.parent;
-        this.preference = getRequest.preference;
-        this.fields = getRequest.fields;
-        this.fetchSourceContext = getRequest.fetchSourceContext;
-        this.refresh = getRequest.refresh;
-        this.realtime = getRequest.realtime;
-        this.version = getRequest.version;
-        this.versionType = getRequest.versionType;
-        this.ignoreErrorsOnGeneratedFields = getRequest.ignoreErrorsOnGeneratedFields;
-    }
-
-    /**
      * Constructs a new get request against the specified index. The {@link #type(String)} and {@link #id(String)}
      * must be set.
      */

--- a/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -160,26 +160,6 @@ public class IndexRequest extends ReplicationRequest<IndexRequest> implements Do
     }
 
     /**
-     * Copy constructor that creates a new index request that is a copy of the one provided as an argument.
-     * The new request will inherit though headers and context from the original request that caused it.
-     */
-    public IndexRequest(IndexRequest indexRequest) {
-        super(indexRequest);
-        this.type = indexRequest.type;
-        this.id = indexRequest.id;
-        this.routing = indexRequest.routing;
-        this.parent = indexRequest.parent;
-        this.timestamp = indexRequest.timestamp;
-        this.ttl = indexRequest.ttl;
-        this.source = indexRequest.source;
-        this.opType = indexRequest.opType;
-        this.refresh = indexRequest.refresh;
-        this.version = indexRequest.version;
-        this.versionType = indexRequest.versionType;
-        this.contentType = indexRequest.contentType;
-    }
-
-    /**
      * Constructs a new index request against the specific index. The {@link #type(String)}
      * {@link #source(byte[])} must be set.
      */

--- a/core/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/percolate/TransportPercolateAction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.percolate;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.TransportGetAction;
 import org.elasticsearch.action.support.ActionFilters;
@@ -74,9 +73,7 @@ public class TransportPercolateAction extends TransportBroadcastAction<Percolate
     protected void doExecute(Task task, final PercolateRequest request, final ActionListener<PercolateResponse> listener) {
         request.startTime = System.currentTimeMillis();
         if (request.getRequest() != null) {
-            //create a new get request to make sure it has the same headers and context as the original percolate request
-            GetRequest getRequest = new GetRequest(request.getRequest());
-            getAction.execute(getRequest, new ActionListener<GetResponse>() {
+            getAction.execute(request.getRequest(), new ActionListener<GetResponse>() {
                 @Override
                 public void onResponse(GetResponse getResponse) {
                     if (!getResponse.isExists()) {

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -77,23 +77,6 @@ public class SearchRequest extends ActionRequest<SearchRequest> implements Indic
     }
 
     /**
-     * Copy constructor that creates a new search request that is a copy of the one provided as an argument.
-     * The new request will inherit though headers and context from the original request that caused it.
-     */
-    public SearchRequest(SearchRequest searchRequest) {
-        this.searchType = searchRequest.searchType;
-        this.indices = searchRequest.indices;
-        this.routing = searchRequest.routing;
-        this.preference = searchRequest.preference;
-        this.template = searchRequest.template;
-        this.source = searchRequest.source;
-        this.requestCache = searchRequest.requestCache;
-        this.scroll = searchRequest.scroll;
-        this.types = searchRequest.types;
-        this.indicesOptions = searchRequest.indicesOptions;
-    }
-
-    /**
      * Constructs a new search request against the indices. No indices provided here means that search
      * will run against all indices.
      */

--- a/core/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -59,8 +59,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
         final AtomicInteger counter = new AtomicInteger(responses.length());
         for (int i = 0; i < responses.length(); i++) {
             final int index = i;
-            SearchRequest searchRequest = new SearchRequest(request.requests().get(i));
-            searchAction.execute(searchRequest, new ActionListener<SearchResponse>() {
+            searchAction.execute(request.requests().get(i), new ActionListener<SearchResponse>() {
                 @Override
                 public void onResponse(SearchResponse searchResponse) {
                     responses.set(index, new MultiSearchResponse.Item(searchResponse, null));

--- a/core/src/main/java/org/elasticsearch/action/support/replication/BasicReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/BasicReplicationRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.support.replication;
 
-import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.index.shard.ShardId;
 
 /**
@@ -38,13 +37,4 @@ public class BasicReplicationRequest extends ReplicationRequest<BasicReplication
     public BasicReplicationRequest(ShardId shardId) {
         super(shardId);
     }
-
-    /**
-     * Copy constructor that creates a new request that is a copy of the one
-     * provided as an argument.
-     */
-    protected BasicReplicationRequest(BasicReplicationRequest request) {
-        super(request);
-    }
-
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -71,16 +71,6 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
     }
 
     /**
-     * Copy constructor that creates a new request that is a copy of the one provided as an argument.
-     * The new request will inherit though headers and context from the original request that caused it.
-     */
-    protected ReplicationRequest(Request request) {
-        this.timeout = request.timeout();
-        this.index = request.index();
-        this.consistencyLevel = request.consistencyLevel();
-    }
-
-    /**
      * A timeout to wait if the index operation can't be performed immediately. Defaults to <tt>1m</tt>.
      */
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
-import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.index.IndexRequest;
@@ -169,7 +168,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
         final UpdateHelper.Result result = updateHelper.prepare(request, indexShard);
         switch (result.operation()) {
             case UPSERT:
-                IndexRequest upsertRequest = new IndexRequest((IndexRequest)result.action());
+                IndexRequest upsertRequest = result.action();
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
                 final BytesReference upsertSourceBytes = upsertRequest.source();
                 indexAction.execute(upsertRequest, new ActionListener<IndexResponse>() {
@@ -206,7 +205,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 });
                 break;
             case INDEX:
-                IndexRequest indexRequest = new IndexRequest((IndexRequest)result.action());
+                IndexRequest indexRequest = result.action();
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
                 final BytesReference indexSourceBytes = indexRequest.source();
                 indexAction.execute(indexRequest, new ActionListener<IndexResponse>() {
@@ -236,8 +235,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 });
                 break;
             case DELETE:
-                DeleteRequest deleteRequest = new DeleteRequest(result.action(), request);
-                deleteAction.execute(deleteRequest, new ActionListener<DeleteResponse>() {
+                deleteAction.execute(result.action(), new ActionListener<DeleteResponse>() {
                     @Override
                     public void onResponse(DeleteResponse response) {
                         UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), false);

--- a/core/src/main/java/org/elasticsearch/transport/TransportMessage.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportMessage.java
@@ -25,11 +25,8 @@ import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.transport.TransportAddress;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
-public abstract class TransportMessage<TM extends TransportMessage<TM>> implements Streamable {
+public abstract class TransportMessage implements Streamable {
 
     private TransportAddress remoteAddress;
 

--- a/core/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -23,7 +23,7 @@ import org.elasticsearch.tasks.Task;
 
 /**
  */
-public abstract class TransportRequest extends TransportMessage<TransportRequest> {
+public abstract class TransportRequest extends TransportMessage {
 
     public static class Empty extends TransportRequest {
         public static final Empty INSTANCE = new Empty();

--- a/core/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -32,7 +32,6 @@ public abstract class TransportRequest extends TransportMessage<TransportRequest
     public TransportRequest() {
     }
 
-
     /**
      * Returns the task object that should be used to keep track of the processing of the request.
      *
@@ -48,5 +47,4 @@ public abstract class TransportRequest extends TransportMessage<TransportRequest
     public String getDescription() {
         return "";
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/transport/TransportResponse.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportResponse.java
@@ -21,7 +21,7 @@ package org.elasticsearch.transport;
 
 /**
  */
-public abstract class TransportResponse extends TransportMessage<TransportResponse> {
+public abstract class TransportResponse extends TransportMessage {
 
     public static class Empty extends TransportResponse {
         public static final Empty INSTANCE = new Empty();


### PR DESCRIPTION
As a followup of #15776 we can remove all copy constructors that are left in our request classes, that were used to copy headers and context. Also, `TransportMessage` doesn't need a generic type anymore.
