### PR TITLE
Add setting to disable importing dynamic indices on shared filesystems

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -436,7 +436,6 @@
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]env[/\\]Environment.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]env[/\\]NodeEnvironment.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]gateway[/\\]AsyncShardFetch.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]gateway[/\\]DanglingIndicesState.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]gateway[/\\]Gateway.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]gateway[/\\]GatewayAllocator.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]gateway[/\\]GatewayMetaState.java" checks="LineLength" />

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -56,6 +56,7 @@ import org.elasticsearch.discovery.zen.fd.FaultDetection;
 import org.elasticsearch.discovery.zen.ping.unicast.UnicastZenPing;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.gateway.DanglingIndicesState;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.gateway.PrimaryShardAllocator;
 import org.elasticsearch.http.HttpTransportSettings;
@@ -397,6 +398,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING,
                     BootstrapSettings.MLOCKALL_SETTING,
                     BootstrapSettings.SECCOMP_SETTING,
-                    BootstrapSettings.CTRLHANDLER_SETTING
+                    BootstrapSettings.CTRLHANDLER_SETTING,
+                    DanglingIndicesState.IMPORT_ON_SHARED_FS_SETTING
             )));
 }

--- a/core/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
+++ b/core/src/main/java/org/elasticsearch/gateway/DanglingIndicesState.java
@@ -131,9 +131,11 @@ public class DanglingIndicesState extends AbstractComponent {
                             logger.info("ignoring dangling index [{}] because it is on a shared filesystem", indexMetaData.getIndex());
                             continue;
                         }
-                        logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, auto import to cluster state", indexName);
+                        logger.info("[{}] dangling index, exists on local file system, but not in cluster metadata, " +
+                                        "auto import to cluster state", indexName);
                         if (!indexMetaData.getIndex().getName().equals(indexName)) {
-                            logger.info("dangled index directory name is [{}], state name is [{}], renaming to directory name", indexName, indexMetaData.getIndex());
+                            logger.info("dangled index directory name is [{}], state name is [{}], renaming to directory name",
+                                    indexName, indexMetaData.getIndex());
                             indexMetaData = IndexMetaData.builder(indexMetaData).index(indexName).build();
                         }
                         newIndices.put(indexName, indexMetaData);
@@ -157,7 +159,8 @@ public class DanglingIndicesState extends AbstractComponent {
             return;
         }
         try {
-            allocateDangledIndices.allocateDangled(Collections.unmodifiableCollection(new ArrayList<>(danglingIndices.values())), new LocalAllocateDangledIndices.Listener() {
+            allocateDangledIndices.allocateDangled(Collections.unmodifiableCollection(new ArrayList<>(danglingIndices.values())),
+                    new LocalAllocateDangledIndices.Listener() {
                 @Override
                 public void onResponse(LocalAllocateDangledIndices.AllocateDangledResponse response) {
                     logger.trace("allocated dangled");

--- a/core/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/ShadowEngine.java
@@ -82,7 +82,7 @@ public class ShadowEngine extends Engine {
                     this.lastCommittedSegmentInfos = readLastCommittedSegmentInfos(searcherManager, store);
                     success = true;
                 } else {
-                    throw new IllegalStateException("failed to open a shadow engine after" +
+                    throw new IllegalStateException("failed to open a shadow engine after " +
                             nonexistentRetryTime + "ms, " +
                             "directory is not an index");
                 }


### PR DESCRIPTION
The `gateway.local.dangling.import_shared_fs` defaults to
`false` (meaning don't import them).

Relates to #16358

(also cleans up and removes the checkstyle linelength suppression for DanglingIndicesState)
