### PR TITLE
Remove es.useLinkedTransferQueue

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/ConcurrentCollections.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/ConcurrentCollections.java
@@ -36,8 +36,6 @@ import java.util.concurrent.LinkedTransferQueue;
  */
 public abstract class ConcurrentCollections {
 
-    private final static boolean useLinkedTransferQueue = Boolean.parseBoolean(System.getProperty("es.useLinkedTransferQueue", "false"));
-
     static final int aggressiveConcurrencyLevel;
 
     static {
@@ -71,9 +69,6 @@ public abstract class ConcurrentCollections {
     }
 
     public static <T> Queue<T> newQueue() {
-        if (useLinkedTransferQueue) {
-            return new LinkedTransferQueue<>();
-        }
         return new ConcurrentLinkedQueue<>();
     }
 

--- a/docs/reference/migration/migrate_3_0.asciidoc
+++ b/docs/reference/migration/migrate_3_0.asciidoc
@@ -323,6 +323,13 @@ hatch of setting the system property "es.netty.gathering" to "false".
 Time has proven enabling gathering by default is a non-issue and this
 non-documented setting has been removed.
 
+==== Removed es.useLinkedTransferQueue
+
+The system property `es.useLinkedTransferQueue` could be used to
+control the queue implementation used in the cluster service and the
+handling of ping responses during discovery. This was an undocumented
+setting and has been removed.
+
 [[breaking_30_mapping_changes]]
 === Mapping changes
 


### PR DESCRIPTION
This commit removes the system property "es.useLinkedTransferQueue" that
defaulted to false and was used to control the queue implementation used
in a few places.
