### PR TITLE
Suggest: Move name of suggestion to SuggestBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -393,9 +393,7 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
-     * Delegates to
-     * {@link org.elasticsearch.search.suggest.SuggestBuilder#addSuggestion(org.elasticsearch.search.suggest.SuggestBuilder.SuggestionBuilder)}
-     * .
+     * Delegates to {@link SearchSourceBuilder#suggest(SuggestBuilder)}
      */
     public SearchRequestBuilder suggest(SuggestBuilder suggestBuilder) {
         sourceBuilder().suggest(suggestBuilder);

--- a/core/src/main/java/org/elasticsearch/action/suggest/SuggestRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/suggest/SuggestRequestBuilder.java
@@ -44,9 +44,11 @@ public class SuggestRequestBuilder extends BroadcastOperationRequestBuilder<Sugg
 
     /**
      * Add a definition for suggestions to the request
+     * @param name the name for the suggestion that will also be used in the response
+     * @param suggestion the suggestion configuration
      */
-    public SuggestRequestBuilder addSuggestion(SuggestionBuilder<?> suggestion) {
-        suggest.addSuggestion(suggestion);
+    public SuggestRequestBuilder addSuggestion(String name, SuggestionBuilder<?> suggestion) {
+        suggest.addSuggestion(name, suggestion);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -48,6 +48,7 @@ import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.search.suggest.SuggestBuilder;
+import org.elasticsearch.search.suggest.term.TermSuggestionBuilder.SuggestMode;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -56,7 +57,6 @@ import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.search.suggest.SuggestBuilders.termSuggestion;
-import static org.elasticsearch.search.suggest.term.TermSuggestionBuilder.SuggestMode;
 
 /**
  *
@@ -255,8 +255,8 @@ public class RestSearchAction extends BaseRestHandler {
             String suggestText = request.param("suggest_text", request.param("q"));
             int suggestSize = request.paramAsInt("suggest_size", 5);
             String suggestMode = request.param("suggest_mode");
-            searchSourceBuilder.suggest(new SuggestBuilder().addSuggestion(
-                    termSuggestion(suggestField).field(suggestField)
+            searchSourceBuilder.suggest(new SuggestBuilder().addSuggestion(suggestField,
+                    termSuggestion().field(suggestField)
                         .text(suggestText).size(suggestSize)
                         .suggestMode(SuggestMode.resolve(suggestMode))));
         }

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestBuilders.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestBuilders.java
@@ -31,33 +31,30 @@ public abstract class SuggestBuilders {
     /**
      * Creates a term suggestion lookup query with the provided <code>name</code>
      *
-     * @param name The suggestion name
      * @return a {@link org.elasticsearch.search.suggest.term.TermSuggestionBuilder}
      * instance
      */
-    public static TermSuggestionBuilder termSuggestion(String name) {
-        return new TermSuggestionBuilder(name);
+    public static TermSuggestionBuilder termSuggestion() {
+        return new TermSuggestionBuilder();
     }
 
     /**
      * Creates a phrase suggestion lookup query with the provided <code>name</code>
      *
-     * @param name The suggestion name
      * @return a {@link org.elasticsearch.search.suggest.phrase.PhraseSuggestionBuilder}
      * instance
      */
-    public static PhraseSuggestionBuilder phraseSuggestion(String name) {
-        return new PhraseSuggestionBuilder(name);
+    public static PhraseSuggestionBuilder phraseSuggestion() {
+        return new PhraseSuggestionBuilder();
     }
 
     /**
      * Creates a completion suggestion lookup query with the provided <code>name</code>
      *
-     * @param name The suggestion name
      * @return a {@link org.elasticsearch.search.suggest.completion.CompletionSuggestionBuilder}
      * instance
      */
-    public static CompletionSuggestionBuilder completionSuggestion(String name) {
-        return new CompletionSuggestionBuilder(name);
+    public static CompletionSuggestionBuilder completionSuggestion() {
+        return new CompletionSuggestionBuilder();
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -50,7 +50,7 @@ import java.util.Set;
  */
 public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSuggestionBuilder> {
 
-    public static final CompletionSuggestionBuilder PROTOTYPE = new CompletionSuggestionBuilder("_na_"); // name doesn't matter
+    public static final CompletionSuggestionBuilder PROTOTYPE = new CompletionSuggestionBuilder();
     static final String SUGGESTION_NAME = "completion";
     static final ParseField PAYLOAD_FIELD = new ParseField("payload");
     static final ParseField CONTEXTS_FIELD = new ParseField("contexts", "context");
@@ -59,10 +59,6 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
     private RegexOptions regexOptions;
     private final Map<String, List<QueryContext>> queryContexts = new HashMap<>();
     private final Set<String> payloadFields = new HashSet<>();
-
-    public CompletionSuggestionBuilder(String name) {
-        super(name);
-    }
 
     /**
      * Sets the prefix to provide completions for.
@@ -179,7 +175,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
     }
 
     @Override
-    protected CompletionSuggestionBuilder innerFromXContent(QueryParseContext parseContext, String name) throws IOException {
+    protected CompletionSuggestionBuilder innerFromXContent(QueryParseContext parseContext) throws IOException {
         // NORELEASE implement parsing logic
         throw new UnsupportedOperationException();
     }
@@ -233,8 +229,8 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
     }
 
     @Override
-    public CompletionSuggestionBuilder doReadFrom(StreamInput in, String name) throws IOException {
-        CompletionSuggestionBuilder completionSuggestionBuilder = new CompletionSuggestionBuilder(name);
+    public CompletionSuggestionBuilder doReadFrom(StreamInput in) throws IOException {
+        CompletionSuggestionBuilder completionSuggestionBuilder = new CompletionSuggestionBuilder();
         if (in.readBoolean()) {
             int numPayloadField = in.readVInt();
             for (int i = 0; i < numPayloadField; i++) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.analysis.ShingleTokenFilterFactory;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -59,7 +58,7 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
 
     private static final String SUGGESTION_NAME = "phrase";
 
-    public static final PhraseSuggestionBuilder PROTOTYPE = new PhraseSuggestionBuilder("_na_");
+    public static final PhraseSuggestionBuilder PROTOTYPE = new PhraseSuggestionBuilder();
 
     protected static final ParseField MAXERRORS_FIELD = new ParseField("max_errors");
     protected static final ParseField RWE_LIKELIHOOD_FIELD = new ParseField("real_word_error_likelihood");
@@ -93,10 +92,6 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     private boolean collatePrune = PhraseSuggestionContext.DEFAULT_COLLATE_PRUNE;
     private SmoothingModel model;
     private final Map<String, List<CandidateGenerator>> generators = new HashMap<>();
-
-    public PhraseSuggestionBuilder(String name) {
-        super(name);
-    }
 
     /**
      * Sets the gram size for the n-gram model used for this suggester. The
@@ -398,9 +393,9 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     }
 
     @Override
-    protected PhraseSuggestionBuilder innerFromXContent(QueryParseContext parseContext, String suggestionName) throws IOException {
+    protected PhraseSuggestionBuilder innerFromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
-        PhraseSuggestionBuilder suggestion = new PhraseSuggestionBuilder(suggestionName);
+        PhraseSuggestionBuilder suggestion = new PhraseSuggestionBuilder();
         ParseFieldMatcher parseFieldMatcher = parseContext.parseFieldMatcher();
         XContentParser.Token token;
         String fieldName = null;
@@ -621,8 +616,8 @@ public final class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSugge
     }
 
     @Override
-    public PhraseSuggestionBuilder doReadFrom(StreamInput in, String name) throws IOException {
-        PhraseSuggestionBuilder builder = new PhraseSuggestionBuilder(name);
+    public PhraseSuggestionBuilder doReadFrom(StreamInput in) throws IOException {
+        PhraseSuggestionBuilder builder = new PhraseSuggestionBuilder();
         builder.maxErrors = in.readFloat();
         builder.realWordErrorLikelihood = in.readFloat();
         builder.confidence = in.readFloat();

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
@@ -67,7 +67,7 @@ import static org.elasticsearch.search.suggest.SuggestUtils.Fields.SUGGEST_MODE;
  */
 public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuilder> {
 
-    public static final TermSuggestionBuilder PROTOTYPE = new TermSuggestionBuilder("_na_"); // name doesn't matter
+    public static final TermSuggestionBuilder PROTOTYPE = new TermSuggestionBuilder();
     private static final String SUGGESTION_NAME = "term";
 
     private SuggestMode suggestMode = SuggestMode.MISSING;
@@ -80,14 +80,6 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
     private Integer prefixLength = DEFAULT_PREFIX_LENGTH;
     private Integer minWordLength = DEFAULT_MIN_WORD_LENGTH;
     private Float minDocFreq = DEFAULT_MIN_DOC_FREQ;
-
-    /**
-     * @param name
-     *            The name of this suggestion. This is a required parameter.
-     */
-    public TermSuggestionBuilder(String name) {
-        super(name);
-    }
 
     /**
      * The global suggest mode controls what suggested terms are included or
@@ -345,9 +337,9 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
     }
 
     @Override
-    protected TermSuggestionBuilder innerFromXContent(QueryParseContext parseContext, String name) throws IOException {
+    protected TermSuggestionBuilder innerFromXContent(QueryParseContext parseContext) throws IOException {
         XContentParser parser = parseContext.parser();
-        TermSuggestionBuilder suggestion = new TermSuggestionBuilder(name);
+        TermSuggestionBuilder suggestion = new TermSuggestionBuilder();
         ParseFieldMatcher parseFieldMatcher = parseContext.parseFieldMatcher();
         XContentParser.Token token;
         String fieldName = null;
@@ -431,8 +423,8 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
     }
 
     @Override
-    public TermSuggestionBuilder doReadFrom(StreamInput in, String name) throws IOException {
-        TermSuggestionBuilder builder = new TermSuggestionBuilder(name);
+    public TermSuggestionBuilder doReadFrom(StreamInput in) throws IOException {
+        TermSuggestionBuilder builder = new TermSuggestionBuilder();
         builder.suggestMode = SuggestMode.PROTOTYPE.readFrom(in);
         builder.accuracy = in.readFloat();
         builder.sort = SortBy.PROTOTYPE.readFrom(in);
@@ -470,18 +462,21 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
     public enum SuggestMode implements Writeable<SuggestMode> {
         /** Only suggest terms in the suggest text that aren't in the index. This is the default. */
         MISSING {
+            @Override
             public org.apache.lucene.search.spell.SuggestMode toLucene() {
                 return org.apache.lucene.search.spell.SuggestMode.SUGGEST_WHEN_NOT_IN_INDEX;
             }
         },
         /** Only suggest terms that occur in more docs then the original suggest text term. */
         POPULAR {
+            @Override
             public org.apache.lucene.search.spell.SuggestMode toLucene() {
                 return org.apache.lucene.search.spell.SuggestMode.SUGGEST_MORE_POPULAR;
             }
         },
         /** Suggest any matching suggest terms based on tokens in the suggest text. */
         ALWAYS {
+            @Override
             public org.apache.lucene.search.spell.SuggestMode toLucene() {
               return org.apache.lucene.search.spell.SuggestMode.SUGGEST_ALWAYS;
             }
@@ -516,30 +511,35 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
         /** This is the default and is based on <code>damerau_levenshtein</code>, but highly optimized
          * for comparing string distance for terms inside the index. */
         INTERNAL {
+            @Override
             public StringDistance toLucene() {
                 return DirectSpellChecker.INTERNAL_LEVENSHTEIN;
             }
         },
         /** String distance algorithm based on Damerau-Levenshtein algorithm. */
         DAMERAU_LEVENSHTEIN {
+            @Override
             public StringDistance toLucene() {
                 return new LuceneLevenshteinDistance();
             }
         },
         /** String distance algorithm based on Levenstein edit distance algorithm. */
         LEVENSTEIN {
+            @Override
             public StringDistance toLucene() {
                 return new LevensteinDistance();
             }
         },
         /** String distance algorithm based on Jaro-Winkler algorithm. */
         JAROWINKLER {
+            @Override
             public StringDistance toLucene() {
                 return new JaroWinklerDistance();
             }
         },
         /** String distance algorithm based on character n-grams. */
         NGRAM {
+            @Override
             public StringDistance toLucene() {
                 return new NGramDistance();
             }

--- a/core/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
@@ -139,9 +139,9 @@ public class SuggestStatsIT extends ESIntegTestCase {
     private SuggestRequestBuilder addSuggestions(SuggestRequestBuilder request, int i) {
         for (int s = 0; s < randomIntBetween(2, 10); s++) {
             if (randomBoolean()) {
-                request.addSuggestion(new PhraseSuggestionBuilder("s" + s).field("f").text("test" + i + " test" + (i - 1)));
+                request.addSuggestion("s" + s, new PhraseSuggestionBuilder().field("f").text("test" + i + " test" + (i - 1)));
             } else {
-                request.addSuggestion(new TermSuggestionBuilder("s" + s).field("f").text("test" + i));
+                request.addSuggestion("s" + s, new TermSuggestionBuilder().field("f").text("test" + i));
             }
         }
         return request;

--- a/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -749,7 +749,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
     }
 
     private static SuggestRequestBuilder suggest(String... indices) {
-        return client().prepareSuggest(indices).addSuggestion(SuggestBuilders.termSuggestion("name").field("a"));
+        return client().prepareSuggest(indices).addSuggestion("name", SuggestBuilders.termSuggestion().field("a"));
     }
 
     private static GetAliasesRequestBuilder getAliases(String... indices) {

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -49,15 +49,9 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.EnvironmentModule;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.AbstractQueryTestCase;
-import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.EmptyQueryBuilder;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.TermQueryBuilder;
-import org.elasticsearch.index.query.WrapperQueryBuilder;
-import org.elasticsearch.index.query.functionscore.ScoreFunctionParser;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -417,7 +411,8 @@ public class SearchSourceBuilderTests extends ESTestCase {
         if (randomBoolean()) {
             // NORELEASE need a random suggest builder method
             builder.suggest(new SuggestBuilder().setGlobalText(randomAsciiOfLengthBetween(1, 5)).addSuggestion(
-                    SuggestBuilders.termSuggestion(randomAsciiOfLengthBetween(1, 5))));
+                    randomAsciiOfLengthBetween(1, 5),
+                    SuggestBuilders.termSuggestion()));
         }
         if (randomBoolean()) {
             // NORELEASE need a random inner hits builder method

--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -204,10 +204,8 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             context.reset(parser);
             // we need to skip the start object and the name, those will be parsed by outer SuggestBuilder
             parser.nextToken();
-            parser.nextToken();
-            parser.nextToken();
 
-            SuggestionBuilder<?> secondSuggestionBuilder = SuggestionBuilder.fromXContent(context, suggestionBuilder.name(), suggesters);
+            SuggestionBuilder<?> secondSuggestionBuilder = SuggestionBuilder.fromXContent(context, suggesters);
             assertNotSame(suggestionBuilder, secondSuggestionBuilder);
             assertEquals(suggestionBuilder, secondSuggestionBuilder);
             assertEquals(suggestionBuilder.hashCode(), secondSuggestionBuilder.hashCode());
@@ -253,7 +251,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
             SuggestBuilder suggestBuilder = new SuggestBuilder();
             SB suggestionBuilder = randomTestBuilder();
-            suggestBuilder.addSuggestion(suggestionBuilder);
+            suggestBuilder.addSuggestion(randomAsciiOfLength(10), suggestionBuilder);
 
             if (suggestionBuilder.text() == null) {
                 // we either need suggestion text or global text

--- a/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -105,7 +105,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                     ));
         }
         indexRandom(true, indexRequestBuilders);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion10", "suggestion9", "suggestion8", "suggestion7", "suggestion6");
     }
 
@@ -126,7 +126,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                     ));
         }
         indexRandom(true, indexRequestBuilders);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).regex("sugg.*es");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).regex("sugg.*es");
         assertSuggestions("foo", prefix, "sugg10estion", "sugg9estion", "sugg8estion", "sugg7estion", "sugg6estion");
     }
 
@@ -147,7 +147,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                     ));
         }
         indexRandom(true, indexRequestBuilders);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg", Fuzziness.ONE);
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg", Fuzziness.ONE);
         assertSuggestions("foo", prefix, "sugxgestion10", "sugxgestion9", "sugxgestion8", "sugxgestion7", "sugxgestion6");
     }
 
@@ -173,13 +173,13 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         for (int i = 0; i < size; i++) {
             outputs[i] = "suggestion" + (numDocs - i);
         }
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sug").size(size);
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sug").size(size);
         assertSuggestions("foo", prefix, outputs);
 
-        CompletionSuggestionBuilder regex = SuggestBuilders.completionSuggestion("foo").field(FIELD).regex("su[g|s]g").size(size);
+        CompletionSuggestionBuilder regex = SuggestBuilders.completionSuggestion().field(FIELD).regex("su[g|s]g").size(size);
         assertSuggestions("foo", regex, outputs);
 
-        CompletionSuggestionBuilder fuzzyPrefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg", Fuzziness.ONE).size(size);
+        CompletionSuggestionBuilder fuzzyPrefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg", Fuzziness.ONE).size(size);
         assertSuggestions("foo", fuzzyPrefix, outputs);
     }
 
@@ -198,9 +198,9 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
 
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg").
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg").
             size(numDocs).payload(Collections.singletonList("count"));
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(prefix).execute().actionGet();
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo", prefix).execute().actionGet();
         assertNoFailures(suggestResponse);
         CompletionSuggestion completionSuggestion = suggestResponse.getSuggest().getSuggestion("foo");
         CompletionSuggestion.Entry options = completionSuggestion.getEntries().get(0);
@@ -245,9 +245,9 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                 client().prepareIndex(INDEX, TYPE, "2").setSource(FIELD, "suggestion")
         );
         indexRandom(true, indexRequestBuilders);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
             .payload(Collections.singletonList("test_field"));
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(prefix).execute().actionGet();
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo", prefix).execute().actionGet();
         assertNoFailures(suggestResponse);
         CompletionSuggestion completionSuggestion = suggestResponse.getSuggest().getSuggestion("foo");
         CompletionSuggestion.Entry options = completionSuggestion.getEntries().get(0);
