### PR TITLE
Add breaking change notes for logging

### DIFF
--- a/docs/reference/migration/migrate_5_0.asciidoc
+++ b/docs/reference/migration/migrate_5_0.asciidoc
@@ -667,6 +667,13 @@ to index a document only if it doesn't already exist.
 
 The inner DirectCandidateGenerator class has been moved out to its own class called DirectCandidateGeneratorBuilder.
 
+==== Elasticsearch will no longer detect logging implementations
+
+Elasticsearch now logs only to log4j 1.2. Previously if log4j wasn't on the classpath it made some effort to degrade to
+slf4j or java.util.logging. Now it'll fail to work without the log4j 1.2 api. The log4j-over-slf4j bridge ought to work
+when using the java client. As should log4j 2's log4j-1.2-api. The Elasticsearch server now only supports log4j as
+configured by logging.yml and it no longer makes any effort to work if log4j isn't present.
+
 [[breaking_50_cache_concurrency]]
 === Cache concurrency level settings removed
 


### PR DESCRIPTION
ba5be0332dbf28a3fa4b0e73d4222a1da39b5dfe removed support for degrading
to slf4j and j.u.l but didn't document this as a breaking change because
it is only breaking for folks using Elasticsearch's jar as a java client.
People do that so this counts as a breaking change.

Also, if anyone was brave enough to try and replace log4j on an installed
version of Elasticsearch that will no longer work and this documents that
as well. It doens't get a full heading and instead lives with the java
client notes. Mostly because I can't imagine it worked consistently enough
for anyone to actually do it in the first place. We just never tested it
well enough to make sure we didn't break it after it was implemented.
