### PR TITLE
Clarify text about date format range

### DIFF
--- a/docs/reference/mapping/params/format.asciidoc
+++ b/docs/reference/mapping/params/format.asciidoc
@@ -57,15 +57,15 @@ The following tables lists all the defaults ISO formats supported:
 `epoch_millis`::
 
     A formatter for the number of milliseconds since the epoch. Note, that
-    this timestamp allows a max length of 13 chars, so dates older than 1653
-    and 2286 are not supported. You should use a different date formatter in
+    this timestamp allows a max length of 13 chars, so only dates between 1653
+    and 2286 are supported. You should use a different date formatter in
     that case.
 
 `epoch_second`::
 
     A formatter for the number of seconds since the epoch. Note, that this
-    timestamp allows a max length of 10 chars, so dates older than 1653 and
-    2286 are not supported. You should use a different date formatter in that
+    timestamp allows a max length of 10 chars, so only dates between 1653 and
+    2286 are supported. You should use a different date formatter in that
     case.
 
 [[strict-date-time]]`date_optional_time` or `strict_date_optional_time`::


### PR DESCRIPTION
Older than a certain year-range was a bit unclear in my opinion.