@@ -283,9 +283,9 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "2").setSource(source));
         indexRandom(true, indexRequestBuilders);
 
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
             .payload(Arrays.asList("title", "count"));
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(prefix).execute().actionGet();
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo", prefix).execute().actionGet();
         assertNoFailures(suggestResponse);
         CompletionSuggestion completionSuggestion = suggestResponse.getSuggest().getSuggestion("foo");
         List<CompletionSuggestion.Entry.Option> options = completionSuggestion.getEntries().get(0).getOptions();
@@ -334,9 +334,9 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             payloadFields.add("test_field" + i);
         }
 
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
             .size(suggestionSize).payload(payloadFields);
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(prefix).execute().actionGet();
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo", prefix).execute().actionGet();
         assertNoFailures(suggestResponse);
         CompletionSuggestion completionSuggestion = suggestResponse.getSuggest().getSuggestion("foo");
         CompletionSuggestion.Entry options = completionSuggestion.getEntries().get(0);
@@ -434,8 +434,8 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
 
         refresh();
 
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                new CompletionSuggestionBuilder("testSuggestions").field(FIELD).text("test").size(10)
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("testSuggestions",
+                new CompletionSuggestionBuilder().field(FIELD).text("test").size(10)
         ).execute().actionGet();
 
         assertSuggestions(suggestResponse, "testSuggestions", "testing");
