### PR TITLE
Remove es.max-open-files flag

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -256,11 +256,6 @@ final class Bootstrap {
             PidFile.create(environment.pidFile(), true);
         }
 
-        if (System.getProperty("es.max-open-files", "false").equals("true")) {
-            ESLogger logger = Loggers.getLogger(Bootstrap.class);
-            logger.info("max_open_files [{}]", ProcessProbe.getInstance().getMaxFileDescriptorCount());
-        }
-
         // warn if running using the client VM
         if (JvmInfo.jvmInfo().getVmName().toLowerCase(Locale.ROOT).contains("client")) {
             ESLogger logger = Loggers.getLogger(Bootstrap.class);

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -303,6 +303,14 @@ The 'default' similarity has been renamed to 'classic'.
 `indices.memory.min_shard_index_buffer_size` and `indices.memory.max_shard_index_buffer_size` are removed since Elasticsearch now allows any one shard to any
 amount of heap as long as the total indexing buffer heap used across all shards is below the node's `indices.memory.index_buffer_size` (default: 10% of the JVM heap)
 
+==== Removed es.max-open-files
+
+Setting the system property es.max-open-files to true to get
+Elasticsearch to print the number of maximum open files for the
+Elasticsearch process has been removed. This same information can be
+obtained from the <<cluster-nodes-info>> API, and a warning is logged
+on startup if it is set too low.
+
 [[breaking_30_mapping_changes]]
 === Mapping changes
 

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -35,11 +35,7 @@ Make sure to increase the number of open files descriptors on the
 machine (or for the user running elasticsearch). Setting it to 32k or
 even 64k is recommended.
 
-In order to test how many open files the process can open, start it with
-`-Des.max-open-files` set to `true`. This will print the number of open
-files the process can open on startup.
-
-Alternatively, you can retrieve the `max_file_descriptors` for each node
+You can retrieve the `max_file_descriptors` for each node
 using the <<cluster-nodes-info>> API, with:
 
 [source,js]


### PR DESCRIPTION
This commit removes the es.max-open-files flag as the same information
can be obtained from the cluster nodes info API, and is warn logged on
startup if it's set too low anyway.

Relates #483, relates #16506 
