### PR TITLE
Remove ability to disable Netty gathering writes

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/netty/NettyUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/netty/NettyUtils.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.common.netty;
 
-import org.elasticsearch.common.Booleans;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.transport.netty.NettyInternalESLoggerFactory;
 import org.jboss.netty.logging.InternalLogger;
 import org.jboss.netty.logging.InternalLoggerFactory;
@@ -74,7 +72,7 @@ public class NettyUtils {
      * sized pages, and if its a single one, makes sure that it gets sliced and wrapped in a composite
      * buffer.
      */
-    public static final boolean DEFAULT_GATHERING;
+    public static final boolean DEFAULT_GATHERING = true;
 
     private static EsThreadNameDeterminer ES_THREAD_NAME_DETERMINER = new EsThreadNameDeterminer();
 
@@ -95,13 +93,6 @@ public class NettyUtils {
         });
 
         ThreadRenamingRunnable.setThreadNameDeterminer(ES_THREAD_NAME_DETERMINER);
-
-        /**
-         * This is here just to give us an option to rollback the change, if its stable, we should remove
-         * the option to even set it.
-         */
-        DEFAULT_GATHERING = Booleans.parseBoolean(System.getProperty("es.netty.gathering"), true);
-        Loggers.getLogger(NettyUtils.class).debug("using gathering [{}]", DEFAULT_GATHERING);
     }
 
     public static void setup() {

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -316,6 +316,13 @@ Elasticsearch process has been removed. This same information can be
 obtained from the <<cluster-nodes-info>> API, and a warning is logged
 on startup if it is set too low.
 
+==== Removed es.netty.gathering
+
+Disabling Netty from using NIO gathering could be done via the escape
+hatch of settings the system property "es.netty.gathering" to "false".
+Time has proven enabling gathering by default is a non-issue and this
+non-documented setting has been removed.
+
 [[breaking_30_mapping_changes]]
 === Mapping changes
 


### PR DESCRIPTION
Java NIO has the notion of gathering writes. These are writes that
gather data from multiple buffers into a single channel. These gathering
writes in Netty have been enabled by default with the possibility to
disable them using "es.netty.gathering". This flag was added in case
having gathering writes on by default did not work out. We have not
published this ability and sufficient time has passed to render
judgement that using gathering writes is okay.

Relates #7811
