### PR TITLE
Remove http_address from _cat/nodeattrs

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
@@ -23,8 +23,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
-import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
-import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.Client;
@@ -70,17 +68,10 @@ public class RestNodeAttrsAction extends AbstractCatAction {
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
                 NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
                 nodesInfoRequest.clear().jvm(false).os(false).process(true);
-                client.admin().cluster().nodesInfo(nodesInfoRequest, new RestActionListener<NodesInfoResponse>(channel) {
+                client.admin().cluster().nodesInfo(nodesInfoRequest, new RestResponseListener<NodesInfoResponse>(channel) {
                     @Override
-                    public void processResponse(final NodesInfoResponse nodesInfoResponse) {
-                        NodesStatsRequest nodesStatsRequest = new NodesStatsRequest();
-                        nodesStatsRequest.clear().jvm(false).os(false).fs(false).indices(false).process(false);
-                        client.admin().cluster().nodesStats(nodesStatsRequest, new RestResponseListener<NodesStatsResponse>(channel) {
-                            @Override
-                            public RestResponse buildResponse(NodesStatsResponse nodesStatsResponse) throws Exception {
-                                return RestTable.buildResponse(buildTable(request, clusterStateResponse, nodesInfoResponse, nodesStatsResponse), channel);
-                            }
-                        });
+                    public RestResponse buildResponse(NodesInfoResponse nodesInfoResponse) throws Exception {
+                        return RestTable.buildResponse(buildTable(request, clusterStateResponse, nodesInfoResponse), channel);
                     }
                 });
             }
@@ -103,7 +94,7 @@ public class RestNodeAttrsAction extends AbstractCatAction {
         return table;
     }
 
-    private Table buildTable(RestRequest req, ClusterStateResponse state, NodesInfoResponse nodesInfo, NodesStatsResponse nodesStats) {
+    private Table buildTable(RestRequest req, ClusterStateResponse state, NodesInfoResponse nodesInfo) {
         boolean fullId = req.paramAsBoolean("full_id", false);
 
         DiscoveryNodes nodes = state.getState().nodes();

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
@@ -43,9 +43,6 @@ import org.elasticsearch.rest.action.support.RestActionListener;
 import org.elasticsearch.rest.action.support.RestResponseListener;
 import org.elasticsearch.rest.action.support.RestTable;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestNodeAttrsAction extends AbstractCatAction {
@@ -115,32 +112,22 @@ public class RestNodeAttrsAction extends AbstractCatAction {
         for (DiscoveryNode node : nodes) {
             NodeInfo info = nodesInfo.getNodesMap().get(node.id());
             for(ObjectObjectCursor<String, String> att : node.attributes()) {
-                buildRow(fullId, table, node, info, att.key, att.value);
-            }
-            if (info.getServiceAttributes() != null) {
-                for (Map.Entry<String, String> entry : info.getServiceAttributes().entrySet()) {
-                    buildRow(fullId, table, node, info, entry.getKey(), entry.getValue());
+                table.startRow();
+                table.addCell(node.name());
+                table.addCell(fullId ? node.id() : Strings.substring(node.getId(), 0, 4));
+                table.addCell(info == null ? null : info.getProcess().getId());
+                table.addCell(node.getHostName());
+                table.addCell(node.getHostAddress());
+                if (node.address() instanceof InetSocketTransportAddress) {
+                    table.addCell(((InetSocketTransportAddress) node.address()).address().getPort());
+                } else {
+                    table.addCell("-");
                 }
+                table.addCell(att.key);
+                table.addCell(att.value);
+                table.endRow();
             }
         }
-
         return table;
-    }
-
-    private final void buildRow(boolean fullId, Table table, DiscoveryNode node, NodeInfo info, String key, String value) {
-        table.startRow();
-        table.addCell(node.name());
-        table.addCell(fullId ? node.id() : Strings.substring(node.getId(), 0, 4));
-        table.addCell(info == null ? null : info.getProcess().getId());
-        table.addCell(node.getHostName());
-        table.addCell(node.getHostAddress());
-        if (node.address() instanceof InetSocketTransportAddress) {
-            table.addCell(((InetSocketTransportAddress) node.address()).address().getPort());
-        } else {
-            table.addCell("-");
-        }
-        table.addCell(key);
-        table.addCell(value);
-        table.endRow();
     }
 }


### PR DESCRIPTION
This was recently added with #16770 but it turns out it is not a proper node attribute, so it is enough to print it out as part of `_cat/nodes` only. Turns out that node service attributes which `http_address` belongs to are used only for reporting purposes by nodes info, and may make the output confusing if printed out as part of node attributes, as for instance they cannot be used to select nodes like other node attributes.
