### PR TITLE
Deprecate Mapper Attachment Plugin

### DIFF
--- a/docs/plugins/mapper-attachments.asciidoc
+++ b/docs/plugins/mapper-attachments.asciidoc
@@ -1,6 +1,8 @@
 [[mapper-attachments]]
 === Mapper Attachments Plugin
 
+deprecated[5.0.0,The `mapper-attachments` plugin will be replaced by the `ingest-attachment` plugin]
+
 The mapper attachments plugin lets Elasticsearch index file attachments in common formats (such as PPT, XLS, PDF)
 using the Apache text extraction library http://lucene.apache.org/tika/[Tika].
 

--- a/docs/plugins/mapper.asciidoc
+++ b/docs/plugins/mapper.asciidoc
@@ -10,8 +10,9 @@ The core mapper plugins are:
 
 <<mapper-attachments>>::
 
-The mapper-attachments integrates http://lucene.apache.org/tika/[Apache Tika] to provide a new field
-type `attachment` to allow indexing of documents such as PDFs and Microsoft Word.
+deprecated[5.0.0,The `mapper-attachments` plugin will be replaced by the `ingest-attachment` plugin]:
+The mapper-attachments integrates http://lucene.apache.org/tika/[Apache Tika] to provide a new field type `attachment`
+to allow indexing of documents such as PDFs and Microsoft Word.
 
 <<mapper-size>>::
 


### PR DESCRIPTION
Now that we have the ingest-attachment plugin (https://github.com/elastic/elasticsearch/pull/16490)  we should deprecate the mapper-attachment plugin.

Closes #16650.

Backport of #16669 in 2.x branch
