### PR TITLE
Allow to configure analyzers on keyword fields.

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzers.java
+++ b/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzers.java
@@ -19,6 +19,8 @@
 package org.elasticsearch.indices.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.Analyzer.TokenStreamComponents;
+import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.ar.ArabicAnalyzer;
 import org.apache.lucene.analysis.bg.BulgarianAnalyzer;
 import org.apache.lucene.analysis.br.BrazilianAnalyzer;
@@ -26,6 +28,8 @@ import org.apache.lucene.analysis.ca.CatalanAnalyzer;
 import org.apache.lucene.analysis.cjk.CJKAnalyzer;
 import org.apache.lucene.analysis.ckb.SoraniAnalyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.SimpleAnalyzer;
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
@@ -95,6 +99,21 @@ public enum PreBuiltAnalyzers {
         @Override
         protected Analyzer create(Version version) {
             return new KeywordAnalyzer();
+        }
+    },
+
+    /** A lowercase analyzer, mostly useful for keyword fields. */
+    LOWERCASE(CachingStrategy.ONE) {
+        @Override
+        protected Analyzer create(Version version) {
+            return new Analyzer() {
+                @Override
+                protected TokenStreamComponents createComponents(String fieldName) {
+                    KeywordTokenizer source = new KeywordTokenizer();
+                    LowerCaseFilter result = new LowerCaseFilter(source);
+                    return new TokenStreamComponents(source, result);
+                }
+            };
         }
     },
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/core/KeywordFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/core/KeywordFieldMapperTests.java
@@ -204,7 +204,12 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
 
     public void testAnalyzer() throws IOException {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "keyword").field("analyzer", "lowercase").endObject().endObject()
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "keyword")
+                        .field("analyzer", "lowercase")
+                      .endObject()
+                    .endObject()
                 .endObject().endObject().string();
 
         DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
@@ -225,7 +230,12 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
 
     public void testIllegalAnalyzer() throws IOException {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field").field("type", "keyword").field("analyzer", "standard").endObject().endObject()
+                .startObject("properties")
+                    .startObject("field")
+                        .field("type", "keyword")
+                        .field("analyzer", "standard")
+                      .endObject()
+                    .endObject()
                 .endObject().endObject().string();
 
         final IllegalArgumentException e =


### PR DESCRIPTION
This commit allows an analyzer to be configured on a keyword field. The analyzer
must generate exactly one token for any input string. This is not something that
can be checked easily so the approach I used is to run the analyzer on a couple
test inputs and check that it generates one token as expected.

One expected use-case for this feature is to normalize case, so for ease of use
I made `lowercase` a built-in analyzer which puts a lowercase filter on top of
a keyword tokenizer.
