### PR TITLE
Add example for require_field_match to highlighting docs

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -421,6 +421,17 @@ be highlighted regardless of whether the query matched specifically on them.
 The default behaviour is `true`, meaning that only fields that hold a query
 match will be highlighted.
 
+[source,js]
+--------------------------------------------------
+{
+    "query" : {...},
+    "highlight" : {
+        "require_field_match": false
+        "fields" : {...}
+    }
+}
+--------------------------------------------------
+
 [[boundary-characters]]
 ==== Boundary Characters
 


### PR DESCRIPTION
I think showing how this configuration option is used explicitly is better than inferring that it's another option that can be passed.
