### PR TITLE
Add deprecation logging for deprecated queries.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AndQueryParser.java
@@ -23,6 +23,9 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -35,9 +38,12 @@ import java.util.ArrayList;
 public class AndQueryParser implements QueryParser {
 
     public static final String NAME = "and";
+    private final DeprecationLogger deprecationLogger;
 
     @Inject
     public AndQueryParser() {
+        ESLogger logger = Loggers.getLogger(getClass());
+        deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override
@@ -47,6 +53,8 @@ public class AndQueryParser implements QueryParser {
 
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        deprecationLogger.deprecated("The [and] query is deprecated, please use a [bool] query instead with [must] clauses.");
+
         XContentParser parser = parseContext.parser();
 
         ArrayList<Query> queries = new ArrayList<>();

--- a/core/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FQueryFilterParser.java
@@ -22,6 +22,9 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -34,9 +37,12 @@ import java.io.IOException;
 public class FQueryFilterParser implements QueryParser {
 
     public static final String NAME = "fquery";
+    private final DeprecationLogger deprecationLogger;
 
     @Inject
     public FQueryFilterParser() {
+        ESLogger logger = Loggers.getLogger(getClass());
+        deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override
@@ -46,6 +52,8 @@ public class FQueryFilterParser implements QueryParser {
 
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        deprecationLogger.deprecated("The [fquery] filter is deprecated, you can now use queries as filters directly.");
+
         XContentParser parser = parseContext.parser();
 
         Query query = null;

--- a/core/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FilteredQueryParser.java
@@ -22,6 +22,9 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -34,9 +37,12 @@ import java.io.IOException;
 public class FilteredQueryParser implements QueryParser {
 
     public static final String NAME = "filtered";
+    private final DeprecationLogger deprecationLogger;
 
     @Inject
     public FilteredQueryParser() {
+        ESLogger logger = Loggers.getLogger(getClass());
+        deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override
@@ -46,6 +52,9 @@ public class FilteredQueryParser implements QueryParser {
 
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        deprecationLogger.deprecated("The [filtered] query is deprecated, please use a [bool] query instead with a [must] "
+                + "clause for the query part and a [filter] clause for the filter part.");
+
         XContentParser parser = parseContext.parser();
 
         Query query = Queries.newMatchAllQuery();

--- a/core/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/LimitQueryParser.java
@@ -21,6 +21,9 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -30,9 +33,12 @@ import java.io.IOException;
 public class LimitQueryParser implements QueryParser {
 
     public static final String NAME = "limit";
+    private final DeprecationLogger deprecationLogger;
 
     @Inject
     public LimitQueryParser() {
+        ESLogger logger = Loggers.getLogger(getClass());
+        deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override
@@ -42,6 +48,8 @@ public class LimitQueryParser implements QueryParser {
 
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        deprecationLogger.deprecated("The [limit] query is deprecated, please use the [terminate_after] parameter of the search API instead.");
+
         XContentParser parser = parseContext.parser();
 
         int limit = -1;

--- a/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MissingQueryParser.java
@@ -25,6 +25,9 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -42,9 +45,12 @@ public class MissingQueryParser implements QueryParser {
     public static final String NAME = "missing";
     public static final boolean DEFAULT_NULL_VALUE = false;
     public static final boolean DEFAULT_EXISTENCE_VALUE = true;
+    private final DeprecationLogger deprecationLogger;
 
     @Inject
     public MissingQueryParser() {
+        ESLogger logger = Loggers.getLogger(getClass());
+        deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override
@@ -54,6 +60,8 @@ public class MissingQueryParser implements QueryParser {
 
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        deprecationLogger.deprecated("The [missing] query is deprecated, please use an [exist] query in a [must_not] clause instead.");
+
         XContentParser parser = parseContext.parser();
 
         String fieldPattern = null;

--- a/core/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/OrQueryParser.java
@@ -23,6 +23,9 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -35,9 +38,12 @@ import java.util.ArrayList;
 public class OrQueryParser implements QueryParser {
 
     public static final String NAME = "or";
+    private final DeprecationLogger deprecationLogger;
 
     @Inject
     public OrQueryParser() {
+        ESLogger logger = Loggers.getLogger(getClass());
+        deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override
@@ -47,6 +53,8 @@ public class OrQueryParser implements QueryParser {
 
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        deprecationLogger.deprecated("The [or] query is deprecated, please use a [bool] query instead with [should] clauses.");
+
         XContentParser parser = parseContext.parser();
 
         ArrayList<Query> queries = new ArrayList<>();

--- a/core/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryFilterParser.java
@@ -22,6 +22,9 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 
 import java.io.IOException;
 
@@ -29,9 +32,12 @@ import java.io.IOException;
 public class QueryFilterParser implements QueryParser {
 
     public static final String NAME = "query";
+    private final DeprecationLogger deprecationLogger;
 
     @Inject
     public QueryFilterParser() {
+        ESLogger logger = Loggers.getLogger(getClass());
+        deprecationLogger = new DeprecationLogger(logger);
     }
 
     @Override
@@ -41,6 +47,7 @@ public class QueryFilterParser implements QueryParser {
 
     @Override
     public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        deprecationLogger.deprecated("The [query] filter is deprecated, you can now use queries as filters directly.");
         return new ConstantScoreQuery(parseContext.parseInnerQuery());
     }
 }


### PR DESCRIPTION
This adds deprecation logging for the `and`, `fquery`, `filtered`, `or` an
`query` queries.

Closes #16885