@@ -635,16 +635,16 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
                 .get();
         assertThat(putMappingResponse.isAcknowledged(), is(true));
 
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("suggs").field(FIELD + ".suggest").text("f").size(10)
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("suggs",
+                SuggestBuilders.completionSuggestion().field(FIELD + ".suggest").text("f").size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, "suggs");
 
         client().prepareIndex(INDEX, TYPE, "1").setRefresh(true).setSource(jsonBuilder().startObject().field(FIELD, "Foo Fighters").endObject()).get();
         ensureGreen(INDEX);
 
-        SuggestResponse afterReindexingResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("suggs").field(FIELD + ".suggest").text("f").size(10)
+        SuggestResponse afterReindexingResponse = client().prepareSuggest(INDEX).addSuggestion("suggs",
+                SuggestBuilders.completionSuggestion().field(FIELD + ".suggest").text("f").size(10)
         ).execute().actionGet();
         assertSuggestions(afterReindexingResponse, "suggs", "Foo Fighters");
     }
@@ -660,13 +660,13 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
 
         refresh();
 
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Nirv").size(10)
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Nirv").size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
 
-        suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Nirw", Fuzziness.ONE).size(10)
+        suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Nirw", Fuzziness.ONE).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -683,14 +683,14 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         refresh();
 
         // edit distance 1
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Norw", Fuzziness.ONE).size(10)
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Norw", Fuzziness.ONE).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
         // edit distance 2
