### PR TITLE
Add `ingest_took` to bulk response

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -35,29 +35,51 @@ import java.util.Iterator;
  */
 public class BulkResponse extends ActionResponse implements Iterable<BulkItemResponse> {
 
+    public final static long NO_INGEST_TOOK = -1L;
+
     private BulkItemResponse[] responses;
     private long tookInMillis;
+    private long ingestTookInMillis;
 
     BulkResponse() {
     }
 
     public BulkResponse(BulkItemResponse[] responses, long tookInMillis) {
+        this(responses, tookInMillis, NO_INGEST_TOOK);
+    }
+
+    public BulkResponse(BulkItemResponse[] responses, long tookInMillis, long ingestTookInMillis) {
         this.responses = responses;
         this.tookInMillis = tookInMillis;
+        this.ingestTookInMillis = ingestTookInMillis;
     }
 
     /**
-     * How long the bulk execution took.
+     * How long the bulk execution took. Excluding ingest preprocessing.
      */
     public TimeValue getTook() {
         return new TimeValue(tookInMillis);
     }
 
     /**
-     * How long the bulk execution took in milliseconds.
+     * How long the bulk execution took in milliseconds. Excluding ingest preprocessing.
      */
     public long getTookInMillis() {
         return tookInMillis;
+    }
+
+    /**
+     * If ingest is enabled returns the bulk ingest preprocessing time, otherwise 0 is returned.
+     */
+    public TimeValue getIngestTook() {
+        return new TimeValue(ingestTookInMillis);
+    }
+
+    /**
+     * If ingest is enabled returns the bulk ingest preprocessing time. in milliseconds, otherwise -1 is returned.
+     */
+    public long getIngestTookInMillis() {
+        return ingestTookInMillis;
     }
 
     /**
@@ -106,6 +128,7 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
             responses[i] = BulkItemResponse.readBulkItem(in);
         }
         tookInMillis = in.readVLong();
+        ingestTookInMillis = in.readZLong();
     }
 
     @Override
@@ -116,5 +139,6 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
             response.writeTo(out);
         }
         out.writeVLong(tookInMillis);
+        out.writeZLong(ingestTookInMillis);
     }
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/bulk/RestBulkAction.java
@@ -93,6 +93,9 @@ public class RestBulkAction extends BaseRestHandler {
             public RestResponse buildResponse(BulkResponse response, XContentBuilder builder) throws Exception {
                 builder.startObject();
                 builder.field(Fields.TOOK, response.getTookInMillis());
+                if (response.getIngestTookInMillis() != BulkResponse.NO_INGEST_TOOK) {
+                    builder.field(Fields.INGEST_TOOK, response.getIngestTookInMillis());
+                }
                 builder.field(Fields.ERRORS, response.hasFailures());
                 builder.startArray(Fields.ITEMS);
                 for (BulkItemResponse itemResponse : response) {
@@ -112,6 +115,7 @@ public class RestBulkAction extends BaseRestHandler {
         static final XContentBuilderString ITEMS = new XContentBuilderString("items");
         static final XContentBuilderString ERRORS = new XContentBuilderString("errors");
         static final XContentBuilderString TOOK = new XContentBuilderString("took");
+        static final XContentBuilderString INGEST_TOOK = new XContentBuilderString("ingest_took");
     }
 
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/70_bulk.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/ingest/70_bulk.yaml
@@ -48,6 +48,7 @@ setup:
               _type:  test_type
               _id:    test_id2
           - f1: v2
+  - gte: { ingest_took: 0 }
 
   - do:
       get:
@@ -85,6 +86,8 @@ setup:
               _id:    test_id2
               pipeline: pipeline2
           - f1: v2
+  - gte: { ingest_took: 0 }
+
   - do:
       get:
         index: test_index


### PR DESCRIPTION
 The `ingest_took` indicates how much time was spent on ingest preprocessing.

The `ingest_took` is separate from `took`, which keeps track how much time is spent on indexing/deleting/updating. The `ingest_took` is only visible in the rest response if at least one index request has ingest enabled.
