### PR TITLE
Remove writeLockTimeout from InternalEngine

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -928,12 +928,6 @@ public class InternalEngine extends Engine {
             iwc.setSimilarity(engineConfig.getSimilarity());
             iwc.setRAMBufferSizeMB(engineConfig.getIndexingBufferSize().mbFrac());
             iwc.setCodec(engineConfig.getCodec());
-            /* We set this timeout to a highish value to work around
-             * the default poll interval in the Lucene lock that is
-             * 1000ms by default. We might need to poll multiple times
-             * here but with 1s poll this is only executed twice at most
-             * in combination with the default writelock timeout*/
-            iwc.setWriteLockTimeout(5000);
             iwc.setUseCompoundFile(true); // always use compound on flush - reduces # of file-handles on refresh
             // Warm-up hook for newly-merged segments. Warming up segments here is better since it will be performed at the end
             // of the merge operation and won't slow down _refresh


### PR DESCRIPTION
`writeLockTimeout` has been removed in Lucene 6 completely and since we have
the shard locking mechanism now for quite a while we don't need this anymore.
Shards should only be allocated once all resources are released such that there
can't be any other shard holding the lock to that index in any sane situation.