-        suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Norw", Fuzziness.TWO).size(10)
+        suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Norw", Fuzziness.TWO).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -706,13 +706,13 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
 
         refresh();
 
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Nriv", FuzzyOptions.builder().setTranspositions(false).build()).size(10)
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Nriv", FuzzyOptions.builder().setTranspositions(false).build()).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
-        suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Nriv", Fuzziness.ONE).size(10)
+        suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Nriv", Fuzziness.ONE).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -728,13 +728,13 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
 
         refresh();
 
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Nriva", FuzzyOptions.builder().setFuzzyMinLength(6).build()).size(10)
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Nriva", FuzzyOptions.builder().setFuzzyMinLength(6).build()).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
-        suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Nrivan", FuzzyOptions.builder().setFuzzyMinLength(6).build()).size(10)
+        suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Nrivan", FuzzyOptions.builder().setFuzzyMinLength(6).build()).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -750,13 +750,13 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
 
         refresh();
 
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Nirw", FuzzyOptions.builder().setFuzzyPrefixLength(4).build()).size(10)
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Nirw", FuzzyOptions.builder().setFuzzyPrefixLength(4).build()).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
-        suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("Nirvo", FuzzyOptions.builder().setFuzzyPrefixLength(4).build()).size(10)
+        suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo",
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("Nirvo", FuzzyOptions.builder().setFuzzyPrefixLength(4).build()).size(10)
         ).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "Nirvana");
     }
