### PR TITLE
Use and test relative time in TransportBulkAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
@@ -33,7 +33,7 @@ public class CreateIndexResponse extends AcknowledgedResponse {
     CreateIndexResponse() {
     }
 
-    public CreateIndexResponse(boolean acknowledged) {
+    CreateIndexResponse(boolean acknowledged) {
         super(acknowledged);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
@@ -33,7 +33,7 @@ public class CreateIndexResponse extends AcknowledgedResponse {
     CreateIndexResponse() {
     }
 
-    CreateIndexResponse(boolean acknowledged) {
+    public CreateIndexResponse(boolean acknowledged) {
         super(acknowledged);
     }
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -249,7 +249,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
 
         @Override
         protected void doExecute(Task task, CreateIndexRequest request, ActionListener<CreateIndexResponse> listener) {
-            listener.onResponse(new CreateIndexResponse(true));
+            listener.onResponse(newResponse());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -1,3 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
 package org.elasticsearch.action.bulk;
 
 import org.apache.lucene.util.Constants;

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -1,0 +1,242 @@
+package org.elasticsearch.action.bulk;
+
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.AutoCreateIndex;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.cluster.TestClusterService;
+import org.elasticsearch.test.transport.CapturingTransport;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+public class TransportBulkActionTookTests extends ESTestCase {
+
+    private static ThreadPool THREAD_POOL;
+
+    @BeforeClass
+    public static void startThreadPool() {
+        THREAD_POOL = new ThreadPool(TransportBulkActionTookTests.class.getSimpleName());
+    }
+
+    private TransportBulkAction createAction(boolean controlled, AtomicLong expected) {
+        CapturingTransport capturingTransport = new CapturingTransport();
+        ClusterService clusterService = new TestClusterService(THREAD_POOL);
+        TransportService transportService = new TransportService(capturingTransport, THREAD_POOL);
+        transportService.start();
+        transportService.acceptIncomingRequests();
+        IndexNameExpressionResolver resolver = new Resolver(Settings.EMPTY);
+        ActionFilters actionFilters = new ActionFilters(new HashSet<>());
+
+        TransportCreateIndexAction createIndexAction = new TransportCreateIndexAction(
+                Settings.EMPTY,
+                transportService,
+                clusterService,
+                THREAD_POOL,
+                null,
+                actionFilters,
+                resolver);
+
+        if (controlled) {
+
+            return new TestTransportBulkAction(
+                    Settings.EMPTY,
+                    THREAD_POOL,
+                    transportService,
+                    clusterService,
+                    null,
+                    createIndexAction,
+                    actionFilters,
+                    resolver,
+                    null,
+                    expected::get) {
+                @Override
+                public void executeBulk(BulkRequest bulkRequest, ActionListener<BulkResponse> listener) {
+                    expected.set(1000000);
+                    super.executeBulk(bulkRequest, listener);
+                }
+
+                @Override
+                void executeBulk(
+                        BulkRequest bulkRequest,
+                        long startTimeNanos,
+                        ActionListener<BulkResponse> listener,
+                        AtomicArray<BulkItemResponse> responses) {
+                    expected.set(1000000);
+                    super.executeBulk(bulkRequest, startTimeNanos, listener, responses);
+                }
+            };
+        } else {
+            return new TestTransportBulkAction(
+                    Settings.EMPTY,
+                    THREAD_POOL,
+                    transportService,
+                    clusterService,
+                    null,
+                    createIndexAction,
+                    actionFilters,
+                    resolver,
+                    null,
+                    System::nanoTime) {
+                @Override
+                public void executeBulk(BulkRequest bulkRequest, ActionListener<BulkResponse> listener) {
+                    long elapsed = spinForAtLeastOneMillisecond();
+                    expected.set(elapsed);
+                    super.executeBulk(bulkRequest, listener);
+                }
+
+                @Override
+                void executeBulk(
+                        BulkRequest bulkRequest,
+                        long startTimeNanos,
+                        ActionListener<BulkResponse> listener,
+                        AtomicArray<BulkItemResponse> responses) {
+                    long elapsed = spinForAtLeastOneMillisecond();
+                    expected.set(elapsed);
+                    super.executeBulk(bulkRequest, startTimeNanos, listener, responses);
+                }
+            };
+        }
+    }
+
+    @AfterClass
+    public static void destroyThreadPool() {
+        ThreadPool.terminate(THREAD_POOL, 30, TimeUnit.SECONDS);
+        // since static must set to null to be eligible for collection
+        THREAD_POOL = null;
+    }
+
+    // test unit conversion with a controlled clock
+    public void testTookWithControlledClock() throws Exception {
+        runTestTook(true);
+    }
+
+    // test took advances with System#nanoTime
+    public void testTookWithRealClock() throws Exception {
+        runTestTook(false);
+    }
+
+    private void runTestTook(boolean controlled) throws Exception {
+        String bulkAction = copyToStringFromClasspath("/org/elasticsearch/action/bulk/simple-bulk.json");
+        // translate Windows line endings (\r\n) to standard ones (\n)
+        if (Constants.WINDOWS) {
+            bulkAction = Strings.replace(bulkAction, "\r\n", "\n");
+        }
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, null);
+        AtomicLong expected = new AtomicLong();
+        TransportBulkAction action = createAction(controlled, expected);
+        action.doExecute(bulkRequest, new ActionListener<BulkResponse>() {
+            @Override
+            public void onResponse(BulkResponse bulkItemResponses) {
+                if (controlled) {
+                    assertThat(
+                            bulkItemResponses.getTook().getMillis(),
+                            equalTo(TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS)));
+                } else {
+                    assertThat(
+                            bulkItemResponses.getTook().getMillis(),
+                            greaterThanOrEqualTo(TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS)));
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+
+            }
+        });
+    }
+
+    static class Resolver extends IndexNameExpressionResolver {
+        public Resolver(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public String[] concreteIndices(ClusterState state, IndicesRequest request) {
+            return request.indices();
+        }
+    }
+
+    static class TestTransportBulkAction extends TransportBulkAction {
+
+        public TestTransportBulkAction(
+                Settings settings,
+                ThreadPool threadPool,
+                TransportService transportService,
+                ClusterService clusterService,
+                TransportShardBulkAction shardBulkAction,
+                TransportCreateIndexAction createIndexAction,
+                ActionFilters actionFilters,
+                IndexNameExpressionResolver indexNameExpressionResolver,
+                AutoCreateIndex autoCreateIndex,
+                LongSupplier relativeTimeProvider) {
+            super(
+                    settings,
+                    threadPool,
+                    transportService,
+                    clusterService,
+                    shardBulkAction,
+                    createIndexAction,
+                    actionFilters,
+                    indexNameExpressionResolver,
+                    autoCreateIndex,
+                    relativeTimeProvider);
+        }
+
+        @Override
+        boolean needToCheck() {
+            return randomBoolean();
+        }
+
+        @Override
+        boolean shouldAutoCreate(String index, ClusterState state) {
+            return randomBoolean();
+        }
+
+    }
+
+    static class TestTransportCreateIndexAction extends TransportCreateIndexAction {
+
+        public TestTransportCreateIndexAction(
+                Settings settings,
+                TransportService transportService,
+                ClusterService clusterService,
+                ThreadPool threadPool,
+                MetaDataCreateIndexService createIndexService,
+                ActionFilters actionFilters,
+                IndexNameExpressionResolver indexNameExpressionResolver) {
+            super(settings, transportService, clusterService, threadPool, createIndexService, actionFilters, indexNameExpressionResolver);
+        }
+
+        @Override
+        protected void doExecute(Task task, CreateIndexRequest request, ActionListener<CreateIndexResponse> listener) {
+            listener.onResponse(new CreateIndexResponse(true));
+        }
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -21,8 +21,7 @@ import org.elasticsearch.test.cluster.TestClusterService;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
@@ -33,20 +32,22 @@ import java.util.function.LongSupplier;
 import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.mockito.Mockito.mock;
 
 public class TransportBulkActionTookTests extends ESTestCase {
 
-    private static ThreadPool THREAD_POOL;
+    private ThreadPool threadPool;
 
-    @BeforeClass
-    public static void startThreadPool() {
-        THREAD_POOL = new ThreadPool(TransportBulkActionTookTests.class.getSimpleName());
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = mock(ThreadPool.class);
     }
 
     private TransportBulkAction createAction(boolean controlled, AtomicLong expected) {
         CapturingTransport capturingTransport = new CapturingTransport();
-        ClusterService clusterService = new TestClusterService(THREAD_POOL);
-        TransportService transportService = new TransportService(capturingTransport, THREAD_POOL);
+        ClusterService clusterService = new TestClusterService(threadPool);
+        TransportService transportService = new TransportService(capturingTransport, threadPool);
         transportService.start();
         transportService.acceptIncomingRequests();
         IndexNameExpressionResolver resolver = new Resolver(Settings.EMPTY);
@@ -56,7 +57,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
                 Settings.EMPTY,
                 transportService,
                 clusterService,
-                THREAD_POOL,
+                threadPool,
                 null,
                 actionFilters,
                 resolver);
@@ -65,7 +66,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
 
             return new TestTransportBulkAction(
                     Settings.EMPTY,
-                    THREAD_POOL,
+                    threadPool,
                     transportService,
                     clusterService,
                     null,
@@ -93,7 +94,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
         } else {
             return new TestTransportBulkAction(
                     Settings.EMPTY,
-                    THREAD_POOL,
+                    threadPool,
                     transportService,
                     clusterService,
                     null,
@@ -121,13 +122,6 @@ public class TransportBulkActionTookTests extends ESTestCase {
                 }
             };
         }
-    }
-
-    @AfterClass
-    public static void destroyThreadPool() {
-        ThreadPool.terminate(THREAD_POOL, 30, TimeUnit.SECONDS);
-        // since static must set to null to be eligible for collection
-        THREAD_POOL = null;
     }
 
     // test unit conversion with a controlled clock

--- a/core/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedRunnableTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedRunnableTests.java
@@ -46,20 +46,13 @@ public class PrioritizedRunnableTests extends ESTestCase {
 
     // test age advances with System#nanoTime
     public void testGetAgeInMillisWithRealClock() throws InterruptedException {
-        long nanosecondsInMillisecond = TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS);
         PrioritizedRunnable runnable = new PrioritizedRunnable(Priority.NORMAL) {
             @Override
             public void run() {
             }
         };
 
-        // force at least one millisecond to elapse, but ensure the
-        // clock has enough resolution to observe the passage of time
-        long start = System.nanoTime();
-        long elapsed;
-        while ((elapsed = (System.nanoTime() - start)) < nanosecondsInMillisecond) {
-            // busy spin
-        }
+        long elapsed = spinForAtLeastOneMillisecond();
 
         // creation happened before start, so age will be at least as
         // large as elapsed

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -651,4 +651,16 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
         throw new AssertionFailedError("Expected exception " + expectedType.getSimpleName());
     }
+
+    protected static long spinForAtLeastOneMillisecond() {
+        long nanosecondsInMillisecond = TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS);
+        // force at least one millisecond to elapse, but ensure the
+        // clock has enough resolution to observe the passage of time
+        long start = System.nanoTime();
+        long elapsed;
+        while ((elapsed = (System.nanoTime() - start)) < nanosecondsInMillisecond) {
+            // busy spin
+        }
+        return elapsed;
+    }
 }


### PR DESCRIPTION
This commit modifies TransportBulkAction to use relative time instead of
absolute time when measuring how long a bulk request took to be
processed, and adds tests for this functionality.
