### PR TITLE
Fix elasticsearch-plugin script on cygwin environment

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -94,6 +94,15 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+
+# Special-case path variables.
+case `uname` in
+    CYGWIN*)
+        ES_HOME=`cygpath -p -w "$ES_HOME"`
+        CONF_DIR=`cygpath -p -w "$CONF_DIR"`
+    ;;
+esac
+
 # check if properties already has a config file or config dir
 if [ -e "$CONF_DIR" ]; then
   case "$properties" in
@@ -110,4 +119,4 @@ fi
 HOSTNAME=`hostname | cut -d. -f1`
 export HOSTNAME
 
-eval "$JAVA" -client -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginCli $args
+eval "\"$JAVA\"" -client -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginCli $args


### PR DESCRIPTION
More information, see: https://github.com/elastic/elasticsearch/issues/16666

I have applied same solution than _elasticsearch_ script, see: https://github.com/elastic/elasticsearch/blob/master/distribution/src/main/resources/bin/elasticsearch#L121-L127 but it is neccesary to apply to ES_HOME and CONF_DIR variables.

It is also necessary to escape JAVA variable as we can use spaces at Java path:
https://github.com/jorgediaz-lr/elasticsearch/blob/16666_fix_plugin_script_on_cygwin/distribution/src/main/resources/bin/elasticsearch-plugin#L122

Closes #16666
