### PR TITLE
Fix python script filename extension

### DIFF
--- a/docs/plugins/lang-python.asciidoc
+++ b/docs/plugins/lang-python.asciidoc
@@ -141,10 +141,10 @@ GET test/_search
 === File scripts
 
 You can save your scripts to a file in the `config/scripts/` directory on
-every node. The `.python` file suffix identifies the script as containing
+every node. The `.py` file suffix identifies the script as containing
 Python:
 
-First, save this file as `config/scripts/my_script.python` on every node
+First, save this file as `config/scripts/my_script.py` on every node
 in the cluster:
 
 [source,python]
@@ -188,5 +188,5 @@ GET test/_search
 ----
 // AUTOSENSE
 
-<1> The function score query retrieves the script with filename `my_script.python`.
+<1> The function score query retrieves the script with filename `my_script.py`.
 


### PR DESCRIPTION
Python scripts need to be saved as *.py, not *.python
