### PR TITLE
Use HttpInfo in cat/_nodes instead of node attribute

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -33,8 +33,11 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.http.HttpInfo;
 import org.elasticsearch.index.cache.query.QueryCacheStats;
 import org.elasticsearch.index.cache.request.RequestCacheStats;
 import org.elasticsearch.index.engine.SegmentsStats;
@@ -92,7 +95,7 @@ public class RestNodesAction extends AbstractCatAction {
             @Override
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
                 NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
-                nodesInfoRequest.clear().jvm(true).os(true).process(true);
+                nodesInfoRequest.clear().jvm(true).os(true).process(true).http(true);
                 client.admin().cluster().nodesInfo(nodesInfoRequest, new RestActionListener<NodesInfoResponse>(channel) {
                     @Override
                     public void processResponse(final NodesInfoResponse nodesInfoResponse) {
@@ -249,9 +252,14 @@ public class RestNodesAction extends AbstractCatAction {
             } else {
                 table.addCell("-");
             }
-            final Map<String, String> serviceAttributes = info == null ? null : info.getServiceAttributes();
-            if (serviceAttributes != null) {
-                table.addCell(serviceAttributes.getOrDefault("http_address", "-"));
+            final HttpInfo httpInfo = info == null ? null : info.getHttp();
+            if (httpInfo != null) {
+                TransportAddress transportAddress = httpInfo.getAddress().publishAddress();
+                if (transportAddress instanceof InetSocketTransportAddress) {
+                    table.addCell(NetworkAddress.formatAddress(((InetSocketTransportAddress)transportAddress).address()));
+                } else {
+                    table.addCell(transportAddress.toString());
+                }
             } else {
                 table.addCell("-");
             }


### PR DESCRIPTION
The node attribute also renders the type of the inet address
as well as the host name which is unneeded in the cat action.
