### PR TITLE
Hot inlined methods in your area

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.index.TransportIndexAction;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.action.update.UpdateHelper;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -111,185 +112,7 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
         Translog.Location location = null;
         for (int requestIndex = 0; requestIndex < request.items().length; requestIndex++) {
             BulkItemRequest item = request.items()[requestIndex];
-            if (item.request() instanceof IndexRequest) {
-                IndexRequest indexRequest = (IndexRequest) item.request();
-                preVersions[requestIndex] = indexRequest.version();
-                preVersionTypes[requestIndex] = indexRequest.versionType();
-                try {
-                    WriteResult<IndexResponse> result = shardIndexOperation(request, indexRequest, metaData, indexShard, true);
-                    location = locationToSync(location, result.location);
-                    // add the response
-                    IndexResponse indexResponse = result.response();
-                    setResponse(item, new BulkItemResponse(item.id(), indexRequest.opType().lowercase(), indexResponse));
-                } catch (Throwable e) {
-                    // rethrow the failure if we are going to retry on primary and let parent failure to handle it
-                    if (retryPrimaryException(e)) {
-                        // restore updated versions...
-                        for (int j = 0; j < requestIndex; j++) {
-                            applyVersion(request.items()[j], preVersions[j], preVersionTypes[j]);
-                        }
-                        throw (ElasticsearchException) e;
-                    }
-                    if (ExceptionsHelper.status(e) == RestStatus.CONFLICT) {
-                        logger.trace("{} failed to execute bulk item (index) {}", e, request.shardId(), indexRequest);
-                    } else {
-                        logger.debug("{} failed to execute bulk item (index) {}", e, request.shardId(), indexRequest);
-                    }
-                    // if its a conflict failure, and we already executed the request on a primary (and we execute it
-                    // again, due to primary relocation and only processing up to N bulk items when the shard gets closed)
-                    // then just use the response we got from the successful execution
-                    if (item.getPrimaryResponse() != null && isConflictException(e)) {
-                        setResponse(item, item.getPrimaryResponse());
-                    } else {
-                        setResponse(item, new BulkItemResponse(item.id(), indexRequest.opType().lowercase(),
-                                new BulkItemResponse.Failure(request.index(), indexRequest.type(), indexRequest.id(), e)));
-                    }
-                }
-            } else if (item.request() instanceof DeleteRequest) {
-                DeleteRequest deleteRequest = (DeleteRequest) item.request();
-                preVersions[requestIndex] = deleteRequest.version();
-                preVersionTypes[requestIndex] = deleteRequest.versionType();
-
-                try {
-                    // add the response
-                    final WriteResult<DeleteResponse> writeResult = TransportDeleteAction.executeDeleteRequestOnPrimary(deleteRequest, indexShard);
-                    DeleteResponse deleteResponse = writeResult.response();
-                    location = locationToSync(location, writeResult.location);
-                    setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_DELETE, deleteResponse));
-                } catch (Throwable e) {
-                    // rethrow the failure if we are going to retry on primary and let parent failure to handle it
-                    if (retryPrimaryException(e)) {
-                        // restore updated versions...
-                        for (int j = 0; j < requestIndex; j++) {
-                            applyVersion(request.items()[j], preVersions[j], preVersionTypes[j]);
-                        }
-                        throw (ElasticsearchException) e;
-                    }
-                    if (ExceptionsHelper.status(e) == RestStatus.CONFLICT) {
-                        logger.trace("{} failed to execute bulk item (delete) {}", e, request.shardId(), deleteRequest);
-                    } else {
-                        logger.debug("{} failed to execute bulk item (delete) {}", e, request.shardId(), deleteRequest);
-                    }
-                    // if its a conflict failure, and we already executed the request on a primary (and we execute it
-                    // again, due to primary relocation and only processing up to N bulk items when the shard gets closed)
-                    // then just use the response we got from the successful execution
-                    if (item.getPrimaryResponse() != null && isConflictException(e)) {
-                        setResponse(item, item.getPrimaryResponse());
-                    } else {
-                        setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_DELETE,
-                                new BulkItemResponse.Failure(request.index(), deleteRequest.type(), deleteRequest.id(), e)));
-                    }
-                }
-            } else if (item.request() instanceof UpdateRequest) {
-                UpdateRequest updateRequest = (UpdateRequest) item.request();
-                preVersions[requestIndex] = updateRequest.version();
-                preVersionTypes[requestIndex] = updateRequest.versionType();
-                //  We need to do the requested retries plus the initial attempt. We don't do < 1+retry_on_conflict because retry_on_conflict may be Integer.MAX_VALUE
-                for (int updateAttemptsCount = 0; updateAttemptsCount <= updateRequest.retryOnConflict(); updateAttemptsCount++) {
-                    UpdateResult updateResult;
-                    try {
-                        updateResult = shardUpdateOperation(metaData, request, updateRequest, indexShard);
-                    } catch (Throwable t) {
-                        updateResult = new UpdateResult(null, null, false, t, null);
-                    }
-                    if (updateResult.success()) {
-                        if (updateResult.writeResult != null) {
-                            location = locationToSync(location, updateResult.writeResult.location);
-                        }
-                        switch (updateResult.result.operation()) {
-                            case UPSERT:
-                            case INDEX:
-                                WriteResult<IndexResponse> result = updateResult.writeResult;
-                                IndexRequest indexRequest = updateResult.request();
-                                BytesReference indexSourceAsBytes = indexRequest.source();
-                                // add the response
-                                IndexResponse indexResponse = result.response();
-                                UpdateResponse updateResponse = new UpdateResponse(indexResponse.getShardInfo(), indexResponse.getShardId(), indexResponse.getType(), indexResponse.getId(), indexResponse.getVersion(), indexResponse.isCreated());
-                                if (updateRequest.fields() != null && updateRequest.fields().length > 0) {
-                                    Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(indexSourceAsBytes, true);
-                                    updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), indexResponse.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), indexSourceAsBytes));
-                                }
-                                item = request.items()[requestIndex] = new BulkItemRequest(request.items()[requestIndex].id(), indexRequest);
-                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, updateResponse));
-                                break;
-                            case DELETE:
-                                WriteResult<DeleteResponse> writeResult = updateResult.writeResult;
-                                DeleteResponse response = writeResult.response();
-                                DeleteRequest deleteRequest = updateResult.request();
-                                updateResponse = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), false);
-                                updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), response.getVersion(), updateResult.result.updatedSourceAsMap(), updateResult.result.updateSourceContentType(), null));
-                                // Replace the update request to the translated delete request to execute on the replica.
-                                item = request.items()[requestIndex] = new BulkItemRequest(request.items()[requestIndex].id(), deleteRequest);
-                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, updateResponse));
-                                break;
-                            case NONE:
-                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, updateResult.noopResult));
-                                item.setIgnoreOnReplica(); // no need to go to the replica
-                                break;
-                        }
-                        // NOTE: Breaking out of the retry_on_conflict loop!
-                        break;
-                    } else if (updateResult.failure()) {
-                        Throwable t = updateResult.error;
-                        if (updateResult.retry) {
-                            // updateAttemptCount is 0 based and marks current attempt, if it's equal to retryOnConflict we are going out of the iteration
-                            if (updateAttemptsCount >= updateRequest.retryOnConflict()) {
-                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE,
-                                        new BulkItemResponse.Failure(request.index(), updateRequest.type(), updateRequest.id(), t)));
-                            }
-                        } else {
-                            // rethrow the failure if we are going to retry on primary and let parent failure to handle it
-                            if (retryPrimaryException(t)) {
-                                // restore updated versions...
-                                for (int j = 0; j < requestIndex; j++) {
-                                    applyVersion(request.items()[j], preVersions[j], preVersionTypes[j]);
-                                }
-                                throw (ElasticsearchException) t;
-                            }
-                            // if its a conflict failure, and we already executed the request on a primary (and we execute it
-                            // again, due to primary relocation and only processing up to N bulk items when the shard gets closed)
-                            // then just use the response we got from the successful execution
-                            if (item.getPrimaryResponse() != null && isConflictException(t)) {
-                                setResponse(item, item.getPrimaryResponse());
-                            } else if (updateResult.result == null) {
-                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, new BulkItemResponse.Failure(request.index(), updateRequest.type(), updateRequest.id(), t)));
-                            } else {
-                                switch (updateResult.result.operation()) {
-                                    case UPSERT:
-                                    case INDEX:
-                                        IndexRequest indexRequest = updateResult.request();
-                                        if (ExceptionsHelper.status(t) == RestStatus.CONFLICT) {
-                                            logger.trace("{} failed to execute bulk item (index) {}", t, request.shardId(), indexRequest);
-                                        } else {
-                                            logger.debug("{} failed to execute bulk item (index) {}", t, request.shardId(), indexRequest);
-                                        }
-                                        setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE,
-                                                new BulkItemResponse.Failure(request.index(), indexRequest.type(), indexRequest.id(), t)));
-                                        break;
-                                    case DELETE:
-                                        DeleteRequest deleteRequest = updateResult.request();
-                                        if (ExceptionsHelper.status(t) == RestStatus.CONFLICT) {
-                                            logger.trace("{} failed to execute bulk item (delete) {}", t, request.shardId(), deleteRequest);
-                                        } else {
-                                            logger.debug("{} failed to execute bulk item (delete) {}", t, request.shardId(), deleteRequest);
-                                        }
-                                        setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_DELETE,
-                                                new BulkItemResponse.Failure(request.index(), deleteRequest.type(), deleteRequest.id(), t)));
-                                        break;
-                                }
-                            }
-                            // NOTE: Breaking out of the retry_on_conflict loop!
-                            break;
-                        }
-
-                    }
-                }
-            } else {
-                throw new IllegalStateException("Unexpected index operation: " + item.request());
-            }
-
-            assert item.getPrimaryResponse() != null;
-            assert preVersionTypes[requestIndex] != null;
+            location = handleItem(metaData, request, indexShard, preVersions, preVersionTypes, location, requestIndex, item);
         }
 
         processAfterWrite(request.refresh(), indexShard, location);
