### PR TITLE
snapshots doc: Repository Verification `verify` example

### DIFF
--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -186,7 +186,7 @@ The verification process can also be executed manually by running the following 
 
 [source,js]
 -----------------------------------
-POST /_snapshot/my_backup/_verify
+POST /_snapshot/s3_repository/_verify
 -----------------------------------
 // AUTOSENSE
 


### PR DESCRIPTION
Replace `my_backup` in the example line

```
POST /_snapshot/my_backup/_verify
```

by `s3_repository` to match the repository name in above example : 

```
PUT /_snapshot/s3_repository?verify=false
{
  "type": "s3",
  "settings": {
    "bucket": "my_s3_bucket",
    "region": "eu-west-1"
  }
}
```
