### PR TITLE
Crank NamingConventionsCheck to 11

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -53,8 +53,8 @@ public class PluginBuildPlugin extends BuildPlugin {
             }
 
             project.namingConventions {
-                // Plugins decalare extensions of ESIntegTestCase as "Tests" instead of IT.
-                skipIntegTestInDisguise = true
+                // Plugins can decalare extensions of ESIntegTestCase as "Tests" instead of "IT".
+                esIntegTestsCanBeTests = true
             }
         }
         createIntegTestTask(project)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/NamingConventionsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/NamingConventionsTask.groovy
@@ -51,11 +51,10 @@ public class NamingConventionsTask extends LoggedExec {
     FileCollection classpath = project.sourceSets.test.runtimeClasspath
 
     /**
-     * Should we skip the integ tests in disguise tests? Defaults to true because only core names its
-     * integ tests correctly.
+     * Can subclasses of ESIntegTestCase be Tests or IT (true) or must they always be IT (false). Defaults to false.
      */
     @Input
-    boolean skipIntegTestInDisguise = false
+    boolean esIntegTestsCanBeTests = false
 
     public NamingConventionsTask() {
         dependsOn(classpath)
@@ -69,8 +68,8 @@ public class NamingConventionsTask extends LoggedExec {
         project.afterEvaluate {
             doFirst {
                 args('-cp', classpath.asPath, 'org.elasticsearch.test.NamingConventionsCheck')
-                if (skipIntegTestInDisguise) {
-                    args('--skip-integ-tests-in-disguise')
+                if (esIntegTestsCanBeTests) {
+                    args('--es-integ-tests-can-be-tests')
                 }
                 /*
                  * The test framework has classes that fail the checks to validate that the checks fail properly.

--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -1125,7 +1125,6 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]discovery[/\\]zen[/\\]NodeJoinControllerTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]discovery[/\\]zen[/\\]ZenDiscoveryIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]discovery[/\\]zen[/\\]ZenDiscoveryUnitTests.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]discovery[/\\]zen[/\\]ping[/\\]unicast[/\\]UnicastZenPingIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]discovery[/\\]zen[/\\]publish[/\\]PendingClusterStatesQueueTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]discovery[/\\]zen[/\\]publish[/\\]PublishClusterStateActionTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]document[/\\]DocumentActionsIT.java" checks="LineLength" />
@@ -1604,10 +1603,7 @@
   <suppress files="qa[/\\]evil-tests[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]bootstrap[/\\]EvilSecurityTests.java" checks="LineLength" />
   <suppress files="qa[/\\]evil-tests[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]common[/\\]cli[/\\]CheckFileCommandTests.java" checks="LineLength" />
   <suppress files="qa[/\\]evil-tests[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]tribe[/\\]TribeUnitTests.java" checks="LineLength" />
-  <suppress files="qa[/\\]smoke-test-client[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]smoketest[/\\]ESSmokeClientTestCase.java" checks="LineLength" />
   <suppress files="qa[/\\]smoke-test-ingest-with-all-dependencies[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]ingest[/\\]CombineProcessorsTests.java" checks="LineLength" />
-  <suppress files="qa[/\\]smoke-test-ingest-with-all-dependencies[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]ingest[/\\]IngestDocumentMustacheIT.java" checks="LineLength" />
-  <suppress files="qa[/\\]smoke-test-ingest-with-all-dependencies[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]ingest[/\\]IngestMustacheSetProcessorIT.java" checks="LineLength" />
   <suppress files="test[/\\]framework[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]bootstrap[/\\]BootstrapForTesting.java" checks="LineLength" />
   <suppress files="test[/\\]framework[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]MockInternalClusterInfoService.java" checks="LineLength" />
   <suppress files="test[/\\]framework[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]cluster[/\\]routing[/\\]TestShardRouting.java" checks="LineLength" />

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ping/unicast/UnicastZenPingTests.java
@@ -44,7 +44,7 @@ import java.net.InetSocketAddress;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class UnicastZenPingIT extends ESTestCase {
+public class UnicastZenPingTests extends ESTestCase {
     public void testSimplePings() throws InterruptedException {
         Settings settings = Settings.EMPTY;
         int startPort = 11000 + randomIntBetween(0, 1000);
@@ -56,14 +56,16 @@ public class UnicastZenPingIT extends ESTestCase {
         NetworkService networkService = new NetworkService(settings);
         ElectMasterService electMasterService = new ElectMasterService(settings, Version.CURRENT);
 
-        NettyTransport transportA = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry());
+        NettyTransport transportA = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE,
+                Version.CURRENT, new NamedWriteableRegistry());
         final TransportService transportServiceA = new TransportService(transportA, threadPool).start();
         transportServiceA.acceptIncomingRequests();
         final DiscoveryNode nodeA = new DiscoveryNode("UZP_A", transportServiceA.boundAddress().publishAddress(), Version.CURRENT);
 
         InetSocketTransportAddress addressA = (InetSocketTransportAddress) transportA.boundAddress().publishAddress();
 
-        NettyTransport transportB = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE, Version.CURRENT, new NamedWriteableRegistry());
+        NettyTransport transportB = new NettyTransport(settings, threadPool, networkService, BigArrays.NON_RECYCLING_INSTANCE,
+                Version.CURRENT, new NamedWriteableRegistry());
         final TransportService transportServiceB = new TransportService(transportB, threadPool).start();
         transportServiceB.acceptIncomingRequests();
         final DiscoveryNode nodeB = new DiscoveryNode("UZP_B", transportServiceA.boundAddress().publishAddress(), Version.CURRENT);
@@ -75,7 +77,8 @@ public class UnicastZenPingIT extends ESTestCase {
                 NetworkAddress.formatAddress(new InetSocketAddress(addressB.address().getAddress(), addressB.address().getPort())))
                 .build();
 
-        UnicastZenPing zenPingA = new UnicastZenPing(hostsSettings, threadPool, transportServiceA, clusterName, Version.CURRENT, electMasterService, null);
+        UnicastZenPing zenPingA = new UnicastZenPing(hostsSettings, threadPool, transportServiceA, clusterName, Version.CURRENT,
+                electMasterService, null);
         zenPingA.setPingContextProvider(new PingContextProvider() {
             @Override
             public DiscoveryNodes nodes() {
@@ -94,7 +97,8 @@ public class UnicastZenPingIT extends ESTestCase {
         });
         zenPingA.start();
 
-        UnicastZenPing zenPingB = new UnicastZenPing(hostsSettings, threadPool, transportServiceB, clusterName, Version.CURRENT, electMasterService, null);
+        UnicastZenPing zenPingB = new UnicastZenPing(hostsSettings, threadPool, transportServiceB, clusterName, Version.CURRENT,
+                electMasterService, null);
         zenPingB.setPingContextProvider(new PingContextProvider() {
             @Override
             public DiscoveryNodes nodes() {

--- a/plugins/jvm-example/build.gradle
+++ b/plugins/jvm-example/build.gradle
@@ -43,6 +43,6 @@ task exampleFixture(type: org.elasticsearch.gradle.test.Fixture) {
 
 integTest {
   dependsOn exampleFixture
-  systemProperty 'external.address', "${ -> exampleFixture.addressAndPort }"
+  systemProperty 'fixture.address', "${ -> exampleFixture.addressAndPort }"
 }
 

--- a/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/ExampleExternalIT.java
+++ b/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/ExampleExternalIT.java
@@ -27,16 +27,12 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.test.ESClientTestCase;
-
-import static org.hamcrest.Matchers.greaterThan;
+import org.elasticsearch.test.ESExternalDepsTestCase;
 
 /**
  * Example integration test against an external client.
  */
-public class ExampleExternalIT extends ESClientTestCase {
+public class ExampleExternalIT extends ESExternalDepsTestCase {
     public void testExampleFixture() throws Exception {
         String stringAddress = Objects.requireNonNull(System.getProperty("fixture.address"));
         URL url = new URL("http://" + stringAddress);
@@ -45,14 +41,5 @@ public class ExampleExternalIT extends ESClientTestCase {
              BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
            assertEquals("TEST", reader.readLine());
         }
-    }
-
-    public void testSimpleClient() {
-        Client client = getClient();
-
-        ClusterHealthResponse health = client.admin().cluster().prepareHealth().setWaitForYellowStatus().get();
-        String clusterName = health.getClusterName();
-        int numberOfNodes = health.getNumberOfNodes();
-        assertThat("cluster [" + clusterName + "] should have at least 1 node", numberOfNodes, greaterThan(0));
     }
 }

--- a/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/ExampleExternalIT.java
+++ b/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/ExampleExternalIT.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 import org.elasticsearch.test.ESExternalDepsTestCase;
 
 /**
- * Example integration test against an external client.
+ * Example integration test against a fixture.
  */
 public class ExampleExternalIT extends ESExternalDepsTestCase {
     public void testExampleFixture() throws Exception {

--- a/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/ExampleTests.java
+++ b/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/ExampleTests.java
@@ -17,34 +17,17 @@
  * under the License.
  */
 
-package org.elasticsearch.test.test;
+package org.elasticsearch.plugin.example;
 
 import org.elasticsearch.test.ESTestCase;
 
-import junit.framework.TestCase;
+import static org.hamcrest.Matchers.is;
 
 /**
- * These inner classes all fail the NamingConventionsCheck. They have to live in the tests or else they won't be scanned.
+ * Example unit test.
  */
-public class NamingConventionsCheckBadClasses {
-    public static final class NotImplementingTests {
-    }
-
-    public static final class WrongName extends ESTestCase {
-    }
-
-    public static abstract class DummyAbstractTests extends ESTestCase {
-    }
-
-    public interface DummyInterfaceTests {
-    }
-
-    public static final class InnerTests extends ESTestCase {
-    }
-
-    public static final class WrongNameTheSecond extends ESTestCase {
-    }
-
-    public static final class PlainUnit extends TestCase {
+public class ExampleTests extends ESTestCase {
+    public void testExample() throws Exception {
+        assertThat(true, is(true));
     }
 }

--- a/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/ExampleTests.java
+++ b/plugins/jvm-example/src/test/java/org/elasticsearch/plugin/example/ExampleTests.java
@@ -21,13 +21,16 @@ package org.elasticsearch.plugin.example;
 
 import org.elasticsearch.test.ESTestCase;
 
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.endsWith;
 
 /**
  * Example unit test.
  */
 public class ExampleTests extends ESTestCase {
     public void testExample() throws Exception {
-        assertThat(true, is(true));
+        // Normal junit assertions work.
+        assertTrue(true);
+        // Elasticsearch tests tend to use hamcrest assertions though. They give nice error messages.
+        assertThat("stuff", endsWith("ff"));
     }
 }

--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
@@ -17,16 +17,16 @@
  * under the License.
  */
 
-package org.elasticsearch.test;
+package org.elasticsearch.smoketest;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
@@ -38,10 +38,15 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.internal.InternalSettingsPreparer;
+import org.elasticsearch.test.ESExternalDepsTestCase;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 import static org.hamcrest.Matchers.notNullValue;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
 
 /**
  * An abstract base class to run integration tests against an Elasticsearch cluster running outside of the test process.
@@ -53,23 +58,23 @@ import static org.hamcrest.Matchers.notNullValue;
  * If you want to debug this module from your IDE, then start an external cluster by yourself, maybe with `gradle run`,
  * then run JUnit. If you changed the default port, set "-Dtests.cluster=localhost:PORT" when running your test.
  */
-@LuceneTestCase.SuppressSysoutChecks(bugUrl = "we log a lot on purpose")
-public abstract class ESClientTestCase extends LuceneTestCase {
+public abstract class ESSmokeClientTestCase extends ESExternalDepsTestCase {
 
     /**
      * Key used to eventually switch to using an external cluster and provide its transport addresses
      */
     public static final String TESTS_CLUSTER = "tests.cluster";
 
-    protected static final ESLogger logger = ESLoggerFactory.getLogger(ESClientTestCase.class.getName());
+    protected static final ESLogger logger = ESLoggerFactory.getLogger(ESSmokeClientTestCase.class.getName());
 
     private static final AtomicInteger counter = new AtomicInteger();
     private static Client client;
     private static String clusterAddresses;
+    protected String index;
 
     private static Client startClient(Path tempDir, TransportAddress... transportAddresses) {
         Settings clientSettings = Settings.settingsBuilder()
-                .put("node.name", "client_test_case_client_" + counter.getAndIncrement())
+                .put("node.name", "qa_smoke_client_" + counter.getAndIncrement())
                 // prevents any settings to be replaced by system properties.
                 .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING.getKey(), true)
                 .put("client.transport.ignore_cluster_name", true)
@@ -107,13 +112,6 @@ public abstract class ESClientTestCase extends LuceneTestCase {
         return startClient(createTempDir(), transportAddresses);
     }
 
-    /**
-     * Fetches the client without building it if it doesn't already exist.
-     */
-    protected Client getClientNoCreate() {
-        return client;
-    }
-
     public static Client getClient() {
         if (client == null) {
             try {
@@ -139,6 +137,27 @@ public abstract class ESClientTestCase extends LuceneTestCase {
         if (client != null) {
             client.close();
             client = null;
+        }
+    }
+
+    @Before
+    public void defineIndexName() {
+        doClean();
+        index = "qa-smoke-test-client-" + randomAsciiOfLength(10).toLowerCase(Locale.getDefault());
+    }
+
+    @After
+    public void cleanIndex() {
+        doClean();
+    }
+
+    private void doClean() {
+        if (client != null) {
+            try {
+                client.admin().indices().prepareDelete(index).get();
+            } catch (Exception e) {
+                // We ignore this cleanup exception
+            }
         }
     }
 }

--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/SmokeTestClientIT.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/SmokeTestClientIT.java
@@ -19,44 +19,14 @@
 
 package org.elasticsearch.smoketest;
 
-import java.util.Locale;
-
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.test.ESClientTestCase;
-import org.junit.After;
-import org.junit.Before;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.greaterThan;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
-
-public class SmokeTestClientIT extends ESClientTestCase {
-    protected String index;
-
-    @Before
-    public void defineIndexName() {
-        doClean();
-        index = "qa-smoke-test-client-" + randomAsciiOfLength(10).toLowerCase(Locale.getDefault());
-    }
-
-    @After
-    public void cleanIndex() {
-        doClean();
-    }
-
-    private void doClean() {
-        if (getClientNoCreate() != null) {
-            try {
-                getClientNoCreate().admin().indices().prepareDelete(index).get();
-            } catch (Exception e) {
-                // We ignore this cleanup exception
-            }
-        }
-    }
-
+public class SmokeTestClientIT extends ESSmokeClientTestCase {
     /**
      * Check that we are connected to a cluster.
      */

--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/SmokeTestClientIT.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/SmokeTestClientIT.java
@@ -19,16 +19,46 @@
 
 package org.elasticsearch.smoketest;
 
+import java.util.Locale;
+
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.test.ESClientTestCase;
+import org.junit.After;
+import org.junit.Before;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class SmokeTestClientIT extends ESSmokeClientTestCase {
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
+
+public class SmokeTestClientIT extends ESClientTestCase {
+    protected String index;
+
+    @Before
+    public void defineIndexName() {
+        doClean();
+        index = "qa-smoke-test-client-" + randomAsciiOfLength(10).toLowerCase(Locale.getDefault());
+    }
+
+    @After
+    public void cleanIndex() {
+        doClean();
+    }
+
+    private void doClean() {
+        if (getClientNoCreate() != null) {
+            try {
+                getClientNoCreate().admin().indices().prepareDelete(index).get();
+            } catch (Exception e) {
+                // We ignore this cleanup exception
+            }
+        }
+    }
+
     /**
-     * Check that we are connected to a cluster named "elasticsearch".
+     * Check that we are connected to a cluster.
      */
     public void testSimpleClient() {
         Client client = getClient();

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/IngestDocumentMustacheTests.java
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/IngestDocumentMustacheTests.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class IngestDocumentMustacheIT extends AbstractMustacheTestCase {
+public class IngestDocumentMustacheTests extends AbstractMustacheTestCase {
 
     public void testAccessMetaDataViaTemplate() {
         Map<String, Object> document = new HashMap<>();
@@ -52,10 +52,12 @@ public class IngestDocumentMustacheIT extends AbstractMustacheTestCase {
         innerObject.put("qux", Collections.singletonMap("fubar", "hello qux and fubar"));
         document.put("foo", innerObject);
         IngestDocument ingestDocument = new IngestDocument("index", "type", "id", null, null, null, null, document);
-        ingestDocument.setFieldValue(templateService.compile("field1"), ValueSource.wrap("1 {{foo.bar}} {{foo.baz}} {{foo.qux.fubar}}", templateService));
+        ingestDocument.setFieldValue(templateService.compile("field1"),
+                ValueSource.wrap("1 {{foo.bar}} {{foo.baz}} {{foo.qux.fubar}}", templateService));
         assertThat(ingestDocument.getFieldValue("field1", String.class), equalTo("1 hello bar hello baz hello qux and fubar"));
 
-        ingestDocument.setFieldValue(templateService.compile("field1"), ValueSource.wrap("2 {{_source.foo.bar}} {{_source.foo.baz}} {{_source.foo.qux.fubar}}", templateService));
+        ingestDocument.setFieldValue(templateService.compile("field1"),
+                ValueSource.wrap("2 {{_source.foo.bar}} {{_source.foo.baz}} {{_source.foo.qux.fubar}}", templateService));
         assertThat(ingestDocument.getFieldValue("field1", String.class), equalTo("2 hello bar hello baz hello qux and fubar"));
     }
 
@@ -79,7 +81,9 @@ public class IngestDocumentMustacheIT extends AbstractMustacheTestCase {
         ingestMap.put("timestamp", "bogus_timestamp");
         document.put("_ingest", ingestMap);
         IngestDocument ingestDocument = new IngestDocument("index", "type", "id", null, null, null, null, document);
-        ingestDocument.setFieldValue(templateService.compile("ingest_timestamp"), ValueSource.wrap("{{_ingest.timestamp}} and {{_source._ingest.timestamp}}", templateService));
-        assertThat(ingestDocument.getFieldValue("ingest_timestamp", String.class), equalTo(ingestDocument.getIngestMetadata().get("timestamp") + " and bogus_timestamp"));
+        ingestDocument.setFieldValue(templateService.compile("ingest_timestamp"),
+                ValueSource.wrap("{{_ingest.timestamp}} and {{_source._ingest.timestamp}}", templateService));
+        assertThat(ingestDocument.getFieldValue("ingest_timestamp", String.class),
+                equalTo(ingestDocument.getIngestMetadata().get("timestamp") + " and bogus_timestamp"));
     }
 }

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/IngestMustacheRemoveProcessorTests.java
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/IngestMustacheRemoveProcessorTests.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class IngestMustacheRemoveProcessorIT extends AbstractMustacheTestCase {
+public class IngestMustacheRemoveProcessorTests extends AbstractMustacheTestCase {
 
     public void testRemoveProcessorMustacheExpression() throws Exception {
         RemoveProcessor.Factory factory = new RemoveProcessor.Factory(templateService);

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/IngestMustacheSetProcessorTests.java
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/IngestMustacheSetProcessorTests.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class IngestMustacheSetProcessorIT extends AbstractMustacheTestCase {
+public class IngestMustacheSetProcessorTests extends AbstractMustacheTestCase {
 
     public void testExpression() throws Exception {
         SetProcessor processor = createSetProcessor("_index", "text {{var}}");
@@ -50,11 +50,13 @@ public class IngestMustacheSetProcessorIT extends AbstractMustacheTestCase {
     }
 
     public void testSetWithTemplates() throws Exception {
-        IngestDocument.MetaData randomMetaData = randomFrom(IngestDocument.MetaData.INDEX, IngestDocument.MetaData.TYPE, IngestDocument.MetaData.ID);
+        IngestDocument.MetaData randomMetaData = randomFrom(IngestDocument.MetaData.INDEX, IngestDocument.MetaData.TYPE,
+                IngestDocument.MetaData.ID);
         Processor processor = createSetProcessor("field{{_type}}", "_value {{" + randomMetaData.getFieldName() + "}}");
         IngestDocument ingestDocument = createIngestDocument(new HashMap<>());
         processor.execute(ingestDocument);
-        assertThat(ingestDocument.getFieldValue("field_type", String.class), Matchers.equalTo("_value " + ingestDocument.getFieldValue(randomMetaData.getFieldName(), String.class)));
+        assertThat(ingestDocument.getFieldValue("field_type", String.class),
+                Matchers.equalTo("_value " + ingestDocument.getFieldValue(randomMetaData.getFieldName(), String.class)));
     }
 
     private SetProcessor createSetProcessor(String fieldName, Object fieldValue) throws Exception {

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/TemplateServiceTests.java
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/TemplateServiceTests.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class TemplateServiceIT extends AbstractMustacheTestCase {
+public class TemplateServiceTests extends AbstractMustacheTestCase {
 
     public void testTemplates() {
         Map<String, Object> model = new HashMap<>();

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/ValueSourceMustacheTests.java
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/ValueSourceMustacheTests.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class ValueSourceMustacheIT extends AbstractMustacheTestCase {
+public class ValueSourceMustacheTests extends AbstractMustacheTestCase {
 
     public void testValueSourceWithTemplates() {
         Map<String, Object> model = new HashMap<>();

--- a/test/framework/src/main/java/org/elasticsearch/test/ESExternalDepsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESExternalDepsTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+/**
+ * A test case with external dependencies that are started by gradle. See {@link org.elasticsearch.test.rest.ESRestTestCase} or
+ * ESSokeClientTestCase for tests that depend on a running Elasticsearch cluster or ExampleExternalIT for one that tests a test fixture. The
+ * only thing these have in common is that that are run by gradle during the integTest task and that their dependencies are started by
+ * gradle before that task is run and shut down after that task is finished.
+ */
+public class ESExternalDepsTestCase extends ESTestCase {
+
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/NamingConventionsCheck.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/NamingConventionsCheck.java
@@ -93,7 +93,7 @@ public class NamingConventionsCheck {
             assertViolation("MissingRestTestSuffix", check.missingIntegTestSuffix);
             assertViolation("MissingClientTestSuffix", check.missingIntegTestSuffix);
             assertViolation("NamedLikeUnitButRestTests", check.namedLikeUnitButNotUnit);
-            assertViolation("NamedLikeUnitButClientTests", check.namedLikeUnitButNotUnit);
+            assertViolation("NamedLikeUnitButExternalDepsTests", check.namedLikeUnitButNotUnit);
         }
 
         // Now we should have no violations
@@ -118,7 +118,7 @@ public class NamingConventionsCheck {
     final Set<Class<?>> namedLikeIntegButNotInteg = new HashSet<>();
 
     private final boolean esIntegTestsCanBeUnitTests;
-    
+
     public NamingConventionsCheck(boolean esIntegTestsCanBeUnitTests) {
         this.esIntegTestsCanBeUnitTests = esIntegTestsCanBeUnitTests;
     }
@@ -272,10 +272,7 @@ public class NamingConventionsCheck {
         NOT_A_TEST, UNIT, ES_INTEG, INTEG, PLAIN_UNIT;
 
         public static TestClassType fromClass(Class<?> clazz) {
-            if (ESRestTestCase.class.isAssignableFrom(clazz)) {
-                return INTEG;
-            }
-            if (ESClientTestCase.class.isAssignableFrom(clazz)) {
+            if (ESExternalDepsTestCase.class.isAssignableFrom(clazz)) {
                 return INTEG;
             }
             if (ESIntegTestCase.class.isAssignableFrom(clazz)) {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -19,32 +19,8 @@
 
 package org.elasticsearch.test.rest;
 
-import com.carrotsearch.randomizedtesting.RandomizedTest;
-import org.apache.lucene.util.IOUtils;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.SuppressForbidden;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.rest.client.RestException;
-import org.elasticsearch.test.rest.parser.RestTestParseException;
-import org.elasticsearch.test.rest.parser.RestTestSuiteParser;
-import org.elasticsearch.test.rest.section.DoSection;
-import org.elasticsearch.test.rest.section.ExecutableSection;
-import org.elasticsearch.test.rest.section.RestTestSuite;
-import org.elasticsearch.test.rest.section.SkipSection;
-import org.elasticsearch.test.rest.section.TestSection;
-import org.elasticsearch.test.rest.spec.RestApi;
-import org.elasticsearch.test.rest.spec.RestSpec;
-import org.elasticsearch.test.rest.support.FileUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -61,10 +37,34 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.ESExternalDepsTestCase;
+import org.elasticsearch.test.rest.client.RestException;
+import org.elasticsearch.test.rest.parser.RestTestParseException;
+import org.elasticsearch.test.rest.parser.RestTestSuiteParser;
+import org.elasticsearch.test.rest.section.DoSection;
+import org.elasticsearch.test.rest.section.ExecutableSection;
+import org.elasticsearch.test.rest.section.RestTestSuite;
+import org.elasticsearch.test.rest.section.SkipSection;
+import org.elasticsearch.test.rest.section.TestSection;
+import org.elasticsearch.test.rest.spec.RestApi;
+import org.elasticsearch.test.rest.spec.RestSpec;
+import org.elasticsearch.test.rest.support.FileUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+
 /**
  * Runs the clients test suite against an elasticsearch cluster.
  */
-public abstract class ESRestTestCase extends ESTestCase {
+public abstract class ESRestTestCase extends ESExternalDepsTestCase {
 
     /**
      * Property that allows to control which REST tests get run. Supports comma separated list of tests

--- a/test/framework/src/test/java/org/elasticsearch/test/NamingConventionsCheckTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/NamingConventionsCheckTests.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.RestTestCandidate;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@linkplain NamingConventionsCheck}. It has a self test mode that covers most cases but this is quicker to run and easier to
+ * debug.
+ */
+public class NamingConventionsCheckTests extends ESTestCase {
+    private NamingConventionsCheck check(Class<?> clazz) {
+        return check(getRandom().nextBoolean(), clazz);
+    }
+
+    private NamingConventionsCheck check(boolean esIntegTestsCanBeUnitTests, Class<?> clazz) {
+        NamingConventionsCheck check = new NamingConventionsCheck(esIntegTestsCanBeUnitTests);
+        check.check(clazz);
+        return check;
+    }
+
+    public void testNotRunnableTestsIsNotRunnable() {
+        assertTrue(check(NonRunnableTests.class).notRunnable.contains(NonRunnableTests.class));
+    }
+
+    public static abstract class NonRunnableTests extends ESTestCase {
+    }
+
+    public void testNotRunnableITIsNotRunnable() {
+        assertTrue(check(NonRunnableIT.class).notRunnable.contains(NonRunnableIT.class));
+    }
+
+    public static abstract class NonRunnableIT extends ESTestCase {
+    }
+
+    public void testInterfaceTestsIsNotRunnable() {
+        assertTrue(check(InterfaceTests.class).notRunnable.contains(InterfaceTests.class));
+    }
+
+    public interface InterfaceTests {
+    }
+
+    public void testInterfaceITIsNotRunnable() {
+        assertTrue(check(InterfaceIT.class).notRunnable.contains(InterfaceIT.class));
+    }
+
+    public interface InterfaceIT {
+    }
+
+    public void testInnerTestsIsInnerClass() {
+        assertTrue(check(InnerTests.class).innerClasses.contains(InnerTests.class));
+    }
+
+    public static final class InnerTests extends ESTestCase {
+    }
+
+    public void testInnerTIIsInnerClass() {
+        assertTrue(check(InnerIT.class).innerClasses.contains(InnerIT.class));
+    }
+
+    public static final class InnerIT extends ESClientTestCase {
+    }
+
+    public void testNothingNamedLikeTestsNamedLikeUnitButNotUnit() {
+        assertTrue(check(NothingNamedLikeTests.class).namedLikeUnitButNotUnit.contains(NothingNamedLikeTests.class));
+    }
+
+    public static final class NothingNamedLikeTests {
+    }
+
+    public void testNothingNamedLikeITNamedLikeIntegButNotInteg() {
+        assertTrue(check(NothingNamedLikeIT.class).namedLikeIntegButNotInteg.contains(NothingNamedLikeIT.class));
+    }
+
+    public static final class NothingNamedLikeIT {
+    }
+
+    public void testPlainUnitsArePlainUnit() {
+        assertTrue(check(PlainUnit.class).plainUnit.contains(PlainUnit.class));
+        assertTrue(check(PlainUnitTests.class).plainUnit.contains(PlainUnitTests.class));
+        assertTrue(check(PlainUnitTests.class).plainUnit.contains(PlainUnitTests.class));
+    }
+
+    public static final class PlainUnit extends TestCase {
+    }
+
+    public static final class PlainUnitTests extends TestCase {
+    }
+
+    public static final class PlainUnitIT extends TestCase {
+    }
+
+    public void testMissingUnitTestSuffixIsMissingUnitTestSuffix() {
+        assertTrue(check(MissingUnitTestSuffix.class).missingUnitTestSuffix.contains(MissingUnitTestSuffix.class));
+    }
+
+    public static final class MissingUnitTestSuffix extends ESTestCase {
+    }
+
+    public void testNamedLikeIntegButUnitITIsNamedLikeIntegButNotInteg() {
+        assertTrue(check(NamedLikeIntegButUnitIT.class).namedLikeIntegButNotInteg.contains(NamedLikeIntegButUnitIT.class));
+    }
+
+    public static final class NamedLikeIntegButUnitIT extends ESTestCase {
+    }
+
+    public void testMissingIntegTestSuffixIsMissingIntegTestSuffix() {
+        assertTrue(check(MissingIntegTestSuffix.class).missingIntegTestSuffix.contains(MissingIntegTestSuffix.class));
+    }
+
+    public static final class MissingIntegTestSuffix extends ESIntegTestCase {
+    }
+
+    public void testNamedLikeUnitButIntegTestsIsNamedLikeUnitButNotUnit() {
+        assertTrue(check(false, NamedLikeUnitButIntegTests.class).namedLikeUnitButNotUnit.contains(NamedLikeUnitButIntegTests.class));
+        assertFalse(check(true, NamedLikeUnitButIntegTests.class).namedLikeUnitButNotUnit.contains(NamedLikeUnitButIntegTests.class));
+    }
+
+    public static final class NamedLikeUnitButIntegTests extends ESIntegTestCase {
+    }
+
+    public void testMissingRestTestSuffixIsMissingIntegTestSuffix() {
+        assertTrue(check(MissingRestTestSuffix.class).missingIntegTestSuffix.contains(MissingRestTestSuffix.class));
+    }
+
+    public static final class MissingRestTestSuffix extends ESRestTestCase {
+        public MissingRestTestSuffix(RestTestCandidate testCandidate) {
+            super(testCandidate);
+        }
+    }
+
+    public void testMissingClientTestSuffixIsMissingIntegTestSuffix() {
+        assertTrue(check(MissingClientTestSuffix.class).missingIntegTestSuffix.contains(MissingClientTestSuffix.class));
+    }
+
+    public static final class MissingClientTestSuffix extends ESClientTestCase {
+    }
+
+    public void testNamedLikeUnitButRestTestsIsNamedLikeUnitButNotUnit() {
+        assertTrue(check(NamedLikeUnitButRestTests.class).namedLikeUnitButNotUnit.contains(NamedLikeUnitButRestTests.class));
+    }
+
+    public static final class NamedLikeUnitButRestTests extends ESRestTestCase {
+        public NamedLikeUnitButRestTests(RestTestCandidate testCandidate) {
+            super(testCandidate);
+        }
+    }
+
+    public void testNamedLikeUnitButClientTestsIsNamedLikeUnitButNotUnit() {
+        assertTrue(check(NamedLikeUnitButClientTests.class).namedLikeUnitButNotUnit.contains(NamedLikeUnitButClientTests.class));
+    }
+
+    public static final class NamedLikeUnitButClientTests extends ESClientTestCase {
+    }
+}

--- a/test/framework/src/test/java/org/elasticsearch/test/NamingConventionsCheckTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/NamingConventionsCheckTests.java
@@ -78,7 +78,7 @@ public class NamingConventionsCheckTests extends ESTestCase {
         assertTrue(check(InnerIT.class).innerClasses.contains(InnerIT.class));
     }
 
-    public static final class InnerIT extends ESClientTestCase {
+    public static final class InnerIT extends ESExternalDepsTestCase {
     }
 
     public void testNothingNamedLikeTestsNamedLikeUnitButNotUnit() {
@@ -153,7 +153,7 @@ public class NamingConventionsCheckTests extends ESTestCase {
         assertTrue(check(MissingClientTestSuffix.class).missingIntegTestSuffix.contains(MissingClientTestSuffix.class));
     }
 
-    public static final class MissingClientTestSuffix extends ESClientTestCase {
+    public static final class MissingClientTestSuffix extends ESExternalDepsTestCase {
     }
 
     public void testNamedLikeUnitButRestTestsIsNamedLikeUnitButNotUnit() {
@@ -167,9 +167,10 @@ public class NamingConventionsCheckTests extends ESTestCase {
     }
 
     public void testNamedLikeUnitButClientTestsIsNamedLikeUnitButNotUnit() {
-        assertTrue(check(NamedLikeUnitButClientTests.class).namedLikeUnitButNotUnit.contains(NamedLikeUnitButClientTests.class));
+        assertTrue(
+                check(NamedLikeUnitButExternalDepsTests.class).namedLikeUnitButNotUnit.contains(NamedLikeUnitButExternalDepsTests.class));
     }
 
-    public static final class NamedLikeUnitButClientTests extends ESClientTestCase {
+    public static final class NamedLikeUnitButExternalDepsTests extends ESExternalDepsTestCase {
     }
 }


### PR DESCRIPTION
Tightens lots of the rules around classes that are named like integration
tests. They must actually be integration tests and runnable. To do so it
had to learn that ESRestTestCase subclasses are integration tests.

Introduces NamingConventionsCheckTest which is easier to run and debug
than NamingConventionsCheck --self-test.

Fixes all of the test name violations. To do so this commit had to pull
ESSmokeClientTestCase into :test:framework as ESClientTestCase as the
common superclass for all tests that use an external es cluster only.
