### PR TITLE
Elasticsearch monitoring support for Dynatrace Application Monitoring

### DIFF
--- a/docs/plugins/management.asciidoc
+++ b/docs/plugins/management.asciidoc
@@ -38,6 +38,7 @@ A number of plugins have been contributed by our community:
 * https://github.com/polyfractal/elasticsearch-inquisitor[Inquisitor Plugin] (by Zachary Tong)
 * https://github.com/lmenezes/elasticsearch-kopf[Kopf Plugin] (by lmenezes)
 * https://github.com/timschlechter/swagger-for-elasticsearch[Swagger for Elasticsearch] (by Tim Schlechter)
+* https://github.com/Dynatrace/Dynatrace-Elasticsearch-Plugin[Elasticsearch monitoring plugin for Dynatrace Application Monitoring] (by Dynatrace)
 
 These community plugins appear to have been abandoned:
 


### PR DESCRIPTION
Dynatrace provides functionality which can be used to fetch health data and monitor multiple Elasticsearch cluster.
