### PR TITLE
Class permission for Groovy references

### DIFF
--- a/modules/lang-groovy/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/lang-groovy/src/main/plugin-metadata/plugin-security.policy
@@ -55,4 +55,5 @@ grant {
   permission org.elasticsearch.script.ClassPermission "org.codehaus.groovy.runtime.GeneratedClosure";
   permission org.elasticsearch.script.ClassPermission "groovy.lang.MetaClass";
   permission org.elasticsearch.script.ClassPermission "groovy.lang.Range";
+  permission org.elasticsearch.script.ClassPermission "groovy.lang.Reference";
 };

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/script/groovy/GroovySecurityTests.java
@@ -90,6 +90,7 @@ public class GroovySecurityTests extends ESTestCase {
         // Groovy closures
         assertSuccess("[1, 2, 3, 4].findAll { it % 2 == 0 }");
         assertSuccess("def buckets=[ [2, 4, 6, 8], [10, 12, 16, 14], [18, 22, 20, 24] ]; buckets[-3..-1].every { it.every { i -> i % 2 == 0 } }");
+        assertSuccess("def val = \"\"; [1, 2, 3, 4].each { val += it }; val");
         // Groovy uses reflection to invoke closures. These reflective calls are optimized by the JVM after "sun.reflect.inflationThreshold"
         // invocations. After the inflation step, access to sun.reflect.MethodAccessorImpl is required from the security manager. This test,
         // assuming a inflation threshold below 100 (15 is current value on Oracle JVMs), checks that the relevant permission is available.


### PR DESCRIPTION
This commit adds a class permission for groovy.lang.Reference so they
can be used in scripts.

Closes #16657
