### PR TITLE
Adds Node Ingest indicator (i) to _cat/nodes API

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -139,7 +139,7 @@ public class RestNodesAction extends AbstractCatAction {
         table.addCell("load_5m", "alias:l;text-align:right;desc:5m load avg");
         table.addCell("load_15m", "alias:l;text-align:right;desc:15m load avg");
         table.addCell("uptime", "default:false;alias:u;text-align:right;desc:node uptime");
-        table.addCell("node.role", "alias:r,role,dc,nodeRole;desc:d:data node, c:client node");
+        table.addCell("node.role", "alias:r,role,dc,nodeRole;desc:d:data node, c:client node, i:ingest node");
         table.addCell("master", "alias:m;desc:m:master-eligible, *:current master");
         table.addCell("name", "alias:n;desc:node name");
 
@@ -276,8 +276,8 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(!hasLoadAverage || osStats.getCpu().getLoadAverage()[1] == -1 ? null : String.format(Locale.ROOT, "%.2f", osStats.getCpu().getLoadAverage()[1]));
             table.addCell(!hasLoadAverage || osStats.getCpu().getLoadAverage()[2] == -1 ? null : String.format(Locale.ROOT, "%.2f", osStats.getCpu().getLoadAverage()[2]));
             table.addCell(jvmStats == null ? null : jvmStats.getUptime());
-            table.addCell(node.clientNode() ? "c" : node.dataNode() ? "d" : "-");
-            table.addCell(masterId == null ? "x" : masterId.equals(node.id()) ? "*" : node.masterNode() ? "m" : "-");
+            table.addCell(node.isClientNode() ? "c" : node.isDataNode() ? "d" : node.isIngestNode() ? "i" : "-");
+            table.addCell(masterId == null ? "x" : masterId.equals(node.id()) ? "*" : node.isMasterNode() ? "m" : "-");
             table.addCell(node.name());
 
             CompletionStats completionStats = indicesStats == null ? null : stats.getIndices().getCompletion();

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -105,7 +105,7 @@ descriptors |1024
 |`cpu` | |No |Recent system CPU usage as percent |12
 |`uptime` |`u` |No |Node uptime |17.3m
 |`node.role` |`r`, `role`, `dc`, `nodeRole` |Yes |Data node (d); Client
-node (c) |d
+node (c); Ingest node (i) |d
 |`master` |`m` |Yes |Current master (*); master eligible (m) |m
 |`name` |`n` |Yes |Node name |Venom
 |`completion.size` |`cs`, `completionSize` |No |Size of completion |0b


### PR DESCRIPTION
This commit adds Node ingest information to the `_cat/nodes` endpoint.

Note that this implementation is probably wrong because it will print `i` iif the node is not a client node nor a data node.

May be it would be better to add a new column instead `ingest.processors` and write the number of available processors once #16865 will be merged?

@martijnvg WDYT?
