### PR TITLE
Introduce the notion of hidden indices

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -120,9 +120,7 @@ public class IndicesOptions {
     }
 
     public static IndicesOptions readIndicesOptions(StreamInput in) throws IOException {
-        //if we read from a node that doesn't support the newly added flag (allowAliasesToMultipleIndices)
-        //we just receive the old corresponding value with the new flag set to true (default)
-        int id = in.readInt();
+        final int id = in.readInt();
         return new IndicesOptions(id);
     }
 
@@ -162,12 +160,8 @@ public class IndicesOptions {
     }
 
     public static IndicesOptions fromMap(Map<String, Object> map, IndicesOptions defaultSettings) {
-        return fromParameters(
-                map.containsKey("expand_wildcards") ? map.get("expand_wildcards") : map.get("expandWildcards"),
-                map.containsKey("ignore_unavailable") ? map.get("ignore_unavailable") : map.get("ignoreUnavailable"),
-                map.containsKey("allow_no_indices") ? map.get("allow_no_indices") : map.get("allowNoIndices"),
-                map.getOrDefault("include_hidden", map.getOrDefault("includeHidden", "false")),
-                defaultSettings);
+        return fromParameters(map.get("expand_wildcards"), map.get("ignore_unavailable"),
+            map.get("allow_no_indices"), map.get("include_hidden"), defaultSettings);
     }
 
     /**
@@ -177,11 +171,8 @@ public class IndicesOptions {
     public static boolean isIndicesOptions(String name) {
         switch (name) {
             case "expand_wildcards":
-            case "expandWildcards":
             case "ignore_unavailable":
-            case "ignoreUnavailable":
             case "allow_no_indices":
-            case "allowNoIndices":
             case "include_hidden":
                 return true;
             default:
@@ -309,7 +300,7 @@ public class IndicesOptions {
                 ", allow_no_indices=" + allowNoIndices() +
                 ", expand_wildcards_open=" + expandWildcardsOpen() +
                 ", expand_wildcards_closed=" + expandWildcardsClosed() +
-                ", allow_alisases_to_multiple_indices=" + allowAliasesToMultipleIndices() +
+                ", allow_aliases_to_multiple_indices=" + allowAliasesToMultipleIndices() +
                 ", forbid_closed_indices=" + forbidClosedIndices() +
                 ", include_hidden=" + includeHidden() +
                 ']';

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -258,7 +258,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         this.indexCreatedVersion = indexCreatedVersion;
         this.indexUpgradedVersion = indexUpgradedVersion;
         this.minimumCompatibleLuceneVersion = minimumCompatibleLuceneVersion;
-        this.hidden = INDEX_HIDDEN_SETTING.get(settings);
+        // by default we treat indices that start with '.' as hidden
+        this.hidden = INDEX_HIDDEN_SETTING.exists(settings) ? INDEX_HIDDEN_SETTING.get(settings) : index.getName().startsWith(".");
     }
 
     public Index getIndex() {
@@ -309,7 +310,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     }
 
     /**
-     * Retruns <code>true</code> if the index is a hidden index
+     * Returns <code>true</code> if the index is a hidden index
      */
     public boolean isHidden() {
         return hidden;

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -157,6 +157,11 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     public static final Setting<Integer> INDEX_NUMBER_OF_REPLICAS_SETTING = Setting.intSetting(SETTING_NUMBER_OF_REPLICAS, 1, 0, true, Setting.Scope.INDEX);
     public static final String SETTING_SHADOW_REPLICAS = "index.shadow_replicas";
     public static final Setting<Boolean> INDEX_SHADOW_REPLICAS_SETTING = Setting.boolSetting(SETTING_SHADOW_REPLICAS, false, false, Setting.Scope.INDEX);
+    /**
+     * Hidden indices don't show up if we search across all indices neither do they expand to expressions. For instance the .scripts index is
+     * hidden by default.
+     */
+    public static final Setting<Boolean> INDEX_HIDDEN_SETTING = Setting.boolSetting("index.hidden", false, true, Setting.Scope.INDEX);
 
     public static final String SETTING_SHARED_FILESYSTEM = "index.shared_filesystem";
     public static final Setting<Boolean> INDEX_SHARED_FILESYSTEM_SETTING = Setting.boolSetting(SETTING_SHARED_FILESYSTEM, false, false, Setting.Scope.INDEX);
@@ -228,6 +233,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
     private final Version indexCreatedVersion;
     private final Version indexUpgradedVersion;
     private final org.apache.lucene.util.Version minimumCompatibleLuceneVersion;
+    private final boolean hidden;
 
     private IndexMetaData(Index index, long version, State state, int numberOfShards, int numberOfReplicas, Settings settings,
                           ImmutableOpenMap<String, MappingMetaData> mappings, ImmutableOpenMap<String, AliasMetaData> aliases,
@@ -252,6 +258,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
         this.indexCreatedVersion = indexCreatedVersion;
         this.indexUpgradedVersion = indexUpgradedVersion;
         this.minimumCompatibleLuceneVersion = minimumCompatibleLuceneVersion;
+        this.hidden = INDEX_HIDDEN_SETTING.get(settings);
     }
 
     public Index getIndex() {
@@ -299,6 +306,13 @@ public class IndexMetaData implements Diffable<IndexMetaData>, FromXContentBuild
      */
     public org.apache.lucene.util.Version getMinimumCompatibleVersion() {
         return minimumCompatibleLuceneVersion;
+    }
+
+    /**
+     * Retruns <code>true</code> if the index is a hidden index
+     */
+    public boolean isHidden() {
+        return hidden;
     }
 
     public long getCreationDate() {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -273,9 +273,6 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                             indexSettingsBuilder.put(request.settings());
                             if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
                                 indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 1));
-                                if (IndexMetaData.INDEX_HIDDEN_SETTING.exists(request.settings()) == false) {
-                                    indexSettingsBuilder.put(IndexMetaData.INDEX_HIDDEN_SETTING.getKey(), "true");
-                                }
                             } else {
                                 if (indexSettingsBuilder.get(SETTING_NUMBER_OF_SHARDS) == null) {
                                     indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 5));

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -273,6 +273,9 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                             indexSettingsBuilder.put(request.settings());
                             if (request.index().equals(ScriptService.SCRIPT_INDEX)) {
                                 indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 1));