@@ -774,19 +774,19 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
 
         // suggestion with a character, which needs unicode awareness
         org.elasticsearch.search.suggest.completion.CompletionSuggestionBuilder completionSuggestionBuilder =
-                SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("öööи", FuzzyOptions.builder().setUnicodeAware(true).build()).size(10);
+                SuggestBuilders.completionSuggestion().field(FIELD).prefix("öööи", FuzzyOptions.builder().setUnicodeAware(true).build()).size(10);
 
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(completionSuggestionBuilder).execute().actionGet();
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo", completionSuggestionBuilder).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "ööööö");
 
         // removing unicode awareness leads to no result
-        completionSuggestionBuilder = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("öööи", FuzzyOptions.builder().setUnicodeAware(false).build()).size(10);
-        suggestResponse = client().prepareSuggest(INDEX).addSuggestion(completionSuggestionBuilder).execute().actionGet();
+        completionSuggestionBuilder = SuggestBuilders.completionSuggestion().field(FIELD).prefix("öööи", FuzzyOptions.builder().setUnicodeAware(false).build()).size(10);
+        suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo", completionSuggestionBuilder).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo");
 
         // increasing edit distance instead of unicode awareness works again, as this is only a single character
-        completionSuggestionBuilder = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("öööи", FuzzyOptions.builder().setUnicodeAware(false).setFuzziness(Fuzziness.TWO).build()).size(10);
-        suggestResponse = client().prepareSuggest(INDEX).addSuggestion(completionSuggestionBuilder).execute().actionGet();
+        completionSuggestionBuilder = SuggestBuilders.completionSuggestion().field(FIELD).prefix("öööи", FuzzyOptions.builder().setUnicodeAware(false).setFuzziness(Fuzziness.TWO).build()).size(10);
+        suggestResponse = client().prepareSuggest(INDEX).addSuggestion("foo", completionSuggestionBuilder).execute().actionGet();
         assertSuggestions(suggestResponse, false, "foo", "ööööö");
     }
 
