### PR TITLE
Fix organization rename in all files in project

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/index/FilterableTermsEnum.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/index/FilterableTermsEnum.java
@@ -76,7 +76,7 @@ public class FilterableTermsEnum extends TermsEnum {
         this.docsEnumFlag = docsEnumFlag;
         if (filter == null) {
             // Important - need to use the doc count that includes deleted docs
-            // or we have this issue: https://github.com/elasticsearch/elasticsearch/issues/7951
+            // or we have this issue: https://github.com/elastic/elasticsearch/issues/7951
             numDocs = reader.maxDoc();
         }
         List<LeafReaderContext> leaves = reader.leaves();

--- a/core/src/main/java/org/elasticsearch/script/ExplainableSearchScript.java
+++ b/core/src/main/java/org/elasticsearch/script/ExplainableSearchScript.java
@@ -45,7 +45,7 @@ import java.io.IOException;
 /**
  * To be implemented by {@link SearchScript} which can provided an {@link Explanation} of the score
  * This is currently not used inside elasticsearch but it is used, see for example here:
- * https://github.com/elasticsearch/elasticsearch/issues/8561
+ * https://github.com/elastic/elasticsearch/issues/8561
  */
 public interface ExplainableSearchScript extends LeafSearchScript {
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkProcessorIT.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkProcessorIT.java
@@ -153,7 +153,7 @@ public class BulkProcessorIT extends ESIntegTestCase {
         assertMultiGetResponse(multiGetRequestBuilder.get(), numDocs);
     }
 
-    //https://github.com/elasticsearch/elasticsearch/issues/5038
+    //https://github.com/elastic/elasticsearch/issues/5038
     public void testBulkProcessorConcurrentRequestsNoNodeAvailableException() throws Exception {
         //we create a transport client with no nodes to make sure it throws NoNodeAvailableException
         Settings settings = Settings.builder()

--- a/core/src/test/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunctionTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/search/function/ScriptScoreFunctionTests.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ScriptScoreFunctionTests extends ESTestCase {
     /**
-     * Tests https://github.com/elasticsearch/elasticsearch/issues/2426
+     * Tests https://github.com/elastic/elasticsearch/issues/2426
      */
     public void testScriptScoresReturnsNaN() throws IOException {
         ScoreFunction scoreFunction = new ScriptScoreFunction(new Script("Float.NaN"), new FloatValueScript(Float.NaN));

--- a/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/DiscoveryWithServiceDisruptionsIT.java
@@ -198,7 +198,7 @@ public class DiscoveryWithServiceDisruptionsIT extends ESIntegTestCase {
 
 
     /**
-     * Test that no split brain occurs under partial network partition. See https://github.com/elasticsearch/elasticsearch/issues/2488
+     * Test that no split brain occurs under partial network partition. See https://github.com/elastic/elasticsearch/issues/2488
      */
     public void testFailWithMinimumMasterNodesConfigured() throws Exception {
         List<String> nodes = startCluster(3);

--- a/core/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/core/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -285,7 +285,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
                     logger.info("--> one node is closed - start indexing data into the second one");
                     client.prepareIndex("test", "type1", "3").setSource(jsonBuilder().startObject().field("field", "value3").endObject()).execute().actionGet();
                     // TODO: remove once refresh doesn't fail immediately if there a master block:
-                    // https://github.com/elasticsearch/elasticsearch/issues/9997
+                    // https://github.com/elastic/elasticsearch/issues/9997
                     client.admin().cluster().prepareHealth("test").setWaitForYellowStatus().get();
                     client.admin().indices().prepareRefresh().execute().actionGet();
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/all/SimpleAllMapperTests.java
@@ -366,7 +366,7 @@ public class SimpleAllMapperTests extends ESSingleNodeTestCase {
         }
     }
 
-    // related to https://github.com/elasticsearch/elasticsearch/issues/5864
+    // related to https://github.com/elastic/elasticsearch/issues/5864
     public void testMistypedTypeInRoot() throws IOException {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/all/mistyped_type_in_root.json");
         try {
@@ -378,7 +378,7 @@ public class SimpleAllMapperTests extends ESSingleNodeTestCase {
         }
     }
 
-    // issue https://github.com/elasticsearch/elasticsearch/issues/5864
+    // issue https://github.com/elastic/elasticsearch/issues/5864
     public void testMisplacedMappingAsRoot() throws IOException {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/all/misplaced_mapping_key_in_root.json");
         try {
@@ -390,7 +390,7 @@ public class SimpleAllMapperTests extends ESSingleNodeTestCase {
         }
     }
 
-    // issue https://github.com/elasticsearch/elasticsearch/issues/5864
+    // issue https://github.com/elastic/elasticsearch/issues/5864
     // test that RootObjectMapping still works
     public void testRootObjectMapperPropertiesDoNotCauseException() throws IOException {
         DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
@@ -404,7 +404,7 @@ public class SimpleAllMapperTests extends ESSingleNodeTestCase {
         parser.parse("test", new CompressedXContent(mapping));
     }
 
-    // issue https://github.com/elasticsearch/elasticsearch/issues/5864
+    // issue https://github.com/elastic/elasticsearch/issues/5864
     public void testMetadataMappersStillWorking() throws MapperParsingException, IOException {
         String mapping = "{";
         Map<String, String> rootTypes = new HashMap<>();

--- a/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -185,7 +185,7 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
         }
     }
 
-    // https://github.com/elasticsearch/elasticsearch/issues/7240
+    // https://github.com/elastic/elasticsearch/issues/7240
     public void testEmptyBooleanQuery() throws Exception {
         XContentBuilder contentBuilder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         BytesReference query = contentBuilder.startObject().startObject("bool").endObject().endObject().bytes();

--- a/core/src/test/java/org/elasticsearch/index/store/ExceptionRetryIT.java
+++ b/core/src/test/java/org/elasticsearch/index/store/ExceptionRetryIT.java
@@ -69,7 +69,7 @@ public class ExceptionRetryIT extends ESIntegTestCase {
     /**
      * Tests retry mechanism when indexing. If an exception occurs when indexing then the indexing request is tried again before finally failing.
      * If auto generated ids are used this must not lead to duplicate ids
-     * see https://github.com/elasticsearch/elasticsearch/issues/8788
+     * see https://github.com/elastic/elasticsearch/issues/8788
      */
     public void testRetryDueToExceptionOnNetworkLayer() throws ExecutionException, InterruptedException, IOException {
         final AtomicBoolean exceptionThrown = new AtomicBoolean(false);

--- a/core/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
@@ -117,7 +117,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
 
     /**
      * Test case for #5030: Upgrading analysis plugins fails
-     * See https://github.com/elasticsearch/elasticsearch/issues/5030
+     * See https://github.com/elastic/elasticsearch/issues/5030
      */
     public void testThatPluginAnalyzersCanBeUpdated() throws Exception {
         final XContentBuilder mapping = jsonBuilder().startObject()

--- a/core/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -169,7 +169,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
     }
 
     /*
-    Second regression test for https://github.com/elasticsearch/elasticsearch/issues/3381
+    Second regression test for https://github.com/elastic/elasticsearch/issues/3381
      */
     public void testUpdateMappingNoChanges() throws Exception {
         client().admin().indices().prepareCreate("test")

--- a/core/src/test/java/org/elasticsearch/routing/AliasRoutingIT.java
+++ b/core/src/test/java/org/elasticsearch/routing/AliasRoutingIT.java
@@ -249,7 +249,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
     }
 
     /*
-    See https://github.com/elasticsearch/elasticsearch/issues/2682
+    See https://github.com/elastic/elasticsearch/issues/2682
     Searching on more than one index, if one of those is an alias with configured routing, the shards that belonged
     to the other indices (without routing) were not taken into account in PlainOperationRouting#searchShards.
     That affected the number of shards that we executed the search on, thus some documents were missing in the search results.
@@ -273,7 +273,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
     }
 
     /*
-    See https://github.com/elasticsearch/elasticsearch/pull/3268
+    See https://github.com/elastic/elasticsearch/pull/3268
     Searching on more than one index, if one of those is an alias with configured routing, the shards that belonged
     to the other indices (without routing) were not taken into account in PlainOperationRouting#searchShardsCount.
     That could cause returning 1, which led to forcing the QUERY_AND_FETCH mode.

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterIT.java
@@ -106,7 +106,7 @@ public class FilterIT extends ESIntegTestCase {
     }
 
     // See NullPointer issue when filters are empty:
-    // https://github.com/elasticsearch/elasticsearch/issues/8438
+    // https://github.com/elastic/elasticsearch/issues/8438
     public void testEmptyFilterDeclarations() throws Exception {
         QueryBuilder emptyFilter = new BoolQueryBuilder();
         SearchResponse response = client().prepareSearch("idx").addAggregation(filter("tag1", emptyFilter)).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersIT.java
@@ -132,7 +132,7 @@ public class FiltersIT extends ESIntegTestCase {
     }
 
     // See NullPointer issue when filters are empty:
-    // https://github.com/elasticsearch/elasticsearch/issues/8438
+    // https://github.com/elastic/elasticsearch/issues/8438
     public void testEmptyFilterDeclarations() throws Exception {
         QueryBuilder<?> emptyFilter = new BoolQueryBuilder();
         SearchResponse response = client().prepareSearch("idx")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/NestedIT.java
@@ -360,7 +360,7 @@ public class NestedIT extends ESIntegTestCase {
         }
     }
 
-    // Test based on: https://github.com/elasticsearch/elasticsearch/issues/9280
+    // Test based on: https://github.com/elastic/elasticsearch/issues/9280
     public void testParentFilterResolvedCorrectly() throws Exception {
         XContentBuilder mapping = jsonBuilder().startObject().startObject("provider").startObject("properties")
                     .startObject("comments")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -309,7 +309,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
         indexRandom(true, false, indexRequestBuilderList);
 
         // Now create some holes in the index with selective deletes caused by updates.
-        // This is the scenario that caused this issue https://github.com/elasticsearch/elasticsearch/issues/7951
+        // This is the scenario that caused this issue https://github.com/elastic/elasticsearch/issues/7951
         // Scoring algorithms throw exceptions if term docFreqs exceed the reported size of the index
         // from which they are taken so need to make sure this doesn't happen.
         String[] text = cat1v1;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
@@ -49,7 +49,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
         return randomBoolean() ? null : randomFrom(SignificantTermsAggregatorFactory.ExecutionMode.values()).toString();
     }
 
-    // see https://github.com/elasticsearch/elasticsearch/issues/5998
+    // see https://github.com/elastic/elasticsearch/issues/5998
     public void testShardMinDocCountSignificantTermsTest() throws Exception {
         String termtype = "text";
         if (randomBoolean()) {
@@ -107,7 +107,7 @@ public class TermsShardMinDocCountIT extends ESIntegTestCase {
         }
     }
 
-    // see https://github.com/elasticsearch/elasticsearch/issues/5998
+    // see https://github.com/elastic/elasticsearch/issues/5998
     public void testShardMinDocCountTermsTest() throws Exception {
         final String [] termTypes = {"text", "long", "integer", "float", "double"};
         String termtype = termTypes[randomInt(termTypes.length - 1)];

--- a/core/src/test/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -405,7 +405,7 @@ public class QueryRescorerIT extends ESIntegTestCase {
         }
     }
 
-    // forces QUERY_THEN_FETCH because of https://github.com/elasticsearch/elasticsearch/issues/4829
+    // forces QUERY_THEN_FETCH because of https://github.com/elastic/elasticsearch/issues/4829
     public void testEquivalence() throws Exception {
         // no dummy docs since merges can change scores while we run queries.
         int numDocs = indexRandomNumbers("whitespace", -1, false);

--- a/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/highlight/HighlighterSearchIT.java
@@ -2477,7 +2477,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[COUNT];
         for (int i = 0; i < COUNT; i++) {
             //generating text with word to highlight in a different position
-            //(https://github.com/elasticsearch/elasticsearch/issues/4103)
+            //(https://github.com/elastic/elasticsearch/issues/4103)
             String prefix = randomAsciiOfLengthBetween(5, 30);
             prefixes.put(String.valueOf(i), prefix);
             indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field1", "Sentence " + prefix

--- a/core/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesIT.java
+++ b/core/src/test/java/org/elasticsearch/search/matchedqueries/MatchedQueriesIT.java
@@ -315,7 +315,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
     }
 
     /**
-     * Test case for issue #4361: https://github.com/elasticsearch/elasticsearch/issues/4361
+     * Test case for issue #4361: https://github.com/elastic/elasticsearch/issues/4361
      */
     public void testMatchedWithShould() throws Exception {
         createIndex("test");

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -156,7 +156,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(client().prepareSearch().setQuery(queryStringQuery("")).get(), 0L); // return no docs
     }
 
-    // see https://github.com/elasticsearch/elasticsearch/issues/3177
+    // see https://github.com/elastic/elasticsearch/issues/3177
     public void testIssue3177() {
         createIndex("test");
         client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -86,7 +86,7 @@ public class FieldSortIT extends ESIntegTestCase {
         return pluginList(InternalSettingsPlugin.class);
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elasticsearch/elasticsearch/issues/9421")
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/9421")
     public void testIssue8226() {
         int numIndices = between(5, 10);
         final boolean useMapping = randomBoolean();
@@ -1382,7 +1382,7 @@ public class FieldSortIT extends ESIntegTestCase {
     }
 
     /**
-     * Test case for issue 6150: https://github.com/elasticsearch/elasticsearch/issues/6150
+     * Test case for issue 6150: https://github.com/elastic/elasticsearch/issues/6150
      */
     public void testNestedSort() throws IOException, InterruptedException, ExecutionException {
         assertAcked(prepareCreate("test")

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceIT.java
@@ -341,7 +341,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
     }
 
     // Regression bug:
-    // https://github.com/elasticsearch/elasticsearch/issues/2851
+    // https://github.com/elastic/elasticsearch/issues/2851
     public void testDistanceSortingWithMissingGeoPoint() throws Exception {
         Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT);
         Settings settings = Settings.settingsBuilder().put(IndexMetaData.SETTING_VERSION_CREATED, version).build();

--- a/core/src/test/java/org/elasticsearch/search/source/SourceFetchingIT.java
+++ b/core/src/test/java/org/elasticsearch/search/source/SourceFetchingIT.java
@@ -76,7 +76,7 @@ public class SourceFetchingIT extends ESIntegTestCase {
 
     /**
      * Test Case for #5132: Source filtering with wildcards broken when given multiple patterns
-     * https://github.com/elasticsearch/elasticsearch/issues/5132
+     * https://github.com/elastic/elasticsearch/issues/5132
      */
     public void testSourceWithWildcardFiltering() {
         createIndex("test");

--- a/core/src/test/java/org/elasticsearch/search/stats/SearchStatsUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/search/stats/SearchStatsUnitTests.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SearchStatsUnitTests extends ESTestCase {
-    // https://github.com/elasticsearch/elasticsearch/issues/7644
+    // https://github.com/elastic/elasticsearch/issues/7644
     public void testShardLevelSearchGroupStats() throws Exception {
         // let's create two dummy search stats with groups
         Map<String, Stats> groupStats1 = new HashMap<>();

--- a/docs/perl/index.asciidoc
+++ b/docs/perl/index.asciidoc
@@ -104,21 +104,21 @@ please use `Search::Elasticsearch::Client::0_90::Direct` as follows:
 
 == Reporting issues
 
-The GitHub repository is http://github.com/elasticsearch/elasticsearch-perl
+The GitHub repository is https://github.com/elastic/elasticsearch-perl
 and any issues can be reported on the issues list at
-http://github.com/elasticsearch/elasticsearch-perl/issues.
+https://github.com/elastic/elasticsearch-perl/issues.
 
 == Contributing
 
 Open source contributions are welcome. Please read our
-https://github.com/elasticsearch/elasticsearch-perl/blob/master/CONTRIBUTING.asciidoc[guide to contributing].
+https://github.com/elastic/elasticsearch-perl/blob/master/CONTRIBUTING.asciidoc[guide to contributing].
 
 == Copyright and License
 
 This software is Copyright (c) 2013-2015 by Elasticsearch BV.
 
 This is free software, licensed under:
-https://github.com/elasticsearch/elasticsearch-perl/blob/master/LICENSE.txt[The Apache License Version 2.0].
+https://github.com/elastic/elasticsearch-perl/blob/master/LICENSE.txt[The Apache License Version 2.0].
 
 
 

--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -76,13 +76,13 @@ releases 2.0 and later do not support rivers.
 [float]
 ==== Supported by Elasticsearch:
 
-* https://github.com/elasticsearch/puppet-elasticsearch[Puppet]:
+* https://github.com/elastic/puppet-elasticsearch[Puppet]:
   Elasticsearch puppet module.
 
 [float]
 ==== Supported by the community:
 
-* http://github.com/elasticsearch/cookbook-elasticsearch[Chef]:
+* https://github.com/elastic/cookbook-elasticsearch[Chef]:
   Chef cookbook for Elasticsearch
 
 This project appears to have been abandoned:

--- a/docs/reference/analysis/tokenfilters/phonetic-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/phonetic-tokenfilter.asciidoc
@@ -2,4 +2,4 @@
 === Phonetic Token Filter
 
 The `phonetic` token filter is provided as a plugin and located
-https://github.com/elasticsearch/elasticsearch-analysis-phonetic[here].
+https://github.com/elastic/elasticsearch-analysis-phonetic[here].

--- a/docs/reference/migration/migrate_1_0.asciidoc
+++ b/docs/reference/migration/migrate_1_0.asciidoc
@@ -262,7 +262,7 @@ use the empty stopwords list (ie `_none_`) instead.
 When dates are specified without a year, for example: `Dec 15 10:00:00` they
 are treated as dates in 2000 during indexing and range searches... except for
 the upper included bound `lte` where they were treated as dates in 1970!  Now,
-all https://github.com/elasticsearch/elasticsearch/issues/4451[dates without years]
+all https://github.com/elastic/elasticsearch/issues/4451[dates without years]
 use `1970` as the default.
 
 === Parameters
@@ -270,7 +270,7 @@ use `1970` as the default.
 * Geo queries used to use `miles` as the default unit.  And we
   http://en.wikipedia.org/wiki/Mars_Climate_Orbiter[all know what
   happened at NASA] because of that decision.  The new default unit is
-  https://github.com/elasticsearch/elasticsearch/issues/4515[`meters`].
+  https://github.com/elastic/elasticsearch/issues/4515[`meters`].
 
 * For all queries that support _fuzziness_, the `min_similarity`, `fuzziness`
   and `edit_distance` parameters have been unified as the single parameter

--- a/docs/reference/migration/migrate_1_4.asciidoc
+++ b/docs/reference/migration/migrate_1_4.asciidoc
@@ -89,4 +89,4 @@ restrained set to a specific `field`. It will be removed in 2.0.
 
 Groovy is the new default scripting language in Elasticsearch, and is enabled in `sandbox` mode
 by default.  MVEL has been removed from core, but is available as a plugin:
-https://github.com/elasticsearch/elasticsearch-lang-mvel
+https://github.com/elastic/elasticsearch-lang-mvel

--- a/docs/reference/modules/memcached.asciidoc
+++ b/docs/reference/modules/memcached.asciidoc
@@ -7,7 +7,7 @@ as possible).
 
 It is provided as a plugin called `transport-memcached` and installing
 is explained
-https://github.com/elasticsearch/elasticsearch-transport-memcached[here]
+https://github.com/elastic/elasticsearch-transport-memcached[here]
 . Another option is to download the memcached plugin and placing it
 under the `plugins` directory.
 

--- a/docs/reference/modules/thrift.asciidoc
+++ b/docs/reference/modules/thrift.asciidoc
@@ -8,10 +8,10 @@ transport, it should make using Elasticsearch more efficient (though it has limi
 documentation).
 
 Using thrift requires installing the `transport-thrift` plugin, located
-https://github.com/elasticsearch/elasticsearch-transport-thrift[here].
+https://github.com/elastic/elasticsearch-transport-thrift[here].
 
 The thrift
-https://github.com/elasticsearch/elasticsearch-transport-thrift/blob/master/elasticsearch.thrift[schema]
+https://github.com/elastic/elasticsearch-transport-thrift/blob/master/elasticsearch.thrift[schema]
 can be used to generate thrift clients.
 
 [cols="<,<",options="header",]

--- a/docs/resiliency/index.asciidoc
+++ b/docs/resiliency/index.asciidoc
@@ -1,7 +1,7 @@
 = Elasticsearch Resiliency Status
 
 :JIRA: https://issues.apache.org/jira/browse/LUCENE-
-:GIT:  https://github.com/elasticsearch/elasticsearch/issues/
+:GIT:  https://github.com/elastic/elasticsearch/issues/
 
 == Overview
 
@@ -11,7 +11,7 @@ system, Elasticsearch is complex and has many moving parts, each of which can
 encounter edge cases that require proper handling.  Our resiliency project is
 an ongoing effort to find and fix these edge cases. If you want to keep up
 with all this project on GitHub, see our issues list under the tag
-https://github.com/elasticsearch/elasticsearch/issues?q=label%3Aresiliency[resiliency].
+https://github.com/elastic/elasticsearch/issues?q=label%3Aresiliency[resiliency].
 
 While GitHub is great for sharing our work, it can be difficult to get an
 overview of the current state of affairs and the previous work that has been
@@ -51,7 +51,7 @@ source of information on unexpected edge cases and your bug reports
 help us make fixes that ensure that our system continues to be
 resilient.
 
-If you encounter an issue, https://github.com/elasticsearch/elasticsearch/issues[please report it]!
+If you encounter an issue, https://github.com/elastic/elasticsearch/issues[please report it]!
 
 We are committed to tracking down and fixing all the issues that are posted.
 
@@ -368,7 +368,7 @@ A hash collision makes it possible for two different files to have the same leng
 Even when minimum master nodes is set, split brain can still occur under certain conditions, e.g. disconnection between master eligible nodes, which can lead to data loss. The scenario is described in detail in {GIT}2488[issue 2488]:
 
 * Introduce a new testing infrastructure to simulate different types of node disconnections, including loss of network connection, lost messages, message delays, etc. See {GIT}5631[MockTransportService] support and {GIT}6505[service disruption] for more details. (STATUS: DONE, v1.4.0.Beta1).
-* Added tests that simulated the bug described in issue 2488. You can take a look at the https://github.com/elasticsearch/elasticsearch/commit/7bf3ffe73c44f1208d1f7a78b0629eb48836e726[original commit] of a reproduction on master. (STATUS: DONE, v1.2.0)
+* Added tests that simulated the bug described in issue 2488. You can take a look at the https://github.com/elastic/elasticsearch/commit/7bf3ffe73c44f1208d1f7a78b0629eb48836e726[original commit] of a reproduction on master. (STATUS: DONE, v1.2.0)
 * The bug described in {GIT}2488[issue 2488] is caused by an issue in our zen discovery gossip protocol. This specific issue has been fixed, and work has been done to make the algorithm more resilient. (STATUS: DONE, v1.4.0.Beta1)
 
 [float]
@@ -507,7 +507,7 @@ In order to run a more resilient cluster, we recommend running dedicated master 
 These changes include:
 
 * Improve the balancing algorithm to execute faster across large clusters / many indices. (See issue {GIT}4458[#4458] and {GIT}4459[#4459])
-* Improve cluster state publishing to not create an additional network buffer per node. (More in https://github.com/elasticsearch/elasticsearch/commit/a9e259d438c3cb1d3bef757db2d2a91cf85be609[this commit].)
+* Improve cluster state publishing to not create an additional network buffer per node. (More in https://github.com/elastic/elasticsearch/commit/a9e259d438c3cb1d3bef757db2d2a91cf85be609[this commit].)
 * Improve master handling of large scale mapping updates from data nodes by batching them into a single cluster event. (See issue {GIT}4373[#4373].)
 * Add an ack mechanism where next phase cluster updates are processed only when nodes acknowledged they received the previous cluster state. (See issues {GIT}3736[#3736], {GIT}3786[#3786], {GIT}4114[#4114], {GIT}4169[#4169], {GIT}4228[#4228] and {GIT}4421[#4421], which also include enhancements to the ack mechanism implementation.)
 
@@ -523,7 +523,7 @@ In order to best validate for resiliency in Elasticsearch, we rewrote the Elasti
 
 Each of our integration tests runs against a cluster with a random number of nodes, and indices have a random number of shards and replicas. Merge settings change for every run, indexing is done in serial or async fashion or even wrapped in a bulk operation and thread pool sizes vary to ensure that we don’t produce a deadlock no matter what happens. The list of places we use this randomization infrastructure is long, and growing every day, and has saved us headaches several times before we shipped a particular feature.
 
-At Elasticsearch, we live the philosophy that we can miss a bug once, but never a second time. We make our tests more evil as you go, introducing randomness in all the areas where we discovered bugs. We figure if our tests don’t fail, we are not trying hard enough! If you are interested in how we have evolved our test infrastructure over time check out https://github.com/elasticsearch/elasticsearch/issues?q=label%3Atest[issues labeled with ``test'' on GitHub].
+At Elasticsearch, we live the philosophy that we can miss a bug once, but never a second time. We make our tests more evil as you go, introducing randomness in all the areas where we discovered bugs. We figure if our tests don’t fail, we are not trying hard enough! If you are interested in how we have evolved our test infrastructure over time check out https://github.com/elastic/elasticsearch/issues?q=label%3Atest[issues labeled with ``test'' on GitHub].
 
 [float]
 === Lucene Loses Data On File Descriptors Failure (STATUS: DONE, v0.90.0)

--- a/docs/ruby/client.asciidoc
+++ b/docs/ruby/client.asciidoc
@@ -3,7 +3,7 @@
 The `elasticsearch` http://rubygems.org/gems/elasticsearch[Rubygem] provides a low-level client
 for communicating with an Elasticsearch cluster, fully compatible with other official clients.
 
-Full documentation is hosted at http://github.com/elasticsearch/elasticsearch-ruby[Github]
+Full documentation is hosted at https://github.com/elastic/elasticsearch-ruby[Github]
 and http://rubydoc.info/gems/elasticsearch[RubyDoc]
 -- this documentation provides only an overview of features.
 
@@ -83,10 +83,10 @@ client.search index: 'my-index', body: { query: { match: { title: 'test' } } }
 
 The `elasticsearch` gem combines two separate Rubygems:
 
-* https://github.com/elasticsearch/elasticsearch-ruby/tree/master/elasticsearch-transport[`elasticsearch-transport`]
+* https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-transport[`elasticsearch-transport`]
 provides a HTTP Ruby client for connecting to the Elasticsearch cluster,
 
-* https://github.com/elasticsearch/elasticsearch-ruby/tree/master/elasticsearch-api[`elasticsearch-api`]
+* https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-api[`elasticsearch-api`]
 provides a Ruby API for the Elasticsearch RESTful API.
 
 Please see their respective documentation for configuration options and technical details.
@@ -100,10 +100,10 @@ persistent ("keep-alive") HTTP connections.
 
 === Extensions
 
-The https://github.com/elasticsearch/elasticsearch-ruby/tree/master/elasticsearch-extensions[`elasticsearch-extensions`]
+The https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-extensions[`elasticsearch-extensions`]
 Rubygem provides a number of extensions to the core client, such as an API to programatically launch
 Elasticsearch clusters (eg. for testing purposes), and more.
 
 Please see its
-https://github.com/elasticsearch/elasticsearch-ruby/tree/master/elasticsearch-extensions[documentation]
+https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-extensions[documentation]
 for more information.

--- a/docs/ruby/model.asciidoc
+++ b/docs/ruby/model.asciidoc
@@ -62,5 +62,5 @@ response.results.first._source.title
 # => "Quick brown fox"
 ------------------------------------
 
-Please see the full https://github.com/elasticsearch/elasticsearch-rails/tree/master/elasticsearch-model[documentation]
+Please see the full https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-model[documentation]
 for more information.

--- a/docs/ruby/persistence.asciidoc
+++ b/docs/ruby/persistence.asciidoc
@@ -80,11 +80,11 @@ The repository module provides a number of features and facilities to configure 
 as well as support for extending your own, custom repository class.
 
 Please refer to the
-https://github.com/elasticsearch/elasticsearch-rails/tree/master/elasticsearch-persistence#the-repository-pattern[documentation]
+https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-persistence#the-repository-pattern[documentation]
 for more information.
 
 Also, check out the
-https://github.com/elasticsearch/elasticsearch-rails/tree/master/elasticsearch-persistence#example-application[example application] which demonstrates the usage patterns of the _repository_ approach to persistence.
+https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-persistence#example-application[example application] which demonstrates the usage patterns of the _repository_ approach to persistence.
 
 === Active Record
 
@@ -219,8 +219,8 @@ article.save
 ------------------------------------
 
 Please see the extensive documentation in the library
-https://github.com/elasticsearch/elasticsearch-rails/tree/master/elasticsearch-persistence#the-activerecord-pattern[README]
+https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-persistence#the-activerecord-pattern[README]
 for detailed information.
 
 Also, check out the
-https://github.com/elasticsearch/elasticsearch-rails/tree/master/elasticsearch-persistence#example-application-1[example application] which demonstrates the usage patterns of the _active record_ approach to persistence.
+https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-persistence#example-application-1[example application] which demonstrates the usage patterns of the _active record_ approach to persistence.

--- a/docs/ruby/rails.asciidoc
+++ b/docs/ruby/rails.asciidoc
@@ -13,4 +13,4 @@ provides features suitable for Ruby on Rails applications.
 
 You can generate a fully working example Ruby on Rails application with templates provides.
 
-Please refer to the https://github.com/elasticsearch/elasticsearch-rails/tree/master/elasticsearch-rails[documentation] for more information.
+Please refer to the https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-rails[documentation] for more information.

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/BulkTests.java
@@ -404,7 +404,7 @@ public class BulkTests extends ESIntegTestCase {
     }
 
     /*
-    Test for https://github.com/elasticsearch/elasticsearch/issues/3444
+    Test for https://github.com/elastic/elasticsearch/issues/3444
      */
     public void testBulkUpdateDocAsUpsertWithParent() throws Exception {
         client().admin().indices().prepareCreate("test")
@@ -441,7 +441,7 @@ public class BulkTests extends ESIntegTestCase {
     }
 
     /*
-    Test for https://github.com/elasticsearch/elasticsearch/issues/3444
+    Test for https://github.com/elastic/elasticsearch/issues/3444
      */
     public void testBulkUpdateUpsertWithParent() throws Exception {
         assertAcked(prepareCreate("test")
@@ -475,7 +475,7 @@ public class BulkTests extends ESIntegTestCase {
     }
 
     /*
-     * Test for https://github.com/elasticsearch/elasticsearch/issues/8365
+     * Test for https://github.com/elastic/elasticsearch/issues/8365
      */
     public void testBulkUpdateChildMissingParentRouting() throws Exception {
         assertAcked(prepareCreate("test").addMapping("parent", "{\"parent\":{}}").addMapping("child",

--- a/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/EquivalenceTests.java
+++ b/modules/lang-groovy/src/test/java/org/elasticsearch/messy/tests/EquivalenceTests.java
@@ -344,7 +344,7 @@ public class EquivalenceTests extends ESIntegTestCase {
         assertEquals(numDocs, response.getHits().getTotalHits());
     }
 
-    // https://github.com/elasticsearch/elasticsearch/issues/6435
+    // https://github.com/elastic/elasticsearch/issues/6435
     public void testReduce() throws Exception {
         createIndex("idx");
         final int value = randomIntBetween(0, 10);

--- a/plugins/discovery-azure/src/test/java/org/elasticsearch/discovery/azure/AzureMinimumMasterNodesTests.java
+++ b/plugins/discovery-azure/src/test/java/org/elasticsearch/discovery/azure/AzureMinimumMasterNodesTests.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Reported issue in #15
- * (https://github.com/elasticsearch/elasticsearch-cloud-azure/issues/15)
+ * (https://github.com/elastic/elasticsearch-cloud-azure/issues/15)
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE,
         numDataNodes = 0,

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/discovery/gce/GceUnicastHostsProvider.java
@@ -144,7 +144,7 @@ public class GceUnicastHostsProvider extends AbstractComponent implements Unicas
                 logger.trace("gce instance {} with status {} found.", name, status);
 
                 // We don't want to connect to TERMINATED status instances
-                // See https://github.com/elasticsearch/elasticsearch-cloud-gce/issues/3
+                // See https://github.com/elastic/elasticsearch-cloud-gce/issues/3
                 if (Status.TERMINATED.equals(status)) {
                     logger.debug("node {} is TERMINATED. Ignoring", name);
                     continue;

--- a/plugins/lang-python/src/test/resources/rest-api-spec/test/lang_python/30_update.yaml
+++ b/plugins/lang-python/src/test/resources/rest-api-spec/test/lang_python/30_update.yaml
@@ -1,7 +1,7 @@
 # Integration tests for Lang Python components
 #
 
-# Test case for #4: https://github.com/elasticsearch/elasticsearch-lang-python/issues/4
+# Test case for #4: https://github.com/elastic/elasticsearch-lang-python/issues/4
 # Update request that uses python script with no parameters fails with NullPointerException
 #
 "Python Update With Empty Parameters":
@@ -30,7 +30,7 @@
 
 ---
 
-# Test case for #19: https://github.com/elasticsearch/elasticsearch-lang-python/issues/19
+# Test case for #19: https://github.com/elastic/elasticsearch-lang-python/issues/19
 # Multi-line or multi-statement Python scripts raise NullPointerException
 #
 "Python Update With Multi Lines":

--- a/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/EncryptedDocMapperTests.java
+++ b/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/EncryptedDocMapperTests.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 /**
- * Test for https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/18
+ * Test for https://github.com/elastic/elasticsearch-mapper-attachments/issues/18
  * Note that we have converted /org/elasticsearch/index/mapper/xcontent/testContentLength.txt
  * to a /org/elasticsearch/index/mapper/xcontent/encrypted.pdf with password `12345678`.
  */

--- a/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/MetadataMapperTests.java
+++ b/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/MetadataMapperTests.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 /**
- * Test for https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/38
+ * Test for https://github.com/elastic/elasticsearch-mapper-attachments/issues/38
  */
 public class MetadataMapperTests extends AttachmentUnitTestCase {
 

--- a/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/VariousDocTests.java
+++ b/plugins/mapper-attachments/src/test/java/org/elasticsearch/mapper/attachments/VariousDocTests.java
@@ -63,7 +63,7 @@ public class VariousDocTests extends AttachmentUnitTestCase {
     }
 
     /**
-     * Test for https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/104
+     * Test for https://github.com/elastic/elasticsearch-mapper-attachments/issues/104
      */
     public void testWordDocxDocument104() throws Exception {
         assertParseable("issue-104.docx");
@@ -112,7 +112,7 @@ public class VariousDocTests extends AttachmentUnitTestCase {
 
     /**
      * Test for ASCIIDOC
-     * Not yet supported by Tika: https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/29
+     * Not yet supported by Tika: https://github.com/elastic/elasticsearch-mapper-attachments/issues/29
      */
     public void testAsciidocDocument() throws Exception {
         assertParseable("asciidoc.asciidoc");

--- a/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/10_index.yaml
+++ b/plugins/mapper-attachments/src/test/resources/rest-api-spec/test/mapper_attachments/10_index.yaml
@@ -2,7 +2,7 @@
 #
 
 ---
-# https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/23
+# https://github.com/elastic/elasticsearch-mapper-attachments/issues/23
 "Index empty attachment":
 
     - do:
@@ -28,7 +28,7 @@
               file: { }
 
 ---
-# https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/18
+# https://github.com/elastic/elasticsearch-mapper-attachments/issues/18
 # Encoded content with https://www.base64encode.org/
 # File1
 #<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
@@ -102,7 +102,7 @@
 # See https://github.com/elastic/elasticsearch/pull/13077
 # See https://github.com/elastic/elasticsearch-mapper-attachments/pull/150#issuecomment-134247110
 #
-# https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/18
+# https://github.com/elastic/elasticsearch-mapper-attachments/issues/18
 # Encoded content with https://www.base64encode.org/
 # File1
 #<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotRestoreTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotRestoreTests.java
@@ -174,7 +174,7 @@ public class AzureSnapshotRestoreTests extends AbstractAzureWithThirdPartyTestCa
     }
 
     /**
-     * For issue #51: https://github.com/elasticsearch/elasticsearch-cloud-azure/issues/51
+     * For issue #51: https://github.com/elastic/elasticsearch-cloud-azure/issues/51
      */
     public void testMultipleSnapshots() throws URISyntaxException, StorageException {
         final String indexName = "test-idx-1";
@@ -298,7 +298,7 @@ public class AzureSnapshotRestoreTests extends AbstractAzureWithThirdPartyTestCa
     }
 
     /**
-     * For issue #26: https://github.com/elasticsearch/elasticsearch-cloud-azure/issues/26
+     * For issue #26: https://github.com/elastic/elasticsearch-cloud-azure/issues/26
      */
     public void testListBlobs_26() throws StorageException, URISyntaxException {
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");
@@ -356,7 +356,7 @@ public class AzureSnapshotRestoreTests extends AbstractAzureWithThirdPartyTestCa
     }
 
     /**
-     * For issue #28: https://github.com/elasticsearch/elasticsearch-cloud-azure/issues/28
+     * For issue #28: https://github.com/elastic/elasticsearch-cloud-azure/issues/28
      */
     public void testGetDeleteNonExistingSnapshot_28() throws StorageException, URISyntaxException {
         ClusterAdminClient client = client().admin().cluster();
@@ -383,7 +383,7 @@ public class AzureSnapshotRestoreTests extends AbstractAzureWithThirdPartyTestCa
     }
 
     /**
-     * For issue #21: https://github.com/elasticsearch/elasticsearch-cloud-azure/issues/21
+     * For issue #21: https://github.com/elastic/elasticsearch-cloud-azure/issues/21
      */
     public void testForbiddenContainerName() throws Exception {
         checkContainerName("", false);
@@ -437,7 +437,7 @@ public class AzureSnapshotRestoreTests extends AbstractAzureWithThirdPartyTestCa
     }
 
     /**
-     * Test case for issue #23: https://github.com/elasticsearch/elasticsearch-cloud-azure/issues/23
+     * Test case for issue #23: https://github.com/elastic/elasticsearch-cloud-azure/issues/23
      */
     public void testNonExistingRepo_23() {
         Client client = client();

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
@@ -352,7 +352,7 @@ abstract public class AbstractS3SnapshotRestoreTest extends AbstractAwsTestCase 
     }
 
     /**
-     * Test case for issue #86: https://github.com/elasticsearch/elasticsearch-cloud-aws/issues/86
+     * Test case for issue #86: https://github.com/elastic/elasticsearch-cloud-aws/issues/86
      */
     public void testNonExistingRepo86() {
         Client client = client();
@@ -373,7 +373,7 @@ abstract public class AbstractS3SnapshotRestoreTest extends AbstractAwsTestCase 
     }
 
     /**
-     * For issue #86: https://github.com/elasticsearch/elasticsearch-cloud-aws/issues/86
+     * For issue #86: https://github.com/elastic/elasticsearch-cloud-aws/issues/86
      */
     public void testGetDeleteNonExistingSnapshot86() {
         ClusterAdminClient client = client().admin().cluster();


### PR DESCRIPTION
Basically a query-replace of "https://github.com/elasticsearch/" with "https://github.com/elastic/"

We get a lot of PRs to this effect, so I figured doing it all in one swoop would be easiest.