+                                if (IndexMetaData.INDEX_HIDDEN_SETTING.exists(request.settings()) == false) {
+                                    indexSettingsBuilder.put(IndexMetaData.INDEX_HIDDEN_SETTING.getKey(), "true");
+                                }
                             } else {
                                 if (indexSettingsBuilder.get(SETTING_NUMBER_OF_SHARDS) == null) {
                                     indexSettingsBuilder.put(SETTING_NUMBER_OF_SHARDS, settings.getAsInt(SETTING_NUMBER_OF_SHARDS, 5));

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -63,6 +63,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING,
         MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING,
         IndexMetaData.INDEX_ROUTING_EXCLUDE_GROUP_SETTING,
+        IndexMetaData.INDEX_HIDDEN_SETTING,
         IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING,
         IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING,
         IndexMetaData.INDEX_AUTO_EXPAND_REPLICAS_SETTING,

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/settings/RestUpdateSettingsAction.java
@@ -46,10 +46,7 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
             "pretty",
             "timeout",
             "master_timeout",
-            "index",
-            "expand_wildcards",
-            "ignore_unavailable",
-            "allow_no_indices"));
+            "index"));
 
     @Inject
     public RestUpdateSettingsAction(Settings settings, RestController controller, Client client) {
@@ -80,7 +77,7 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
             }
         }
         for (Map.Entry<String, String> entry : request.params().entrySet()) {
-            if (VALUES_TO_EXCLUDE.contains(entry.getKey())) {
+            if (VALUES_TO_EXCLUDE.contains(entry.getKey()) || IndicesOptions.isIndicesOptions(entry.getKey())) {
                 continue;
             }
             updateSettings.put(entry.getKey(), entry.getValue());

--- a/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -31,7 +31,7 @@ public class IndicesOptionsTests extends ESTestCase {
     public void testSerialization() throws Exception {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
             BytesStreamOutput output = new BytesStreamOutput();
             Version outputVersion = randomVersion(random());
@@ -61,9 +61,10 @@ public class IndicesOptionsTests extends ESTestCase {
             boolean expandToClosedIndices = randomBoolean();
             boolean allowAliasesToMultipleIndices = randomBoolean();
             boolean forbidClosedIndices = randomBoolean();
+            boolean includeHidden = randomBoolean();
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(
                     ignoreUnavailable, allowNoIndices,expandToOpenIndices, expandToClosedIndices,
-                    allowAliasesToMultipleIndices, forbidClosedIndices
+                    allowAliasesToMultipleIndices, forbidClosedIndices, includeHidden
             );
 
             assertThat(indicesOptions.ignoreUnavailable(), equalTo(ignoreUnavailable));
@@ -73,6 +74,7 @@ public class IndicesOptionsTests extends ESTestCase {
             assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
             assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
             assertThat(indicesOptions.forbidClosedIndices(), equalTo(forbidClosedIndices));
+            assertThat(indicesOptions.includeHidden(), equalTo(includeHidden));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData.State;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.test.ESTestCase;
@@ -354,8 +353,6 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
             results = indexNameExpressionResolver.concreteIndices(context, Strings.EMPTY_ARRAY);
             assertEquals(0, results.length);
-
-
         }
 
         //ignore unavailable but don't allow no indices

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -147,4 +147,36 @@ public class MetaDataTests extends ESTestCase {
             assertEquals("Unexpected field [random]", e.getMessage());
         }
     }
+
+    public void testHiddenIndex() {
+        IndexMetaData.Builder builder = IndexMetaData.builder("index")
+            .settings(Settings.builder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetaData.INDEX_HIDDEN_SETTING.getKey(), true))
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+        assertTrue(builder.build().isHidden());
+
+        builder = IndexMetaData.builder(".foo")
+            .settings(Settings.builder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+        assertTrue(builder.build().isHidden());
+
+        builder = IndexMetaData.builder("foo")
+            .settings(Settings.builder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+        assertFalse(builder.build().isHidden());
+
+        builder = IndexMetaData.builder(".foo")
+            .settings(Settings.builder()
+                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetaData.INDEX_HIDDEN_SETTING.getKey(), false))
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+        assertFalse(builder.build().isHidden());
+    }
 }

--- a/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
@@ -19,10 +19,14 @@
 
 package org.elasticsearch.indices;
 
+import org.apache.lucene.index.IndexOptions;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.joda.time.DateTime;
@@ -30,6 +34,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -50,7 +55,8 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         client().prepareIndex(dateMathExp1, "type", "1").setSource("{}").get();
         client().prepareIndex(dateMathExp2, "type", "2").setSource("{}").get();
         client().prepareIndex(dateMathExp3, "type", "3").setSource("{}").get();
-        refresh();
+        assertNoFailures(client().admin().indices().prepareRefresh().setIndicesOptions(IndicesOptions.fromParameters(null,
+            null, null, true, IndicesOptions.strictExpandOpenAndForbidClosed())).get());
 
         SearchResponse searchResponse = client().prepareSearch(dateMathExp1, dateMathExp2, dateMathExp3).get();
         assertHitCount(searchResponse, 3);
@@ -68,7 +74,9 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         assertThat(getResponse.isExists(), is(true));
         assertThat(getResponse.getId(), equalTo("3"));
 
-        IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(dateMathExp1, dateMathExp2, dateMathExp3).get();
+        IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(dateMathExp1, dateMathExp2,
+            dateMathExp3).setIndicesOptions(IndicesOptions.fromParameters(null,null,null,true, SearchRequest.DEFAULT_INDICES_OPTIONS))
+            .get();
         assertThat(indicesStatsResponse.getIndex(index1), notNullValue());
         assertThat(indicesStatsResponse.getIndex(index2), notNullValue());
         assertThat(indicesStatsResponse.getIndex(index3), notNullValue());
@@ -98,13 +106,16 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         client().prepareIndex(dateMathExp1, "type", "1").setSource("{}").get();
         client().prepareIndex(dateMathExp2, "type", "2").setSource("{}").get();
         client().prepareIndex(dateMathExp3, "type", "3").setSource("{}").get();
-        refresh();
+        assertNoFailures(client().admin().indices().prepareRefresh().setIndicesOptions(IndicesOptions.fromParameters(null,
+            null, null, true, IndicesOptions.strictExpandOpenAndForbidClosed())).get());
 
-        SearchResponse searchResponse = client().prepareSearch(dateMathExp1, dateMathExp2, dateMathExp3).get();
+        SearchResponse searchResponse = client().prepareSearch(dateMathExp1, dateMathExp2, dateMathExp3)
+            .setIndicesOptions(IndicesOptions.fromParameters(null,null,null,true, SearchRequest.DEFAULT_INDICES_OPTIONS)).get();
         assertHitCount(searchResponse, 3);
         assertSearchHits(searchResponse, "1", "2", "3");
 
-        IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(dateMathExp1, dateMathExp2, dateMathExp3).get();
+        IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(dateMathExp1, dateMathExp2,
+            dateMathExp3).get();
         assertThat(indicesStatsResponse.getIndex(index1), notNullValue());
         assertThat(indicesStatsResponse.getIndex(index2), notNullValue());
         assertThat(indicesStatsResponse.getIndex(index3), notNullValue());
@@ -126,5 +137,4 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         assertThat(clusterState.metaData().index(index2), notNullValue());
         assertThat(clusterState.metaData().index(index3), notNullValue());
     }
-
 }

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -51,6 +51,11 @@ If `none` is specified then wildcard expansion will be disabled and if `all`
 is specified, wildcard expressions will expand to all indices (this is equivalent
 to specifying `open,closed`).
 
+`include_hidden`::
+
+Controls whether to include hidden indices when resolving expressions. Hidden indices
+are always included if an alias is resolved.
+
 The defaults settings for the above parameters depend on the api being used.
 
 NOTE: Single index APIs such as the <<docs>> and the

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -399,14 +399,32 @@ $ curl -XPUT 'http://localhost:9200/twitter/tweet/1?timeout=5m' -d '{
 }'
 --------------------------------------------------
 
