### PR TITLE
Backport add setFactory permission to GceDiscoveryPlugin

### DIFF
--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -40,9 +40,12 @@ import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.discovery.DiscoveryService;
@@ -55,6 +58,7 @@ import org.elasticsearch.gateway.GatewayModule;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.http.HttpServer;
 import org.elasticsearch.http.HttpServerModule;
+import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.search.shape.ShapeModule;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.IndicesService;
@@ -93,7 +97,15 @@ import org.elasticsearch.tribe.TribeService;
 import org.elasticsearch.watcher.ResourceWatcherModule;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -275,7 +287,14 @@ public class Node implements Releasable {
             injector.getInstance(HttpServer.class).start();
         }
         injector.getInstance(TribeService.class).start();
-
+        if (settings.getAsBoolean("node.portsfile", false)) {
+            if (settings.getAsBoolean("http.enabled", true)) {
+                HttpServerTransport http = injector.getInstance(HttpServerTransport.class);
+                writePortsFile("http", http.boundAddress());
+            }
+            TransportService transport = injector.getInstance(TransportService.class);
+            writePortsFile("transport", transport.boundAddress());
+        }
         logger.info("started");
 
         return this;
@@ -425,5 +444,28 @@ public class Node implements Releasable {
 
     public Injector injector() {
         return this.injector;
+    }
+
+    /** Writes a file to the logs dir containing the ports for the given transport type */
+    private void writePortsFile(String type, BoundTransportAddress boundAddress) {
+        Path tmpPortsFile = environment.logsFile().resolve(type + ".ports.tmp");
+        try (BufferedWriter writer = Files.newBufferedWriter(tmpPortsFile, Charset.forName("UTF-8"))) {
+            for (TransportAddress address : boundAddress.boundAddresses()) {
+                InetAddress inetAddress = InetAddress.getByName(address.getAddress());
+                if (inetAddress instanceof Inet6Address && inetAddress.isLinkLocalAddress()) {
+                    // no link local, just causes problems
+                    continue;
+                }
+                writer.write(NetworkAddress.formatAddress(new InetSocketAddress(inetAddress, address.getPort())) + "\n");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write ports file", e);
+        }
+        Path portsFile = environment.logsFile().resolve(type + ".ports");
+        try {
+            Files.move(tmpPortsFile, portsFile, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to rename ports file", e);
+        }
     }
 }

--- a/plugins/cloud-gce/pom.xml
+++ b/plugins/cloud-gce/pom.xml
@@ -31,6 +31,8 @@ governing permissions and limitations under the License. -->
         <!-- currently has no unit tests -->
         <tests.rest.suite>cloud_gce</tests.rest.suite>
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
+        <ssl.antfile>${project.basedir}/ssl-setup.xml</ssl.antfile>
+        <keystore>${project.build.testOutputDirectory}/test-node.jks</keystore>
     </properties>
 
     <dependencies>
@@ -60,6 +62,30 @@ governing permissions and limitations under the License. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+            <!-- generate certificates/keys -->
+                <execution>
+                    <id>certificate-setup</id>
+                    <phase>generate-test-resources</phase>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                    <configuration>
+                        <target>
+                            <delete file="${keystore}" quiet="true"/> <!-- must clean it up first -->
+                            <mkdir dir="${project.build.testOutputDirectory}"/> <!-- the directory must exist first -->
+                            <exec executable="keytool" failonerror="true">
+                                <arg line="-genkey -keyalg RSA -alias selfsigned -keystore ${keystore} -storepass keypass -keypass keypass -validity 712 -keysize 2048 -dname CN=127.0.0.1"/>
+                            </exec>
+                        </target>
+                        <skip>${skip.integ.tests}</skip>
+                    </configuration>
+                </execution>
+            </executions>
             </plugin>
         </plugins>
     </build>

--- a/plugins/cloud-gce/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/cloud-gce/src/main/plugin-metadata/plugin-security.policy
@@ -20,4 +20,5 @@
 grant {
   // needed because of problems in gce
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+  permission java.lang.RuntimePermission "setFactory";
 };

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceComputeServiceMock.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceComputeServiceMock.java
@@ -44,6 +44,8 @@ import java.security.GeneralSecurityException;
 public class GceComputeServiceMock extends GceComputeServiceImpl {
 
     protected HttpTransport mockHttpTransport;
+    private static final String GCE_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/instance";
+
 
     public GceComputeServiceMock(Settings settings, NetworkService networkService) {
         super(settings, networkService);
@@ -80,19 +82,18 @@ public class GceComputeServiceMock extends GceComputeServiceImpl {
         };
     }
 
-    private String readGoogleInternalJsonResponse(String url) throws IOException {
+    public static String readGoogleInternalJsonResponse(String url) throws IOException {
         return readJsonResponse(url, "http://metadata.google.internal/");
     }
 
-    private String readGoogleApiJsonResponse(String url) throws IOException {
+    public static String readGoogleApiJsonResponse(String url) throws IOException {
         return readJsonResponse(url, "https://www.googleapis.com/");
     }
 
-    private String readJsonResponse(String url, String urlRoot) throws IOException {
+    public static String readJsonResponse(String url, String urlRoot) throws IOException {
         // We extract from the url the mock file path we want to use
         String mockFileName = Strings.replace(url, urlRoot, "");
 
-        logger.debug("--> read mock file from [{}]", mockFileName);
         URL resource = GceComputeServiceMock.class.getResource(mockFileName);
         if (resource == null) {
             throw new IOException("can't read [" + url + "] in src/test/resources/org/elasticsearch/discovery/gce");
@@ -106,7 +107,6 @@ public class GceComputeServiceMock extends GceComputeServiceImpl {
                 }
             });
             String response = sb.toString();
-            logger.trace("{}", response);
             return response;
         }
     }

--- a/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoverTests.java
+++ b/plugins/cloud-gce/src/test/java/org/elasticsearch/discovery/gce/GceDiscoverTests.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.gce;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.cloud.gce.CloudGcePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
+
+
+@ESIntegTestCase.SuppressLocalMode
+@ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
+@SuppressForbidden(reason = "use http server")
+// TODO this should be a IT but currently all ITs in this project run against a real cluster
+public class GceDiscoverTests extends ESIntegTestCase {
+    private static HttpsServer httpsServer;
+    private static HttpServer httpServer;
+    private static Path logDir;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return pluginList(CloudGcePlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        Path resolve = logDir.resolve(Integer.toString(nodeOrdinal));
+        try {
+            Files.createDirectory(resolve);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+            .put("discovery.type", "gce")
+            .put("path.logs", resolve)
+            .put("transport.tcp.port", 0)
+            .put("node.portsfile", "true")
+            .put("cloud.gce.project_id", "testproject")
+            .put("cloud.gce.zone", "primaryzone")
+            .put("discovery.initial_state_timeout", "1s")
+            .put("cloud.gce.host", "http://" + httpServer.getAddress().getHostName() + ":" + httpServer.getAddress().getPort())
+            .put("cloud.gce.root_url", "https://" + httpsServer.getAddress().getHostName() +
+                ":" + httpsServer.getAddress().getPort())
+            // this is annoying but by default the client pulls a static list of trusted CAs
+            .put("cloud.gce.validate_certificates", false)
+            .build();
+    }
+
+    @BeforeClass
+    public static void startHttpd() throws Exception {
+        logDir = createTempDir();
+        SSLContext sslContext = getSSLContext();
+        // we generated the keyfile with 127.0.0.1 - hence the hardcoding
+        httpsServer = HttpsServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpServer.createContext("/computeMetadata/v1/instance/service-accounts/default/token", new AuthHandler());
+
+        httpsServer.createContext("/compute/v1/projects/testproject/zones/primaryzone/instances", new InstanceHandler());
+        httpsServer.start();
+        httpServer.start();
+    }
+
+    private static SSLContext getSSLContext() throws Exception {
+        char[] passphrase = "keypass".toCharArray();
+        KeyStore ks = KeyStore.getInstance("JKS");
+        try (InputStream stream = GceDiscoverTests.class.getResourceAsStream("/test-node.jks")) {
+            assertNotNull("can't find keystore file", stream);
+            ks.load(stream, passphrase);
+        }
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, passphrase);
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(ks);
+        SSLContext ssl = SSLContext.getInstance("TLS");
+        ssl.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        return ssl;
+    }
+
+    @AfterClass
+    public static void stopHttpd() throws IOException {
+        for (int i = 0; i < internalCluster().size(); i++) {
+            // shut them all down otherwise we get spammed with connection refused exceptions
+            internalCluster().stopRandomDataNode();
+        }
+        httpsServer.stop(0);
+        httpServer.stop(0);
+        httpsServer = null;
+        httpServer = null;
+        logDir = null;
+    }
+
+    public void testJoin() throws ExecutionException, InterruptedException {
+        // only wait for the cluster to form
+        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(2)).get());
+        // add one more node and wait for it to join
+        internalCluster().startDataOnlyNodeAsync().get();
+        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(3)).get());
+    }
+
+    @SuppressForbidden(reason = "use http server")
+    private static class InstanceHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange s) throws IOException {
+            Headers headers = s.getResponseHeaders();
+            headers.add("Content-Type", "application/json; charset=UTF-8");
+            ESLogger logger = Loggers.getLogger(GceDiscoverTests.class);
+            try {
+                Path[] files = FileSystemUtils.files(logDir);
+                StringBuilder builder = new StringBuilder("{\"id\": \"dummy\",\"items\":[");
+                int foundFiles = 0;
+                for (int i = 0; i < files.length; i++) {
+                    Path resolve = files[i].resolve("transport.ports");
+                    if (Files.exists(resolve)) {
+                        if (foundFiles++ > 0) {
+                            builder.append(",");
+                        }
+                        List<String> addressses = Files.readAllLines(resolve, StandardCharsets.UTF_8);
+                        Collections.shuffle(addressses, random());
+                        logger.debug("addresses for node: [{}] published addresses [{}]", files[i].getFileName(), addressses);
+                        builder.append("{\"description\": \"ES Node ").append(files[i].getFileName())
+                            .append("\",\"networkInterfaces\": [ {");
+                        builder.append("\"networkIP\": \"").append(addressses.get(0)).append("\"}],");
+                        builder.append("\"status\" : \"RUNNING\"}");
+                    }
+                }
+                builder.append("]}");
+                String responseString = builder.toString();
+                logger.warn("{}", responseString);
+                final byte[] responseAsBytes = responseString.getBytes(StandardCharsets.UTF_8);
+                s.sendResponseHeaders(200, responseAsBytes.length);
+                OutputStream responseBody = s.getResponseBody();
+                responseBody.write(responseAsBytes);
+                responseBody.close();
+            } catch (Exception e) {
+                //
+                byte[] responseAsBytes = ("{ \"error\" : {\"message\" : \"" + e.toString() + "\" } }").getBytes(StandardCharsets.UTF_8);
+                s.sendResponseHeaders(500, responseAsBytes.length);
+                OutputStream responseBody = s.getResponseBody();
+                responseBody.write(responseAsBytes);
+                responseBody.close();
+            }
+
+
+        }
+    }
+
+    @SuppressForbidden(reason = "use http server")
+    private static class AuthHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange s) throws IOException {
+            String response = GceComputeServiceMock.readGoogleInternalJsonResponse(
+                "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token");
+            byte[] responseAsBytes = response.getBytes(StandardCharsets.UTF_8);
+            s.sendResponseHeaders(200, responseAsBytes.length);
+            OutputStream responseBody = s.getResponseBody();
+            responseBody.write(responseAsBytes);
+            responseBody.close();
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a missing permission and a simple test that
ensures we discover other nodes via a mock http endpoint.

Backport of #16860
Relates to #16485
