### PR TITLE
Combine node name and task id into single string task id

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
@@ -36,14 +36,6 @@ public class CancelTasksRequest extends BaseTasksRequest<CancelTasksRequest> {
 
     private String reason = DEFAULT_REASON;
 
-    /**
-     * Cancel tasks on the specified nodes. If none are passed, all cancellable tasks on
-     * all nodes will be cancelled.
-     */
-    public CancelTasksRequest(String... nodesIds) {
-        super(nodesIds);
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
@@ -54,7 +46,6 @@ public class CancelTasksRequest extends BaseTasksRequest<CancelTasksRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(reason);
-
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/TransportCancelTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/TransportCancelTasksAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.TaskInfo;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
@@ -36,6 +35,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.EmptyTransportResponseHandler;
 import org.elasticsearch.transport.TransportChannel;
@@ -84,9 +84,9 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
     }
 
     protected void processTasks(CancelTasksRequest request, Consumer<CancellableTask> operation) {
-        if (request.taskId() != BaseTasksRequest.ALL_TASKS) {
+        if (request.taskId().isSet() == false) {
             // we are only checking one task, we can optimize it
-            CancellableTask task = taskManager.getCancellableTask(request.taskId());
+            CancellableTask task = taskManager.getCancellableTask(request.taskId().getId());
             if (task != null) {
                 if (request.match(task)) {
                     operation.accept(task);
@@ -94,7 +94,7 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
                     throw new IllegalArgumentException("task [" + request.taskId() + "] doesn't support this operation");
                 }
             } else {
-                if (taskManager.getTask(request.taskId()) != null) {
+                if (taskManager.getTask(request.taskId().getId()) != null) {
                     // The task exists, but doesn't support cancellation
                     throw new IllegalArgumentException("task [" + request.taskId() + "] doesn't support cancellation");
                 } else {
@@ -135,11 +135,14 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
     }
 
     private void setBanOnNodes(String reason, CancellableTask task, Set<String> nodes, BanLock banLock) {
-        sendSetBanRequest(nodes, new BanParentTaskRequest(clusterService.localNode().getId(), task.getId(), reason), banLock);
+        sendSetBanRequest(nodes,
+            BanParentTaskRequest.createSetBanParentTaskRequest(new TaskId(clusterService.localNode().getId(), task.getId()), reason),
+            banLock);
     }
 
     private void removeBanOnNodes(CancellableTask task, Set<String> nodes) {
-        sendRemoveBanRequest(nodes, new BanParentTaskRequest(clusterService.localNode().getId(), task.getId()));
+        sendRemoveBanRequest(nodes,
+            BanParentTaskRequest.createRemoveBanParentTaskRequest(new TaskId(clusterService.localNode().getId(), task.getId())));
     }
 
     private void sendSetBanRequest(Set<String> nodes, BanParentTaskRequest request, BanLock banLock) {
@@ -148,8 +151,8 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
             DiscoveryNode discoveryNode = clusterState.getNodes().get(node);
             if (discoveryNode != null) {
                 // Check if node still in the cluster
-                logger.debug("Sending ban for tasks with the parent [{}:{}] to the node [{}], ban [{}]", request.parentNodeId, request
-                    .parentTaskId, node, request.ban);
+                logger.debug("Sending ban for tasks with the parent [{}] to the node [{}], ban [{}]", request.parentTaskId, node,
+                    request.ban);
                 transportService.sendRequest(discoveryNode, BAN_PARENT_ACTION_NAME, request,
                     new EmptyTransportResponseHandler(ThreadPool.Names.SAME) {
                         @Override
@@ -164,8 +167,8 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
                     });
             } else {
                 banLock.onBanSet();
-                logger.debug("Cannot send ban for tasks with the parent [{}:{}] to the node [{}] - the node no longer in the cluster",
-                    request.parentNodeId, request.parentTaskId, node);
+                logger.debug("Cannot send ban for tasks with the parent [{}] to the node [{}] - the node no longer in the cluster",
+                    request.parentTaskId, node);
             }
         }
     }
@@ -176,13 +179,12 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
             DiscoveryNode discoveryNode = clusterState.getNodes().get(node);
             if (discoveryNode != null) {
                 // Check if node still in the cluster
-                logger.debug("Sending remove ban for tasks with the parent [{}:{}] to the node [{}]", request.parentNodeId,
-                    request.parentTaskId, node);
+                logger.debug("Sending remove ban for tasks with the parent [{}] to the node [{}]", request.parentTaskId, node);
                 transportService.sendRequest(discoveryNode, BAN_PARENT_ACTION_NAME, request, EmptyTransportResponseHandler
                     .INSTANCE_SAME);
             } else {
-                logger.debug("Cannot send remove ban request for tasks with the parent [{}:{}] to the node [{}] - the node no longer in " +
-                    "the cluster", request.parentNodeId, request.parentTaskId, node);
+                logger.debug("Cannot send remove ban request for tasks with the parent [{}] to the node [{}] - the node no longer in " +
+                    "the cluster", request.parentTaskId, node);
             }
         }
     }
@@ -218,23 +220,27 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
 
     private static class BanParentTaskRequest extends TransportRequest {
 
-        private String parentNodeId;
-
-        private long parentTaskId;
+        private TaskId parentTaskId;
 
         private boolean ban;
 
         private String reason;
 
-        BanParentTaskRequest(String parentNodeId, long parentTaskId, String reason) {
-            this.parentNodeId = parentNodeId;
+        static BanParentTaskRequest createSetBanParentTaskRequest(TaskId parentTaskId, String reason) {
+            return new BanParentTaskRequest(parentTaskId, reason);
+        }
+
+        static BanParentTaskRequest createRemoveBanParentTaskRequest(TaskId parentTaskId) {
+            return new BanParentTaskRequest(parentTaskId);
+        }
+
+        private BanParentTaskRequest(TaskId parentTaskId, String reason) {
             this.parentTaskId = parentTaskId;
             this.ban = true;
             this.reason = reason;
         }
 
-        BanParentTaskRequest(String parentNodeId, long parentTaskId) {
-            this.parentNodeId = parentNodeId;
+        private BanParentTaskRequest(TaskId parentTaskId) {
             this.parentTaskId = parentTaskId;
             this.ban = false;
         }
@@ -245,8 +251,7 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            parentNodeId = in.readString();
-            parentTaskId = in.readLong();
+            parentTaskId = new TaskId(in);
             ban = in.readBoolean();
             if (ban) {
                 reason = in.readString();
@@ -256,8 +261,7 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(parentNodeId);
-            out.writeLong(parentTaskId);
+            parentTaskId.writeTo(out);
             out.writeBoolean(ban);
             if (ban) {
                 out.writeString(reason);
@@ -269,13 +273,13 @@ public class TransportCancelTasksAction extends TransportTasksAction<Cancellable
         @Override
         public void messageReceived(final BanParentTaskRequest request, final TransportChannel channel) throws Exception {
             if (request.ban) {
-                logger.debug("Received ban for the parent [{}:{}] on the node [{}], reason: [{}]", request.parentNodeId, request
-                    .parentTaskId, clusterService.localNode().getId(), request.reason);
-                taskManager.setBan(request.parentNodeId, request.parentTaskId, request.reason);
+                logger.debug("Received ban for the parent [{}] on the node [{}], reason: [{}]", request.parentTaskId,
+                    clusterService.localNode().getId(), request.reason);
+                taskManager.setBan(request.parentTaskId, request.reason);
             } else {
-                logger.debug("Removing ban for the parent [{}:{}] on the node [{}]", request.parentNodeId, request.parentTaskId,
+                logger.debug("Removing ban for the parent [{}] on the node [{}]", request.parentTaskId,
                     clusterService.localNode().getId());
-                taskManager.removeBan(request.parentNodeId, request.parentTaskId);
+                taskManager.removeBan(request.parentTaskId);
             }
             channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksRequest.java
@@ -33,14 +33,6 @@ public class ListTasksRequest extends BaseTasksRequest<ListTasksRequest> {
     private boolean detailed = false;
 
     /**
-     * Get information from nodes based on the nodes ids specified. If none are passed, information
-     * for all nodes will be returned.
-     */
-    public ListTasksRequest(String... nodesIds) {
-        super(nodesIds);
-    }
-
-    /**
      * Should the detailed task information be returned.
      */
     public boolean detailed() {
@@ -48,7 +40,7 @@ public class ListTasksRequest extends BaseTasksRequest<ListTasksRequest> {
     }
 
     /**
-     * Should the node settings be returned.
+     * Should the detailed task information be returned.
      */
     public ListTasksRequest detailed(boolean detailed) {
         this.detailed = detailed;

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -138,11 +138,13 @@ public class ListTasksResponse extends BaseTasksResponse implements ToXContent {
                 }
                 builder.endObject();
             }
-            builder.startArray("tasks");
+            builder.startObject("tasks");
             for(TaskInfo task : entry.getValue()) {
+                builder.startObject(task.getTaskId().toString(), XContentBuilder.FieldCaseConversion.NONE);
                 task.toXContent(builder, params);
+                builder.endObject();
             }
-            builder.endArray();
+            builder.endObject();
             builder.endObject();
         }
         builder.endObject();

--- a/core/src/main/java/org/elasticsearch/action/support/ChildTaskActionRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ChildTaskActionRequest.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 
 import java.io.IOException;
 
@@ -31,40 +32,35 @@ import java.io.IOException;
  */
 public abstract class ChildTaskActionRequest<Request extends ActionRequest<Request>> extends ActionRequest<Request> {
 
-    private String parentTaskNode;
-
-    private long parentTaskId;
+    private TaskId parentTaskId = TaskId.EMPTY_TASK_ID;
 
     protected ChildTaskActionRequest() {
 
     }
 
     public void setParentTask(String parentTaskNode, long parentTaskId) {
-        this.parentTaskNode = parentTaskNode;
-        this.parentTaskId = parentTaskId;
+        this.parentTaskId = new TaskId(parentTaskNode, parentTaskId);
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        parentTaskNode = in.readOptionalString();
-        parentTaskId = in.readLong();
+        parentTaskId = new TaskId(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalString(parentTaskNode);
-        out.writeLong(parentTaskId);
+        parentTaskId.writeTo(out);
     }
 
     @Override
     public final Task createTask(long id, String type, String action) {
-        return createTask(id, type, action, parentTaskNode, parentTaskId);
+        return createTask(id, type, action, parentTaskId);
     }
 
-    public Task createTask(long id, String type, String action, String parentTaskNode, long parentTaskId) {
-        return new Task(id, type, action, getDescription(), parentTaskNode, parentTaskId);
+    public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+        return new Task(id, type, action, getDescription(), parentTaskId);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/action/support/ChildTaskRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ChildTaskRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.support;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
@@ -31,38 +32,33 @@ import java.io.IOException;
  */
 public class ChildTaskRequest extends TransportRequest {
 
-    private String parentTaskNode;
-
-    private long parentTaskId;
+    private TaskId parentTaskId = TaskId.EMPTY_TASK_ID;
 
     protected ChildTaskRequest() {
     }
 
     public void setParentTask(String parentTaskNode, long parentTaskId) {
-        this.parentTaskNode = parentTaskNode;
-        this.parentTaskId = parentTaskId;
+        this.parentTaskId = new TaskId(parentTaskNode, parentTaskId);
     }
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        parentTaskNode = in.readOptionalString();
-        parentTaskId = in.readLong();
+        parentTaskId = new TaskId(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalString(parentTaskNode);
-        out.writeLong(parentTaskId);
+        parentTaskId.writeTo(out);
     }
 
     @Override
     public final Task createTask(long id, String type, String action) {
-        return createTask(id, type, action, parentTaskNode, parentTaskId);
+        return createTask(id, type, action, parentTaskId);
     }
 
-    public Task createTask(long id, String type, String action, String parentTaskNode, long parentTaskId) {
-        return new Task(id, type, action, getDescription(), parentTaskNode, parentTaskId);
+    public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+        return new Task(id, type, action, getDescription(), parentTaskId);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -186,8 +187,8 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
     }
 
     @Override
-    public Task createTask(long id, String type, String action, String parentTaskNode, long parentTaskId) {
-        return new ReplicationTask(id, type, action, getDescription(), parentTaskNode, parentTaskId);
+    public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+        return new ReplicationTask(id, type, action, getDescription(), parentTaskId);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationTask.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationTask.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.action.support.replication;
 
-import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 
 import java.io.IOException;
 
@@ -35,8 +35,8 @@ import static java.util.Objects.requireNonNull;
 public class ReplicationTask extends Task {
     private volatile String phase = "starting";
 
-    public ReplicationTask(long id, String type, String action, String description, String parentNode, long parentId) {
-        super(id, type, action, description, parentNode, parentId);
+    public ReplicationTask(long id, String type, String action, String description, TaskId parentTaskId) {
+        super(id, type, action, description, parentTaskId);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -124,13 +124,17 @@ public abstract class TransportTasksAction<
     }
 
     protected String[] resolveNodes(TasksRequest request, ClusterState clusterState) {
-        return clusterState.nodes().resolveNodesIds(request.nodesIds());
+        if (request.taskId().isSet()) {
+            return clusterState.nodes().resolveNodesIds(request.nodesIds());
+        } else {
+            return new String[]{request.taskId().getNodeId()};
+        }
     }
 
     protected void processTasks(TasksRequest request, Consumer<OperationTask> operation) {
-        if (request.taskId() != BaseTasksRequest.ALL_TASKS) {
+        if (request.taskId().isSet() == false) {
             // we are only checking one task, we can optimize it
-            Task task = taskManager.getTask(request.taskId());
+            Task task = taskManager.getTask(request.taskId().getId());
             if (task != null) {
                 if (request.match(task)) {
                     operation.accept((OperationTask) task);
@@ -143,13 +147,14 @@ public abstract class TransportTasksAction<
         } else {
             for (Task task : taskManager.getTasks().values()) {
                 if (request.match(task)) {
-                    operation.accept((OperationTask)task);
+                    operation.accept((OperationTask) task);
                 }
             }
         }
     }
 
-    protected abstract TasksResponse newResponse(TasksRequest request, List<TaskResponse> tasks, List<TaskOperationFailure> taskOperationFailures, List<FailedNodeException> failedNodeExceptions);
+    protected abstract TasksResponse newResponse(TasksRequest request, List<TaskResponse> tasks, List<TaskOperationFailure>
+        taskOperationFailures, List<FailedNodeException> failedNodeExceptions);
 
     @SuppressWarnings("unchecked")
     protected TasksResponse newResponse(TasksRequest request, AtomicReferenceArray responses) {
@@ -232,34 +237,36 @@ public abstract class TransportTasksAction<
                             onFailure(idx, nodeId, new NoSuchNodeException(nodeId));
                         } else if (!clusterService.localNode().shouldConnectTo(node) && !clusterService.localNode().equals(node)) {
                             // the check "!clusterService.localNode().equals(node)" is to maintain backward comp. where before
-                            // we allowed to connect from "local" client node to itself, certain tests rely on it, if we remove it, we need to fix
+                            // we allowed to connect from "local" client node to itself, certain tests rely on it, if we remove it, we
+                            // need to fix
                             // those (and they randomize the client node usage, so tricky to find when)
                             onFailure(idx, nodeId, new NodeShouldNotConnectException(clusterService.localNode(), node));
                         } else {
                             NodeTaskRequest nodeRequest = new NodeTaskRequest(request);
                             nodeRequest.setParentTask(clusterService.localNode().id(), task.getId());
                             taskManager.registerChildTask(task, node.getId());
-                            transportService.sendRequest(node, transportNodeAction, nodeRequest, builder.build(), new BaseTransportResponseHandler<NodeTasksResponse>() {
-                                @Override
-                                public NodeTasksResponse newInstance() {
-                                    return new NodeTasksResponse();
-                                }
+                            transportService.sendRequest(node, transportNodeAction, nodeRequest, builder.build(),
+                                new BaseTransportResponseHandler<NodeTasksResponse>() {
+                                    @Override
+                                    public NodeTasksResponse newInstance() {
+                                        return new NodeTasksResponse();
+                                    }
 
-                                @Override
-                                public void handleResponse(NodeTasksResponse response) {
-                                    onOperation(idx, response);
-                                }
+                                    @Override
+                                    public void handleResponse(NodeTasksResponse response) {
+                                        onOperation(idx, response);
+                                    }
 
-                                @Override
-                                public void handleException(TransportException exp) {
-                                    onFailure(idx, node.id(), exp);
-                                }
+                                    @Override
+                                    public void handleException(TransportException exp) {
+                                        onFailure(idx, node.id(), exp);
+                                    }
 
-                                @Override
-                                public String executor() {
-                                    return ThreadPool.Names.SAME;
-                                }
-                            });
+                                    @Override
+                                    public String executor() {
+                                        return ThreadPool.Names.SAME;
+                                    }
+                                });
                         }
                     } catch (Throwable t) {
                         onFailure(idx, nodeId, t);

--- a/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
+++ b/core/src/main/java/org/elasticsearch/client/ClusterAdminClient.java
@@ -272,7 +272,7 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      *
      * @param request The nodes tasks request
      * @return The result future
-     * @see org.elasticsearch.client.Requests#listTasksRequest(String...)
+     * @see org.elasticsearch.client.Requests#listTasksRequest()
      */
     ActionFuture<ListTasksResponse> listTasks(ListTasksRequest request);
 
@@ -281,7 +281,7 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      *
      * @param request  The nodes tasks request
      * @param listener A listener to be notified with a result
-     * @see org.elasticsearch.client.Requests#listTasksRequest(String...)
+     * @see org.elasticsearch.client.Requests#listTasksRequest()
      */
     void listTasks(ListTasksRequest request, ActionListener<ListTasksResponse> listener);
 
@@ -295,7 +295,7 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      *
      * @param request The nodes tasks request
      * @return The result future
-     * @see org.elasticsearch.client.Requests#cancelTasksRequest(String...)
+     * @see org.elasticsearch.client.Requests#cancelTasksRequest()
      */
     ActionFuture<CancelTasksResponse> cancelTasks(CancelTasksRequest request);
 
@@ -304,7 +304,7 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      *
      * @param request  The nodes tasks request
      * @param listener A cancelener to be notified with a result
-     * @see org.elasticsearch.client.Requests#cancelTasksRequest(String...)
+     * @see org.elasticsearch.client.Requests#cancelTasksRequest()
      */
     void cancelTasks(CancelTasksRequest request, ActionListener<CancelTasksResponse> listener);
 

--- a/core/src/main/java/org/elasticsearch/client/Requests.java
+++ b/core/src/main/java/org/elasticsearch/client/Requests.java
@@ -419,23 +419,11 @@ public class Requests {
     /**
      * Creates a nodes tasks request against one or more nodes. Pass <tt>null</tt> or an empty array for all nodes.
      *
-     * @param nodesIds The nodes ids to get the tasks for
-     * @return The nodes tasks request
-     * @see org.elasticsearch.client.ClusterAdminClient#listTasks(ListTasksRequest)
-     */
-    public static ListTasksRequest listTasksRequest(String... nodesIds) {
-        return new ListTasksRequest(nodesIds);
-    }
-
-    /**
-     * Creates a nodes tasks request against one or more nodes. Pass <tt>null</tt> or an empty array for all nodes.
-     *
-     * @param nodesIds The nodes ids to cancel the tasks on
      * @return The nodes tasks request
      * @see org.elasticsearch.client.ClusterAdminClient#cancelTasks(CancelTasksRequest)
      */
-    public static CancelTasksRequest cancelTasksRequest(String... nodesIds) {
-        return new CancelTasksRequest(nodesIds);
+    public static CancelTasksRequest cancelTasksRequest() {
+        return new CancelTasksRequest();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/tasks/RestCancelTasksAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/node/tasks/RestCancelTasksAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.support.RestToXContentListener;
+import org.elasticsearch.tasks.TaskId;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
@@ -40,22 +41,20 @@ public class RestCancelTasksAction extends BaseRestHandler {
     public RestCancelTasksAction(Settings settings, RestController controller, Client client) {
         super(settings, client);
         controller.registerHandler(POST, "/_tasks/_cancel", this);
-        controller.registerHandler(POST, "/_tasks/{nodeId}/_cancel", this);
-        controller.registerHandler(POST, "/_tasks/{nodeId}/{taskId}/_cancel", this);
+        controller.registerHandler(POST, "/_tasks/{taskId}/_cancel", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, final RestChannel channel, final Client client) {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
-        long taskId = request.paramAsLong("taskId", ListTasksRequest.ALL_TASKS);
+        TaskId taskId = new TaskId(request.param("taskId"));
         String[] actions = Strings.splitStringByCommaToArray(request.param("actions"));
-        String parentNode = request.param("parent_node");
-        long parentTaskId = request.paramAsLong("parent_task", ListTasksRequest.ALL_TASKS);
+        TaskId parentTaskId = new TaskId(request.param("parent_task_id"));
 
-        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest(nodesIds);
+        CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
         cancelTasksRequest.taskId(taskId);
+        cancelTasksRequest.nodesIds(nodesIds);
         cancelTasksRequest.actions(actions);
-        cancelTasksRequest.parentNode(parentNode);
         cancelTasksRequest.parentTaskId(parentTaskId);
         client.admin().cluster().cancelTasks(cancelTasksRequest, new RestToXContentListener<>(channel));
     }

--- a/core/src/main/java/org/elasticsearch/tasks/CancellableTask.java
+++ b/core/src/main/java/org/elasticsearch/tasks/CancellableTask.java
@@ -32,8 +32,8 @@ public class CancellableTask extends Task {
         super(id, type, action, description);
     }
 
-    public CancellableTask(long id, String type, String action, String description, String parentNode, long parentId) {
-        super(id, type, action, description, parentNode, parentId);
+    public CancellableTask(long id, String type, String action, String description, TaskId parentTaskId) {
+        super(id, type, action, description, parentTaskId);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/tasks/Task.java
+++ b/core/src/main/java/org/elasticsearch/tasks/Task.java
@@ -30,8 +30,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
  */
 public class Task {
 
-    public static final long NO_PARENT_ID = 0;
-
     private final long id;
 
     private final String type;
@@ -40,22 +38,18 @@ public class Task {
 
     private final String description;
 
-    private final String parentNode;
-
-    private final long parentId;
-
+    private final TaskId parentTask;
 
     public Task(long id, String type, String action, String description) {
-        this(id, type, action, description, null, NO_PARENT_ID);
+        this(id, type, action, description, TaskId.EMPTY_TASK_ID);
     }
 
-    public Task(long id, String type, String action, String description, String parentNode, long parentId) {
+    public Task(long id, String type, String action, String description, TaskId parentTask) {
         this.id = id;
         this.type = type;
         this.action = action;
         this.description = description;
-        this.parentNode = parentNode;
-        this.parentId = parentId;
+        this.parentTask = parentTask;
     }
 
     /**
@@ -75,7 +69,7 @@ public class Task {
             description = getDescription();
             status = getStatus();
         }
-        return new TaskInfo(node, getId(), getType(), getAction(), description, status, parentNode, parentId);
+        return new TaskInfo(node, getId(), getType(), getAction(), description, status, parentTask);
     }
 
     /**
@@ -107,17 +101,10 @@ public class Task {
     }
 
     /**
-     * Returns the parent node of the task or null if the task doesn't have any parent tasks
-     */
-    public String getParentNode() {
-        return parentNode;
-    }
-
-    /**
      * Returns id of the parent task or NO_PARENT_ID if the task doesn't have any parent tasks
      */
-    public long getParentId() {
-        return parentId;
+    public TaskId getParentTaskId() {
+        return parentTask;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/tasks/TaskId.java
+++ b/core/src/main/java/org/elasticsearch/tasks/TaskId.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.tasks;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+
+/**
+ * Task id that consists of node id and id of the task on the node
+ */
+public final class TaskId implements Writeable<TaskId> {
+
+    public final static TaskId EMPTY_TASK_ID = new TaskId("", -1L);
+
+    private final String nodeId;
+    private final long id;
+
+    public TaskId(String nodeId, long id) {
+        this.nodeId = nodeId;
+        this.id = id;
+    }
+
+    public TaskId(String taskId) {
+        if (Strings.hasLength(taskId) && "unset".equals(taskId) == false) {
+            String[] s = Strings.split(taskId, ":");
+            if (s == null || s.length != 2) {
+                throw new IllegalArgumentException("malformed task id " + taskId);
+            }
+            this.nodeId = s[0];
+            try {
+                this.id = Long.parseLong(s[1]);
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("malformed task id " + taskId, ex);
+            }
+        } else {
+            nodeId = "";
+            id = -1L;
+        }
+    }
+
+    public TaskId(StreamInput in) throws IOException {
+        nodeId = in.readString();
+        id = in.readLong();
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public boolean isSet() {
+        return id == -1L;
+    }
+
+    @Override
+    public String toString() {
+        if (isSet()) {
+            return "unset";
+        } else {
+            return nodeId + ":" + id;
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(nodeId);
+        out.writeLong(id);
+    }
+
+    @Override
+    public TaskId readFrom(StreamInput in) throws IOException {
+        return new TaskId(in);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TaskId taskId = (TaskId) o;
+
+        if (id != taskId.id) return false;
+        return nodeId.equals(taskId.nodeId);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = nodeId.hashCode();
+        result = 31 * result + (int) (id ^ (id >>> 32));
+        return result;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -87,8 +88,8 @@ public class CancellableTasksTests extends TaskManagerTestCase {
         }
 
         @Override
-        public Task createTask(long id, String type, String action, String parentTaskNode, long parentTaskId) {
-            return new CancellableTask(id, type, action, getDescription(), parentTaskNode, parentTaskId);
+        public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+            return new CancellableTask(id, type, action, getDescription(), parentTaskId);
         }
     }
 
@@ -235,9 +236,9 @@ public class CancellableTasksTests extends TaskManagerTestCase {
         });
 
         // Cancel main task
-        CancelTasksRequest request = new CancelTasksRequest(testNodes[0].discoveryNode.getId());
+        CancelTasksRequest request = new CancelTasksRequest();
         request.reason("Testing Cancellation");
-        request.taskId(mainTask.getId());
+        request.taskId(new TaskId(testNodes[0].discoveryNode.getId(), mainTask.getId()));
         // And send the cancellation request to a random node
         CancelTasksResponse response = testNodes[randomIntBetween(0, testNodes.length - 1)].transportCancelTasksAction.execute(request)
             .get();
@@ -269,7 +270,8 @@ public class CancellableTasksTests extends TaskManagerTestCase {
 
         // Make sure that tasks are no longer running
         ListTasksResponse listTasksResponse = testNodes[randomIntBetween(0, testNodes.length - 1)]
-            .transportListTasksAction.execute(new ListTasksRequest(testNodes[0].discoveryNode.getId()).taskId(mainTask.getId())).get();
+            .transportListTasksAction.execute(new ListTasksRequest().taskId(
+                new TaskId(testNodes[0].discoveryNode.getId(), mainTask.getId()))).get();
         assertEquals(0, listTasksResponse.getTasks().size());
 
         // Make sure that there are no leftover bans, the ban removal is async, so we might return from the cancellation
@@ -311,7 +313,7 @@ public class CancellableTasksTests extends TaskManagerTestCase {
 
         // Make sure that tasks are running
         ListTasksResponse listTasksResponse = testNodes[randomIntBetween(0, testNodes.length - 1)]
-            .transportListTasksAction.execute(new ListTasksRequest().parentNode(mainNode).taskId(mainTask.getId())).get();
+            .transportListTasksAction.execute(new ListTasksRequest().parentTaskId(new TaskId(mainNode, mainTask.getId()))).get();
         assertThat(listTasksResponse.getTasks().size(), greaterThanOrEqualTo(blockOnNodes.size()));
 
         // Simulate the coordinating node leaving the cluster
@@ -328,9 +330,9 @@ public class CancellableTasksTests extends TaskManagerTestCase {
         if (simulateBanBeforeLeaving) {
             logger.info("--> Simulate issuing cancel request on the node that is about to leave the cluster");
             // Simulate issuing cancel request on the node that is about to leave the cluster
-            CancelTasksRequest request = new CancelTasksRequest(testNodes[0].discoveryNode.getId());
+            CancelTasksRequest request = new CancelTasksRequest();
             request.reason("Testing Cancellation");
-            request.taskId(mainTask.getId());
+            request.taskId(new TaskId(testNodes[0].discoveryNode.getId(), mainTask.getId()));
             // And send the cancellation request to a random node
             CancelTasksResponse response = testNodes[0].transportCancelTasksAction.execute(request).get();
             logger.info("--> Done simulating issuing cancel request on the node that is about to leave the cluster");
@@ -354,7 +356,7 @@ public class CancellableTasksTests extends TaskManagerTestCase {
             // Make sure that tasks are no longer running
             try {
                 ListTasksResponse listTasksResponse1 = testNodes[randomIntBetween(1, testNodes.length - 1)]
-                    .transportListTasksAction.execute(new ListTasksRequest().parentNode(mainNode).taskId(mainTask.getId())).get();
+                    .transportListTasksAction.execute(new ListTasksRequest().taskId(new TaskId(mainNode, mainTask.getId()))).get();
                 assertEquals(0, listTasksResponse1.getTasks().size());
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -47,6 +47,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -84,8 +85,8 @@ public class TestTaskPlugin extends Plugin {
 
         private volatile boolean blocked = true;
 
-        public TestTask(long id, String type, String action, String description, String parentNode, long parentId) {
-            super(id, type, action, description, parentNode, parentId);
+        public TestTask(long id, String type, String action, String description, TaskId parentTaskId) {
+            super(id, type, action, description, parentTaskId);
         }
 
         public boolean isBlocked() {
@@ -172,8 +173,8 @@ public class TestTaskPlugin extends Plugin {
         }
 
         @Override
-        public Task createTask(long id, String type, String action, String parentTaskNode, long parentTaskId) {
-            return new TestTask(id, type, action, this.getDescription(), parentTaskNode, parentTaskId);
+        public Task createTask(long id, String type, String action, TaskId parentTaskId) {
+            return new TestTask(id, type, action, this.getDescription(), parentTaskId);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -43,13 +43,11 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.tasks.MockTaskManager;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.local.LocalTransport;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -103,9 +101,9 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         }
 
         @Override
-        public Task createTask(long id, String type, String action, String parentTaskNode, long parentTaskId) {
+        public Task createTask(long id, String type, String action, TaskId parentTaskId) {
             if (enableTaskManager) {
-                return super.createTask(id, type, action, parentTaskNode, parentTaskId);
+                return super.createTask(id, type, action, parentTaskId);
             } else {
                 return null;
             }
@@ -313,7 +311,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         }
         Task task = actions[0].execute(request, listener);
         logger.info("Awaiting for all actions to start");
-        actionLatch.await();
+        assertTrue(actionLatch.await(10, TimeUnit.SECONDS));
         logger.info("Done waiting for all actions to start");
         return task;
     }
@@ -426,14 +424,13 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
 
         // Find tasks with common parent
         listTasksRequest = new ListTasksRequest();
-        listTasksRequest.parentNode(parentNode);
-        listTasksRequest.parentTaskId(parentTaskId);
+        listTasksRequest.parentTaskId(new TaskId(parentNode, parentTaskId));
         response = testNode.transportListTasksAction.execute(listTasksRequest).get();
         assertEquals(testNodes.length, response.getTasks().size());
         for (TaskInfo task : response.getTasks()) {
             assertEquals("testAction[n]", task.getAction());
-            assertEquals(parentNode, task.getParentNode());
-            assertEquals(parentTaskId, task.getParentId());
+            assertEquals(parentNode, task.getParentTaskId().getNodeId());
+            assertEquals(parentTaskId, task.getParentTaskId().getId());
         }
 
         // Release all tasks and wait for response
@@ -514,7 +511,8 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         String actionName = "testAction"; // only pick the main action
 
         // Try to cancel main task using action name
-        CancelTasksRequest request = new CancelTasksRequest(testNodes[0].discoveryNode.getId());
+        CancelTasksRequest request = new CancelTasksRequest();
+        request.nodesIds(testNodes[0].discoveryNode.getId());
         request.reason("Testing Cancellation");
         request.actions(actionName);
         CancelTasksResponse response = testNodes[randomIntBetween(0, testNodes.length - 1)].transportCancelTasksAction.execute(request)
@@ -527,9 +525,9 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
 
 
         // Try to cancel main task using id
-        request = new CancelTasksRequest(testNodes[0].discoveryNode.getId());
+        request = new CancelTasksRequest();
         request.reason("Testing Cancellation");
-        request.taskId(task.getId());
+        request.taskId(new TaskId(testNodes[0].discoveryNode.getId(), task.getId()));
         response = testNodes[randomIntBetween(0, testNodes.length - 1)].transportCancelTasksAction.execute(request).get();
 
         // Shouldn't match any tasks since testAction doesn't support cancellation
@@ -601,7 +599,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
                 @Override
                 protected TestTaskResponse taskOperation(TestTasksRequest request, Task task) {
                     logger.info("Task action on node " + node);
-                    if (failTaskOnNode == node && task.getParentNode() != null) {
+                    if (failTaskOnNode == node && task.getParentTaskId().isSet() == false) {
                         logger.info("Failing on node " + node);
                         throw new RuntimeException("Task level failure");
                     }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -1015,7 +1015,7 @@ public class TransportReplicationActionTests extends ESTestCase {
      * half the time.
      */
     private ReplicationTask maybeTask() {
-        return random().nextBoolean() ? new ReplicationTask(0, null, null, null, null, 0) : null;
+        return random().nextBoolean() ? new ReplicationTask(0, null, null, null, null) : null;
     }
 
     /**

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -4,18 +4,18 @@
     "methods": ["POST"],
     "url": {
       "path": "/_tasks",
-      "paths": ["/_tasks/_cancel", "/_tasks/{node_id}/_cancel", "/_tasks/{node_id}/{task_id}/_cancel"],
+      "paths": ["/_tasks/_cancel", "/_tasks/{task_id}/_cancel"],
       "parts": {
-        "node_id": {
-          "type": "list",
-          "description": "A comma-separated list of node IDs or names to limit the request; use `_local` to cancel only tasks on the node you're connecting to, leave empty to cancel tasks on all nodes"
-        },
         "task_id": {
           "type": "number",
           "description": "Cancel the task with specified id"
         }
       },
       "params": {
+        "node_id": {
+          "type": "list",
+          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
+        },
         "actions": {
           "type": "list",
           "description": "A comma-separated list of actions that should be cancelled. Leave empty to cancel all."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -4,18 +4,18 @@
     "methods": ["GET"],
     "url": {
       "path": "/_tasks",
-      "paths": ["/_tasks", "/_tasks/{node_id}", "/_tasks/{node_id}/{task_id}"],
+      "paths": ["/_tasks", "/_tasks/{task_id}"],
       "parts": {
-        "node_id": {
-          "type": "list",
-          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
-        },
         "task_id": {
           "type": "number",
           "description": "Return the task with specified id"
         }
       },
       "params": {
+        "node_id": {
+          "type": "list",
+          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
+        },
         "actions": {
           "type": "list",
           "description": "A comma-separated list of actions that should be returned. Leave empty to return all."

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.cancel/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.cancel/10_basic.yaml
@@ -2,7 +2,6 @@
 "tasks_cancel test":
   - do:
       tasks.cancel:
-          node_id: _local
-          task_id: 1
+          actions: "unknown_action"
 
   - length: { nodes: 0 }


### PR DESCRIPTION
This commit changes the URL for task operations from `/_tasks/{nodeId}/{taskId}` to `/_tasks/{taskId}`, where `{taskId}` has a form of `nodeid:id`
