### PR TITLE
Use MappedFieldType.termQuery to generate simple_query_string queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -362,7 +362,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             // Before 3.0 some metadata mappers are also registered under the root object mapper
             // So we avoid false positives by deduplicating mappers
             // given that we check exact equality, this would still catch the case that a mapper
-            // is defined under the root object 
+            // is defined under the root object
             Collection<FieldMapper> uniqueFieldMappers = Collections.newSetFromMap(new IdentityHashMap<FieldMapper, Boolean>());
             uniqueFieldMappers.addAll(fieldMappers);
             fieldMappers = uniqueFieldMappers;

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -167,6 +167,19 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 0l);
     }
 
+    // See: https://github.com/elastic/elasticsearch/issues/16577
+    public void testSimpleQueryStringUsesFieldAnalyzer() throws Exception {
+        client().prepareIndex("test", "type1", "1").setSource("foo", 123, "bar", "abc").get();
+        client().prepareIndex("test", "type1", "2").setSource("foo", 234, "bar", "bcd").get();
+
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch().setQuery(
+                simpleQueryStringQuery("123").field("foo").field("bar")).get();
+        assertHitCount(searchResponse, 1L);
+        assertSearchHits(searchResponse, "1");
+    }
+
     @Test
     public void testQueryStringLocale() {
         createIndex("test");


### PR DESCRIPTION
For Numeric types, if the query's text is passed to create a boolean
query, the 'Long' analyzer can return an exception similar to:

```
IllegalArgumentException: Illegal shift value, must be 0..63; got shift=2147483647
```

This change looks up the `MappedFieldType` for the specified fields (if
available) and uses the `.termQuery` function to create the query from
the string, instead of analyzing it by creating a new boolean query by
default.

Resolves #16577

This is fixed in 2.3+ by Lucene 5.5
