### PR TITLE
Document cpu usage in _cat/nodes.

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -102,6 +102,7 @@ descriptors percentage |1
 |`file_desc.max` |`fdm`, `fileDescriptorMax` |No |Maximum number of file
 descriptors |1024
 |`load` |`l` |No |Most recent load average |0.22
+|`cpu` | |No |Recent system CPU usage as percent |12
 |`uptime` |`u` |No |Node uptime |17.3m
 |`node.role` |`r`, `role`, `dc`, `nodeRole` |Yes |Data node (d); Client
 node (c) |d


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/15302 added cpu usage to the _cat/nodes endpoint, but it wasn't documented, so I added that.
