### PR TITLE
Disable production limits on snapshot builds

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -22,6 +22,7 @@ package org.elasticsearch.bootstrap;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.StringHelper;
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.PidFile;
@@ -358,6 +359,9 @@ final class Bootstrap {
     )));
 
     private static boolean enforceLimits(Settings settings) {
+        if (Build.CURRENT.isSnapshot()) {
+            return false;
+        }
         for (Setting setting : ENFORCE_SETTINGS) {
             if (setting.exists(settings)) {
                 return true;


### PR DESCRIPTION
This commit disables the production limits checks on snapshot
builds. This is at a minimum short-term relief for developers that do in
fact bind to external network interfaces, and is possibly a long-term
fix as well. The situation with using the JVM flag MaxFDLimit is far too
complicated.

Closes #16813