@@ -815,8 +815,8 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
         refresh();
         ensureGreen();
         // load the fst index into ram
-        client().prepareSuggest(INDEX).addSuggestion(SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("f")).get();
-        client().prepareSuggest(INDEX).addSuggestion(SuggestBuilders.completionSuggestion("foo").field(otherField).prefix("f")).get();
+        client().prepareSuggest(INDEX).addSuggestion("foo", SuggestBuilders.completionSuggestion().field(FIELD).prefix("f")).get();
+        client().prepareSuggest(INDEX).addSuggestion("foo", SuggestBuilders.completionSuggestion().field(otherField).prefix("f")).get();
 
         // Get all stats
         IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(INDEX).setIndices(INDEX).setCompletion(true).get();
@@ -914,21 +914,21 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
 
 
     public void assertSuggestions(String suggestionName, SuggestionBuilder suggestBuilder, String... suggestions) {
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestBuilder
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionName, suggestBuilder
         ).execute().actionGet();
         assertSuggestions(suggestResponse, suggestionName, suggestions);
 
     }
     public void assertSuggestions(String suggestion, String... suggestions) {
         String suggestionName = RandomStrings.randomAsciiOfLength(random(), 10);
-        CompletionSuggestionBuilder suggestionBuilder = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggestion).size(10);
+        CompletionSuggestionBuilder suggestionBuilder = SuggestBuilders.completionSuggestion().field(FIELD).text(suggestion).size(10);
         assertSuggestions(suggestionName, suggestionBuilder, suggestions);
     }
 
     public void assertSuggestionsNotInOrder(String suggestString, String... suggestions) {
         String suggestionName = RandomStrings.randomAsciiOfLength(random(), 10);
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(
-                SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text(suggestString).size(10)
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionName,
+                SuggestBuilders.completionSuggestion().field(FIELD).text(suggestString).size(10)
         ).execute().actionGet();
 
         assertSuggestions(suggestResponse, false, suggestionName, suggestions);

--- a/core/src/test/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.suggest;
 
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+
 import org.apache.lucene.spatial.util.GeoHashUtils;
 import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -89,7 +90,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
     }
 
@@ -121,7 +122,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).regex("sugg.*es");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).regex("sugg.*es");
         assertSuggestions("foo", prefix, "sugg9estion", "sugg8estion", "sugg7estion", "sugg6estion", "sugg5estion");
     }
 
@@ -153,7 +154,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg", Fuzziness.ONE);
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg", Fuzziness.ONE);
         assertSuggestions("foo", prefix, "sugxgestion9", "sugxgestion8", "sugxgestion7", "sugxgestion6", "sugxgestion5");
     }
 
@@ -178,7 +179,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
                 .categoryContexts("cat", CategoryQueryContext.builder().setCategory("cat0").build());
 
         assertSuggestions("foo", prefix, "suggestion8", "suggestion6", "suggestion4", "suggestion2", "suggestion0");
@@ -205,7 +206,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
                 .categoryContexts("cat",
                         CategoryQueryContext.builder().setCategory("cat0").setBoost(3).build(),
                         CategoryQueryContext.builder().setCategory("cat1").build()
@@ -235,7 +236,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
 
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
     }
@@ -265,17 +266,17 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         ensureYellow(INDEX);
 
         // filter only on context cat
-        CompletionSuggestionBuilder catFilterSuggest = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder catFilterSuggest = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         catFilterSuggest.categoryContexts("cat", CategoryQueryContext.builder().setCategory("cat0").build());
         assertSuggestions("foo", catFilterSuggest, "suggestion8", "suggestion6", "suggestion4", "suggestion2", "suggestion0");
 
         // filter only on context type
-        CompletionSuggestionBuilder typeFilterSuggest = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder typeFilterSuggest = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         typeFilterSuggest.categoryContexts("type", CategoryQueryContext.builder().setCategory("type2").build(),
                 CategoryQueryContext.builder().setCategory("type1").build());
         assertSuggestions("foo", typeFilterSuggest, "suggestion9", "suggestion6", "suggestion5", "suggestion2", "suggestion1");
 