-[float]
-[[hidden]]
+float]
+[[hidden-indices]]
 === Hidden Indices
 
-An index can be hidden by setting `index.hidden` to `true` when then index is created.
-A hidden index will not be resolved from expression ie. the index `.scripts` is hidden
-by default from `5.0` on and won't be deleted if `_all` indices are deleted unless the indices
-option `include_hidden` is specified. Yet, if the index is specified explitily or via an alias
-the index is not treated as hidden. This is useful for indices that should not be included if for instance
-`_all` is searched or if indices are currently re-indexed and follow some kind of index name pattern. This
-setting can be updated.
+added[5.0.0]
+
+An index can be hidden by setting `index.hidden` to `true`. This setting
+defaults to `false` unless the index name starts with `.`, such as `.kibana`.
+This is a dynamic setting which can be updated on an existing index.
+
+A hidden index will not be returned by multi-index expressions like `_all`, `*`,
+or `.marvel-*`. For instance, deleting `_all` indices will not delete hidden
+indices. Hidden indices can be referenced directly by name (eg `.kibana`) or
+by an alias that points to the index (eg `marvel-current`).
+
+Hidden indices can be revealed by including the `include_hidden` query string
+parameter, such as:
+
+[source,js]
+--------------------
+DELETE /_all?include_hidden
+--------------------
+
+or:
+
+[source,js]
+--------------------
+GET .marvel-*/_count?include_hidden
+--------------------

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -398,3 +398,15 @@ $ curl -XPUT 'http://localhost:9200/twitter/tweet/1?timeout=5m' -d '{
     "message" : "trying out Elasticsearch"
 }'
 --------------------------------------------------
