### PR TITLE
Update to serial differencing aggregation doc

### DIFF
--- a/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
@@ -76,7 +76,7 @@ A `serial_diff` aggregation looks like this in isolation:
             },
             "thirtieth_difference": {
                "serial_diff": {                <3>
-                  "buckets_path": "lemmings",
+                  "buckets_path": "the_sum",
                   "lag" : 30
                }
             }


### PR DESCRIPTION
Hi,

`thirtieth_difference` should use `the_sum` metric as the `buckets_path`.
