### PR TITLE
Add note about size being per shard here

### DIFF
--- a/docs/java-api/search.asciidoc
+++ b/docs/java-api/search.asciidoc
@@ -72,6 +72,10 @@ while (true) {
     }
 }
 --------------------------------------------------
+[NOTE]
+====
+The size-parameter is per shard, so if you run a query against multiple indices (leading to many shards being involved in the query) the result might be more documents per execution of the scroll than you would expect!
+====
 
 [[java-search-msearch]]
 === MultiSearch API


### PR DESCRIPTION
It seems the current note via the comment is too less intrusive for people to notice and it leads to unexpected high number of search-hits per scroll if not explained a bit more.
