### PR TITLE
Fix minor spelling

### DIFF
--- a/docs/reference/mapping/params/fielddata.asciidoc
+++ b/docs/reference/mapping/params/fielddata.asciidoc
@@ -9,7 +9,7 @@ of documents that contain the term.
 Sorting, aggregations, and access to field values in scripts requires a
 different data access pattern.  Instead of lookup up the term and finding
 documents, we need to be able to look up the document and find the terms that
-is has in a field.
+it has in a field.
 
 Most fields can use index-time, on-disk <<doc-values,`doc_values`>> to support
 this type of data access pattern, but `analyzed` string fields do not support


### PR DESCRIPTION
Old: the terms that is has in a field.
Fixed: the terms that it has in a field.
