### PR TITLE
Only wait for initial state unless we already got a master

### DIFF
--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -317,18 +317,15 @@ public class Node implements Closeable {
         discovery.start();
         transportService.acceptIncomingRequests();
         discovery.startInitialJoin();
-
         // tribe nodes don't have a master so we shouldn't register an observer
         if (DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.get(settings).millis() > 0) {
             final ThreadPool thread = injector.getInstance(ThreadPool.class);
             ClusterStateObserver observer = new ClusterStateObserver(clusterService, null, logger, thread.getThreadContext());
-            final CountDownLatch latch = new CountDownLatch(1);
             if (observer.observedState().nodes().masterNodeId() == null) {
+                final CountDownLatch latch = new CountDownLatch(1);
                 observer.waitForNextChange(new ClusterStateObserver.Listener() {
                     @Override
-                    public void onNewClusterState(ClusterState state) {
-                        latch.countDown();
-                    }
+                    public void onNewClusterState(ClusterState state) { latch.countDown(); }
 
                     @Override
                     public void onClusterServiceClose() {
@@ -337,16 +334,17 @@ public class Node implements Closeable {
 
                     @Override
                     public void onTimeout(TimeValue timeout) {
-                        assert false;
+                        logger.warn("timed out while waiting for initial discovery state - timeout: {}",
+                            DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.get(settings));
+                        latch.countDown();
                     }
-                    // use null timeout as we use timeout on the latchwait
-                }, MasterNodeChangePredicate.INSTANCE, null);
-            }
+                }, MasterNodeChangePredicate.INSTANCE, DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.get(settings));
 
-            try {
-                latch.await(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.get(settings).millis(), TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                throw new ElasticsearchTimeoutException("Interrupted while waiting for initial discovery state");
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new ElasticsearchTimeoutException("Interrupted while waiting for initial discovery state");
+                }
             }
         }
 


### PR DESCRIPTION
This seems to be an error introduced in refactoring around #16821
where we now wait 30seconds by default if the node already joined
a cluster and got a master. This can slow down tests dramatically
especially on slow boxes and notebooks.

here is a related test failure: http://build-us-00.elastic.co/job/es_core_master_oracle_6/5269/
