### PR TITLE
Expose http address in cat/nodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
@@ -43,6 +43,9 @@ import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestNodeAttrsAction extends AbstractCatAction {
@@ -112,23 +115,32 @@ public class RestNodeAttrsAction extends AbstractCatAction {
         for (DiscoveryNode node : nodes) {
             NodeInfo info = nodesInfo.getNodesMap().get(node.id());
             for(ObjectObjectCursor<String, String> att : node.attributes()) {
-                table.startRow();
-                table.addCell(node.name());
-                table.addCell(fullId ? node.id() : Strings.substring(node.getId(), 0, 4));
-                table.addCell(info == null ? null : info.getProcess().getId());
-                table.addCell(node.getHostName());
-                table.addCell(node.getHostAddress());
-                if (node.address() instanceof InetSocketTransportAddress) {
-                    table.addCell(((InetSocketTransportAddress) node.address()).address().getPort());
-                } else {
-                    table.addCell("-");
+                buildRow(fullId, table, node, info, att.key, att.value);
+            }
+            if (info.getServiceAttributes() != null) {
+                for (Map.Entry<String, String> entry : info.getServiceAttributes().entrySet()) {
+                    buildRow(fullId, table, node, info, entry.getKey(), entry.getValue());
                 }
-                table.addCell(att.key);
-                table.addCell(att.value);
-                table.endRow();
             }
         }
 
         return table;
+    }
+
+    private final void buildRow(boolean fullId, Table table, DiscoveryNode node, NodeInfo info, String key, String value) {
+        table.startRow();
+        table.addCell(node.name());
+        table.addCell(fullId ? node.id() : Strings.substring(node.getId(), 0, 4));
+        table.addCell(info == null ? null : info.getProcess().getId());
+        table.addCell(node.getHostName());
+        table.addCell(node.getHostAddress());
+        if (node.address() instanceof InetSocketTransportAddress) {
+            table.addCell(((InetSocketTransportAddress) node.address()).address().getPort());
+        } else {
+            table.addCell("-");
+        }
+        table.addCell(key);
+        table.addCell(value);
+        table.endRow();
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -64,6 +64,7 @@ import org.elasticsearch.script.ScriptStats;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 import java.util.Locale;
+import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -117,6 +118,7 @@ public class RestNodesAction extends AbstractCatAction {
         table.addCell("pid", "default:false;alias:p;desc:process id");
         table.addCell("ip", "alias:i;desc:ip address");
         table.addCell("port", "default:false;alias:po;desc:bound transport port");
+        table.addCell("http_address", "default:false;alias:http;desc:bound http adress");
 
         table.addCell("version", "default:false;alias:v;desc:es version");
         table.addCell("build", "default:false;alias:b;desc:es build hash");
@@ -244,6 +246,12 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(node.getHostAddress());
             if (node.address() instanceof InetSocketTransportAddress) {
                 table.addCell(((InetSocketTransportAddress) node.address()).address().getPort());
+            } else {
+                table.addCell("-");
+            }
+            final Map<String, String> serviceAttributes = info.getServiceAttributes();
+            if (serviceAttributes != null) {
+                table.addCell(serviceAttributes.getOrDefault("http_address", "-"));
             } else {
                 table.addCell("-");
             }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yaml
@@ -48,3 +48,12 @@
       $body: |
                /^      file_desc\.current  \s+  file_desc\.percent  \s+  file_desc\.max   \n
                   (\s+ (-1|\d+)            \s+  \d+                 \s+  (-1|\d+)         \n)+  $/
+
+  - do:
+      cat.nodes:
+          h: http
+          v: true
+
+  - match:
+      $body: |
+               /^      http \n ((\d{1,3}\.){3}\d{1,3}:\d{1,5}\n)+  $/


### PR DESCRIPTION
We expose a lot of information like IP address and port but never
expose the http address/ip:port in the CAT API. It's nice to have it
there too since otherwise json parsing is required to get this information