-        CompletionSuggestionBuilder multiContextFilterSuggest = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder multiContextFilterSuggest = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         // query context order should never matter
         if (randomBoolean()) {
             multiContextFilterSuggest.categoryContexts("type", CategoryQueryContext.builder().setCategory("type2").build());
@@ -313,21 +314,21 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         ensureYellow(INDEX);
 
         // boost only on context cat
-        CompletionSuggestionBuilder catBoostSuggest = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder catBoostSuggest = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         catBoostSuggest.categoryContexts("cat",
                 CategoryQueryContext.builder().setCategory("cat0").setBoost(3).build(),
                 CategoryQueryContext.builder().setCategory("cat1").build());
         assertSuggestions("foo", catBoostSuggest, "suggestion8", "suggestion6", "suggestion4", "suggestion9", "suggestion2");
 
         // boost only on context type
-        CompletionSuggestionBuilder typeBoostSuggest = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder typeBoostSuggest = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         typeBoostSuggest.categoryContexts("type",
                 CategoryQueryContext.builder().setCategory("type2").setBoost(2).build(),
                 CategoryQueryContext.builder().setCategory("type1").setBoost(4).build());
         assertSuggestions("foo", typeBoostSuggest, "suggestion9", "suggestion5", "suggestion6", "suggestion1", "suggestion2");
 
         // boost on both contexts
-        CompletionSuggestionBuilder multiContextBoostSuggest = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder multiContextBoostSuggest = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         // query context order should never matter
         if (randomBoolean()) {
             multiContextBoostSuggest.categoryContexts("type",
@@ -374,7 +375,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
     }
 
@@ -405,7 +406,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
 
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion0", "suggestion1", "suggestion2", "suggestion3", "suggestion4");
     }
 
@@ -431,7 +432,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
     }
 
@@ -458,10 +459,10 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
 
-        CompletionSuggestionBuilder geoFilteringPrefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder geoFilteringPrefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
                 .geoContexts("geo", GeoQueryContext.builder().setGeoPoint(new GeoPoint(geoPoints[0])).build());
 
         assertSuggestions("foo", geoFilteringPrefix, "suggestion8", "suggestion6", "suggestion4", "suggestion2", "suggestion0");
@@ -490,12 +491,12 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
 
         GeoQueryContext context1 = GeoQueryContext.builder().setGeoPoint(geoPoints[0]).setBoost(2).build();
         GeoQueryContext context2 = GeoQueryContext.builder().setGeoPoint(geoPoints[1]).build();
-        CompletionSuggestionBuilder geoBoostingPrefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder geoBoostingPrefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
                 .geoContexts("geo", context1, context2);
 
         assertSuggestions("foo", geoBoostingPrefix, "suggestion8", "suggestion6", "suggestion4", "suggestion9", "suggestion7");
@@ -526,7 +527,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
                 .geoContexts("geo", GeoQueryContext.builder().setGeoPoint(new GeoPoint(52.2263, 4.543)).build());
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
     }
@@ -564,10 +565,10 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
         ensureYellow(INDEX);
