### PR TITLE
remove "_all" from RestoreSnapshotRequest#indices javadocs

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -149,7 +149,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      * Sets the list of indices that should be restored from snapshot
      * <p>
      * The list of indices supports multi-index syntax. For example: "+test*" ,"-test42" will index all indices with
-     * prefix "test" except index "test42". Aliases are not supported. An empty list or {"_all"} will restore all open
+     * prefix "test" except index "test42". Aliases are not supported. An empty list will restore all open
      * indices in the snapshot.
      *
      * @param indices list of indices
@@ -164,7 +164,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      * Sets the list of indices that should be restored from snapshot
      * <p>
      * The list of indices supports multi-index syntax. For example: "+test*" ,"-test42" will index all indices with
-     * prefix "test" except index "test42". Aliases are not supported. An empty list or {"_all"} will restore all open
+     * prefix "test" except index "test42". Aliases are not supported. An empty list will restore all open
      * indices in the snapshot.
      *
      * @param indices list of indices


### PR DESCRIPTION
The comment was misleading. Setting indices to ["_all"] doesn't work, it
results in an IndexMissingException.

The `RestoreService` calls into `ShapshotUtils.filterIndices` to resolve the indices from the RestoreRequest.  And it doesn't contain any code related to `_all`. There are also no tests that indicate that `_all` can be used. (At least I couldn't find any)
