### PR TITLE
Settings with complex matchers should not overlap

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -22,7 +22,6 @@ package org.elasticsearch.common.settings;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.util.set.Sets;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -63,6 +62,11 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
                 throw new IllegalArgumentException("illegal settings key: [" + setting.getKey() + "]");
             }
             if (setting.hasComplexMatcher()) {
+                Setting<?> overlappingSetting = findOverlappingSetting(setting, complexMatchers);
+                if (overlappingSetting != null) {
+                    throw new IllegalArgumentException("complex setting key: [" + setting.getKey() + "] overlaps existing setting key: [" +
+                        overlappingSetting.getKey() + "]");
+                }
                 complexMatchers.putIfAbsent(setting.getKey(), setting);
             } else {
                 keySettings.putIfAbsent(setting.getKey(), setting);
@@ -410,4 +414,19 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
         return changed;
     }
 
+    private static Setting<?> findOverlappingSetting(Setting<?> newSetting, Map<String, Setting<?>> complexMatchers) {
+        assert newSetting.hasComplexMatcher();
+        if (complexMatchers.containsKey(newSetting.getKey())) {
+            // we return null here because we use a putIfAbsent call when inserting into the map, so if it exists then we already checked
+            // the setting to make sure there are no overlapping settings.
+            return null;
+        }
+
+        for (Setting<?> existingSetting : complexMatchers.values()) {
+            if (newSetting.match(existingSetting.getKey()) || existingSetting.match(newSetting.getKey())) {
+                return existingSetting;
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
It is possible to register multiple settings with complex matchers that could both match
a given key. The behavior when this occurs can lead to issues and depends on the
number of settings that have been registered. In order to identify the setting for a given
key, we iterate over the values in a map to find the first setting that matches the given key
and iteration order of a map should not be relied upon.

This commit checks complex settings when adding them and if the keys for these overlap,
an IllegalArgumentException is now thrown.
