### PR TITLE
Document `sum` as supported scoring type for has_child queries

### DIFF
--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -23,7 +23,7 @@ an example:
 ==== Scoring capabilities
 
 The `has_child` also has scoring support. The
-supported score modes are `sum`, `min`, `max`, `total`, `avg` or `none`. The default is
+supported score modes are `min`, `max`, `sum`, `avg` or `none`. The default is
 `none` and yields the same behaviour as in previous versions. If the
 score mode is set to another value than `none`, the scores of all the
 matching child documents are aggregated into the associated parent

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -23,7 +23,7 @@ an example:
 ==== Scoring capabilities
 
 The `has_child` also has scoring support. The
-supported score modes are `min`, `max`, `total`, `avg` or `none`. The default is
+supported score modes are `sum`, `min`, `max`, `total`, `avg` or `none`. The default is
 `none` and yields the same behaviour as in previous versions. If the
 score mode is set to another value than `none`, the scores of all the
 matching child documents are aggregated into the associated parent


### PR DESCRIPTION
the examples all use `sum` for the `"score_mode"` field, but it isn't listed in the list of supported modes.