-        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg");
+        CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg");
         assertSuggestions("foo", prefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
 
-        CompletionSuggestionBuilder geoNeighbourPrefix = SuggestBuilders.completionSuggestion("foo").field(FIELD).prefix("sugg")
+        CompletionSuggestionBuilder geoNeighbourPrefix = SuggestBuilders.completionSuggestion().field(FIELD).prefix("sugg")
                 .geoContexts("geo", GeoQueryContext.builder().setGeoPoint(GeoPoint.fromGeohash(geohash)).build());
 
         assertSuggestions("foo", geoNeighbourPrefix, "suggestion9", "suggestion8", "suggestion7", "suggestion6", "suggestion5");
@@ -624,16 +625,16 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         refresh();
 
         String suggestionName = randomAsciiOfLength(10);
-        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(suggestionName).field(FIELD).text("h").size(10)
+        CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion().field(FIELD).text("h").size(10)
                 .geoContexts("st", GeoQueryContext.builder().setGeoPoint(new GeoPoint(52.52, 13.4)).build());
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(context).get();
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionName, context).get();
 
         assertEquals(suggestResponse.getSuggest().size(), 1);
         assertEquals("Hotel Amsterdam in Berlin", suggestResponse.getSuggest().getSuggestion(suggestionName).iterator().next().getOptions().iterator().next().getText().string());
     }
 
     public void assertSuggestions(String suggestionName, SuggestionBuilder suggestBuilder, String... suggestions) {
-        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestBuilder
+        SuggestResponse suggestResponse = client().prepareSuggest(INDEX).addSuggestion(suggestionName, suggestBuilder
         ).execute().actionGet();
         CompletionSuggestSearchIT.assertSuggestions(suggestResponse, suggestionName, suggestions);
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchIT.java
@@ -67,7 +67,7 @@ public class CustomSuggesterSearchIT extends ESIntegTestCase {
         String randomField = randomAsciiOfLength(10);
         String randomSuffix = randomAsciiOfLength(10);
         SuggestBuilder suggestBuilder = new SuggestBuilder();
-        suggestBuilder.addSuggestion(new CustomSuggestionBuilder("someName", randomField, randomSuffix).text(randomText));
+        suggestBuilder.addSuggestion("someName", new CustomSuggestionBuilder(randomField, randomSuffix).text(randomText));
         SearchRequestBuilder searchRequestBuilder = client().prepareSearch("test").setTypes("test").setFrom(0).setSize(1)
                 .suggest(suggestBuilder);
 
@@ -84,13 +84,12 @@ public class CustomSuggesterSearchIT extends ESIntegTestCase {
 
     static class CustomSuggestionBuilder extends SuggestionBuilder<CustomSuggestionBuilder> {
 
-        public final static CustomSuggestionBuilder PROTOTYPE = new CustomSuggestionBuilder("_na_", "_na_", "_na_");
+        public final static CustomSuggestionBuilder PROTOTYPE = new CustomSuggestionBuilder("_na_", "_na_");
 
         private String randomField;
         private String randomSuffix;
 
-        public CustomSuggestionBuilder(String name, String randomField, String randomSuffix) {
-            super(name);
+        public CustomSuggestionBuilder(String randomField, String randomSuffix) {
             this.randomField = randomField;
             this.randomSuffix = randomSuffix;
         }
@@ -114,8 +113,8 @@ public class CustomSuggesterSearchIT extends ESIntegTestCase {
         }
 
         @Override
-        public CustomSuggestionBuilder doReadFrom(StreamInput in, String name) throws IOException {
-            return new CustomSuggestionBuilder(in.readString(), in.readString(), in.readString());
+        public CustomSuggestionBuilder doReadFrom(StreamInput in) throws IOException {
+            return new CustomSuggestionBuilder(in.readString(), in.readString());
         }
 
         @Override
@@ -130,10 +129,10 @@ public class CustomSuggesterSearchIT extends ESIntegTestCase {
         }
 
         @Override
-        protected CustomSuggestionBuilder innerFromXContent(QueryParseContext parseContext, String name)
+        protected CustomSuggestionBuilder innerFromXContent(QueryParseContext parseContext)
                 throws IOException {
             // TODO some parsing
-            return new CustomSuggestionBuilder(name, randomField, randomSuffix);
+            return new CustomSuggestionBuilder(randomField, randomSuffix);
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.suggest.completion;
 
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.search.suggest.AbstractSuggestionBuilderTestCase;
-import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 import org.elasticsearch.search.suggest.completion.context.CategoryQueryContext;
 import org.elasticsearch.search.suggest.completion.context.GeoQueryContext;
@@ -30,7 +29,6 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,7 +42,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
 
     @Override
     protected CompletionSuggestionBuilder randomSuggestionBuilder() {
-        CompletionSuggestionBuilder testBuilder = new CompletionSuggestionBuilder(randomAsciiOfLength(10));
+        CompletionSuggestionBuilder testBuilder = new CompletionSuggestionBuilder();
         switch (randomIntBetween(0, 3)) {
             case 0:
                 testBuilder.prefix(randomAsciiOfLength(10));
@@ -96,6 +94,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
         // skip for now
     }
 
+    @Override
     protected void mutateSpecificParameters(CompletionSuggestionBuilder builder) throws IOException {
         switch (randomIntBetween(0, 5)) {
             case 0:

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -47,7 +47,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
     }
 
     public static PhraseSuggestionBuilder randomPhraseSuggestionBuilder() {
-        PhraseSuggestionBuilder testBuilder = new PhraseSuggestionBuilder(randomAsciiOfLength(10));
+        PhraseSuggestionBuilder testBuilder = new PhraseSuggestionBuilder();
         maybeSet(testBuilder::maxErrors, randomFloat());
         maybeSet(testBuilder::separator, randomAsciiOfLengthBetween(1, 10));
         maybeSet(testBuilder::realWordErrorLikelihood, randomFloat());

--- a/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
@@ -40,7 +40,7 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
      */
     @Override
     protected TermSuggestionBuilder randomSuggestionBuilder() {
-        TermSuggestionBuilder testBuilder = new TermSuggestionBuilder(randomAsciiOfLength(10));
+        TermSuggestionBuilder testBuilder = new TermSuggestionBuilder();
         maybeSet(testBuilder::suggestMode, randomSuggestMode());
         maybeSet(testBuilder::accuracy, randomFloat());
         maybeSet(testBuilder::sort, randomSort());
@@ -124,7 +124,7 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
     }
 
     public void testInvalidParameters() throws IOException {
-        TermSuggestionBuilder builder = new TermSuggestionBuilder(randomAsciiOfLength(10));
+        TermSuggestionBuilder builder = new TermSuggestionBuilder();
         // test invalid accuracy values
         try {
             builder.accuracy(-0.5f);
@@ -237,7 +237,7 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
     }
 
     public void testDefaultValuesSet() {
-        TermSuggestionBuilder builder = new TermSuggestionBuilder(randomAsciiOfLength(10));
+        TermSuggestionBuilder builder = new TermSuggestionBuilder();
         assertThat(builder.accuracy(), notNullValue());
         assertThat(builder.maxEdits(), notNullValue());
         assertThat(builder.maxInspections(), notNullValue());


### PR DESCRIPTION
Currently each suggestion keeps track of its own name. This has
the disadvantage of having to pass down the parsed name property
in the suggestions fromXContent() and the serialization methods
as an argument, since we need it in the ctor.

This change moves the naming of the suggestions to the surrounding
SuggestBuilder and by this eliminates the need for passind down
the names in the parsing and serialization methods. By making
`name` a required argument in SuggestBuilder#addSuggestion() we
also make sure it is always set and prevent using the same name twice,
which wasn't possible before.