+
+[float]
+[[hidden]]
+=== Hidden Indices
+
+An index can be hidden by setting `index.hidden` to `true` when then index is created.
+A hidden index will not be resolved from expression ie. the index `.scripts` is hidden
+by default from `5.0` on and won't be deleted if `_all` indices are deleted unless the indices
+option `include_hidden` is specified. Yet, if the index is specified explitily or via an alias
+the index is not treated as hidden. This is useful for indices that should not be included if for instance
+`_all` is searched or if indices are currently re-indexed and follow some kind of index name pattern. This
+setting can be updated.

--- a/docs/reference/migration/migrate_5_0.asciidoc
+++ b/docs/reference/migration/migrate_5_0.asciidoc
@@ -21,6 +21,8 @@ your application to Elasticsearch 5.0.
 * <<breaking_50_scripting>>
 * <<breaking_50_term_vectors>>
 * <<breaking_50_security>>
+* <<breaking_50_indices_options>>
+* <<breaking_50_hidden_indices>>
 
 [[breaking_50_search_changes]]
 === Warmers
@@ -838,3 +840,18 @@ distributed document frequencies anymore.
 
 The option to disable the security manager `--security.manager.enabled` has been removed. In order to grant special
 permissions to elasticsearch users must tweak the local Java Security Policy.