@@ -299,6 +122,198 @@ public class TransportShardBulkAction extends TransportReplicationAction<BulkSha
             responses[i] = items[i].getPrimaryResponse();
         }
         return new Tuple<>(new BulkShardResponse(request.shardId(), responses), request);
+    }
+
+    private Translog.Location handleItem(MetaData metaData, BulkShardRequest request, IndexShard indexShard, long[] preVersions, VersionType[] preVersionTypes, Translog.Location location, int requestIndex, BulkItemRequest item) {
+        if (item.request() instanceof IndexRequest) {
+            location = index(metaData, request, indexShard, preVersions, preVersionTypes, location, requestIndex, item);
+        } else if (item.request() instanceof DeleteRequest) {
+            location = delete(request, indexShard, preVersions, preVersionTypes, location, requestIndex, item);
+        } else if (item.request() instanceof UpdateRequest) {
+            Tuple<Translog.Location, BulkItemRequest> tuple = update(metaData, request, indexShard, preVersions, preVersionTypes, location, requestIndex, item);
+            location = tuple.v1();
+            item = tuple.v2();
+        } else {
+            throw new IllegalStateException("Unexpected index operation: " + item.request());
+        }
+
+        assert item.getPrimaryResponse() != null;
+        assert preVersionTypes[requestIndex] != null;
+        return location;
+    }
+
+    private Translog.Location index(MetaData metaData, BulkShardRequest request, IndexShard indexShard, long[] preVersions, VersionType[] preVersionTypes, Translog.Location location, int requestIndex, BulkItemRequest item) {
+        IndexRequest indexRequest = (IndexRequest) item.request();
+        preVersions[requestIndex] = indexRequest.version();
+        preVersionTypes[requestIndex] = indexRequest.versionType();
+        try {
+            WriteResult<IndexResponse> result = shardIndexOperation(request, indexRequest, metaData, indexShard, true);
+            location = locationToSync(location, result.location);
+            // add the response
+            IndexResponse indexResponse = result.response();
+            setResponse(item, new BulkItemResponse(item.id(), indexRequest.opType().lowercase(), indexResponse));
+        } catch (Throwable e) {
+            // rethrow the failure if we are going to retry on primary and let parent failure to handle it
+            if (retryPrimaryException(e)) {
+                // restore updated versions...
+                for (int j = 0; j < requestIndex; j++) {
+                    applyVersion(request.items()[j], preVersions[j], preVersionTypes[j]);
+                }
+                throw (ElasticsearchException) e;
+            }
+            logFailure(e, "index", request.shardId(), indexRequest);
+            // if its a conflict failure, and we already executed the request on a primary (and we execute it
+            // again, due to primary relocation and only processing up to N bulk items when the shard gets closed)
+            // then just use the response we got from the successful execution
+            if (item.getPrimaryResponse() != null && isConflictException(e)) {
+                setResponse(item, item.getPrimaryResponse());
+            } else {
+                setResponse(item, new BulkItemResponse(item.id(), indexRequest.opType().lowercase(),
+                        new BulkItemResponse.Failure(request.index(), indexRequest.type(), indexRequest.id(), e)));
+            }
+        }
+        return location;
+    }
+
+    private <ReplicationRequestT extends ReplicationRequest<ReplicationRequestT>> void logFailure(Throwable e, String operation, ShardId shardId, ReplicationRequest<ReplicationRequestT> request) {
+        if (ExceptionsHelper.status(e) == RestStatus.CONFLICT) {
+            logger.trace("{} failed to execute bulk item ({}) {}", e, shardId, operation, request);
+        } else {
+            logger.debug("{} failed to execute bulk item ({}) {}", e, shardId, operation, request);
+        }
+    }
+
+    private Translog.Location delete(BulkShardRequest request, IndexShard indexShard, long[] preVersions, VersionType[] preVersionTypes, Translog.Location location, int requestIndex, BulkItemRequest item) {
+        DeleteRequest deleteRequest = (DeleteRequest) item.request();
+        preVersions[requestIndex] = deleteRequest.version();
+        preVersionTypes[requestIndex] = deleteRequest.versionType();
+
+        try {
+            // add the response
+            final WriteResult<DeleteResponse> writeResult = TransportDeleteAction.executeDeleteRequestOnPrimary(deleteRequest, indexShard);
+            DeleteResponse deleteResponse = writeResult.response();
+            location = locationToSync(location, writeResult.location);
+            setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_DELETE, deleteResponse));
+        } catch (Throwable e) {
+            // rethrow the failure if we are going to retry on primary and let parent failure to handle it
+            if (retryPrimaryException(e)) {
+                // restore updated versions...
+                for (int j = 0; j < requestIndex; j++) {
+                    applyVersion(request.items()[j], preVersions[j], preVersionTypes[j]);
+                }
+                throw (ElasticsearchException) e;
+            }
+            logFailure(e, "delete", request.shardId(), deleteRequest);
+            // if its a conflict failure, and we already executed the request on a primary (and we execute it
+            // again, due to primary relocation and only processing up to N bulk items when the shard gets closed)
+            // then just use the response we got from the successful execution
+            if (item.getPrimaryResponse() != null && isConflictException(e)) {
+                setResponse(item, item.getPrimaryResponse());
+            } else {
+                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_DELETE,
+                        new BulkItemResponse.Failure(request.index(), deleteRequest.type(), deleteRequest.id(), e)));
+            }
+        }
+        return location;
+    }
+
+    private Tuple<Translog.Location, BulkItemRequest> update(MetaData metaData, BulkShardRequest request, IndexShard indexShard, long[] preVersions, VersionType[] preVersionTypes, Translog.Location location, int requestIndex, BulkItemRequest item) {
+        UpdateRequest updateRequest = (UpdateRequest) item.request();
+        preVersions[requestIndex] = updateRequest.version();
+        preVersionTypes[requestIndex] = updateRequest.versionType();
+        //  We need to do the requested retries plus the initial attempt. We don't do < 1+retry_on_conflict because retry_on_conflict may be Integer.MAX_VALUE
+        for (int updateAttemptsCount = 0; updateAttemptsCount <= updateRequest.retryOnConflict(); updateAttemptsCount++) {
+            UpdateResult updateResult;
+            try {
+                updateResult = shardUpdateOperation(metaData, request, updateRequest, indexShard);
+            } catch (Throwable t) {
+                updateResult = new UpdateResult(null, null, false, t, null);
+            }
+            if (updateResult.success()) {
+                if (updateResult.writeResult != null) {
+                    location = locationToSync(location, updateResult.writeResult.location);
+                }
+                switch (updateResult.result.operation()) {
+                    case UPSERT:
+                    case INDEX:
+                        WriteResult<IndexResponse> result = updateResult.writeResult;
+                        IndexRequest indexRequest = updateResult.request();
+                        BytesReference indexSourceAsBytes = indexRequest.source();
+                        // add the response
+                        IndexResponse indexResponse = result.response();
+                        UpdateResponse updateResponse = new UpdateResponse(indexResponse.getShardInfo(), indexResponse.getShardId(), indexResponse.getType(), indexResponse.getId(), indexResponse.getVersion(), indexResponse.isCreated());
+                        if (updateRequest.fields() != null && updateRequest.fields().length > 0) {
+                            Tuple<XContentType, Map<String, Object>> sourceAndContent = XContentHelper.convertToMap(indexSourceAsBytes, true);
+                            updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), indexResponse.getVersion(), sourceAndContent.v2(), sourceAndContent.v1(), indexSourceAsBytes));
+                        }
+                        item = request.items()[requestIndex] = new BulkItemRequest(request.items()[requestIndex].id(), indexRequest);
+                        setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, updateResponse));
+                        break;
+                    case DELETE:
+                        WriteResult<DeleteResponse> writeResult = updateResult.writeResult;
+                        DeleteResponse response = writeResult.response();
+                        DeleteRequest deleteRequest = updateResult.request();
+                        updateResponse = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getVersion(), false);
+                        updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest, request.index(), response.getVersion(), updateResult.result.updatedSourceAsMap(), updateResult.result.updateSourceContentType(), null));
+                        // Replace the update request to the translated delete request to execute on the replica.
+                        item = request.items()[requestIndex] = new BulkItemRequest(request.items()[requestIndex].id(), deleteRequest);
+                        setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, updateResponse));
+                        break;
+                    case NONE:
+                        setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, updateResult.noopResult));
+                        item.setIgnoreOnReplica(); // no need to go to the replica
+                        break;
+                }
+                // NOTE: Breaking out of the retry_on_conflict loop!
+                break;
+            } else if (updateResult.failure()) {
+                Throwable t = updateResult.error;
+                if (updateResult.retry) {
+                    // updateAttemptCount is 0 based and marks current attempt, if it's equal to retryOnConflict we are going out of the iteration
+                    if (updateAttemptsCount >= updateRequest.retryOnConflict()) {
+                        setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE,
+                            new BulkItemResponse.Failure(request.index(), updateRequest.type(), updateRequest.id(), t)));
+                    }
+                } else {
+                    // rethrow the failure if we are going to retry on primary and let parent failure to handle it
+                    if (retryPrimaryException(t)) {
+                        // restore updated versions...
+                        for (int j = 0; j < requestIndex; j++) {
+                            applyVersion(request.items()[j], preVersions[j], preVersionTypes[j]);
+                        }
+                        throw (ElasticsearchException) t;
+                    }
+                    // if its a conflict failure, and we already executed the request on a primary (and we execute it
+                    // again, due to primary relocation and only processing up to N bulk items when the shard gets closed)
+                    // then just use the response we got from the successful execution
+                    if (item.getPrimaryResponse() != null && isConflictException(t)) {
+                        setResponse(item, item.getPrimaryResponse());
+                    } else if (updateResult.result == null) {
+                        setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE, new BulkItemResponse.Failure(request.index(), updateRequest.type(), updateRequest.id(), t)));
+                    } else {
+                        switch (updateResult.result.operation()) {
+                            case UPSERT:
+                            case INDEX:
+                                IndexRequest indexRequest = updateResult.request();
+                                logFailure(t, "index", request.shardId(), indexRequest);
+                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_UPDATE,
+                                    new BulkItemResponse.Failure(request.index(), indexRequest.type(), indexRequest.id(), t)));
+                                break;
+                            case DELETE:
+                                DeleteRequest deleteRequest = updateResult.request();
+                                logFailure(t, "delete", request.shardId(), deleteRequest);
+                                setResponse(item, new BulkItemResponse(item.id(), OP_TYPE_DELETE,
+                                    new BulkItemResponse.Failure(request.index(), deleteRequest.type(), deleteRequest.id(), t)));
+                                break;
+                        }
+                    }
+                    // NOTE: Breaking out of the retry_on_conflict loop!
+                    break;
+                }
+
+            }
+        }
+        return Tuple.tuple(location, item);
     }
 
     private void setResponse(BulkItemRequest request, BulkItemResponse response) {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -399,27 +399,16 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
     // in the index,bulk,update and delete apis.
     public String resolveIndexRouting(@Nullable String parent, @Nullable String routing, String aliasOrIndex) {
         if (aliasOrIndex == null) {
-            if (routing ==  null) {
-                return parent;
-            }
-            return routing;
+            return routingOrParent(parent, routing);
         }
 
         AliasOrIndex result = getAliasAndIndexLookup().get(aliasOrIndex);
         if (result == null || result.isAlias() == false) {
-            if (routing == null) {
-                return parent;
-            }
-            return routing;
+            return routingOrParent(parent, routing);
         }
         AliasOrIndex.Alias alias = (AliasOrIndex.Alias) result;
         if (result.getIndices().size() > 1) {
-            String[] indexNames = new String[result.getIndices().size()];
-            int i = 0;
-            for (IndexMetaData indexMetaData : result.getIndices()) {
-                indexNames[i++] = indexMetaData.getIndex().getName();
-            }
-            throw new IllegalArgumentException("Alias [" + aliasOrIndex + "] has more than one index associated with it [" + Arrays.toString(indexNames) + "], can't execute a single index op");
+            rejectSingleIndexOperation(aliasOrIndex, result);
         }
         AliasMetaData aliasMd = alias.getFirstAliasMetaData();
         if (aliasMd.indexRouting() != null) {
@@ -434,6 +423,19 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, Fr
             // Alias routing overrides the parent routing (if any).
             return aliasMd.indexRouting();
         }
+        return routingOrParent(parent, routing);
+    }
+
+    private void rejectSingleIndexOperation(String aliasOrIndex, AliasOrIndex result) {
+        String[] indexNames = new String[result.getIndices().size()];
+        int i = 0;
+        for (IndexMetaData indexMetaData : result.getIndices()) {
+            indexNames[i++] = indexMetaData.getIndex().getName();
+        }
+        throw new IllegalArgumentException("Alias [" + aliasOrIndex + "] has more than one index associated with it [" + Arrays.toString(indexNames) + "], can't execute a single index op");
+    }
+
+    private String routingOrParent(@Nullable String parent, @Nullable String routing) {
         if (routing == null) {
             return parent;
         }

--- a/core/src/main/java/org/elasticsearch/common/Base64.java
+++ b/core/src/main/java/org/elasticsearch/common/Base64.java
@@ -1048,16 +1048,21 @@ public final class Base64 {
 
         int len34 = len * 3 / 4;       // Estimate on array size
         byte[] outBuff = new byte[len34]; // Upper limit on size of output
-        int outBuffPosn = 0;             // Keep track of where we're writing
 
+        int outBuffPosn = decode(source, off, len, options, DECODABET, outBuff);
+
+        byte[] out = new byte[outBuffPosn];
+        System.arraycopy(outBuff, 0, out, 0, outBuffPosn);
+        return out;
+    }   // end decode
+
+    private static int decode(byte[] source, int off, int len, int options, byte[] DECODABET, byte[] outBuff) throws IOException {
+        int outBuffPosn = 0;             // Keep track of where we're writing
         byte[] b4 = new byte[4];     // Four byte buffer from source, eliminating white space
         int b4Posn = 0;               // Keep track of four byte input buffer
-        int i = 0;               // Source array counter
-        byte sbiDecode = 0;               // Special value from DECODABET
+        for (int i = off; i < off + len; i++) {  // Loop through source
 
-        for (i = off; i < off + len; i++) {  // Loop through source
-
-            sbiDecode = DECODABET[source[i] & 0xFF];
+            byte sbiDecode = DECODABET[source[i] & 0xFF];
 
             // White space, Equals sign, or legit Base64 character
             // Note the values such as -5 and -9 in the
@@ -1073,7 +1078,7 @@ public final class Base64 {
                         if (source[i] == EQUALS_SIGN) {
                             // check if the equals sign is somewhere in between
                             if (i+1 < len + off) {
-                              throw new java.io.IOException(String.format(Locale.ROOT,
+                              throw new IOException(String.format(Locale.ROOT,
                                       "Found equals sign at position %d of the base64 string, not at the end", i));
                             }
                             break;
@@ -1081,7 +1086,7 @@ public final class Base64 {
                     }   // end if: quartet built
                     else {
                       if (source[i] == EQUALS_SIGN && len + off > i && source[i+1] != EQUALS_SIGN) {
-                        throw new java.io.IOException(String.format(Locale.ROOT,
+                        throw new IOException(String.format(Locale.ROOT,
                                 "Found equals sign at position %d of the base64 string, not at the end", i));
                       } // enf if: equals sign and next character not as well
                     } // end else:
@@ -1089,15 +1094,12 @@ public final class Base64 {
             }   // end if: white space, equals sign or better
             else {
                 // There's a bad input character in the Base64 stream.
-                throw new java.io.IOException(String.format(Locale.ROOT,
+                throw new IOException(String.format(Locale.ROOT,
                         "Bad Base64 input character decimal %d in array position %d", ((int) source[i]) & 0xFF, i));
             }   // end else:
         }   // each input character
-
-        byte[] out = new byte[outBuffPosn];
-        System.arraycopy(outBuff, 0, out, 0, outBuffPosn);
-        return out;
-    }   // end decode
+        return outBuffPosn;
+    }
 
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/Base64.java
+++ b/core/src/main/java/org/elasticsearch/common/Base64.java
@@ -942,17 +942,10 @@ public final class Base64 {
      *                                  or there is not enough room in the array.
      * @since 1.3
      */
-    private static int decode4to3(
-            byte[] source, int srcOffset,
-            byte[] destination, int destOffset, int options) {
-
+    private static int decode4to3(byte[] source, int srcOffset, byte[] destination, int destOffset, int options) {
         // Lots of error checking and exception throwing
-        if (source == null) {
-            throw new NullPointerException("Source array was null.");
-        }   // end if
-        if (destination == null) {
-            throw new NullPointerException("Destination array was null.");
-        }   // end if
+        Objects.requireNonNull(source, "Source array was null.");
+        Objects.requireNonNull(destination, "Destination array was null.");
         if (srcOffset < 0 || srcOffset + 3 >= source.length) {
             throw new IllegalArgumentException(String.format(Locale.ROOT,
                     "Source array with length %d cannot have offset of %d and still process four bytes.", source.length, srcOffset));
@@ -962,56 +955,36 @@ public final class Base64 {
                     "Destination array with length %d cannot have offset of %d and still store three bytes.", destination.length, destOffset));
         }   // end if
 
-
         byte[] DECODABET = getDecodabet(options);
+
+
+        // Two ways to do the same thing. Don't know which way I like best.
+        //int outBuff =   ( ( DECODABET[ source[ srcOffset    ] ] << 24 ) >>>  6 )
+        //              | ( ( DECODABET[ source[ srcOffset + 1] ] << 24 ) >>> 12 );
+        int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
+                | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12);
+
+        destination[destOffset] = (byte) (outBuff >>> 16);
 
         // Example: Dk==
         if (source[srcOffset + 2] == EQUALS_SIGN) {
-            // Two ways to do the same thing. Don't know which way I like best.
-            //int outBuff =   ( ( DECODABET[ source[ srcOffset    ] ] << 24 ) >>>  6 )
-            //              | ( ( DECODABET[ source[ srcOffset + 1] ] << 24 ) >>> 12 );
-            int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
-                    | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12);
-
-            destination[destOffset] = (byte) (outBuff >>> 16);
             return 1;
         }
 
-        // Example: DkL=
-        else if (source[srcOffset + 3] == EQUALS_SIGN) {
-            // Two ways to do the same thing. Don't know which way I like best.
-            //int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] << 24 ) >>>  6 )
-            //              | ( ( DECODABET[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
-            //              | ( ( DECODABET[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 );
-            int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
-                    | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12)
-                    | ((DECODABET[source[srcOffset + 2]] & 0xFF) << 6);
+        outBuff |= ((DECODABET[source[srcOffset + 2]] & 0xFF) << 6);
+        destination[destOffset + 1] = (byte) (outBuff >>> 8);
 
-            destination[destOffset] = (byte) (outBuff >>> 16);
-            destination[destOffset + 1] = (byte) (outBuff >>> 8);
+        // Example: DkL=
+        if (source[srcOffset + 3] == EQUALS_SIGN) {
             return 2;
         }
 
+        outBuff |= ((DECODABET[source[srcOffset + 3]] & 0xFF));
+        destination[destOffset + 2] = (byte) (outBuff);
+
         // Example: DkLE
-        else {
-            // Two ways to do the same thing. Don't know which way I like best.
-            //int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] << 24 ) >>>  6 )
-            //              | ( ( DECODABET[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
-            //              | ( ( DECODABET[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 )
-            //              | ( ( DECODABET[ source[ srcOffset + 3 ] ] << 24 ) >>> 24 );
-            int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
-                    | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12)
-                    | ((DECODABET[source[srcOffset + 2]] & 0xFF) << 6)
-                    | ((DECODABET[source[srcOffset + 3]] & 0xFF));
-
-
-            destination[destOffset] = (byte) (outBuff >> 16);
-            destination[destOffset + 1] = (byte) (outBuff >> 8);
-            destination[destOffset + 2] = (byte) (outBuff);
-
-            return 3;
-        }
-    }   // end decodeToBytes
+        return 3;
+    }
 
 
     /**
@@ -1056,13 +1029,9 @@ public final class Base64 {
      * @throws java.io.IOException If bogus characters exist in source data
      * @since 1.3
      */
-    public static byte[] decode(byte[] source, int off, int len, int options)
-            throws java.io.IOException {
-
+    public static byte[] decode(byte[] source, int off, int len, int options) throws java.io.IOException {
         // Lots of error checking and exception throwing
-        if (source == null) {
-            throw new NullPointerException("Cannot decode null source array.");
-        }   // end if
+        Objects.requireNonNull(source, "Cannot decode null source array.");
         if (off < 0 || off + len > source.length) {
             throw new IllegalArgumentException(String.format(Locale.ROOT,
                     "Source array with length %d cannot have offset of %d and process %d bytes.", source.length, off, len));

--- a/core/src/main/java/org/elasticsearch/common/Base64.java
+++ b/core/src/main/java/org/elasticsearch/common/Base64.java
@@ -18,8 +18,10 @@
  */
 package org.elasticsearch.common;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * <p>Encodes and decodes to and from Base64 notation.</p>
@@ -161,7 +163,7 @@ import java.util.Locale;
  * @author rob@iharder.net
  * @version 2.3.7
  */
-public class Base64 {
+public final class Base64 {
 
 /* ********  P U B L I C   F I E L D S  ******** */
 
@@ -791,10 +793,7 @@ public class Base64 {
      * @since 2.3.1
      */
     public static byte[] encodeBytesToBytes(byte[] source, int off, int len, int options) throws java.io.IOException {
-
-        if (source == null) {
-            throw new NullPointerException("Cannot serialize a null array.");
-        }   // end if: null
+        Objects.requireNonNull(source, "Cannot serialize a null array.");
 
         if (off < 0) {
             throw new IllegalArgumentException("Cannot have negative offset: " + off);
@@ -809,102 +808,108 @@ public class Base64 {
                     String.format(Locale.ROOT, "Cannot have offset of %d and length of %d with array of length %d", off, len, source.length));
         }   // end if: off < 0
 
-
         // Compress?
         if ((options & GZIP) != 0) {
-            java.io.ByteArrayOutputStream baos = null;
-            java.util.zip.GZIPOutputStream gzos = null;
-            Base64.OutputStream b64os = null;
-
-            try {
-                // GZip -> Base64 -> ByteArray
-                baos = new java.io.ByteArrayOutputStream();
-                b64os = new Base64.OutputStream(baos, ENCODE | options);
-                gzos = new java.util.zip.GZIPOutputStream(b64os);
-
-                gzos.write(source, off, len);
-                gzos.close();
-            }   // end try
-            catch (java.io.IOException e) {
-                // Catch it and then throw it immediately so that
-                // the finally{} block is called for cleanup.
-                throw e;
-            }   // end catch
-            finally {
-                try {
-                    gzos.close();
-                } catch (Exception e) {
-                }
-                try {
-                    b64os.close();
-                } catch (Exception e) {
-                }
-                try {
-                    baos.close();
-                } catch (Exception e) {
-                }
-            }   // end finally
-
-            return baos.toByteArray();
+            return encodeCompressedBytes(source, off, len, options);
         }   // end if: compress
 
         // Else, don't compress. Better not to use streams at all then.
         else {
-            boolean breakLines = (options & DO_BREAK_LINES) != 0;
-
-            //int    len43   = len * 4 / 3;
-            //byte[] outBuff = new byte[   ( len43 )                      // Main 4:3
-            //                           + ( (len % 3) > 0 ? 4 : 0 )      // Account for padding
-            //                           + (breakLines ? ( len43 / MAX_LINE_LENGTH ) : 0) ]; // New lines
-            // Try to determine more precisely how big the array needs to be.
-            // If we get it right, we don't have to do an array copy, and
-            // we save a bunch of memory.
-            int encLen = (len / 3) * 4 + (len % 3 > 0 ? 4 : 0); // Bytes needed for actual encoding
-            if (breakLines) {
-                encLen += encLen / MAX_LINE_LENGTH; // Plus extra newline characters
-            }
-            byte[] outBuff = new byte[encLen];
-
-
-            int d = 0;
-            int e = 0;
-            int len2 = len - 2;
-            int lineLength = 0;
-            for (; d < len2; d += 3, e += 4) {
-                encode3to4(source, d + off, 3, outBuff, e, options);
-
-                lineLength += 4;
-                if (breakLines && lineLength >= MAX_LINE_LENGTH) {
-                    outBuff[e + 4] = NEW_LINE;
-                    e++;
-                    lineLength = 0;
-                }   // end if: end of line
-            }   // en dfor: each piece of array
-
-            if (d < len) {
-                encode3to4(source, d + off, len - d, outBuff, e, options);
-                e += 4;
-            }   // end if: some padding needed
-
-
-            // Only resize array if we didn't guess it right.
-            if (e <= outBuff.length - 1) {
-                // If breaking lines and the last byte falls right at
-                // the line length (76 bytes per line), there will be
-                // one extra byte, and the array will need to be resized.
-                // Not too bad of an estimate on array size, I'd say.
-                byte[] finalOut = new byte[e];
-                System.arraycopy(outBuff, 0, finalOut, 0, e);
-                //System.err.println("Having to resize array from " + outBuff.length + " to " + e );
-                return finalOut;
-            } else {
-                //System.err.println("No need to resize array.");
-                return outBuff;
-            }
-
+            return encodeNonCompressedBytes(source, off, len, options);
         }   // end else: don't compress
 
     }   // end encodeBytesToBytes
+
+    private static byte[] encodeNonCompressedBytes(byte[] source, int off, int len, int options) {
+        boolean breakLines = (options & DO_BREAK_LINES) != 0;
+
+        //int    len43   = len * 4 / 3;
+        //byte[] outBuff = new byte[   ( len43 )                      // Main 4:3
+        //                           + ( (len % 3) > 0 ? 4 : 0 )      // Account for padding
+        //                           + (breakLines ? ( len43 / MAX_LINE_LENGTH ) : 0) ]; // New lines
+        // Try to determine more precisely how big the array needs to be.
+        // If we get it right, we don't have to do an array copy, and
+        // we save a bunch of memory.
+        int encLen = (len / 3) * 4 + (len % 3 > 0 ? 4 : 0); // Bytes needed for actual encoding
+        if (breakLines) {
+            encLen += encLen / MAX_LINE_LENGTH; // Plus extra newline characters
+        }
+        byte[] outBuff = new byte[encLen];
+
+
+        int d = 0;
+        int e = 0;
+        int len2 = len - 2;
+        int lineLength = 0;
+        for (; d < len2; d += 3, e += 4) {
+            encode3to4(source, d + off, 3, outBuff, e, options);
+
+            lineLength += 4;
+            if (breakLines && lineLength >= MAX_LINE_LENGTH) {
+                outBuff[e + 4] = NEW_LINE;
+                e++;
+                lineLength = 0;
+            }   // end if: end of line
+        }   // en dfor: each piece of array
+
+        if (d < len) {
+            encode3to4(source, d + off, len - d, outBuff, e, options);
+            e += 4;
+        }   // end if: some padding needed
+
+
+        // Only resize array if we didn't guess it right.
+        if (e <= outBuff.length - 1) {
+            // If breaking lines and the last byte falls right at
+            // the line length (76 bytes per line), there will be
+            // one extra byte, and the array will need to be resized.
+            // Not too bad of an estimate on array size, I'd say.
+            byte[] finalOut = new byte[e];
+            System.arraycopy(outBuff, 0, finalOut, 0, e);
+            //System.err.println("Having to resize array from " + outBuff.length + " to " + e );
+            return finalOut;
+        } else {
+            //System.err.println("No need to resize array.");
+            return outBuff;
+        }
+    }
+
+    private static byte[] encodeCompressedBytes(byte[] source, int off, int len, int options) throws IOException {
+        java.io.ByteArrayOutputStream baos = null;
+        java.util.zip.GZIPOutputStream gzos = null;
+        OutputStream b64os = null;
+
+        try {
+            // GZip -> Base64 -> ByteArray
+            baos = new java.io.ByteArrayOutputStream();
+            b64os = new OutputStream(baos, ENCODE | options);
+            gzos = new java.util.zip.GZIPOutputStream(b64os);
+
+            gzos.write(source, off, len);
+            gzos.close();
+        }   // end try
+        catch (IOException e) {
+            // Catch it and then throw it immediately so that
+            // the finally{} block is called for cleanup.
+            throw e;
+        }   // end catch
+        finally {
+            try {
+                gzos.close();
+            } catch (Exception e) {
+            }
+            try {
+                b64os.close();
+            } catch (Exception e) {
+            }
+            try {
+                baos.close();
+            } catch (Exception e) {
+            }
+        }   // end finally
+
+        return baos.toByteArray();
+    }
 
 
 /* ********  D E C O D I N G   M E T H O D S  ******** */

--- a/core/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/core/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -118,37 +118,9 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
         // .addAndGet() instead of looping (because we don't have to check a
         // limit), which makes the RamAccountingTermsEnum case faster.
         if (this.memoryBytesLimit == -1) {
-            newUsed = this.used.addAndGet(bytes);
-            if (logger.isTraceEnabled()) {
-                logger.trace("[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: [-1b]]",
-                        this.name, new ByteSizeValue(bytes), label, new ByteSizeValue(newUsed));
-            }
+            newUsed = noLimit(bytes, label);
         } else {
-            // Otherwise, check the addition and commit the addition, looping if
-            // there are conflicts. May result in additional logging, but it's
-            // trace logging and shouldn't be counted on for additions.
-            long currentUsed;
-            do {
-                currentUsed = this.used.get();
-                newUsed = currentUsed + bytes;
-                long newUsedWithOverhead = (long) (newUsed * overheadConstant);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: {} [{}], estimate: {} [{}]]",
-                            this.name,
-                            new ByteSizeValue(bytes), label, new ByteSizeValue(newUsed),
-                            memoryBytesLimit, new ByteSizeValue(memoryBytesLimit),
-                            newUsedWithOverhead, new ByteSizeValue(newUsedWithOverhead));
-                }
-                if (memoryBytesLimit > 0 && newUsedWithOverhead > memoryBytesLimit) {
-                    logger.warn("[{}] New used memory {} [{}] for data of [{}] would be larger than configured breaker: {} [{}], breaking",
-                            this.name,
-                            newUsedWithOverhead, new ByteSizeValue(newUsedWithOverhead), label,
-                            memoryBytesLimit, new ByteSizeValue(memoryBytesLimit));
-                    circuitBreak(label, newUsedWithOverhead);
-                }
-                // Attempt to set the new used value, but make sure it hasn't changed
-                // underneath us, if it has, keep trying until we are able to set it
-            } while (!this.used.compareAndSet(currentUsed, newUsed));
+            newUsed = limit(bytes, label);
         }
 
         // Additionally, we need to check that we haven't exceeded the parent's limit
@@ -161,6 +133,45 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
             this.addWithoutBreaking(-bytes);
             throw e;
         }
+        return newUsed;
+    }
+
+    private long noLimit(long bytes, String label) {
+        long newUsed;
+        newUsed = this.used.addAndGet(bytes);
+        if (logger.isTraceEnabled()) {
+            logger.trace("[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: [-1b]]",
+                this.name, new ByteSizeValue(bytes), label, new ByteSizeValue(newUsed));
+        }
+        return newUsed;
+    }
+
+    private long limit(long bytes, String label) {
+        long newUsed;// Otherwise, check the addition and commit the addition, looping if
+        // there are conflicts. May result in additional logging, but it's
+        // trace logging and shouldn't be counted on for additions.
+        long currentUsed;
+        do {
+            currentUsed = this.used.get();
+            newUsed = currentUsed + bytes;
+            long newUsedWithOverhead = (long) (newUsed * overheadConstant);
+            if (logger.isTraceEnabled()) {
+                logger.trace("[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: {} [{}], estimate: {} [{}]]",
+                        this.name,
+                        new ByteSizeValue(bytes), label, new ByteSizeValue(newUsed),
+                        memoryBytesLimit, new ByteSizeValue(memoryBytesLimit),
+                        newUsedWithOverhead, new ByteSizeValue(newUsedWithOverhead));
+            }
+            if (memoryBytesLimit > 0 && newUsedWithOverhead > memoryBytesLimit) {
+                logger.warn("[{}] New used memory {} [{}] for data of [{}] would be larger than configured breaker: {} [{}], breaking",
+                        this.name,
+                        newUsedWithOverhead, new ByteSizeValue(newUsedWithOverhead), label,
+                        memoryBytesLimit, new ByteSizeValue(memoryBytesLimit));
+                circuitBreak(label, newUsedWithOverhead);
+            }
+            // Attempt to set the new used value, but make sure it hasn't changed
+            // underneath us, if it has, keep trying until we are able to set it
+        } while (!this.used.compareAndSet(currentUsed, newUsed));
         return newUsed;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -265,17 +265,17 @@ public class TimeValue implements Streamable {
             long millis;
             String lowerSValue = sValue.toLowerCase(Locale.ROOT).trim();
             if (lowerSValue.endsWith("ms")) {
-                millis = (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 2)));
+                millis = parse(lowerSValue, 2, 1);
             } else if (lowerSValue.endsWith("s")) {
-                millis = (long) Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * 1000;
+                millis = parse(lowerSValue, 1, 1000);
             } else if (lowerSValue.endsWith("m")) {
-                millis = (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * 60 * 1000);
+                millis = parse(lowerSValue, 1, 60 * 1000);
             } else if (lowerSValue.endsWith("h")) {
-                millis = (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * 60 * 60 * 1000);
+                millis = parse(lowerSValue, 1, 60 * 60 * 1000);
             } else if (lowerSValue.endsWith("d")) {
-                millis = (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * 24 * 60 * 60 * 1000);
+                millis = parse(lowerSValue, 1, 24 * 60 * 60 * 1000);
             } else if (lowerSValue.endsWith("w")) {
-                millis = (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * 7 * 24 * 60 * 60 * 1000);
+                millis = parse(lowerSValue, 1, 7 * 24 * 60 * 60 * 1000);
             } else if (lowerSValue.equals("-1")) {
                 // Allow this special value to be unit-less:
                 millis = -1;
@@ -290,6 +290,10 @@ public class TimeValue implements Streamable {
         } catch (NumberFormatException e) {
             throw new ElasticsearchParseException("Failed to parse [{}]", e, sValue);
         }
+    }
+
+    private static long parse(String s, int suffixLength, long scale) {
+        return (long) (Double.parseDouble(s.substring(0, s.length() - suffixLength)) * scale);
     }
 
     static final long C0 = 1L;

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -44,8 +44,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  *
@@ -1227,52 +1229,99 @@ public final class XContentBuilder implements BytesStream, Releasable {
         generator.writeEndObject();
     }
 
+    @FunctionalInterface
+    interface Writer {
+        void write(XContentGenerator g, Object v) throws IOException;
+    }
+
+    private final static Map<Class<?>, Writer> MAP = new HashMap<>();
+
+    static {
+        MAP.put(String.class, (g, v) -> g.writeString((String) v));
+        MAP.put(Integer.class, (g, v) -> g.writeNumber((Integer) v));
+        MAP.put(Long.class, (g, v) -> g.writeNumber((Long) v));
+        MAP.put(Float.class, (g, v) -> g.writeNumber((Float) v));
+        MAP.put(Double.class, (g, v) -> g.writeNumber((Double) v));
+        MAP.put(Byte.class, (g, v) -> g.writeNumber((Byte) v));
+        MAP.put(Short.class, (g, v) -> g.writeNumber((Short) v));
+        MAP.put(Boolean.class, (g, v) -> g.writeBoolean((Boolean) v));
+        MAP.put(GeoPoint.class, (g, v) -> {
+            g.writeStartObject();
+            g.writeNumberField("lat", ((GeoPoint) v).lat());
+            g.writeNumberField("lon", ((GeoPoint) v).lon());
+            g.writeEndObject();
+        });
+        MAP.put(int[].class, (g, v) -> {
+            g.writeStartArray();
+            for (int item : (int[]) v) {
+                g.writeNumber(item);
+            }
+            g.writeEndArray();
+        });
+        MAP.put(long[].class, (g, v) -> {
+            g.writeStartArray();
+            for (long item : (long[]) v) {
+                g.writeNumber(item);
+            }
+            g.writeEndArray();
+        });
+        MAP.put(float[].class, (g, v) -> {
+            g.writeStartArray();
+            for (float item : (float[]) v) {
+                g.writeNumber(item);
+            }
+            g.writeEndArray();
+        });
+        MAP.put(double[].class, (g, v) -> {
+            g.writeStartArray();
+            for (double item : (double[])v) {
+                g.writeNumber(item);
+            }
+            g.writeEndArray();
+        });
+        MAP.put(byte[].class, (g, v) -> g.writeBinary((byte[]) v));
+        MAP.put(short[].class, (g, v) -> {
+            g.writeStartArray();
+            for (short item : (short[])v) {
+                g.writeNumber(item);
+            }
+            g.writeEndArray();
+        });
+        MAP.put(BytesRef.class, (g, v) -> {
+            BytesRef bytes = (BytesRef) v;
+            g.writeBinary(bytes.bytes, bytes.offset, bytes.length);
+        });
+        MAP.put(Text.class, (g, v) -> {
+            Text text = (Text) v;
+            if (text.hasBytes() && text.bytes().hasArray()) {
+                g.writeUTF8String(text.bytes().array(), text.bytes().arrayOffset(), text.bytes().length());
+            } else if (text.hasString()) {
+                g.writeString(text.string());
+            } else {
+                BytesArray bytesArray = text.bytes().toBytesArray();
+                g.writeUTF8String(bytesArray.array(), bytesArray.arrayOffset(), bytesArray.length());
+            };
+        });
+    }
+
     private void writeValue(Object value) throws IOException {
         if (value == null) {
             generator.writeNull();
             return;
         }
         Class<?> type = value.getClass();
-        if (type == String.class) {
-            generator.writeString((String) value);
-        } else if (type == Integer.class) {
-            generator.writeNumber(((Integer) value).intValue());
-        } else if (type == Long.class) {
-            generator.writeNumber(((Long) value).longValue());
-        } else if (type == Float.class) {
-            generator.writeNumber(((Float) value).floatValue());
-        } else if (type == Double.class) {
-            generator.writeNumber(((Double) value).doubleValue());
-        } else if (type == Byte.class) {
-            generator.writeNumber(((Byte)value).byteValue());
-        } else if (type == Short.class) {
-            generator.writeNumber(((Short) value).shortValue());
-        } else if (type == Boolean.class) {
-            generator.writeBoolean(((Boolean) value).booleanValue());
-        } else if (type == GeoPoint.class) {
-            generator.writeStartObject();
-            generator.writeNumberField("lat", ((GeoPoint) value).lat());
-            generator.writeNumberField("lon", ((GeoPoint) value).lon());
-            generator.writeEndObject();
+        Writer writer = MAP.get(type);
+        if (writer != null) {
+            writer.write(generator, value);
         } else if (value instanceof Map) {
             writeMap((Map) value);
         } else if (value instanceof Path) {
             //Path implements Iterable<Path> and causes endless recursion and a StackOverFlow if treated as an Iterable here
             generator.writeString(value.toString());
         } else if (value instanceof Iterable) {
-            generator.writeStartArray();
-            for (Object v : (Iterable<?>) value) {
-                writeValue(v);
-            }
-            generator.writeEndArray();
+            writeIterable((Iterable<?>) value);
         } else if (value instanceof Object[]) {
-            generator.writeStartArray();
-            for (Object v : (Object[]) value) {
-                writeValue(v);
-            }
-            generator.writeEndArray();
-        } else if (type == byte[].class) {
-            generator.writeBinary((byte[]) value);
+            writeObjectArray((Object[]) value);
         } else if (value instanceof Date) {
             generator.writeString(XContentBuilder.defaultDatePrinter.print(((Date) value).getTime()));
         } else if (value instanceof Calendar) {
@@ -1280,56 +1329,9 @@ public final class XContentBuilder implements BytesStream, Releasable {
         } else if (value instanceof ReadableInstant) {
             generator.writeString(XContentBuilder.defaultDatePrinter.print((((ReadableInstant) value)).getMillis()));
         } else if (value instanceof BytesReference) {
-            BytesReference bytes = (BytesReference) value;
-            if (!bytes.hasArray()) {
-                bytes = bytes.toBytesArray();
-            }
-            generator.writeBinary(bytes.array(), bytes.arrayOffset(), bytes.length());
-        } else if (value instanceof BytesRef) {
-            BytesRef bytes = (BytesRef) value;
-            generator.writeBinary(bytes.bytes, bytes.offset, bytes.length);
-        } else if (value instanceof Text) {
-            Text text = (Text) value;
-            if (text.hasBytes() && text.bytes().hasArray()) {
-                generator.writeUTF8String(text.bytes().array(), text.bytes().arrayOffset(), text.bytes().length());
-            } else if (text.hasString()) {
-                generator.writeString(text.string());
-            } else {
-                BytesArray bytesArray = text.bytes().toBytesArray();
-                generator.writeUTF8String(bytesArray.array(), bytesArray.arrayOffset(), bytesArray.length());
-            }
+            writeBytesReference((BytesReference) value);
         } else if (value instanceof ToXContent) {
             ((ToXContent) value).toXContent(this, ToXContent.EMPTY_PARAMS);
-        } else if (value instanceof double[]) {
-            generator.writeStartArray();
-            for (double v : (double[]) value) {
-                generator.writeNumber(v);
-            }
-            generator.writeEndArray();
-        } else if (value instanceof long[]) {
-            generator.writeStartArray();
-            for (long v : (long[]) value) {
-                generator.writeNumber(v);
-            }
-            generator.writeEndArray();
-        } else if (value instanceof int[]) {
-            generator.writeStartArray();
-            for (int v : (int[]) value) {
-                generator.writeNumber(v);
-            }
-            generator.writeEndArray();
-        } else if (value instanceof float[]) {
-            generator.writeStartArray();
-            for (float v : (float[]) value) {
-                generator.writeNumber(v);
-            }
-            generator.writeEndArray();
-        } else if (value instanceof short[]) {
-            generator.writeStartArray();
-            for (short v : (short[]) value) {
-                generator.writeNumber(v);
-            }
-            generator.writeEndArray();
         } else {
             // if this is a "value" object, like enum, DistanceUnit, ..., just toString it
             // yea, it can be misleading when toString a Java class, but really, jackson should be used in that case
@@ -1337,4 +1339,29 @@ public final class XContentBuilder implements BytesStream, Releasable {
             //throw new ElasticsearchIllegalArgumentException("type not supported for generic value conversion: " + type);
         }
     }
+
+    private void writeBytesReference(BytesReference value) throws IOException {
+        BytesReference bytes = value;
+        if (!bytes.hasArray()) {
+            bytes = bytes.toBytesArray();
+        }
+        generator.writeBinary(bytes.array(), bytes.arrayOffset(), bytes.length());
+    }
+
+    private void writeIterable(Iterable<?> value) throws IOException {
+        generator.writeStartArray();
+        for (Object v : value) {
+            writeValue(v);
+        }
+        generator.writeEndArray();
+    }
+
+    private void writeObjectArray(Object[] value) throws IOException {
+        generator.writeStartArray();
+        for (Object v : value) {
+            writeValue(v);
+        }
+        generator.writeEndArray();
+    }
+
 }

--- a/core/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -52,10 +52,7 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Values.CLOSE;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Values.KEEP_ALIVE;
 
-/**
- *
- */
-public class NettyHttpChannel extends HttpChannel {
+public final class NettyHttpChannel extends HttpChannel {
 
     private final NettyHttpServerTransport transport;
     private final Channel channel;
@@ -93,18 +90,11 @@ public class NettyHttpChannel extends HttpChannel {
 
         String opaque = nettyRequest.headers().get("X-Opaque-Id");
         if (opaque != null) {
-            resp.headers().add("X-Opaque-Id", opaque);
+            setHeaderField(resp, "X-Opaque-Id", opaque);
         }
 
         // Add all custom headers
-        Map<String, List<String>> customHeaders = response.getHeaders();
-        if (customHeaders != null) {
-            for (Map.Entry<String, List<String>> headerEntry : customHeaders.entrySet()) {
-                for (String headerValue : headerEntry.getValue()) {
-                    resp.headers().add(headerEntry.getKey(), headerValue);
-                }
-            }
-        }
+        addCustomHeaders(response, resp);
 
         BytesReference content = response.content();
         ChannelBuffer buffer;
@@ -114,30 +104,11 @@ public class NettyHttpChannel extends HttpChannel {
             resp.setContent(buffer);
 
             // If our response doesn't specify a content-type header, set one
-            if (!resp.headers().contains(HttpHeaders.Names.CONTENT_TYPE)) {
-                resp.headers().add(HttpHeaders.Names.CONTENT_TYPE, response.contentType());
-            }
-
+            setHeaderField(resp, HttpHeaders.Names.CONTENT_TYPE, response.contentType(), false);
             // If our response has no content-length, calculate and set one
-            if (!resp.headers().contains(HttpHeaders.Names.CONTENT_LENGTH)) {
-                resp.headers().add(HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(buffer.readableBytes()));
-            }
+            setHeaderField(resp, HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(buffer.readableBytes()), false);
 
-            if (transport.resetCookies) {
-                String cookieString = nettyRequest.headers().get(HttpHeaders.Names.COOKIE);
-                if (cookieString != null) {
-                    CookieDecoder cookieDecoder = new CookieDecoder();
-                    Set<Cookie> cookies = cookieDecoder.decode(cookieString);
-                    if (!cookies.isEmpty()) {
-                        // Reset the cookies if necessary.
-                        CookieEncoder cookieEncoder = new CookieEncoder(true);
-                        for (Cookie cookie : cookies) {
-                            cookieEncoder.addCookie(cookie);
-                        }
-                        resp.headers().add(HttpHeaders.Names.SET_COOKIE, cookieEncoder.encode());
-                    }
-                }
-            }
+            addCookies(resp);
 
             ChannelFuture future;
 
@@ -161,6 +132,45 @@ public class NettyHttpChannel extends HttpChannel {
         } finally {
             if (!addedReleaseListener && content instanceof Releasable) {
                 ((Releasable) content).close();
+            }
+        }
+    }
+
+    private void setHeaderField(HttpResponse resp, String headerField, String value) {
+        setHeaderField(resp, headerField, value, true);
+    }
+
+    private void setHeaderField(HttpResponse resp, String headerField, String value, boolean override) {
+        if (override || !resp.headers().contains(headerField)) {
+            resp.headers().add(headerField, value);
+        }
+    }
+
+    private void addCookies(HttpResponse resp) {
+        if (transport.resetCookies) {
+            String cookieString = nettyRequest.headers().get(HttpHeaders.Names.COOKIE);
+            if (cookieString != null) {
+                CookieDecoder cookieDecoder = new CookieDecoder();
+                Set<Cookie> cookies = cookieDecoder.decode(cookieString);
+                if (!cookies.isEmpty()) {
+                    // Reset the cookies if necessary.
+                    CookieEncoder cookieEncoder = new CookieEncoder(true);
+                    for (Cookie cookie : cookies) {
+                        cookieEncoder.addCookie(cookie);
+                    }
+                    setHeaderField(resp, HttpHeaders.Names.SET_COOKIE, cookieEncoder.encode());
+                }
+            }
+        }
+    }
+
+    private void addCustomHeaders(RestResponse response, HttpResponse resp) {
+        Map<String, List<String>> customHeaders = response.getHeaders();
+        if (customHeaders != null) {
+            for (Map.Entry<String, List<String>> headerEntry : customHeaders.entrySet()) {
+                for (String headerValue : headerEntry.getValue()) {
+                    setHeaderField(resp, headerEntry.getKey(), headerValue);
+                }
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
+++ b/core/src/main/java/org/elasticsearch/http/netty/NettyHttpChannel.java
@@ -43,6 +43,7 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -196,101 +197,57 @@ public class NettyHttpChannel extends HttpChannel {
 
     private static final HttpResponseStatus TOO_MANY_REQUESTS = new HttpResponseStatus(429, "Too Many Requests");
 
-    private HttpResponseStatus getStatus(RestStatus status) {
-        switch (status) {
-            case CONTINUE:
-                return HttpResponseStatus.CONTINUE;
-            case SWITCHING_PROTOCOLS:
-                return HttpResponseStatus.SWITCHING_PROTOCOLS;
-            case OK:
-                return HttpResponseStatus.OK;
-            case CREATED:
-                return HttpResponseStatus.CREATED;
-            case ACCEPTED:
-                return HttpResponseStatus.ACCEPTED;
-            case NON_AUTHORITATIVE_INFORMATION:
-                return HttpResponseStatus.NON_AUTHORITATIVE_INFORMATION;
-            case NO_CONTENT:
-                return HttpResponseStatus.NO_CONTENT;
-            case RESET_CONTENT:
-                return HttpResponseStatus.RESET_CONTENT;
-            case PARTIAL_CONTENT:
-                return HttpResponseStatus.PARTIAL_CONTENT;
-            case MULTI_STATUS:
-                // no status for this??
-                return HttpResponseStatus.INTERNAL_SERVER_ERROR;
-            case MULTIPLE_CHOICES:
-                return HttpResponseStatus.MULTIPLE_CHOICES;
-            case MOVED_PERMANENTLY:
-                return HttpResponseStatus.MOVED_PERMANENTLY;
-            case FOUND:
-                return HttpResponseStatus.FOUND;
-            case SEE_OTHER:
-                return HttpResponseStatus.SEE_OTHER;
-            case NOT_MODIFIED:
-                return HttpResponseStatus.NOT_MODIFIED;
-            case USE_PROXY:
-                return HttpResponseStatus.USE_PROXY;
-            case TEMPORARY_REDIRECT:
-                return HttpResponseStatus.TEMPORARY_REDIRECT;
-            case BAD_REQUEST:
-                return HttpResponseStatus.BAD_REQUEST;
-            case UNAUTHORIZED:
-                return HttpResponseStatus.UNAUTHORIZED;
-            case PAYMENT_REQUIRED:
-                return HttpResponseStatus.PAYMENT_REQUIRED;
-            case FORBIDDEN:
-                return HttpResponseStatus.FORBIDDEN;
-            case NOT_FOUND:
-                return HttpResponseStatus.NOT_FOUND;
-            case METHOD_NOT_ALLOWED:
-                return HttpResponseStatus.METHOD_NOT_ALLOWED;
-            case NOT_ACCEPTABLE:
-                return HttpResponseStatus.NOT_ACCEPTABLE;
-            case PROXY_AUTHENTICATION:
-                return HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
-            case REQUEST_TIMEOUT:
-                return HttpResponseStatus.REQUEST_TIMEOUT;
-            case CONFLICT:
-                return HttpResponseStatus.CONFLICT;
-            case GONE:
-                return HttpResponseStatus.GONE;
-            case LENGTH_REQUIRED:
-                return HttpResponseStatus.LENGTH_REQUIRED;
-            case PRECONDITION_FAILED:
-                return HttpResponseStatus.PRECONDITION_FAILED;
-            case REQUEST_ENTITY_TOO_LARGE:
-                return HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
-            case REQUEST_URI_TOO_LONG:
-                return HttpResponseStatus.REQUEST_URI_TOO_LONG;
-            case UNSUPPORTED_MEDIA_TYPE:
-                return HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
-            case REQUESTED_RANGE_NOT_SATISFIED:
-                return HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
-            case EXPECTATION_FAILED:
-                return HttpResponseStatus.EXPECTATION_FAILED;
-            case UNPROCESSABLE_ENTITY:
-                return HttpResponseStatus.BAD_REQUEST;
-            case LOCKED:
-                return HttpResponseStatus.BAD_REQUEST;
-            case FAILED_DEPENDENCY:
-                return HttpResponseStatus.BAD_REQUEST;
-            case TOO_MANY_REQUESTS:
-                return TOO_MANY_REQUESTS;
-            case INTERNAL_SERVER_ERROR:
-                return HttpResponseStatus.INTERNAL_SERVER_ERROR;
-            case NOT_IMPLEMENTED:
-                return HttpResponseStatus.NOT_IMPLEMENTED;
-            case BAD_GATEWAY:
-                return HttpResponseStatus.BAD_GATEWAY;
-            case SERVICE_UNAVAILABLE:
-                return HttpResponseStatus.SERVICE_UNAVAILABLE;
-            case GATEWAY_TIMEOUT:
-                return HttpResponseStatus.GATEWAY_TIMEOUT;
-            case HTTP_VERSION_NOT_SUPPORTED:
-                return HttpResponseStatus.HTTP_VERSION_NOT_SUPPORTED;
-            default:
-                return HttpResponseStatus.INTERNAL_SERVER_ERROR;
-        }
+    static EnumMap<RestStatus, HttpResponseStatus> MAP = new EnumMap<>(RestStatus.class);
+
+    static {
+        MAP.put(RestStatus.CONTINUE, HttpResponseStatus.CONTINUE);
+        MAP.put(RestStatus.SWITCHING_PROTOCOLS, HttpResponseStatus.SWITCHING_PROTOCOLS);
+        MAP.put(RestStatus.OK, HttpResponseStatus.OK);
+        MAP.put(RestStatus.CREATED, HttpResponseStatus.CREATED);
+        MAP.put(RestStatus.ACCEPTED, HttpResponseStatus.ACCEPTED);
+        MAP.put(RestStatus.NON_AUTHORITATIVE_INFORMATION, HttpResponseStatus.NON_AUTHORITATIVE_INFORMATION);
+        MAP.put(RestStatus.NO_CONTENT, HttpResponseStatus.NO_CONTENT);
+        MAP.put(RestStatus.RESET_CONTENT, HttpResponseStatus.RESET_CONTENT);
+        MAP.put(RestStatus.PARTIAL_CONTENT, HttpResponseStatus.PARTIAL_CONTENT);
+        MAP.put(RestStatus.MULTI_STATUS, HttpResponseStatus.INTERNAL_SERVER_ERROR); // no status for this??
+        MAP.put(RestStatus.MULTIPLE_CHOICES, HttpResponseStatus.MULTIPLE_CHOICES);
+        MAP.put(RestStatus.MOVED_PERMANENTLY, HttpResponseStatus.MOVED_PERMANENTLY);
+        MAP.put(RestStatus.FOUND, HttpResponseStatus.FOUND);
+        MAP.put(RestStatus.SEE_OTHER, HttpResponseStatus.SEE_OTHER);
+        MAP.put(RestStatus.NOT_MODIFIED, HttpResponseStatus.NOT_MODIFIED);
+        MAP.put(RestStatus.USE_PROXY, HttpResponseStatus.USE_PROXY);
+        MAP.put(RestStatus.TEMPORARY_REDIRECT, HttpResponseStatus.TEMPORARY_REDIRECT);
+        MAP.put(RestStatus.BAD_REQUEST, HttpResponseStatus.BAD_REQUEST);
+        MAP.put(RestStatus.UNAUTHORIZED, HttpResponseStatus.UNAUTHORIZED);
+        MAP.put(RestStatus.PAYMENT_REQUIRED, HttpResponseStatus.PAYMENT_REQUIRED);
+        MAP.put(RestStatus.FORBIDDEN, HttpResponseStatus.FORBIDDEN);
+        MAP.put(RestStatus.NOT_FOUND, HttpResponseStatus.NOT_FOUND);
+        MAP.put(RestStatus.METHOD_NOT_ALLOWED, HttpResponseStatus.METHOD_NOT_ALLOWED);
+        MAP.put(RestStatus.NOT_ACCEPTABLE, HttpResponseStatus.NOT_ACCEPTABLE);
+        MAP.put(RestStatus.PROXY_AUTHENTICATION, HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED);
+        MAP.put(RestStatus.REQUEST_TIMEOUT, HttpResponseStatus.REQUEST_TIMEOUT);
+        MAP.put(RestStatus.CONFLICT, HttpResponseStatus.CONFLICT);
+        MAP.put(RestStatus.GONE, HttpResponseStatus.GONE);
+        MAP.put(RestStatus.LENGTH_REQUIRED, HttpResponseStatus.LENGTH_REQUIRED);
+        MAP.put(RestStatus.PRECONDITION_FAILED, HttpResponseStatus.PRECONDITION_FAILED);
+        MAP.put(RestStatus.REQUEST_ENTITY_TOO_LARGE, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE);
+        MAP.put(RestStatus.REQUEST_URI_TOO_LONG, HttpResponseStatus.REQUEST_URI_TOO_LONG);
+        MAP.put(RestStatus.UNSUPPORTED_MEDIA_TYPE, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE);
+        MAP.put(RestStatus.REQUESTED_RANGE_NOT_SATISFIED, HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
+        MAP.put(RestStatus.EXPECTATION_FAILED, HttpResponseStatus.EXPECTATION_FAILED);
+        MAP.put(RestStatus.UNPROCESSABLE_ENTITY, HttpResponseStatus.BAD_REQUEST);
+        MAP.put(RestStatus.LOCKED, HttpResponseStatus.BAD_REQUEST);
+        MAP.put(RestStatus.FAILED_DEPENDENCY, HttpResponseStatus.BAD_REQUEST);
+        MAP.put(RestStatus.TOO_MANY_REQUESTS, TOO_MANY_REQUESTS);
+        MAP.put(RestStatus.INTERNAL_SERVER_ERROR, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+        MAP.put(RestStatus.NOT_IMPLEMENTED, HttpResponseStatus.NOT_IMPLEMENTED);
+        MAP.put(RestStatus.BAD_GATEWAY, HttpResponseStatus.BAD_GATEWAY);
+        MAP.put(RestStatus.SERVICE_UNAVAILABLE, HttpResponseStatus.SERVICE_UNAVAILABLE);
+        MAP.put(RestStatus.GATEWAY_TIMEOUT, HttpResponseStatus.GATEWAY_TIMEOUT);
+        MAP.put(RestStatus.HTTP_VERSION_NOT_SUPPORTED, HttpResponseStatus.HTTP_VERSION_NOT_SUPPORTED);
+    }
+
+    private static HttpResponseStatus getStatus(RestStatus status) {
+        return MAP.getOrDefault(status, HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
An important optimization that a compiler can make is to inline
methods. The JVM JIT compiler makes decisions about inlining methods
based on method size and how hot the method is. For example, small
methods (less than 35 bytes by default, but tunable via
`-XX:MaxInlineSize=N` ) are automatically inlined. And hot methods are
inlined only if they are not large (less than 325 bytes by default, but
tunable via `-XX:MaxFreqInlineSize=N`). Hot methods that the JVM could
not inline in Elasticsearch can be found by enabling the JVM to trace
method inlining via `-XX:+UnlockDiagnoticVMOptions -XX:+PrintInlining`
and then looking for "hot method too big" for any methods in a
sub-package of `org.elasticsearch`. It is generally recommend to not
tune the inlining flags. Instead, we can enable the JVM to inline these
hot methods by breaking these methods down into smaller methods.

The methods that are hot but could not be inlined while benchmarking
Elasticsearch are:

``` text
org.elasticsearch.action.bulk.TransportShardBulkAction::shardOperationOnPrimary (1918 bytes)   hot method too big
org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryPhase::doRun (344 bytes)   hot method too big
org.elasticsearch.action.support.replication.TransportReplicationAction$ReplicationPhase::<init> (440 bytes)   hot method too big
org.elasticsearch.action.support.replication.TransportReplicationAction$ReroutePhase::doRun (739 bytes)   hot method too big
org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$DateMathExpressionResolver::resolveExpression (740 bytes)   hot method too big
org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver::resolve (1110 bytes)   hot method too big
org.elasticsearch.cluster.metadata.MetaData::resolveIndexRouting (351 bytes)   hot method too big
org.elasticsearch.common.Base64::decode (389 bytes)   hot method too big
org.elasticsearch.common.Base64::decode4to3 (350 bytes)   hot method too big
org.elasticsearch.common.Base64::encodeBytesToBytes (456 bytes)   hot method too big
org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker::addEstimateBytesAndMaybeBreak (372 bytes)   hot method too big
org.elasticsearch.common.xcontent.XContentBuilder::writeValue (1203 bytes)   hot method too big
org.elasticsearch.http.netty.NettyHttpChannel::getStatus (388 bytes)   hot method too big
org.elasticsearch.http.netty.NettyHttpChannel::sendResponse (562 bytes)   hot method too big
org.elasticsearch.index.fielddata.ordinals.OrdinalsBuilder$OrdinalsStore::addOrdinal (348 bytes)   hot method too big
org.elasticsearch.index.mapper.DocumentParser::parseObject (687 bytes)   hot method too big
org.elasticsearch.rest.support.RestUtils::decodeComponent (387 bytes)   hot method too big
org.elasticsearch.search.aggregations.AggregationPhase::execute (558 bytes)   hot method too big
org.elasticsearch.search.aggregations.bucket.terms.GlobalOrdinalsStringTermsAggregator::buildAggregation (540 bytes)   hot method too big
org.elasticsearch.search.aggregations.bucket.terms.InternalTerms::doReduce (687 bytes)   hot method too big
org.elasticsearch.search.controller.SearchPhaseController::sortDocs (673 bytes)   hot method too big
org.elasticsearch.search.fetch.FetchPhase::execute (645 bytes)   hot method too big
org.elasticsearch.search.internal.InternalSearchHit::toXContent (890 bytes)   hot method too big
org.elasticsearch.search.query.QueryPhase::execute (1174 bytes)   hot method too big
```

This commit refactors most of the methods that are hot but the JVM could
not inline because they are too large so that they JVM can now inline
them. Simple micro-benchmarking on a few (but not all) of these methods
showed modest performance gains on the order of 5%. This refactoring has
the additional advantage that by breaking these large methods into
smaller methods, they are simpler to understand and maintain.

The methods not addressed by this pull request are:

```
org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$DateMathExpressionResolver::resolveExpression (740 bytes)   hot method too big
org.elasticsearch.search.aggregations.AggregationPhase::execute (558 bytes)   hot method too big
org.elasticsearch.search.aggregations.bucket.terms.GlobalOrdinalsStringTermsAggregator::buildAggregation (540 bytes)   hot method too big
org.elasticsearch.search.aggregations.bucket.terms.InternalTerms::doReduce (687 bytes)   hot method too big
org.elasticsearch.search.controller.SearchPhaseController::sortDocs (673 bytes)   hot method too big
org.elasticsearch.search.fetch.FetchPhase::execute (645 bytes)   hot method too big
org.elasticsearch.search.internal.InternalSearchHit::toXContent (890 bytes)   hot method too big
org.elasticsearch.search.query.QueryPhase::execute (1174 bytes)   hot method too big
```

All other methods are addressed.
