### PR TITLE
Handle RejectedExecution gracefully in TransportService during shutdown

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -191,9 +191,18 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
                 if (holderToNotify != null) {
                     // callback that an exception happened, but on a different thread since we don't
                     // want handlers to worry about stack overflows
-                    threadPool.generic().execute(new Runnable() {
+                    threadPool.generic().execute(new AbstractRunnable() {
                         @Override
-                        public void run() {
+                        public void onRejection(Throwable t) {
+                            // if we get rejected during node shutdown we don't wanna bubble it up
+                            logger.debug("failed to notify response handler on rejection, action: {}", t, holderToNotify.action());
+                        }
+                        @Override
+                        public void onFailure(Throwable t) {
+                            logger.warn("failed to notify response handler on exception, action: {}", t, holderToNotify.action());
+                        }
+                        @Override
+                        public void doRun() {
                             holderToNotify.handler().handleException(new TransportException("transport stopped, action: " + holderToNotify.action()));
                         }
                     });
@@ -333,11 +342,11 @@ public class TransportService extends AbstractLifecycleComponent<TransportServic
                     @Override
                     public void onRejection(Throwable t) {
                         // if we get rejected during node shutdown we don't wanna bubble it up
-                        logger.debug("failed to notify response handler on rejection", t);
+                        logger.debug("failed to notify response handler on rejection, action: {}", t, holderToNotify.action());
                     }
                     @Override
                     public void onFailure(Throwable t) {
-                        logger.warn("failed to notify response handler on exception", t);
+                        logger.warn("failed to notify response handler on exception, action: {}", t, holderToNotify.action());
                     }
                     @Override
                     protected void doRun() throws Exception {


### PR DESCRIPTION
Today we might run into a rejected execution exception when we shutdown the node while handling a transport exception. The exception is run in a seperate thread but that thread might not be able to execute due to the shutdown. Today we barf and fill the logs with large exception. This commit catches this exception and logs it as debug logging instead.

Extends changes made in 8652cd8