+
+[[breaking_50_indices_options]]
+=== Indices Options
+CamelCase indices options like `expandWildcards` are not supported anymore. The corresponding underscore variant should be used
+instead. 
+
+[[breaking_50_hidden_indices]]
+=== Hidden Indices
+All indices that name starts with a `.` are considered hidden and won't be resolved in expressions by default.  
+For instance the `.marvel-` indices won't be searchable unless the index option `include_hidden` is provided on the request.
+
+[source,js]
+--------------------
+GET .marvel-*/_count?include_hidden
+--------------------

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptIndexSettingsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptIndexSettingsTests.java
@@ -70,7 +70,8 @@ public class ScriptIndexSettingsTests extends ESIntegTestCase {
 
         String numberOfShards = settingsResponse.getSetting(ScriptService.SCRIPT_INDEX,"index.number_of_shards");
         String numberOfReplicas = settingsResponse.getSetting(ScriptService.SCRIPT_INDEX,"index.auto_expand_replicas");
-
+        boolean hidden = Boolean.parseBoolean(settingsResponse.getSetting(ScriptService.SCRIPT_INDEX,"index.hidden"));
+        assertTrue(".script index must be hidden", hidden);
         assertEquals("Number of shards should be 1", "1", numberOfShards);
         assertEquals("Auto expand replicas should be 0-all", "0-all", numberOfReplicas);
     }

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptIndexSettingsTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/ScriptIndexSettingsTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.indexedscripts.put.PutIndexedScriptResponse;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.ScriptService;
@@ -70,8 +71,8 @@ public class ScriptIndexSettingsTests extends ESIntegTestCase {
 
         String numberOfShards = settingsResponse.getSetting(ScriptService.SCRIPT_INDEX,"index.number_of_shards");
         String numberOfReplicas = settingsResponse.getSetting(ScriptService.SCRIPT_INDEX,"index.auto_expand_replicas");
-        boolean hidden = Boolean.parseBoolean(settingsResponse.getSetting(ScriptService.SCRIPT_INDEX,"index.hidden"));
-        assertTrue(".script index must be hidden", hidden);
+        IndexMetaData imd = client().admin().cluster().prepareState().get().getState().metaData().index(ScriptService.SCRIPT_INDEX);
+        assertTrue(".script index must be hidden", imd.isHidden());
         assertEquals("Number of shards should be 1", "1", numberOfShards);
         assertEquals("Auto expand replicas should be 0-all", "0-all", numberOfReplicas);
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -20,6 +20,11 @@
         "master_timeout": {
           "type" : "time",
           "description" : "Specify timeout for connection to master"
+        },
+        "include_hidden": {
+          "type": "boolean",
+          "description": "Whether to include hidden indices when resolving an index expression.",
+          "default" : "false"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
@@ -30,10 +30,15 @@
           "default": "open",
           "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
         },
-          "flat_settings": {
-              "type": "boolean",
-              "description": "Return settings in flat format (default: false)"
-          }
+        "include_hidden": {
+          "type": "boolean",
+          "description": "Whether to include hidden indices when resolving an index expression.",
+          "default" : "false"
+        },
+        "flat_settings": {
+            "type": "boolean",
+            "description": "Return settings in flat format (default: false)"
+        }
       }
     },
     "body": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.exists/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.exists/10_basic.yaml
@@ -23,3 +23,39 @@
         local: true
 
   - is_false: ''
+
+
+---
+"Test indices.exists with hidden index":
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          hidden: true
+  - do:
+      indices.exists:
+        index: test_index
+  - is_true: ''
+
+  - do:
+      indices.delete:
+        index: test*
+
+  - do:
+      indices.exists:
+        index: test_index
+  - is_true: ''
+
+  - do:
+      indices.put_settings:
+        index: test*
+        include_hidden: true
+        body:
+          hidden: false
+  - do:
+      indices.delete:
+        index: test*
+  - do:
+      indices.exists:
+        index: test_index
+  - is_false: ''

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -265,6 +265,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         // wipe indices
         Map<String, String> deleteIndicesArgs = new HashMap<>();
         deleteIndicesArgs.put("index", "*");
+        deleteIndicesArgs.put("include_hidden", "true");
         try {
             adminExecutionContext.callApi("indices.delete", deleteIndicesArgs, Collections.emptyList(), Collections.emptyMap());
         } catch (RestException e) {


### PR DESCRIPTION
With the setting `index.hidden` an index can be marked as hidden which
prevents the index from being resolved in index expressions or with `_all` / `*`.
Yet, if the index is access explicitly or the expression resolves to an alias pointing
to a hidden index the index is accessible. This is mainly a use case to prevent accidential
access of a metadata or cluster private index from an ordinary search.
