### PR TITLE
Fix Unknown [repository] type [azure] error with 2.2.0

### DIFF
--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/AzureModule.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/AzureModule.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cloud.azure.management.AzureComputeSettingsFilter;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.cloud.azure.storage.AzureStorageService.Storage;
 import org.elasticsearch.cloud.azure.storage.AzureStorageServiceImpl;
+import org.elasticsearch.cloud.azure.storage.AzureStorageSettings;
 import org.elasticsearch.cloud.azure.storage.AzureStorageSettingsFilter;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.AbstractModule;
@@ -145,11 +146,10 @@ public class AzureModule extends AbstractModule {
             return false;
         }
 
-        if (isPropertyMissing(settings, Storage.ACCOUNT) ||
-                isPropertyMissing(settings, Storage.KEY)) {
-            logger.debug("azure repository is not set using [{}] and [{}] properties",
-                    Storage.ACCOUNT,
-                    Storage.KEY);
+        if (AzureStorageSettings.parse(settings).v1() == null) {
+            logger.debug("azure repository is not set using [{}xxx.account] and [{}xxx.key] properties",
+                Storage.PREFIX,
+                Storage.PREFIX);
             return false;
         }
 

--- a/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
+++ b/plugins/cloud-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
@@ -44,11 +44,7 @@ public interface AzureStorageService {
 
         public static final String TIMEOUT = "cloud.azure.storage.timeout";
 
-        public static final String ACCOUNT = "repositories.azure.account";
-        public static final String LOCATION_MODE = "repositories.azure.location_mode";
-        public static final String KEY = "cloud.azure.storage.key";
         public static final String CONTAINER = "repositories.azure.container";
-        public static final String BASE_PATH = "repositories.azure.base_path";
         public static final String CHUNK_SIZE = "repositories.azure.chunk_size";
         public static final String COMPRESS = "repositories.azure.compress";
     }

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/cloud/azure/AbstractAzureRepositoryServiceTestCase.java
@@ -83,8 +83,8 @@ public abstract class AbstractAzureRepositoryServiceTestCase extends AbstractAzu
                 .put(Storage.CONTAINER, "snapshots");
 
         // We use sometime deprecated settings in tests
-        builder.put(Storage.ACCOUNT, "mock_azure_account")
-                .put(Storage.KEY, "mock_azure_key");
+        builder.put(Storage.ACCOUNT_DEPRECATED, "mock_azure_account")
+                .put(Storage.KEY_DEPRECATED, "mock_azure_key");
 
         return builder.build();
     }

--- a/plugins/cloud-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSettingsParserTest.java
+++ b/plugins/cloud-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSettingsParserTest.java
@@ -65,8 +65,8 @@ public class AzureSettingsParserTest extends LuceneTestCase {
 
     public void testDeprecatedSettings() {
         Settings settings = Settings.builder()
-                .put(Storage.ACCOUNT, "myaccount1")
-                .put(Storage.KEY, "mykey1")
+                .put(Storage.ACCOUNT_DEPRECATED, "myaccount1")
+                .put(Storage.KEY_DEPRECATED, "mykey1")
                 .build();
 
         Tuple<AzureStorageSettings, Map<String, AzureStorageSettings>> tuple = AzureStorageSettings.parse(settings);


### PR DESCRIPTION
This regression has been introduced in 2.2.0 by #13779 where we removed support for `cloud.azure.storage.account` and replaced by `cloud.azure.storage.my_account.account`.
But Azure plugin tries to detect when it starts if all needed settings to use an `azure` repository have been set. If not the case, the plugin does not expose `azure` as an available repository.

Sadly, this check has been badly updated in 2.2.0 so it can never find the expected settings to start correctly.

This gives the following effect:

``` yaml
cloud:
    azure:
        storage:
            my_account:
                account: your_azure_storage_account
                key: your_azure_storage_key
```

When you try to execute the following API you get Unknown [repository] type [azure]:

``` sh
[msimos@msi-gs60 elasticsearch-2.2.0]$ curl -XPUT http://localhost:9200/_snapshot/mybackup?pretty -d '{
"type": "azure"
}'
```

``` js
{
  "error" : {
    "root_cause" : [ {
      "type" : "repository_exception",
      "reason" : "[mybackup] failed to create repository"
    } ],
    "type" : "repository_exception",
    "reason" : "[mybackup] failed to create repository",
    "caused_by" : {
      "type" : "illegal_argument_exception",
      "reason" : "Unknown [repository] type [azure]"
    }
  },
  "status" : 500
}
```

``` sh
[msimos@msi-gs60 elasticsearch-2.2.0]$ curl -XGE http://localhost:9200/_cat/plugins?v
name   component   version type url
node01 cloud-azure 2.2.0   j
node01 license     2.2.0   j
node01 shield      2.2.0   j
```

In the elasticsearch log file you see this error:

```
[2016-02-19 10:54:47,357][DEBUG][cloud.azure              ] [node01] starting azure services
[2016-02-19 10:54:47,357][DEBUG][cloud.azure              ] [node01] azure repository is not set using [repositories.azure.account] and [cloud.azure.storage.key] properties
```

Closes #16734

Note that this does not happen in master branch because we split the azure plugin and we always define `azure` as a repository when the `repository-azure` plugin starts.
