### PR TITLE
API for listing index file sizes

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -166,7 +166,7 @@ public class CommonStats implements Streamable, ToXContent {
                     completion = indexShard.completionStats(flags.completionDataFields());
                     break;
                 case Segments:
-                    segments = indexShard.segmentStats();
+                    segments = indexShard.segmentStats(flags.includeSegmentFileSizes());
                     break;
                 case Percolate:
                     percolate = indexShard.percolateStats();

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -38,6 +39,7 @@ public class CommonStatsFlags implements Streamable, Cloneable {
     private String[] groups = null;
     private String[] fieldDataFields = null;
     private String[] completionDataFields = null;
+    private boolean includeSegmentFileSizes = false;
 
 
     /**
@@ -62,6 +64,7 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         groups = null;
         fieldDataFields = null;
         completionDataFields = null;
+        includeSegmentFileSizes = false;
         return this;
     }
 
@@ -74,6 +77,7 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         groups = null;
         fieldDataFields = null;
         completionDataFields = null;
+        includeSegmentFileSizes = false;
         return this;
     }
 
@@ -137,6 +141,15 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         return this.completionDataFields;
     }
 
+    public CommonStatsFlags includeSegmentFileSizes(boolean includeSegmentFileSizes) {
+        this.includeSegmentFileSizes = includeSegmentFileSizes;
+        return this;
+    }
+
+    public boolean includeSegmentFileSizes() {
+        return this.includeSegmentFileSizes;
+    }
+
     public boolean isSet(Flag flag) {
         return flags.contains(flag);
     }
@@ -177,6 +190,9 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         out.writeStringArrayNullable(groups);
         out.writeStringArrayNullable(fieldDataFields);
         out.writeStringArrayNullable(completionDataFields);
+        if (out.getVersion().onOrAfter(Version.V_5_0_0)) {
+            out.writeBoolean(includeSegmentFileSizes);
+        }
     }
 
     @Override
@@ -192,6 +208,11 @@ public class CommonStatsFlags implements Streamable, Cloneable {
         groups = in.readStringArray();
         fieldDataFields = in.readStringArray();
         completionDataFields = in.readStringArray();
+        if (in.getVersion().onOrAfter(Version.V_5_0_0)) {
+            includeSegmentFileSizes = in.readBoolean();
+        } else {
+            includeSegmentFileSizes = false;
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -265,6 +265,15 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
         return flags.isSet(Flag.Recovery);
     }
 
+    public boolean includeSegmentFileSizes() {
+        return flags.includeSegmentFileSizes();
+    }
+
+    public IndicesStatsRequest includeSegmentFileSizes(boolean includeSegmentFileSizes) {
+        flags.includeSegmentFileSizes(includeSegmentFileSizes);
+        return this;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequestBuilder.java
@@ -166,4 +166,9 @@ public class IndicesStatsRequestBuilder extends BroadcastOperationRequestBuilder
         request.recovery(recovery);
         return this;
     }
+
+    public IndicesStatsRequestBuilder setIncludeSegmentFileSizes(boolean includeSegmentFileSizes) {
+        request.includeSegmentFileSizes(includeSegmentFileSizes);
+        return this;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -144,6 +144,7 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
         }
         if (request.segments()) {
             flags.set(CommonStatsFlags.Flag.Segments);
+            flags.includeSegmentFileSizes(request.includeSegmentFileSizes());
         }
         if (request.completion()) {
             flags.set(CommonStatsFlags.Flag.Completion);

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -630,8 +630,8 @@ public class IndexShard extends AbstractIndexShardComponent {
         return engine.getMergeStats();
     }
 
-    public SegmentsStats segmentStats() {
-        SegmentsStats segmentsStats = getEngine().segmentsStats();
+    public SegmentsStats segmentStats(boolean includeSegmentFileSizes) {
+        SegmentsStats segmentsStats = getEngine().segmentsStats(includeSegmentFileSizes);
         segmentsStats.addBitsetMemoryInBytes(shardBitsetFilterCache.getMemorySizeInBytes());
         return segmentsStats;
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/stats/RestNodesStatsAction.java
@@ -109,6 +109,9 @@ public class RestNodesStatsAction extends BaseRestHandler {
         if (nodesStatsRequest.indices().isSet(Flag.Indexing) && (request.hasParam("types"))) {
             nodesStatsRequest.indices().types(request.paramAsStringArray("types", null));
         }
+        if (nodesStatsRequest.indices().isSet(Flag.Segments) && (request.hasParam("include_segment_file_sizes"))) {
+            nodesStatsRequest.indices().includeSegmentFileSizes(true);
+        }
 
         client.admin().cluster().nodesStats(nodesStatsRequest, new RestToXContentListener<NodesStatsResponse>(channel));
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/stats/RestIndicesStatsAction.java
@@ -104,6 +104,10 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             indicesStatsRequest.fieldDataFields(request.paramAsStringArray("fielddata_fields", request.paramAsStringArray("fields", Strings.EMPTY_ARRAY)));
         }
 
+        if (indicesStatsRequest.segments() && request.hasParam("include_segment_file_sizes")) {
+            indicesStatsRequest.includeSegmentFileSizes(true);
+        }
+
         client.admin().indices().stats(indicesStatsRequest, new RestBuilderListener<IndicesStatsResponse>(channel) {
             @Override
             public RestResponse buildResponse(IndicesStatsResponse response, XContentBuilder builder) throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.engine;
 
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
@@ -126,6 +128,7 @@ import static java.util.Collections.emptyMap;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.PRIMARY;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.REPLICA;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
@@ -293,8 +296,8 @@ public class InternalEngineTests extends ESTestCase {
              Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE)) {
             List<Segment> segments = engine.segments(false);
             assertThat(segments.isEmpty(), equalTo(true));
-            assertThat(engine.segmentsStats().getCount(), equalTo(0L));
-            assertThat(engine.segmentsStats().getMemoryInBytes(), equalTo(0L));
+            assertThat(engine.segmentsStats(false).getCount(), equalTo(0L));
+            assertThat(engine.segmentsStats(false).getMemoryInBytes(), equalTo(0L));
 
             // create a doc and refresh
             ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, null);
@@ -306,7 +309,7 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(1));
-            SegmentsStats stats = engine.segmentsStats();
+            SegmentsStats stats = engine.segmentsStats(false);
             assertThat(stats.getCount(), equalTo(1L));
             assertThat(stats.getTermsMemoryInBytes(), greaterThan(0L));
             assertThat(stats.getStoredFieldsMemoryInBytes(), greaterThan(0L));
@@ -324,7 +327,7 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(1));
-            assertThat(engine.segmentsStats().getCount(), equalTo(1L));
+            assertThat(engine.segmentsStats(false).getCount(), equalTo(1L));
             assertThat(segments.get(0).isCommitted(), equalTo(true));
             assertThat(segments.get(0).isSearch(), equalTo(true));
             assertThat(segments.get(0).getNumDocs(), equalTo(2));
@@ -337,12 +340,12 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(2));
-            assertThat(engine.segmentsStats().getCount(), equalTo(2L));
-            assertThat(engine.segmentsStats().getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
-            assertThat(engine.segmentsStats().getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
-            assertThat(engine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0L));
-            assertThat(engine.segmentsStats().getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
-            assertThat(engine.segmentsStats().getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
+            assertThat(engine.segmentsStats(false).getCount(), equalTo(2L));
+            assertThat(engine.segmentsStats(false).getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
+            assertThat(engine.segmentsStats(false).getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
+            assertThat(engine.segmentsStats(false).getTermVectorsMemoryInBytes(), equalTo(0L));
+            assertThat(engine.segmentsStats(false).getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
+            assertThat(engine.segmentsStats(false).getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
             assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
             assertThat(segments.get(0).isCommitted(), equalTo(true));
             assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -363,7 +366,7 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(2));
-            assertThat(engine.segmentsStats().getCount(), equalTo(2L));
+            assertThat(engine.segmentsStats(false).getCount(), equalTo(2L));
             assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
             assertThat(segments.get(0).isCommitted(), equalTo(true));
             assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -384,7 +387,7 @@ public class InternalEngineTests extends ESTestCase {
 
             segments = engine.segments(false);
             assertThat(segments.size(), equalTo(3));
-            assertThat(engine.segmentsStats().getCount(), equalTo(3L));
+            assertThat(engine.segmentsStats(false).getCount(), equalTo(3L));
             assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
             assertThat(segments.get(0).isCommitted(), equalTo(true));
             assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -484,6 +487,29 @@ public class InternalEngineTests extends ESTestCase {
                 // we should have had just 1 merge, so last generation should be exact
                 assertEquals(gen2 + 1, store.readLastCommittedSegmentsInfo().getLastGeneration());
             }
+        }
+    }
+
+    public void testSegmentsStatsIncludingFileSizes() throws Exception {
+        try (Store store = createStore();
+            Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE)) {
+            assertThat(engine.segmentsStats(true).getFileSizes().size(), equalTo(0));
+
+            ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, null);
+            engine.index(new Engine.Index(newUid("1"), doc));
+            engine.refresh("test");
+
+            SegmentsStats stats = engine.segmentsStats(true);
+            assertThat(stats.getFileSizes().size(), greaterThan(0));
+            assertThat((Iterable<Long>) () -> stats.getFileSizes().valuesIt(), everyItem(greaterThan(0L)));
+
+            ObjectObjectCursor<String, Long> firstEntry = stats.getFileSizes().iterator().next();
+
+            ParsedDocument doc2 = testParsedDocument("2", "2", "test", null, -1, -1, testDocumentWithTextField(), B_2, null);
+            engine.index(new Engine.Index(newUid("2"), doc2));
+            engine.refresh("test");
+
+            assertThat(engine.segmentsStats(true).getFileSizes().get(firstEntry.key), greaterThan(firstEntry.value));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/ShadowEngineTests.java
@@ -276,8 +276,8 @@ public class ShadowEngineTests extends ESTestCase {
         primaryEngine = createInternalEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE);
         List<Segment> segments = primaryEngine.segments(false);
         assertThat(segments.isEmpty(), equalTo(true));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(0L));
-        assertThat(primaryEngine.segmentsStats().getMemoryInBytes(), equalTo(0L));
+        assertThat(primaryEngine.segmentsStats(false).getCount(), equalTo(0L));
+        assertThat(primaryEngine.segmentsStats(false).getMemoryInBytes(), equalTo(0L));
 
         // create a doc and refresh
         ParsedDocument doc = testParsedDocument("1", "1", "test", null, -1, -1, testDocumentWithTextField(), B_1, null);
@@ -289,7 +289,7 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(1));
-        SegmentsStats stats = primaryEngine.segmentsStats();
+        SegmentsStats stats = primaryEngine.segmentsStats(false);
         assertThat(stats.getCount(), equalTo(1L));
         assertThat(stats.getTermsMemoryInBytes(), greaterThan(0L));
         assertThat(stats.getStoredFieldsMemoryInBytes(), greaterThan(0L));
@@ -306,7 +306,7 @@ public class ShadowEngineTests extends ESTestCase {
         // Check that the replica sees nothing
         segments = replicaEngine.segments(false);
         assertThat(segments.size(), equalTo(0));
-        stats = replicaEngine.segmentsStats();
+        stats = replicaEngine.segmentsStats(false);
         assertThat(stats.getCount(), equalTo(0L));
         assertThat(stats.getTermsMemoryInBytes(), equalTo(0L));
         assertThat(stats.getStoredFieldsMemoryInBytes(), equalTo(0L));
@@ -323,7 +323,7 @@ public class ShadowEngineTests extends ESTestCase {
         // Check that the primary AND replica sees segments now
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(1));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(1L));
+        assertThat(primaryEngine.segmentsStats(false).getCount(), equalTo(1L));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));
         assertThat(segments.get(0).getNumDocs(), equalTo(2));
@@ -332,7 +332,7 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = replicaEngine.segments(false);
         assertThat(segments.size(), equalTo(1));
-        assertThat(replicaEngine.segmentsStats().getCount(), equalTo(1L));
+        assertThat(replicaEngine.segmentsStats(false).getCount(), equalTo(1L));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));
         assertThat(segments.get(0).getNumDocs(), equalTo(2));
@@ -346,12 +346,12 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(2));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(2L));
-        assertThat(primaryEngine.segmentsStats().getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
-        assertThat(primaryEngine.segmentsStats().getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
-        assertThat(primaryEngine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0L));
-        assertThat(primaryEngine.segmentsStats().getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
-        assertThat(primaryEngine.segmentsStats().getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
+        assertThat(primaryEngine.segmentsStats(false).getCount(), equalTo(2L));
+        assertThat(primaryEngine.segmentsStats(false).getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
+        assertThat(primaryEngine.segmentsStats(false).getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
+        assertThat(primaryEngine.segmentsStats(false).getTermVectorsMemoryInBytes(), equalTo(0L));
+        assertThat(primaryEngine.segmentsStats(false).getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
+        assertThat(primaryEngine.segmentsStats(false).getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
         assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -370,12 +370,12 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = replicaEngine.segments(false);
         assertThat(segments.size(), equalTo(2));
-        assertThat(replicaEngine.segmentsStats().getCount(), equalTo(2L));
-        assertThat(replicaEngine.segmentsStats().getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
-        assertThat(replicaEngine.segmentsStats().getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
-        assertThat(replicaEngine.segmentsStats().getTermVectorsMemoryInBytes(), equalTo(0L));
-        assertThat(replicaEngine.segmentsStats().getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
-        assertThat(replicaEngine.segmentsStats().getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
+        assertThat(replicaEngine.segmentsStats(false).getCount(), equalTo(2L));
+        assertThat(replicaEngine.segmentsStats(false).getTermsMemoryInBytes(), greaterThan(stats.getTermsMemoryInBytes()));
+        assertThat(replicaEngine.segmentsStats(false).getStoredFieldsMemoryInBytes(), greaterThan(stats.getStoredFieldsMemoryInBytes()));
+        assertThat(replicaEngine.segmentsStats(false).getTermVectorsMemoryInBytes(), equalTo(0L));
+        assertThat(replicaEngine.segmentsStats(false).getNormsMemoryInBytes(), greaterThan(stats.getNormsMemoryInBytes()));
+        assertThat(replicaEngine.segmentsStats(false).getDocValuesMemoryInBytes(), greaterThan(stats.getDocValuesMemoryInBytes()));
         assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -393,7 +393,7 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(2));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(2L));
+        assertThat(primaryEngine.segmentsStats(false).getCount(), equalTo(2L));
         assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));
@@ -416,7 +416,7 @@ public class ShadowEngineTests extends ESTestCase {
 
         segments = primaryEngine.segments(false);
         assertThat(segments.size(), equalTo(3));
-        assertThat(primaryEngine.segmentsStats().getCount(), equalTo(3L));
+        assertThat(primaryEngine.segmentsStats(false).getCount(), equalTo(3L));
         assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
         assertThat(segments.get(0).isCommitted(), equalTo(true));
         assertThat(segments.get(0).isSearch(), equalTo(true));

--- a/docs/reference/indices/stats.asciidoc
+++ b/docs/reference/indices/stats.asciidoc
@@ -39,6 +39,8 @@ specified as well in the URI. Those stats can be any of:
                 groups). The `groups` parameter accepts a comma separated list of group names.
                 Use `_all` to return statistics for all groups.
 
+`segments`::    Retrieve the memory use of the open segments. Optionally, setting the `include_segment_file_sizes` flag, report the aggregated disk usage of each one of the Lucene index files.
+
 `completion`::  Completion suggest statistics.
 `fielddata`::   Fielddata statistics.
 `flush`::       Flush statistics.


### PR DESCRIPTION
I'd like to propose this API to query index file sizes, as part of SegmentsStats.

_Copypasting a comment previously posted on #16131:_

Some comments/questions follow.

I'm consolidating file sizes using the same criteria of `SegmentsStats` to expose disk usage of Lucene index files: `Terms`, `TermVectors`, `StoredFields`, `Norms`, `DocValues` (class `IndexResources` in `SegmentsStats`).

`SegmentsStats` currently exposes memory consumption as bytes of each of the aforementioned so it's possible to add these as part of a class (`IndexResources`) and expose it as two fields of `SegmentsStats`, one for memory resources (existing stats) and other for disk resources. This is what I implemented in my branch, but I'm not sure if it would be better to expose this as another "sister" class of `SegmentsStats`, member of `CommonStats`, and leave `SegmentsStats` as it is. I'm however aware that my `toXContent` serialization could break clients expecting certain fields that now are placed elsewhere.

Some other couple questions I've got:
1. Is it necessary to consolidate sizes by the same criteria of `SegmentsStats` or may be better doing it using the file extensions? This last option has the advantage that would include additional information about postings, i.e., separate size info for positions, payloads, etc.
2. The meat of the matter: Is the way I open the Directory from the `SegmentInfo` and the compound reader a sensible approach? I'm not sure if this could introduce issues with the `Store`.

Closes #16131
