### PR TITLE
Use MappedFieldType.termQuery to generate simple_query_string queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -459,6 +459,17 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     /**
+     * Returns the {@link MappedFieldType} for the give fullName.
+     *
+     * If multiple types have fields with the same full name, the first is returned.
+     *
+     * This is an alias to make {@code fullName} easier to find
+     */
+    public MappedFieldType getFieldForName(String fullName) {
+        return this.fullName(fullName);
+    }
+
+    /**
      * Returns all the fields that match the given pattern. If the pattern is prefixed with a type
      * then the fields will be returned with a type prefix.
      */


### PR DESCRIPTION
For Numeric types, if the query's text is passed to create a boolean
query, the 'Long' analyzer can return an exception similar to:

```
IllegalArgumentException: Illegal shift value, must be 0..63; got shift=2147483647
```

This change looks up the `MappedFieldType` for the specified fields (if
available) and uses the `.termQuery` function to create the query from
the string, instead of analyzing it by creating a new boolean query by
default.

Resolves #16577
